### PR TITLE
Bump docker 18.09 to the latest patch

### DIFF
--- a/roles/container-engine/docker/vars/debian.yml
+++ b/roles/container-engine/docker/vars/debian.yml
@@ -14,7 +14,7 @@ docker_versioned_pkg:
   '17.12': docker-ce=17.12.1~ce-0~debian
   '18.03': docker-ce=18.03.1~ce-0~debian
   '18.06': docker-ce=18.06.1~ce~3-0~debian
-  '18.09': docker-ce_18.09.0~3-0~debian-{{ ansible_distribution_release|lower }}
+  '18.09': docker-ce_18.09.1~3-0~debian-{{ ansible_distribution_release|lower }}
   'stable': docker-ce=18.06.1~ce~3-0~debian
   'edge': docker-ce=17.12.1~ce-0~debian
 

--- a/roles/container-engine/docker/vars/redhat.yml
+++ b/roles/container-engine/docker/vars/redhat.yml
@@ -15,7 +15,7 @@ docker_versioned_pkg:
   '17.12': docker-ce-17.12.1.ce-1.el7.centos
   '18.03': docker-ce-18.03.1.ce-1.el7.centos
   '18.06': docker-ce-18.06.1.ce-3.el7
-  '18.09': docker-ce-18.09.0-3.el7
+  '18.09': docker-ce-18.09.1-3.el7
   'stable': docker-ce-18.06.1.ce-3.el7
   'edge': docker-ce-17.12.1.ce-1.el7.centos
 

--- a/roles/container-engine/docker/vars/ubuntu-amd64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-amd64.yml
@@ -11,7 +11,7 @@ docker_versioned_pkg:
   '17.09': docker-ce=17.09.0~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
   '17.12': docker-ce=17.12.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
   '18.06': docker-ce=18.06.1~ce~3-0~ubuntu
-  '18.09': docker-ce_18.09.0~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '18.09': docker-ce_18.09.1~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   'stable': docker-ce=18.06.1~ce~3-0~ubuntu
   'edge': docker-ce=18.06.1~ce~3-0~ubuntu
 

--- a/roles/container-engine/docker/vars/ubuntu-arm64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-arm64.yml
@@ -7,7 +7,7 @@ docker_versioned_pkg:
   '17.09': docker-ce=17.09.1~ce-0~ubuntu
   '17.12': docker-ce=17.12.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
   '18.06': docker-ce=18.06.1~ce~3-0~ubuntu
-  '18.09': docker-ce_18.09.0~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '18.09': docker-ce_18.09.1~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   'stable': docker-ce=18.06.1~ce~3-0~ubuntu
   'edge': docker-ce=18.06.1~ce~3-0~ubuntu
 

--- a/roles/container-engine/docker/vars/ubuntu-bionic.yml
+++ b/roles/container-engine/docker/vars/ubuntu-bionic.yml
@@ -7,7 +7,7 @@ docker_versioned_pkg:
   'latest': docker-ce
   '18.03': docker-ce=18.03.1~ce-3-0~ubuntu
   '18.06': docker-ce=18.06.1~ce~3-0~ubuntu
-  '18.09': docker-ce_18.09.0~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '18.09': docker-ce_18.09.1~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   'stable': docker-ce=18.06.1~ce~3-0~ubuntu
   'edge': docker-ce=18.06.1~ce~3-0~ubuntu
 


### PR DESCRIPTION
Docker 18.09.1 is out and it includes some kmem fixes that are quite critical for RHEL distros, details here: https://docs.docker.com/engine/release-notes/#18091