### PR TITLE
set kubespray-defaults kube_api_anonymous_auth to true

### DIFF
--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -3,7 +3,7 @@
 # This change obseletes editing ansible.cfg file depending on bastion existance
 ansible_ssh_common_args: "{% if 'bastion' in groups['all'] %} -o ProxyCommand='ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -W %h:%p {{ hostvars['bastion']['ansible_user'] }}@{{ hostvars['bastion']['ansible_host'] }} {% if ansible_ssh_private_key_file is defined %}-i {{ ansible_ssh_private_key_file }}{% endif %} ' {% endif %}"
 
-kube_api_anonymous_auth: false
+kube_api_anonymous_auth: true
 
 # Default value, but will be set to true automatically if detected
 is_atomic: false


### PR DESCRIPTION
This is set to true already in group_vars/k8s-cluster.yml but not in kubespray-defaults/defaults/main.yaml