### PR TITLE
Metrics server resizer addon needs to target metrics server deployment

### DIFF
--- a/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
@@ -2,7 +2,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: metrics-server
+  name: metrics-server-{{ metrics_server_version }}
   namespace: kube-system
   labels:
     app.kubernetes.io/name: metrics-server

--- a/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
@@ -2,7 +2,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: metrics-server-{{ metrics_server_version }}
+  name: metrics-server
   namespace: kube-system
   labels:
     app.kubernetes.io/name: metrics-server
@@ -103,7 +103,7 @@ spec:
           - --memory={{ metrics_server_memory }}
           - --extra-memory={{ metrics_server_memory_per_node }}
           - --threshold=5
-          - --deployment=metrics-server-{{ metrics_server_version }}
+          - --deployment=metrics-server
           - --container=metrics-server
           - --poll-period=300000
           - --estimator=exponential


### PR DESCRIPTION
The metrics server resizer does not correctly target the metrics server deployment.   The deployment name should match the deployment specified in the resizer in [line 106](https://github.com/kubernetes-sigs/kubespray/blob/master/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2#L106)
