### PR TITLE
Fix --kubelet-certificate-authority not defined

### DIFF
--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -51,7 +51,6 @@ spec:
     - --client-ca-file={{ kube_cert_dir }}/ca.pem
     - --profiling=false
     - --repair-malformed-updates=false
-    - --kubelet-certificate-authority={{ kube_cert_dir }}/ca.pem
     - --kubelet-client-certificate={{ kube_cert_dir }}/node-{{ inventory_hostname }}.pem
     - --kubelet-client-key={{ kube_cert_dir }}/node-{{ inventory_hostname }}-key.pem
     - --service-account-lookup=true

--- a/roles/kubernetes/secrets/templates/openssl.conf.j2
+++ b/roles/kubernetes/secrets/templates/openssl.conf.j2
@@ -15,19 +15,10 @@ DNS.5 = localhost
 {% for host in groups['kube-master'] %}
 DNS.{{ counter["dns"] }} = {{ host }}{{ increment(counter, 'dns') }}
 {% endfor %}
-{% for host in groups['kube-node'] %}
-DNS.{{ counter["dns"] }} = {{ host }}{{ increment(counter, 'dns') }}
-{% endfor %}
 {% if apiserver_loadbalancer_domain_name is defined  %}
 DNS.{{ counter["dns"] }} = {{ apiserver_loadbalancer_domain_name }}{{ increment(counter, 'dns') }}
 {% endif %}
 {% for host in groups['kube-master'] %}
-{% if hostvars[host]['access_ip'] is defined  %}
-IP.{{ counter["ip"] }} = {{ hostvars[host]['access_ip'] }}{{ increment(counter, 'ip') }}
-{% endif %}
-IP.{{ counter["ip"] }} = {{ hostvars[host]['ip'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}{{ increment(counter, 'ip') }}
-{% endfor %}
-{% for host in groups['kube-node'] %}
 {% if hostvars[host]['access_ip'] is defined  %}
 IP.{{ counter["ip"] }} = {{ hostvars[host]['access_ip'] }}{{ increment(counter, 'ip') }}
 {% endif %}


### PR DESCRIPTION
`--kubelet-certificate-authority` is currently undefined on the kube apiserver. Enabling it causes the following error to happen, as nodes are not in the signed ip range in certs:

```
Error attaching, falling back to logs: error dialing backend: x509: certificate is valid for 10.50.63.11, 10.50.63.11, 10.50.63.12, 10.50.63.12, 10.50.63.13, 10.50.63.13, 10.248.0.1, 10.50.63.10, 127.0.0.1, 10.50.63.10, not 10.50.64.11
Error from server: Get https://10.50.64.11:10250/containerLogs/default/load-generator-5c4d59d5dd-mcg9h/load-generator: x509: certificate is valid for 10.50.63.11, 10.50.63.11, 10.50.63.12, 10.50.63.12, 10.50.63.13, 10.50.63.13, 10.248.0.1, 10.50.63.10, 127.0.0.1, 10.50.63.10, not 10.50.64.11
```

Looking at the `openssl.conf` file on a master, it reveals that no node ip adresses are actually in any certs for the nodes:

```
# cat /etc/kubernetes/openssl.conf
[req]
req_extensions = v3_req
distinguished_name = req_distinguished_name
[req_distinguished_name]
[ v3_req ]
basicConstraints = CA:FALSE
keyUsage = nonRepudiation, digitalSignature, keyEncipherment
subjectAltName = @alt_names
[alt_names]
DNS.1 = kubernetes
DNS.2 = kubernetes.default
DNS.3 = kubernetes.default.svc
DNS.4 = kubernetes.default.svc.cluster.local
DNS.5 = localhost
DNS.6 = odn1-kube-cluster01-master01
DNS.7 = odn1-kube-cluster01-master02
DNS.8 = odn1-kube-cluster01-master03
DNS.9 = odn1-kube-lb.privatedns.zone
IP.1 = 10.50.63.11
IP.2 = 10.50.63.11
IP.3 = 10.50.63.12
IP.4 = 10.50.63.12
IP.5 = 10.50.63.13
IP.6 = 10.50.63.13
IP.7 = 10.248.0.1
IP.8 = 10.50.63.10
IP.9 = 127.0.0.1
IP.10 = 10.50.63.10
```

Like here, `10.50.64.11` is missing which is a node, not a master.