### PR TITLE
ipsec implementation tested to work with ubuntu,coreos-stable and centos

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -29,6 +29,7 @@
     - { role: kernel-upgrade, tags: kernel-upgrade, when: kernel_upgrade is defined and kernel_upgrade }
     - { role: kubernetes/preinstall, tags: preinstall }
     - { role: docker, tags: docker }
+    - { role: ipsec, when: ipsec|default(false) }
     - role: rkt
       tags: rkt
       when: "'rkt' in [etcd_deployment_type, kubelet_deployment_type, vault_deployment_type]"

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -7,6 +7,9 @@ etcd_data_dir: /var/lib/etcd
 # Directory where the binaries will be installed
 bin_dir: /usr/local/bin
 
+## use ipsec transport to secure the network between k8s nodes
+ipsec: true
+
 ## The access_ip variable is used to define how other nodes should access
 ## the node.  This is used in flannel to allow other flannel nodes to see
 ## this node for example.  The access_ip is really useful AWS and Google

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -8,7 +8,7 @@ etcd_data_dir: /var/lib/etcd
 bin_dir: /usr/local/bin
 
 ## use ipsec transport to secure the network between k8s nodes
-ipsec: true
+#ipsec: true
 
 ## The access_ip variable is used to define how other nodes should access
 ## the node.  This is used in flannel to allow other flannel nodes to see

--- a/roles/ipsec/handlers/main.yml
+++ b/roles/ipsec/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: restart ipsec
+  systemd:
+      name: ipsec
+      state: restarted
+
+- name: reload ipsec unit
+  systemd:
+      name: ipsec
+      daemon_reload: true

--- a/roles/ipsec/tasks/main.yaml
+++ b/roles/ipsec/tasks/main.yaml
@@ -1,86 +1,34 @@
-- name: install systemd-containers on ubunt
-  apt:
-      name: systemd-container
-      state: installed
-  when: ansible_os_family == "Debian"
-# nspawn binary path
-- name: set systemd nspawn binary path on ubuntu
-  set_fact: 
-      ipsec_nspawn_binary: /usr/bin/systemd-nspawn
-  when: ansible_os_family == "Debian"
-- name: set systemd nspawn binary path on ubuntu
-  set_fact: 
-      ipsec_nspawn_binary: /bin/systemd-nspawn
-  when: ansible_os_family != "Debian"
-# modprobe binary path
-- name: set systemd nspawn binary path on ubuntu
-  set_fact: 
-      ipsec_modprobe_binary: /sbin/modprobe
-  when: ansible_os_family == "Debian"
-- name: set systemd nspawn binary path on ubuntu
-  set_fact: 
-      ipsec_modprobe_binary: /usr/sbin/modprobe
-  when: ansible_os_family != 'Deboam'
+- name: gather os specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - files:
+        - "{{ ansible_os_family|lower }}.yml"
+        - defaults.yml
+      paths:
+        - ../vars
+      skip: true
+  tags: facts
 
 - name: create directories
   file:
       path: '{{ item }}'
       state: directory
-  with_items: 
+  with_items:
       - /etc/ipsec.d
   become: yes
-- name: copy machine instllation script
-  copy:
-      content: |
-          #!/bin/bash
-          set -e
-          docker rm -f foo || true
-          mkdir -p /var/lib/machines/ipsec-libreswan
-          docker export $(docker create --name foo fedora bash) | tar -x -C /var/lib/machines/ipsec-libreswan  -f -
-          docker rm -f foo
-          systemd-machine-id-setup --root /var/lib/machines/ipsec-libreswan
-          systemd-nspawn -M ipsec-libreswan dnf clean all
-          systemd-nspawn  \
-          --bind /etc/ipsec.d --machine=ipsec-libreswan  \
-          dnf -y install libreswan
 
