### PR TITLE
README: Make usage section clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ To deploy the cluster you can use :
     cat inventory/mycluster/group_vars/k8s-cluster/k8s-cluster.yml
 
     # Deploy Kubespray with Ansible Playbook - run the playbook as root
-    # The option `-b` is required, as for example writing SSL keys in /etc/,
+    # The option `--become` is required, as for example writing SSL keys in /etc/,
     # installing packages and interacting with various systemd daemons.
-    # Without -b the playbook will fail to run!
+    # Without --become the playbook will fail to run!
     ansible-playbook -i inventory/mycluster/hosts.yml --become --become-user=root cluster.yml
 
 Note: When Ansible is already installed via system packages on the control machine, other python packages installed via `sudo pip install -r requirements.txt` will go to a different directory tree (e.g. `/usr/local/lib/python2.7/dist-packages` on Ubuntu) from Ansible's (e.g. `/usr/lib/python2.7/dist-packages/ansible` still on Ubuntu).
@@ -145,7 +145,7 @@ Requirements
     should be configured in the target servers. Then the `ansible_become` flag
     or command parameters `--become or -b` should be specified.
 
-Hardware:        
+Hardware:
 These limits are safe guarded by Kubespray. Actual requirements for your workload can differ. For a sizing guide go to the [Building Large Clusters](https://kubernetes.io/docs/setup/cluster-large/#size-of-master-and-master-components) guide.
 
 -   Master


### PR DESCRIPTION
Long option --become was used in the example but in the comment describing it the short option -b was used.
Use same option in description and example to avoid confusion.