### PR TITLE
bootstrap: rework role

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-centos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-centos.yml
@@ -1,5 +1,5 @@
 ---
-- name: check if atomic host
+- name: Check if atomic host
   stat:
     path: /run/ostree-booted
   register: ostree
@@ -19,24 +19,25 @@
     regexp: "^enabled=.*"
     line: "enabled=0"
     state: present
+  become: true
   when: fastestmirror.stat.exists
 
 - name: Add proxy to /etc/yum.conf if http_proxy is defined
   lineinfile:
     path: "/etc/yum.conf"
-    line: "proxy={{http_proxy}}"
+    line: "proxy={{ http_proxy }}"
     create: yes
     state: present
+  become: true
   when: http_proxy is defined
 
 - name: Install libselinux-python and yum-utils for bootstrap
   yum:
-    name: "{{ packages }}"
-    state: present
-  vars:
-    packages:
+    name:
       - libselinux-python
       - yum-utils
+    state: present
+  become: true
   when:
     - not is_atomic
 
@@ -51,6 +52,7 @@
   yum:
     name: epel-release
     state: present
+  become: true
   when:
     - epel_enabled
     - not is_atomic
@@ -60,6 +62,7 @@
   yum:
     name: python-pip
     state: present
+  become: true
   when:
     - not is_atomic
     - package_python_pip.results | length != 0

--- a/roles/bootstrap-os/tasks/bootstrap-clearlinux.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-clearlinux.yml
@@ -12,3 +12,4 @@
     enabled: yes
     daemon_reload: yes
     state: started
+  become: true

--- a/roles/bootstrap-os/tasks/bootstrap-coreos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-coreos.yml
@@ -1,5 +1,5 @@
 ---
-- name: Bootstrap | Check if bootstrap is needed
+- name: Check if bootstrap is needed
   raw: stat /opt/bin/.bootstrapped
   register: need_bootstrap
   environment: {}
@@ -14,7 +14,7 @@
   tags:
     - facts
 
-- name: Bootstrap | Run bootstrap.sh
+- name: Run bootstrap.sh
   script: bootstrap.sh
   when: need_bootstrap.rc != 0
 
@@ -23,13 +23,13 @@
   tags:
     - facts
 
-- name: Bootstrap | Install pip3
+- name: Install pip3
   command: "{{ ansible_python_interpreter }} -m ensurepip"
   args:
     creates: "{{ bin_dir }}/pypy3/bin/pip3"
   register: pip_installed
 
-- name: Bootstrap | Install pip3 link
+- name: Install pip3 link
   file:
     src: "{{ bin_dir }}/pypy3/bin/pip3"
     dest: "{{ bin_dir }}/pip3"
@@ -45,7 +45,7 @@
   environment:
     PATH: "{{ ansible_env.PATH }}:{{ bin_dir }}"
 
-- name: Bootstrap | Disable auto-upgrade
+- name: Disable auto-upgrade
   systemd:
     name: locksmithd.service
     masked: true

--- a/roles/bootstrap-os/tasks/bootstrap-debian.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-debian.yml
@@ -4,7 +4,7 @@
   register: need_bootstrap
   failed_when: false
   changed_when: false
-  # This command should also be called in check mode
+  # This command should always run, even in check mode
   check_mode: false
   with_items:
     - python
@@ -18,6 +18,8 @@
   register: need_http_proxy
   failed_when: false
   changed_when: false
+  # This command should always run, even in check mode
+  check_mode: false
   environment: {}
   when:
     - http_proxy is defined
@@ -35,6 +37,8 @@
   register: need_https_proxy
   failed_when: false
   changed_when: false
+  # This command should always run, even in check mode
+  check_mode: false
   environment: {}
   when:
     - https_proxy is defined

--- a/roles/bootstrap-os/tasks/bootstrap-debian.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-debian.yml
@@ -1,11 +1,11 @@
 ---
