### PR TITLE
Bugfixes for Local Volume Provisioner

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s-cluster/addons.yml
@@ -21,17 +21,17 @@ metrics_server_enabled: false
 local_volume_provisioner_enabled: false
 # local_volume_provisioner_namespace: kube-system
 # local_volume_provisioner_storage_classes:
-#   - local-storage:
-#       host_dir: /mnt/disks
-#       mount_dir: /mnt/disks
-#   - fast-disks:
-#       host_dir: /mnt/fast-disks
-#       mount_dir: /mnt/fast-disks
-#       block_cleaner_command:
-#          - "/scripts/shred.sh"
-#          - "2"
-#       volume_mode: Filesystem
-#       fs_type: ext4
+#   local-storage:
+#     host_dir: /mnt/disks
+#     mount_dir: /mnt/disks
+#   fast-disks:
+#     host_dir: /mnt/fast-disks
+#     mount_dir: /mnt/fast-disks
+#     block_cleaner_command:
+#       - "/scripts/shred.sh"
+#       - "2"
+#     volume_mode: Filesystem
+#     fs_type: ext4
 
 # CephFS provisioner deployment
 cephfs_provisioner_enabled: false

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/README.md
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/README.md
@@ -5,26 +5,26 @@ The [local storage provisioner](https://github.com/kubernetes-incubator/external
 is NOT a dynamic storage provisioner as you would
 expect from a cloud provider. Instead, it simply creates PersistentVolumes for
 all mounts under the host_dir of the specified storage class.
-These storage classes are specified in the `local_volume_provisioner_storage_classes` list.
-An example this list:
+These storage classes are specified in the `local_volume_provisioner_storage_classes` nested dictionary.
+Example:
 
 ```yaml
 local_volume_provisioner_storage_classes:
-  - local-storage:
-      host_dir: /mnt/disks
-      mount_dir: /mnt/disks
-  - fast-disks:
-      host_dir: /mnt/fast-disks
-      mount_dir: /mnt/fast-disks
-      block_cleaner_command:
-         - "/scripts/shred.sh"
-         - "2"
-      volume_mode: Filesystem
-      fs_type: ext4
+  local-storage:
+    host_dir: /mnt/disks
+    mount_dir: /mnt/disks
+  fast-disks:
+    host_dir: /mnt/fast-disks
+    mount_dir: /mnt/fast-disks
+    block_cleaner_command:
+       - "/scripts/shred.sh"
+       - "2"
+    volume_mode: Filesystem
+    fs_type: ext4
 ```
 
-For each dictionary in `local_volume_provisioner_storage_classes` a storageClass with the
-same name is created. The keys of this dictionary are converted to camelCase and added
+For each key in `local_volume_provisioner_storage_classes` a storageClass with the
+same name is created. The subkeys of each storage class are converted to camelCase and added
 as attributes to the storageClass.
 The result of the above example is:
 
@@ -32,16 +32,16 @@ The result of the above example is:
 data:
   storageClassMap: |
     local-storage:
-       hostDir: /mnt/disks
-       mountDir: /mnt/disks
+      hostDir: /mnt/disks
+      mountDir: /mnt/disks
     fast-disks:
-       hostDir: /mnt/fast-disks
-       mountDir:  /mnt/fast-disks
-       blockCleanerCommand:
-         - "/scripts/shred.sh"
-         - "2"
-       volumeMode: Filesystem
-       fsType: ext4
+      hostDir: /mnt/fast-disks
+      mountDir:  /mnt/fast-disks
+      blockCleanerCommand:
+        - "/scripts/shred.sh"
+        - "2"
+      volumeMode: Filesystem
+      fsType: ext4
 ```
 
 The default StorageClass is local-storage on /mnt/disks,

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/tasks/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/tasks/main.yml
@@ -10,7 +10,6 @@
   with_nested:
     - "{{ groups['k8s-cluster'] }}"
     - "{{ local_volume_provisioner_storage_classes.keys() }}"
-  failed_when: false
 
 - name: Local Volume Provisioner | Create addon dir
   file:

--- a/roles/kubernetes-apps/external_provisioner/meta/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/meta/main.yml
@@ -1,7 +1,9 @@
 ---
 dependencies:
   - role: kubernetes-apps/external_provisioner/local_volume_provisioner
-    when: local_volume_provisioner_enabled
+    when:
+      - local_volume_provisioner_enabled
+      - inventory_hostname == groups['kube-master'][0]
     tags:
       - apps
       - local-volume-provisioner

--- a/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
+++ b/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
@@ -47,14 +47,12 @@
 
 - name: Create local volume provisioner directories
   file:
-    path: "{{ local_volume_provisioner_storage_classes[item.1].host_dir }}"
+    path: "{{ local_volume_provisioner_storage_classes[item].host_dir }}"
     state: directory
     owner: root
     group: root
     mode: 0700
-  with_nested:
-    - "{{ groups['k8s-cluster'] }}"
-    - "{{ local_volume_provisioner_storage_classes.keys() }}"
+  with_items: "{{ local_volume_provisioner_storage_classes.keys() }}"
   when:
     - inventory_hostname in groups['k8s-cluster']
     - local_volume_provisioner_enabled


### PR DESCRIPTION
- Fixed an issue where storage class host directories were looped
through excessive target hosts
- Fixes examples in the LVP `README.md` to use nested dicts instead of a
list of dicts