### PR TITLE
Fix tolerations for metrics-server and nginx-ingress

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s-cluster/addons.yml
@@ -52,9 +52,9 @@ ingress_nginx_enabled: false
 # ingress_nginx_nodeselector:
 #   node-role.kubernetes.io/master: ""
 # ingress_nginx_tolerations:
-#   - key: "key"
+#   - key: "node-role.kubernetes.io/master"
 #     operator: "Equal"
-#     value: "value"
+#     value: ""
 #     effect: "NoSchedule"
 # ingress_nginx_namespace: "ingress-nginx"
 # ingress_nginx_insecure_port: 80

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
@@ -9,9 +9,8 @@ nodeRegistration:
 {% endif %}
 {% if inventory_hostname in groups['kube-master'] and inventory_hostname not in groups['kube-node'] %}
   taints:
-  - key: "kubeadmNode"
-    value: "master"
-    effect: "NoSchedule"
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
 {% endif %}
 {% if container_manager == 'crio' %}
   criSocket: /var/run/crio/crio.sock


### PR DESCRIPTION
I'm not sure when it happened but recent maser taint key is changed node-role.kubernetes.io/master to  kubeadmNode like this:

    Node                                               Taint
    master1.infra   kubeadmNode=master:NoSchedule
    master2.infra   kubeadmNode=master:NoSchedule
    master3.infra   kubeadmNode=master:NoSchedule


So I fixed metrics-server and ingress-nginx taint.
