### PR TITLE
kubernetes-apps: retry get default token name

### DIFF
--- a/roles/kubernetes-apps/rotate_tokens/tasks/main.yml
+++ b/roles/kubernetes-apps/rotate_tokens/tasks/main.yml
@@ -3,6 +3,9 @@
   shell: "{{ bin_dir }}/kubectl get secrets -o custom-columns=name:{.metadata.name} --no-headers | grep -m1 default-token"
   register: default_token
   changed_when: false
+  until: default_token.rc == 0
+  delay: 1
+  retries: 5
 
 - name: Rotate Tokens | Get default token data
   command: "{{ bin_dir }}/kubectl get secrets {{ default_token.stdout }} -ojson"


### PR DESCRIPTION
In some installation, it can take up to 3sec to get the value. Retrying
for 5 sec will ensure the command won't return 1.

Fixes: https://github.com/kubernetes-incubator/kubespray/issues/1905
Signed-off-by: Sébastien Han <seb@redhat.com>