### PR TITLE
[calico/canal] mount host's xtables lock and enable calico locking for <v3.2.1

### DIFF
--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -76,6 +76,12 @@ spec:
               value: "{{ calico_endpoint_to_host_action|default('RETURN') }}"
             - name: FELIX_HEALTHHOST
               value: "{{ calico_healthhost }}"
+            # Prior to v3.2.1 iptables didn't acquire the lock, so Calico's own implementation of the lock should be used,
+            # this is not required in later versions https://github.com/projectcalico/calico/issues/2179
+{% if calico_version is version('v3.2.1', '<') %}
+            - name: FELIX_IPTABLESLOCKTIMEOUTSECS
+              value: "10"
+{% endif %}
 # should be set in etcd before deployment
 #            # Configure the IP Pool from which Pod IPs will be chosen.
 #            - name: CALICO_IPV4POOL_CIDR
@@ -170,6 +176,9 @@ spec:
               readOnly: false
             - mountPath: /calico-secrets
               name: etcd-certs
+            - name: xtables-lock
+              mountPath: /run/xtables.lock
+              readOnly: false
       volumes:
         # Used by calico/node.
         - name: lib-modules
@@ -192,6 +201,11 @@ spec:
         - name: etcd-certs
           hostPath:
             path: "{{ calico_cert_dir }}"
+        # Mount the global iptables lock file, used by calico/node
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate
   updateStrategy:
     rollingUpdate:
       maxUnavailable: {{ serial | default('20%') }}

--- a/roles/network_plugin/canal/templates/canal-node.yaml.j2
+++ b/roles/network_plugin/canal/templates/canal-node.yaml.j2
@@ -173,6 +173,12 @@ spec:
                   fieldPath: spec.nodeName
             - name: FELIX_HEALTHENABLED
               value: "true"
+            # Prior to v3.2.1 iptables didn't acquire the lock, so Calico's own implementation of the lock should be used,
+            # this is not required in later versions https://github.com/projectcalico/calico/issues/2179
+{% if calico_version is version('v3.2.1', '<') %}
+            - name: FELIX_IPTABLESLOCKTIMEOUTSECS
+              value: "10"
+{% endif %}
             # Etcd SSL vars
             - name: ETCD_CA_CERT_FILE
               valueFrom:
@@ -220,6 +226,9 @@ spec:
             - name: "canal-certs"
               mountPath: "{{ canal_cert_dir }}"
               readOnly: true
+            - name: xtables-lock
+              mountPath: /run/xtables.lock
+              readOnly: false
   updateStrategy:
     rollingUpdate:
       maxUnavailable: {{ serial | default('20%') }}


### PR DESCRIPTION
This PR extends @fcgravalos original work in https://github.com/kubernetes-incubator/kubespray/pull/3191 to ensure the `calico-node` container mounts host's `/run/xtables.lock` file as well.

Calico have implemented some changes in how this lock file is used in v3.2.4 (https://docs.projectcalico.org/v3.2/releases/) and v3.3.0 (https://docs.projectcalico.org/v3.3/releases/)

These versions of calico/node launch iptables with `-w` flag to specify the lock wait time (defaults to 10s), prior to these calico versions the behavior depends on the version of the embedded iptables.

It seems that prior to v3.2.1 the calico-node container image comes with iptables v1.6.1 which doesn't handle the lock and calico needs to manage one on its own, hence I included `FELIX_IPTABLESLOCKTIMEOUTSECS=10` env variable only for calico versions <v3.2.1, since these older versions don't create their own lock and calico/node should do it.

versions 3.2.1 --> 3.2.4 (not including) are actually broken in this regard (https://github.com/projectcalico/calico/issues/2179), since they already include iptables v1.6.2 but do not have the `-w` flag implementation so in case iptables is locked it fails hard without waiting for the lock to be released.