### PR TITLE
Update helm version for security and stablity fixes

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -210,7 +210,7 @@ test_image_repo: busybox
 test_image_tag: latest
 busybox_image_repo: busybox
 busybox_image_tag: 1.29.2
-helm_version: "v2.11.0"
+helm_version: "v2.12.2"
 helm_image_repo: "lachlanevenson/k8s-helm"
 helm_image_tag: "{{ helm_version }}"
 tiller_image_repo: "gcr.io/kubernetes-helm/tiller"


### PR DESCRIPTION
Helm v2.12.2 has fixes for a security vuln, and there have been several improvements since our last update.