### PR TITLE
Support DigitalOcean (Experimental)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Deploy a Production Ready Kubernetes Cluster
 
 If you have questions, join us on the [kubernetes slack](https://kubernetes.slack.com), channel **\#kubespray**.
 
--   Can be deployed on **AWS, GCE, Azure, OpenStack, vSphere, Oracle Cloud Infrastructure (Experimental), or Baremetal**
+-   Can be deployed on **AWS, GCE, Azure, OpenStack, vSphere, Oracle Cloud Infrastructure (Experimental), DigitalOcean (Experimental), or Baremetal**
 -   **Highly available** cluster
 -   **Composable** (Choice of the network plugin for instance)
 -   Supports most popular **Linux distributions**
@@ -70,6 +70,7 @@ Documents
 -   [AWS](docs/aws.md)
 -   [Azure](docs/azure.md)
 -   [vSphere](docs/vsphere.md)
+-   [DigitalOcean](docs/digitalocean.md)
 -   [Large deployments](docs/large-deployments.md)
 -   [Upgrades basics](docs/upgrades.md)
 -   [Roadmap](docs/roadmap.md)

--- a/docs/digitalocean.md
+++ b/docs/digitalocean.md
@@ -1,0 +1,51 @@
+DigitalOcean
+============
+
+## Support
+
+ * LoadBalancer creation via [digitalocean-cloud-controller-manager](https://github.com/digitalocean/digitalocean-cloud-controller-manager)
+ * PersistentVolumes attached to Block Storage via [csi-digitalocean](https://github.com/digitalocean/csi-digitalocean)
+
+## Example Configuration
+
+```yaml
+### Digital Ocean specific config
+cloud_provider: digitalocean
+## Provide your own API token
+digitalocean_api_token: 
+## Pick your ccm release: https://github.com/digitalocean/digitalocean-cloud-controller-manager/releases
+digitalocean_ccm_version: v0.1.14
+## Pick your csi release: https://github.com/digitalocean/csi-digitalocean/releases
+digitalocean_csi_version: v1.1.0
+kube_network_plugin: flannel
+kubelet_preferred_address_types: InternalIP,ExternalIP,Hostname
+docker_dns_servers_strict: false
+## These are Digital Ocean specific DNS servers
+upstream_dns_servers:
+  - 67.207.67.3
+  - 67.207.67.2
+## Host names *must* be the same as the droplet name
+override_system_hostname: false
+```
+
+## Notes
+
+ * Droplets must be created with private networking enabled.
+ * Use the droplet's private IP addresses when configuring kubespray.
+ * Hostnames must match the droplet name, so you must set `override_system_hostname: false`.
+ 
+## Cloud Init Example
+
+For Ubuntu/Debian images, you can copy/paste this into the User Data
+field on the droplet creation page. This will automatically install
+initial dependencies for ansible:
+
+```yaml
+#cloud-config
+
+## Ubuntu 18.04 ansible target
+
+runcmd:
+  - apt-get update && apt-get install -y python-minimal
+```
+

--- a/inventory/sample/group_vars/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster.yml
@@ -264,3 +264,39 @@ persistent_volumes_enabled: false
 ## See https://github.com/kubernetes-incubator/kubespray/issues/2141
 ## Set this variable to true to get rid of this issue
 volume_cross_zone_attachment: false
+# Add Persistent Volumes Storage Class for corresponding cloud provider ( OpenStack is only supported now )
+persistent_volumes_enabled: false
+
+## Container Engine Acceleration
+## Enable container accelertion feature, for example use gpu acceleration in containers
+# nvidia_accelerator_enabled: true
+## Nvidia GPU driver install. Install will by done by a (init) pod running as a daemonset.
+## Important: if you use Ubuntu then you should set in all.yml 'docker_storage_options: -s overlay2'
+## Array with nvida_gpu_nodes, leave empty or comment if you dont't want to install drivers.
+## Labels and taints won't be set to nodes if they are not in the array.
+# nvidia_gpu_nodes:
+#   - kube-gpu-001
+# nvidia_driver_version: "384.111"
+## flavor can be tesla or gtx
+# nvidia_gpu_flavor: gtx
+
+### Digital Ocean specific config
+# cloud_provider: digitalocean
+## Provide your own API token
+# digitalocean_api_token: 
+## Pick your ccm release: https://github.com/digitalocean/digitalocean-cloud-controller-manager/releases
+# digitalocean_ccm_version: v0.1.14
+## Pick your csi release: https://github.com/digitalocean/csi-digitalocean/releases
+# digitalocean_csi_version: v1.1.0
+## Pick your helm release: https://github.com/helm/helm/releases
+# helm_version: v2.11.0
+# helm_enabled: true
+# kube_network_plugin: flannel
+# kubelet_preferred_address_types: InternalIP,ExternalIP,Hostname
+# docker_dns_servers_strict: false
+## These are Digital Ocean specific DNS servers
+# upstream_dns_servers:
+#  - 67.207.67.3
+#  - 67.207.67.2
+## Host names *must* be the same as the droplet name
+# override_system_hostname: false

--- a/roles/kubernetes-apps/cloud_controller/digitalocean/defaults/main.yml
+++ b/roles/kubernetes-apps/cloud_controller/digitalocean/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+digitalocean_ccm_version: v0.1.14
+digitalocean_csi_version: v1.1.0

--- a/roles/kubernetes-apps/cloud_controller/digitalocean/tasks/config-check.yml
+++ b/roles/kubernetes-apps/cloud_controller/digitalocean/tasks/config-check.yml
@@ -1,0 +1,5 @@
+---
+- name: "Digital Ocean Cloud Controller Manager | Config Check | digitalocean_api_token"
+  fail:
+    msg: "digitalocean_api_token is missing"
+  when: (digitalocean_api_token is not defined or digitalocean_api_token == "")

--- a/roles/kubernetes-apps/cloud_controller/digitalocean/tasks/main.yml
+++ b/roles/kubernetes-apps/cloud_controller/digitalocean/tasks/main.yml
@@ -1,0 +1,61 @@
+---
+
+- include: config-check.yml
+  tags: digitalocean
+
+- name: "Digital Ocean Cloud Controller Manager | Create Digital Ocean Secret"
+  template:
+    src: digital-ocean-secret.yml.j2
+    dest: /tmp/digital-ocean-secret.yml
+  when: inventory_hostname == groups['kube-master'][0]
+  tags: digitalocean
+
+- name: "Digital Ocean Cloud Controller Manager | Apply Digital Ocean Secret"
+  kube:
+    kubectl: "{{ bin_dir }}/kubectl"
+    filename: "/tmp/digital-ocean-secret.yml"
+  when: inventory_hostname == groups['kube-master'][0]
+  tags: digitalocean
+
+- name: "Digital Ocean Cloud Controller Manager | Cleanup"
+  file:
+    path: /tmp/digital-ocean-secret.yml
+    state: absent
+
+- name: "Digital Ocean Cloud Controller Manager | Download Manifest"
+  get_url:
+    url: "https://raw.githubusercontent.com/digitalocean/digitalocean-cloud-controller-manager/master/releases/{{digitalocean_ccm_version}}.yml"
+    dest: "/tmp/digitalocean-cloud-controller-manager.yml"
+    force: yes
+  register: result
+  until: "'OK' in result.msg"
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  when: inventory_hostname == groups['kube-master'][0]
+  tags: digitalocean
+
+- name: "Digital Ocean Cloud Controller Manager | Apply Controller Manifest"
+  kube:
+    kubectl: "{{ bin_dir }}/kubectl"
+    filename: "/tmp/digitalocean-cloud-controller-manager.yml"
+  when: inventory_hostname == groups['kube-master'][0]
+  tags: digitalocean
+
+- name: "Digital Ocean Cloud Storage Interface | Download Manifest"
+  get_url:
+    url: "https://raw.githubusercontent.com/digitalocean/csi-digitalocean/master/deploy/kubernetes/releases/csi-digitalocean-{{digitalocean_csi_version}}.yaml"
+    dest: "/tmp/digitalocean-cloud-storage-interface.yml"
+    force: yes
+  register: result
+  until: "'OK' in result.msg"
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  when: inventory_hostname == groups['kube-master'][0]
+  tags: digitalocean
+
+- name: "Digital Ocean Cloud Storage Interface | Apply CSI Manifest"
+  kube:
+    kubectl: "{{ bin_dir }}/kubectl"
+    filename: "/tmp/digitalocean-cloud-storage-interface.yml"
+  when: inventory_hostname == groups['kube-master'][0]
+  tags: digitalocean

--- a/roles/kubernetes-apps/cloud_controller/digitalocean/templates/digital-ocean-secret.yml.j2
+++ b/roles/kubernetes-apps/cloud_controller/digitalocean/templates/digital-ocean-secret.yml.j2
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: digitalocean
+  namespace: kube-system
+stringData:
+  access-token: "{{ digitalocean_api_token }}"

--- a/roles/kubernetes-apps/meta/main.yml
+++ b/roles/kubernetes-apps/meta/main.yml
@@ -32,3 +32,8 @@ dependencies:
     when: cloud_provider is defined and cloud_provider == "oci"
     tags:
       - oci
+
+  - role: kubernetes-apps/cloud_controller/digitalocean
+    when: cloud_provider is defined and cloud_provider == "digitalocean"
+    tags:
+      - digitalocean

--- a/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
@@ -48,8 +48,8 @@ spec:
     - --cloud-config={{ kube_config_dir }}/cloud_config
 {% elif cloud_provider is defined and cloud_provider in ["aws", "external"] %}
     - --cloud-provider={{cloud_provider}}
-{% elif cloud_provider is defined and cloud_provider == "oci" %}
-    - --cloud_provider=external
+{% elif cloud_provider is defined and cloud_provider in ["oci", "digitalocean"] %}
+    - --cloud-provider=external
 {% endif %}
 {% if kube_network_plugin is defined and kube_network_plugin == 'cloud' %}
     - --configure-cloud-routes=true

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -94,7 +94,7 @@ kube_hyperkube_image_repo: ""
 
 # If non-empty, will use this string as identification instead of the actual hostname
 kube_override_hostname: >-
-  {%- if cloud_provider is defined and cloud_provider in [ 'aws' ] -%}
+  {%- if cloud_provider is defined and cloud_provider in [ 'aws', 'digitalocean' ] -%}
   {%- else -%}
   {{ inventory_hostname }}
   {%- endif -%}

--- a/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
@@ -102,7 +102,7 @@ KUBE_ALLOW_PRIV="--allow-privileged=true"
 KUBELET_CLOUDPROVIDER="--cloud-provider={{ cloud_provider }} --cloud-config={{ kube_config_dir }}/cloud_config"
 {% elif cloud_provider is defined and cloud_provider in ["aws", "external"] %}
 KUBELET_CLOUDPROVIDER="--cloud-provider={{ cloud_provider }}"
-{% elif cloud_provider is defined and cloud_provider == "oci" %}
+{% elif cloud_provider is defined and cloud_provider in ["oci", "digitalocean"] %}
 KUBELET_CLOUDPROVIDER="--cloud-provider=external"
 {% else %}
 KUBELET_CLOUDPROVIDER=""

--- a/roles/kubernetes/node/templates/kubelet.standard.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.standard.env.j2
@@ -125,7 +125,7 @@ KUBE_ALLOW_PRIV="--allow-privileged=true"
 KUBELET_CLOUDPROVIDER="--cloud-provider={{ cloud_provider }} --cloud-config={{ kube_config_dir }}/cloud_config"
 {% elif cloud_provider is defined and cloud_provider in ["aws", "external"] %}
 KUBELET_CLOUDPROVIDER="--cloud-provider={{ cloud_provider }}"
-{% elif cloud_provider is defined and cloud_provider == "oci" %}
+{% elif cloud_provider is defined and cloud_provider in ["oci", "digitalocean"] %}
 KUBELET_CLOUDPROVIDER="--cloud-provider=external"
 {% else %}
 KUBELET_CLOUDPROVIDER=""

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -118,7 +118,7 @@
 
 - name: check cloud_provider value
   assert:
-    that: cloud_provider in ['generic', 'gce', 'aws', 'azure', 'openstack', 'vsphere', 'oci', 'external']
+    that: cloud_provider in ['generic', 'gce', 'aws', 'azure', 'openstack', 'vsphere', 'oci', 'digitalocean', 'external']
     msg: "If set the 'cloud_provider' var must be set either to 'generic', 'gce', 'aws', 'azure', 'openstack', 'vsphere', or external"
   when:
     - cloud_provider is defined


### PR DESCRIPTION
I've copied from the existing oci cloud controller plugin, and implemented support for the alpha version of [digitalocean-cloud-controller-manager](https://github.com/digitalocean/digitalocean-cloud-controller-manager/) and [csi-digitalocean](https://github.com/digitalocean/csi-digitalocean/)

Notes:
 * ~~For all of the network plugins, I have added a toleration for "node.cloudprovider.kubernetes.io/uninitialized" - this should be useful for all configurations that are based on a cloud controller manager, and will ensure that the networking components can still be started when the ccm has yet to be initialized.~~ I have now removed this as #3391 took care of this.
 * Check out the included docs/digitalocean.md for details.