### PR TITLE
3824 ability to specify resources on helm init

### DIFF
--- a/roles/kubernetes-apps/helm/defaults/main.yml
+++ b/roles/kubernetes-apps/helm/defaults/main.yml
@@ -1,6 +1,12 @@
 ---
 helm_enabled: false
 
+#
+helm_resources_requests_cpu: "100m"
+helm_resources_requests_memory: "100m"
+helm_resources_limits_cpu: "100m"
+helm_resources_limits_memory: "100m"
+
 # specify a dir and attach it to helm for HELM_HOME.
 helm_home_dir: "/root/.helm"
 

--- a/roles/kubernetes-apps/helm/defaults/main.yml
+++ b/roles/kubernetes-apps/helm/defaults/main.yml
@@ -1,12 +1,6 @@
 ---
 helm_enabled: false
 
-#
-helm_resources_requests_cpu: "100m"
-helm_resources_requests_memory: "100m"
-helm_resources_limits_cpu: "100m"
-helm_resources_limits_memory: "100m"
-
 # specify a dir and attach it to helm for HELM_HOME.
 helm_home_dir: "/root/.helm"
 

--- a/roles/kubernetes-apps/helm/tasks/main.yml
+++ b/roles/kubernetes-apps/helm/tasks/main.yml
@@ -49,6 +49,10 @@
     {% if tiller_max_history is defined %} --history-max={{ tiller_max_history }}{% endif %}
     {% if tiller_enable_tls %} --tiller-tls --tiller-tls-verify --tiller-tls-cert={{ tiller_tls_cert }} --tiller-tls-key={{ tiller_tls_key }} --tls-ca-cert={{ tiller_tls_ca_cert }} {% endif %}
     {% if tiller_secure_release_info %} --override 'spec.template.spec.containers[0].command'='{/tiller,--storage=secret}' {% endif %}
+    {% if helm_resources_limits_cpu %} --override 'spec.template.spec.containers[0].resources.limits.cpu'='{{ helm_resources_limits_cpu }}'{% endif %}
+    {% if helm_resources_limits_memory %} --override 'spec.template.spec.containers[0].resources.limits.memory'='{{ helm_resources_limits_memory }}'{% endif %}
+    {% if helm_resources_requests_cpu %} --override 'spec.template.spec.containers[0].resources.requests.cpu'='{{ helm_resources_requests_cpu }}'{% endif %}
+    {% if helm_resources_requests_memory %} --override 'spec.template.spec.containers[0].resources.requests.memory'='{{ helm_resources_requests_memory }}'{% endif %}
     {% else %}
     --client-only
     {% endif %}


### PR DESCRIPTION
If on namespace is created resourcequota (with cpu and memory limits or/and with cpu and memory requests) - no pod can be created without specifying those params in contained spec.
Tiller pod is not an exclusion.
So we want to have the ability to specify those params on tiller init.
In current version of kubespray is not such ability.