### PR TITLE
fix assertions, use msg instead of message

### DIFF
--- a/contrib/network-storage/heketi/roles/provision/tasks/secret.yml
+++ b/contrib/network-storage/heketi/roles/provision/tasks/secret.yml
@@ -8,7 +8,9 @@
 - register: "clusterrolebinding_state"
   command: "{{bin_dir}}/kubectl get clusterrolebinding heketi-gluster-admin -o=name --ignore-not-found=true"
   changed_when: false
-- assert: { that: "clusterrolebinding_state.stdout != \"\"", message: "Cluster role binding is not present." }
+- assert:
+    that: "clusterrolebinding_state.stdout != \"\""
+    msg: "Cluster role binding is not present."
 
 - register: "secret_state"
   command: "{{bin_dir}}/kubectl get secret heketi-config-secret -o=name --ignore-not-found=true"
@@ -24,4 +26,6 @@
 - register: "secret_state"
   command: "{{bin_dir}}/kubectl get secret heketi-config-secret -o=name --ignore-not-found=true"
   changed_when: false
-- assert: { that: "secret_state.stdout != \"\"", message: "Heketi config secret is not present." }
+- assert:
+    that: "secret_state.stdout != \"\""
+    msg: "Heketi config secret is not present."


### PR DESCRIPTION
Hi,
in `contrib/network-storage/heketi/roles/provision/tasks/secret.yml` `message` is used instead of `msg`, that's causing ansible (3.7.1) to error.
Greetings, Sascha