### PR TITLE
modify config for MS Azure for special case "Azure Germany"

### DIFF
--- a/roles/kubernetes/node/templates/azure-cloud-config.j2
+++ b/roles/kubernetes/node/templates/azure-cloud-config.j2
@@ -1,4 +1,7 @@
 {
+{% if 'germany' in azure_location -%}
+  "cloud": "AzureGermanCloud",
+{% endif -%}
   "tenantId": "{{ azure_tenant_id }}",
   "subscriptionId": "{{ azure_subscription_id }}",
   "aadClientId": "{{ azure_aad_client_id }}",


### PR DESCRIPTION
The MS Azure "special" regions (Azure Germany, but mosz probably also
the others, i.e., US Gov and China) use API endpoints different from
those in the "normal" Azure regions. On Azure Germany, kubernetes must
be configured to use special Azure API endpoints passing the paramerter
"cloud".

Very possibly, that conditional configuration can/should be extended to
cover the Azure China and Azure US Gov as well.