### PR TITLE
Update check for sane defaults

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -108,7 +108,7 @@
 
 - name: Stop if RBAC and anonymous-auth are not enabled when insecure port is disabled
   assert:
-    that: rbac_enabled and kube_api_anonymous_auth
+    that: rbac_enabled or kube_api_anonymous_auth
   when: kube_apiserver_insecure_port == 0
   ignore_errors: "{{ ignore_assert_errors }}"
 


### PR DESCRIPTION
The default configuration fails without a change in this location.

We need one of these to evaluate true, but not necessarily both.
