### PR TITLE
fix ingress nodeSelector label

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s-cluster/addons.yml
@@ -50,7 +50,7 @@ cephfs_provisioner_enabled: false
 ingress_nginx_enabled: false
 # ingress_nginx_host_network: false
 # ingress_nginx_nodeselector:
-#   node-role.kubernetes.io/master: ""
+#   node-role.kubernetes.io/node: ""
 # ingress_nginx_tolerations:
 #   - key: "key"
 #     operator: "Equal"

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
@@ -2,7 +2,7 @@
 ingress_nginx_namespace: "ingress-nginx"
 ingress_nginx_host_network: false
 ingress_nginx_nodeselector:
-  node-role.kubernetes.io/master: ""
+  node-role.kubernetes.io/node: ""
 ingress_nginx_tolerations: []
 ingress_nginx_insecure_port: 80
 ingress_nginx_secure_port: 443


### PR DESCRIPTION
Dear，
There is a bug about ingress nodeselector labels. We shouldn't use the label (node-role.kubernetes.io/master: ""), because this label will cause the node's role to become master. This will result in scheduling errors or other errors.
Although this is only an example, it can mislead the user's use.
So, we can use the label (node-role.kubernetes.io/node: "") for instead.
