### PR TITLE
Use recommended defaults for dns autoscale

### DIFF
--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -4,8 +4,8 @@ dns_memory_limit: 170Mi
 dns_cpu_requests: 100m
 dns_memory_requests: 70Mi
 dns_min_replicas: 2
-dns_nodes_per_replica: 10
-dns_cores_per_replica: 20
+dns_nodes_per_replica: 16
+dns_cores_per_replica: 256
 dns_prevent_single_point_failure: "{{ 'true' if dns_min_replicas|int > 1 else 'false' }}"
 
 # Netchecker


### PR DESCRIPTION
Use recommended defaults for `dns_nodes_per_replica` and `dns_cores_per_replica`.  See [here[(https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml#L101) for recommended defaults. 

This has caused issues with not all coreDNS pods being schedulable.  See https://github.com/kubernetes-sigs/kubespray/issues/3880 and https://github.com/kubernetes-sigs/kubespray/issues/3876