### PR TITLE
use apiserver_loadbalancer_domain_name without loadbalancer_apiserver

### DIFF
--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -54,7 +54,7 @@
       localhost
       127.0.0.1
       {{ ' '.join(groups['kube-master']) }}
-      {%- if loadbalancer_apiserver is defined %}
+      {%- if apiserver_loadbalancer_domain_name is defined %}
       {{ apiserver_loadbalancer_domain_name }}
       {%- endif %}
       {% for host in groups['kube-master'] -%}


### PR DESCRIPTION
would it possible to change to condition to set apiserver_loadbalancer_domain_name as apiserver_sans, if apiserver_loadbalancer_domain_name was defined?

in my usecase, i want to use kubespray out-of-the box with minimal adjustments, but i want to access the API Service via LB. for that usecase it would be nice if it would be possible to setup apiserver_loadbalancer_domain_name without setting up loadbalancer_apiserver address/port