### PR TITLE
fix registry_storage_class equals empty string

### DIFF
--- a/roles/kubernetes-apps/registry/tasks/main.yml
+++ b/roles/kubernetes-apps/registry/tasks/main.yml
@@ -59,8 +59,8 @@
     - { name: registry-pvc, file: registry-pvc.yml, type: pvc }
   register: registry_manifests
   when:
-    - registry_storage_class != none
-    - registry_disk_size != none
+    - registry_storage_class != none and registry_storage_class != ""
+    - registry_disk_size != none and registry_disk_size != ""
     - inventory_hostname == groups['kube-master'][0]
 
 - name: Registry | Apply PVC manifests
@@ -73,6 +73,6 @@
     state: "latest"
   with_items: "{{ registry_manifests.results }}"
   when:
-    - registry_storage_class != none
-    - registry_disk_size != none
+    - registry_storage_class != none and registry_storage_class != ""
+    - registry_disk_size != none and registry_disk_size != ""
     - inventory_hostname == groups['kube-master'][0]

--- a/roles/kubernetes-apps/registry/templates/registry-rs.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-rs.yml.j2
@@ -44,7 +44,7 @@ spec:
               protocol: TCP
       volumes:
         - name: registry-pvc
-{% if registry_storage_class != none %}
+{% if registry_storage_class != "" %}
           persistentVolumeClaim:
             claimName: registry-pvc
 {% else %}


### PR DESCRIPTION
Dear,
When registry_storage_class is defined and equals "", {% if registry_storage_class != none %} which defined in roles/kubernetes-apps/registry/templates/registry-rs.yml.j2 is true. It is not logical. So we should change none to "".
Thanks!