### PR TITLE
[Calico] Define FELIX_KUBENODEPORTRANGES when kube-proxy in ipvs mode

### DIFF
--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -124,7 +124,7 @@ spec:
               value: "{{ calico_endpoint_to_host_action|default('RETURN') }}"
             - name: FELIX_HEALTHHOST
               value: "{{ calico_healthhost }}"
-{% if kube_proxy_mode == 'ipvs' %}
+{% if kube_proxy_mode == 'ipvs' and kube_apiserver_node_port_range is defined %}
             - name: FELIX_KUBENODEPORTRANGES
               value: "{{ kube_apiserver_node_port_range.split('-')[0] }}:{{ kube_apiserver_node_port_range.split('-')[1] }}"
 {% endif %}

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -124,6 +124,10 @@ spec:
               value: "{{ calico_endpoint_to_host_action|default('RETURN') }}"
             - name: FELIX_HEALTHHOST
               value: "{{ calico_healthhost }}"
+{% if kube_proxy_mode == 'ipvs' %}
+            - name: FELIX_KUBENODEPORTRANGES
+              value: "{{ kube_apiserver_node_port_range.split('-')[0] }}:{{ kube_apiserver_node_port_range.split('-')[1] }}"
+{% endif %}
             # Prior to v3.2.1 iptables didn't acquire the lock, so Calico's own implementation of the lock should be used,
             # this is not required in later versions https://github.com/projectcalico/calico/issues/2179
 {% if calico_version is version('v3.2.1', '<') %}


### PR DESCRIPTION
fixes https://github.com/kubernetes-sigs/kubespray/issues/4172