-
-          systemd-nspawn  \
-          --bind /etc/ipsec.d --machine=ipsec-libreswan  \
-          systemctl enable ipsec
-      dest: /tmp/create-container
-      mode: 744
-  become: yes
-
-- name: create machine
-  block:
-    - name: create machine 
-      shell: /tmp/create-container
-      args:
-        creates: /var/lib/machines/ipsec-libreswan
-        executable: /bin/bash
-      become: yes
-  rescue:
-    - shell: rm -rf /var/lib/machines/ipsec-libreswan
-    - fail:
-        msg: ipsec-libreswan machine creation failed
-#  - name: set quota for mache
-#    shell: machinectl set-limit ipsec-libreswan 1G
-#    become: yes
 - name: intit nsss
   shell: |
       set -e
-      systemd-nspawn  \
-          --bind /etc/ipsec.d  --machine=ipsec-libreswan  \
-          ipsec initnss
+      docker run -v /etc/ipsec.d:/etc/ipsec.d cornelius/docker-ipsec-libreswan  \
+      ipsec initnss
   become: yes
   args:
      creates: /etc/ipsec.d/cert9.db
 
 - name: create hostkey
   shell: |
-      systemd-nspawn  \
-          --bind /etc/ipsec.d   --bind /tmp --machine=ipsec-libreswan  \
+      docker run -v /etc/ipsec.d:/etc/ipsec.d cornelius/docker-ipsec-libreswan   \
           ipsec newhostkey --output /etc/ipsec.d/{{ ansible_hostname }}.secrets
   become: yes
   args:
@@ -88,25 +36,22 @@
 
 - name: register host key
   shell: |
-      systemd-nspawn -x -M tmp -D /var/lib/machines/ipsec-libreswan \
-          --bind /etc/ipsec.d  \
+      docker run -v /etc/ipsec.d:/etc/ipsec.d cornelius/docker-ipsec-libreswan   \
            ipsec showhostkey --list | sed -n '1s/.* //p'
   register: ipsec_ckaid
   become: yes
   changed_when: false
 - name: register ipsec_left
   shell: |
-      systemd-nspawn -x -M tmp -D /var/lib/machines/ipsec-libreswan \
-          --bind /etc/ipsec.d   \
+      docker run -v /etc/ipsec.d:/etc/ipsec.d cornelius/docker-ipsec-libreswan   \
            ipsec showhostkey --left --ckaid {{ ipsec_ckaid.stdout }}
   register: ipsec_left
   changed_when: false
   become: yes
 - name: register ipsec_right
   shell: |
-      systemd-nspawn -x -M tmp -D /var/lib/machines/ipsec-libreswan \
-          --bind /etc/ipsec.d \
-           ipsec showhostkey --right --ckaid {{ ipsec_ckaid.stdout }}
+      docker run -v /etc/ipsec.d:/etc/ipsec.d cornelius/docker-ipsec-libreswan   \
+               ipsec showhostkey --right --ckaid {{ ipsec_ckaid.stdout }}
   register: ipsec_right
   become: yes
   changed_when: false
@@ -117,7 +62,8 @@
       src: templates/cluster.conf.j2
   become: yes
   register: ipsec_cluster_conf
-- name: creaty ipsec service
+
+- name: create ipsec service
   copy:
       content: |
           [Unit]
@@ -125,21 +71,22 @@
           After=network-online.target
           Wants=network-online.target
           [Service]
