### PR TITLE
Fixed Ubuntu 18.04's docker version(fixes #3424).

### DIFF
--- a/roles/docker/vars/ubuntu-bionic.yml
+++ b/roles/docker/vars/ubuntu-bionic.yml
@@ -1,11 +1,13 @@
 ---
 docker_kernel_min_version: '3.10'
 
+# overide defaults, missing 17.03 for Ubuntu 18.04
+docker_version: '18.06'
+
 use_docker_engine: false
 
 docker_versioned_pkg:
   'latest': docker-ce
-  '17.03': docker-ce=17.03.2~ce-0~ubuntu-xenial
   '18.03': docker-ce=18.03.1~ce-3-0~ubuntu
   '18.06': docker-ce=18.06.1~ce~3-0~ubuntu
   'stable': docker-ce=18.06.1~ce~3-0~ubuntu


### PR DESCRIPTION
docker-ce 17.03 is invalid for bionic docker-ce repository.
Remove 17.03 and override default version.
