### PR TITLE
Correctly execute yum module

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0070-system-packages.yml
+++ b/roles/kubernetes/preinstall/tasks/0070-system-packages.yml
@@ -3,6 +3,7 @@
   yum:
     update_cache: yes
     name: '*'
+    state: latest
   register: yum_task_result
   until: yum_task_result is succeeded
   retries: 4


### PR DESCRIPTION
As specified in https://docs.ansible.com/ansible/2.7/modules/yum_module
the 'name' parameter can only be set to "'*'" when the 'state' parameter
is specified as "latest"

Without the "state: latest" option it can happen that ansible freezes: https://github.com/ansible/ansible/issues/51284