### PR TITLE
controlPlaneEndpoint set up through load balancer should be possible …

### DIFF
--- a/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1alpha1.j2
+++ b/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1alpha1.j2
@@ -3,7 +3,7 @@ kind: NodeConfiguration
 caCertPath: {{ kube_cert_dir }}/ca.crt
 token: {{ kubeadm_token }}
 discoveryTokenAPIServers:
-{% if groups['kube-master'] | length > 1 and kubeadm_config_api_fqdn is defined %}
+{% if kubeadm_config_api_fqdn is defined %}
 - {{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
 {% else %}
 - {{ kubeadm_discovery_address | replace("https://", "")}}

--- a/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1alpha2.j2
+++ b/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1alpha2.j2
@@ -8,7 +8,7 @@ discoveryToken: {{ kubeadm_token }}
 tlsBootstrapToken: {{ kubeadm_token }}
 token: {{ kubeadm_token }}
 discoveryTokenAPIServers:
-{% if groups['kube-master'] | length > 1 and kubeadm_config_api_fqdn is defined %}
+{% if kubeadm_config_api_fqdn is defined %}
 - {{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
 {% else %}
 - {{ kubeadm_discovery_address | replace("https://", "")}}

--- a/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1alpha3.j2
+++ b/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1alpha3.j2
@@ -8,7 +8,7 @@ discoveryToken: {{ kubeadm_token }}
 tlsBootstrapToken: {{ kubeadm_token }}
 token: {{ kubeadm_token }}
 discoveryTokenAPIServers:
-{% if groups['kube-master'] | length > 1 and kubeadm_config_api_fqdn is defined %}
+{% if kubeadm_config_api_fqdn is defined %}
 - {{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
 {% else %}
 - {{ kubeadm_discovery_address | replace("https://", "")}}

--- a/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1beta1.j2
+++ b/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1beta1.j2
@@ -2,7 +2,7 @@ apiVersion: kubeadm.k8s.io/v1beta1
 kind: JoinConfiguration
 discovery:
   bootstrapToken:
-{% if groups['kube-master'] | length > 1 and kubeadm_config_api_fqdn is defined %}
+{% if kubeadm_config_api_fqdn is defined %}
     apiServerEndpoint: {{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
 {% else %}
     apiServerEndpoint: {{ kubeadm_discovery_address | replace("https://", "")}}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: kubeadm.k8s.io/v1alpha1
 kind: MasterConfiguration
 api:
-{% if groups['kube-master'] | length >= 1 and kubeadm_config_api_fqdn is defined %}
+{% if kubeadm_config_api_fqdn is defined %}
   controlPlaneEndpoint: {{ kubeadm_config_api_fqdn }}
   bindPort: {{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
 {% else %}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: kubeadm.k8s.io/v1alpha1
 kind: MasterConfiguration
 api:
-{% if groups['kube-master'] | length > 1 and kubeadm_config_api_fqdn is defined %}
+{% if groups['kube-master'] | length >= 1 and kubeadm_config_api_fqdn is defined %}
   controlPlaneEndpoint: {{ kubeadm_config_api_fqdn }}
   bindPort: {{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
 {% else %}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: kubeadm.k8s.io/v1alpha2
 kind: MasterConfiguration
 api:
-{% if groups['kube-master'] | length > 1 and kubeadm_config_api_fqdn is defined %}
+{% if groups['kube-master'] | length >= 1 and kubeadm_config_api_fqdn is defined %}
   controlPlaneEndpoint: {{ kubeadm_config_api_fqdn }}
   bindPort: {{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
 {% else %}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: kubeadm.k8s.io/v1alpha2
 kind: MasterConfiguration
 api:
-{% if groups['kube-master'] | length >= 1 and kubeadm_config_api_fqdn is defined %}
+{% if kubeadm_config_api_fqdn is defined %}
   controlPlaneEndpoint: {{ kubeadm_config_api_fqdn }}
   bindPort: {{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
 {% else %}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
@@ -37,7 +37,7 @@ networking:
   serviceSubnet: {{ kube_service_addresses }}
   podSubnet: {{ kube_pods_subnet }}
 kubernetesVersion: {{ kube_version }}
-{% if groups['kube-master'] | length > 1 and kubeadm_config_api_fqdn is defined %}
+{% if groups['kube-master'] | length >= 1 and kubeadm_config_api_fqdn is defined %}
 controlPlaneEndpoint: {{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
 {% else %}
 controlPlaneEndpoint: {{ ip | default(ansible_default_ipv4.address) }}:{{ kube_apiserver_port }}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
@@ -37,7 +37,7 @@ networking:
   serviceSubnet: {{ kube_service_addresses }}
   podSubnet: {{ kube_pods_subnet }}
 kubernetesVersion: {{ kube_version }}
-{% if groups['kube-master'] | length >= 1 and kubeadm_config_api_fqdn is defined %}
+{% if kubeadm_config_api_fqdn is defined %}
 controlPlaneEndpoint: {{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
 {% else %}
 controlPlaneEndpoint: {{ ip | default(ansible_default_ipv4.address) }}:{{ kube_apiserver_port }}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
@@ -38,7 +38,7 @@ networking:
   serviceSubnet: {{ kube_service_addresses }}
   podSubnet: {{ kube_pods_subnet }}
 kubernetesVersion: {{ kube_version }}
-{% if groups['kube-master'] | length > 1 and kubeadm_config_api_fqdn is defined %}
+{% if groups['kube-master'] | length >= 1 and kubeadm_config_api_fqdn is defined %}
 controlPlaneEndpoint: {{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
 {% else %}
 controlPlaneEndpoint: {{ ip | default(ansible_default_ipv4.address) }}:{{ kube_apiserver_port }}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
@@ -38,7 +38,7 @@ networking:
   serviceSubnet: {{ kube_service_addresses }}
   podSubnet: {{ kube_pods_subnet }}
 kubernetesVersion: {{ kube_version }}
-{% if groups['kube-master'] | length >= 1 and kubeadm_config_api_fqdn is defined %}
+{% if and kubeadm_config_api_fqdn is defined %}
 controlPlaneEndpoint: {{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
 {% else %}
 controlPlaneEndpoint: {{ ip | default(ansible_default_ipv4.address) }}:{{ kube_apiserver_port }}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
@@ -38,7 +38,7 @@ networking:
   serviceSubnet: {{ kube_service_addresses }}
   podSubnet: {{ kube_pods_subnet }}
 kubernetesVersion: {{ kube_version }}
-{% if and kubeadm_config_api_fqdn is defined %}
+{% if kubeadm_config_api_fqdn is defined %}
 controlPlaneEndpoint: {{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
 {% else %}
 controlPlaneEndpoint: {{ ip | default(ansible_default_ipv4.address) }}:{{ kube_apiserver_port }}


### PR DESCRIPTION
… even in single master setups

Enable load balancer for single-master setups
Fixes an issue where single-master setups are not reachable using the usual admin.conf from outside the cluster. 