### PR TITLE
Fix readOnly flag in kubeadm-config.v1beta1.yaml.j2

### DIFF
--- a/roles/kubernetes/master/defaults/main/main.yml
+++ b/roles/kubernetes/master/defaults/main/main.yml
@@ -143,7 +143,7 @@ kube_kubeadm_scheduler_extra_args: {}
 #  - name: name
 #    hostPath: /host/path
 #    mountPath: /mount/path
-#    writable: false
+#    readOnly: true
 apiserver_extra_volumes: {}
 controller_manager_extra_volumes: {}
 scheduler_extra_volumes: {}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
@@ -44,7 +44,7 @@ controlPlaneEndpoint: {{ ip | default(ansible_default_ipv4.address) }}:{{ kube_a
 {% endif %}
 certificatesDir: {{ kube_cert_dir }}
 imageRepository: {{ kube_image_repo }}
-UseHyperKubeImage: false
+useHyperKubeImage: false
 apiServer:
   extraArgs:
     authorization-mode: {{ authorization_modes | join(',') }}
@@ -151,14 +151,14 @@ apiServer:
   - name: {{ audit_log_name }}
     hostPath: {{ audit_log_hostpath }}
     mountPath: {{ audit_log_mountpath }}
-    writable: true
+    readOnly: false
 {% endif %}
 {% endif %}
 {% for volume in apiserver_extra_volumes %}
   - name: {{ volume.name }}
     hostPath: {{ volume.hostPath }}
     mountPath: {{ volume.mountPath }}
-    writable: {{ volume.writable | default(false)}}
+    readOnly: {{ volume.readOnly | d(not volume.writable) }}
 {% endfor %}
 {% endif %}
   certSANs:
@@ -201,7 +201,7 @@ controllerManager:
   - name: {{ volume.name }}
     hostPath: {{ volume.hostPath }}
     mountPath: {{ volume.mountPath }}
-    writable: {{ volume.writable | default(false)}}
+    readOnly: {{ volume.readOnly | d(not volume.writable) }}
 {% endfor %}
 {% endif %}
 scheduler:
@@ -222,7 +222,7 @@ scheduler:
   - name: {{ volume.name }}
     hostPath: {{ volume.hostPath }}
     mountPath: {{ volume.mountPath }}
-    writable: {{ volume.writable | default(false)}}
+    readOnly: {{ volume.readOnly | d(not volume.writable) }}
 {% endfor %}
 {% endif %}
 ---


### PR DESCRIPTION
In v1beta1 of `ClusterConfiguration` the extraVolumes `writable` field was changed to `readOnly` and its boolean value must be negated.

Also, the json field for `useHyperKubeImage` was incorrectly capitalized.