### PR TITLE
expanded file and image caching functionality

### DIFF
--- a/roles/download/tasks/download_container.yml
+++ b/roles/download/tasks/download_container.yml
@@ -10,10 +10,6 @@
   tags:
     - facts
 
-- debug:
-    msg:
-      - "pull_args: {{ pull_args }}"
-
 - name: container_download | Download containers if pull is required or told to always pull (delegate)
   command: "{{ docker_bin_dir }}/docker pull {{ pull_args }}"
   become: true

--- a/roles/download/tasks/download_container.yml
+++ b/roles/download/tasks/download_container.yml
@@ -1,7 +1,7 @@
 ---
 - name: container_download | Make download decision if pull is required by tag or sha256
-  include_tasks: set_docker_image_facts.yml
-  delegate_to: "{{ download_delegate if download_run_once or omit }}"
+  import_tasks: set_docker_image_facts.yml
+  delegate_to: "{{ download_delegate if download_run_once or inventory_hostname }}"
   delegate_facts: yes
   run_once: "{{ download_run_once }}"
   when:
@@ -10,32 +10,25 @@
   tags:
     - facts
 
-# FIXME(mattymo): In Ansible 2.4 omitting download delegate is broken. Move back
-#                 to one task in the future.
+- debug:
+    msg:
+      - "pull_args: {{ pull_args }}"
+
 - name: container_download | Download containers if pull is required or told to always pull (delegate)
   command: "{{ docker_bin_dir }}/docker pull {{ pull_args }}"
+  become: true
   register: pull_task_result
   until: pull_task_result is succeeded
-  retries: 4
-  delay: "{{ retry_stagger | random + 3 }}"
-  when:
-    - download_run_once
-    - download.enabled
-    - download.container
-    - pull_required|default(download_always_pull)
-  delegate_to: "{{ download_delegate }}"
+  delegate_to: "{{ download_delegate if download_run_once or inventory_hostname }}"
   delegate_facts: yes
-  run_once: yes
-
-- name: container_download | Download containers if pull is required or told to always pull (all nodes)
-  command: "{{ docker_bin_dir }}/docker pull {{ pull_args }}"
-  register: pull_task_result
-  until: pull_task_result is succeeded
+  run_once: "{{ download_run_once }}"
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   when:
-    - not download_run_once
     - download.enabled
     - download.container
     - pull_required|default(download_always_pull)
-    - group_names | intersect(download.groups) | length
+    - download_run_once or (group_names | intersect(download.groups) | length)
+  tags:
+    - upload
+    - upgrade

--- a/roles/download/tasks/download_file.yml
+++ b/roles/download/tasks/download_file.yml
@@ -4,25 +4,94 @@
     msg:
       - "URL: {{ download.url }}"
       - "Dest: {{ download.dest }}"
+  run_once: true
 
-- name: file_download | Create dest directory
+- set_fact:
+    cache_path: "{{ local_release_dir }}/{{ download.dest | regex_replace('^\\/', '') }}"
+  tags:
+    - facts
+
+- name: file_download | Create local cache directory
   file:
-    path: "{{download.dest|dirname}}"
+    path: "{{ cache_path | dirname }}"
+    state: directory
+    recurse: yes
+  delegate_to: localhost
+  delegate_facts: false
+  run_once: true
+  become: false
+  when:
+    - download.enabled
+    - download.file
+  tags:
+    - localhost
+    - upload
+    - upgrade
+
+- name: file_download | Create dest directory on node
+  file:
+    path: "{{ download.dest | dirname }}"
+    owner: "{{ download.owner | default(omit) }}"
+    mode: 0755
     state: directory
     recurse: yes
   when:
     - download.enabled
     - download.file
     - group_names | intersect(download.groups) | length
+  tags:
+    - upload
+    - upgrade
 
