### PR TITLE
Calico: Ability to define the default IPPool CIDR (instead of kube_pods_subnet)

### DIFF
--- a/docs/calico.md
+++ b/docs/calico.md
@@ -67,6 +67,15 @@ To re-define you need to edit the inventory and add a group variable `calico_net
 calico_network_backend: none
 ```
 
+##### Optional : Define the default pool CIDR
+
+By default, `kube_pods_subnet` is used as the IP range CIDR for the default IP Pool.
+In some cases you may want to add several pools and not have them considered by Kubernetes as external (which means that they must be within or equal to the range defined in `kube_pods_subnet`), it starts with the default IP Pool of which IP range CIDR can by defined in group_vars (k8s-cluster/k8s-net-calico.yml):
+
+```
+calico_pool_cidr: 10.233.64.0/20
+```
+
 ##### Optional : BGP Peering with border routers
 
 In some cases you may want to route the pods subnet and so NAT is not needed on the nodes.
@@ -85,6 +94,12 @@ Peers can be defined using the `peers` variable (see docs/calico_peer_example ex
 In order to define global peers, the `peers` variable can be defined in group_vars with the "scope" attribute of each global peer set to "global".
 In order to define peers on a per node basis, the `peers` variable must be defined in hostvars.
 NB: Ansible's `hash_behaviour` is by default set to "replace", thus defining both global and per node peers would end up with having only per node peers. If having both global and per node peers defined was meant to happen, global peers would have to be defined in hostvars for each host (as well as per node peers)
+
+Since calico 3.4, Calico supports advertising Kubernetes service cluster IPs over BGP, just as it advertises pod IPs.
+This can be enabled by setting the following variable as follow in group_vars (k8s-cluster/k8s-net-calico.yml)
+```
+calico_advertise_cluster_ips: true
+```
 
 ##### Optional : Define global AS number
 

--- a/inventory/sample/group_vars/k8s-cluster/k8s-net-calico.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-net-calico.yml
@@ -11,6 +11,9 @@
 # add default ippool name
 # calico_pool_name: "default-pool"
 
+# add default ippool CIDR (must be inside kube_pods_subnet, defaults to kube_pods_subnet otherwise)
+# calico_pool_cidr: 1.2.3.4/5
+
 # Global as_num (/calico/bgp/v1/global/as_num)
 # global_as_num: "64512"
 

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -75,12 +75,22 @@
 
 - name: Calico | Check if calico network pool has already been configured
   shell: >
-    {{ bin_dir }}/calicoctl get ippool | grep -w "{{ kube_pods_subnet }}" | wc -l
+    {{ bin_dir }}/calicoctl get ippool | grep -w "{{ calico_pool_cidr | default(kube_pods_subnet) }}" | wc -l
   register: calico_conf
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   delegate_to: "{{ groups['kube-master'][0] }}"
   run_once: true
+
+- name: Calico | Ensure that calico_pool_cidr is within kube_pods_subnet when defined
+  assert:
+    that: "[calico_pool_cidr] | ipaddr(kube_pods_subnet) | length == 1"
+    msg: "{{ calico_pool_cidr }} is not within or equal to {{ kube_pods_subnet }}"
+  delegate_to: localhost
+  run_once: true
+  when:
+    - 'calico_conf.stdout == "0"'
+    - calico_pool_cidr is defined
 
 - name: Calico | Configure calico network pool
   shell: >
@@ -91,7 +101,7 @@
           "name": "{{ calico_pool_name }}",
         },
         "spec": {
-          "cidr": "{{ kube_pods_subnet }}",
+          "cidr": "{{ calico_pool_cidr | default(kube_pods_subnet) }}",
           "ipipMode": "{{ ipip_mode }}",
           "natOutgoing": {{ nat_outgoing|default(false) and not peer_with_router|default(false) }} }} " | {{ bin_dir }}/calicoctl create -f -
   run_once: true
@@ -107,7 +117,7 @@
         "spec": {"disabled": false, "ipip": {"enabled": {{ ipip }}, "mode": "{{ ipip_mode|lower }}"},
                  "nat-outgoing": {{ nat_outgoing|default(false) and not peer_with_router|default(false) }}},
         "apiVersion": "v1",
-        "metadata": {"cidr": "{{ kube_pods_subnet }}"}
+        "metadata": {"cidr": "{{ calico_pool_cidr | default(kube_pods_subnet) }}"}
       }' | {{ bin_dir }}/calicoctl apply -f -
   environment:
     NO_DEFAULT_POOLS: true

--- a/roles/network_plugin/calico/templates/cni-calico.conflist.j2
+++ b/roles/network_plugin/calico/templates/cni-calico.conflist.j2
@@ -17,7 +17,7 @@
       "ipam": {
         "type": "calico-ipam",
         "assign_ipv4": "true",
-        "ipv4_pools": ["{{ kube_pods_subnet }}"]
+        "ipv4_pools": ["{{ calico_pool_cidr | default(kube_pods_subnet) }}"]
       },
 {% if enable_network_policy %}
       "policy": {


### PR DESCRIPTION
If `kube_pods_subnet` is the default pool CIDR for calico, any other pool created in calico (i.e. not in that range) will be considered by kubernetes as external.
`calico_pool_cidr` enables having a smaller subnet (inside `kube_pods_subnet`) with the abilty to define other ippools (inside `kube_pods_subnet` as well)