### PR TITLE
Tell Git to ignore the inventory/mycluster directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 .vagrant
 *.retry
 **/vagrant_ansible_inventory
-inventory/credentials/
-inventory/group_vars/fake_hosts.yml
-inventory/host_vars/
 temp
 .idea
 .tox
@@ -17,6 +14,12 @@ contrib/terraform/aws/credentials.tfvars
 *~
 vagrant/
 
+# Ansible inventory
+inventory/*
+!inventory/local
+!inventory/sample
+inventory/*/artifacts/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -24,7 +27,6 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-inventory/*/artifacts/
 env/
 build/
 credentials/


### PR DESCRIPTION
The inventory/mycluster directory gets created when someone follows
the instructions in README.md, but it should never be committed to
the kubespray repo. Ignore it.