### PR TITLE
Reset: Check for kube-ipvs0 presence before removing it

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -112,10 +112,16 @@
   when:
     - kube_proxy_mode == 'ipvs'
 
+- name: reset | check kube-ipvs0 network device
+  stat:
+    path: /sys/class/net/kube-ipvs0
+  register: kube_ipvs0
+
 - name: reset | Remove kube-ipvs0
   command: "ip link del kube-ipvs0"
   when:
     - kube_proxy_mode == 'ipvs'
+    - kube_ipvs0.stat.exists
 
 - name: reset | delete some files and directories
   file:


### PR DESCRIPTION
What this PR is about:
Addition of a check of the presence of the kube-ipvs0 interface before removing it