### PR TITLE
Adding linux node selectors

### DIFF
--- a/roles/dnsmasq/templates/dnsmasq-autoscaler.yml.j2
+++ b/roles/dnsmasq/templates/dnsmasq-autoscaler.yml.j2
@@ -37,6 +37,8 @@ spec:
       tolerations:
         - effect: NoSchedule
           operator: Exists
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       containers:
         - name: autoscaler
           image: "{{ dnsmasqautoscaler_image_repo }}:{{ dnsmasqautoscaler_image_tag }}"
@@ -54,5 +56,3 @@ spec:
             - --default-params={"linear":{"nodesPerReplica":{{ dnsmasq_nodes_per_replica }},"preventSinglePointFailure":true}}
             - --logtostderr=true
             - --v={{ kube_log_level }}
-      nodeSelector:
-        beta.kubernetes.io/os: linux

--- a/roles/kubernetes-apps/ansible/templates/dashboard.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dashboard.yml.j2
@@ -143,6 +143,8 @@ spec:
 {% if kube_version is version('v1.11.1', '>=') %}
       priorityClassName: system-cluster-critical
 {% endif %}
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       containers:
       - name: kubernetes-dashboard
         image: {{ dashboard_image_repo }}:{{ dashboard_image_tag }}

--- a/roles/kubernetes-apps/ansible/templates/netchecker-server-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-server-deployment.yml.j2
@@ -14,6 +14,8 @@ spec:
 {% if kube_version is version('v1.11.1', '>=') %}
       priorityClassName: {% if netcheck_namespace == 'kube-system' %}system-cluster-critical{% else %}k8s-cluster-critical{% endif %}{{''}}
 {% endif %}
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       containers:
         - name: netchecker-server
           image: "{{ netcheck_server_image_repo }}:{{ netcheck_server_image_tag }}"

--- a/roles/kubernetes-apps/container_engine_accelerator/nvidia_gpu/templates/k8s-device-plugin-nvidia-daemonset.yml.j2
+++ b/roles/kubernetes-apps/container_engine_accelerator/nvidia_gpu/templates/k8s-device-plugin-nvidia-daemonset.yml.j2
@@ -28,6 +28,8 @@ spec:
         effect: "NoExecute"
       - operator: "Exists"
         effect: "NoSchedule"
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       hostNetwork: true
       hostPID: true
       volumes:

--- a/roles/kubernetes-apps/container_engine_accelerator/nvidia_gpu/templates/nvidia-driver-install-daemonset.yml.j2
+++ b/roles/kubernetes-apps/container_engine_accelerator/nvidia_gpu/templates/nvidia-driver-install-daemonset.yml.j2
@@ -35,6 +35,8 @@ spec:
       - key: "nvidia.com/gpu"
         effect: "NoSchedule"
         operator: "Exists"
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       hostNetwork: true
       hostPID: true
       volumes:

--- a/roles/kubernetes-apps/external_provisioner/cephfs_provisioner/templates/deploy-cephfs-provisioner.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/cephfs_provisioner/templates/deploy-cephfs-provisioner.yml.j2
@@ -23,6 +23,8 @@ spec:
       priorityClassName: {% if cephfs_provisioner_namespace == 'kube-system' %}system-cluster-critical{% else %}k8s-cluster-critical{% endif %}{{''}}
 {% endif %}
       serviceAccount: cephfs-provisioner
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       containers:
         - name: cephfs-provisioner
           image: {{ cephfs_provisioner_image_repo }}:{{ cephfs_provisioner_image_tag }}

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-ds.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-ds.yml.j2
@@ -25,6 +25,8 @@ spec:
       tolerations:
         - effect: NoSchedule
           operator: Exists
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       containers:
         - name: provisioner
           image: {{ local_volume_provisioner_image_repo }}:{{ local_volume_provisioner_image_tag }}

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/deploy-cert-manager.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/deploy-cert-manager.yml.j2
@@ -26,6 +26,8 @@ spec:
       priorityClassName: {% if cert_manager_namespace == 'kube-system' %}system-cluster-critical{% else %}k8s-cluster-critical{% endif %}{{''}}
 {% endif %}
       serviceAccountName: cert-manager
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       containers:
         - name: cert-manager
           image: {{ cert_manager_controller_image_repo }}:{{ cert_manager_controller_image_tag }}

