### PR TITLE
Cleanup download role

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -34,83 +34,56 @@ download_delegate: "{% if download_localhost %}localhost{% else %}{{groups['kube
 # Arch of Docker images and needed packages
 image_arch: "{{host_architecture | default('amd64')}}"
 
-# Versions
-kube_version: v1.12.3
-kubeadm_version: "{{ kube_version }}"
-etcd_version: v3.2.24
-
 # kubernetes image repo define
 kube_image_repo: "gcr.io/google-containers"
 
-# TODO(mattymo): Move calico versions to roles/network_plugins/calico/defaults
-# after migration to container download
-calico_version: "v3.1.3"
-calico_ctl_version: "v3.1.3"
+# Versions
+addon_resizer_version: "1.8.3"
+busybox_version: "1.29.2"
 calico_cni_version: "v3.1.3"
+calico_ctl_version: "v3.1.3"
 calico_policy_version: "v3.1.3"
 calico_rr_version: "v0.6.1"
-
-flannel_version: "v0.10.0"
-flannel_cni_version: "v0.3.0"
-
-cni_version: "v0.6.0"
-
-weave_version: 2.5.0
-pod_infra_version: 3.1
-contiv_version: 1.2.1
+calico_version: "v3.1.3"
+cephfs_provisioner_version: "v2.1.0-k8s1.11"
+cert_manager_version: "v0.5.2"
 cilium_version: "v1.3.0"
+cni_version: "v0.6.0"
+contiv_etcd_init_version: "latest"
+contiv_init_version: "latest"
+contiv_ovs_version: "latest"
+contiv_version: 1.2.1
+coredns_version: "1.2.6"
+dashboard_version: "v1.10.0"
+dnsautoscaler_version: 1.3.0
+dnsmasq_version: "2.78"
+dnsmasqautoscaler_version: 1.1.2
+etcd_version: v3.2.24
+flannel_cni_version: "v0.3.0"
+flannel_version: "v0.10.0"
+helm_version: "v2.11.0"
+ingress_nginx_controller_version: "0.21.0"
 kube_router_version: "v0.2.1"
+kube_version: v1.12.3
+kubeadm_version: "{{ kube_version }}"
+kubedns_version: 1.14.13
+local_volume_provisioner_version: "v2.1.0"
+metrics_server_version: "v0.3.1"
 multus_version: "v3.1.autoconf"
+netcheck_version: "v1.0"
+nginx_version: "1.13"
+pod_infra_version: "3.1"
+registry_proxy_version: "0.4"
+registry_version: "2.6"
+socat_image_version: "latest"
+weave_version: 2.5.0
 
 # Download URLs
 kubeadm_download_url: "https://storage.googleapis.com/kubernetes-release/release/{{ kubeadm_version }}/bin/linux/{{ image_arch }}/kubeadm"
-hyperkube_download_url: "https://storage.googleapis.com/kubernetes-release/release/{{ kube_version }}/bin/linux/amd64/hyperkube"
+kubelet_download_url: "https://storage.googleapis.com/kubernetes-release/release/{{ kubeadm_version }}/bin/linux/{{ image_arch }}/kubelet"
+kubectl_download_url: "https://storage.googleapis.com/kubernetes-release/release/{{ kubeadm_version }}/bin/linux/{{ image_arch }}/kubectl"
 etcd_download_url: "https://github.com/coreos/etcd/releases/download/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-amd64.tar.gz"
 cni_download_url: "https://github.com/containernetworking/plugins/releases/download/{{ cni_version }}/cni-plugins-{{ image_arch }}-{{ cni_version }}.tgz"
