### PR TITLE
ingress-nginx: fix aufs storage driver incompatibility

### DIFF
--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
@@ -43,6 +43,8 @@ spec:
             - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
             - --publish-service=$(POD_NAMESPACE)/ingress-nginx
             - --annotations-prefix=nginx.ingress.kubernetes.io
+            - --http-port=8080
+            - --https-port=8443
           securityContext:
             capabilities:
                 drop:
@@ -62,10 +64,10 @@ spec:
                   fieldPath: metadata.namespace
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 8080
               hostPort: {{ ingress_nginx_insecure_port }}
             - name: https
-              containerPort: 443
+              containerPort: 8443
               hostPort: {{ ingress_nginx_secure_port }}
           livenessProbe:
             failureThreshold: 3


### PR DESCRIPTION
ingress-nginx changed in 0.16.2 from root to www-data user for nginx-ingress-controller
To achieve this setcap cap_net_bind_service is needed.

See: https://github.com/kubernetes/ingress-nginx/commit/79199dd84c8149abee909cebfa8393deffa5fad5#diff-631c440a9ca70cdc7428a187a6820011

aufs does not support setcap. Due that aufs is the default storage driver on docker 17.03 (and as well in kubespray)
let's remap http and https port to unprivileged ports


Updating to ingress-nginx 0.16.2 added this regression. Following solutions could be possible:

- Change to overlay2 storage driver as default in kubespray (this will kick out all user with older kernel)

- Stick on 0.15.0 release and wait till docker 18.06.0 (with containerd 1.1.1 and overlay2 as default) is released and upgrade docker and ingress-nginx (which will kickout old kernels as well :p )

- Remap, like suggested here, to unprivileged ports


Without this patch ingress-nginx-controller pod will fail to bind port 80 and 443 on nodes with aufs storage driver

```
F0713 09:43:31.317783       7 main.go:72] Port 80 is already in use. Please check the flag --http-port
```




Signed-off-by: Lars Greiss <l.greiss@mediacologne.de>