### PR TITLE
setting --volume-plugin-dir properly when using kubeadm

### DIFF
--- a/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
@@ -128,4 +128,8 @@ KUBELET_CLOUDPROVIDER="--cloud-provider=external --cloud-config={{ kube_config_d
 KUBELET_CLOUDPROVIDER=""
 {% endif %}
 
+{% if kubelet_flexvolumes_plugins_dir is defined %}
+KUBELET_VOLUME_PLUGIN="--volume-plugin-dir={{ kubelet_flexvolumes_plugins_dir }}"
+{% endif %}
+
 PATH={{ bin_dir }}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin


### PR DESCRIPTION
This fixes a problem when using Container Linux and Rook on the release-2.8 tree.

`journalctl -u kubelet` showed that kubelet was using the default `/usr/...` path even though `kubelet_flexvolumes_plugins_dir` was set to `/var/lib/kubelet/volume-plugins`.

The .service file was correctly `mkdir -p {{ kubelet_flexvolumes_plugins_dir }}`; however, kubelet was looking in the wrong place.

`master` and `release-2.8` differ, so maybe this problem is fixed elsewhere.  

I have not tested `master`, only `release-2.8`.