-
-# Checksums
-hyperkube_checksums:
-  v1.12.3: 600aad3f0d016716abd85931239806193ffbe95f2edfdcea11532d518ae5cdb1
-  v1.12.2: 566dfed398c20c9944f8999d6370cb584cb8c228b3c5881137b6b3d9306e4b06
-  v1.12.1: 4aa23cfb2fc2e2e4d0cbe0d83a648c38e4baabd6c66f5cdbbb40cbc7582fdc74
-  v1.12.0: f80336201f3152a5307c01f8a7206847398dde15c69b3d20c76a7d9520b60daf
-  v1.11.3: dac8da16dd6688e52b5dc510f5dd0a20b54350d52fb27ceba2f018ba2c8be692
-  v1.11.2: d727f8cae3fc26b1add9b4ff0d4d9b99605544ff7fb3baeecdca394362adbfb8
-  v1.11.1: 019ce1ecf4c6a70c06a7f4ef107443351458b4d9e6b9ce4a436bfbfbef93feea
-  v1.11.0: 7e191c164dc2c942abd37e4b50846e0be31ca959afffeff6b034beacbc2a106a
-  v1.10.8: f8a68514a6c858089f44ec93b2ffb2d764ea67d3b02b19112348f73ffcfe4386
-  v1.10.7: 13e25eb39467014fd169f38b7cd6bec8ff55525b8001c7abba85957e6470b6cc
-  v1.10.6: 0daa34fa58470e5f20def10d3dd544922c28c558719d3338ad8c524154c91257
-  v1.10.5: 1a53456f9d33a7c07adb1636f20f1d0b92b8e7647063a70d0ce134a238e680fe
-  v1.10.4: 16e36693c15494036d930139a749ec1bc492b7fefa2c3adc1abbe8f38178ae7c
-  v1.10.3: e807753dc309635902a56069ee06fc390944ef034b72c53b2e1e51d0c9ead8a3
-  v1.10.2: 3843fb594a18c4a64d77736bab72000ec4b8c4ddf178e20ec3249f709e9ed9c1
-  v1.10.1: 6e0642ad6bae68dc81b8d1c9efa18e265e17e23da1895862823cafac08c0344c
-  v1.10.0: b5575b2fb4266754c1675b8cd5d9b6cac70f3fee7a05c4e80da3a9e83e58c57e
-kubeadm_checksums:
-  v1.12.3: c675aa3be82754b3f8dfdde2a1526a72986713312d46d898e65cb564c6aa8ad4
-  v1.12.2: 51bc4bfd1d934a27245111c0ad1f793d5147ed15389415a1509502f23fcfa642
-  v1.12.1: 5d95efd65aad398d85a9802799f36410ae7a95f9cbe73c8b10d2213c10a6d7be
-  v1.12.0: 463fb058b7fa2591fb01f29f2451b054f6cbaa0f8a20394b4a4eb5d68473176f
-  v1.11.3: 422a7a32ed9a7b1eaa2a4f9d121674dfbe80eb41e206092c13017d097f75aaec
-  v1.11.2: 6b17720a65b8ff46efe92a5544f149c39a221910d89939838d75581d4e6924c0
-  v1.11.1: 425ec24b95f7217ee06d1588aba22f206a5829f8c6a5352c2862368552361fe6
-  v1.11.0: 0000478fc59a24ec1727de744188d13c4d702a644954132efa9d9954371b3553
-  v1.10.8: 42660875dd94c93267bd2f567c67d692b362bd143d7502967a62c5474b2b25b8
-  v1.10.7: cdeb07fd3705e973800c4aa0b8a510d5dba1de8e1039428cfebdaf3d93e332b6
-  v1.10.6: e1d49a6b33b384f681468add2e9ee08552069ae0d6b0ad59e1c943ddbaeac3fa
-  v1.10.5: f231d4bcc9f2ed15597272e5359e380cc760c0b57a1f7cb97ce2bbab5df774e0
-  v1.10.4: 7e1169bbbeed973ab402941672dec957638dea5952a1e8bc89a37d5e709cc4b4
-  v1.10.3: b2a6f0764b89a4a13a3da4471af943ce98efeb29e2913c9e7880fe27f4f43a5f
-  v1.10.2: 394d7d340214c91d669186cf4f2110d8eb840ca965399b4d8b22d0545a60e377
-  v1.10.1: 012e48fb92b1c22543b12ab2db7d780777972043287404c98cca4d2c6ec964ec
-  v1.10.0: ebbac985834289037b544523c3e2f39bb44bea938aca9d9e88ef7e880fb8472f
-
-etcd_binary_checksum: 947849dbcfa13927c81236fb76a7c01d587bbab42ab1e807184cd91b026ebed7
-cni_binary_checksum: f04339a21b8edf76d415e7f17b620e63b8f37a76b2f706671587ab6464411f2d
-
-hyperkube_binary_checksum: "{{ hyperkube_checksums[kube_version] }}"
-kubeadm_binary_checksum: "{{ kubeadm_checksums[kubeadm_version] }}"
 
 # Containers
 # In some cases, we need a way to set --registry-mirror or --insecure-registry for docker,
@@ -120,106 +93,90 @@ kubeadm_binary_checksum: "{{ kubeadm_checksums[kubeadm_version] }}"
 # You need to deploy kubernetes cluster on local private development.
 # Also provide the address of your own private registry.
 # And use --insecure-registry options for docker
