### PR TITLE
Add timeout to Get current version of calico cluster version

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -138,6 +138,8 @@
 - name: "Get current version of calico cluster version"
   shell: "{{ bin_dir }}/calicoctl version  | grep 'Cluster Version:' | awk '{ print $3}'"
   register: calico_version_on_server
+  async: 10
+  poll: 3
   run_once: yes
   delegate_to: "{{ groups['kube-master'][0] }}"
   when:

--- a/roles/network_plugin/calico/tasks/check.yml
+++ b/roles/network_plugin/calico/tasks/check.yml
@@ -14,6 +14,8 @@
   register: calico_version_on_server
   run_once: yes
   delegate_to: "{{ groups['kube-master'][0] }}"
+  async: 10
+  poll: 3
 
 - name: "Determine if calico upgrade is needed"
   block:


### PR DESCRIPTION
Avoid waiting forever for this task that should be very quick.

Fixes: #4148