### PR TITLE
[terraform/openstack] Provision k8s_master_no_etcd nodes with a floating IP

### DIFF
--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -49,6 +49,7 @@ module "compute" {
   network_name                                 = "${var.network_name}"
   flavor_bastion                               = "${var.flavor_bastion}"
   k8s_master_fips                              = "${module.ips.k8s_master_fips}"
+  k8s_master_no_etcd_fips                      = "${module.ips.k8s_master_no_etcd_fips}"
   k8s_node_fips                                = "${module.ips.k8s_node_fips}"
   bastion_fips                                 = "${module.ips.bastion_fips}"
   bastion_allowed_remote_ips                   = "${var.bastion_allowed_remote_ips}"

--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -287,6 +287,12 @@ resource "openstack_compute_floatingip_associate_v2" "k8s_master" {
   floating_ip = "${var.k8s_master_fips[count.index]}"
 }
 
+resource "openstack_compute_floatingip_associate_v2" "k8s_master_no_etcd" {
+  count       = "${var.number_of_k8s_masters_no_etcd}"
+  instance_id = "${element(openstack_compute_instance_v2.k8s_master_no_etcd.*.id, count.index)}"
+  floating_ip = "${var.k8s_master_no_etcd_fips[count.index]}"
+}
+
 resource "openstack_compute_floatingip_associate_v2" "k8s_node" {
   count       = "${var.number_of_k8s_nodes}"
   floating_ip = "${var.k8s_node_fips[count.index]}"

--- a/contrib/terraform/openstack/modules/compute/variables.tf
+++ b/contrib/terraform/openstack/modules/compute/variables.tf
@@ -54,6 +54,10 @@ variable "k8s_master_fips" {
   type = "list"
 }
 
+variable "k8s_master_no_etcd_fips" {
+  type = "list"
+}
+
 variable "k8s_node_fips" {
   type = "list"
 }

--- a/contrib/terraform/openstack/modules/ips/main.tf
+++ b/contrib/terraform/openstack/modules/ips/main.tf
@@ -10,6 +10,12 @@ resource "openstack_networking_floatingip_v2" "k8s_master" {
   depends_on = ["null_resource.dummy_dependency"]
 }
 
+resource "openstack_networking_floatingip_v2" "k8s_master_no_etcd" {
+  count      = "${var.number_of_k8s_masters_no_etcd}"
+  pool       = "${var.floatingip_pool}"
+  depends_on = ["null_resource.dummy_dependency"]
+}
+
 resource "openstack_networking_floatingip_v2" "k8s_node" {
   count      = "${var.number_of_k8s_nodes}"
   pool       = "${var.floatingip_pool}"

--- a/contrib/terraform/openstack/modules/ips/outputs.tf
+++ b/contrib/terraform/openstack/modules/ips/outputs.tf
@@ -2,6 +2,10 @@ output "k8s_master_fips" {
   value = ["${openstack_networking_floatingip_v2.k8s_master.*.address}"]
 }
 
+output "k8s_master_no_etcd_fips" {
+  value = ["${openstack_networking_floatingip_v2.k8s_master_no_etcd.*.address}"]
+}
+
 output "k8s_node_fips" {
   value = ["${openstack_networking_floatingip_v2.k8s_node.*.address}"]
 }


### PR DESCRIPTION
Fixes https://github.com/kubernetes-incubator/kubespray/issues/2300.

I followed the same pattern as the other node types that support a floating IP.

Thanks!