### PR TITLE
Fixup 4094: Debug agents when nothing is return

### DIFF
--- a/tests/testcases/040_check-network-adv.yml
+++ b/tests/testcases/040_check-network-adv.yml
@@ -71,6 +71,14 @@
     - debug: var=agents.content|from_json
       failed_when: not agents is success and not agents.content=='{}'
       run_once: true
+      when:
+        - agents.content[0] == '{'
+
+    - debug: var=agents
+      failed_when: not agents is success and not agents.content=='{}'
+      run_once: true
+      when:
+        - agents.content[0] != '{'
 
     - name: Check netchecker status
       uri: url=http://{{ ansible_default_ipv4.address }}:{{netchecker_port}}/api/v1/connectivity_check status_code=200 return_content=yes


### PR DESCRIPTION
There is still an issue when the request in "Get netchecker agents" task does not get anything returned (cf. https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/152034352).