### PR TITLE
added rpm caching to docker rpm repository

### DIFF
--- a/inventory/sample/group_vars/all/docker.yml
+++ b/inventory/sample/group_vars/all/docker.yml
@@ -25,6 +25,10 @@ docker_log_opts: "--log-opt max-size=50m --log-opt max-file=5"
 # define docker bin_dir
 docker_bin_dir: "/usr/bin"
 
+# keep docker packages after installation; speeds up repeated ansible provisioning runs when '1'
+# kubespray deletes the docker package on each run, so caching the package makes sense
+docker_rpm_keepcache: 0
+
 ## An obvious use case is allowing insecure-registry access to self hosted registries.
 ## Can be ipaddress and domain_name.
 ## example define 172.19.16.11 or mirror.registry.io

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -124,7 +124,6 @@
     line: 'obsoletes=0'
   when: ansible_distribution in ["CentOS","RedHat"] and not is_atomic
 
-
 - name: ensure docker packages are installed
   action: "{{ docker_package_info.pkg_mgr }}"
   args:

--- a/roles/container-engine/docker/templates/rh_docker.repo.j2
+++ b/roles/container-engine/docker/templates/rh_docker.repo.j2
@@ -3,6 +3,7 @@ name=Docker-CE Repository
 baseurl={{ docker_rh_repo_base_url }}
 enabled=1
 gpgcheck=1
+keepcache={{ docker_rpm_keepcache | default('1') }}
 gpgkey={{ docker_rh_repo_gpgkey }}
 {% if http_proxy is defined %}proxy={{ http_proxy }}{% endif %}
 
@@ -11,5 +12,6 @@ name=Docker-Engine Repository
 baseurl={{ dockerproject_rh_repo_base_url }}
 enabled=1
 gpgcheck=1
+keepcache={{ docker_rpm_keepcache | default('1') }}
 gpgkey={{ dockerproject_rh_repo_gpgkey }}
 {% if http_proxy is defined %}proxy={{ http_proxy }}{% endif %}


### PR DESCRIPTION
Added docker_keepcache var to dockery.yml to improve repeated ansible runs (only works for rpm packages); this is a nice timesaver while debugging kubespray on my laptop.