### PR TITLE
enable usage of Calico network policies on MS Azure

### DIFF
--- a/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
@@ -58,6 +58,12 @@ spec:
     - --service-cluster-ip-range={{ kube_service_addresses }}
     - --node-cidr-mask-size={{ kube_network_node_prefix }}
 {% endif %}
+{% if kube_network_plugin is defined and kube_network_plugin == 'calico' and cloud_provider is defined and cloud_provider == 'azure' %}
+    - --allocate-node-cidrs=true
+    - --cluster-cidr={{ kube_pods_subnet }}
+    - --service-cluster-ip-range={{ kube_service_addresses }}
+    - --node-cidr-mask-size={{ kube_network_node_prefix }}
+{% endif %}
 {% if kube_feature_gates %}
     - --feature-gates={{ kube_feature_gates|join(',') }}
 {% endif %}

--- a/roles/kubernetes/preinstall/tasks/verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/verify-settings.yml
@@ -21,11 +21,21 @@
   when: network_plugin is defined
   ignore_errors: "{{ ignore_assert_errors }}"
 
-- name: Stop if incompatible network plugin and cloudprovider
+- name: Prevent incompatible combination of Calico and MS Azure
   assert:
-    that: network_plugin != 'calico'
-    msg: "Azure and Calico are not compatible. See https://github.com/projectcalico/calicoctl/issues/949 for details."
-  when: cloud_provider is defined and cloud_provider == 'azure'
+    that:
+      - azure_route_table_name is defined
+      - calico_network_backend is defined
+      - calico_network_backend == 'none'
+      - kube_network_node_prefix is defined
+      - kube_pods_subnet is defined
+      - kube_service_addresses is defined
+    msg: "Azure and Calico are only compatible when Azure routing tables are used (and connected to the subnet the cluster nodes are placed in). See https://github.com/projectcalico/calicoctl/issues/949 and https://docs.projectcalico.org/v3.1/reference/public-cloud/azure for details."
+  when:
+    - cloud_provider is defined
+    - cloud_provider == 'azure'
+    - kube_network_plugin is defined
+    - kube_network_plugin == 'calico'
   ignore_errors: "{{ ignore_assert_errors }}"
 
 # simplify this items-list when   https://github.com/ansible/ansible/issues/15753  is resolved

--- a/roles/network_plugin/calico/templates/calico-config.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-config.yml.j2
@@ -10,10 +10,14 @@ data:
   etcd_key: "/calico-secrets/key.pem"
 {% if calico_network_backend is defined and calico_network_backend == 'none' %}
   cluster_type: "kubespray"
-{%- else %}
+{% else %}
   cluster_type: "kubespray,bgp"
 {% endif %}
+{% if calico_network_backend is undefined %}
   calico_backend: "bird"
+{% else %}
+  calico_backend: "{{ calico_network_backend }}"
+{% endif %}
 {% if inventory_hostname in groups['k8s-cluster'] and peer_with_router|default(false) %}
   as: "{{ local_as|default(global_as_num) }}"
 {% endif -%}

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -67,12 +67,18 @@ spec:
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "{{ calico_endpoint_to_host_action|default('RETURN') }}"
-# should be set in etcd before deployment
-#            # Configure the IP Pool from which Pod IPs will be chosen.
-#            - name: CALICO_IPV4POOL_CIDR
-#              value: "192.168.0.0/16"
-#            - name: CALICO_IPV4POOL_IPIP
-#              value: "always"
+{% if cloud_provider is defined and cloud_provider == 'azure' %}
+            # should be set in etcd before deployment
+            # Configure the IP Pool from which Pod IPs will be chosen.
+            - name: CALICO_IPV4POOL_CIDR
+              value: "{{ kube_pods_subnet }}"
+{% endif %}
+            - name: CALICO_IPV4POOL_IPIP
+{% if cloud_provider is defined and cloud_provider == 'azure' %}
+              value: "off"
+{%  else %}
+              value: "always"
+{% endif %}
             # Disable IPv6 on Kubernetes.
             - name: FELIX_IPV6SUPPORT
               value: "false"

--- a/roles/network_plugin/calico/templates/cni-calico.conflist.j2
+++ b/roles/network_plugin/calico/templates/cni-calico.conflist.j2
@@ -3,11 +3,11 @@
   "cniVersion":"0.3.1",
   "plugins":[
     {
-    {% if cloud_provider is defined %}
+{% if cloud_provider is defined %}
       "nodename": "{{ calico_kubelet_name.stdout }}",
-    {% else %}
+{% else %}
       "nodename": "{{ inventory_hostname }}",
-    {% endif %}
+{% endif %}
       "type": "calico",
       "etcd_endpoints": "{{ etcd_access_addresses }}",
       "etcd_cert_file": "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem",
@@ -15,18 +15,23 @@
       "etcd_ca_cert_file": "{{ etcd_cert_dir }}/ca.pem",
       "log_level": "info",
       "ipam": {
+{% if cloud_provider is defined and cloud_provider == 'azure' %}
+      "type": "host-local",
+      "subnet": "usePodCidr"
+{% else %}
         "type": "calico-ipam",
         "assign_ipv4": "true",
         "ipv4_pools": ["{{ kube_pods_subnet }}"]
+{% endif %}
       },
-    {% if enable_network_policy %}
+{% if enable_network_policy %}
       "policy": {
         "type": "k8s"
       },
-    {%- endif %}
-    {% if calico_mtu is defined and calico_mtu is number %}
+{%- endif %}
+{% if calico_mtu is defined and calico_mtu is number %}
       "mtu": {{ calico_mtu }},
-    {%- endif %}
+{%- endif %}
       "kubernetes": {
         "kubeconfig": "{{ kube_config_dir }}/node-kubeconfig.yaml"
       }


### PR DESCRIPTION
It is possible to use Calico on MS Azure provided that routes are not
propagated via BGP, but are added to MS Azure "Native" route tables.

Relevant documentation regrettably is
somewhat scattered, please cf.
- https://github.com/projectcalico/calicoctl/issues/949 closing remarks,
- https://docs.projectcalico.org/v3.1/reference/public-cloud/azure and
- https://github.com/Azure/acs-engine/pull/151, which describes how to
  use calico in differently built clusters.

In essence, it is necessary to
- make the controller manager assign each node a pod-subnet and
  provision routes to the pod-subnets via the Azure API,
- make calico take IPs for pods from that pod-subnet and
- prevent calico from using bird, which restricts calico to a
  "policy-only" mode.

This pull request solves _some_ issues mentioned in the discussion of
PR #2286.