### PR TITLE
Set IP env var to autodetect when calico_ip_auto_method is defined

### DIFF
--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -128,6 +128,8 @@ spec:
 {% if calico_ip_auto_method is defined %}
             - name: IP_AUTODETECTION_METHOD
               value: "{{ calico_ip_auto_method }}"
+            - name: IP
+              value: "autodetect"
 {% else %}
             - name: IP
               valueFrom:


### PR DESCRIPTION
Fixes #4084 