### PR TITLE
 Fix deprecation warnings

### DIFF
--- a/roles/container-engine/docker/tasks/pre-upgrade.yml
+++ b/roles/container-engine/docker/tasks/pre-upgrade.yml
@@ -9,7 +9,7 @@
     - docker.io
   when:
     - ansible_os_family == 'Debian'
-    - (docker_versioned_pkg[docker_version | string] | search('docker-ce'))
+    - (docker_versioned_pkg[docker_version | string] is search('docker-ce'))
 
 - name: Ensure old versions of Docker are not installed. | RedHat
   package:
@@ -28,5 +28,5 @@
     - docker-engine-selinux.noarch
   when:
     - ansible_os_family == 'RedHat'
-    - (docker_versioned_pkg[docker_version | string] | search('docker-ce'))
+    - (docker_versioned_pkg[docker_version | string] is search('docker-ce'))
     - not is_atomic

--- a/roles/kubernetes/preinstall/tasks/0070-system-packages.yml
+++ b/roles/kubernetes/preinstall/tasks/0070-system-packages.yml
@@ -88,13 +88,12 @@
 - name: Install packages requirements
   action:
     module: "{{ ansible_pkg_mgr }}"
-    name: "{{ item }}"
+    name: "{{ required_pkgs | default([]) | union(common_required_pkgs|default([])) }}"
     state: latest
   register: pkgs_task_result
   until: pkgs_task_result is succeeded
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
-  with_items: "{{required_pkgs | default([]) | union(common_required_pkgs|default([]))}}"
   when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS", "ClearLinux"] or is_atomic)
   tags:
     - bootstrap-os

--- a/tests/testcases/040_check-network-adv.yml
+++ b/tests/testcases/040_check-network-adv.yml
@@ -37,7 +37,7 @@
       run_once: true
       delegate_to: "{{groups['kube-master'][0]}}"
       register: nca_pod
-      until: nca_pod.stdout_lines|length >= groups['k8s-cluster']|intersect(play_hosts)|length * 2
+      until: nca_pod.stdout_lines|length >= groups['k8s-cluster']|intersect(ansible_play_hosts)|length * 2
       retries: 3
       delay: 10
       failed_when: false
@@ -64,7 +64,7 @@
       delay: "{{ agent_report_interval }}"
       until: agents.content|length > 0 and
         agents.content[0] == '{' and
-        agents.content|from_json|length >= groups['k8s-cluster']|intersect(play_hosts)|length * 2
+        agents.content|from_json|length >= groups['k8s-cluster']|intersect(ansible_play_hosts)|length * 2
       failed_when: false
       no_log: true
 


### PR DESCRIPTION
- Use `ansible_play_hosts` instead of `play_hosts`
- Use tests directly instead of as filters
- Pass pkgs list into name parameter of ansible_pkg_mgr module