-etcd_image_repo: "quay.io/coreos/etcd"
-etcd_image_tag: "{{ etcd_version }}{%- if image_arch != 'amd64' -%}-{{ image_arch }}{%- endif -%}"
-flannel_image_repo: "quay.io/coreos/flannel"
-flannel_image_tag: "{{ flannel_version }}"
-flannel_cni_image_repo: "quay.io/coreos/flannel-cni"
-flannel_cni_image_tag: "{{ flannel_cni_version }}"
-calicoctl_image_repo: "quay.io/calico/ctl"
-calicoctl_image_tag: "{{ calico_ctl_version }}"
-calico_node_image_repo: "quay.io/calico/node"
-calico_node_image_tag: "{{ calico_version }}"
+addon_resizer_image_repo: "k8s.gcr.io/addon-resizer"
+addon_resizer_image_tag: "{{ addon_resizer_version }}"
+busybox_image_repo: "busybox"
+busybox_image_tag: "{{ busybox_version }}"
 calico_cni_image_repo: "quay.io/calico/cni"
 calico_cni_image_tag: "{{ calico_cni_version }}"
+calico_node_image_repo: "quay.io/calico/node"
+calico_node_image_tag: "{{ calico_version }}"
 calico_policy_image_repo: "quay.io/calico/kube-controllers"
 calico_policy_image_tag: "{{ calico_policy_version }}"
 calico_rr_image_repo: "quay.io/calico/routereflector"
 calico_rr_image_tag: "{{ calico_rr_version }}"
-pod_infra_image_repo: "gcr.io/google_containers/pause-{{ image_arch }}"
-pod_infra_image_tag: "{{ pod_infra_version }}"
-install_socat_image_repo: "xueshanf/install-socat"
-install_socat_image_tag: "latest"
-netcheck_version: "v1.0"
-netcheck_agent_image_repo: "quay.io/l23network/k8s-netchecker-agent"
-netcheck_agent_image_tag: "{{ netcheck_version }}"
-netcheck_server_image_repo: "quay.io/l23network/k8s-netchecker-server"
-netcheck_server_image_tag: "{{ netcheck_version }}"
-weave_kube_image_repo: "docker.io/weaveworks/weave-kube"
-weave_kube_image_tag: "{{ weave_version }}"
-weave_npc_image_repo: "docker.io/weaveworks/weave-npc"
-weave_npc_image_tag: "{{ weave_version }}"
-contiv_image_repo: "contiv/netplugin"
-contiv_image_tag: "{{ contiv_version }}"
-contiv_init_image_repo: "contiv/netplugin-init"
-contiv_init_image_tag: "latest"
+calicoctl_image_repo: "quay.io/calico/ctl"
+calicoctl_image_tag: "{{ calico_ctl_version }}"
+cephfs_provisioner_image_repo: "quay.io/external_storage/cephfs-provisioner"
+cephfs_provisioner_image_tag: "{{ cephfs_provisioner_version }}"
+cert_manager_controller_image_repo: "quay.io/jetstack/cert-manager-controller"
+cert_manager_controller_image_tag: "{{ cert_manager_version }}"
+cilium_image_repo: "docker.io/cilium/cilium"
+cilium_image_tag: "{{ cilium_version }}"
 contiv_auth_proxy_image_repo: "contiv/auth_proxy"
 contiv_auth_proxy_image_tag: "{{ contiv_version }}"
 contiv_etcd_init_image_repo: "ferest/etcd-initer"
-contiv_etcd_init_image_tag: latest
+contiv_etcd_init_image_tag: "{{ contiv_etcd_init_version }}"
+contiv_image_repo: "contiv/netplugin"
+contiv_image_tag: "{{ contiv_version }}"
+contiv_init_image_repo: "contiv/netplugin-init"
+contiv_init_image_tag: "{{ contiv_init_version }}"
 contiv_ovs_image_repo: "contiv/ovs"
-contiv_ovs_image_tag: "latest"
-cilium_image_repo: "docker.io/cilium/cilium"
-cilium_image_tag: "{{ cilium_version }}"
-kube_router_image_repo: "cloudnativelabs/kube-router"
-kube_router_image_tag: "{{ kube_router_version }}"
-multus_image_repo: "docker.io/nfvpe/multus"
-multus_image_tag: "{{ multus_version }}"
-nginx_image_repo: nginx
-nginx_image_tag: 1.13
-dnsmasq_version: 2.78
-dnsmasq_image_repo: "andyshinn/dnsmasq"
-dnsmasq_image_tag: "{{ dnsmasq_version }}"
-kubedns_version: 1.14.13
-kubedns_image_repo: "gcr.io/google_containers/k8s-dns-kube-dns-{{ image_arch }}"
-kubedns_image_tag: "{{ kubedns_version }}"
-
-coredns_version: "1.2.6"
+contiv_ovs_image_tag: "{{ contiv_ovs_version }}"
 coredns_image_repo: "coredns/coredns"
 coredns_image_tag: "{{ coredns_version }}"