-#  raw: cat /etc/issue.net | grep '{{ bootstrap_versions }}'
-
-- name: Bootstrap | Check if bootstrap is needed
+- name: Check if bootstrap is needed
   raw: which "{{ item }}"
   register: need_bootstrap
   failed_when: false
   changed_when: false
+  # This command should also be called in check mode
+  check_mode: false
   with_items:
     - python
     - pip
@@ -14,39 +14,44 @@
   tags: facts
 
 - name: Check http::proxy in /etc/apt/apt.conf
-  raw: grep -qsi 'Acquire::http::Proxy' /etc/apt/apt.conf
+  raw: grep -qsi 'Acquire::http::proxy' /etc/apt/apt.conf
   register: need_http_proxy
   failed_when: false
   changed_when: false
   environment: {}
-  tags: facts
-
-- name: Add http_proxy to /etc/apt/apt.conf if http_proxy is defined
-  raw: echo 'Acquire::http::Proxy "{{http_proxy}}";' >> /etc/apt/apt.conf
-  environment: {}
   when:
-    - need_http_proxy.rc != 0
     - http_proxy is defined
 
+- name: Add http_proxy to /etc/apt/apt.conf if http_proxy is defined
+  raw: echo 'Acquire::http::proxy "{{ http_proxy }}";' >> /etc/apt/apt.conf
+  become: true
+  environment: {}
+  when:
+    - http_proxy is defined
+    - need_http_proxy.rc != 0
+
 - name: Check https::proxy in /etc/apt/apt.conf
-  raw: grep -qsi 'Acquire::https::Proxy' /etc/apt/apt.conf
+  raw: grep -qsi 'Acquire::https::proxy' /etc/apt/apt.conf
   register: need_https_proxy
   failed_when: false
   changed_when: false
   environment: {}
-  tags: facts
-
-- name: Add https_proxy to /etc/apt/apt.conf if https_proxy is defined
-  raw: echo 'Acquire::https::proxy "{{https_proxy}}";' >> /etc/apt/apt.conf
-  environment: {}
   when:
-    - need_https_proxy.rc != 0
     - https_proxy is defined
 
-- name: Bootstrap | Install python 2.x, pip, and dbus
+- name: Add https_proxy to /etc/apt/apt.conf if https_proxy is defined
+  raw: echo 'Acquire::https::proxy "{{ https_proxy }}";' >> /etc/apt/apt.conf
+  become: true
+  environment: {}
+  when:
+    - https_proxy is defined
+    - need_https_proxy.rc != 0
+
+- name: Install python, pip, and dbus
   raw:
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y python-minimal python-pip dbus
+  become: true
   environment: {}
   when:
     need_bootstrap.results | map(attribute='rc') | sort | last | bool

--- a/roles/bootstrap-os/tasks/bootstrap-fedora.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-fedora.yml
@@ -1,6 +1,5 @@
 ---
-
-- name: Bootstrap | Check if bootstrap is needed
+- name: Check if bootstrap is needed
   raw: which "{{ item }}"
   register: need_bootstrap
   failed_when: false
@@ -12,6 +11,7 @@
 
 - name: Install python on fedora
   raw: "dnf install --assumeyes --quiet python"
+  become: true
   environment: {}
   when: need_bootstrap.results | map(attribute='rc') | sort | last | bool
 
@@ -19,3 +19,4 @@
   dnf:
     name: libselinux-python
     state: present
+  become: true

--- a/roles/bootstrap-os/tasks/bootstrap-opensuse.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-opensuse.yml
@@ -5,3 +5,4 @@
     state: present
   with_items:
     - python-cryptography
+  become: true

--- a/roles/bootstrap-os/tasks/bootstrap-ubuntu.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-ubuntu.yml
@@ -1,6 +1,4 @@
 ---
-#  raw: cat /etc/issue.net | grep '{{ bootstrap_versions }}'
-
 - name: List ubuntu_packages
   set_fact:
     ubuntu_packages:
@@ -9,36 +7,57 @@
       - python-pip
       - dbus
 