+- name: file_download | Check if file is available in cache
+  stat:
+    path: "{{ cache_path }}"
+  register: cached_file
+  run_once: true
+  changed_when: false
+  delegate_to: localhost
+  delegate_facts: no
+  when:
+    - download.enabled
+    - download.file
+  tags:
+    - upload
+    - upgrade
+    - facts
+
+- name: file_download | Copy file from cache to nodes, if it is available
+  synchronize:
+    src: "{{ cache_path }}"
+    dest: "{{ download.dest }}"
+    use_ssh_args: "{{ has_bastion | default(false) }}"
+    mode: push
+  run_once: "{{ download_run_once }}"
+  become: true
+  register: get_task
+  until: get_task is succeeded
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  when:
+    - download.enabled
+    - download.file
+    - cached_file.stat.exists
+    - not (download_run_once and download_delegate == 'localhost')
+    - ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"]
+  tags:
+    - upload
+    - upgrade
+
+# This must always be called, to check if the checksum matches. On no-match the file is re-downloaded.
 - name: file_download | Download item
   get_url:
     url: "{{download.url}}"
-    dest: "{{download.dest}}"
-    sha256sum: "{{download.sha256 | default(omit)}}"
+    dest: "{{ cache_path if (download_run_once and download_delegate == 'localhost') else download.dest }}"
+    checksum: "{{ 'sha256:'+download.sha256 if download.sha256 or omit}}"
     owner: "{{ download.owner|default(omit) }}"
     mode: "{{ download.mode|default(omit) }}"
     validate_certs: "{{ download_validate_certs }}"
+  delegate_to: "{{ download_delegate if download_run_once else inventory_hostname }}"
+  run_once: "{{ download_run_once }}"
   register: get_url_result
   until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
   retries: 4
@@ -30,17 +99,26 @@
   when:
     - download.enabled
     - download.file
-    - group_names | intersect(download.groups) | length
+    - download_run_once or (group_names | intersect(download.groups) | length)
+  tags:
+    - upload
+    - upgrade
 
-- name: file_download | Extract archives
-  unarchive:
-    src: "{{download.dest}}"
-    dest: "{{download.dest|dirname}}"
-    owner: "{{ download.owner|default(omit) }}"
-    mode: "{{ download.mode|default(omit) }}"
-    copy: no
+- name: file_download | copy file to ansible host file cache
+  synchronize:
+    src: "{{ download.dest }}"
+    dest: "{{ cache_path }}"
+    use_ssh_args: "{{has_bastion | default(false) }}"
+    mode: pull
+  run_once: true
+  become: true
   when:
     - download.enabled
     - download.file
-    - download.unarchive|default(False)
-    - group_names | intersect(download.groups) | length
+    - get_url_result.changed or not cached_file.stat.exists
+    - not (download_run_once and download_delegate == 'localhost')
+    - download_delegate == inventory_hostname
+    - ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"]
+  tags:
+    - upload
+    - upgrade

--- a/roles/download/tasks/extract_file.yml
+++ b/roles/download/tasks/extract_file.yml
@@ -1,0 +1,13 @@
+---
+- name: file_download | Extract archives
+  unarchive:
+    src: "{{download.dest}}"
+    dest: "{{download.dest|dirname}}"
+    owner: "{{ download.owner|default(omit) }}"
+    mode: "{{ download.mode|default(omit) }}"
+    copy: no
+  when:
+    - download.enabled
+    - download.file
+    - download.unarchive|default(False)
+    - group_names | intersect(download.groups) | length

--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -1,9 +1,22 @@
 ---
-- include_tasks: download_prep.yml
+- name: "download | Prep for file / container downloads"
+  include_tasks: prep_container_download.yml
   when:
     - not skip_downloads|default(false)
+    - download_container
 
-- name: "Download items"
+- name: "download | Upload locally cached container images"
+  include_tasks: sync_container_cache.yml
+  vars:
+    download: "{{ download_defaults | combine(item.value) }}"
+  with_dict: "{{ downloads }}"
+  when:
+    - not skip_downloads|default(false)
+    - download_container
+    - item.value.enabled
+    - item.value.container|default(False)
+
+- name: "download | Download files / containers"
   include_tasks: "download_{% if download.container %}container{% else %}file{% endif %}.yml"
   vars:
     download: "{{ download_defaults | combine(item.value) }}"
