### PR TITLE
Fix kubeadm_controller_extra_args

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
@@ -129,6 +129,9 @@ controllerManagerExtraArgs:
 {% if kube_feature_gates %}
   feature-gates: {{ kube_feature_gates|join(',') }}
 {% endif %}
+{% for key in kube_kubeadm_controller_extra_args %}
+  {{ key }}: "{{ kube_kubeadm_controller_extra_args[key] }}"
+{% endfor %}
 {% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws"] %}
   cloud-provider: {{cloud_provider}}
   cloud-config: {{ kube_config_dir }}/cloud_config
@@ -173,9 +176,6 @@ apiServerExtraVolumes:
 {% endif %}
 {% endif %}
 {% endif %}
-{% for key in kube_kubeadm_controller_extra_args %}
-  {{ key }}: "{{ kube_kubeadm_controller_extra_args[key] }}"
-{% endfor %}
 {% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws", "external"] %}
 controllerManagerExtraVolumes:
 {% if cloud_provider is defined and cloud_provider in ["openstack"] and openstack_cacert is defined %}


### PR DESCRIPTION
For some reason this had been moved to the wrong dictionary, outside of `controllerManagerExtraArgs` and into `apiServerExtraVolumes` where it has no effect.