### PR TITLE
Add metrics service to kube-dns

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/kubedns-svc.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/kubedns-svc.yml.j2
@@ -20,3 +20,6 @@ spec:
   - name: dns-tcp
     port: 53
     protocol: TCP
+  - name: metrics
+    port: 10055
+    protocol: TCP


### PR DESCRIPTION
Metrics port is exposed through a service for CoreDNS but not for kube-dns.

This allows to scrap metrics by Prometheus to improve monitoring and service status check.