-          ExecStartPre={{ ipsec_modprobe_binary }} af_key
-          ExecStart={{ ipsec_nspawn_binary }} --quiet --capability CAP_NET_ADMIN,CAP_SYS_MODULE --tmpfs /var/run/pluto --bind /proc/sys/net --bind /proc/net --bind-ro /lib/modules \
-                    --bind /etc/ipsec.d  --machine=ipsec-libreswan -jb
-          ExecStop=/bin/machinectl poweroff ipsec-libreswan
-          ExecReload=/bin/systemctl --machine ipsec-libreswan reload ipsec
+          ExecStartPre={{ ipsec_modprobe_binary }}  af_key
+          ExecStartPre=/usr/bin/docker pull cornelius/docker-ipsec-libreswan
+          ExecStartPre=-/usr/bin/docker rm -f ipsec-libreswan
+          ExecStart=/usr/bin/docker run --privileged --net host -v /etc/ipsec.d:/etc/ipsec.d --name=ipsec-libreswan cornelius/docker-ipsec-libreswan
+          ExecStop=/usr/bin/docker stop ipsec-libreswan
+          ExecReload=/usr/bin/docker exec ipsec-libreswan systemctl reload ipsec
+          Restart=always
           [Install]
-          WantedBy=multi-user.target
+          WantedBy=network-online.target
       dest: /etc/systemd/system/ipsec.service
-  become: yes
-  register: ipsec_unit_file
+  register: ipsec_systemd_unit_file
 
-- name: enable ipsec service
+- name: start and enable ipsec service
   systemd:
-      name: ipsec
-      state: '{{ ipsec_cluster_conf.changed | ternary("restarted","started") }}'
-      daemon_reload: '{{ ipsec_unit_file.changed }}'
-      enabled: true
-  become: yes
+    name: ipsec
+    state: '{{ ipsec_cluster_conf.changed|ternary("restarted","started") }}'
+    enabled: yes
+    daemon_reload: '{{ ipsec_systemd_unit_file|changed }}'
+

--- a/roles/ipsec/tasks/main.yaml
+++ b/roles/ipsec/tasks/main.yaml
@@ -61,18 +61,17 @@
       dest: /etc/ipsec.d/cluster.conf
       src: templates/cluster.conf.j2
   become: yes
-  register: ipsec_cluster_conf
+  notify: restart ipsec
 
 - name: create ipsec service
   template:
     src: ipsec.service.j2
     dest: /etc/systemd/system/ipsec.service
-  register: ipsec_systemd_unit_file
+  notify: reload ipsec unit
 
 - name: start and enable ipsec service
   systemd:
     name: ipsec
-    state: '{{ ipsec_cluster_conf.changed|ternary("restarted","started") }}'
+    state: started
     enabled: yes
-    daemon_reload: '{{ ipsec_systemd_unit_file|changed }}'
 

