### PR TITLE
Install the latest filesystem creation packages

### DIFF
--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -15,6 +15,8 @@ common_required_pkgs:
   - bash-completion
   - socat
   - unzip
+  - e2fsprogs
+  - xfsprogs
 
 # Set to true if your network does not support IPv6
 # This maybe necessary for pulling Docker images from


### PR DESCRIPTION
This PR ensures that the e2fsprogs and xfsprogs packages are installed on all Kubernetes nodes and that the packages are the latest versions. It also ensures that the nodes can create XFS filesystems when necessary, since not all distros install xfsprogs by default.

- e2fsprogs - ext2/ext3/ext4 file system utilities
- xfsprogs - Utilities for managing the XFS filesystem