### PR TITLE
Move local_release_dir to /opt/releases by default

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -26,7 +26,7 @@ kube_image_repo: "gcr.io/google-containers"
 
 # Where the binaries will be downloaded.
 # Note: ensure that you've enough disk space (about 1G)
-local_release_dir: "/tmp/releases"
+local_release_dir: "/opt/releases"
 # Random shifts for retrying failed ops like pushing/downloading
 retry_stagger: 5
 

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-local_release_dir: /tmp/releases
+local_release_dir: /opt/releases
 
 # Used to only evaluate vars from download role
 skip_downloads: false

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -40,7 +40,7 @@ docker_bin_dir: /usr/bin
 etcd_data_dir: /var/lib/etcd
 # Where the binaries will be downloaded.
 # Note: ensure that you've enough disk space (about 1G)
-local_release_dir: "/tmp/releases"
+local_release_dir: "/opt/releases"
 # Random shifts for retrying failed ops like pushing/downloading
 retry_stagger: 5
 


### PR DESCRIPTION
 Move `local_release_dir` to /opt/releases by default

The reason behind this is that `/tmp` can be mounted as noexec
(I think that's the default on Centos 7).

```
tmpfs   /tmp    tmpfs   defaults,noexec,nosuid,nodev    0 0
```

This prevents any binaries to be run in `/tmp`. Currently some `kubeadm`
commands are run in `local_release_dir`:

```
- name: container_download | download images for kubeadm config images
command: "{{ local_release_dir }}/kubeadm config images pull --config={{ kube_config_dir }}/kubeadm-images.yaml"
```

This task fails on Centos 7 if `local_release_dir` points to `/tmp/releases`.