### PR TITLE
Fix setting host_architecture var for etcd

### DIFF
--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -1,4 +1,18 @@
 ---
+- set_fact:
+    architecture_groups:
+      x86_64: amd64
+      aarch64: arm64
+
+- name: ansible_architecture_rename
+  set_fact:
+    host_architecture: >-
+      {%- if ansible_architecture in architecture_groups -%}
+      {{architecture_groups[ansible_architecture]}}
+      {%- else -%}
+       {{ansible_architecture}}
+      {% endif %}
+
 - include_tasks: check_certs.yml
   when: cert_management == "script"
   tags:


### PR DESCRIPTION
Setting host_architecture to allow etcd upgrade working through: ansible-playbook -b -i inventory/sample/hosts.ini cluster.yml --tags=etcd (on other case host_architecture is missing)