### PR TITLE
fix for bug #3052 delegate the listing of the current images when download_once is true

### DIFF
--- a/roles/download/tasks/set_docker_image_facts.yml
+++ b/roles/download/tasks/set_docker_image_facts.yml
@@ -7,7 +7,40 @@
     pull_args: >-
       {%- if pull_by_digest %}{{download.repo}}@sha256:{{download.sha256}}{%- else -%}{{download.repo}}:{{download.tag}}{%- endif -%}
 
-- name: Register docker images info
+- name: Register docker images info (delegate)
+  raw: >-
+    {{ docker_bin_dir }}/docker images -q | xargs {{ docker_bin_dir }}/docker inspect -f "{{ '{{' }} if .RepoTags {{ '}}' }}{{ '{{' }} (index .RepoTags 0) {{ '}}' }}{{ '{{' }} end {{ '}}' }}{{ '{{' }} if .RepoDigests {{ '}}' }},{{ '{{' }} (index .RepoDigests 0) {{ '}}' }}{{ '{{' }} end {{ '}}' }}" | tr '\n' ','
+  no_log: true
+  register: docker_images_delegate
+  failed_when: false
+  changed_when: false
+  check_mode: no
+  delegate_to: "{{ download_delegate }}"
+  delegate_facts: no
+  when:
+    - download_run_once
+    - not download_always_pull
+
+- name: set pull_required (delegate)
+  set_fact:
+    pull_required: >-
+      {%- if pull_args in docker_images_delegate.stdout.split(',') %}false{%- else -%}true{%- endif -%}
+  when:
+    - download_run_once
+    - not download_always_pull
+
+- name: Check the local digest sha256 corresponds to the given image tag (delegate)
+  assert:
+    that: "{{download.repo}}:{{download.tag}} in docker_images_delegate.stdout.split(',')"
+  when:
+    - download_run_once
+    - not download_always_pull
+    - not pull_required
+    - pull_by_digest
+  tags:
+    - asserts
+
+- name: Register docker images info (all nodes)
   raw: >-
     {{ docker_bin_dir }}/docker images -q | xargs {{ docker_bin_dir }}/docker inspect -f "{{ '{{' }} if .RepoTags {{ '}}' }}{{ '{{' }} (index .RepoTags 0) {{ '}}' }}{{ '{{' }} end {{ '}}' }}{{ '{{' }} if .RepoDigests {{ '}}' }},{{ '{{' }} (index .RepoDigests 0) {{ '}}' }}{{ '{{' }} end {{ '}}' }}" | tr '\n' ','
   no_log: true
@@ -15,16 +48,25 @@
   failed_when: false
   changed_when: false
   check_mode: no
-  when: not download_always_pull
+  when:
+    - not download_always_pull
+    - not download_run_once
 
-- set_fact:
+- name: set pull_required (all nodes)
+  set_fact:
     pull_required: >-
       {%- if pull_args in docker_images.stdout.split(',') %}false{%- else -%}true{%- endif -%}
-  when: not download_always_pull
+  when:
+    - not download_run_once
+    - not download_always_pull
 
-- name: Check the local digest sha256 corresponds to the given image tag
+- name: Check the local digest sha256 corresponds to the given image tag (all nodes)
   assert:
     that: "{{download.repo}}:{{download.tag}} in docker_images.stdout.split(',')"
-  when: not download_always_pull and not pull_required and pull_by_digest
+  when:
+    - not download_run_once
+    - not download_always_pull
+    - not pull_required
+    - pull_by_digest
   tags:
     - asserts


### PR DESCRIPTION
Hi,

This PR attempts to fix #3052.

I have had to follow what was done in download_container.yml to get round ansible/ansible#30760

I'd have rather not have separate tasks for download_once: true vs download_once: false but I think this works. Open to changing this if anyone has any ideas of a cleaner way to implement this.

This is a replacement PR for #3056