### PR TITLE
enable kubelet client certificate rotation

### DIFF
--- a/docs/vars.md
+++ b/docs/vars.md
@@ -116,6 +116,8 @@ Stack](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/dns-stack.m
 * *kubelet_cgroup_driver* - Allows manual override of the
   cgroup-driver option for Kubelet. By default autodetection is used
   to match Docker configuration.
+* *kubelet_rotate_certificates* - Auto rotate the kubelet client certificates by requesting new certificates 
+  from the kube-apiserver when the certificate expiration approaches.
 * *node_labels* - Labels applied to nodes via kubelet --node-labels parameter.
   For example, labels can be set in the inventory as variables or more widely in group_vars.
   *node_labels* must be defined as a dict:

--- a/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
@@ -28,7 +28,9 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {% endif %}
 --enforce-node-allocatable={{ kubelet_enforce_node_allocatable }} \
 --client-ca-file={{ kube_cert_dir }}/ca.crt \
---rotate-certificates=true \
+{% if kubelet_rotate_certificates %}
+--rotate-certificates \
+{% endif %}
 --pod-manifest-path={{ kube_manifest_dir }} \
 {% if kube_version is version('v1.12.0', '<') %}
 --cadvisor-port={{ kube_cadvisor_port }} \

--- a/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
@@ -28,6 +28,7 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {% endif %}
 --enforce-node-allocatable={{ kubelet_enforce_node_allocatable }} \
 --client-ca-file={{ kube_cert_dir }}/ca.crt \
+--rotate-certificates=true \
 --pod-manifest-path={{ kube_manifest_dir }} \
 {% if kube_version is version('v1.12.0', '<') %}
 --cadvisor-port={{ kube_cadvisor_port }} \

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -299,6 +299,10 @@ kubelet_authentication_token_webhook: true
 # When enabled, access to the kubelet API requires authorization by delegation to the API server
 kubelet_authorization_mode_webhook: false
 
+# kubelet uses certificates for authenticating to the Kubernetes API
+# Automatically generate a new key and request a new certificate from the Kubernetes API as the current certificate approaches expiration
+kubelet_rotate_certificates: true
+
 ## v1.11 feature
 feature_gate_v1_11:
   - "PersistentLocalVolumes={{ local_volume_provisioner_enabled | string }}"


### PR DESCRIPTION
kubeadm generate certificate only on 1 year, and we need to renew it

kubeadm enable kubelet certificate rotation by default
https://github.com/kubernetes/kubernetes/pull/52196

but kubespray generate own kubelet.env file with config parameters without enabled certificate rotations

so add --rotate-certificates to kubelet config