### PR TITLE
More dynamic local-storage-provisioner approach

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s-cluster/addons.yml
@@ -21,18 +21,18 @@ metrics_server_enabled: false
 local_volume_provisioner_enabled: false
 # local_volume_provisioner_namespace: kube-system
 # local_volume_provisioner_storage_classes:
-#   - "{{ local_volume_provisioner_storage_class | default('local-storage') }}"
-#       host_dir: "{{ local_volume_provisioner_base_dir | default ('/mnt/disks') }}"
-#       mount_dir: "{{ local_volume_provisioner_mount_dir | default('/mnt/disks') }}"
-#   - "local-ssd"
-#       host_dir: "/mnt/local-storage/ssd"
-#       mount_dir: "/mnt/local-storage/ssd"
-#   - "local-hdd"
-#       host_dir: "/mnt/local-storage/hdd"
-#       mount_dir: "/mnt/local-storage/hdd"
-#   - "local-shared"
-#       host_dir: "/mnt/local-storage/shared"
-#       mount_dir: "/mnt/local-storage/shared"
+#   "{{ local_volume_provisioner_storage_class | default('local-storage') }}"
+#     host_dir: "{{ local_volume_provisioner_base_dir | default ('/mnt/disks') }}"
+#     mount_dir: "{{ local_volume_provisioner_mount_dir | default('/mnt/disks') }}"
+#   "local-ssd"
+#     host_dir: "/mnt/local-storage/ssd"
+#     mount_dir: "/mnt/local-storage/ssd"
+#   "local-hdd"
+#     host_dir: "/mnt/local-storage/hdd"
+#     mount_dir: "/mnt/local-storage/hdd"
+#   "local-shared"
+#     host_dir: "/mnt/local-storage/shared"
+#     mount_dir: "/mnt/local-storage/shared"
 
 # CephFS provisioner deployment
 cephfs_provisioner_enabled: false

--- a/inventory/sample/group_vars/k8s-cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s-cluster/addons.yml
@@ -21,18 +21,17 @@ metrics_server_enabled: false
 local_volume_provisioner_enabled: false
 # local_volume_provisioner_namespace: kube-system
 # local_volume_provisioner_storage_classes:
-#   "{{ local_volume_provisioner_storage_class | default('local-storage') }}"
-#     host_dir: "{{ local_volume_provisioner_base_dir | default ('/mnt/disks') }}"
-#     mount_dir: "{{ local_volume_provisioner_mount_dir | default('/mnt/disks') }}"
-#   "local-ssd"
-#     host_dir: "/mnt/local-storage/ssd"
-#     mount_dir: "/mnt/local-storage/ssd"
-#   "local-hdd"
-#     host_dir: "/mnt/local-storage/hdd"
-#     mount_dir: "/mnt/local-storage/hdd"
-#   "local-shared"
-#     host_dir: "/mnt/local-storage/shared"
-#     mount_dir: "/mnt/local-storage/shared"
+#   - local-storage:
+#       host_dir: /mnt/disks
+#       mount_dir: /mnt/disks
+#   - fast-disks:
+#       host_dir: /mnt/fast-disks
+#       mount_dir: /mnt/fast-disks
+#       block_cleaner_command:
+#          - "/scripts/shred.sh"
+#          - "2"
+#       volume_mode: Filesystem
+#       fs_type: ext4
 
 # CephFS provisioner deployment
 cephfs_provisioner_enabled: false

--- a/inventory/sample/group_vars/k8s-cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s-cluster/addons.yml
@@ -21,18 +21,18 @@ metrics_server_enabled: false
 local_volume_provisioner_enabled: false
 # local_volume_provisioner_namespace: kube-system
 # local_volume_provisioner_storage_classes:
