### PR TITLE
Documented docker_version acceptable values

### DIFF
--- a/docs/vars.md
+++ b/docs/vars.md
@@ -17,7 +17,8 @@ Some variables of note include:
 * *calico_version* - Specify version of Calico to use
 * *calico_cni_version* - Specify version of Calico CNI plugin to use
 * *docker_version* - Specify version of Docker to used (should be quoted
-  string)
+  string). Must match one of the keys defined for *docker_versioned_pkg*
+  in `roles/container-engine/docker/vars/*.yml`.
 * *etcd_version* - Specify version of ETCD to use
 * *ipip* - Enables Calico ipip encapsulation by default
 * *kube_network_plugin* - Sets k8s network plugin (default Calico)


### PR DESCRIPTION
Added a line documenting where to find acceptable values for the
`docker_version` setting. If you use a value that is not used as
a key value by `docker_versioned_pkg` the container-engine/docker
playbook will throw a "Unexpected templating type error". (e.g.
If you use '18.06.1' or '18.06.1-ce', neither of which is used
as a key value of `docker_versioned_pkg`, rather than '18.06',
you'll get an error when installing on Ubuntu 18.04.)