### PR TITLE
Allow to spawn bastion with no fip and in another network

### DIFF
--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -2,10 +2,6 @@ locals {
   effective_bastion_network_name = "${var.bastion_network_name == "" ? var.network_name : var.bastion_network_name}"
 }
 
-data "openstack_networking_network_v2" "bastion_network" {
-  name = "${local.effective_bastion_network_name}"
-}
-
 module "network" {
   source = "modules/network"
 
@@ -68,7 +64,7 @@ module "compute" {
   supplementary_node_groups                    = "${var.supplementary_node_groups}"
   worker_allowed_ports                         = "${var.worker_allowed_ports}"
   bastion_network_name                         = "${local.effective_bastion_network_name}"
-  bastion_network_id                           = "${data.openstack_networking_network_v2.bastion_network.id}"
+  bastion_network_id                           = "${module.network.bastion_network_id}"
 
   network_id = "${module.network.router_id}"
 }

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -1,12 +1,23 @@
+locals {
+  effective_bastion_network_name = "${var.bastion_network_name == "" ? var.network_name : var.bastion_network_name}"
+}
+
+data "openstack_networking_network_v2" "bastion_network" {
+  name = "${local.effective_bastion_network_name}"
+}
+
 module "network" {
   source = "modules/network"
 
-  external_net    = "${var.external_net}"
-  network_name    = "${var.network_name}"
-  subnet_cidr     = "${var.subnet_cidr}"
-  cluster_name    = "${var.cluster_name}"
-  dns_nameservers = "${var.dns_nameservers}"
-  use_neutron     = "${var.use_neutron}"
+  external_net                = "${var.external_net}"
+  network_name                = "${var.network_name}"
+  subnet_cidr                 = "${var.subnet_cidr}"
+  cluster_name                = "${var.cluster_name}"
+  dns_nameservers             = "${var.dns_nameservers}"
+  use_neutron                 = "${var.use_neutron}"
+  bastion_network_name        = "${local.effective_bastion_network_name}"
+  network_router_extra_routes = "${var.network_router_extra_routes}"
+  bastion_subnet_extra_routes = "${var.bastion_subnet_extra_routes}"
 }
 
 module "ips" {
@@ -34,6 +45,7 @@ module "compute" {
   number_of_k8s_masters_no_floating_ip_no_etcd = "${var.number_of_k8s_masters_no_floating_ip_no_etcd}"
   number_of_k8s_nodes                          = "${var.number_of_k8s_nodes}"
   number_of_bastions                           = "${var.number_of_bastions}"
+  number_of_bastions_no_floating_ip            = "${var.number_of_bastions_no_floating_ip}"
   number_of_k8s_nodes_no_floating_ip           = "${var.number_of_k8s_nodes_no_floating_ip}"
   number_of_gfs_nodes_no_floating_ip           = "${var.number_of_gfs_nodes_no_floating_ip}"
   gfs_volume_size_in_gb                        = "${var.gfs_volume_size_in_gb}"
@@ -55,6 +67,8 @@ module "compute" {
   supplementary_master_groups                  = "${var.supplementary_master_groups}"
   supplementary_node_groups                    = "${var.supplementary_node_groups}"
   worker_allowed_ports                         = "${var.worker_allowed_ports}"
+  bastion_network_name                         = "${local.effective_bastion_network_name}"
+  bastion_network_id                           = "${data.openstack_networking_network_v2.bastion_network.id}"
 
   network_id = "${module.network.router_id}"
 }

--- a/contrib/terraform/openstack/modules/compute/variables.tf
+++ b/contrib/terraform/openstack/modules/compute/variables.tf
@@ -20,6 +20,8 @@ variable "number_of_k8s_nodes_no_floating_ip" {}
 
 variable "number_of_bastions" {}
 
+variable "number_of_bastions_no_floating_ip" {}
+
 variable "number_of_gfs_nodes_no_floating_ip" {}
 
 variable "gfs_volume_size_in_gb" {}
@@ -76,4 +78,10 @@ variable "supplementary_node_groups" {
 
 variable "worker_allowed_ports" {
   type = "list"
+}
+
+variable "bastion_network_name" {}
+
+variable "bastion_network_id" {
+  default = ""
 }

--- a/contrib/terraform/openstack/modules/network/main.tf
+++ b/contrib/terraform/openstack/modules/network/main.tf
@@ -26,6 +26,25 @@ resource "openstack_networking_router_interface_v2" "k8s" {
   subnet_id = "${openstack_networking_subnet_v2.k8s.id}"
 }
 
+data "openstack_networking_network_v2" "bastion_network" {
+  name = "${var.bastion_network_name}"
+}
+
+data "openstack_networking_subnet_v2" "bastion_ntwk_subnets" {
+  network_id = "${data.openstack_networking_network_v2.bastion_network.id}"
+}
+
+data "openstack_networking_subnet_v2" "k8s_ntwk_subnets" {
+  network_id = "${openstack_networking_network_v2.k8s.id}"
+  depends_on = ["openstack_networking_subnet_v2.k8s"]
+}
+
+resource "openstack_networking_router_interface_v2" "k8s_router_interface_to_bastion" {
+  count     = "${(var.use_neutron && (var.bastion_network_name != var.network_name)) ? 1 : 0}"
+  router_id = "${openstack_networking_router_v2.k8s.id}"
+  subnet_id = "${element(data.openstack_networking_subnet_v2.bastion_ntwk_subnets.*.id, 0)}"
+}
+
 resource "openstack_networking_router_route_v2" "k8s_router_extra_routes" {
   count            = "${(!var.use_neutron) ? 0 : length(keys(var.network_router_extra_routes))}"
   depends_on       = ["openstack_networking_router_interface_v2.k8s"]
@@ -34,27 +53,9 @@ resource "openstack_networking_router_route_v2" "k8s_router_extra_routes" {
   next_hop         = "${lookup(var.network_router_extra_routes, element(keys(var.network_router_extra_routes), count.index))}"
 }
 
-data "openstack_networking_network_v2" "bastion_network" {
-  name = "${var.bastion_network_name}"
-}
-
-data "openstack_networking_subnet_v2" "k8s_ntwk_subnets" {
-  network_id = "${openstack_networking_network_v2.k8s.id}"
-}
-
-data "openstack_networking_subnet_v2" "bastion_ntwk_subnets" {
-  network_id = "${data.openstack_networking_network_v2.bastion_network.id}"
-}
-
-resource "openstack_networking_router_interface_v2" "k8s_router_interface_to_bastion" {
-  count     = "${(var.use_neutron && (var.bastion_network_name != var.network_name)) ? 1 : 0}"
-  router_id = "${openstack_networking_router_v2.k8s.id}"
-  subnet_id = "${element(data.openstack_networking_subnet_v2.k8s_ntwk_subnets.*.id, 0)}"
-}
-
 resource "openstack_networking_subnet_route_v2" "bastion_subnet_extra_routes" {
-  count     = "${length(keys(var.bastion_subnet_extra_routes))}"
-  subnet_id = "${element(data.openstack_networking_subnet_v2.bastion_ntwk_subnets.*.id, 0)}"
+  count            = "${length(keys(var.bastion_subnet_extra_routes))}"
+  subnet_id        = "${element(data.openstack_networking_subnet_v2.bastion_ntwk_subnets.*.id, 0)}"
   destination_cidr = "${element(keys(var.bastion_subnet_extra_routes), count.index)}"
   next_hop         = "${lookup(var.bastion_subnet_extra_routes, element(keys(var.bastion_subnet_extra_routes), count.index))}"
 }

--- a/contrib/terraform/openstack/modules/network/outputs.tf
+++ b/contrib/terraform/openstack/modules/network/outputs.tf
@@ -10,3 +10,7 @@ output "router_internal_port_id" {
 output "subnet_id" {
   value = "${element(concat(openstack_networking_subnet_v2.k8s.*.id, list("")), 0)}"
 }
+
+output "bastion_network_id" {
+  value = "${element(data.openstack_networking_network_v2.bastion_network.*.id, 0)}"
+}

--- a/contrib/terraform/openstack/modules/network/variables.tf
+++ b/contrib/terraform/openstack/modules/network/variables.tf
@@ -2,6 +2,8 @@ variable "external_net" {}
 
 variable "network_name" {}
 
+variable "bastion_network_name" {}
+
 variable "cluster_name" {}
 
 variable "dns_nameservers" {
@@ -11,3 +13,11 @@ variable "dns_nameservers" {
 variable "subnet_cidr" {}
 
 variable "use_neutron" {}
+
+variable "network_router_extra_routes" {
+  type = "map"
+}
+
+variable "bastion_subnet_extra_routes" {
+  type = "map"
+}

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -12,6 +12,10 @@ variable "number_of_bastions" {
   default = 1
 }
 
+variable "number_of_bastions_no_floating_ip" {
+  default = 0
+}
+
 variable "number_of_k8s_masters" {
   default = 2
 }
@@ -155,4 +159,23 @@ variable "worker_allowed_ports" {
       "remote_ip_prefix" = "0.0.0.0/0"
     }
   ]
+}
+
+variable "bastion_network_name" {
+  description = "network name where bastion is expected to be created"
+  default = ""
+}
+
+variable "bastion_subnet_extra_routes" {
+  description = "A map of routes to register near the bastion subnet (key=route, value=nexthop)"
+  type = "map"
+  default = {
+  }
+}
+
+variable "network_router_extra_routes" {
+  description = "A map of routes to register near the kube neutron router (key=route, value=nexthop)"
+  type = "map"
+  default = {
+  }
 }


### PR DESCRIPTION
Aim of the PR is to allow to spawn a bastion in another openstack network:
- We can choose if we want to attach a floating ip to the bastion or not (we can imagine that the target bastion network is a VPC that we can reach from an enterprise network) but for which we do not want public exposure)
- We can inject extra static routing rules on the k8s network
- We can inject routes on the bastion subnet