### PR TITLE
Added filters for integer conversion of kubelet_max_pods and kube_net…

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -75,7 +75,7 @@
 # NOTICE: the check blatantly ignores the inet6-case
 - name: Guarantee that enough network address space is available for all pods
   assert:
-    that: "{{ kubelet_max_pods | default(110) <= (2 ** (32 - kube_network_node_prefix)) - 2 }}"
+    that: "{{ (kubelet_max_pods | default(110)) | int <= (2 ** (32 - kube_network_node_prefix | int)) - 2 }}"
     msg: "Do not schedule more pods on a node than inet addresses are available."
   ignore_errors: "{{ ignore_assert_errors }}"
   when:


### PR DESCRIPTION
The assertion at https://github.com/kubernetes-sigs/kubespray/blob/master/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml#L78 doesn't convert the kubelet_max_pods and kube_network_node_prefix to an integer in the jinja template. This can cause the assertion to fail when these variables are set using set_fact which sets the values as strings.