### PR TITLE
Fixup 4125: Debug agents when requests time out

### DIFF
--- a/tests/testcases/040_check-network-adv.yml
+++ b/tests/testcases/040_check-network-adv.yml
@@ -72,13 +72,9 @@
       failed_when: not agents is success and not agents.content=='{}'
       run_once: true
       when:
+        - agents.content is defined
+        - agents.content != ''
         - agents.content[0] == '{'
-
-    - debug: var=agents
-      failed_when: not agents is success and not agents.content=='{}'
-      run_once: true
-      when:
-        - agents.content[0] != '{'
 
     - name: Check netchecker status
       uri: url=http://{{ ansible_default_ipv4.address }}:{{netchecker_port}}/api/v1/connectivity_check status_code=200 return_content=yes
@@ -124,6 +120,7 @@
       run_once: true
       when:
         - not agents.content == '{}'
+        - result.content != ''
         - result.content[0] == '{'
 
     - debug: var=result
@@ -131,7 +128,6 @@
       run_once: true
       when:
         - not agents.content == '{}'
-        - result.content[0] != '{'
 
     - debug: msg="Cannot get reports from agents, consider as PASSING"
       run_once: true


### PR DESCRIPTION
There is still an issue when the request in "Get netchecker agents" task does not get anything returned (cf. https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/152190150)