-
+dashboard_image_repo: "gcr.io/google_containers/kubernetes-dashboard-{{ image_arch }}"
+dashboard_image_tag: "{{ dashboard_version }}"
+dnsautoscaler_image_repo: "gcr.io/google_containers/cluster-proportional-autoscaler-{{ image_arch }}"
+dnsautoscaler_image_tag: "{{ dnsautoscaler_version }}"
+dnsmasq_image_repo: "andyshinn/dnsmasq"
+dnsmasq_image_tag: "{{ dnsmasq_version }}"
 dnsmasq_nanny_image_repo: "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-{{ image_arch }}"
 dnsmasq_nanny_image_tag: "{{ kubedns_version }}"
 dnsmasq_sidecar_image_repo: "gcr.io/google_containers/k8s-dns-sidecar-{{ image_arch }}"
 dnsmasq_sidecar_image_tag: "{{ kubedns_version }}"
-dnsmasqautoscaler_version: 1.1.2
 dnsmasqautoscaler_image_repo: "gcr.io/google_containers/cluster-proportional-autoscaler-{{ image_arch }}"
 dnsmasqautoscaler_image_tag: "{{ dnsmasqautoscaler_version }}"
-dnsautoscaler_version: 1.3.0
-dnsautoscaler_image_repo: "gcr.io/google_containers/cluster-proportional-autoscaler-{{ image_arch }}"
-dnsautoscaler_image_tag: "{{ dnsautoscaler_version }}"
-test_image_repo: busybox
-test_image_tag: latest
-busybox_image_repo: busybox
-busybox_image_tag: 1.29.2
-helm_version: "v2.11.0"
+etcd_image_repo: "quay.io/coreos/etcd"
+etcd_image_tag: "{{ etcd_version }}{%- if image_arch != 'amd64' -%}-{{ image_arch }}{%- endif -%}"
+flannel_cni_image_repo: "quay.io/coreos/flannel-cni"
+flannel_cni_image_tag: "{{ flannel_cni_version }}"
+flannel_image_repo: "quay.io/coreos/flannel"
+flannel_image_tag: "{{ flannel_version }}"
 helm_image_repo: "lachlanevenson/k8s-helm"
 helm_image_tag: "{{ helm_version }}"
-tiller_image_repo: "gcr.io/kubernetes-helm/tiller"
-tiller_image_tag: "{{ helm_version }}"
-
-registry_image_repo: "registry"
-registry_image_tag: "2.6"
-registry_proxy_image_repo: "gcr.io/google_containers/kube-registry-proxy"
-registry_proxy_image_tag: "0.4"
-metrics_server_version: "v0.3.1"
+ingress_nginx_controller_image_repo: "quay.io/kubernetes-ingress-controller/nginx-ingress-controller"
+ingress_nginx_controller_image_tag: "{{ ingress_nginx_controller_version }}"
+install_socat_image_repo: "xueshanf/install-socat"
+install_socat_image_tag: "{{ socat_image_version }}"
+kube_router_image_repo: "cloudnativelabs/kube-router"
+kube_router_image_tag: "{{ kube_router_version }}"
+kubedns_image_repo: "gcr.io/google_containers/k8s-dns-kube-dns-{{ image_arch }}"
+kubedns_image_tag: "{{ kubedns_version }}"
+local_volume_provisioner_image_repo: "quay.io/external_storage/local-volume-provisioner"
+local_volume_provisioner_image_tag: "{{ local_volume_provisioner_version }}"
 metrics_server_image_repo: "k8s.gcr.io/metrics-server-amd64"
 metrics_server_image_tag: "{{ metrics_server_version }}"
