### PR TITLE
Default values for variable dns_servers and dns_domain  are set twice

### DIFF
--- a/roles/container-engine/defaults/main.yml
+++ b/roles/container-engine/defaults/main.yml
@@ -1,6 +1,0 @@
----
-## DNS
-dns_domain: cluster.local
-dns_servers: []
-upstream_dns_servers: []
-searchdomains: []

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -59,7 +59,7 @@ dns_mode: coredns
 enable_nodelocaldns: False
 
 # Should be set to a cluster IP if using a custom cluster DNS
-# manual_dns_server: 10.x.x.x
+manual_dns_server: ""
 
 # Can be docker_dns, host_resolvconf or none
 resolvconf_mode: docker_dns


### PR DESCRIPTION
Default values for variable `dns_servers` and `dns_domain`  are set twice in files:

values from inventory in roles/kubespray-defaults/defaults/main.yml
hardcoded values in roles/container-engine/defaults/main.yml

`dns_servers` set empty in roles/container-engine/defaults/main.yml, then
skydns_server not set in docker_dns_servers variables and no cluster dns in "DOCKER_DNS_OPTIONS=--dns"
`dns_domain` harcoded to cluster.local

also set default value for `manual_dns_servers`

another variables in roles/container-engine/defaults not need to set