@@ -13,14 +26,24 @@
     - item.value.enabled
     - (not (item.value.container|default(False))) or (item.value.container and download_container)
 
-- name: "Sync container"
-  include_tasks: sync_container.yml
+- name: "download | Sync files / containers"
+  include_tasks: "sync_{% if download.container %}container{% else %}file{% endif %}.yml"
   vars:
     download: "{{ download_defaults | combine(item.value) }}"
   with_dict: "{{ downloads }}"
   when:
     - not skip_downloads|default(false)
     - item.value.enabled
-    - item.value.container | default(false)
     - download_run_once
+    - group_names | intersect(download.groups) | length
+
+- name: "download | Extract file archives"
+  include_tasks: "extract_file.yml"
+  vars:
+    download: "{{ download_defaults | combine(item.value) }}"
+  with_dict: "{{ downloads }}"
+  when:
+    - not skip_downloads|default(false)
+    - item.value.enabled
+    - download.file
     - group_names | intersect(download.groups) | length

--- a/roles/download/tasks/prep_container_download.yml
+++ b/roles/download/tasks/prep_container_download.yml
@@ -1,14 +1,4 @@
 ---
-- name: Register docker images info
-  shell: >-
-    {{ docker_bin_dir }}/docker images -q | xargs {{ docker_bin_dir }}/docker inspect -f "{{ '{{' }} (index .RepoTags 0) {{ '}}' }},{{ '{{' }} (index .RepoDigests 0) {{ '}}' }}" | tr '\n' ','
-  no_log: true
-  register: docker_images
-  failed_when: false
-  changed_when: false
-  check_mode: no
-  when: download_container
-
 - name: container_download | Create dest directory for saved/loaded container images
   file:
     path: "{{local_release_dir}}/containers"
@@ -16,7 +6,8 @@
     recurse: yes
     mode: 0755
     owner: "{{ansible_ssh_user|default(ansible_user_id)}}"
-  when: download_container
+  tags:
+    - upload
 
 - name: container_download | create local directory for saved/loaded container images
   file:
@@ -25,11 +16,8 @@
     recurse: yes
   delegate_to: localhost
   delegate_facts: false
-  become: false
   run_once: true
-  when:
-    - download_run_once
-    - download_delegate == 'localhost'
-    - download_container
+  become: false
   tags:
+    - upload
     - localhost

--- a/roles/download/tasks/set_docker_image_facts.yml
+++ b/roles/download/tasks/set_docker_image_facts.yml
@@ -7,6 +7,8 @@
     pull_args: >-
       {%- if pull_by_digest %}{{download.repo}}@sha256:{{download.sha256}}{%- else -%}{{download.repo}}:{{download.tag}}{%- endif -%}
 
+# NOTE: The ampersand hell in this block is needed because docker-inspect uses go templates, which uses double ampersands as delimeters, just like Jinja does.
+#       If you want to understand the template, just replace all instances  of {{ `{{` }} with {{ and {{ '}}' }} with }}.
 - name: Register docker images info
   shell: >-
     {{ docker_bin_dir }}/docker images -q | xargs {{ docker_bin_dir }}/docker inspect -f "{{ '{{' }} if .RepoTags {{ '}}' }}{{ '{{' }} (index .RepoTags 0) {{ '}}' }}{{ '{{' }} end {{ '}}' }}{{ '{{' }} if .RepoDigests {{ '}}' }},{{ '{{' }} (index .RepoDigests 0) {{ '}}' }}{{ '{{' }} end {{ '}}' }}" | tr '\n' ','