-#   - name: "{{ local_volume_provisioner_storage_class | default('local-storage') }}"
-#     host_dir: "{{ local_volume_provisioner_base_dir | default ('/mnt/disks') }}"
-#     mount_dir: "{{ local_volume_provisioner_mount_dir | default('/mnt/disks') }}"
-#   - name: "local-ssd"
-#     host_dir: "/mnt/local-storage/ssd"
-#     mount_dir: "/mnt/local-storage/ssd"
-#   - name: "local-hdd"
-#     host_dir: "/mnt/local-storage/hdd"
-#     mount_dir: "/mnt/local-storage/hdd"
-#   - name: "local-shared"
-#     host_dir: "/mnt/local-storage/shared"
-#     mount_dir: "/mnt/local-storage/shared"
+#   - "{{ local_volume_provisioner_storage_class | default('local-storage') }}"
+#       host_dir: "{{ local_volume_provisioner_base_dir | default ('/mnt/disks') }}"
+#       mount_dir: "{{ local_volume_provisioner_mount_dir | default('/mnt/disks') }}"
+#   - "local-ssd"
+#       host_dir: "/mnt/local-storage/ssd"
+#       mount_dir: "/mnt/local-storage/ssd"
+#   - "local-hdd"
+#       host_dir: "/mnt/local-storage/hdd"
+#       mount_dir: "/mnt/local-storage/hdd"
+#   - "local-shared"
+#       host_dir: "/mnt/local-storage/shared"
+#       mount_dir: "/mnt/local-storage/shared"
 
 # CephFS provisioner deployment
 cephfs_provisioner_enabled: false

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/README.md
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/README.md
@@ -1,9 +1,11 @@
 Local Storage Provisioner
 =========================
 
