### PR TITLE
Support both --address and --bind-address for scheduler and controller manager

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
@@ -129,7 +129,11 @@ controllerManagerExtraArgs:
   node-monitor-period: {{ kube_controller_node_monitor_period }}
   pod-eviction-timeout: {{ kube_controller_pod_eviction_timeout }}
   node-cidr-mask-size: "{{ kube_network_node_prefix }}"
+{% if kube_version is version('v1.14', '<') %}
+  address: {{ kube_controller_manager_bind_address }}
+{% else %}
   bind-address: {{ kube_controller_manager_bind_address }}
+{% endif %}
 {% if kube_feature_gates %}
   feature-gates: {{ kube_feature_gates|join(',') }}
 {% endif %}
@@ -143,7 +147,11 @@ controllerManagerExtraArgs:
   cloud-config: {{ kube_config_dir }}/cloud_config
 {% endif %}
 schedulerExtraArgs:
+{% if kube_version is version('v1.14', '<') %}
+  address: {{ kube_scheduler_bind_address }}
+{% else %}
   bind-address: {{ kube_scheduler_bind_address }}
+{% endif %}
 {% if kube_feature_gates %}
   feature-gates: {{ kube_feature_gates|join(',') }}
 {% endif %}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
@@ -172,7 +172,11 @@ controllerManager:
     node-monitor-period: {{ kube_controller_node_monitor_period }}
     pod-eviction-timeout: {{ kube_controller_pod_eviction_timeout }}
     node-cidr-mask-size: "{{ kube_network_node_prefix }}"
+{% if kube_version is version('v1.14', '<') %}
+    address: {{ kube_controller_manager_bind_address }}
+{% else %}
     bind-address: {{ kube_controller_manager_bind_address }}
+{% endif %}
 {% if kube_feature_gates %}
     feature-gates: {{ kube_feature_gates|join(',') }}
 {% endif %}
@@ -206,7 +210,11 @@ controllerManager:
 {% endif %}
 scheduler:
   extraArgs:
+{% if kube_version is version('v1.14', '<') %}
+    address: {{ kube_scheduler_bind_address }}
+{% else %}
     bind-address: {{ kube_scheduler_bind_address }}
+{% endif %}
 {% if kube_feature_gates %}
     feature-gates: {{ kube_feature_gates|join(',') }}
 {% endif %}


### PR DESCRIPTION
fixes https://github.com/kubernetes-sigs/kubespray/issues/4111

Since the fix to kubeadm is available only in K8s 1.14, we can use the deprecated `--address` flag for releases < 1.14