### PR TITLE
fix kubeadm-setup when enable access_ip

### DIFF
--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -58,7 +58,7 @@
       {{ apiserver_loadbalancer_domain_name }}
       {% endif %}
       {% for host in groups['kube-master'] -%}
-      {%- if hostvars[host]['access_ip'] is defined -%}
+      {%- if hostvars[host]['access_ip'] is defined %}
       {{ hostvars[host]['access_ip'] }}
       {% endif %}
       {{ hostvars[host]['ip'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}


### PR DESCRIPTION
Fix whitespace issue for fact of apiserver_sans when enable access_ip.