### PR TITLE
Fixing the conditional whether or not installing python-pip

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-centos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-centos.yml
@@ -53,7 +53,7 @@
     state: present
   when:
     - not is_atomic
-    - package_python_pip.results | length != 0
+    - package_python_pip.results | length == 0
 
 - name: Install pip for bootstrap
   yum:
@@ -61,4 +61,4 @@
     state: present
   when:
     - not is_atomic
-    - package_python_pip.results | length != 0
+    - package_python_pip.results | length == 0


### PR DESCRIPTION
Currently kubespray installs `epel-release` package and then `python-pip` package from EPEL RPM repository even if `python-pip` is installed in the system

Current code is doing a yum list to check if python-pip is installed and then deciding whether or not to install epel-release and python-pip based on the result of this check, checking if the list returned by yum is different from 0 which means the list is not empty i.e. python-pip is already installed.

The fix changes the conditional to test if the list returns 0 items, meaning python-pip is missing and needs to be installed. I'll create another PR for the offline documentation to add a note about python-pip requirement on the hosts, because epel-release points to fedora repositories on the internet.