### PR TITLE
Ubuntu boostrap proxy friendly

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-ubuntu.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-ubuntu.yml
@@ -21,8 +21,11 @@
 
 - name: Bootstrap | Install python 2.x and pip
   raw:
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y {{ubuntu_packages | join(" ")}}
+    (export no_proxy={{proxy_env.no_proxy if (proxy_env is defined and proxy_env.no_proxy is defined) else ""}} \
+    http_proxy={{proxy_env.http_proxy if (proxy_env is defined and proxy_env.http_proxy is defined) else ""}} \
+    https_proxy={{proxy_env.https_proxy if (proxy_env is defined and proxy_env.https_proxy is defined) else ""}} \
+    DEBIAN_FRONTEND=noninteractive; \
+    apt-get update && apt-get install -y {{ubuntu_packages | join(" ")}})
   environment: {}
   when:
     - need_bootstrap.results | map(attribute='rc') | sort | last | bool


### PR DESCRIPTION
Bootstrap is currently failing when done through proxies.
This is a fix.

Thx.