### PR TITLE
Fix docker 18.09.1 systemd service

### DIFF
--- a/roles/container-engine/docker/templates/docker.service.j2
+++ b/roles/container-engine/docker/templates/docker.service.j2
@@ -2,13 +2,13 @@
 Description=Docker Application Container Engine
 Documentation=http://docs.docker.com
 {% if ansible_os_family == "RedHat" %}
-After=network.target docker-storage-setup.service
+After=network.target docker-storage-setup.service{% if installed_docker_version.stdout is version('18.09.1', '>=') %} containerd.service{% endif %}
 Wants=docker-storage-setup.service
 {% elif ansible_os_family == "Debian" %}
-After=network.target docker.socket
+After=network.target docker.socket{% if installed_docker_version.stdout is version('18.09.1', '>=') %} containerd.service{% endif %}
 Wants=docker.socket
 {% elif ansible_os_family == "Suse" %}
-After=network.target
+After=network.target{% if installed_docker_version.stdout is version('18.09.1', '>=') %} containerd.service{% endif %}
 {% endif %}
 
 [Service]


### PR DESCRIPTION
The `docker-ce` 18.09.1 packaging missed an `After` dependency on containerd in the systemd service.

Upstream PR: https://github.com/docker/docker-ce-packaging/pull/290