### PR TITLE
set calico MTU with calicoctl

### DIFF
--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -201,3 +201,9 @@
   when:
     - inventory_hostname in groups['kube-master']
     - rbac_enabled or item.type not in rbac_resources
+
+# doesn't really produce any useful infomration about when change was made
+- name: Calico | Set requested custom MTU for tunnel
+  shell: |
+    calicoctl config set --raw=felix IpInIpMtu {{ calico_mtu }}
+  when: inventory_hostname == groups['kube-master'][0] and calico_mtu is defined

--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -206,4 +206,4 @@
 - name: Calico | Set requested custom MTU for tunnel
   shell: |
     calicoctl config set --raw=felix IpInIpMtu {{ calico_mtu }}
-  when: inventory_hostname == groups['kube-master'][0] and calico_mtu is defined
+  when: inventory_hostname == groups['kube-master'][0] and calico_mtu is defined and ipip


### PR DESCRIPTION
* fix: when calico_mtu is changed, the env var is not really applied in the container; this is a workaround to set it with `calicoctl`