### PR TITLE
Provide a way to specify dnsPolicy for ingress_nginx

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster.yml
@@ -208,6 +208,8 @@ cephfs_provisioner_enabled: false
 # Nginx ingress controller deployment
 ingress_nginx_enabled: false
 # ingress_nginx_host_network: false
+# # Possible values: Default, ClusterFirst, ClusterFirstWithHostNet, None
+# ingress_nginx_dns_policy: ClusterFirst
 # ingress_nginx_nodeselector:
 #   node-role.kubernetes.io/master: "true"
 # ingress_nginx_namespace: "ingress-nginx"

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 ingress_nginx_namespace: "ingress-nginx"
 ingress_nginx_host_network: false
+ingress_nginx_dns_policy: ClusterFirst
 ingress_nginx_nodeselector:
   node-role.kubernetes.io/master: "true"
 ingress_nginx_insecure_port: 80

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
@@ -27,6 +27,9 @@ spec:
 {% if ingress_nginx_host_network %}
       hostNetwork: true
 {% endif %}
+{% if ingress_nginx_dns_policy %}
+      dnsPolicy: {{ ingress_nginx_dns_policy }}
+{% endif %}
 {% if ingress_nginx_nodeselector %}
       nodeSelector:
         {{ ingress_nginx_nodeselector | to_nice_yaml }}


### PR DESCRIPTION
This change allows to specify `dnsPolicy`, especially useful to set `ClusterFirstWithHostNet` along with `hostNetwork: true`.

NOTE: `Default` is not the default DNS policy. If dnsPolicy is not explicitly specified, then `ClusterFirst` is used.
