### PR TITLE
remove os_family variable from bootstrap-os

### DIFF
--- a/roles/bootstrap-os/defaults/main.yml
+++ b/roles/bootstrap-os/defaults/main.yml
@@ -1,7 +1,4 @@
 ---
-bootstrap_os:
-os_family: "{{bootstrap_os}}"
-
 pip_python_coreos_modules:
   - httplib2
   - six

--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -5,45 +5,26 @@
   changed_when: false
   environment: {}
 
-- name: Set bootstrap_os
-  set_fact:
-    os_family: >-
-      {%- if 'Ubuntu' in os_release.stdout -%}
-      ubuntu
-      {%- elif 'Debian' in os_release.stdout -%}
-      debian
-      {%- elif 'CoreOS' in os_release.stdout -%}
-      coreos
-      {%- elif 'Fedora' in os_release.stdout -%}
-      fedora
-      {%- elif 'CentOS' in os_release.stdout -%}
-      centos
-      {%- elif 'OpenSUSE' in os_release.stdout -%}
-      opensuse
-      {%- elif 'Clear Linux OS' in os_release.stdout -%}
-      clearlinux
-      {%- endif -%}
-
 - include_tasks: bootstrap-ubuntu.yml
-  when: os_family == "ubuntu"
+  when: "Ubuntu" in os_release.stdout
 
 - include_tasks: bootstrap-debian.yml
-  when: os_family == "debian"
+  when: "Debian" in os_release.stdout
 
 - include_tasks: bootstrap-coreos.yml
-  when: os_family == "coreos"
+  when: "CoreOS" in os_release.stdout
 
 - include_tasks: bootstrap-fedora.yml
-  when: os_family == "fedora"
+  when: "Fedora" in os_release.stdout
 
 - include_tasks: bootstrap-centos.yml
-  when: os_family == "centos"
+  when: "CentOS" in os_release.stdout
 
 - include_tasks: bootstrap-opensuse.yml
-  when: os_family == "opensuse"
+  when: "OpenSUSE" in os_release.stdout
 
 - include_tasks: bootstrap-clearlinux.yml
-  when: os_family == "clearlinux"
+  when: "Clear Linux OS" in os_release.stdout
 
 - import_tasks: setup-pipelining.yml
 

--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -6,25 +6,25 @@
   environment: {}
 
 - include_tasks: bootstrap-ubuntu.yml
-  when: "Ubuntu" in os_release.stdout
+  when: '"Ubuntu" in os_release.stdout'
 
 - include_tasks: bootstrap-debian.yml
-  when: "Debian" in os_release.stdout
+  when: '"Debian" in os_release.stdout'
 
 - include_tasks: bootstrap-coreos.yml
-  when: "CoreOS" in os_release.stdout
+  when: '"CoreOS" in os_release.stdout'
 
 - include_tasks: bootstrap-fedora.yml
-  when: "Fedora" in os_release.stdout
+  when: '"Fedora" in os_release.stdout'
 
 - include_tasks: bootstrap-centos.yml
-  when: "CentOS" in os_release.stdout
+  when: '"CentOS" in os_release.stdout'
 
 - include_tasks: bootstrap-opensuse.yml
-  when: "OpenSUSE" in os_release.stdout
+  when: '"OpenSUSE" in os_release.stdout'
 
 - include_tasks: bootstrap-clearlinux.yml
-  when: "Clear Linux OS" in os_release.stdout
+  when: '"Clear Linux OS" in os_release.stdout'
 
 - import_tasks: setup-pipelining.yml
 


### PR DESCRIPTION
This variable is only used one single time and only there because not every machine at that point might have python installed yet (so running the setup module is not yet possible safely).

I moved the checks where the value of the variable is being decided down to the place where it was used.

Edit: Also the title of the task setting the variable was actually wrong.