### PR TITLE
Make it clear that Calico on Openstack needs more configuration

### DIFF
--- a/docs/calico.md
+++ b/docs/calico.md
@@ -170,6 +170,8 @@ By default the felix agent(calico-node) will abort if the Kernel RPF setting is 
 calico_node_ignorelooserpf: true
 ```
 
+##### Calico on OpenStack
+
 Note that in OpenStack you must allow `ipip` traffic in your security groups,
 otherwise you will experience timeouts.
 To do this you must add a rule which allows it, for example:

--- a/docs/openstack.md
+++ b/docs/openstack.md
@@ -44,3 +44,8 @@ and `kube_pods_subnet` (default `10.233.64.0/18`.)
     neutron port-update e5ae2045-a1e1-4e99-9aac-4353889449a7 --allowed_address_pairs list=true type=dict ip_address=10.233.0.0/18 ip_address=10.233.64.0/18
 
 Now you can finally run the playbook.
+
+One more thing you need to is to enable IP protocol v4 (`ipip`) traffic in your security group.
+See more info the [Calico documentation page][1].
+
+[1]: https://github.com/kubernetes-incubator/kubespray/blob/master/docs/calico.md#cloud-providers-configuration


### PR DESCRIPTION
This PR adds some more clarity how to run K8S with Calico on top of OpenStack.