### PR TITLE
fix contrib/network-storage/heketi use of assert module (message -> msg)

### DIFF
--- a/contrib/network-storage/heketi/roles/provision/tasks/secret.yml
+++ b/contrib/network-storage/heketi/roles/provision/tasks/secret.yml
@@ -8,7 +8,7 @@
 - register: "clusterrolebinding_state"
   command: "{{bin_dir}}/kubectl get clusterrolebinding heketi-gluster-admin -o=name --ignore-not-found=true"
   changed_when: false
-- assert: { that: "clusterrolebinding_state.stdout != \"\"", message: "Cluster role binding is not present." }
+- assert: { that: "clusterrolebinding_state.stdout != \"\"", msg: "Cluster role binding is not present." }
 
 - register: "secret_state"
   command: "{{bin_dir}}/kubectl get secret heketi-config-secret -o=name --ignore-not-found=true"
@@ -24,4 +24,4 @@
 - register: "secret_state"
   command: "{{bin_dir}}/kubectl get secret heketi-config-secret -o=name --ignore-not-found=true"
   changed_when: false
-- assert: { that: "secret_state.stdout != \"\"", message: "Heketi config secret is not present." }
+- assert: { that: "secret_state.stdout != \"\"", msg: "Heketi config secret is not present." }

--- a/contrib/network-storage/heketi/roles/provision/tasks/secret.yml
+++ b/contrib/network-storage/heketi/roles/provision/tasks/secret.yml
@@ -2,26 +2,37 @@
 - register: "clusterrolebinding_state"
   command: "{{bin_dir}}/kubectl get clusterrolebinding heketi-gluster-admin -o=name --ignore-not-found=true"
   changed_when: false
+
 - name: "Kubernetes Apps | Deploy cluster role binding."
   when: "clusterrolebinding_state.stdout == \"\""
   command: "{{bin_dir}}/kubectl create clusterrolebinding heketi-gluster-admin --clusterrole=edit --serviceaccount=default:heketi-service-account"
+
 - register: "clusterrolebinding_state"
   command: "{{bin_dir}}/kubectl get clusterrolebinding heketi-gluster-admin -o=name --ignore-not-found=true"
   changed_when: false
-- assert: { that: "clusterrolebinding_state.stdout != \"\"", msg: "Cluster role binding is not present." }
+
+- assert:
+    that: "clusterrolebinding_state.stdout != \"\""
+    msg: "Cluster role binding is not present."
 
 - register: "secret_state"
   command: "{{bin_dir}}/kubectl get secret heketi-config-secret -o=name --ignore-not-found=true"
   changed_when: false
+
 - name: "Render Heketi secret configuration."
   become: true
   template:
     src: "heketi.json.j2"
     dest: "{{ kube_config_dir }}/heketi.json"
+
 - name: "Deploy Heketi config secret"
   when: "secret_state.stdout == \"\""
   command: "{{bin_dir}}/kubectl create secret generic heketi-config-secret --from-file={{ kube_config_dir }}/heketi.json"
+
 - register: "secret_state"
   command: "{{bin_dir}}/kubectl get secret heketi-config-secret -o=name --ignore-not-found=true"
   changed_when: false
-- assert: { that: "secret_state.stdout != \"\"", msg: "Heketi config secret is not present." }
+
+- assert:
+    that: "secret_state.stdout != \"\""
+    msg: "Heketi config secret is not present."

--- a/contrib/network-storage/heketi/roles/provision/tasks/secret.yml
+++ b/contrib/network-storage/heketi/roles/provision/tasks/secret.yml
@@ -4,7 +4,8 @@
   changed_when: false
 
 - name: "Kubernetes Apps | Deploy cluster role binding."
-  when: "clusterrolebinding_state.stdout == \"\""
+  when:
+    - clusterrolebinding_state.stdout == ""
   command: "{{bin_dir}}/kubectl create clusterrolebinding heketi-gluster-admin --clusterrole=edit --serviceaccount=default:heketi-service-account"
 
 - register: "clusterrolebinding_state"
@@ -12,7 +13,8 @@
   changed_when: false
 
 - assert:
-    that: "clusterrolebinding_state.stdout != \"\""
+    that:
+      - clusterrolebinding_state.stdout != ""
     msg: "Cluster role binding is not present."
 
 - register: "secret_state"
@@ -26,7 +28,8 @@
     dest: "{{ kube_config_dir }}/heketi.json"
 
 - name: "Deploy Heketi config secret"
-  when: "secret_state.stdout == \"\""
+  when:
+    - secret_state.stdout == ""
   command: "{{bin_dir}}/kubectl create secret generic heketi-config-secret --from-file={{ kube_config_dir }}/heketi.json"
 
 - register: "secret_state"
@@ -34,5 +37,6 @@
   changed_when: false
 
 - assert:
-    that: "secret_state.stdout != \"\""
+    that:
+      - secret_state.stdout != ""
     msg: "Heketi config secret is not present."


### PR DESCRIPTION
The `heketi/roles/provision` role uses `message:` where `msg:` should be used, causing a sufficiently new Ansible to error out (tested: 2.7.1).