--- a/roles/ipsec/tasks/main.yaml
+++ b/roles/ipsec/tasks/main.yaml
@@ -1,0 +1,145 @@
+- name: install systemd-containers on ubunt
+  apt:
+      name: systemd-container
+      state: installed
+  when: ansible_os_family == "Debian"
+# nspawn binary path
+- name: set systemd nspawn binary path on ubuntu
+  set_fact: 
+      ipsec_nspawn_binary: /usr/bin/systemd-nspawn
+  when: ansible_os_family == "Debian"
+- name: set systemd nspawn binary path on ubuntu
+  set_fact: 
+      ipsec_nspawn_binary: /bin/systemd-nspawn
+  when: ansible_os_family != "Debian"
+# modprobe binary path
+- name: set systemd nspawn binary path on ubuntu
+  set_fact: 
+      ipsec_modprobe_binary: /sbin/modprobe
+  when: ansible_os_family == "Debian"
+- name: set systemd nspawn binary path on ubuntu
+  set_fact: 
+      ipsec_modprobe_binary: /usr/sbin/modprobe
+  when: ansible_os_family != 'Deboam'
+
+- name: create directories
+  file:
+      path: '{{ item }}'
+      state: directory
+  with_items: 
+      - /etc/ipsec.d
+  become: yes
+- name: copy machine instllation script
+  copy:
+      content: |
+          #!/bin/bash
+          set -e
+          docker rm -f foo || true
+          mkdir -p /var/lib/machines/ipsec-libreswan
+          docker export $(docker create --name foo fedora bash) | tar -x -C /var/lib/machines/ipsec-libreswan  -f -
+          docker rm -f foo
+          systemd-machine-id-setup --root /var/lib/machines/ipsec-libreswan
+          systemd-nspawn -M ipsec-libreswan dnf clean all
+          systemd-nspawn  \
+          --bind /etc/ipsec.d --machine=ipsec-libreswan  \
+          dnf -y install libreswan
+
+
+          systemd-nspawn  \
+          --bind /etc/ipsec.d --machine=ipsec-libreswan  \
+          systemctl enable ipsec
+      dest: /tmp/create-container
+      mode: 744
+  become: yes
+
+- name: create machine
+  block:
+    - name: create machine 
+      shell: /tmp/create-container
+      args:
+        creates: /var/lib/machines/ipsec-libreswan
+        executable: /bin/bash
+      become: yes
+  rescue:
+    - shell: rm -rf /var/lib/machines/ipsec-libreswan
+    - fail:
+        msg: ipsec-libreswan machine creation failed
+#  - name: set quota for mache
+#    shell: machinectl set-limit ipsec-libreswan 1G
+#    become: yes
+- name: intit nsss
+  shell: |
+      set -e
+      systemd-nspawn  \
+          --bind /etc/ipsec.d  --machine=ipsec-libreswan  \
+          ipsec initnss
+  become: yes
+  args:
+     creates: /etc/ipsec.d/cert9.db
+
+- name: create hostkey
+  shell: |
+      systemd-nspawn  \
+          --bind /etc/ipsec.d   --bind /tmp --machine=ipsec-libreswan  \
+          ipsec newhostkey --output /etc/ipsec.d/{{ ansible_hostname }}.secrets
+  become: yes
+  args:
+     creates: /etc/ipsec.d/{{ ansible_hostname  }}.secrets
+
+- name: register host key
+  shell: |
+      systemd-nspawn -x -M tmp -D /var/lib/machines/ipsec-libreswan \
+          --bind /etc/ipsec.d  \
+           ipsec showhostkey --list | sed -n '1s/.* //p'
+  register: ipsec_ckaid
+  become: yes
+  changed_when: false
+- name: register ipsec_left
+  shell: |
+      systemd-nspawn -x -M tmp -D /var/lib/machines/ipsec-libreswan \
+          --bind /etc/ipsec.d   \
+           ipsec showhostkey --left --ckaid {{ ipsec_ckaid.stdout }}
+  register: ipsec_left
+  changed_when: false
+  become: yes
+- name: register ipsec_right
+  shell: |
+      systemd-nspawn -x -M tmp -D /var/lib/machines/ipsec-libreswan \
+          --bind /etc/ipsec.d \
+           ipsec showhostkey --right --ckaid {{ ipsec_ckaid.stdout }}
+  register: ipsec_right
+  become: yes
+  changed_when: false
+
+- name: template /etc/ipsec.d/cluster.conf
+  template:
+      dest: /etc/ipsec.d/cluster.conf
+      src: templates/cluster.conf.j2
+  become: yes
+  register: ipsec_cluster_conf
+- name: creaty ipsec service
+  copy:
+      content: |
+          [Unit]
+          Description=LibreSwan IPSEC running in ipsec-libreswan
+          After=network-online.target
+          Wants=network-online.target
+          [Service]
+          ExecStartPre={{ ipsec_modprobe_binary }} af_key
+          ExecStart={{ ipsec_nspawn_binary }} --quiet --capability CAP_NET_ADMIN,CAP_SYS_MODULE --tmpfs /var/run/pluto --bind /proc/sys/net --bind /proc/net --bind-ro /lib/modules \
+                    --bind /etc/ipsec.d  --machine=ipsec-libreswan -jb
+          ExecStop=/bin/machinectl poweroff ipsec-libreswan
+          ExecReload=/bin/systemctl --machine ipsec-libreswan reload ipsec
+          [Install]
+          WantedBy=multi-user.target
+      dest: /etc/systemd/system/ipsec.service
+  become: yes
+  register: ipsec_unit_file
+
+- name: enable ipsec service
+  systemd:
+      name: ipsec
+      state: '{{ ipsec_cluster_conf.changed | ternary("restarted","started") }}'
+      daemon_reload: '{{ ipsec_unit_file.changed }}'
+      enabled: true
+  become: yes

