### PR TITLE
check kube_pods_subnet and kube_service_addresses to valid ip network range

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -160,15 +160,15 @@
 - name: "Check that kube_service_addresses is a network range"
   assert:
     that:
-      - kube_service_addresses | ipaddr
-    msg: "kube_service_addresses is not a valid network range"
+      - kube_service_addresses | ipaddr('net')
+    msg: "kube_service_addresses = '{{ kube_service_addresses }}' is not a valid network range"
   run_once: yes
 
 - name: "Check that kube_pods_subnet is a network range"
   assert:
     that:
-      - kube_pods_subnet | ipaddr
-    msg: "kube_pods_subnet is not a valid network range"
+      - kube_pods_subnet | ipaddr('net')
+    msg: "kube_pods_subnet = '{{ kube_pods_subnet }}' is not a valid network range"
   run_once: yes
 
 - name: "Check that kube_pods_subnet does not collide with kube_service_addresses"


### PR DESCRIPTION
check kube_pods_subnet and kube_service_addresses to valid ip network range, not single ip address

`kube_service_addresses: 10.0.3.0/16`
Verify task check:
`kube_service_addresses | ipaddr` return `10.0.3.0/16`

but 
`skydns_server: "{{ kube_service_addresses|ipaddr('net')|ipaddr(3)|ipaddr('address') }}"`
and 
`kube_service_addresses | ipaddr('net')` return `False` so
`skydns_server` set to `False` and docker optioons in docker-dns.conf set `--dns False`

Closes #4187
#4179