### PR TITLE
change kube_proxy_mode as iptables because kube-proxy ipvs mode hangs

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -95,7 +95,8 @@ kube_apiserver_insecure_port: 0 # (disabled)
 
 # Kube-proxy proxyMode configuration.
 # Can be ipvs, iptables
-kube_proxy_mode: ipvs
+# Change to ipvs after fix https://github.com/kubernetes/kubernetes/issues/71071
+kube_proxy_mode: iptables
 
 # Kube-proxy nodeport address.
 # cidr to bind nodeport services. Flag --nodeport-addresses on kube-proxy manifest


### PR DESCRIPTION
Change kube_proxy_mode as iptables because kube-proxy ipvs mode hangs
https://github.com/kubernetes/kubernetes/issues/71071

After fix https://github.com/kubernetes/kubernetes/issues/71071 need change to ipvs

With "kube_proxy_mode: ipvs"  - https://github.com/kubernetes-sigs/kubespray/issues/3865
With "kube_proxy_mode: iptables" now as well.