--- a/roles/ipsec/tasks/main.yaml
+++ b/roles/ipsec/tasks/main.yaml
@@ -60,6 +60,9 @@
   template:
       dest: /etc/ipsec.d/cluster.conf
       src: templates/cluster.conf.j2
+      owner: root
+      group: root
+      mode: 600
   become: yes
   notify: restart ipsec
 

--- a/roles/ipsec/tasks/main.yaml
+++ b/roles/ipsec/tasks/main.yaml
@@ -20,7 +20,7 @@
 - name: intit nsss
   shell: |
       set -e
-      docker run -v /etc/ipsec.d:/etc/ipsec.d cornelius/docker-ipsec-libreswan  \
+      docker run --rm  -v /etc/ipsec.d:/etc/ipsec.d cornelius/docker-ipsec-libreswan  \
       ipsec initnss
   become: yes
   args:
@@ -28,7 +28,7 @@
 
 - name: create hostkey
   shell: |
-      docker run -v /etc/ipsec.d:/etc/ipsec.d cornelius/docker-ipsec-libreswan   \
+      docker run --rm  -v /etc/ipsec.d:/etc/ipsec.d cornelius/docker-ipsec-libreswan   \
           ipsec newhostkey --output /etc/ipsec.d/{{ ansible_hostname }}.secrets
   become: yes
   args:
@@ -36,21 +36,21 @@
 
 - name: register host key
   shell: |
-      docker run -v /etc/ipsec.d:/etc/ipsec.d cornelius/docker-ipsec-libreswan   \
+      docker run --rm  -v /etc/ipsec.d:/etc/ipsec.d cornelius/docker-ipsec-libreswan   \
            ipsec showhostkey --list | sed -n '1s/.* //p'
   register: ipsec_ckaid
   become: yes
   changed_when: false
 - name: register ipsec_left
   shell: |
-      docker run -v /etc/ipsec.d:/etc/ipsec.d cornelius/docker-ipsec-libreswan   \
+      docker run --rm -v /etc/ipsec.d:/etc/ipsec.d cornelius/docker-ipsec-libreswan   \
            ipsec showhostkey --left --ckaid {{ ipsec_ckaid.stdout }}
   register: ipsec_left
   changed_when: false
   become: yes
 - name: register ipsec_right
   shell: |
-      docker run -v /etc/ipsec.d:/etc/ipsec.d cornelius/docker-ipsec-libreswan   \
+      docker run --rm  -v /etc/ipsec.d:/etc/ipsec.d cornelius/docker-ipsec-libreswan   \
                ipsec showhostkey --right --ckaid {{ ipsec_ckaid.stdout }}
   register: ipsec_right
   become: yes
@@ -64,23 +64,9 @@
   register: ipsec_cluster_conf
 
 - name: create ipsec service
-  copy:
-      content: |
-          [Unit]
-          Description=LibreSwan IPSEC running in ipsec-libreswan
-          After=network-online.target
-          Wants=network-online.target
-          [Service]
-          ExecStartPre={{ ipsec_modprobe_binary }}  af_key
-          ExecStartPre=/usr/bin/docker pull cornelius/docker-ipsec-libreswan
-          ExecStartPre=-/usr/bin/docker rm -f ipsec-libreswan
-          ExecStart=/usr/bin/docker run --privileged --net host -v /etc/ipsec.d:/etc/ipsec.d --name=ipsec-libreswan cornelius/docker-ipsec-libreswan
-          ExecStop=/usr/bin/docker stop ipsec-libreswan
-          ExecReload=/usr/bin/docker exec ipsec-libreswan systemctl reload ipsec
-          Restart=always
-          [Install]
-          WantedBy=network-online.target
-      dest: /etc/systemd/system/ipsec.service
+  template:
+    src: ipsec.service.j2
+    dest: /etc/systemd/system/ipsec.service
   register: ipsec_systemd_unit_file
 
 - name: start and enable ipsec service

