### PR TITLE
kube-router enable DSR

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/k8s-net-kube-router.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-net-kube-router.yml
@@ -19,6 +19,9 @@
 # Add LoadbBalancer IP of service status as set by the LB provider to the RIB so that it gets advertised to the BGP peers.
 # kube_router_advertise_loadbalancer_ip: false
 
+# Adjust manifest of kube-router daemonset template with DSR needed changes
+# kube_router_enable_dsr: false
+
 # Array of arbitrary extra arguments to kube-router, see
 # https://github.com/cloudnativelabs/kube-router/blob/master/docs/user-guide.md
 # kube_router_extra_args: []

--- a/roles/network_plugin/kube-router/defaults/main.yml
+++ b/roles/network_plugin/kube-router/defaults/main.yml
@@ -18,6 +18,9 @@ kube_router_advertise_external_ip: false
 # Add LoadbBalancer IP of service status as set by the LB provider to the RIB so that it gets advertised to the BGP peers.
 kube_router_advertise_loadbalancer_ip: false
 
+# Adjust manifest of kube-router daemonset template with DSR needed changes
+kube_router_enable_dsr: false
+
 # Array of arbitrary extra arguments to kube-router, see
 # https://github.com/cloudnativelabs/kube-router/blob/master/docs/user-guide.md
 kube_router_extra_args: []

--- a/roles/network_plugin/kube-router/templates/kube-router.yml.j2
+++ b/roles/network_plugin/kube-router/templates/kube-router.yml.j2
@@ -115,6 +115,11 @@ spec:
         securityContext:
           privileged: true
         volumeMounts:
+{% if kube_router_enable_dsr %}
+        - name: docker-socket
+          mountPath: /var/run/docker.sock
+          readOnly: true
+{% endif %}
         - name: lib-modules
           mountPath: /lib/modules
           readOnly: true
@@ -149,12 +154,22 @@ spec:
         - name: kubeconfig
           mountPath: /var/lib/kube-router
       hostNetwork: true
+{% if kube_router_enable_dsr %}
+      hostIPC: true
+      hostPID: true
+{% endif %}
       tolerations:
       - operator: Exists
       # Mark pod as critical for rescheduling (Will have no effect starting with kubernetes 1.12)
       - key: CriticalAddonsOnly
         operator: "Exists"
       volumes:
+{% if kube_router_enable_dsr %}
+      - name: docker-socket
+        hostPath:
+          path: /var/run/docker.sock
+          type: Socket
+{% endif %}
       - name: lib-modules
         hostPath:
           path: /lib/modules


### PR DESCRIPTION
For DSR (direct server return) to work with kube-router, a few changes are needed to its manifest.

The following documentation describes the changes:
https://github.com/cloudnativelabs/kube-router/blob/master/docs/user-guide.md#direct-server-return

These changes are implemented in this PR when the flag `kube_router_enable_dsr` is set to true (false by default)

Cheers!