### PR TITLE
Run less CI jobs on each PR

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -364,6 +364,8 @@ gce_centos7-flannel-addons:
   except: ['triggers']
   only: [/^pr-.*$/]
 
+### MANUAL JOBS
+
 gce_centos-weave-kubeadm-sep:
   stage: deploy-part2
   <<: *job
@@ -372,10 +374,7 @@ gce_centos-weave-kubeadm-sep:
     <<: *gce_variables
     <<: *centos_weave_kubeadm_variables
   when: on_success
-  except: ['triggers']
-  only: [/^pr-.*$/]
-
-### MANUAL JOBS
+  only: ['triggers']
 
 gce_ubuntu-weave-sep:
   stage: deploy-part2
@@ -385,8 +384,7 @@ gce_ubuntu-weave-sep:
     <<: *gce_variables
     <<: *ubuntu_weave_sep_variables
   when: manual
-  except: ['triggers']
-  only: [/^pr-.*$/]
+  only: ['triggers']
 
 gce_coreos-calico-sep-triggers:
   stage: deploy-part2


### PR DESCRIPTION
Do not run the `gce_centos-weave-kubeadm-sep` on each PR as it does a 3 node deployment, and after that does a full upgrade run too. No need to do this on each PR and it will save $ on CI jobs.