### PR TITLE
kubernetesVersion is required in InitConfiguration

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
@@ -1,5 +1,6 @@
 apiVersion: kubeadm.k8s.io/v1alpha3
 kind: InitConfiguration
+kubernetesVersion: {{ kube_version }}
 apiEndpoint:
   advertiseAddress: {{ ip | default(ansible_default_ipv4.address) }}
   bindPort: {{ kube_apiserver_port }}


### PR DESCRIPTION
What this PR is about:
It adds `kubernetesVersion` to `InitConfiguration` 
This prevents kubeadm from requesting dl.k8s.io for the current stable version (which fails in offline evnironements)