### PR TITLE
preinstall: Fix distro check while verifying settings

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -21,7 +21,7 @@
 
 - name: Stop if unknown OS
   assert:
-    that: ansible_os_family in ['RedHat', 'CentOS', 'Fedora', 'Ubuntu', 'Debian', 'CoreOS', 'Container Linux by CoreOS', 'openSUSE Leap', 'openSUSE Tumbleweed', 'ClearLinux']
+    that: ansible_os_family in ['RedHat', 'Debian', 'CoreOS', 'Suse', 'ClearLinux']
   ignore_errors: "{{ ignore_assert_errors }}"
 
 - name: Stop if unknown network plugin


### PR DESCRIPTION
PR 3855 replaced ansible_distribution with ansible_os_family which
is not correct. [1] This PR fixes that by rolling back the change
done in 0020-verify-settings.yml playbook.

[1] https://github.com/kubernetes-sigs/kubespray/pull/3855/files#diff-6b7131cc37b80a00fced4ea1cba65782