### PR TITLE
Add initial Oracle Linux Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Supported Linux Distributions
 -   **Fedora** 28
 -   **Fedora/CentOS** Atomic
 -   **openSUSE** Leap 42.3/Tumbleweed
+-   **Oracle Linux** 7
 
 Note: Upstart/SysV init based OS types are not supported.
 

--- a/roles/bootstrap-os/tasks/bootstrap-oraclelinux.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-oraclelinux.yml
@@ -1,0 +1,21 @@
+---
+- name: Download Oracle Linux public yum repo
+  get_url:
+    url: https://yum.oracle.com/public-yum-ol7.repo
+    dest: /etc/yum.repos.d/public-yum-ol7.repo
+
+- name: Enable Oracle Linux repo
+  ini_file:
+    dest: /etc/yum.repos.d/public-yum-ol7.repo
+    section: "{{ item }}"
+    option: enabled
+    value: "1"
+  with_items:
+    - ol7_latest
+    - ol7_addons
+    - ol7_developer_EPEL
+
+- name: Install packages requirements for bootstrap
+  yum:
+    name: container-selinux
+    state: present

--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -22,6 +22,9 @@
 - include_tasks: bootstrap-fedora.yml
   when: '"Fedora" in os_release.stdout'
 
+- include_tasks: bootstrap-oraclelinux.yml
+  when: '"Oracle Linux" in os_release.stdout'
+
 - include_tasks: bootstrap-opensuse.yml
   when: '"openSUSE" in os_release.stdout'
 

--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -22,7 +22,7 @@
     description: OpenShift Origin Repo
     baseurl: "{{ crio_rhel_repo_base_url }}"
     gpgcheck: no
-  when: ansible_distribution in ["CentOS","RedHat"] and not is_atomic
+  when: ansible_distribution in ["CentOS","RedHat","OracleLinux"] and not is_atomic
 
 - name: Make sure needed folders exist in the system
   with_items:

--- a/roles/container-engine/docker/defaults/main.yml
+++ b/roles/container-engine/docker/defaults/main.yml
@@ -29,7 +29,7 @@ docker_yum_conf: /etc/yum_docker.conf
 # Fedora docker-ce repo
 docker_fedora_repo_base_url: 'https://download.docker.com/linux/fedora/$releasever/$basearch/stable'
 docker_fedora_repo_gpgkey: 'https://download.docker.com/linux/fedora/gpg'
-# CentOS/RedHat docker-ce repo
+# CentOS/RedHat/OracleLinux docker-ce repo
 docker_rh_repo_base_url: 'https://download.docker.com/linux/centos/7/$basearch/stable'
 docker_rh_repo_gpgkey: 'https://download.docker.com/linux/centos/gpg'
 # Ubuntu docker-ce repo

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -103,11 +103,11 @@
     dest: "{{ yum_repo_dir }}/docker.repo"
   when: ansible_distribution == "Fedora" and not is_atomic
 
-- name: Configure docker repository on RedHat/CentOS
+- name: Configure docker repository on RedHat/CentOS/OracleLinux
   template:
     src: "rh_docker.repo.j2"
     dest: "{{ yum_repo_dir }}/docker.repo"
-  when: ansible_distribution in ["CentOS","RedHat"] and not is_atomic
+  when: ansible_distribution in ["CentOS","RedHat","OracleLinux"] and not is_atomic
 
 - name: check if container-selinux is available
   yum:
@@ -135,7 +135,7 @@
     src: "{{ yum_conf }}"
     dest: "{{ docker_yum_conf }}"
     remote_src: yes
-  when: ansible_distribution in ["CentOS","RedHat"] and not is_atomic
+  when: ansible_distribution in ["CentOS","RedHat","OracleLinux"] and not is_atomic
 
 - name: Edit copy of yum.conf to set obsoletes=0
   lineinfile:
@@ -143,7 +143,7 @@
     state: present
     regexp: '^obsoletes='
     line: 'obsoletes=0'
-  when: ansible_distribution in ["CentOS","RedHat"] and not is_atomic
+  when: ansible_distribution in ["CentOS","RedHat","OracleLinux"] and not is_atomic
 
 - name: ensure docker packages are installed
   action: "{{ docker_package_info.pkg_mgr }}"

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -15,7 +15,7 @@
 
 - name: Stop if unknown OS
   assert:
-    that: ansible_os_family in ['RedHat', 'CentOS', 'Fedora', 'Ubuntu', 'Debian', 'CoreOS', 'Container Linux by CoreOS', 'Suse', 'ClearLinux']
+    that: ansible_os_family in ['RedHat', 'CentOS', 'Fedora', 'Ubuntu', 'Debian', 'CoreOS', 'Container Linux by CoreOS', 'Suse', 'ClearLinux', 'OracleLinux']
   ignore_errors: "{{ ignore_assert_errors }}"
 
 - name: Stop if unknown network plugin

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -90,6 +90,6 @@
   when:
     - not dns_late
     - azure_check.stat.exists
-    - ansible_distribution in ["CentOS","RedHat"]
+    - ansible_distribution in ["CentOS","RedHat","OracleLinux"]
   tags:
     - bootstrap-os


### PR DESCRIPTION
Add Oracle Linux Support. There is already a similar pull [request](https://github.com/kubernetes-sigs/kubespray/pull/2968), but there is no any progress since early July so I've decided to create my own. Please review. Happy to get your feedback and ideas for improvements if you have any. Thanks.