### PR TITLE
Fix kubeadm config extra volumes

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
@@ -158,7 +158,7 @@ apiServer:
   - name: {{ volume.name }}
     hostPath: {{ volume.hostPath }}
     mountPath: {{ volume.mountPath }}
-    readOnly: {{ volume.readOnly | d(not volume.writable) }}
+    readOnly: {{ volume.readOnly | d(not (volume.writable | d(false))) }}
 {% endfor %}
 {% endif %}
   certSANs:
@@ -201,7 +201,7 @@ controllerManager:
   - name: {{ volume.name }}
     hostPath: {{ volume.hostPath }}
     mountPath: {{ volume.mountPath }}
-    readOnly: {{ volume.readOnly | d(not volume.writable) }}
+    readOnly: {{ volume.readOnly | d(not (volume.writable | d(false))) }}
 {% endfor %}
 {% endif %}
 scheduler:
@@ -222,7 +222,7 @@ scheduler:
   - name: {{ volume.name }}
     hostPath: {{ volume.hostPath }}
     mountPath: {{ volume.mountPath }}
-    readOnly: {{ volume.readOnly | d(not volume.writable) }}
+    readOnly: {{ volume.readOnly | d(not (volume.writable | d(false))) }}
 {% endfor %}
 {% endif %}
 ---


### PR DESCRIPTION
I found a potential use case where `writable` could be null and therefore not treated like a boolean, so this adds an extra default statement to avoid negating a non-boolean as boolean which would lead to undefined. refs #4020