### PR TITLE
Fix newline issue of priorityClassName when enable ingress_nginx_tolerations

### DIFF
--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
@@ -32,7 +32,7 @@ spec:
 {% if ingress_nginx_tolerations %}
       tolerations:
         {{ ingress_nginx_tolerations | to_nice_yaml(indent=2) | indent(width=8) }}
-{%- endif %}
+{% endif %}
 {% if kube_version is version('v1.11.1', '>=') %}
       priorityClassName: {% if ingress_nginx_namespace == 'kube-system' %}system-node-critical{% else %}k8s-cluster-critical{% endif %}{{''}}
 {% endif %}


### PR DESCRIPTION
Fix newline issue of priorityClassName when enable ingress_nginx_tolerations.

This is the problem of ds-ingress-nginx-controller.yml file.
```
...
      tolerations:
        - effect: NoSchedule
          key: key
          operator: Equal
          value: value      priorityClassName: k8s-cluster-critical
      containers:
        - name: ingress-nginx-controller
...
```