### PR TITLE
fix deprecated loop around pip module (#3981)

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-coreos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-coreos.yml
@@ -47,9 +47,8 @@
 
 - name: Install required python modules
   pip:
-    name: "{{ item }}"
+    name: "{{ pip_python_coreos_modules }}"
     extra_args: "{{ pip_extra_args | default(omit) }}"
-  with_items: "{{ pip_python_coreos_modules }}"
   environment:
     PATH: "{{ ansible_env.PATH }}:{{ bin_dir }}"
 


### PR DESCRIPTION
Fixes Ansible deprecation warning #3981 