### PR TITLE
Use external LB IP for external api endpoint

### DIFF
--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -3,7 +3,7 @@
   set_fact:
     external_apiserver_address: >-
       {%- if loadbalancer_apiserver is defined and loadbalancer_apiserver.port is defined -%}
-      {{ apiserver_loadbalancer_domain_name }}
+      {{ loadbalancer_apiserver.address }}
       {%- else -%}
       {{ kube_apiserver_access_address }}
       {%- endif -%}


### PR DESCRIPTION
Use loadbalancer_apiserver.address instead of apiserver_loadbalancer_domain_name for kudadm init --apiserver-advertise-address argument

https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#options states apiserver-advertise-address needs to be a IPv4 or IPv6 address