### PR TITLE
Grammar fixes for CRI-O documentation

### DIFF
--- a/docs/cri-o.md
+++ b/docs/cri-o.md
@@ -1,28 +1,28 @@
-cri-o
+CRI-O
 ===============
 
-cri-o is container developed by kubernetes project.
-Currently, only basic function is supported for cri-o.
+[CRI-O] is a lightweight container runtime for Kubernetes.
+Kubespray supports basic functionality for using CRI-O as the default container runtime in a cluster.
 
-* cri-o is supported kubernetes 1.11.1 or later.
-* helm and other feature may not be supported due to docker dependency.
-* scale.yml and upgrade-cluster.yml are not supported.
+* Kubernetes supports CRI-O on v1.11.1 or later.
+* Helm and other tools may not function as normal due to dependency on Docker.
+* `scale.yml` and `upgrade-cluster.yml` are not supported on clusters using CRI-O.
 
-helm and other feature may not be supported due to docker dependency.
-
-Use cri-o instead of docker, set following variable:
+_To use CRI-O instead of Docker, set the following variables:_
 
 #### all.yml
 
-```
+```yaml
 download_container: false
 skip_downloads: false
 ```
 
 #### k8s-cluster.yml
 
-```
+```yaml
 etcd_deployment_type: host
 kubelet_deployment_type: host
 container_manager: crio
 ```
+
+[CRI-O]: https://cri-o.io/


### PR DESCRIPTION
fixes #3877

Edited the [CRI-O documentation](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/cri-o.md) for basic English grammar and added some markdown formatting.
Capitalization now conforms to what is used in the CRI-O repository.