### PR TITLE
allows to override the bind addresses for controller-manager and sche…

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
@@ -104,6 +104,7 @@ controllerManagerExtraArgs:
   node-monitor-grace-period: {{ kube_controller_node_monitor_grace_period }}
   node-monitor-period: {{ kube_controller_node_monitor_period }}
   pod-eviction-timeout: {{ kube_controller_pod_eviction_timeout }}
+  address: {{ kube_controller_manager_bind_address }}
 {% if kube_feature_gates %}
   feature-gates: {{ kube_feature_gates|join(',') }}
 {% endif %}
@@ -129,6 +130,7 @@ apiServerExtraVolumes:
   {{ key }}: "{{ kube_kubeadm_controller_extra_args[key] }}"
 {% endfor %}
 schedulerExtraArgs:
+  address: {{ kube_scheduler_bind_address }}
 {% if kube_feature_gates %}
   feature-gates: {{ kube_feature_gates|join(',') }}
 {% endif %}

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -143,6 +143,9 @@ kube_apiserver_port: 6443
 kube_apiserver_insecure_bind_address: 127.0.0.1
 kube_apiserver_insecure_port: 8080
 
+kube_controller_manager_bind_address: 127.0.0.1
+kube_scheduler_bind_address: 127.0.0.1
+
 # dynamic kubelet configuration
 dynamic_kubelet_configuration: false
 


### PR DESCRIPTION
This P/R allows to override the listen (bind) addresses for controller-manager and scheduler
Useful for Prometheus metrics monitoring

Only kube_kubeadm_scheduler_extra_args exists