-- name: Bootstrap | Check if bootstrap is needed
-  raw: dpkg -l | cut -d' ' -f3 |grep -e ^{{item}}$
+- name: Check if bootstrap is needed
+  raw: dpkg -l | cut -d' ' -f3 | grep -e ^{{ item }}$
   register: need_bootstrap
   failed_when: false
   changed_when: false
-  with_items: "{{ubuntu_packages}}"
+  # This command should also be called in check mode
+  check_mode: false
+  with_items: "{{ ubuntu_packages }}"
   environment: {}
   tags:
     - facts
 
-- name: Add proxy to /etc/apt/apt.conf if http_proxy is defined
-  lineinfile:
-    path: "/etc/apt/apt.conf"
-    line: 'Acquire::http::proxy "{{http_proxy}}";'
-    create: yes
-    state: present
-  when: http_proxy is defined
+- name: Check http::proxy in /etc/apt/apt.conf
+  raw: grep -qsi 'Acquire::http::proxy' /etc/apt/apt.conf
+  register: need_http_proxy
+  failed_when: false
+  changed_when: false
+  environment: {}
+  when:
+    - http_proxy is defined
 
-- name: Add proxy to /etc/apt/apt.conf if https_proxy is defined
-  lineinfile:
-    path: "/etc/apt/apt.conf"
-    line: 'Acquire::https::proxy "{{https_proxy}}";'
-    create: yes
-    state: present
-  when: https_proxy is defined
+- name: Add http_proxy to /etc/apt/apt.conf if http_proxy is defined
+  raw: echo 'Acquire::http::proxy "{{ http_proxy }}";' >> /etc/apt/apt.conf
+  become: true
+  environment: {}
+  when:
+    - http_proxy is defined
+    - need_http_proxy.rc != 0
 
-- name: Bootstrap | Install python 2.x and pip
+- name: Check https::proxy in /etc/apt/apt.conf
+  raw: grep -qsi 'Acquire::https::proxy' /etc/apt/apt.conf
+  register: need_https_proxy
+  failed_when: false
+  changed_when: false
+  environment: {}
+  when:
+    - https_proxy is defined
+
+- name: Add https_proxy to /etc/apt/apt.conf if https_proxy is defined
+  raw: echo 'Acquire::https::proxy "{{ https_proxy }}";' >> /etc/apt/apt.conf
+  become: true
+  environment: {}
+  when:
+    - https_proxy is defined
+    - need_https_proxy.rc != 0
+
+- name: Install python and pip
   raw:
     apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y {{ubuntu_packages | join(" ")}}
+    DEBIAN_FRONTEND=noninteractive apt-get install -y {{ ubuntu_packages | join(" ") }}
+  become: true
   environment: {}
   when:
     - need_bootstrap.results | map(attribute='rc') | sort | last | bool

--- a/roles/bootstrap-os/tasks/bootstrap-ubuntu.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-ubuntu.yml
@@ -12,7 +12,7 @@
   register: need_bootstrap
   failed_when: false
   changed_when: false
-  # This command should also be called in check mode
+  # This command should always run, even in check mode
   check_mode: false
   with_items: "{{ ubuntu_packages }}"
   environment: {}
@@ -24,6 +24,8 @@
   register: need_http_proxy
   failed_when: false
   changed_when: false
+  # This command should always run, even in check mode
+  check_mode: false
   environment: {}
   when:
     - http_proxy is defined
@@ -41,6 +43,8 @@
   register: need_https_proxy
   failed_when: false
   changed_when: false
+  # This command should always run, even in check mode
+  check_mode: false
   environment: {}
   when:
     - https_proxy is defined

--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -3,6 +3,8 @@
   raw: cat /etc/os-release
   register: os_release
   changed_when: false
+  # This command should also be called in check mode
+  check_mode: false
   environment: {}
 
 - include_tasks: bootstrap-ubuntu.yml
@@ -41,13 +43,13 @@
 
 - name: Assign inventory name to unconfigured hostnames (non-CoreOS and Tumbleweed)
   hostname:
-    name: "{{inventory_hostname}}"
+    name: "{{ inventory_hostname }}"
   when:
     - override_system_hostname
     - ansible_os_family not in ['Suse', 'CoreOS', 'Container Linux by CoreOS', 'ClearLinux']
 
 - name: Assign inventory name to unconfigured hostnames (CoreOS and Tumbleweed only)
-  command: "hostnamectl set-hostname  {{inventory_hostname}}"
+  command: "hostnamectl set-hostname {{ inventory_hostname }}"
   register: hostname_changed
   when:
     - override_system_hostname

--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -3,7 +3,7 @@
   raw: cat /etc/os-release
   register: os_release
   changed_when: false
-  # This command should also be called in check mode
+  # This command should always run, even in check mode
   check_mode: false
   environment: {}
 

--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -28,8 +28,6 @@
 - include_tasks: bootstrap-clearlinux.yml
   when: '"Clear Linux OS" in os_release.stdout'
 
-- import_tasks: setup-pipelining.yml
-
 - name: Create remote_tmp for it is used by another module
   file:
     path: "{{ lookup('config', 'DEFAULT_REMOTE_TMP', on_missing='skip', wantlist=True) | first | default('~/.ansible/tmp') }}"

--- a/roles/bootstrap-os/tasks/setup-pipelining.yml
+++ b/roles/bootstrap-os/tasks/setup-pipelining.yml
@@ -1,8 +1,7 @@
 ---
-# Remove requiretty to make ssh pipelining work
-
-- name: Remove require tty
+- name: Remove requiretty to make ssh pipelining work
   lineinfile:
     regexp: '^\w+\s+requiretty'
     dest: /etc/sudoers
     state: absent
+  become: true

--- a/roles/bootstrap-os/tasks/setup-pipelining.yml
+++ b/roles/bootstrap-os/tasks/setup-pipelining.yml
@@ -1,7 +1,0 @@
----
-- name: Remove requiretty to make ssh pipelining work
-  lineinfile:
-    regexp: '^\w+\s+requiretty'
-    dest: /etc/sudoers
-    state: absent
-  become: true


### PR DESCRIPTION
* support being called from a non-root user
* run some commands in check mode
* unify spelling/task names

Tested with molecule (https://molecule.readthedocs.io) and Vagrant boxes locally on:
- Centos 7
- Centos Atomic Host
- Debian 7
- Debian 8
- Debian 9
- Debian Testing
- Fedora 28
- Fedora 28 Atomic (breaks at the `Install required python packages` task, because the dnf module tries to install `python2-dnf` and fails, might be a problem in Ansible)
- Fedora 29
- Fedora 29 Atomic (breaks at the `Install required python packages` task, because the dnf module tries to install `python2-dnf` and fails, might be a problem in Ansible)
- OpenSUSE 42.3
- OpenSUSE 15.0
- Ubuntu 14.04
- Ubuntu 16.04
- Ubuntu 18.04
- Ubuntu 18.10

Not tested so far (because I messed up something in Vagrant I guess or I haven't found working boxes) on:
- ClearLinuxOS
- CoreOS Alpha
- CoreOS Beta
- CoreOS Stable
- Ubuntu 19.04

If you want to I can add the molecule files too - but since they can't be run in CI they might be more confusing than helpful.

Some things I still want to know before I consider being "done" with this role and moving on to the more substantial ones:

* Which (Python) packages should actually be installed after this role is done? On some systems it installs more than on others for no reason apparent to me.
* Which facts should be set after this role finishes (e.g. CoreOS sets `ansible_python_interpreter`, a directory called `remote_tmp` is being created...)?

In general it would be great to have something I could use to verify the system state against, here are a few tools to do that and the language in which such state would be encoded:
* YAML statements: https://github.com/aelsabbahy/goss
* Python: https://testinfra.readthedocs.io
* Ruby: https://serverspec.org/

A spec would for example verify that binaries for `python` and `pip` are in the system's `PATH`, that some essential packages are installed, the hostname is set to `inventory_hostname`, the folder for `remote_tmp` exists...