### PR TITLE
[contrib/metallb] Update MetalLB to v0.7.3

### DIFF
--- a/contrib/metallb/roles/provision/defaults/main.yml
+++ b/contrib/metallb/roles/provision/defaults/main.yml
@@ -5,3 +5,4 @@ metallb:
     cpu: "100m"
     memory: "100Mi"
   port: "7472"
+  version: v0.7.3

--- a/contrib/metallb/roles/provision/templates/metallb.yml.j2
+++ b/contrib/metallb/roles/provision/templates/metallb.yml.j2
@@ -55,22 +55,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: metallb-system
-  name: leader-election
-  labels:
-    app: metallb
-rules:
-- apiGroups: [""]
-  resources: ["endpoints"]
-  resourceNames: ["metallb-speaker"]
-  verbs: ["get", "update"]
-- apiGroups: [""]
-  resources: ["endpoints"]
-  verbs: ["create"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  namespace: metallb-system
   name: config-watcher
   labels:
     app: metallb
@@ -131,21 +115,6 @@ roleRef:
   kind: Role
   name: config-watcher
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  namespace: metallb-system
-  name: leader-election
-  labels:
-    app: metallb
-subjects:
-- kind: ServiceAccount
-  name: speaker
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: leader-election
----
 apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
@@ -173,7 +142,7 @@ spec:
       hostNetwork: true
       containers:
       - name: speaker
-        image: metallb/speaker:v0.6.2
+        image: metallb/speaker:{{ metallb.version }}
         imagePullPolicy: IfNotPresent
         args:
         - --port={{ metallb.port }}
@@ -230,7 +199,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: controller
-        image: metallb/controller:v0.6.2
+        image: metallb/controller:{{ metallb.version }}
         imagePullPolicy: IfNotPresent
         args:
         - --port={{ metallb.port }}
@@ -250,5 +219,3 @@ spec:
           readOnlyRootFilesystem: true
 
 ---
-
-


### PR DESCRIPTION
Updates MetalLB to v0.7.3 and add a variable to configure MetalLB image version.

Since v0.7.0 the leader election Role and RoleBinding are not necessary: https://metallb.universe.tf/release-notes/#version-0-7-0
See upstream manifest: https://raw.githubusercontent.com/google/metallb/v0.7.3/manifests/metallb.yaml