### PR TITLE
Fix random failure in debug: var=result.content|from_json

### DIFF
--- a/tests/files/gce_centos7-calico-ha.yml
+++ b/tests/files/gce_centos7-calico-ha.yml
@@ -1,7 +1,7 @@
 # Instance settings
 cloud_image_family: centos-7
 cloud_region: us-central1-c
-cloud_machine_type: "n1-standard-1"
+cloud_machine_type: "n1-standard-2"
 mode: ha
 
 # Deployment settings

--- a/tests/files/gce_centos7-flannel-addons.yml
+++ b/tests/files/gce_centos7-flannel-addons.yml
@@ -1,7 +1,7 @@
 # Instance settings
 cloud_image_family: centos-7
 cloud_region: us-central1-c
-cloud_machine_type: "n1-standard-1"
+cloud_machine_type: "n1-standard-2"
 mode: ha
 
 # Deployment settings
@@ -12,8 +12,6 @@ etcd_events_cluster_setup: true
 local_volume_provisioner_enabled: true
 etcd_deployment_type: host
 deploy_netchecker: true
-netchecker_agent_cpu_requests: 10m
-netchecker_agent_cpu_limit: 15m
 dns_min_replicas: 1
 cloud_provider: gce
 kube_encrypt_secret_data: true

--- a/tests/files/gce_centos7-flannel-addons.yml
+++ b/tests/files/gce_centos7-flannel-addons.yml
@@ -12,10 +12,12 @@ etcd_events_cluster_setup: true
 local_volume_provisioner_enabled: true
 etcd_deployment_type: host
 deploy_netchecker: true
+netchecker_agent_cpu_requests: 10m
+netchecker_agent_cpu_limit: 15m
 dns_min_replicas: 1
 cloud_provider: gce
 kube_encrypt_secret_data: true
-ingress_nginx_enabled: true
+#ingress_nginx_enabled: true
 cert_manager_enabled: true
 metrics_server_enabled: true
 kube_token_auth: true

--- a/tests/files/gce_centos7-kube-router.yml
+++ b/tests/files/gce_centos7-kube-router.yml
@@ -1,7 +1,7 @@
 # Instance settings
 cloud_image_family: centos-7
 cloud_region: us-central1-c
-cloud_machine_type: "n1-standard-1"
+cloud_machine_type: "n1-standard-2"
 mode: default
 
 # Deployment settings

--- a/tests/testcases/040_check-network-adv.yml
+++ b/tests/testcases/040_check-network-adv.yml
@@ -40,6 +40,19 @@
       until: nca_pod.stdout_lines|length >= groups['kube-node']|intersect(play_hosts)|length * 2
       retries: 3
       delay: 10
+      failed_when: nca_pod.stdout_lines|length < groups['kube-node']|intersect(play_hosts)|length * 2
+
+    - debug:
+        msg: "{{ nca_pod.stdout_lines|length }} lines ? {{ groups['kube-node']|intersect(play_hosts)|length }} * 2 expected"
+      run_once: true
+
+    - command: "{{ bin_dir }}/kubectl -n {{netcheck_namespace}} describe pod -l app={{ item }}"
+      run_once: true
+      delegate_to: "{{groups['kube-master'][0]}}"
+      no_log: false
+      with_items:
+        - netchecker-agent
+        - netchecker-agent-hostnet
 
     - name: Get netchecker agents
       uri: url=http://{{ ansible_default_ipv4.address }}:{{netchecker_port}}/api/v1/agents/ return_content=yes
@@ -65,16 +78,51 @@
       register: result
       retries: 3
       delay: "{{ agent_report_interval }}"
+      until: result.content|length > 0 and
+        result.content[0] == '{'
       no_log: true
       failed_when: false
       when:
         - agents.content != '{}'
 
+    - debug: var=ncs_pod
+      run_once: true
+      when: not result is success
+
+    - command: "{{ bin_dir }}/kubectl -n kube-system logs -l k8s-app=kube-proxy"
+      run_once: true
+      when: not result is success
+      delegate_to: "{{groups['kube-master'][0]}}"
+      no_log: false
+
+    - command: "{{ bin_dir }}/kubectl -n kube-system logs -l k8s-app={{item}} --all-containers"
+      run_once: true
+      when: not result is success
+      delegate_to: "{{groups['kube-master'][0]}}"
+      no_log: false
+      with_items:
+        - kube-router
+        - flannel
+        - contiv-ovs
+        - contiv-netplugin
+        - contiv-netmaster
+        - canal-node
+        - calico-node
+        - cilium
+
     - debug: var=result.content|from_json
       failed_when: not result is success
       run_once: true
-      when: not agents.content == '{}'
-      delegate_to: "{{groups['kube-master'][0]}}"
+      when:
+        - not agents.content == '{}'
+        - result.content[0] == '{'
+
+    - debug: var=result
+      failed_when: not result is success
+      run_once: true
+      when:
+        - not agents.content == '{}'
+        - result.content[0] != '{'
 
     - debug: msg="Cannot get reports from agents, consider as PASSING"
       run_once: true

--- a/tests/testcases/040_check-network-adv.yml
+++ b/tests/testcases/040_check-network-adv.yml
@@ -37,14 +37,10 @@
       run_once: true
       delegate_to: "{{groups['kube-master'][0]}}"
       register: nca_pod
-      until: nca_pod.stdout_lines|length >= groups['kube-node']|intersect(play_hosts)|length * 2
+      until: nca_pod.stdout_lines|length >= groups['k8s-cluster']|intersect(play_hosts)|length * 2
       retries: 3
       delay: 10
-      failed_when: nca_pod.stdout_lines|length < groups['kube-node']|intersect(play_hosts)|length * 2
-
-    - debug:
-        msg: "{{ nca_pod.stdout_lines|length }} lines ? {{ groups['kube-node']|intersect(play_hosts)|length }} * 2 expected"
-      run_once: true
+      failed_when: false
 
     - command: "{{ bin_dir }}/kubectl -n {{netcheck_namespace}} describe pod -l app={{ item }}"
       run_once: true
@@ -53,6 +49,11 @@
       with_items:
         - netchecker-agent
         - netchecker-agent-hostnet
+      when: not nca_pod is success
+
+    - debug: var=nca_pod.stdout_lines
+      failed_when: not nca_pod is success
+      run_once: true
 
     - name: Get netchecker agents
       uri: url=http://{{ ansible_default_ipv4.address }}:{{netchecker_port}}/api/v1/agents/ return_content=yes
@@ -63,7 +64,7 @@
       delay: "{{ agent_report_interval }}"
       until: agents.content|length > 0 and
         agents.content[0] == '{' and
-        agents.content|from_json|length >= groups['kube-node']|intersect(play_hosts)|length * 2
+        agents.content|from_json|length >= groups['k8s-cluster']|intersect(play_hosts)|length * 2
       failed_when: false
       no_log: true
 


### PR DESCRIPTION
This PR aims to fix this error:
`
TASK [debug] *******************************************************************
task path: /kargo-ci/kubernetes-sigs-kubespray/tests/testcases/040_check-network-adv.yml:73
Thursday 17 January 2019  09:07:45 +0000 (0:00:00.566)       0:00:03.554 ****** 
fatal: [k8s-43688361-147041562-1]: FAILED! => {"msg": "Unexpected failure during module execution."}
`