### PR TITLE
fix(vagrant): sets ansible.inventory_path to file not dir

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -177,8 +177,9 @@ Vagrant.configure("2") do |config|
       if i == $num_instances
         node.vm.provision "ansible" do |ansible|
           ansible.playbook = $playbook
-          if File.exist?(File.join( $inventory, "hosts.ini"))
-            ansible.inventory_path = $inventory
+          $ansible_inventory_path = File.join( $inventory, "hosts.ini")
+          if File.exist?($ansible_inventory_path)
+            ansible.inventory_path = $ansible_inventory_path
           end
           ansible.become = true
           ansible.limit = "all"


### PR DESCRIPTION
This fixes the issue where if there was a hosts.ini file present in the
inventory directory, then Vagrant would set an incorrect path as
ansible.inventory_path