### PR TITLE
set default kube_apiserver_enable_admission_plugins for Kubernetes version 1.10 and later 

### DIFF
--- a/roles/kubernetes/master/defaults/main.yml
+++ b/roles/kubernetes/master/defaults/main.yml
@@ -91,6 +91,7 @@ kube_apiserver_enable_admission_plugins:
   - LimitRanger
   - ServiceAccount
   - DefaultStorageClass
+  - DefaultTolerationSeconds
   - MutatingAdmissionWebhook
   - ValidatingAdmissionWebhook
   - ResourceQuota


### PR DESCRIPTION
[Kube documentation](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#is-there-a-recommended-set-of-admission-controllers-to-use) recomend using this list of admission plugins
--enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota

but after changing option ```--admission-control``` to option ```--enable-admission-plugins```, the default value of option ```--enable-admission-plugins``` in kubespray is empty

```kube_apiserver_enable_admission_plugins: []```

set default value:
```
kube_apiserver_enable_admission_plugins:
  - NamespaceLifecycle
  - LimitRanger
  - ServiceAccount
  - DefaultStorageClass
  - DefaultTolerationSeconds
  - MutatingAdmissionWebhook
  - ValidatingAdmissionWebhook
  - ResourceQuota
```