### PR TITLE
Update Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -176,6 +176,7 @@ Vagrant.configure("2") do |config|
       if i == $num_instances
         node.vm.provision "ansible" do |ansible|
           ansible.playbook = $playbook
+          ansible.compatibility_mode = "2.0"
           if File.exist?(File.join( $inventory, "hosts.ini"))
             ansible.inventory_path = $inventory
           end


### PR DESCRIPTION
make Vagrant play nice with Ansible provider...

ansible remote provisioner says `compatibility_mode` must be a valid mode (possible values: 'auto', '1.8', '2.0')

setting to 2.0 works when tested under Ansible 2.6