### PR TITLE
Added support for rhel docker packages

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster.yml
@@ -132,6 +132,9 @@ skydns_server: "{{ kube_service_addresses|ipaddr('net')|ipaddr(3)|ipaddr('addres
 dnsmasq_dns_server: "{{ kube_service_addresses|ipaddr('net')|ipaddr(2)|ipaddr('address') }}"
 dns_domain: "{{ cluster_name }}"
 
+## Whether to use docker upstream repository
+enable_docker_repo: true
+
 # Path used to store Docker data
 docker_daemon_graph: "/var/lib/docker"
 

--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -41,3 +41,7 @@
     gather_subset: '!all'
     filter: ansible_hostname
   when: ansible_os_family in ['CoreOS', 'Container Linux by CoreOS'] and hostname_changed.changed
+
+- name: Check enable_docker_repo variable assignement
+  fail: msg="enable_docker_repo should be used on RHEL systems with default RedHat repositories configured outside Kubespray"
+  when: ansible_os_family != "RedHat" and not enable_docker_repo

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
-docker_version: '17.03'
+# Enable docker repository by default
+enable_docker_repo: true
+
+docker_version: "{{ '17.03' if enable_docker_repo else '1.12.6' }}"
 
 docker_package_info:
   pkgs:

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -41,7 +41,7 @@
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   with_items: "{{ docker_repo_key_info.repo_keys }}"
-  when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] or is_atomic)
+  when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] or is_atomic) and enable_docker_repo
 
 - name: ensure docker repository is enabled
   action: "{{ docker_repo_info.pkg_repo }}"
@@ -49,7 +49,7 @@
     repo: "{{item}}"
     state: present
   with_items: "{{ docker_repo_info.repos }}"
-  when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] or is_atomic) and (docker_repo_info.repos|length > 0)
+  when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] or is_atomic) and (docker_repo_info.repos|length > 0) and enable_docker_repo
 
 - name: Configure docker repository on RedHat/CentOS
   template:

--- a/roles/docker/tasks/systemd.yml
+++ b/roles/docker/tasks/systemd.yml
@@ -23,7 +23,7 @@
     dest: /etc/systemd/system/docker.service
   register: docker_service_file
   notify: restart docker
-  when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] or is_atomic)
+  when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] or is_atomic) and enable_docker_repo
 
 - name: Write docker options systemd drop-in
   template:

--- a/roles/docker/templates/docker-options.conf.j2
+++ b/roles/docker/templates/docker-options.conf.j2
@@ -1,3 +1,16 @@
+#jinja2: lstrip_blocks: "True"
 [Service]
 Environment="DOCKER_OPTS={{ docker_options | default('') }} \
 --iptables=false"
+{% if ansible_os_family == "RedHat"%}
+  {% if systemd_version.stdout|int >= 226 %}
+TasksMax=infinity
+  {% endif %}
+  {% if not enable_docker_repo %}
+LimitNOFILE=1048576
+LimitNPROC=1048576
+LimitCORE=infinity
+TimeoutStartSec=1min
+Restart=on-abnormal
+  {% endif %}
+{% endif %}

--- a/roles/docker/vars/redhat.yml
+++ b/roles/docker/vars/redhat.yml
@@ -11,6 +11,7 @@ docker_versioned_pkg:
   '17.03': docker-engine-17.03.1.ce-1.el7.centos
   'stable': docker-engine-17.03.1.ce-1.el7.centos
   'edge': docker-engine-17.05.0.ce-1.el7.centos
+  '1.12.6': docker-1.12.6-68.gitec8512b.el7
 
 # https://docs.docker.com/engine/installation/linux/centos/#install-from-a-package
 # https://download.docker.com/linux/centos/7/x86_64/stable/Packages/


### PR DESCRIPTION
Related to issue:
https://github.com/kubernetes-incubator/kubespray/issues/2334
This code change allows to use docker packages provided by RHEL instead of the upstream packages.
The code introduces the enable_docker_repo variable which control if the upstream docker repo is configured.
There are some small changes to systemd configuration as well.