### PR TITLE
Fixing an issue when trying to install docker-ce-18.09 on rhel7 nodes

### DIFF
--- a/roles/container-engine/docker/defaults/main.yml
+++ b/roles/container-engine/docker/defaults/main.yml
@@ -44,6 +44,9 @@ dockerproject_rh_repo_gpgkey: 'https://yum.dockerproject.org/gpg'
 dockerproject_apt_repo_base_url: 'https://apt.dockerproject.org/repo'
 dockerproject_apt_repo_gpgkey: 'https://apt.dockerproject.org/gpg'
 docker_bin_dir: "/usr/bin"
+# CentOS/RedHat Extras repo
+extras_rh_repo_base_url: "http://mirror.centos.org/centos/$releasever/extras/$basearch/"
+extras_rh_repo_gpgkey: "http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-7"
 
 # flag to enable/disable docker cleanup
 docker_orphan_clean_up: false

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -109,6 +109,27 @@
     dest: "{{ yum_repo_dir }}/docker.repo"
   when: ansible_distribution in ["CentOS","RedHat"] and not is_atomic
 
+- name: check if container-selinux is available
+  yum:
+    list: "container-selinux"
+  register: yum_result
+  when: ansible_distribution in ["CentOS","RedHat"] and not is_atomic
+
+- name: Configure extras repository on RedHat/CentOS if container-selinux not avaiable in current repos
+  yum_repository:
+    name: extras
+    description: "CentOS-7 - Extras"
+    state: present
+    baseurl: "{{ extras_rh_repo_base_url }}"
+    file: "extras"
+    gpgcheck: yes
+    gpgkey: "{{extras_rh_repo_gpgkey}}"
+    keepcache: "{{ docker_rpm_keepcache | default('1') }}"
+    proxy: " {{ http_proxy | default(omit) }}"
+  when:
+    - ansible_distribution in ["CentOS","RedHat"] and not is_atomic
+    - yum_result.results | length == 0
+
 - name: Copy yum.conf for editing
   copy:
     src: "{{ yum_conf }}"


### PR DESCRIPTION
Without an enabled extras repo the installation will fail because container-selinux >= 2.9 is required. The check for container-selinux upfront should obviate the need for adding an extras repo if the node is able to find it from another source.

More info: https://nickjanetakis.com/blog/docker-tip-39-installing-docker-ce-on-redhat-rhel-7x