### PR TITLE
Initial OracleLinux 7.x support

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-oraclelinux.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-oraclelinux.yml
@@ -1,0 +1,15 @@
+---
+- name: Install packages requirements for bootstrap
+  yum:
+    name: libselinux-python
+    state: present
+
+- name: Remove swapfile from /etc/fstab
+  mount:
+    name: swap
+    fstype: swap
+    state: absent
+- name: Disable swap
+  command: swapoff -a
+
+  

--- a/roles/bootstrap-os/tasks/bootstrap-oraclelinux.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-oraclelinux.yml
@@ -11,5 +11,3 @@
     state: absent
 - name: Disable swap
   command: swapoff -a
-
-  

--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -14,6 +14,9 @@
 - import_tasks: bootstrap-opensuse.yml
   when: bootstrap_os == "opensuse"
 
+- import_tasks: bootstrap-oraclelinux.yml
+  when: bootstrap_os == "oraclelinux"
+
 - import_tasks: setup-pipelining.yml
 
 - name: check if atomic host

--- a/roles/docker/vars/oraclelinux.yml
+++ b/roles/docker/vars/oraclelinux.yml
@@ -1,0 +1,39 @@
+---
+docker_kernel_min_version: '0'
+
+# https://docs.docker.com/engine/installation/linux/centos/#install-from-a-package
+# https://download.docker.com/linux/centos/7/x86_64/stable/Packages/
+# https://yum.dockerproject.org/repo/main/centos/7
+# or do 'yum --showduplicates list docker-engine'
+docker_versioned_pkg:
+  'latest': docker-engine
+  '1.12': docker-engine-1.12.6-1.0.3.el7
+  '17.03': docker-engine-17.03.1.ce-3.0.1.el7
+  '17.06': docker-engine-17.06.2.ol-1.0.1.el7
+  'stable': docker-engine-17.03.1.ce-3.0.1.el7
+  'edge': docker-engine-17.06.2.ol-1.0.1.el7
+
+docker_selinux_versioned_pkg:
+  'latest': docker-engine-selinux
+  '1.12': docker-engine-selinux-1.12.6-1.0.3.el7
+  '17.03': docker-engine-selinux-17.03.1.ce-3.0.1.el7
+  '17.06': docker-engine-selinux-17.06.2.ol-1.0.1.el7
+  'stable': docker-engine-selinux-17.03.1.ce-3.0.1.el7
+  'edge': docker-engine-selinux-17.06.2.ol-1.0.1.el7
+
+
+docker_package_info:
+  pkg_mgr: yum
+  pkgs:
+    - name: "{{ docker_selinux_versioned_pkg[docker_selinux_version | string] }}"
+      yum_conf: "{{ docker_yum_conf }}"
+    - name: "{{ docker_versioned_pkg[docker_version | string] }}"
+      yum_conf: "{{ docker_yum_conf }}"
+
+docker_repo_key_info:
+  pkg_key: ''
+  repo_keys: []
+
+docker_repo_info:
+  pkg_repo: ''
+  repos: []

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -207,7 +207,7 @@
 
 - name: Enable ol7 addons for OracleLinux
   ini_file:
-    dest: /etc/yum.repos.d/public-yum-ol7.repo # Parameterise this?
+    dest: /etc/yum.repos.d/public-yum-ol7.repo
     section: ol7_addons
     option: enabled
     value: 1
@@ -218,7 +218,7 @@
 
 - name: Enable ol7 openstack for OracleLinux (For python packages needed)
   ini_file:
-    dest: /etc/yum.repos.d/public-yum-ol7.repo # Parameterise this?
+    dest: /etc/yum.repos.d/public-yum-ol7.repo
     section: ol7_openstack40
     option: enabled
     value: 1

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -133,7 +133,7 @@
   delay: "{{ retry_stagger | random + 3 }}"
   when:
     - ansible_pkg_mgr == 'yum'
-    - ansible_distribution != 'RedHat'
+    - ansible_distribution in ['RedHat', 'OracleLinux']
     - not is_atomic
   tags: bootstrap-os
 
@@ -202,6 +202,28 @@
     - ansible_distribution in ["CentOS","RedHat"]
     - not is_atomic
     - epel_enabled|bool
+  tags:
+    - bootstrap-os
+
+- name: Enable ol7 addons for OracleLinux
+  ini_file:
+    dest: /etc/yum.repos.d/public-yum-ol7.repo # Parameterise this?
+    section: ol7_addons
+    option: enabled
+    value: 1
+  when:
+    - ansible_distribution == 'OracleLinux'
+  tags:
+    - bootstrap-os
+
+- name: Enable ol7 openstack for OracleLinux (For python packages needed)
+  ini_file:
+    dest: /etc/yum.repos.d/public-yum-ol7.repo # Parameterise this?
+    section: ol7_openstack40
+    option: enabled
+    value: 1
+  when:
+    - ansible_distribution == 'OracleLinux'
   tags:
     - bootstrap-os
 

--- a/roles/kubernetes/preinstall/tasks/verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/verify-settings.yml
@@ -12,7 +12,7 @@
 
 - name: Stop if unknown OS
   assert:
-    that: ansible_distribution in ['RedHat', 'CentOS', 'Fedora', 'Ubuntu', 'Debian', 'CoreOS', 'Container Linux by CoreOS', 'openSUSE Leap', 'openSUSE Tumbleweed']
+    that: ansible_distribution in ['RedHat', 'CentOS', 'Fedora', 'Ubuntu', 'Debian', 'CoreOS', 'Container Linux by CoreOS', 'openSUSE Leap', 'openSUSE Tumbleweed', 'OracleLinux']
   ignore_errors: "{{ ignore_assert_errors }}"
 
 - name: Stop if unknown network plugin

--- a/roles/kubernetes/preinstall/vars/oraclelinux.yml
+++ b/roles/kubernetes/preinstall/vars/oraclelinux.yml
@@ -1,0 +1,5 @@
+---
+required_pkgs:
+  - libselinux-python
+  - device-mapper-libs
+  - ebtables


### PR DESCRIPTION
This adds support for OracleLinux. 
Mosty it's a case of doing the same as RedHat but we install docekr from the Oracle Yum Repos.