### PR TITLE
Add ansible_python_interpreter for CoreOS deployment in the sample variables.

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -1,6 +1,10 @@
 # Valid bootstrap options (required): ubuntu, coreos, centos, none
 bootstrap_os: none
 
+## Set ansible_python_interpreter for CoreOS cluster implentation to prevent
+## the error "python not found" in the preinstall section
+# ansible_python_interpreter: /opt/bin/python
+
 #Directory where etcd data stored
 etcd_data_dir: /var/lib/etcd
 


### PR DESCRIPTION
Comment the fact that you need to set ansible_python_interpreter to avoid the error "python not found", this advice is explained docs/coreos.yml file but it is not pretty obvious when you just started playing with Kubespray.