### PR TITLE
Replace etcd_events_access_addresses with etcd_events_access_addresses_semicolon in kubeadm config

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
@@ -69,7 +69,7 @@ apiServerExtraArgs:
   endpoint-reconciler-type: lease
 {% endif %}
 {% if etcd_events_cluster_enabled %}
-  etcd-servers-overrides: "/events#{{ etcd_events_access_addresses }}"
+  etcd-servers-overrides: "/events#{{ etcd_events_access_addresses_semicolon }}"
 {% endif %}
   service-node-port-range: {{ kube_apiserver_node_port_range }}
   kubelet-preferred-address-types: "{{ kubelet_preferred_address_types }}"

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
@@ -54,7 +54,7 @@ apiServerExtraArgs:
   endpoint-reconciler-type: lease
 {% endif %}
 {% if etcd_events_cluster_enabled %}
-  etcd-servers-overrides: "/events#{{ etcd_events_access_addresses }}"
+  etcd-servers-overrides: "/events#{{ etcd_events_access_addresses_semicolon }}"
 {% endif %}
   service-node-port-range: {{ kube_apiserver_node_port_range }}
   kubelet-preferred-address-types: "{{ kubelet_preferred_address_types }}"

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
@@ -71,7 +71,7 @@ apiServerExtraArgs:
   endpoint-reconciler-type: lease
 {% endif %}
 {% if etcd_events_cluster_enabled %}
-  etcd-servers-overrides: "/events#{{ etcd_events_access_addresses }}"
+  etcd-servers-overrides: "/events#{{ etcd_events_access_addresses_semicolon }}"
 {% endif %}
   service-node-port-range: {{ kube_apiserver_node_port_range }}
   kubelet-preferred-address-types: "{{ kubelet_preferred_address_types }}"

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
@@ -68,7 +68,7 @@ apiServer:
     endpoint-reconciler-type: lease
 {% endif %}
 {% if etcd_events_cluster_enabled %}
-    etcd-servers-overrides: "/events#{{ etcd_events_access_addresses }}"
+    etcd-servers-overrides: "/events#{{ etcd_events_access_addresses_semicolon }}"
 {% endif %}
     service-node-port-range: {{ kube_apiserver_node_port_range }}
     kubelet-preferred-address-types: "{{ kubelet_preferred_address_types }}"

--- a/tests/files/gce_centos7-flannel-addons.yml
+++ b/tests/files/gce_centos7-flannel-addons.yml
@@ -8,7 +8,7 @@ mode: ha
 kube_network_plugin: flannel
 helm_enabled: true
 kubernetes_audit: true
-etcd_events_cluster_setup: true
+etcd_events_cluster_enabled: true
 local_volume_provisioner_enabled: true
 etcd_deployment_type: host
 deploy_netchecker: true


### PR DESCRIPTION
Fixes #4071 