### PR TITLE
Adding link to ../../contrib in README

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -109,6 +109,7 @@ Create an inventory directory for your cluster by copying the existing sample an
 $ cp -LRp contrib/terraform/openstack/sample-inventory inventory/$CLUSTER
 $ cd inventory/$CLUSTER
 $ ln -s ../../contrib/terraform/openstack/hosts
+$ ln -s ../../contrib
 ```
 
 This will be the base for subsequent Terraform commands.


### PR DESCRIPTION
Fixing README by adding the link to ../../contrib
Otherwise I'm getting terraform errors like:

```
5 error(s) occurred:

* module.compute.openstack_compute_instance_v2.k8s_node[1]: Error running command 'sed s/USER/ubuntu/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/172.16.242.66/ > contrib/terraform/group_vars/no-floating.yml': exit status 1. Output: /bin/sh: contrib/terraform/group_vars/no-floating.yml: No such file or directory
sed: can't read contrib/terraform/openstack/ansible_bastion_template.txt: No such file or directory

* module.compute.openstack_compute_instance_v2.k8s_master[2]: Error running command 'sed s/USER/ubuntu/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/172.16.241.11/ > contrib/terraform/group_vars/no-floating.yml': exit status 1. Output: /bin/sh: contrib/terraform/group_vars/no-floating.yml: No such file or directory
sed: can't read contrib/terraform/openstack/ansible_bastion_template.txt: No such file or directory
```