### PR TITLE
Update CoreDNS label as specified in the Coredns repository

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
@@ -5,7 +5,7 @@ metadata:
   name: "coredns{{ coredns_ordinal_suffix }}"
   namespace: kube-system
   labels:
-    k8s-app: "coredns{{ coredns_ordinal_suffix }}"
+    k8s-app: "kube-dns{{ coredns_ordinal_suffix }}"
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/name: "coredns{{ coredns_ordinal_suffix }}"
@@ -17,11 +17,11 @@ spec:
       maxSurge: 10%
   selector:
     matchLabels:
-      k8s-app: coredns{{ coredns_ordinal_suffix }}
+      k8s-app: kube-dns{{ coredns_ordinal_suffix }}
   template:
     metadata:
       labels:
-        k8s-app: coredns{{ coredns_ordinal_suffix }}
+        k8s-app: kube-dns{{ coredns_ordinal_suffix }}
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
@@ -40,7 +40,7 @@ spec:
           - topologyKey: "kubernetes.io/hostname"
             labelSelector:
               matchLabels:
-                k8s-app: coredns{{ coredns_ordinal_suffix }}
+                k8s-app: kube-dns{{ coredns_ordinal_suffix }}
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100

--- a/roles/kubernetes-apps/ansible/templates/coredns-svc.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-svc.yml.j2
@@ -5,17 +5,16 @@ metadata:
   name: coredns{{ coredns_ordinal_suffix }}
   namespace: kube-system
   labels:
-    k8s-app: coredns{{ coredns_ordinal_suffix }}
+    k8s-app: kube-dns{{ coredns_ordinal_suffix }}
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "coredns{{ coredns_ordinal_suffix }}"
     addonmanager.kubernetes.io/mode: Reconcile
   annotations:
-    prometheus.io/path: /metrics
     prometheus.io/port: "9153"
     prometheus.io/scrape: "true"
 spec:
   selector:
-    k8s-app: coredns{{ coredns_ordinal_suffix }}
+    k8s-app: kube-dns{{ coredns_ordinal_suffix }}
   clusterIP: {{ clusterIP }}
   ports:
     - name: dns


### PR DESCRIPTION
This PR updates the label in the kubespray Deployment and Service for CoreDNS to the current label as specified in https://github.com/coredns/deployment/blob/master/kubernetes/coredns.yaml.sed. This change in label is important for monitoring of CoreDNS as the serviceMonitor in [kube-prometheus](https://github.com/coreos/prometheus-operator/tree/master/contrib/kube-prometheus) uses the updated label for selecting the service that exposes coreDNS metrics. This PR hence removes the need to manually update the label every time kube-prometheus is deployed.