### PR TITLE
Use --env-file for calico-rr

### DIFF
--- a/roles/network_plugin/calico/rr/templates/calico-rr.service.j2
+++ b/roles/network_plugin/calico/rr/templates/calico-rr.service.j2
@@ -8,12 +8,7 @@ EnvironmentFile=/etc/calico/calico-rr.env
 ExecStartPre=-{{ docker_bin_dir }}/docker rm -f calico-rr
 ExecStart={{ docker_bin_dir }}/docker run --net=host --privileged \
  --name=calico-rr \
- -e IP=${IP} \
- -e IP6=${IP6} \
- -e ETCD_ENDPOINTS=${ETCD_ENDPOINTS} \
- -e ETCD_CA_CERT_FILE=${ETCD_CA_CERT_FILE} \
- -e ETCD_CERT_FILE=${ETCD_CERT_FILE} \
- -e ETCD_KEY_FILE=${ETCD_KEY_FILE} \
+ --env-file /etc/calico/calico-rr.env \
  -v /var/log/calico-rr:/var/log/calico \
  -v {{ calico_cert_dir }}:{{ calico_cert_dir }}:ro \
  --memory={{ calico_rr_memory_limit|regex_replace('Mi', 'M') }} --cpu-shares={{ calico_rr_cpu_limit|regex_replace('m', '') }} \


### PR DESCRIPTION
It looks like `calico-rr.service.j2` is moving the content of `calico-rr.env` around, maybe we can use `--env-file` instead? 