### PR TITLE
Add advanced flannel backend config option for canal and flannel CNI

### DIFF
--- a/roles/network_plugin/canal/defaults/main.yml
+++ b/roles/network_plugin/canal/defaults/main.yml
@@ -36,3 +36,13 @@ rbac_resources:
   - sa
   - clusterrole
   - clusterrolebinding
+
+# Advanced flannel backend configuration.
+# If you define the entire Backend block as a nested hash called flannel_backend. Then
+# this will be used instead of the flannel_backend_type variable.
+# For full list of options see docs: https://github.com/coreos/flannel/blob/master/Documentation/backends.md
+# Example:
+# Configure the flannel with the vxlan backend on an alternative port.
+# flannel_backend:
+#    Type: "vxlan"
+#    Port: 4789

--- a/roles/network_plugin/canal/tasks/main.yml
+++ b/roles/network_plugin/canal/tasks/main.yml
@@ -25,10 +25,26 @@
     - {s: "node-{{ inventory_hostname }}-key.pem", d: "key.pem"}
 
 - name: Canal | Set Flannel etcd configuration
+  when: flannel_backend is not defined
   command: |-
     {{ bin_dir }}/etcdctl --peers={{ etcd_access_addresses }} \
     set /{{ cluster_name }}/network/config \
     '{ "Network": "{{ kube_pods_subnet }}", "SubnetLen": {{ kube_network_node_prefix }}, "Backend": { "Type": "{{ flannel_backend_type }}" } }'
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  delegate_to: "{{groups['etcd'][0]}}"
+  changed_when: false
+  run_once: true
+  environment:
+    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem"
+    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem"
+
+- name: Canal | Set Flannel etcd configuration
+  when: flannel_backend is defined
+  command: |-
+    {{ bin_dir }}/etcdctl --peers={{ etcd_access_addresses }} \
+    set /{{ cluster_name }}/network/config \
+    '{ "Network": "{{ kube_pods_subnet }}", "SubnetLen": {{ kube_network_node_prefix }}, "Backend": {{ flannel_backend | to_json }} }'
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   delegate_to: "{{groups['etcd'][0]}}"

--- a/roles/network_plugin/flannel/defaults/main.yml
+++ b/roles/network_plugin/flannel/defaults/main.yml
@@ -12,6 +12,15 @@
 # please refer to flannel's docs : https://github.com/coreos/flannel/blob/master/README.md
 flannel_backend_type: "vxlan"
 
+# Alternatively you can define the entire Backend block as a nested hash
+# called flannel_backend.  See docs: https://github.com/coreos/flannel/blob/master/Documentation/backends.md
+# flannel_backend:
+#    Type: "vxlan"
+#    VNI: 1
+#    Port: 8472
+#    GBP: false
+#    DirectRouting: false
+
 # Limits for apps
 flannel_memory_limit: 500M
 flannel_cpu_limit: 300m

--- a/roles/network_plugin/flannel/defaults/main.yml
+++ b/roles/network_plugin/flannel/defaults/main.yml
@@ -12,14 +12,15 @@
 # please refer to flannel's docs : https://github.com/coreos/flannel/blob/master/README.md
 flannel_backend_type: "vxlan"
 
-# Alternatively you can define the entire Backend block as a nested hash
-# called flannel_backend.  See docs: https://github.com/coreos/flannel/blob/master/Documentation/backends.md
+# Advanced flannel backend configuration.
+# If you define the entire Backend block as a nested hash called flannel_backend. Then
+# this will be used instead of the flannel_backend_type variable.
+# For full list of options see docs: https://github.com/coreos/flannel/blob/master/Documentation/backends.md
+# Example:
+# Configure the flannel with the vxlan backend on an alternative port.
 # flannel_backend:
 #    Type: "vxlan"
-#    VNI: 1
-#    Port: 8472
-#    GBP: false
-#    DirectRouting: false
+#    Port: 4789
 
 # Limits for apps
 flannel_memory_limit: 500M

--- a/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
+++ b/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
@@ -36,7 +36,7 @@ data:
       "Backend": {{ flannel_backend | to_json }}
       {% else %}
       "Backend": {
-        "Type": "{{ flannel_backend_type | default("vxlan") }}"
+        "Type": "{{ flannel_backend_type }}"
       }
       {% endif %}
     }

--- a/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
+++ b/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
@@ -32,9 +32,13 @@ data:
   net-conf.json: |
     {
       "Network": "{{ kube_pods_subnet }}",
+      {% if flannel_backend is defined %}
+      "Backend": {{ flannel_backend | to_json }}
+      {% else %}
       "Backend": {
-        "Type": "{{ flannel_backend_type }}"
+        "Type": "{{ flannel_backend_type | default("vxlan") }}"
       }
+      {% endif %}
     }
 ---
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
Advanced flannel backend configuration.

Allows the entire flannel backend config block to be defined as a nested hash called `flannel_backend`.   When present this will be used instead of the `flannel_backend_type` variable.

For full list of options see docs: https://github.com/coreos/flannel/blob/master/Documentation/backends.md

*Example:*

Configure the flannel with the vxlan backend on an alternative port.

```
flannel_backend:
   Type: "vxlan"
    Port: 4789
```