### PR TITLE
fix(vagrant): forces flannel interface as eth1

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -165,6 +165,7 @@ Vagrant.configure("2") do |config|
 
       host_vars[vm_name] = {
         "ip": ip,
+        "flannel_interface": "eth1",
         "kube_network_plugin": $network_plugin,
         "kube_network_plugin_multus": $multi_networking,
         "docker_keepcache": "1",


### PR DESCRIPTION
Without this pods cannot communicate with each other by default (broken
networking)

Closes #2114