### PR TITLE
Fix 040 check network adv

### DIFF
--- a/tests/testcases/040_check-network-adv.yml
+++ b/tests/testcases/040_check-network-adv.yml
@@ -72,8 +72,8 @@
       when:
         - agents.content != '{}'
 
-    - debug: var=result.content|from_json
-      failed_when: not result is success and not result.content=='{}'
+    - debug: var=result
+      failed_when: not result is success
       run_once: true
       when: not agents.content == '{}'
       delegate_to: "{{groups['kube-master'][0]}}"

--- a/tests/testcases/040_check-network-adv.yml
+++ b/tests/testcases/040_check-network-adv.yml
@@ -65,13 +65,15 @@
       register: result
       retries: 3
       delay: "{{ agent_report_interval }}"
+      until: result.content|length > 0 and
+        result.content[0] == '{'
       no_log: true
       failed_when: false
       when:
         - agents.content != '{}'
 
     - debug: var=result.content|from_json
-      failed_when: not result is success
+      failed_when: not result is success and not result.content=='{}'
       run_once: true
       when: not agents.content == '{}'
       delegate_to: "{{groups['kube-master'][0]}}"


### PR DESCRIPTION
This PR tries to fix the following error
TASK [debug] *******************************************************************
task path: /kargo-ci/kubernetes-sigs-kubespray/tests/testcases/040_check-network-adv.yml:73
Thursday 17 January 2019  09:07:45 +0000 (0:00:00.566)       0:00:03.554 ****** 
fatal: [k8s-43688361-147041562-1]: FAILED! => {"msg": "Unexpected failure during module execution."}