### PR TITLE
Introduce `calico_upgrade_url` var for Calico upgrade tool.

### DIFF
--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -43,6 +43,7 @@ calico_felix_prometheusprocessmetricsenabled: "true"
 ### check latest version https://github.com/projectcalico/calico-upgrade/releases
 calico_upgrade_enabled: true
 calico_upgrade_version: v1.0.5
+calico_upgrade_url: "https://github.com/projectcalico/calico-upgrade/releases/download/{{ calico_upgrade_version }}/calico-upgrade"
 
 # Set the agent log level. Can be debug, warning, info or fatal
 calico_loglevel: info

--- a/roles/network_plugin/calico/tasks/upgrade.yml
+++ b/roles/network_plugin/calico/tasks/upgrade.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Download calico-upgrade tool (force version)"
   get_url:
-    url: "https://github.com/projectcalico/calico-upgrade/releases/download/{{ calico_upgrade_version }}/calico-upgrade"
+    url: "{{ calico_upgrade_url }}"
     dest: "{{ bin_dir }}/calico-upgrade"
     mode: 0755
     owner: root


### PR DESCRIPTION
So that binary can be sourced from anywhere - not only github.

Fixes #4090