### PR TITLE
[contrib/terraform/openstack] Wait for floating IP

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -16,6 +16,7 @@ most modern installs of OpenStack that support the basic services.
 - [ElastX](https://elastx.se/)
 - [EnterCloudSuite](https://www.entercloudsuite.com/)
 - [FugaCloud](https://fuga.cloud/)
+- [T-Systems / Open Telekom Cloud](https://cloud.telekom.de/)
 - [Ultimum](https://ultimum.io/)
 - [VexxHost](https://vexxhost.com/)
 - [Zetta](https://www.zetta.io/)
@@ -23,7 +24,6 @@ most modern installs of OpenStack that support the basic services.
 ### Known incompatible public clouds
 - OVH: No router support
 - Rackspace: No router support
-- T-Systems / Open Telekom Cloud: requires `wait_until_associated`
 
 ## Approach
 The terraform configuration inspects variables found in

--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -278,18 +278,21 @@ resource "openstack_compute_floatingip_associate_v2" "bastion" {
   count       = "${var.number_of_bastions}"
   floating_ip = "${var.bastion_fips[count.index]}"
   instance_id = "${element(openstack_compute_instance_v2.bastion.*.id, count.index)}"
+  wait_until_associated = "true"
 }
 
 resource "openstack_compute_floatingip_associate_v2" "k8s_master" {
   count       = "${var.number_of_k8s_masters}"
   instance_id = "${element(openstack_compute_instance_v2.k8s_master.*.id, count.index)}"
   floating_ip = "${var.k8s_master_fips[count.index]}"
+  wait_until_associated = "true"
 }
 
 resource "openstack_compute_floatingip_associate_v2" "k8s_node" {
   count       = "${var.number_of_k8s_nodes}"
   floating_ip = "${var.k8s_node_fips[count.index]}"
   instance_id = "${element(openstack_compute_instance_v2.k8s_node.*.id, count.index)}"
+  wait_until_associated = "true"
 }
 
 resource "openstack_blockstorage_volume_v2" "glusterfs_volume" {


### PR DESCRIPTION
Some OpenStack cloud providers do not wait until floating IP is associated by default, therefore the `wait_until_associated` flag is necessary. See [compute_floatingip_associate_v2 doc](https://www.terraform.io/docs/providers/openstack/r/compute_floatingip_associate_v2.html#argument-reference)

I ran into this issue with T-Systems Open Telekom Cloud.