--- a/roles/ipsec/templates/cluster.conf.j2
+++ b/roles/ipsec/templates/cluster.conf.j2
@@ -1,4 +1,4 @@
-{% for host in groups['k8s-cluster']|union(groups['etcd']|union(groups['calico-rr']|default([])|unique|sort %}
+{% for host in groups['k8s-cluster']|union(groups['etcd']|union(groups['calico-rr']|default([])))|default([])|unique|sort %}
 {% if host != inventory_hostname %}
 conn {{ host }}
         authby=rsasig

--- a/roles/ipsec/templates/cluster.conf.j2
+++ b/roles/ipsec/templates/cluster.conf.j2
@@ -1,0 +1,14 @@
+{% for host in groups['all'] %}
+{% if host != inventory_hostname %}
+conn {{ host }}
+        authby=rsasig
+        left={{ ip  }}
+        leftid=@{{ansible_hostname }}
+        right={{ hostvars[host]['ip'] }}
+        rightid=@{{ hostvars[host]['ansible_hostname'] }}
+{{ ipsec_left.stdout }}
+{{ hostvars[host]['ipsec_right']['stdout'] }}
+        auto=start
+        type=transport
+{% endif %}
+{% endfor %}

--- a/roles/ipsec/templates/cluster.conf.j2
+++ b/roles/ipsec/templates/cluster.conf.j2
@@ -1,4 +1,4 @@
-{% for host in groups['all'] %}
+{% for host in groups['k8s-cluster']|union(groups['etcd']|union(groups['calico-rr']|default([])|unique|sort %}
 {% if host != inventory_hostname %}
 conn {{ host }}
         authby=rsasig

--- a/roles/ipsec/templates/ipsec.service.j2
+++ b/roles/ipsec/templates/ipsec.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=LibreSwan IPSEC running in ipsec-libreswan
+After=network-online.target
+Wants=network-online.target
+[Service]
+ExecStartPre={{ ipsec_modprobe_binary }}  af_key
+ExecStartPre=/usr/bin/docker pull cornelius/docker-ipsec-libreswan
+ExecStartPre=-/usr/bin/docker rm -f ipsec-libreswan
+ExecStart=/usr/bin/docker run --privileged --net host -v /etc/ipsec.d:/etc/ipsec.d --name=ipsec-libreswan cornelius/docker-ipsec-libreswan
+ExecStop=/usr/bin/docker stop ipsec-libreswan
+ExecReload=/usr/bin/docker exec ipsec-libreswan systemctl reload ipsec
+Restart=always
+[Install]
+WantedBy=network-online.target

--- a/roles/ipsec/vars/defaults.yml
+++ b/roles/ipsec/vars/defaults.yml
@@ -1,0 +1,1 @@
+ipsec_modprobe_binary: /sbin/modprobe

--- a/roles/ipsec/vars/ubuntu.yml
+++ b/roles/ipsec/vars/ubuntu.yml
@@ -1,0 +1,1 @@
+ipsec_modprobe_binary: /usr/sbin/modprobe


### PR DESCRIPTION
Hi,

I want to contribute a role that implements ipsec between all cluster nodes to support environments where you don't trust your network.

The role is tested to work on ubuntu, centos and coreos-stable. 
It is enabled by setting the variable ```ipsec = true``` . It should be idempotent and handle also adding and removing nodes.

It uses a systemd container with a libreswan installation on fedora. I chose this because it seems to work well on all supported distributions.

I wanted to have your comments on this before I put more work in that.