### PR TITLE
Repair a broken docker setup during deployment

### DIFF
--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -208,10 +208,51 @@
 - name: flush handlers so we can wait for docker to come up
   meta: flush_handlers
 
-- name: set fact for docker_version
+- name: get docker version
   command: "docker version -f '{{ '{{' }}.Client.Version{{ '}}' }}'"
-  register: installed_docker_version
+  register: result
+  failed_when: false
   changed_when: false
+  async: 30
+  poll: 5
+
+- name: set fact for installed_docker_version
+  when: '"rc" in result and result.rc == 0'
+  set_fact:
+    installed_docker_version: result.stdout
+
+- name: attempt to fix broken docker
+  when: '"rc" not in result or result.rc != 0'
+  block:
+
+    - name: Write recovery docker options systemd drop-in
+      copy:
+        content: |
+          [Service]
+          Environment="DOCKER_OPTS=  -H unix:///var/run/docker.sock"
+        dest: "/etc/systemd/system/docker.service.d/docker-options.conf"
+      notify: restart docker
+
+    - name: reload systemd config
+      command: systemctl daemon-reload
+
+    - name: restart docker
+      service:
+        name: docker
+        state: restarted
+
+    - name: get docker version (retry)
+      when: '"rc" not in installed_docker_version or installed_docker_version.rc != 0'
+      command: "docker version -f '{{ '{{' }}.Client.Version{{ '}}' }}'"
+      register: result
+      changed_when: false
+      async: 30
+      poll: 5
+
+    - name: set fact for installed_docker_version
+      when: '"rc" in result and result.rc == 0'
+      set_fact:
+        installed_docker_version: result.stdout
 
 - name: check minimum docker version for docker_dns mode. You need at least docker version >= 1.12 for resolvconf_mode=docker_dns
   fail:
@@ -219,7 +260,7 @@
   when: >
         dns_mode != 'none' and
         resolvconf_mode == 'docker_dns' and
-        installed_docker_version.stdout is version('1.12', '<')
+        installed_docker_version is version('1.12', '<')
 
 - name: Set docker systemd config
   import_tasks: systemd.yml

--- a/roles/container-engine/docker/templates/docker.service.j2
+++ b/roles/container-engine/docker/templates/docker.service.j2
@@ -2,13 +2,13 @@
 Description=Docker Application Container Engine
 Documentation=http://docs.docker.com
 {% if ansible_os_family == "RedHat" %}
-After=network.target docker-storage-setup.service{{ ' containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') else '' }}
+After=network.target docker-storage-setup.service{{ ' containerd.service' if installed_docker_version is version('18.09.1', '>=') else '' }}
 Wants=docker-storage-setup.service
 {% elif ansible_os_family == "Debian" %}
-After=network.target docker.socket{{ ' containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') else '' }}
+After=network.target docker.socket{{ ' containerd.service' if installed_docker_version is version('18.09.1', '>=') else '' }}
 Wants=docker.socket
 {% elif ansible_os_family == "Suse" %}
-After=network.target{{ ' containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') else '' }}
+After=network.target{{ ' containerd.service' if installed_docker_version is version('18.09.1', '>=') else '' }}
 {% endif %}
 
 [Service]
@@ -20,7 +20,7 @@ Environment=GOTRACEBACK=crash
 ExecReload=/bin/kill -s HUP $MAINPID
 Delegate=yes
 KillMode=process
-ExecStart={{ docker_bin_dir }}/docker{% if installed_docker_version.stdout is version('17.03', '<') %} daemon{% else %}d{% endif %} \
+ExecStart={{ docker_bin_dir }}/docker{% if installed_docker_version is version('17.03', '<') %} daemon{% else %}d{% endif %} \
 {% if ansible_os_family == "Suse" %}
           --add-runtime oci=/usr/sbin/docker-runc \
 {% endif %}


### PR DESCRIPTION
Avoids a deployment failure when docker setup is not working, something
that could easily happen if kubespray is run with some incompatible
docker_options mentioned.

Limits the amount of time waiting for getting docker version in order
to avoid the case where command never returns.

New code detects if docker services is working and, if not, installs
a recovery docker options file for systemd and restarts the service.

This approach avoids the unfortunate case where kubespray is messing
the node setup and running it again fails at early task
[container-engine/docker : set fact for docker_version]
without giving it any chance to repair the setup.