### PR TITLE
Add update server field in kube-proxy kubeconfig

### DIFF
--- a/inventory/sample/group_vars/all/all.yml
+++ b/inventory/sample/group_vars/all/all.yml
@@ -21,9 +21,9 @@ bin_dir: /usr/local/bin
 ## Internal loadbalancers for apiservers
 #loadbalancer_apiserver_localhost: true
 
-## Local loadbalancer should use this port instead, if defined.
-## Defaults to kube_apiserver_port (6443)
-#nginx_kube_apiserver_port: 8443
+## Local loadbalancer should use this port
+## And must be set port 6443
+nginx_kube_apiserver_port: 6443
 
 ### OTHER OPTIONAL VARIABLES
 ## For some things, kubelet needs to load kernel modules.  For example, dynamic kernel services are needed

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -92,6 +92,33 @@
     - kubeadm_discovery_address != kube_apiserver_endpoint
   notify: restart kubelet
 
+- name: Update server field in kube-proxy kubeconfig
+  shell: >-
+    {{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf get configmap kube-proxy -n kube-system -o yaml
+    | sed 's#server:.*#server:\ {{ kube_apiserver_endpoint }}#g'
+    | {{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf replace -f -
+  delegate_to: "{{groups['kube-master']|first}}"
+  run_once: true
+  when:
+    - kubeadm_config_api_fqdn is not defined
+    - is_kube_master
+    - kubeadm_discovery_address != kube_apiserver_endpoint
+    - not kube_proxy_remove
+  tags:
+    - kube-proxy
+
+- name: Restart all kube-proxy pods to ensure that they load the new configmap
+  shell: "{{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf delete pod -n kube-system -l k8s-app=kube-proxy"
+  delegate_to: "{{groups['kube-master']|first}}"
+  run_once: true
+  when:
+    - kubeadm_config_api_fqdn is not defined
+    - is_kube_master
+    - kubeadm_discovery_address != kube_apiserver_endpoint
+    - not kube_proxy_remove
+  tags:
+    - kube-proxy
+
 # FIXME(mattymo): Reconcile kubelet kubeconfig filename for both deploy modes
 - name: Symlink kubelet kubeconfig for calico/canal
   file:


### PR DESCRIPTION
I know this is a bit hack.
If you use cloud LB, you can use kubeadm's controlPlaneEndpoint to configure kube-proxy's server field.
But for nginx-proxy, it didn't start when kubeadm join.