--- a/roles/download/tasks/sync_container.yml
+++ b/roles/download/tasks/sync_container.yml
@@ -1,9 +1,9 @@
 ---
 - name: container_download | Make download decision if pull is required by tag or sha256
-  include: set_docker_image_facts.yml
-  delegate_to: "{{ download_delegate if download_run_once or omit }}"
+  import_tasks: set_docker_image_facts.yml
+  delegate_to: "{{ download_delegate }}"
   delegate_facts: no
-  run_once: "{{ download_run_once }}"
+  run_once: true
   when:
     - download.enabled
     - download.container
@@ -12,14 +12,14 @@
 
 - set_fact:
     fname: "{{local_release_dir}}/containers/{{download.repo|regex_replace('/|\0|:', '_')}}:{{download.tag|default(download.sha256)|regex_replace('/|\0|:', '_')}}.tar"
-  run_once: true
   when:
     - download.enabled
     - download.container
-    - download_run_once
-
   tags:
     - facts
+
+- debug:
+    msg: "fname: {{fname | default(omit)}}"
 
 - name: "container_download | Set default value for 'container_changed' to false"
   set_fact:
@@ -27,7 +27,6 @@
   when:
     - download.enabled
     - download.container
-    - download_run_once
 
 - name: "container_download | Update the 'container_changed' fact"
   set_fact:
@@ -35,9 +34,7 @@
   when:
     - download.enabled
     - download.container
-    - download_run_once
     - pull_required|default(download_always_pull)
-  run_once: "{{ download_run_once }}"
   tags:
     - facts
 
@@ -48,12 +45,10 @@
   changed_when: false
   delegate_to: "{{ download_delegate }}"
   delegate_facts: no
-  become: false
   run_once: true
   when:
     - download.enabled
     - download.container
-    - download_run_once
   tags:
     - facts
 
@@ -66,9 +61,8 @@
   when:
     - download.enabled
     - download.container
