### PR TITLE
Fixed an issue when generating inventory list, HOST_PREFIX did not get applied

### DIFF
--- a/contrib/inventory_builder/inventory.py
+++ b/contrib/inventory_builder/inventory.py
@@ -68,6 +68,8 @@ HOST_PREFIX = os.environ.get("HOST_PREFIX", "node")
 class KubesprayInventory(object):
 
     def __init__(self, changed_hosts=None, config_file=None):
+
+        self.host_prefix = HOST_PREFIX
         self.config = configparser.ConfigParser(allow_no_value=True,
                                                 delimiters=('\t', ' '))
         self.config_file = config_file
@@ -170,7 +172,7 @@ class KubesprayInventory(object):
                     self.debug("Skipping existing host {0}.".format(host))
                     continue
 
-                next_host = "{0}{1}".format(HOST_PREFIX, next_host_id)
+                next_host = "{0}{1}".format(self.host_prefix, next_host_id)
                 next_host_id += 1
                 all_hosts[next_host] = "ansible_host={0} ip={1}".format(
                     host, host)


### PR DESCRIPTION
When I use HOST_PREFIX when creating an inventory host.ini using contrib/inventory_builder/inventory.py the prefix does not apply.

eg:
declare -a IPS=(10.10.1.3 10.10.1.4 10.10.1.5)
CONFIG_FILE=inventory/mycluster/hosts.ini HOST_PREFIX=mynode python3 contrib/inventory_builder/inventory.py ${IPS[@]}

The host.ini file contains the default node prefix:

eg:
[all]
node1    ansible_host=10.10.1.3 ip=10.10.1.3
node2    ansible_host=10.10.1.4 ip=10.10.1.4
node3    ansible_host=10.10.1.5 ip=10.10.1.5

This small change fixed the issue in inventory.py
