### PR TITLE
Fix error when creating local volume provisioner directories with python3

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
+++ b/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
@@ -52,7 +52,7 @@
     owner: root
     group: root
     mode: 0700
-  with_items: "{{ local_volume_provisioner_storage_classes.keys() }}"
+  with_items: "{{ local_volume_provisioner_storage_classes.keys() | list}}"
   when:
     - inventory_hostname in groups['k8s-cluster']
     - local_volume_provisioner_enabled


### PR DESCRIPTION
…hon 2.7

Use `list` filter to get all key names of local_volume_provisioner_storage_classes. When run this task without `list` filter, system will throw error ```has no attribute dict_key['local-storate']```