### PR TITLE
Add Setting Multi into group_vars

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -73,6 +73,9 @@ kube_users:
 # Can also be set to 'cloud', which lets the cloud provider setup appropriate routing
 kube_network_plugin: calico
 
+# Setting multi_networking to true will install Multus: https://github.com/intel/multus-cni
+kube_network_plugin_multus: false
+
 # Kubernetes internal network for services, unused block of space.
 kube_service_addresses: 10.233.0.0/18
 


### PR DESCRIPTION
I found there is a setting for Multus in Vagrantfile.
However, when I use the group vars from `inventory/sample`, I can't find the Multus setting.
So, I want to improve this part.
Hope this can help people to use it.

Thank you very much.