### PR TITLE
Fix python3 compatibility

### DIFF
--- a/roles/etcd/templates/etcd.env.j2
+++ b/roles/etcd/templates/etcd.env.j2
@@ -28,6 +28,6 @@ ETCD_PEER_CERT_FILE={{ etcd_cert_dir }}/member-{{ inventory_hostname }}.pem
 ETCD_PEER_KEY_FILE={{ etcd_cert_dir }}/member-{{ inventory_hostname }}-key.pem
 ETCD_PEER_CLIENT_CERT_AUTH={{ etcd_peer_client_auth }}
 
-{% for key, value in etcd_extra_vars.items() %}
+{% for key, value in etcd_extra_vars|dictsort %}
 {{ key }}={{ value }}
 {% endfor %}

--- a/roles/kubernetes/node/templates/kubelet.standard.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.standard.env.j2
@@ -96,7 +96,7 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {% endif %}
 {% set inventory_node_labels = [] %}
 {% if node_labels is defined %}
-{%   for labelname, labelvalue in node_labels.iteritems() %}
+{%   for labelname, labelvalue in node_labels.items() %}
 {%     set dummy = inventory_node_labels.append('%s=%s'|format(labelname, labelvalue)) %}
 {%   endfor %}
 {% endif %}


### PR DESCRIPTION
Fix another python3 compatibility (Same spirit of https://github.com/kubernetes-incubator/kubespray/pull/2729)

Amend previous PR to sort iteration and make file less different at each run. If this part is not suitable, I can drop the commit obviously.