### PR TITLE
Fix Registry Mirror Problem

### DIFF
--- a/inventory/sample/group_vars/all/docker.yml
+++ b/inventory/sample/group_vars/all/docker.yml
@@ -52,10 +52,10 @@ docker_rpm_keepcache: 0
 ## This string should be exactly as you wish it to appear.
 docker_options: >-
   {%- if docker_insecure_registries is defined %}
-  {{ docker_insecure_registries | map('regex_replace', '^(.*)$', '--insecure-registry=\1' ) | list | join(' ') }}
+  {{ docker_insecure_registries | map('regex_replace', '^(.*)$', '--insecure-registry=\1 ' ) | list | join(' ') }}
   {%- endif %}
   {% if docker_registry_mirrors is defined %}
-  {{ docker_registry_mirrors | map('regex_replace', '^(.*)$', '--registry-mirror=\1' ) | list | join(' ') }}
+  {{ docker_registry_mirrors | map('regex_replace', '^(.*)$', '--registry-mirror=\1 ' ) | list | join(' ') }}
   {%- endif %}
   {%- if docker_version is version('17.05', '<') %}
   --graph={{ docker_daemon_graph }} {{ docker_log_opts }}


### PR DESCRIPTION
sample docker.yml has this problem when i specified a registry mirror:
`--registry-mirror=https://docker.example.com--data-root=/var/lib/docker`
we need to add an extra space to solve that.