-local_volume_provisioner_image_repo: "quay.io/external_storage/local-volume-provisioner"
-local_volume_provisioner_image_tag: "v2.1.0"
-cephfs_provisioner_image_repo: "quay.io/external_storage/cephfs-provisioner"
-cephfs_provisioner_image_tag: "v2.1.0-k8s1.11"
-ingress_nginx_controller_image_repo: "quay.io/kubernetes-ingress-controller/nginx-ingress-controller"
-ingress_nginx_controller_image_tag: "0.21.0"
-cert_manager_version: "v0.5.2"
-cert_manager_controller_image_repo: "quay.io/jetstack/cert-manager-controller"
-cert_manager_controller_image_tag: "{{ cert_manager_version }}"
-addon_resizer_version: "1.8.3"
-addon_resizer_image_repo: "k8s.gcr.io/addon-resizer"
-addon_resizer_image_tag: "{{ addon_resizer_version }}"
-
-dashboard_image_repo: "gcr.io/google_containers/kubernetes-dashboard-{{ image_arch }}"
-dashboard_image_tag: "v1.10.0"
+multus_image_repo: "docker.io/nfvpe/multus"
+multus_image_tag: "{{ multus_version }}"
+netcheck_agent_image_repo: "quay.io/l23network/k8s-netchecker-agent"
+netcheck_agent_image_tag: "{{ netcheck_version }}"
+netcheck_server_image_repo: "quay.io/l23network/k8s-netchecker-server"
+netcheck_server_image_tag: "{{ netcheck_version }}"
+nginx_image_repo: "nginx"
+nginx_image_tag: "{{ nginx_version }}"
+pod_infra_image_repo: "gcr.io/google_containers/pause-{{ image_arch }}"
+pod_infra_image_tag: "{{ pod_infra_version }}"
+registry_image_repo: "registry"
+registry_image_tag: "{{ registry_version }}"
+registry_proxy_image_repo: "gcr.io/google_containers/kube-registry-proxy"
+registry_proxy_image_tag: "{{ registry_proxy_version }}"
+tiller_image_repo: "gcr.io/kubernetes-helm/tiller"
+tiller_image_tag: "{{ helm_version }}"
+weave_kube_image_repo: "docker.io/weaveworks/weave-kube"
+weave_kube_image_tag: "{{ weave_version }}"
+weave_npc_image_repo: "docker.io/weaveworks/weave-npc"
+weave_npc_image_tag: "{{ weave_version }}"
 
 downloads:
   netcheck_server:
@@ -227,7 +184,6 @@ downloads:
     container: true
     repo: "{{ netcheck_server_image_repo }}"
     tag: "{{ netcheck_server_image_tag }}"
-    sha256: "{{ netcheck_server_digest_checksum|default(None) }}"
     groups:
       - k8s-cluster
 
@@ -236,7 +192,6 @@ downloads:
     container: true
     repo: "{{ netcheck_agent_image_repo }}"
     tag: "{{ netcheck_agent_image_tag }}"
-    sha256: "{{ netcheck_agent_digest_checksum|default(None) }}"
     groups:
       - k8s-cluster
 
@@ -248,7 +203,6 @@ downloads:
     dest: "{{local_release_dir}}/etcd-{{ etcd_version }}-linux-amd64.tar.gz"
     repo: "{{ etcd_image_repo }}"
     tag: "{{ etcd_image_tag }}"
-    sha256: "{{ etcd_binary_checksum if etcd_deployment_type == 'host' else etcd_digest_checksum|d(None) }}"
     url: "{{ etcd_download_url }}"
     unarchive: true
     owner: "root"
@@ -261,7 +215,6 @@ downloads:
     file: true
     version: "{{ cni_version }}"
     dest: "{{local_release_dir}}/cni-plugins-{{ image_arch }}-{{ cni_version }}.tgz"
-    sha256: "{{ cni_binary_checksum }}"
     url: "{{ cni_download_url }}"
     unarchive: false
     owner: "root"
@@ -273,8 +226,7 @@ downloads:
     enabled: true
     file: true
     version: "{{ kubeadm_version }}"
-    dest: "{{local_release_dir}}/kubeadm"
-    sha256: "{{ kubeadm_binary_checksum }}"
+    dest: "{{ local_release_dir }}/kubeadm"
     url: "{{ kubeadm_download_url }}"
     unarchive: false
     owner: "root"
@@ -282,13 +234,24 @@ downloads:
     groups:
       - k8s-cluster
 
-  hyperkube_file:
+  kubectl:
     enabled: true
     file: true
