### PR TITLE
Invoke kubespray-defaults role to set ansible_ssh_common_args variable

### DIFF
--- a/tests/testcases/010_check-apiserver.yml
+++ b/tests/testcases/010_check-apiserver.yml
@@ -1,6 +1,8 @@
 ---
 - hosts: kube-master
 
+  roles:
+  - { role: kubespray-defaults}
   tasks:
   - name: Check the API servers are responding
     uri:

--- a/tests/testcases/020_check-create-pod.yml
+++ b/tests/testcases/020_check-create-pod.yml
@@ -5,6 +5,9 @@
     test_image_repo: busybox
     test_image_tag: latest
 
+  roles:
+  - { role: kubespray-defaults}
+  
   tasks:
 
   - name: Force binaries directory for Container Linux by CoreOS

--- a/tests/testcases/030_check-network.yml
+++ b/tests/testcases/030_check-network.yml
@@ -1,6 +1,9 @@
 ---
 - hosts: kube-master[0]
 
+  roles:
+  - { role: kubespray-defaults}
+  
   tasks:
 
   - name: Force binaries directory for Container Linux by CoreOS

--- a/tests/testcases/040_check-network-adv.yml
+++ b/tests/testcases/040_check-network-adv.yml
@@ -1,5 +1,7 @@
 ---
 - hosts: kube-node
+  roles:
+  - { role: kubespray-defaults}
   tasks:
     - name: Test tunl0 routes
       shell: "! /sbin/ip ro | grep '/26 via' | grep -v tunl0"


### PR DESCRIPTION
Fixes issue #2602 where test/testcases/* fail if master/workers are behind bastion host