### PR TITLE
assert that security_group is defined and usable when on MS Azure

### DIFF
--- a/roles/kubernetes/preinstall/tasks/verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/verify-settings.yml
@@ -28,6 +28,17 @@
   when: cloud_provider is defined and cloud_provider == 'azure'
   ignore_errors: "{{ ignore_assert_errors }}"
 
+- name: Stop if cloud_provider is Azure and security group is undefined
+  assert:
+    that:
+      - azure_security_group_name is defined
+      - azure_security_group_name != ""
+    msg: "kube-controller-manager will crash in azure_loadbalancer.go#L923  when the set collected with az.getSecurityGroup() is empty."
+  when:
+    - cloud_provider is defined
+    - cloud_provider == 'azure'
+  ignore_errors: "{{ ignore_assert_errors }}"
+
 # simplify this items-list when   https://github.com/ansible/ansible/issues/15753  is resolved
 - name: "Stop if known booleans are set as strings (Use JSON format on CLI: -e \"{'key': true }\")"
   assert:


### PR DESCRIPTION
When on MS Azure, when provisioning a loadbalanced service, the call
az.getSecurityGroup() of the kube-controller-manager does not return an
error when the security group passed via azure_security_group_name is
undefined or an empty string ("").

Instead, the invalid setting remains unnoticed until about five minutes
after the first provisioning call against an Azure loadbalancer and will
then crash the kube-controller-manager with a runtime error: "invalid
memory address or nil pointer dereference" when trying to update the
security rules of the (undefined or empty) security group.

Even if dealing with that error may be better introduced at kubernetes
upstream, kubespray should not provision a setup which will lead to
unrecoverable crashes.