### PR TITLE
Reset tasks specific to Calico

### DIFF
--- a/roles/network_plugin/calico/tasks/reset.yml
+++ b/roles/network_plugin/calico/tasks/reset.yml
@@ -1,0 +1,19 @@
+---
+- name: reset | check dummy0 network device
+  stat:
+    path: /sys/class/net/dummy0
+  register: dummy0
+
+- name: reset | remove the network device created by calico
+  command: ip link del dummy0
+  when: dummy0.stat.exists
+
+- name: reset | get remaining routes set by bird
+  command: ip route show proto bird
+  register: bird_routes
+
+- name: reset | remove remaining routes set by bird
+  command: "ip route del {{ bird_route }} proto bird"
+  with_items: "{{ bird_routes.stdout_lines }}"
+  loop_control:
+    loop_var: bird_route

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -205,7 +205,7 @@
 - name: reset | include file with reset tasks specific to the network_plugin if exists
   include_tasks: "{{ (role_path + '/../network_plugin/' + kube_network_plugin + '/tasks/reset.yml') | realpath  }}"
   when:
-    - kube_network_plugin in ['flannel', 'cilium', 'contiv', 'kube-router']
+    - kube_network_plugin in ['flannel', 'cilium', 'contiv', 'kube-router', 'calico']
   tags:
     - network
 


### PR DESCRIPTION
What this PR is about:
- It removes the dummy0 interface added by calico
- It removes the routes added by calico