### PR TITLE
[WIP] kubespray on arm64

### DIFF
--- a/docs/arm64.md
+++ b/docs/arm64.md
@@ -1,0 +1,3 @@
+### Running Kubespray on arm64
+
+Some notes for the implementer.


### PR DESCRIPTION
with @Miouge1 , document what we need to get arm64 (on Packet) running with kubespray.

Not ready to merge yet.

Related issues:
* [x] #4176 Add checksums for arm64 images for hyperkube, kubeadm and cni_binary (@miouge)
* [ ] #2551 Gaps when porting to AArch64 