--- a/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
@@ -27,6 +27,8 @@ spec:
       priorityClassName: system-cluster-critical
 {% endif %}
       serviceAccountName: metrics-server
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       containers:
       - name: metrics-server
         image: {{ metrics_server_image_repo }}:{{ metrics_server_image_tag }}

--- a/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-controllers.yml.j2
+++ b/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-controllers.yml.j2
@@ -30,6 +30,8 @@ spec:
 {% if kube_version is version('v1.11.1', '>=') %}
       priorityClassName: system-cluster-critical
 {% endif %}
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       containers:
         - name: calico-kube-controllers
           image: {{ calico_policy_image_repo }}:{{ calico_policy_image_tag }}

--- a/roles/kubernetes-apps/registry/templates/registry-proxy-ds.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-proxy-ds.yml.j2
@@ -25,6 +25,8 @@ spec:
       priorityClassName: {% if registry_namespace == 'kube-system' %}system-node-critical{% else %}k8s-cluster-critical{% endif %}{{''}}
 {% endif %}
       serviceAccountName: registry-proxy
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       containers:
         - name: registry-proxy
           image: {{ registry_proxy_image_repo }}:{{ registry_proxy_image_tag }}

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -35,6 +35,8 @@ spec:
         # Mark pod as critical for rescheduling (Will have no effect starting with kubernetes 1.12)
         - key: CriticalAddonsOnly
           operator: "Exists"
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0

--- a/roles/network_plugin/canal/templates/canal-node.yaml.j2
+++ b/roles/network_plugin/canal/templates/canal-node.yaml.j2
@@ -25,6 +25,8 @@ spec:
         # Mark pod as critical for rescheduling (Will have no effect starting with kubernetes 1.12)
         - key: CriticalAddonsOnly
           operator: "Exists"
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       volumes:
         # Used by calico/node.
         - name: lib-modules

--- a/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
@@ -30,6 +30,8 @@ spec:
       priorityClassName: system-node-critical
 {% endif %}
       serviceAccountName: cilium
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       initContainers:
         - name: clean-cilium-state
           image: docker.io/library/busybox:1.28.4

--- a/roles/network_plugin/kube-router/templates/kube-router.yml.j2
+++ b/roles/network_plugin/kube-router/templates/kube-router.yml.j2
@@ -65,6 +65,8 @@ spec:
       priorityClassName: system-cluster-critical
 {% endif %}
       serviceAccountName: kube-router
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       containers:
       - name: kube-router
         image: {{ kube_router_image_repo }}:{{ kube_router_image_tag }}

--- a/roles/network_plugin/multus/templates/multus-daemonset.yml.j2
+++ b/roles/network_plugin/multus/templates/multus-daemonset.yml.j2
@@ -17,6 +17,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/arch: amd64
+        beta.kubernetes.io/os: linux
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/roles/network_plugin/weave/templates/weave-net.yml.j2
+++ b/roles/network_plugin/weave/templates/weave-net.yml.j2
@@ -118,6 +118,8 @@ items:
 {% if kube_version is version('v1.11.1', '>=') %}
           priorityClassName: system-node-critical
 {% endif %}
+          nodeSelector:
+            beta.kubernetes.io/os: linux
           containers:
             - name: weave
               command:


### PR DESCRIPTION
Adding linux node selectors to Deployments and DaemonSet manifests so Linux pods are not scheduled on Windows nodes for those that are running hybrid clusters 