### PR TITLE
Fix enabling swap after restart vagrant installation

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -161,7 +161,7 @@ Vagrant.configure("2") do |config|
       node.vm.network :private_network, ip: ip
 
       # Disable swap for each vm
-      node.vm.provision "shell", inline: "swapoff -a"
+      node.vm.provision "shell", inline: "swapoff -a && sed -i '/swap/s/^/#/' /etc/fstab"
 
       host_vars[vm_name] = {
         "ip": ip,


### PR DESCRIPTION
The current solution to disable swap on vagrant installation is not effective after a reboot. Kubelet does not start until you redo the `swapoff -a`  
PR add fix to avoid this.