### PR TITLE
[doc] Remove mention of fuel in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,6 @@ Tools and projects on top of Kubespray
 --------------------------------------
 
 -   [Digital Rebar Provision](https://github.com/digitalrebar/provision/blob/master/doc/integrations/ansible.rst)
--   [Fuel-ccp-installer](https://github.com/openstack/fuel-ccp-installer)
 -   [Terraform Contrib](https://github.com/kubernetes-sigs/kubespray/tree/master/contrib/terraform)
 
 CI Tests


### PR DESCRIPTION
Since fuel is abandoned it's probably better to not mention it in the README