-    - download_run_once
-    - (ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"] or download_delegate == "localhost")
     - (container_changed or not img.stat.exists)
+    - (ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"] or download_delegate == "localhost")
 
 - name: container_download | copy container images to ansible host
   synchronize:
@@ -76,18 +70,15 @@
     dest: "{{ fname }}"
     use_ssh_args: "{{ has_bastion | default(false) }}"
     mode: pull
-  delegate_to: localhost
   delegate_facts: no
   run_once: true
-  become: false
   when:
     - download.enabled
     - download.container
-    - download_run_once
-    - ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"]
-    - inventory_hostname == download_delegate
-    - download_delegate != "localhost"
     - saved.changed
+    - download_delegate != "localhost"
+    - not download_run_once or download_delegate==inventory_hostname
+    - ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"]
 
 - name: container_download | upload container images to nodes
   synchronize:
@@ -95,9 +86,8 @@
     dest: "{{ fname }}"
     use_ssh_args: "{{ has_bastion | default(false) }}"
     mode: push
-  delegate_to: localhost
   delegate_facts: no
-  become: false
+  become: true
   register: get_task
   until: get_task is succeeded
   retries: 4
@@ -105,10 +95,8 @@
   when:
     - download.enabled
     - download.container
-    - download_run_once
-    - (ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"] and
-      inventory_hostname != download_delegate or
-      download_delegate == "localhost")
+    - inventory_hostname != download_delegate or download_delegate == "localhost"
+    - ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"]
   tags:
     - upload
     - upgrade
@@ -118,9 +106,8 @@
   when:
     - download.enabled
     - download.container
-    - download_run_once
-    - (ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"] and
-      inventory_hostname != download_delegate or download_delegate == "localhost")
+    - inventory_hostname != download_delegate or download_delegate == "localhost"
+    - ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"]
   tags:
     - upload
     - upgrade

--- a/roles/download/tasks/sync_container_cache.yml
+++ b/roles/download/tasks/sync_container_cache.yml
@@ -1,0 +1,69 @@
+---
+- name: sync_container_cache | Starting check for cached item
+  debug:
+    verbosity: 1
+    var: download
+
+- set_fact:
+    fname: "{{local_release_dir}}/containers/{{download.repo|regex_replace('/|\0|:', '_')}}:{{download.tag|default(download.sha256)|regex_replace('/|\0|:', '_')}}.tar"
+  when:
+    - download.enabled
+    - download.container
+  tags:
+    - facts
+
+- debug:
+    msg: "fname: {{fname | default(omit)}}"
+
+- name: sync_container_cache | Determine if container image is in cache
+  stat:
+    path: "{{ fname }}"
+  delegate_to: localhost
+  register: cache_image
+  changed_when: false
+  delegate_facts: no
+  become: false
+  when:
+    - download.enabled
+    - download.container
+  tags:
+    - facts
+
+- name: sync_container_cache | Upload cached container image to node(s)
+  synchronize:
+    src: "{{ fname }}"
+    dest: "{{ fname }}"
+    use_ssh_args: "{{ has_bastion | default(false) }}"
+    mode: push
+  run_once: "{{ download_run_once }}"
+  delegate_facts: no
+  become: false
+  register: upload_image
+  until: upload_image is succeeded
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  when:
+    - download.enabled
+    - download.container
+    - cache_image.stat.exists
+    - (not download_run_once) or download_delegate==inventory_hostname
+    - ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"]
+  tags:
+    - upload
+    - upgrade
+
+# NOTE: If download_delegate==localhost, then the account running ansible requires
+#       sudo rights to able to access docker or to be in the docker group. Running
+#       ansible with ask-become-pass is mandatory if user is not in the docker group.
+- name: sync_container_cache | Load container images on node(s)
+  shell: "{{ docker_bin_dir }}/docker load < {{ fname }}"
+  delegate_to: "{{ download_delegate if download_run_once or omit }}"
+  run_once: "{{ download_run_once }}"
+  when:
+    - download.enabled
+    - download.container
+    - cache_image.stat.exists
+    - ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"]
+  tags:
+    - upload
+    - upgrade

--- a/roles/download/tasks/sync_file.yml
+++ b/roles/download/tasks/sync_file.yml
@@ -1,0 +1,21 @@
+---
+- name: file_download | upload file images to nodes
+  synchronize:
+    src: "{{ cache_path }}"
+    dest: "{{ download.dest }}"
+    use_ssh_args: "{{ has_bastion | default(false) }}"
+    mode: push
+  become: true
+  register: get_task
+  until: get_task is succeeded
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  when:
+    - download.enabled
+    - download.file
+    - download_run_once
+    - download_delegate != inventory_hostname or download_delegate == "localhost"
+    - ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"]
+  tags:
+    - upload
+    - upgrade


### PR DESCRIPTION
- In order to cache docker images, a local docker instance is no longer required. Kubespray can download docker images on one of the nodes and then will export them and cache them locally as files. On subsequent vagrant up / destroy runs, these files will be loaded to the delegate_host's docker instance first, before doing a pull. If the image is up to date, this will prevent the image having to be downloaded. Prior to this patch, caching of docker images was only possible with help of a local docker instance, and that is now no longer needed. Sounds complicated, but effectively it works by checking if a files is cached and copying it to the delegate node, before the delegate node starts downloading / updating an image / file. After the node hase updated/downloaded an image/file, it will be copied back to the local machine's cache, and from there on it's business as usual.

- file downloads are also cached now, so that repeated vagrant up/down runs do not trigger downloading of those files. In the case of hyperkube, saving about 240 MB of internet bandwidth per node.

- fixed a FIXME, wher the argument was that delegate_to doesn't play nice with omit. That is a correct observation and the fix is to use default(inventory_host) instead of default(omit).
See ansible/ansible#26009

- sync_containers: removed when:run_once because that is implicitly set by calling it from download/main.yml

- "Register docker images info" task was defined in download_container and set_docker_image_facts. It has been removed from the latter because it was faulty and unused there.
