### PR TITLE
use api server loadbalancer ip if external loadbalancer is used (fixes kube-router deployment)

### DIFF
--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -387,16 +387,14 @@ loadbalancer_apiserver_localhost: "{{ loadbalancer_apiserver is not defined }}"
 # applied if only external loadbalancer_apiserver is defined, otherwise ignored
 apiserver_loadbalancer_domain_name: "lb-apiserver.kubernetes.local"
 kube_apiserver_endpoint: |-
-  {% if not is_kube_master and loadbalancer_apiserver_localhost -%}
+  {% if loadbalancer_apiserver is defined and loadbalancer_apiserver.port is defined -%}
+       https://{{ apiserver_loadbalancer_domain_name|default('lb-apiserver.kubernetes.local') }}:{{ loadbalancer_apiserver.port|default(kube_apiserver_port) }}
+  {%- elif not is_kube_master and loadbalancer_apiserver_localhost -%}
        https://localhost:{{ nginx_kube_apiserver_port|default(kube_apiserver_port) }}
   {%- elif is_kube_master -%}
        https://{{ kube_apiserver_bind_address | regex_replace('0\.0\.0\.0','127.0.0.1') }}:{{ kube_apiserver_port }}
   {%- else -%}
-  {%-   if loadbalancer_apiserver is defined and loadbalancer_apiserver.port is defined -%}
-       https://{{ apiserver_loadbalancer_domain_name|default('lb-apiserver.kubernetes.local') }}:{{ loadbalancer_apiserver.port|default(kube_apiserver_port) }}
-  {%-   else -%}
        https://{{ first_kube_master }}:{{ kube_apiserver_port }}
-  {%-  endif -%}
   {%- endif %}
 kube_apiserver_insecure_endpoint: >-
   http://{{ kube_apiserver_insecure_bind_address | regex_replace('0\.0\.0\.0','127.0.0.1') }}:{{ kube_apiserver_insecure_port }}


### PR DESCRIPTION
this fixes the broken kube-router deployment
the problem has a very good and detailed description in:
https://github.com/kubernetes-sigs/kubespray/issues/3586

tl;dr of the problem:
kube-router generates the file: "/var/lib/kube-router/kubeconfig" from the configmap kube-router-cfg in the kube-system namespace
the problem here arises, because the configmap is created from the master node.
Therefore the ```server: {{ kube_apiserver_endpoint }}``` will have the value 127.0.0.1 instead of the load balancer dns entry, which breaks kube-router on all non-master nodes.

I also verified that changing this order will not break any of the other usages of the variable