-    version: "{{ kube_version }}"
-    dest: "{{ local_release_dir }}/hyperkube"
-    sha256: "{{ hyperkube_binary_checksum }}"
-    url: "{{ hyperkube_download_url }}"
+    version: "{{ kubeadm_version }}"
+    dest: "{{ local_release_dir }}/kubectl"
+    url: "{{ kubectl_download_url }}"
+    unarchive: false
+    owner: "root"
+    mode: "0755"
+    groups:
+      - k8s-cluster
+
+  kubelet:
+    enabled: true
+    file: true
+    version: "{{ kubeadm_version }}"
+    dest: "{{ local_release_dir }}/kubelet"
+    url: "{{ kubelet_download_url }}"
     unarchive: false
     owner: "root"
     mode: "0755"
@@ -300,7 +263,6 @@ downloads:
     container: true
     repo: "{{ cilium_image_repo }}"
     tag: "{{ cilium_image_tag }}"
-    sha256: "{{ cilium_digest_checksum|default(None) }}"
     groups:
       - k8s-cluster
 
@@ -309,7 +271,6 @@ downloads:
     container: true
     repo: "{{ multus_image_repo }}"
     tag: "{{ multus_image_tag }}"
-    sha256: "{{ multus_digest_checksum|default(None) }}"
     groups:
       - k8s-cluster
 
@@ -318,7 +279,6 @@ downloads:
     container: true
     repo: "{{ flannel_image_repo }}"
     tag: "{{ flannel_image_tag }}"
-    sha256: "{{ flannel_digest_checksum|default(None) }}"
     groups:
       - k8s-cluster
 
@@ -327,7 +287,6 @@ downloads:
     container: true
     repo: "{{ flannel_cni_image_repo }}"
     tag: "{{ flannel_cni_image_tag }}"
-    sha256: "{{ flannel_cni_digest_checksum|default(None) }}"
     groups:
       - k8s-cluster
 
@@ -336,7 +295,6 @@ downloads:
     container: true
     repo: "{{ calicoctl_image_repo }}"
     tag: "{{ calicoctl_image_tag }}"
-    sha256: "{{ calicoctl_digest_checksum|default(None) }}"
     groups:
       - k8s-cluster
 
@@ -345,7 +303,6 @@ downloads:
     container: true
     repo: "{{ calico_node_image_repo }}"
     tag: "{{ calico_node_image_tag }}"
-    sha256: "{{ calico_node_digest_checksum|default(None) }}"
     groups:
       - k8s-cluster
 
@@ -354,7 +311,6 @@ downloads:
     container: true
     repo: "{{ calico_cni_image_repo }}"
     tag: "{{ calico_cni_image_tag }}"
-    sha256: "{{ calico_cni_digest_checksum|default(None) }}"
     groups:
       - k8s-cluster
 
@@ -363,7 +319,6 @@ downloads:
     container: true
     repo: "{{ calico_policy_image_repo }}"
     tag: "{{ calico_policy_image_tag }}"
-    sha256: "{{ calico_policy_digest_checksum|default(None) }}"
     groups:
       - k8s-cluster
 
@@ -372,7 +327,6 @@ downloads:
     container: true
     repo: "{{ calico_rr_image_repo }}"
     tag: "{{ calico_rr_image_tag }}"
-    sha256: "{{ calico_rr_digest_checksum|default(None) }}"
     groups:
       - calico-rr
 
@@ -381,7 +335,6 @@ downloads:
     container: true
     repo: "{{ weave_kube_image_repo }}"
     tag: "{{ weave_kube_image_tag }}"
-    sha256: "{{ weave_kube_digest_checksum|default(None) }}"
     groups:
       - k8s-cluster
 
@@ -390,7 +343,6 @@ downloads:
     container: true
     repo: "{{ weave_npc_image_repo }}"
     tag: "{{ weave_npc_image_tag }}"
-    sha256: "{{ weave_npc_digest_checksum|default(None) }}"
     groups:
       - k8s-cluster
 
@@ -399,7 +351,6 @@ downloads:
     container: true
     repo: "{{ contiv_image_repo }}"
     tag: "{{ contiv_image_tag }}"
-    sha256: "{{ contiv_digest_checksum|default(None) }}"
     groups:
       - k8s-cluster
 
@@ -408,7 +359,6 @@ downloads:
     container: true
     repo: "{{ contiv_auth_proxy_image_repo }}"
     tag: "{{ contiv_auth_proxy_image_tag }}"
-    sha256: "{{ contiv_auth_proxy_digest_checksum|default(None) }}"
     groups:
       - k8s-cluster
 
@@ -417,7 +367,6 @@ downloads:
     container: true
     repo: "{{ contiv_etcd_init_image_repo }}"
     tag: "{{ contiv_etcd_init_image_tag }}"
