### PR TITLE
Fix epel_enabled and RHEL support in bootstrap-os

### DIFF
--- a/roles/bootstrap-os/defaults/main.yml
+++ b/roles/bootstrap-os/defaults/main.yml
@@ -5,3 +5,6 @@ pip_python_coreos_modules:
 
 override_system_hostname: true
 coreos_auto_upgrade: true
+
+# Install epel repo on Centos/RHEL
+epel_enabled: false

--- a/roles/bootstrap-os/tasks/bootstrap-centos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-centos.yml
@@ -52,6 +52,7 @@
     name: epel-release
     state: present
   when:
+    - epel_enabled
     - not is_atomic
     - package_python_pip.results | length != 0
 

--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -18,7 +18,7 @@
   when: '"Fedora" in os_release.stdout'
 
 - include_tasks: bootstrap-centos.yml
-  when: '"CentOS" in os_release.stdout'
+  when: '"CentOS" in os_release.stdout or "Red Hat Enterprise Linux" in os_release.stdout'
 
 - include_tasks: bootstrap-opensuse.yml
   when: '"OpenSUSE" in os_release.stdout'

--- a/roles/container-engine/docker/templates/docker.service.j2
+++ b/roles/container-engine/docker/templates/docker.service.j2
@@ -2,13 +2,13 @@
 Description=Docker Application Container Engine
 Documentation=http://docs.docker.com
 {% if ansible_os_family == "RedHat" %}
-After=network.target docker-storage-setup.service{% if installed_docker_version.stdout is version('18.09.1', '>=') %} containerd.service{% endif %}
+After=network.target docker-storage-setup.service{{ ' containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') else '' }}
 Wants=docker-storage-setup.service
 {% elif ansible_os_family == "Debian" %}
-After=network.target docker.socket{% if installed_docker_version.stdout is version('18.09.1', '>=') %} containerd.service{% endif %}
+After=network.target docker.socket{{ ' containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') else '' }}
 Wants=docker.socket
 {% elif ansible_os_family == "Suse" %}
-After=network.target{% if installed_docker_version.stdout is version('18.09.1', '>=') %} containerd.service{% endif %}
+After=network.target{{ ' containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') else '' }}
 {% endif %}
 
 [Service]

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -44,6 +44,9 @@ local_release_dir: "/tmp/releases"
 # Random shifts for retrying failed ops like pushing/downloading
 retry_stagger: 5
 
+# Install epel repo on Centos/RHEL
+epel_enabled: false
+
 # DNS configuration.
 # Kubernetes cluster name, also will be used as DNS domain
 cluster_name: cluster.local


### PR DESCRIPTION
Looks like `epel_enabled` was not configured for the epel install in `bootstrap-centos.yml`. Also, there were no conditionals that would trigger bootstrap for RHEL.