### PR TITLE
Misleading task description

### DIFF
--- a/roles/remove-node/pre-remove/tasks/main.yml
+++ b/roles/remove-node/pre-remove/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: remove-node | Drain node except daemonsets resource
+- name: remove-node | Drain node including daemonsets resource
   command: >-
     {{ bin_dir }}/kubectl --kubeconfig /etc/kubernetes/admin.conf drain
       --force


### PR DESCRIPTION
With --ignore-daemonsets flag, it *does* delete Daemonsets ressources. 
See https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#drain