### PR TITLE
Fix docker_options definition when docker_version is 'latest' rather …

### DIFF
--- a/inventory/sample/group_vars/all/docker.yml
+++ b/inventory/sample/group_vars/all/docker.yml
@@ -57,7 +57,7 @@ docker_options: >-
   {% if docker_registry_mirrors is defined %}
   {{ docker_registry_mirrors | map('regex_replace', '^(.*)$', '--registry-mirror=\1' ) | list | join(' ') }}
   {%- endif %}
-  {%- if docker_version is version('17.05', '<') %}
+  {%- if docker_version != "latest" and docker_version is version('17.05', '<') %}
   --graph={{ docker_daemon_graph }} {{ docker_log_opts }}
   {%- else %}
   --data-root={{ docker_daemon_graph }} {{ docker_log_opts }}

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -216,7 +216,7 @@ docker_options: >-
   {% if docker_registry_mirrors is defined %}
   {{ docker_registry_mirrors | map('regex_replace', '^(.*)$', '--registry-mirror=\1' ) | list | join(' ') }}
   {%- endif %}
-  {%- if docker_version is version('17.05', '<') %}
+  {%- if docker_version != "latest" and docker_version is version('17.05', '<') %}
   --graph={{ docker_daemon_graph }} {{ docker_log_opts }}
   {%- else %}
   --data-root={{ docker_daemon_graph }} {{ docker_log_opts }}


### PR DESCRIPTION
…than a number

- NOTE: it assumes that the 'latest' version is newer than 17.05

Related to #3918 