### PR TITLE
Fix local-volume-provisioner configmap template

### DIFF
--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-cm.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-cm.yml.j2
@@ -21,5 +21,5 @@ data:
     {{ class_name }}:
       {{- convert_keys(storage_class) }}
       {{ storage_class | to_nice_yaml(indent=2) | indent(6) }}
-{%- endfor %}
+{% endfor %}
 


### PR DESCRIPTION
Looks like the template is removing the trailing space between storageclass entries, and since CI only has one storage class we never hit this issue.

This change will prevent the yaml from printing on a single line when multiple storage classes are defined.