### PR TITLE
fix envvars in args

### DIFF
--- a/roles/win_nodes/kubernetes_patch/files/hostnameOverride-patch.json
+++ b/roles/win_nodes/kubernetes_patch/files/hostnameOverride-patch.json
@@ -17,6 +17,6 @@
     {
         "op": "add",
         "path": "/spec/template/spec/containers/0/command/-",
-        "value": "--hostname-override=${NODE_NAME}"
+        "value": "--hostname-override=$(NODE_NAME)"
     }
 ]

--- a/roles/win_nodes/kubernetes_patch/tasks/main.yml
+++ b/roles/win_nodes/kubernetes_patch/tasks/main.yml
@@ -23,7 +23,7 @@
       args:
         chdir: "{{ kubernetes_user_manifests_path }}"
       register: patch_kube_proxy_command
-      when: not current_kube_proxy_command.stdout is search("--hostname-override=${NODE_NAME}")
+      when: not current_kube_proxy_command.stdout is search("--hostname-override=$(NODE_NAME)")
 
     - debug: msg={{ patch_kube_proxy_command.stdout_lines }}
       when: patch_kube_proxy_command is not skipped

--- a/roles/win_nodes/kubernetes_patch/tasks/main.yml
+++ b/roles/win_nodes/kubernetes_patch/tasks/main.yml
@@ -23,7 +23,7 @@
       args:
         chdir: "{{ kubernetes_user_manifests_path }}"
       register: patch_kube_proxy_command
-      when: not current_kube_proxy_command.stdout is search("--hostname-override=$(NODE_NAME)")
+      when: not current_kube_proxy_command.stdout is search("--hostname-override=\$\(NODE_NAME\)")
 
     - debug: msg={{ patch_kube_proxy_command.stdout_lines }}
       when: patch_kube_proxy_command is not skipped


### PR DESCRIPTION
fix env vars substitution error in hostnameOverride-patch.json

https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#use-environment-variables-to-define-arguments

I also want to note that in version 1.13.0, this patch is no longer necessary to apply.
https://github.com/kubernetes/kubernetes/pull/71283/files

https://github.com/kubernetes-sigs/kubespray/issues/4036