-The local storage provisioner is NOT a dynamic storage provisioner as you would
+The [local storage provisioner](https://github.com/kubernetes-incubator/external-storage/tree/master/local-volume)
+is NOT a dynamic storage provisioner as you would
 expect from a cloud provider. Instead, it simply creates PersistentVolumes for
-all manually created volumes specified in the `local_volume_provisioner_storage_classes` list.
+all mounts under the host_dir of the specified storage class.
+These storage classes are specified in the `local_volume_provisioner_storage_classes` list.
 An example this list:
 
 ```yaml

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/README.md
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/README.md
@@ -3,9 +3,47 @@ Local Storage Provisioner
 
 The local storage provisioner is NOT a dynamic storage provisioner as you would
 expect from a cloud provider. Instead, it simply creates PersistentVolumes for
-all manually created volumes located in the directories specified in the `local_volume_provisioner_storage_classes.host_dir` entries.
-The default path is /mnt/disks and the rest of this doc will use that path as
-an example.
+all manually created volumes specified in the `local_volume_provisioner_storage_classes` list.
+An example this list:
+
+```yaml
+local_volume_provisioner_storage_classes:
+  - local-storage:
+      host_dir: /mnt/disks
+      mount_dir: /mnt/disks
+  - fast-disks:
+      host_dir: /mnt/fast-disks
+      mount_dir: /mnt/fast-disks
+      block_cleaner_command:
+         - "/scripts/shred.sh"
+         - "2"
+      volume_mode: Filesystem
+      fs_type: ext4
+```
+
+For each dictionary in `local_volume_provisioner_storage_classes` a storageClass with the
+same name is created. The keys of this dictionary are converted to camelCase and added
+as attributes to the storageClass.
+The result of the above example is:
+
+```yaml
+data:
+  storageClassMap: |
+    local-storage:
+       hostDir: /mnt/disks
+       mountDir: /mnt/disks
+    fast-disks:
+       hostDir: /mnt/fast-disks
+       mountDir:  /mnt/fast-disks
+       blockCleanerCommand:
+         - "/scripts/shred.sh"
+         - "2"
+       volumeMode: Filesystem
+       fsType: ext4
+```
+
+The default StorageClass is local-storage on /mnt/disks,
+the rest of this doc will use that path as an example.
 
 Examples to create local storage volumes
 ----------------------------------------

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/defaults/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/defaults/main.yml
@@ -2,5 +2,5 @@
 local_volume_provisioner_namespace: "kube-system"
 local_volume_provisioner_storage_classes:
   - "{{ local_volume_provisioner_storage_class | default('local-storage') }}":
-      base_dir: "{{ local_volume_provisioner_base_dir | default ('/mnt/disks') }}"
+      host_dir: "{{ local_volume_provisioner_base_dir | default ('/mnt/disks') }}"
       mount_dir: "{{ local_volume_provisioner_mount_dir | default('/mnt/disks') }}"

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/defaults/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 local_volume_provisioner_namespace: "kube-system"
 local_volume_provisioner_storage_classes:
-  - name: "{{ local_volume_provisioner_storage_class | default('local-storage') }}"
-    host_dir: "{{ local_volume_provisioner_base_dir | default ('/mnt/disks') }}"
-    mount_dir: "{{ local_volume_provisioner_mount_dir | default('/mnt/disks') }}"
+  - "{{ local_volume_provisioner_storage_class | default('local-storage') }}":
+      base_dir: "{{ local_volume_provisioner_base_dir | default ('/mnt/disks') }}"
+      mount_dir: "{{ local_volume_provisioner_mount_dir | default('/mnt/disks') }}"

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/defaults/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 local_volume_provisioner_namespace: "kube-system"
+local_volume_provisioner_default_key: &local_volume_provisioner_default_key  "{{ local_volume_provisioner_storage_class | default('local-storage') }}"
 local_volume_provisioner_storage_classes:
-  "{{ local_volume_provisioner_storage_class | default('local-storage') }}":
+  *local_volume_provisioner_default_key
     host_dir: "{{ local_volume_provisioner_base_dir | default ('/mnt/disks') }}"
     mount_dir: "{{ local_volume_provisioner_mount_dir | default('/mnt/disks') }}"

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/defaults/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/defaults/main.yml
@@ -1,7 +1,11 @@
 ---
 local_volume_provisioner_namespace: "kube-system"
-local_volume_provisioner_default_key: &local_volume_provisioner_default_key  "{{ local_volume_provisioner_storage_class | default('local-storage') }}"
-local_volume_provisioner_storage_classes:
-  *local_volume_provisioner_default_key
-    host_dir: "{{ local_volume_provisioner_base_dir | default ('/mnt/disks') }}"
-    mount_dir: "{{ local_volume_provisioner_mount_dir | default('/mnt/disks') }}"
+# Levarages Ansibles string to Python datatype casting. Otherwise the dict_key isn't substituted
+# see https://github.com/ansible/ansible/issues/17324
+local_volume_provisioner_storage_classes: |
+  {
+    "{{ local_volume_provisioner_storage_class | default('local-storage') }}": {
+     "host_dir": "{{ local_volume_provisioner_base_dir | default ('/mnt/disks') }}",
+      "mount_dir": "{{ local_volume_provisioner_mount_dir | default('/mnt/disks') }}"
+    }
+  }

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/defaults/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 local_volume_provisioner_namespace: "kube-system"
 local_volume_provisioner_storage_classes:
-  - "{{ local_volume_provisioner_storage_class | default('local-storage') }}":
-      host_dir: "{{ local_volume_provisioner_base_dir | default ('/mnt/disks') }}"
-      mount_dir: "{{ local_volume_provisioner_mount_dir | default('/mnt/disks') }}"
+  "{{ local_volume_provisioner_storage_class | default('local-storage') }}":
+    host_dir: "{{ local_volume_provisioner_base_dir | default ('/mnt/disks') }}"
+    mount_dir: "{{ local_volume_provisioner_mount_dir | default('/mnt/disks') }}"

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/tasks/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/tasks/main.yml
@@ -1,8 +1,10 @@
 ---
+- set_fact:
+    local_volume_provisioner_storage_classes: "{{ local_volume_provisioner_storage_class_maps.keys() }}"
 
 - name: Local Volume Provisioner | Ensure base dir is created on all hosts
   file:
-    path: "{{ item[1].host_dir }}"
+    path: "{{ local_volume_provisioner_storage_class_maps[item.1].host_dir }}"
     state: directory
     owner: root
     group: root

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/tasks/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 - set_fact:
-    local_volume_provisioner_storage_classes: "{{ local_volume_provisioner_storage_class_maps.keys() }}"
+    local_volume_provisioner_storage_class_names: "{{ local_volume_provisioner_storage_classes.keys() }}"
 
 - name: Local Volume Provisioner | Ensure base dir is created on all hosts
   file:
-    path: "{{ local_volume_provisioner_storage_class_maps[item.1].host_dir }}"
+    path: "{{ local_volume_provisioner_storage_classes[item.1].host_dir }}"
     state: directory
     owner: root
     group: root
@@ -12,7 +12,7 @@
   delegate_to: "{{ item[0] }}"
   with_nested:
     - "{{ groups['k8s-cluster'] }}"
-    - "{{ local_volume_provisioner_storage_classes }}"
+    - "{{ local_volume_provisioner_storage_class_names }}"
   failed_when: false
 
 - name: Local Volume Provisioner | Create addon dir

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/tasks/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/tasks/main.yml
@@ -1,7 +1,4 @@
 ---
-- set_fact:
-    local_volume_provisioner_storage_class_names: "{{ local_volume_provisioner_storage_classes.keys() }}"
-
 - name: Local Volume Provisioner | Ensure base dir is created on all hosts
   file:
     path: "{{ local_volume_provisioner_storage_classes[item.1].host_dir }}"
@@ -12,7 +9,7 @@
   delegate_to: "{{ item[0] }}"
   with_nested:
     - "{{ groups['k8s-cluster'] }}"
-    - "{{ local_volume_provisioner_storage_class_names }}"
+    - "{{ local_volume_provisioner_storage_class_names.keys() }}"
   failed_when: false
 
 - name: Local Volume Provisioner | Create addon dir

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/tasks/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/tasks/main.yml
@@ -9,7 +9,7 @@
   delegate_to: "{{ item[0] }}"
   with_nested:
     - "{{ groups['k8s-cluster'] }}"
-    - "{{ local_volume_provisioner_storage_class_names.keys() }}"
+    - "{{ local_volume_provisioner_storage_classes.keys() }}"
   failed_when: false
 
 - name: Local Volume Provisioner | Create addon dir

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-cm.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-cm.yml.j2
@@ -1,4 +1,4 @@
-# Macro to convert camelCase dictionary keys with to snake_case keys
+# Macro to convert camelCase dictionary keys to snake_case keys
 {%- macro convert_keys(mydict) %}
   {% for key in mydict.keys() -%}
     {% set key_split = key.split('_') -%}

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-cm.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-cm.yml.j2
@@ -1,3 +1,4 @@
+# Macro to convert camelCase dictionary keys with to snake_case keys
 {%- macro convert_keys(mydict) %}
   {% for key in mydict.keys() -%}
     {% set key_split = key.split('_') -%}

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-cm.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-cm.yml.j2
@@ -16,7 +16,7 @@ metadata:
   namespace: {{ local_volume_provisioner_namespace }}
 data:
   storageClassMap: |
-{% for class_name, storage_class in local_volume_provisioner_storage_class_maps.iteritems() %}
+{% for class_name, storage_class in local_volume_provisioner_storage_classes.iteritems() %}
     {{ class_name }}:
       {{- convert_keys(storage_class) }}
       {{ storage_class | to_nice_yaml(indent=2) | indent(6) }}

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-cm.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-cm.yml.j2
@@ -1,3 +1,13 @@
+{%- macro convert_keys(mydict) %}
+  {% for key in mydict.keys() -%}
+    {% set key_split = key.split('_') -%}
+    {% set new_key = key_split[0] + key_split[1:]|map('capitalize')|join -%}
+    {% set value = mydict.pop(key) -%}
+    {{ mydict.__setitem__(new_key, value) -}}
+    {{ convert_keys(value) if value is mapping else None -}}
+  {% endfor -%}
+{% endmacro -%}
+
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -6,8 +16,9 @@ metadata:
   namespace: {{ local_volume_provisioner_namespace }}
 data:
   storageClassMap: |
-{% for class in local_volume_provisioner_storage_classes %}
-    {{ class.name }}:
-      hostDir: {{ class.host_dir }}
-      mountDir: {{ class.mount_dir }}
-{% endfor %}
+{% for class_name, storage_class in local_volume_provisioner_storage_class_maps.iteritems() %}
+    {{ class_name }}:
+      {{- convert_keys(storage_class) }}
+      {{ storage_class | to_nice_yaml(indent=2) | indent(6) }}
+{%- endfor %}
+

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-ds.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-ds.yml.j2
@@ -45,7 +45,7 @@ spec:
               mountPath: /etc/provisioner/config
               readOnly: true
 {% for class_name, class_config in local_volume_provisioner_storage_classes.iteritems() %}
-            - name: local-volume-provisioner-hostpath{{ class_config.mount_dir|replace('/', '-') }}
+            - name: local-volume-provisioner-hostpath{{ class_name }}
               mountPath: {{ class_config.mount_dir }}
               mountPropagation: "HostToContainer"
 {% endfor %}

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-ds.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-ds.yml.j2
@@ -44,17 +44,17 @@ spec:
             - name: local-volume-provisioner
               mountPath: /etc/provisioner/config
               readOnly: true
-{% for class_name in local_volume_provisioner_storage_classes %}
-            - name: local-volume-provisioner-hostpath{{ local_volume_provisioner_storage_classes[class_name].mount_dir|replace('/', '-') }}
-              mountPath: {{ local_volume_provisioner_storage_classes[class_name].mount_dir }}
+{% for class_name, class_config in local_volume_provisioner_storage_classes.iteritems() %}
+            - name: local-volume-provisioner-hostpath{{ class_config.mount_dir|replace('/', '-') }}
+              mountPath: {{ class_config.mount_dir }}
               mountPropagation: "HostToContainer"
 {% endfor %}
       volumes:
         - name: local-volume-provisioner
           configMap:
             name: local-volume-provisioner
-{% for class_name in local_volume_provisioner_storage_classes %}
-        - name: local-volume-provisioner-hostpath{{ local_volume_provisioner_storage_classes[class_name].mount_dir|replace('/', '-') }}
+{% for class_name, class_config in local_volume_provisioner_storage_classes.iteritems() %}
+        - name: local-volume-provisioner-hostpath{{ class_config.mount_dir|replace('/', '-') }}
           hostPath:
-            path: {{ local_volume_provisioner_storage_classes[class_name].host_dir }}
+            path: {{ class_config.host_dir }}
 {% endfor %}

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-ds.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-ds.yml.j2
@@ -44,17 +44,17 @@ spec:
             - name: local-volume-provisioner
               mountPath: /etc/provisioner/config
               readOnly: true
-{% for class in local_volume_provisioner_storage_classes %}
-            - name: {{ class.name }}
-              mountPath: {{ class.mount_dir }}
+{% for class_name in local_volume_provisioner_storage_classes %}
+            - name: local-volume-provisioner-hostpath{{ local_volume_provisioner_storage_class_maps[class_name].mount_dir|replace('/', '-') }}
+              mountPath: {{ local_volume_provisioner_storage_class_maps[class_name].mount_dir }}
               mountPropagation: "HostToContainer"
 {% endfor %}
       volumes:
         - name: local-volume-provisioner
           configMap:
             name: local-volume-provisioner
-{% for class in local_volume_provisioner_storage_classes %}
-        - name: {{ class.name }}
+{% for class_name in local_volume_provisioner_storage_classes %}
+        - name: local-volume-provisioner-hostpath{{ local_volume_provisioner_storage_class_maps[class_name].mount_dir|replace('/', '-') }}
           hostPath:
-            path: {{ class.host_dir }}
+            path: {{ local_volume_provisioner_storage_class_maps[class_name].host_dir }}
 {% endfor %}

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-ds.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-ds.yml.j2
@@ -45,8 +45,8 @@ spec:
               mountPath: /etc/provisioner/config
               readOnly: true
 {% for class_name in local_volume_provisioner_storage_classes %}
-            - name: local-volume-provisioner-hostpath{{ local_volume_provisioner_storage_class_maps[class_name].mount_dir|replace('/', '-') }}
-              mountPath: {{ local_volume_provisioner_storage_class_maps[class_name].mount_dir }}
+            - name: local-volume-provisioner-hostpath{{ local_volume_provisioner_storage_classes[class_name].mount_dir|replace('/', '-') }}
+              mountPath: {{ local_volume_provisioner_storage_classes[class_name].mount_dir }}
               mountPropagation: "HostToContainer"
 {% endfor %}
       volumes:
@@ -54,7 +54,7 @@ spec:
           configMap:
             name: local-volume-provisioner
 {% for class_name in local_volume_provisioner_storage_classes %}
-        - name: local-volume-provisioner-hostpath{{ local_volume_provisioner_storage_class_maps[class_name].mount_dir|replace('/', '-') }}
+        - name: local-volume-provisioner-hostpath{{ local_volume_provisioner_storage_classes[class_name].mount_dir|replace('/', '-') }}
           hostPath:
-            path: {{ local_volume_provisioner_storage_class_maps[class_name].host_dir }}
+            path: {{ local_volume_provisioner_storage_classes[class_name].host_dir }}
 {% endfor %}

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-ds.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-ds.yml.j2
@@ -45,7 +45,7 @@ spec:
               mountPath: /etc/provisioner/config
               readOnly: true
 {% for class_name, class_config in local_volume_provisioner_storage_classes.iteritems() %}
-            - name: local-volume-provisioner-hostpath{{ class_name }}
+            - name: local-volume-provisioner-hostpath-{{ class_name }}
               mountPath: {{ class_config.mount_dir }}
               mountPropagation: "HostToContainer"
 {% endfor %}
@@ -54,7 +54,7 @@ spec:
           configMap:
             name: local-volume-provisioner
 {% for class_name, class_config in local_volume_provisioner_storage_classes.iteritems() %}
-        - name: local-volume-provisioner-hostpath{{ class_config.mount_dir|replace('/', '-') }}
+        - name: local-volume-provisioner-hostpath-{{ class_name }}
           hostPath:
             path: {{ class_config.host_dir }}
 {% endfor %}

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-psp.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-psp.yml.j2
@@ -25,8 +25,8 @@ spec:
     - 'downwardAPI'
     - 'hostPath'
   allowedHostPaths:
-{% for class in local_volume_provisioner_storage_classes %}
-    - pathPrefix: "{{ class.host_dir }}"
+{% for class_name in local_volume_provisioner_storage_classes %}
+    - pathPrefix: "{{ local_volume_provisioner_storage_class_maps[class_name].host_dir }}"
       readOnly: false
 {% endfor %}
   hostNetwork: false

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-psp.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-psp.yml.j2
@@ -25,8 +25,8 @@ spec:
     - 'downwardAPI'
     - 'hostPath'
   allowedHostPaths:
-{% for class_name in local_volume_provisioner_storage_classes %}
-    - pathPrefix: "{{ local_volume_provisioner_storage_classes[class_name].host_dir }}"
+{% for class_name, class_config in local_volume_provisioner_storage_classes.iteritems() %}
+    - pathPrefix: "{{ class_config.host_dir }}"
       readOnly: false
 {% endfor %}
   hostNetwork: false

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-psp.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-psp.yml.j2
@@ -26,7 +26,7 @@ spec:
     - 'hostPath'
   allowedHostPaths:
 {% for class_name in local_volume_provisioner_storage_classes %}
-    - pathPrefix: "{{ local_volume_provisioner_storage_class_maps[class_name].host_dir }}"
+    - pathPrefix: "{{ local_volume_provisioner_storage_classes[class_name].host_dir }}"
       readOnly: false
 {% endfor %}
   hostNetwork: false

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-sc.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-sc.yml.j2
@@ -1,9 +1,9 @@
-{% for class in local_volume_provisioner_storage_classes %}
+{% for class_name in local_volume_provisioner_storage_classes %}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: {{ class.name }}
+  name: {{ class_name }}
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 {% endfor %}

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-sc.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-sc.yml.j2
@@ -1,4 +1,4 @@
-{% for class_name in local_volume_provisioner_storage_classes %}
+{% for class_name in local_volume_provisioner_storage_classes.keys() %}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass

--- a/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
+++ b/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
@@ -47,12 +47,14 @@
 
 - name: Create local volume provisioner directories
   file:
-    path: "{{ item.host_dir }}"
+    path: "{{ local_volume_provisioner_storage_classes[item.1].host_dir }}"
     state: directory
     owner: root
     group: root
     mode: 0700
-  with_items: "{{ local_volume_provisioner_storage_classes }}"
+  with_nested:
+    - "{{ groups['k8s-cluster'] }}"
+    - "{{ local_volume_provisioner_storage_classes.keys() }}"
   when:
     - inventory_hostname in groups['k8s-cluster']
     - local_volume_provisioner_enabled

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -308,10 +308,15 @@ kube_feature_gates: |-
   {%- endif %}
 
 # Local volume provisioner storage classes
-local_volume_provisioner_storage_classes:
-  "{{ local_volume_provisioner_storage_class | default('local-storage') }}"
-    host_dir: "{{ local_volume_provisioner_base_dir | default ('/mnt/disks') }}"
-    mount_dir: "{{ local_volume_provisioner_mount_dir | default('/mnt/disks') }}"
+# Levarages Ansibles string to Python datatype casting. Otherwise the dict_key isn't substituted
+# see https://github.com/ansible/ansible/issues/17324
+local_volume_provisioner_storage_classes: |
+  {
+    "{{ local_volume_provisioner_storage_class | default('local-storage') }}": {
+     "host_dir": "{{ local_volume_provisioner_base_dir | default ('/mnt/disks') }}",
+      "mount_dir": "{{ local_volume_provisioner_mount_dir | default('/mnt/disks') }}"
+    }
+  }
 
 # weave's network password for encryption
 # if null then no network encryption

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -309,7 +309,7 @@ kube_feature_gates: |-
 
 # Local volume provisioner storage classes
 local_volume_provisioner_storage_classes:
-  - name: "{{ local_volume_provisioner_storage_class | default('local-storage') }}"
+  "{{ local_volume_provisioner_storage_class | default('local-storage') }}"
     host_dir: "{{ local_volume_provisioner_base_dir | default ('/mnt/disks') }}"
     mount_dir: "{{ local_volume_provisioner_mount_dir | default('/mnt/disks') }}"
 


### PR DESCRIPTION
Apparently @chadswen and I worked on the same issue but came to a different solution ;)

This PR improves #3450 by making the `local_volume_provisioner_storage_classes ` a list of dicts and expanding these dicts with a snake_case to camelCase conversion. 
For example this config:

```yaml
local_volume_provisioner_storage_classes:
  - local-storage:
      host_dir: /mnt/disks 
      mount_dir: /mnt/disks
  - fast-disks:
      host_dir: /mnt/fast-disks 
      mount_dir: /mnt/fast-disks 
      block_cleaner_command:
         - "/scripts/shred.sh"
         - "2"
      volume_mode: Filesystem
      fs_type: ext4
```

Will result in:

```yaml
data:
  storageClassMap: |
    local-storage:
       hostDir: /mnt/disks
       mountDir: /mnt/disks
    fast-disks:
       hostDir: /mnt/fast-disks
       mountDir:  /mnt/fast-disks 
       blockCleanerCommand:
         - "/scripts/shred.sh"
         - "2"
       volumeMode: Filesystem
       fsType: ext4
```

This allows for any variable that Kubernetes adds tot the StorageClassMap without the need to map the variables.
The Jinja2 macro is an recursive function that converts all the keys to camelCase, it also works with nested dictionaries and lists.