-    sha256: "{{ contiv_etcd_init_digest_checksum|default(None) }}"
     groups:
       - k8s-cluster
 
@@ -426,7 +375,6 @@ downloads:
     container: true
     repo: "{{ kube_router_image_repo }}"
     tag: "{{ kube_router_image_tag }}"
-    sha256: "{{ kube_router_digest_checksum|default(None) }}"
     groups:
       - k8s-cluster
 
@@ -435,7 +383,6 @@ downloads:
     container: true
     repo: "{{ pod_infra_image_repo }}"
     tag: "{{ pod_infra_image_tag }}"
-    sha256: "{{ pod_infra_digest_checksum|default(None) }}"
     groups:
       - k8s-cluster
 
@@ -444,7 +391,6 @@ downloads:
     container: true
     repo: "{{ install_socat_image_repo }}"
     tag: "{{ install_socat_image_tag }}"
-    sha256: "{{ install_socat_digest_checksum|default(None) }}"
     groups:
       - k8s-cluster
 
@@ -453,7 +399,6 @@ downloads:
     container: true
     repo: "{{ nginx_image_repo }}"
     tag: "{{ nginx_image_tag }}"
-    sha256: "{{ nginx_digest_checksum|default(None) }}"
     groups:
       - kube-node
 
@@ -462,7 +407,6 @@ downloads:
     container: true
     repo: "{{ dnsmasq_image_repo }}"
     tag: "{{ dnsmasq_image_tag }}"
-    sha256: "{{ dnsmasq_digest_checksum|default(None) }}"
     groups:
       - kube-node
 
@@ -471,7 +415,6 @@ downloads:
     container: true
     repo: "{{ kubedns_image_repo }}"
     tag: "{{ kubedns_image_tag }}"
-    sha256: "{{ kubedns_digest_checksum|default(None) }}"
     groups:
       - kube-node
 
@@ -480,7 +423,6 @@ downloads:
     container: true
     repo: "{{ coredns_image_repo }}"
     tag: "{{ coredns_image_tag }}"
-    sha256: "{{ coredns_digest_checksum|default(None) }}"
     groups:
       - kube-node
 
@@ -489,7 +431,6 @@ downloads:
     container: true
     repo: "{{ dnsmasq_nanny_image_repo }}"
     tag: "{{ dnsmasq_nanny_image_tag }}"
-    sha256: "{{ dnsmasq_nanny_digest_checksum|default(None) }}"
     groups:
       - kube-node
 
@@ -498,7 +439,6 @@ downloads:
     container: true
     repo: "{{ dnsmasq_sidecar_image_repo }}"
     tag: "{{ dnsmasq_sidecar_image_tag }}"
-    sha256: "{{ dnsmasq_sidecar_digest_checksum|default(None) }}"
     groups:
       - kube-node
 
@@ -507,7 +447,6 @@ downloads:
     container: true
     repo: "{{ dnsautoscaler_image_repo }}"
     tag: "{{ dnsautoscaler_image_tag }}"
-    sha256: "{{ dnsautoscaler_digest_checksum|default(None) }}"
     groups:
       - kube-node
 
@@ -516,23 +455,14 @@ downloads:
     container: true
     repo: "{{ busybox_image_repo }}"
     tag: "{{ busybox_image_tag }}"
-    sha256: "{{ busybox_digest_checksum|default(None) }}"
     groups:
       - k8s-cluster
-
-  testbox:
-    enabled: false
-    container: true
-    repo: "{{ test_image_repo }}"
-    tag: "{{ test_image_tag }}"
-    sha256: "{{ testbox_digest_checksum|default(None) }}"
 
   helm:
     enabled: "{{ helm_enabled }}"
     container: true
     repo: "{{ helm_image_repo }}"
     tag: "{{ helm_image_tag }}"
-    sha256: "{{ helm_digest_checksum|default(None) }}"
     groups:
       - kube-node
 
@@ -541,7 +471,6 @@ downloads:
     container: true
     repo: "{{ tiller_image_repo }}"
     tag: "{{ tiller_image_tag }}"
-    sha256: "{{ tiller_digest_checksum|default(None) }}"
     groups:
       - kube-node
 
@@ -550,7 +479,6 @@ downloads:
     container: true
     repo: "{{ registry_image_repo }}"
     tag: "{{ registry_image_tag }}"
-    sha256: "{{ registry_digest_checksum|default(None) }}"
     groups:
       - kube-node
 
