### PR TITLE
Remove docker-storage-setup dependency if not needed

### DIFF
--- a/roles/container-engine/docker/templates/docker.service.j2
+++ b/roles/container-engine/docker/templates/docker.service.j2
@@ -2,8 +2,8 @@
 Description=Docker Application Container Engine
 Documentation=http://docs.docker.com
 {% if ansible_os_family == "RedHat" %}
-After=network.target docker-storage-setup.service{{ ' containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') else '' }}
-Wants=docker-storage-setup.service
+After=network.target {{ ' docker-storage-setup.service' if docker_container_storage_setup else '' }}{{ ' containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') else '' }}
+{{ 'Wants=docker-storage-setup.service' if docker_container_storage_setup else '' }}
 {% elif ansible_os_family == "Debian" %}
 After=network.target docker.socket{{ ' containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') else '' }}
 Wants=docker.socket


### PR DESCRIPTION
When `docker_container_storage_setup` is set to false, docker service should not depend on docker-storage-setup service because it's not getting installed.

For example, when using `overlay2` storage driver on recent RHEL 7/Centos 7 kernels, you most likely don't need it.