### PR TITLE
Adding option to customize Restricted pod security policy RUNASUSER 

### DIFF
--- a/roles/kubernetes-apps/cluster_roles/templates/psp.yml.j2
+++ b/roles/kubernetes-apps/cluster_roles/templates/psp.yml.j2
@@ -29,7 +29,7 @@ spec:
   hostIPC: false
   hostPID: false
   runAsUser:
-    rule: 'MustRunAsNonRoot'
+    rule: "{{ podsecuritypolicy_restricted_runasuser }}"
   seLinux:
     rule: 'RunAsAny'
   supplementalGroups:

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -436,6 +436,7 @@ etcd_events_peer_addresses: |-
   {%- endfor %}
 
 podsecuritypolicy_enabled: false
+podsecuritypolicy_restricted_runasuser: "MustRunAsNonRoot"
 etcd_heartbeat_interval: "250"
 etcd_election_timeout: "5000"
 etcd_snapshot_count: "10000"


### PR DESCRIPTION
Adding ability to specify the RUNASUSER value in the Restricted Pod Security Policy object. By default the value is MustRunAsNonRoot, which could be too restrictive for some none privileged containers. 