@@ -559,7 +487,6 @@ downloads:
     container: true
     repo: "{{ registry_proxy_image_repo }}"
     tag: "{{ registry_proxy_image_tag }}"
-    sha256: "{{ registry_proxy_digest_checksum|default(None) }}"
     groups:
       - kube-node
 
@@ -568,7 +495,6 @@ downloads:
     container: true
     repo: "{{ metrics_server_image_repo }}"
     tag: "{{ metrics_server_image_tag }}"
-    sha256: "{{ metrics_server_digest_checksum|default(None) }}"
     groups:
       - kube-master
 
@@ -578,7 +504,6 @@ downloads:
     container: true
     repo: "{{ addon_resizer_image_repo }}"
     tag: "{{ addon_resizer_image_tag }}"
-    sha256: "{{ addon_resizer_digest_checksum|default(None) }}"
     groups:
       - kube-master
 
@@ -587,7 +512,6 @@ downloads:
     container: true
     repo: "{{ local_volume_provisioner_image_repo }}"
     tag: "{{ local_volume_provisioner_image_tag }}"
-    sha256: "{{ local_volume_provisioner_digest_checksum|default(None) }}"
     groups:
       - kube-node
 
@@ -596,7 +520,6 @@ downloads:
     container: true
     repo: "{{ cephfs_provisioner_image_repo }}"
     tag: "{{ cephfs_provisioner_image_tag }}"
-    sha256: "{{ cephfs_provisioner_digest_checksum|default(None) }}"
     groups:
       - kube-node
 
@@ -605,7 +528,6 @@ downloads:
     container: true
     repo: "{{ ingress_nginx_controller_image_repo }}"
     tag: "{{ ingress_nginx_controller_image_tag }}"
-    sha256: "{{ ingress_nginx_controller_digest_checksum|default(None) }}"
     groups:
       - kube-node
 
@@ -614,7 +536,6 @@ downloads:
     container: true
     repo: "{{ cert_manager_controller_image_repo }}"
     tag: "{{ cert_manager_controller_image_tag }}"
-    sha256: "{{ cert_manager_controller_digest_checksum|default(None) }}"
     groups:
       - kube-node
 
@@ -623,7 +544,6 @@ downloads:
     container: true
     repo: "{{ dashboard_image_repo }}"
     tag: "{{ dashboard_image_tag }}"
-    sha256: "{{ dashboard_digest_checksum|default(None) }}"
     groups:
       - kube-master
 

--- a/roles/kubernetes-apps/container_engine_accelerator/nvidia_gpu/templates/nvidia-driver-install-daemonset.yml.j2
+++ b/roles/kubernetes-apps/container_engine_accelerator/nvidia_gpu/templates/nvidia-driver-install-daemonset.yml.j2
@@ -76,5 +76,5 @@ spec:
         - name: root-mount
           mountPath: /root
       containers:
-      - image: "gcr.io/google-containers/pause:2.0"
+      - image: "{{ pod_infra_image_repo }}:{{ pod_infra_image_tag }}"
         name: pause

--- a/roles/kubernetes/master/tasks/main.yml
+++ b/roles/kubernetes/master/tasks/main.yml
@@ -13,7 +13,7 @@
 
 - name: Install | Copy kubectl binary from download dir
   synchronize:
-    src: "{{ local_release_dir }}/hyperkube"
+    src: "{{ local_release_dir }}/kubectl"
     dest: "{{ bin_dir }}/kubectl"
     compress: no
     perms: yes

--- a/roles/kubernetes/node/tasks/install.yml
+++ b/roles/kubernetes/node/tasks/install.yml
@@ -21,7 +21,7 @@
 
 - name: install | Copy kubelet binary from download dir
   synchronize:
-    src: "{{ local_release_dir }}/hyperkube"
+    src: "{{ local_release_dir }}/kubelet"
     dest: "{{ bin_dir }}/kubelet"
     compress: no
     perms: yes

--- a/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
@@ -38,7 +38,7 @@ spec:
       serviceAccountName: cilium
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/library/busybox:1.28.4
+          image: "{{ busybox_image_repo }}:{{ busybox_image_tag }}"
           imagePullPolicy: IfNotPresent
           command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
           volumeMounts:


### PR DESCRIPTION
- Cleanup the download role. Now download kubeadm, kubectl and kubelet as per defined in the docs directly.
- Remove unused test container.
- Fix deployments to not have static images defined
- Remove checksum checking for file download. It's broken as it does not take into account of image_arch or even version. Current checksum list only contains checksums of amd64
- 
