### PR TITLE
create artifacts_dir

### DIFF
--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -30,6 +30,16 @@
     mode: "0600"
     backup: yes
 
+- name: Create kube artifacts dir
+  file:
+    path: "{{ artifacts_dir }}"
+    mode: "0750"
+    state: directory
+  delegate_to: localhost
+  become: no
+  run_once: yes
+  when: kubeconfig_localhost|default(false)
+
 - name: Generate admin kubeconfig with external api endpoint
   shell: >-
     {{ bin_dir }}/kubeadm alpha


### PR DESCRIPTION
PR https://github.com/kubernetes-sigs/kubespray/pull/4056 change fetch to copy
but artifacts_dir not create and playbook failed

```
TASK [kubernetes/client : Write admin kubeconfig on ansible host] *****************************************************************************************************
Monday 21 January 2019  20:48:13 +0300 (0:00:01.280)       0:12:26.736 ********
fatal: [master-1.s02.slurm.io -> localhost]: FAILED! => {"changed": false, "checksum": "f09aa007b3efad3450427f98f36a98c5006055a1", "msg": "Destination directory /srv/kubespray/inventory/s02/artifacts does not exist"}
```

