### PR TITLE
Fix azure_subscription_id check task title

### DIFF
--- a/roles/kubernetes/node/tasks/cloud-credentials/azure-credential-check.yml
+++ b/roles/kubernetes/node/tasks/cloud-credentials/azure-credential-check.yml
@@ -4,7 +4,7 @@
     msg: "azure_tenant_id is missing"
   when: azure_tenant_id is not defined or not azure_tenant_id
 
-- name: check openstack_username value
+- name: check azure_subscription_id value
   fail:
     msg: "azure_subscription_id is missing"
   when: azure_subscription_id is not defined or not azure_subscription_id


### PR DESCRIPTION
Task 'check openstack_username value' is wrongly named