### PR TITLE
Add SLES support

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-sles.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-sles.yml
@@ -1,0 +1,7 @@
+---
+- name: Install required packages (SUSE SLES)
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - python2-cryptography

--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -20,6 +20,8 @@
       centos
       {%- elif 'OpenSUSE' in os_release.stdout -%}
       opensuse
+      {%- elif 'SLES' in os_release.stdout -%}
+      sles
       {%- endif -%}
 
 - include_tasks: bootstrap-ubuntu.yml
@@ -40,6 +42,9 @@
 - include_tasks: bootstrap-opensuse.yml
   when: os_family == "opensuse"
 
+- include_tasks: bootstrap-sles.yml
+  when: os_family == "sles"
+
 - import_tasks: setup-pipelining.yml
 
 - name: Create remote_tmp for it is used by another module
@@ -58,14 +63,14 @@
     name: "{{inventory_hostname}}"
   when:
     - override_system_hostname
-    - ansible_distribution not in ['openSUSE Tumbleweed']
+    - ansible_distribution not in ['openSUSE Tumbleweed', 'SLES']
     - ansible_os_family not in ['CoreOS', 'Container Linux by CoreOS']
 
 - name: Assign inventory name to unconfigured hostnames (CoreOS and Tumbleweed only)
   command: "hostnamectl set-hostname  {{inventory_hostname}}"
   register: hostname_changed
   when:
-    - ansible_distribution in ['openSUSE Tumbleweed'] or ansible_os_family in ['CoreOS', 'Container Linux by CoreOS']
+    - ansible_distribution in ['openSUSE Tumbleweed', 'SLES'] or ansible_os_family in ['CoreOS', 'Container Linux by CoreOS']
     - override_system_hostname
 
 - name: Update hostname fact (CoreOS and Tumbleweed only)

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -109,6 +109,19 @@
     dest: "{{ yum_repo_dir }}/docker.repo"
   when: ansible_distribution in ["CentOS","RedHat"] and not is_atomic
 
+# FIXME: maybe better check for enabled product
+- name: Check SLE Container Module
+  shell: zypper lr -n SLE-Module-Containers{{ansible_distribution_version}}-Pool > /dev/null
+  ignore_errors: true
+  register: container_module
+  when: ansible_distribution in ["SLES"] and not is_atomic
+
+- name: Enable SLE Container Module
+  shell: "SUSEConnect --product sle-module-containers/{{ansible_distribution_version}}/{{ansible_architecture}}"
+  when:
+    - container_module is failed
+    - ansible_distribution in ["SLES"] and not is_atomic
+
 - name: Copy yum.conf for editing
   copy:
     src: "{{ yum_conf }}"

--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -7,7 +7,6 @@ ignore_assert_errors: false
 epel_enabled: false
 
 common_required_pkgs:
-  - python-httplib2
   - "{{ (ansible_distribution == 'openSUSE Tumbleweed') | ternary('openssl-1_1', 'openssl') }}"
   - curl
   - rsync

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -21,7 +21,7 @@
 
 - name: Stop if unknown OS
   assert:
-    that: ansible_distribution in ['RedHat', 'CentOS', 'Fedora', 'Ubuntu', 'Debian', 'CoreOS', 'Container Linux by CoreOS', 'openSUSE Leap', 'openSUSE Tumbleweed']
+    that: ansible_distribution in ['RedHat', 'CentOS', 'Fedora', 'Ubuntu', 'Debian', 'CoreOS', 'Container Linux by CoreOS', 'openSUSE Leap', 'openSUSE Tumbleweed', 'SLES']
   ignore_errors: "{{ ignore_assert_errors }}"
 
 - name: Stop if unknown network plugin


### PR DESCRIPTION
Add SUSE Enterprise Linux as supported OS. Currently only docker is tested and works.
The python-httplib2 package seems unnecessary (see bug #1032).