### PR TITLE
Disable gather_facts from non-kubeadm deprecation notice in scale

### DIFF
--- a/scale.yml
+++ b/scale.yml
@@ -14,6 +14,7 @@
     ansible_connection: local
 
 - hosts: localhost
+  gather_facts: False
   tasks:
     - name: deploy warning for non kubeadm
       debug:


### PR DESCRIPTION
Same as #3773, but for scale.yml.

Reproducing that commit message:

fact gathering causes errors when using become (-b) and there is no sudo access
locally