### PR TITLE
change permission /opt/cni/bin after unarchive

### DIFF
--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -33,6 +33,13 @@
     group: root
   changed_when: false
 
+- name: Calico | Copy cni plugins
+  unarchive:
+    src: "{{ local_release_dir }}/cni-plugins-{{ image_arch }}-{{ cni_version }}.tgz"
+    dest: "/opt/cni/bin"
+    mode: 0755
+    remote_src: yes
+
 - name: Calico | Set cni directory permissions
   file:
     path: /opt/cni/bin
@@ -40,13 +47,6 @@
     owner: kube
     recurse: true
     mode: 0755
-
-- name: Calico | Copy cni plugins
-  unarchive:
-    src: "{{ local_release_dir }}/cni-plugins-{{ image_arch }}-{{ cni_version }}.tgz"
-    dest: "/opt/cni/bin"
-    mode: 0755
-    remote_src: yes
 
 - name: Calico | Copy cni plugins from calico/cni container
   command: "{{ docker_bin_dir }}/docker run --rm -v /opt/cni/bin:/cnibindir {{ calico_cni_image_repo }}:{{ calico_cni_image_tag }} sh -c 'cp /opt/cni/bin/* /cnibindir/'"


### PR DESCRIPTION
You have to change owner and permission after calling "Copy cni plugins".
It because `unarchive` module changes owner of `/opt/cni/bin` to root.
So there is no meaning to set owner to `kube` this directory.

You don't have to care about directory existence since already created in `roles/kubernetes/preinstall/tasks/0050-create_directories.yml`.