### PR TITLE
Added space around jinja2 variables

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -38,7 +38,7 @@
   pre_tasks:
     - name: gather facts from all instances
       setup:
-      delegate_to: "{{item}}"
+      delegate_to: "{{ item }}"
       delegate_facts: True
       with_items: "{{ groups['k8s-cluster'] + groups['etcd'] + groups['calico-rr']|default([]) }}"
 

--- a/contrib/azurerm/roles/generate-inventory/tasks/main.yml
+++ b/contrib/azurerm/roles/generate-inventory/tasks/main.yml
@@ -8,4 +8,4 @@
     vm_list: "{{ vm_list_cmd.stdout }}"
 
 - name: Generate inventory
-  template: src=inventory.j2 dest="{{playbook_dir}}/inventory"
+  template: src=inventory.j2 dest="{{ playbook_dir }}/inventory"

--- a/contrib/azurerm/roles/generate-inventory_2/tasks/main.yml
+++ b/contrib/azurerm/roles/generate-inventory_2/tasks/main.yml
@@ -13,4 +13,4 @@
     vm_roles_list: "{{ vm_list_cmd.stdout }}"
 
 - name: Generate inventory
-  template: src=inventory.j2 dest="{{playbook_dir}}/inventory"
+  template: src=inventory.j2 dest="{{ playbook_dir }}/inventory"

--- a/contrib/azurerm/roles/generate-templates/defaults/main.yml
+++ b/contrib/azurerm/roles/generate-templates/defaults/main.yml
@@ -23,15 +23,15 @@ bastionIPAddressName: bastion-pubip
 
 disablePasswordAuthentication: true
 
-sshKeyPath: "/home/{{admin_username}}/.ssh/authorized_keys"
+sshKeyPath: "/home/{{ admin_username }}/.ssh/authorized_keys"
 
 imageReference:
   publisher: "OpenLogic"
   offer: "CentOS"
   sku: "7.2"
   version: "latest"
-imageReferenceJson: "{{imageReference|to_json}}"
+imageReferenceJson: "{{ imageReference|to_json }}"
 
-storageAccountName: "sa{{nameSuffix | replace('-', '')}}"
+storageAccountName: "sa{{ nameSuffix | replace('-', '') }}"
 storageAccountType: "{{ azure_storage_account_type | default('Standard_LRS') }}"
 

--- a/contrib/azurerm/roles/generate-templates/tasks/main.yml
+++ b/contrib/azurerm/roles/generate-templates/tasks/main.yml
@@ -1,9 +1,9 @@
 - set_fact:
-    base_dir: "{{playbook_dir}}/.generated/"
+    base_dir: "{{ playbook_dir }}/.generated/"
 
-- file: path={{base_dir}} state=directory recurse=true
+- file: path={{ base_dir }} state=directory recurse=true
 
-- template: src={{item}} dest="{{base_dir}}/{{item}}"
+- template: src={{ item }} dest="{{ base_dir }}/{{ item }}"
   with_items:
     - network.json
     - storage.json

--- a/contrib/dind/roles/dind-cluster/tasks/main.yaml
+++ b/contrib/dind/roles/dind-cluster/tasks/main.yaml
@@ -11,7 +11,7 @@
 - name: Null-ify some linux tools to ease DIND
   file:
     src: "/bin/true"
-    dest: "{{item}}"
+    dest: "{{ item }}"
     state: link
     force: yes
   with_items:
@@ -51,7 +51,7 @@
     - rsyslog
     - "{{ distro_ssh_service }}"
 
-- name: Create distro user "{{distro_user}}"
+- name: Create distro user "{{ distro_user }}"
   user:
     name: "{{ distro_user }}"
     uid: 1000

--- a/contrib/dind/roles/dind-host/tasks/main.yaml
+++ b/contrib/dind/roles/dind-host/tasks/main.yaml
@@ -27,7 +27,7 @@
       - /lib/modules:/lib/modules
       - "{{ item }}:/dind/docker"
   register: containers
-  with_items: "{{groups.containers}}"
+  with_items: "{{ groups.containers }}"
   tags:
     - addresses
 

--- a/contrib/metallb/roles/provision/tasks/main.yml
+++ b/contrib/metallb/roles/provision/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: "Kubernetes Apps | Install and configure MetalLB"
   kube:
     name: "MetalLB"
-    kubectl: "{{bin_dir}}/kubectl"
+    kubectl: "{{ bin_dir }}/kubectl"
     filename: "{{ kube_config_dir }}/{{ item.item }}"
     state: "{{ item.changed | ternary('latest','present') }}"
   with_items: "{{ rendering.results }}"

--- a/contrib/network-storage/glusterfs/roles/glusterfs/server/tasks/main.yml
+++ b/contrib/network-storage/glusterfs/roles/glusterfs/server/tasks/main.yml
@@ -50,7 +50,7 @@
 - name: Mount glusterfs to retrieve disk size
   mount:
     name: "{{ gluster_mount_dir }}"
-    src: "{{ ip|default(ansible_default_ipv4['address']) }}:/gluster" 
+    src: "{{ ip|default(ansible_default_ipv4['address']) }}:/gluster"
     fstype: glusterfs
     opts: "defaults,_netdev"
     state: mounted

--- a/contrib/network-storage/glusterfs/roles/kubernetes-pv/ansible/tasks/main.yaml
+++ b/contrib/network-storage/glusterfs/roles/kubernetes-pv/ansible/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Kubernetes Apps | Lay Down k8s GlusterFS Endpoint and PV
-  template: src={{item.file}} dest={{kube_config_dir}}/{{item.dest}}
+  template: src={{ item.file }} dest={{ kube_config_dir }}/{{ item.dest }}
   with_items:
           - { file: glusterfs-kubernetes-endpoint.json.j2, type: ep, dest: glusterfs-kubernetes-endpoint.json}
           - { file: glusterfs-kubernetes-pv.yml.j2, type: pv, dest: glusterfs-kubernetes-pv.yml}
@@ -12,9 +12,9 @@
   kube:
     name: glusterfs
     namespace: default
-    kubectl: "{{bin_dir}}/kubectl"
-    resource: "{{item.item.type}}"
-    filename: "{{kube_config_dir}}/{{item.item.dest}}"
-    state: "{{item.changed | ternary('latest','present') }}"
+    kubectl: "{{ bin_dir }}/kubectl"
+    resource: "{{ item.item.type }}"
+    filename: "{{ kube_config_dir }}/{{ item.item.dest }}"
+    state: "{{ item.changed | ternary('latest','present') }}"
   with_items: "{{ gluster_pv.results }}"
   when: inventory_hostname == groups['kube-master'][0] and groups['gfs-cluster'] is defined

--- a/contrib/network-storage/heketi/roles/provision/tasks/bootstrap/deploy.yml
+++ b/contrib/network-storage/heketi/roles/provision/tasks/bootstrap/deploy.yml
@@ -6,7 +6,7 @@
 - name: "Kubernetes Apps | Install and configure Heketi Bootstrap"
   kube:
     name: "GlusterFS"
-    kubectl: "{{bin_dir}}/kubectl"
+    kubectl: "{{ bin_dir }}/kubectl"
     filename: "{{ kube_config_dir }}/heketi-bootstrap.json"
     state: "{{ rendering.changed | ternary('latest', 'present') }}"
 - name: "Wait for heketi bootstrap to complete."

--- a/contrib/network-storage/heketi/roles/provision/tasks/bootstrap/storage.yml
+++ b/contrib/network-storage/heketi/roles/provision/tasks/bootstrap/storage.yml
@@ -6,7 +6,7 @@
 - name: "Create heketi storage."
   kube:
     name: "GlusterFS"
-    kubectl: "{{bin_dir}}/kubectl"
+    kubectl: "{{ bin_dir }}/kubectl"
     filename: "{{ kube_config_dir }}/heketi-storage-bootstrap.json"
     state: "present"
   vars:

--- a/contrib/network-storage/heketi/roles/provision/tasks/glusterfs.yml
+++ b/contrib/network-storage/heketi/roles/provision/tasks/glusterfs.yml
@@ -6,7 +6,7 @@
 - name: "Kubernetes Apps | Install and configure GlusterFS daemonset"
   kube:
     name: "GlusterFS"
-    kubectl: "{{bin_dir}}/kubectl"
+    kubectl: "{{ bin_dir }}/kubectl"
     filename: "{{ kube_config_dir }}/glusterfs-daemonset.json"
     state: "{{ rendering.changed | ternary('latest', 'present') }}"
 - name: "Kubernetes Apps | Label GlusterFS nodes"
@@ -33,6 +33,6 @@
 - name: "Kubernetes Apps | Install and configure Heketi Service Account"
   kube:
     name: "GlusterFS"
-    kubectl: "{{bin_dir}}/kubectl"
+    kubectl: "{{ bin_dir }}/kubectl"
     filename: "{{ kube_config_dir }}/heketi-service-account.json"
     state: "{{ rendering.changed | ternary('latest', 'present') }}"

--- a/contrib/network-storage/heketi/roles/provision/tasks/heketi.yml
+++ b/contrib/network-storage/heketi/roles/provision/tasks/heketi.yml
@@ -6,7 +6,7 @@
 - name: "Kubernetes Apps | Install and configure Heketi"
   kube:
     name: "GlusterFS"
-    kubectl: "{{bin_dir}}/kubectl"
+    kubectl: "{{ bin_dir }}/kubectl"
     filename: "{{ kube_config_dir }}/heketi-deployment.json"
     state: "{{ rendering.changed | ternary('latest', 'present') }}"
 - name: "Ensure heketi is up and running."

--- a/contrib/network-storage/heketi/roles/provision/tasks/main.yml
+++ b/contrib/network-storage/heketi/roles/provision/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: "Kubernetes Apps | Test Heketi"
   register: "heketi_service_state"
-  command: "{{bin_dir}}/kubectl get service heketi-storage-endpoints -o=name --ignore-not-found=true"
+  command: "{{ bin_dir }}/kubectl get service heketi-storage-endpoints -o=name --ignore-not-found=true"
   changed_when: false
 
 - name: "Kubernetes Apps | Bootstrap Heketi"

--- a/contrib/network-storage/heketi/roles/provision/tasks/secret.yml
+++ b/contrib/network-storage/heketi/roles/provision/tasks/secret.yml
@@ -1,19 +1,19 @@
 ---
 - register: "clusterrolebinding_state"
-  command: "{{bin_dir}}/kubectl get clusterrolebinding heketi-gluster-admin -o=name --ignore-not-found=true"
+  command: "{{ bin_dir }}/kubectl get clusterrolebinding heketi-gluster-admin -o=name --ignore-not-found=true"
   changed_when: false
 - name: "Kubernetes Apps | Deploy cluster role binding."
   when: "clusterrolebinding_state.stdout == \"\""
-  command: "{{bin_dir}}/kubectl create clusterrolebinding heketi-gluster-admin --clusterrole=edit --serviceaccount=default:heketi-service-account"
+  command: "{{ bin_dir }}/kubectl create clusterrolebinding heketi-gluster-admin --clusterrole=edit --serviceaccount=default:heketi-service-account"
 - register: "clusterrolebinding_state"
-  command: "{{bin_dir}}/kubectl get clusterrolebinding heketi-gluster-admin -o=name --ignore-not-found=true"
+  command: "{{ bin_dir }}/kubectl get clusterrolebinding heketi-gluster-admin -o=name --ignore-not-found=true"
   changed_when: false
 - assert:
     that: "clusterrolebinding_state.stdout != \"\""
     msg: "Cluster role binding is not present."
 
 - register: "secret_state"
-  command: "{{bin_dir}}/kubectl get secret heketi-config-secret -o=name --ignore-not-found=true"
+  command: "{{ bin_dir }}/kubectl get secret heketi-config-secret -o=name --ignore-not-found=true"
   changed_when: false
 - name: "Render Heketi secret configuration."
   become: true
@@ -22,9 +22,9 @@
     dest: "{{ kube_config_dir }}/heketi.json"
 - name: "Deploy Heketi config secret"
   when: "secret_state.stdout == \"\""
-  command: "{{bin_dir}}/kubectl create secret generic heketi-config-secret --from-file={{ kube_config_dir }}/heketi.json"
+  command: "{{ bin_dir }}/kubectl create secret generic heketi-config-secret --from-file={{ kube_config_dir }}/heketi.json"
 - register: "secret_state"
-  command: "{{bin_dir}}/kubectl get secret heketi-config-secret -o=name --ignore-not-found=true"
+  command: "{{ bin_dir }}/kubectl get secret heketi-config-secret -o=name --ignore-not-found=true"
   changed_when: false
 - assert:
     that: "secret_state.stdout != \"\""

--- a/contrib/network-storage/heketi/roles/provision/tasks/storage.yml
+++ b/contrib/network-storage/heketi/roles/provision/tasks/storage.yml
@@ -7,6 +7,6 @@
 - name: "Kubernetes Apps | Install and configure Heketi Storage"
   kube:
     name: "GlusterFS"
-    kubectl: "{{bin_dir}}/kubectl"
+    kubectl: "{{ bin_dir }}/kubectl"
     filename: "{{ kube_config_dir }}/heketi-storage.json"
     state: "{{ rendering.changed | ternary('latest', 'present') }}"

--- a/contrib/network-storage/heketi/roles/provision/tasks/storageclass.yml
+++ b/contrib/network-storage/heketi/roles/provision/tasks/storageclass.yml
@@ -20,6 +20,6 @@
 - name: "Kubernetes Apps | Install and configure Storace Class"
   kube:
     name: "GlusterFS"
-    kubectl: "{{bin_dir}}/kubectl"
+    kubectl: "{{ bin_dir }}/kubectl"
     filename: "{{ kube_config_dir }}/storageclass.yml"
     state: "{{ rendering.changed | ternary('latest', 'present') }}"

--- a/contrib/vault/roles/etcd/vault/tasks/gen_certs_vault.yml
+++ b/contrib/vault/roles/etcd/vault/tasks/gen_certs_vault.yml
@@ -68,6 +68,6 @@
 
 - name: gen_certs_vault | ensure file permissions
   shell: >-
-    find {{etcd_cert_dir }} -type d -exec chmod 0755 {} \; &&
-    find {{etcd_cert_dir }} -type f -exec chmod 0640 {} \;
+    find {{ etcd_cert_dir }} -type d -exec chmod 0755 {} \; &&
+    find {{ etcd_cert_dir }} -type f -exec chmod 0640 {} \;
   changed_when: false

--- a/contrib/vault/roles/vault/defaults/main.yml
+++ b/contrib/vault/roles/vault/defaults/main.yml
@@ -27,7 +27,7 @@ vault_download_url: "https://releases.hashicorp.com/vault/{{ vault_version }}/va
 hvac_version: 0.6.4
 
 # Arch of Docker images and needed packages
-image_arch: "{{host_architecture}}"
+image_arch: "{{ host_architecture }}"
 
 vault_download_vars:
   container: "{{ vault_deployment_type != 'host' }}"
@@ -74,8 +74,8 @@ vault_config:
       ha_enabled: "true"
       redirect_addr: "https://{{ inventory_hostname }}:{{ vault_port }}"
       tls_ca_file: "{{ etcd_cert_dir }}/ca.pem"
-      tls_cert_file: "{{ etcd_cert_dir}}/node-{{ inventory_hostname }}.pem"
-      tls_key_file: "{{ etcd_cert_dir}}/node-{{ inventory_hostname }}-key.pem"
+      tls_cert_file: "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem"
+      tls_key_file: "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem"
   cluster_name: "kubernetes-vault"
   default_lease_ttl: "{{ vault_default_lease_ttl }}"
   max_lease_ttl: "{{ vault_max_lease_ttl }}"

--- a/contrib/vault/roles/vault/tasks/bootstrap/ca_trust.yml
+++ b/contrib/vault/roles/vault/tasks/bootstrap/ca_trust.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: "bootstrap/ca_trust | pull CA from cert from {{groups.vault|first}}"
+- name: "bootstrap/ca_trust | pull CA from cert from {{ groups.vault|first }}"
   command: "cat {{ vault_cert_dir }}/ca.pem"
   register: vault_cert_file_cat
   delegate_to: "{{ groups['vault']|first }}"

--- a/contrib/vault/roles/vault/tasks/shared/check_etcd.yml
+++ b/contrib/vault/roles/vault/tasks/shared/check_etcd.yml
@@ -11,7 +11,7 @@
   until: vault_etcd_health_check.status == 200 or vault_etcd_health_check.status == 401
   retries: 3
   delay: 2
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{ groups['etcd'][0] }}"
   run_once: true
   failed_when: false
   register: vault_etcd_health_check

--- a/contrib/vault/roles/vault/tasks/shared/check_vault.yml
+++ b/contrib/vault/roles/vault/tasks/shared/check_vault.yml
@@ -30,7 +30,7 @@
   command: |-
     curl \
       --cacert {{ etcd_cert_dir }}/ca.pem \
-      --cert {{ etcd_cert_dir}}/node-{{ inventory_hostname }}.pem \
+      --cert {{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem \
       --key {{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem \
       -X POST -d '{"key": "{{ "/vault/core/seal-config" | b64encode }}"}' \
       {{ etcd_access_addresses.split(',') | first }}/v3alpha/kv/range

--- a/contrib/vault/roles/vault/tasks/shared/gen_ca.yml
+++ b/contrib/vault/roles/vault/tasks/shared/gen_ca.yml
@@ -30,7 +30,7 @@
 
 - name: "bootstrap/gen_ca | Copy {{ gen_ca_mount_path }} root CA key to necessary hosts"
   copy:
-    content: "{{ vault_ca_gen['data']['data']['private_key']}}"
+    content: "{{ vault_ca_gen['data']['data']['private_key'] }}"
     dest: "{{ gen_ca_cert_dir }}/ca-key.pem"
     mode: 0640
   when: '"data" in vault_ca_gen.keys()'

--- a/contrib/vault/roles/vault/tasks/shared/issue_cert.yml
+++ b/contrib/vault/roles/vault/tasks/shared/issue_cert.yml
@@ -23,7 +23,7 @@
   file:
     path: "{{ issue_cert_path | dirname }}"
     state: directory
-    group: "{{ issue_cert_file_group | d('root' )}}"
+    group: "{{ issue_cert_file_group | d('root' ) }}"
     mode: "{{ issue_cert_dir_mode | d('0755') }}"
     owner: "{{ issue_cert_file_owner | d('root') }}"
 
@@ -94,7 +94,7 @@
   copy:
     content: "{{ issue_cert_result['data']['data']['certificate'] }}\n"
     dest: "{{ issue_cert_path }}"
-    group: "{{ issue_cert_file_group | d('root' )}}"
+    group: "{{ issue_cert_file_group | d('root' ) }}"
     mode: "{{ issue_cert_file_mode | d('0644') }}"
     owner: "{{ issue_cert_file_owner | d('root') }}"
 
@@ -102,7 +102,7 @@
   copy:
     content: "{{ issue_cert_result['data']['data']['private_key'] }}"
     dest: "{{ issue_cert_path.rsplit('.', 1)|first }}-key.{{ issue_cert_path.rsplit('.', 1)|last }}"
-    group: "{{ issue_cert_file_group | d('root' )}}"
+    group: "{{ issue_cert_file_group | d('root' ) }}"
     mode: "{{ issue_cert_file_mode | d('0640') }}"
     owner: "{{ issue_cert_file_owner | d('root') }}"
 
@@ -110,7 +110,7 @@
   copy:
     content: "{{ issue_cert_result['data']['data']['issuing_ca'] }}\n"
     dest: "{{ issue_cert_path | dirname }}/{{ issue_cert_ca_filename | default('ca.pem') }}"
-    group: "{{ issue_cert_file_group | d('root' )}}"
+    group: "{{ issue_cert_file_group | d('root' ) }}"
     mode: "{{ issue_cert_file_mode | d('0644') }}"
     owner: "{{ issue_cert_file_owner | d('root') }}"
   when: issue_cert_copy_ca|default(false)
@@ -119,6 +119,6 @@
   copy:
     content: "{{ issue_cert_result['data']['data']['serial_number'] }}"
     dest: "{{ issue_cert_path.rsplit('.', 1)|first }}.serial"
-    group: "{{ issue_cert_file_group | d('root' )}}"
+    group: "{{ issue_cert_file_group | d('root' ) }}"
     mode: "{{ issue_cert_file_mode | d('0640') }}"
     owner: "{{ issue_cert_file_owner | d('root') }}"

--- a/contrib/vault/roles/vault/tasks/shared/sync_file.yml
+++ b/contrib/vault/roles/vault/tasks/shared/sync_file.yml
@@ -17,7 +17,7 @@
     sync_file_key_path: "{{ sync_file_path.rsplit('.', 1)|first + '-key.' + sync_file_path.rsplit('.', 1)|last }}"
   when: sync_file_key_path is not defined or sync_file_key_path == ''
 
-- name: "sync_file | Check if {{sync_file_path}} file exists"
+- name: "sync_file | Check if {{ sync_file_path }} file exists"
   stat:
     path: "{{ sync_file_path }}"
   register: sync_file_stat

--- a/mitogen.yaml
+++ b/mitogen.yaml
@@ -6,7 +6,7 @@
   tasks:
     - name: Create mitogen plugin dir
       file:
-        path: "{{item}}"
+        path: "{{ item }}"
         state: directory
       become: false
       loop:

--- a/roles/adduser/tasks/main.yml
+++ b/roles/adduser/tasks/main.yml
@@ -1,15 +1,15 @@
 ---
 - name: User | Create User Group
   group:
-    name: "{{user.group|default(user.name)}}"
-    system: "{{user.system|default(omit)}}"
+    name: "{{ user.group|default(user.name) }}"
+    system: "{{ user.system|default(omit) }}"
 
 - name: User | Create User
   user:
-    comment: "{{user.comment|default(omit)}}"
-    createhome: "{{user.createhome|default(omit)}}"
-    group: "{{user.group|default(user.name)}}"
-    home: "{{user.home|default(omit)}}"
-    shell: "{{user.shell|default(omit)}}"
-    name: "{{user.name}}"
-    system: "{{user.system|default(omit)}}"
+    comment: "{{ user.comment|default(omit) }}"
+    createhome: "{{ user.createhome|default(omit) }}"
+    group: "{{ user.group|default(user.name) }}"
+    home: "{{ user.home|default(omit) }}"
+    shell: "{{ user.shell|default(omit) }}"
+    name: "{{ user.name }}"
+    system: "{{ user.system|default(omit) }}"

--- a/roles/bootstrap-os/tasks/bootstrap-centos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-centos.yml
@@ -24,7 +24,7 @@
 - name: Add proxy to /etc/yum.conf if http_proxy is defined
   lineinfile:
     path: "/etc/yum.conf"
-    line: "proxy={{http_proxy}}"
+    line: "proxy={{ http_proxy }}"
     create: yes
     state: present
   when: http_proxy is defined

--- a/roles/bootstrap-os/tasks/bootstrap-debian.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-debian.yml
@@ -22,7 +22,7 @@
   tags: facts
 
 - name: Add http_proxy to /etc/apt/apt.conf if http_proxy is defined
-  raw: echo 'Acquire::http::Proxy "{{http_proxy}}";' >> /etc/apt/apt.conf
+  raw: echo 'Acquire::http::Proxy "{{ http_proxy }}";' >> /etc/apt/apt.conf
   environment: {}
   when:
     - need_http_proxy.rc != 0
@@ -37,7 +37,7 @@
   tags: facts
 
 - name: Add https_proxy to /etc/apt/apt.conf if https_proxy is defined
-  raw: echo 'Acquire::https::proxy "{{https_proxy}}";' >> /etc/apt/apt.conf
+  raw: echo 'Acquire::https::proxy "{{ https_proxy }}";' >> /etc/apt/apt.conf
   environment: {}
   when:
     - need_https_proxy.rc != 0

--- a/roles/bootstrap-os/tasks/bootstrap-ubuntu.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-ubuntu.yml
@@ -10,11 +10,11 @@
       - dbus
 
 - name: Bootstrap | Check if bootstrap is needed
-  raw: dpkg -l | cut -d' ' -f3 |grep -e ^{{item}}$
+  raw: dpkg -l | cut -d' ' -f3 |grep -e ^{{ item }}$
   register: need_bootstrap
   failed_when: false
   changed_when: false
-  with_items: "{{ubuntu_packages}}"
+  with_items: "{{ ubuntu_packages }}"
   environment: {}
   tags:
     - facts
@@ -22,7 +22,7 @@
 - name: Add proxy to /etc/apt/apt.conf if http_proxy is defined
   lineinfile:
     path: "/etc/apt/apt.conf"
-    line: 'Acquire::http::proxy "{{http_proxy}}";'
+    line: 'Acquire::http::proxy "{{ http_proxy }}";'
     create: yes
     state: present
   when: http_proxy is defined
@@ -30,7 +30,7 @@
 - name: Add proxy to /etc/apt/apt.conf if https_proxy is defined
   lineinfile:
     path: "/etc/apt/apt.conf"
-    line: 'Acquire::https::proxy "{{https_proxy}}";'
+    line: 'Acquire::https::proxy "{{ https_proxy }}";'
     create: yes
     state: present
   when: https_proxy is defined
@@ -38,7 +38,7 @@
 - name: Bootstrap | Install python 2.x and pip
   raw:
     apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y {{ubuntu_packages | join(" ")}}
+    DEBIAN_FRONTEND=noninteractive apt-get install -y {{ ubuntu_packages | join(" ") }}
   environment: {}
   when:
     - need_bootstrap.results | map(attribute='rc') | sort | last | bool

--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -41,13 +41,13 @@
 
 - name: Assign inventory name to unconfigured hostnames (non-CoreOS and Tumbleweed)
   hostname:
-    name: "{{inventory_hostname}}"
+    name: "{{ inventory_hostname }}"
   when:
     - override_system_hostname
     - ansible_os_family not in ['Suse', 'CoreOS', 'Container Linux by CoreOS', 'ClearLinux']
 
 - name: Assign inventory name to unconfigured hostnames (CoreOS and Tumbleweed only)
-  command: "hostnamectl set-hostname  {{inventory_hostname}}"
+  command: "hostnamectl set-hostname {{ inventory_hostname }}"
   register: hostname_changed
   when:
     - override_system_hostname

--- a/roles/container-engine/docker/handlers/main.yml
+++ b/roles/container-engine/docker/handlers/main.yml
@@ -9,7 +9,7 @@
     - Docker | wait for docker
 
 - name: Docker | reload systemd
-  shell: systemctl daemon-reload
+  command: systemctl daemon-reload
 
 - name: Docker | reload docker.socket
   service:

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -4,7 +4,8 @@
     path: /run/ostree-booted
   register: ostree
 
-- set_fact:
+- name: set is_atomic
+  set_fact:
     is_atomic: "{{ ostree.stat.exists }}"
 
 - name: gather os specific variables
@@ -54,8 +55,8 @@
 - name: ensure docker-ce repository public key is installed
   action: "{{ docker_repo_key_info.pkg_key }}"
   args:
-    id: "{{item}}"
-    url: "{{docker_repo_key_info.url}}"
+    id: "{{ item }}"
+    url: "{{ docker_repo_key_info.url }}"
     state: present
   register: keyserver_task_result
   until: keyserver_task_result is succeeded
@@ -67,7 +68,7 @@
 - name: ensure docker-ce repository is enabled
   action: "{{ docker_repo_info.pkg_repo }}"
   args:
-    repo: "{{item}}"
+    repo: "{{ item }}"
     state: present
   with_items: "{{ docker_repo_info.repos }}"
   when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS", "RedHat", "Suse", "ClearLinux"] or is_atomic) and (docker_repo_info.repos|length > 0)
@@ -75,8 +76,8 @@
 - name: ensure docker-engine repository public key is installed
   action: "{{ dockerproject_repo_key_info.pkg_key }}"
   args:
-    id: "{{item}}"
-    url: "{{dockerproject_repo_key_info.url}}"
+    id: "{{ item }}"
+    url: "{{ dockerproject_repo_key_info.url }}"
     state: present
   register: keyserver_task_result
   until: keyserver_task_result is succeeded
@@ -90,7 +91,7 @@
 - name: ensure docker-engine repository is enabled
   action: "{{ dockerproject_repo_info.pkg_repo }}"
   args:
-    repo: "{{item}}"
+    repo: "{{ item }}"
     state: present
   with_items: "{{ dockerproject_repo_info.repos }}"
   when:
@@ -123,7 +124,7 @@
     baseurl: "{{ extras_rh_repo_base_url }}"
     file: "extras"
     gpgcheck: yes
-    gpgkey: "{{extras_rh_repo_gpgkey}}"
+    gpgkey: "{{ extras_rh_repo_gpgkey }}"
     keepcache: "{{ docker_rpm_keepcache | default('1') }}"
     proxy: " {{ http_proxy | default(omit) }}"
   when:
@@ -148,9 +149,9 @@
 - name: ensure docker packages are installed
   action: "{{ docker_package_info.pkg_mgr }}"
   args:
-    pkg: "{{item.name}}"
-    force: "{{item.force|default(omit)}}"
-    conf_file: "{{item.yum_conf|default(omit)}}"
+    pkg: "{{ item.name }}"
+    force: "{{ item.force|default(omit) }}"
+    conf_file: "{{ item.yum_conf|default(omit) }}"
     state: present
     update_cache: "{{ omit if ansible_distribution == 'Fedora' else True }}"
   register: docker_task_result
@@ -185,7 +186,7 @@
 
 - name: show available packages on ubuntu
   fail:
-    msg: "{{available_packages}}"
+    msg: "{{ available_packages }}"
   when:
     - docker_task_result is failed
     - ansible_distribution == 'Ubuntu'

--- a/roles/container-engine/docker/tasks/set_facts_dns.yml
+++ b/roles/container-engine/docker/tasks/set_facts_dns.yml
@@ -2,11 +2,11 @@
 
 - name: set dns server for docker
   set_fact:
-    docker_dns_servers: "{{dns_servers}}"
+    docker_dns_servers: "{{ dns_servers }}"
 
 - name: show docker_dns_servers
   debug:
-    msg: "{{docker_dns_servers}}"
+    msg: "{{ docker_dns_servers }}"
 
 - name: set base docker dns facts
   set_fact:

--- a/roles/download/tasks/download_file.yml
+++ b/roles/download/tasks/download_file.yml
@@ -7,7 +7,7 @@
 
 - name: file_download | Create dest directory
   file:
-    path: "{{download.dest|dirname}}"
+    path: "{{ download.dest|dirname }}"
     state: directory
     recurse: yes
   when:
@@ -17,9 +17,9 @@
 
 - name: file_download | Download item
   get_url:
-    url: "{{download.url}}"
-    dest: "{{download.dest}}"
-    sha256sum: "{{download.sha256 | default(omit)}}"
+    url: "{{ download.url }}"
+    dest: "{{ download.dest }}"
+    sha256sum: "{{ download.sha256 | default(omit) }}"
     owner: "{{ download.owner|default(omit) }}"
     mode: "{{ download.mode|default(omit) }}"
     validate_certs: "{{ download_validate_certs }}"
@@ -37,8 +37,8 @@
 
 - name: file_download | Extract archives
   unarchive:
-    src: "{{download.dest}}"
-    dest: "{{download.dest|dirname}}"
+    src: "{{ download.dest }}"
+    dest: "{{ download.dest|dirname }}"
     owner: "{{ download.owner|default(omit) }}"
     mode: "{{ download.mode|default(omit) }}"
     copy: no

--- a/roles/download/tasks/download_prep.yml
+++ b/roles/download/tasks/download_prep.yml
@@ -11,16 +11,16 @@
 
 - name: container_download | Create dest directory for saved/loaded container images
   file:
-    path: "{{local_release_dir}}/containers"
+    path: "{{ local_release_dir }}/containers"
     state: directory
     recurse: yes
     mode: 0755
-    owner: "{{ansible_ssh_user|default(ansible_user_id)}}"
+    owner: "{{ ansible_ssh_user|default(ansible_user_id) }}"
   when: download_container
 
 - name: container_download | create local directory for saved/loaded container images
   file:
-    path: "{{local_release_dir}}/containers"
+    path: "{{ local_release_dir }}/containers"
     state: directory
     recurse: yes
   delegate_to: localhost

--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -4,9 +4,10 @@
     - not skip_downloads|default(false)
 
 - name: "Download items"
-  include_tasks: "download_{% if download.container %}container{% else %}file{% endif %}.yml"
+  include_tasks: "{{ include_file }}"
   vars:
     download: "{{ download_defaults | combine(item.value) }}"
+    include_file: "download_{% if download.container %}container{% else %}file{% endif %}.yml"
   with_dict: "{{ downloads }}"
   when:
     - not skip_downloads|default(false)

--- a/roles/download/tasks/set_docker_image_facts.yml
+++ b/roles/download/tasks/set_docker_image_facts.yml
@@ -1,11 +1,13 @@
 ---
-- set_fact:
+- name: set pull_by_digest
+  set_fact:
     pull_by_digest: >-
       {%- if download.sha256 is defined and download.sha256 != '' -%}true{%- else -%}false{%- endif -%}
 
-- set_fact:
+- name: set pull_args
+  set_fact:
     pull_args: >-
-      {%- if pull_by_digest %}{{download.repo}}@sha256:{{download.sha256}}{%- else -%}{{download.repo}}:{{download.tag}}{%- endif -%}
+      {%- if pull_by_digest %}{{ download.repo }}@sha256:{{ download.sha256 }}{%- else -%}{{ download.repo }}:{{ download.tag }}{%- endif -%}
 
 - name: Register docker images info
   shell: >-
@@ -17,14 +19,15 @@
   check_mode: no
   when: not download_always_pull
 
-- set_fact:
+- name: set pull_required
+  set_fact:
     pull_required: >-
       {%- if pull_args in docker_images.stdout.split(',') %}false{%- else -%}true{%- endif -%}
   when: not download_always_pull
 
 - name: Check the local digest sha256 corresponds to the given image tag
   assert:
-    that: "{{download.repo}}:{{download.tag}} in docker_images.stdout.split(',')"
+    that: "{{ download.repo }}:{{ download.tag }} in docker_images.stdout.split(',')"
   when: not download_always_pull and not pull_required and pull_by_digest
   tags:
     - asserts

--- a/roles/download/tasks/sync_container.yml
+++ b/roles/download/tasks/sync_container.yml
@@ -10,8 +10,9 @@
   tags:
     - facts
 
-- set_fact:
-    fname: "{{local_release_dir}}/containers/{{download.repo|regex_replace('/|\0|:', '_')}}:{{download.tag|default(download.sha256)|regex_replace('/|\0|:', '_')}}.tar"
+- name: set fname
+  set_fact:
+    fname: "{{ local_release_dir }}/containers/{{ download.repo|regex_replace('/|\0|:', '_') }}:{{ download.tag|default(download.sha256)|regex_replace('/|\0|:', '_') }}.tar"
   run_once: true
   when:
     - download.enabled
@@ -23,7 +24,7 @@
 
 - name: "container_download | Set default value for 'container_changed' to false"
   set_fact:
-    container_changed: "{{pull_required|default(false)}}"
+    container_changed: "{{ pull_required|default(false) }}"
   when:
     - download.enabled
     - download.container

--- a/roles/etcd/tasks/check_certs.yml
+++ b/roles/etcd/tasks/check_certs.yml
@@ -4,7 +4,7 @@
     paths: "{{ etcd_cert_dir }}"
     patterns: "ca.pem,node*.pem"
     get_checksum: true
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{ groups['etcd'][0] }}"
   register: etcdcert_master
   run_once: true
 
@@ -29,10 +29,10 @@
   when: not item in etcdcert_master.files|map(attribute='path') | list
   run_once: true
   with_items: >-
-       ['{{etcd_cert_dir}}/ca.pem',
+       ['{{ etcd_cert_dir }}/ca.pem',
        {% set all_etcd_hosts = groups['k8s-cluster']|union(groups['etcd'])|union(groups['calico-rr']|default([]))|unique|sort %}
        {% for host in all_etcd_hosts %}
-       '{{etcd_cert_dir}}/node-{{ host }}-key.pem'
+       '{{ etcd_cert_dir }}/node-{{ host }}-key.pem'
        {% if not loop.last %}{{','}}{% endif %}
        {% endfor %}]
 

--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -8,7 +8,7 @@
     mode: 0700
     recurse: yes
 
-- name: "Gen_certs | create etcd script dir (on {{groups['etcd'][0]}})"
+- name: "Gen_certs | create etcd script dir (on {{ groups['etcd'][0] }})"
   file:
     path: "{{ etcd_script_dir }}"
     state: directory
@@ -16,9 +16,9 @@
     mode: 0700
   run_once: yes
   when: inventory_hostname == groups['etcd'][0]
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{ groups['etcd'][0] }}"
 
-- name: "Gen_certs | create etcd cert dir (on {{groups['etcd'][0]}})"
+- name: "Gen_certs | create etcd cert dir (on {{ groups['etcd'][0] }})"
   file:
     path: "{{ etcd_cert_dir }}"
     group: "{{ etcd_cert_group }}"
@@ -28,14 +28,14 @@
     mode: 0700
   run_once: yes
   when: inventory_hostname == groups['etcd'][0]
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{ groups['etcd'][0] }}"
 
 - name: Gen_certs | write openssl config
   template:
     src: "openssl.conf.j2"
     dest: "{{ etcd_config_dir }}/openssl.conf"
   run_once: yes
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{ groups['etcd'][0] }}"
   when:
     - gen_certs|default(false)
     - inventory_hostname == groups['etcd'][0]
@@ -46,7 +46,7 @@
     dest: "{{ etcd_script_dir }}/make-ssl-etcd.sh"
     mode: 0700
   run_once: yes
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{ groups['etcd'][0] }}"
   when:
     - gen_certs|default(false)
     - inventory_hostname == groups['etcd'][0]
@@ -65,7 +65,7 @@
                 {% endif %}
               {% endfor %}"
   run_once: yes
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{ groups['etcd'][0] }}"
   when:
     - gen_certs|default(false)
     - inventory_hostname == groups['etcd'][0]
@@ -88,7 +88,7 @@
         '{{ etcd_cert_dir }}/node-{{ node }}.pem',
         '{{ etcd_cert_dir }}/node-{{ node }}-key.pem',
         {% endfor %}]"
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{ groups['etcd'][0] }}"
   when:
     - inventory_hostname in groups['etcd']
     - sync_certs|default(false)
@@ -134,13 +134,13 @@
   no_log: true
   register: etcd_node_certs
   check_mode: no
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{ groups['etcd'][0] }}"
   when: (('calico-rr' in groups and inventory_hostname in groups['calico-rr']) or
         inventory_hostname in groups['k8s-cluster']) and
         sync_certs|default(false) and inventory_hostname not in groups['etcd']
 
 - name: Gen_certs | Copy certs on nodes
-  shell: "base64 -d <<< '{{etcd_node_certs.stdout|quote}}' | tar xz -C {{ etcd_cert_dir }}"
+  shell: "base64 -d <<< '{{ etcd_node_certs.stdout|quote }}' | tar xz -C {{ etcd_cert_dir }}"
   args:
     executable: /bin/bash
   no_log: true

--- a/roles/etcd/tasks/install_rkt.yml
+++ b/roles/etcd/tasks/install_rkt.yml
@@ -10,13 +10,13 @@
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   changed_when: false
-  environment: "{{proxy_env}}"
+  environment: "{{ proxy_env }}"
   when: etcd_cluster_setup
 
 - name: Install | Copy etcdctl binary from rkt container
   command: >-
     /usr/bin/rkt run
-    --volume=bin-dir,kind=host,source={{ bin_dir}},readOnly=false
+    --volume=bin-dir,kind=host,source={{ bin_dir }},readOnly=false
     --mount=volume=bin-dir,target=/host/bin
     {{ etcd_image_repo }}:{{ etcd_image_tag }}
     --name=etcdctl-binarycopy
@@ -26,5 +26,5 @@
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   changed_when: false
-  environment: "{{proxy_env}}"
+  environment: "{{ proxy_env }}"
   when: etcd_cluster_setup

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -8,9 +8,9 @@
   set_fact:
     host_architecture: >-
       {%- if ansible_architecture in architecture_groups -%}
-      {{architecture_groups[ansible_architecture]}}
+      {{ architecture_groups[ansible_architecture] }}
       {%- else -%}
-       {{ansible_architecture}}
+       {{ ansible_architecture }}
       {% endif %}
 
 - include_tasks: check_certs.yml

--- a/roles/kubernetes-apps/ansible/tasks/netchecker.yml
+++ b/roles/kubernetes-apps/ansible/tasks/netchecker.yml
@@ -13,7 +13,7 @@
     name: "netchecker-server"
     namespace: "{{ netcheck_namespace }}"
     filename: "{{ netchecker_server_manifest.stat.path }}"
-    kubectl: "{{bin_dir}}/kubectl"
+    kubectl: "{{ bin_dir }}/kubectl"
     resource: "deploy"
     state: latest
   when: inventory_hostname == groups['kube-master'][0] and netchecker_server_manifest.stat.exists
@@ -39,13 +39,13 @@
 
 - name: Kubernetes Apps | Append extra templates to Netchecker Templates list for PodSecurityPolicy
   set_fact:
-    netchecker_templates: "{{ netchecker_templates_for_psp + netchecker_templates}}"
+    netchecker_templates: "{{ netchecker_templates_for_psp + netchecker_templates }}"
   when: podsecuritypolicy_enabled
 
 - name: Kubernetes Apps | Lay Down Netchecker Template
   template:
-    src: "{{item.file}}.j2"
-    dest: "{{kube_config_dir}}/{{item.file}}"
+    src: "{{ item.file }}.j2"
+    dest: "{{ kube_config_dir }}/{{ item.file }}"
   with_items: "{{ netchecker_templates }}"
   register: manifests
   when:
@@ -55,18 +55,18 @@
   kube:
     name: "netchecker-server"
     namespace: "{{ netcheck_namespace }}"
-    kubectl: "{{bin_dir}}/kubectl"
+    kubectl: "{{ bin_dir }}/kubectl"
     resource: "po"
     state: absent
   when: inventory_hostname == groups['kube-master'][0]
 
 - name: Kubernetes Apps | Start Netchecker Resources
   kube:
-    name: "{{item.item.name}}"
-    namespace: "{{netcheck_namespace}}"
-    kubectl: "{{bin_dir}}/kubectl"
-    resource: "{{item.item.type}}"
-    filename: "{{kube_config_dir}}/{{item.item.file}}"
+    name: "{{ item.item.name }}"
+    namespace: "{{ netcheck_namespace }}"
+    kubectl: "{{ bin_dir }}/kubectl"
+    resource: "{{ item.item.type }}"
+    filename: "{{ kube_config_dir }}/{{ item.item.file }}"
     state: "latest"
   with_items: "{{ manifests.results }}"
   when: inventory_hostname == groups['kube-master'][0] and not item is skipped

--- a/roles/kubernetes-apps/cloud_controller/oci/tasks/credentials-check.yml
+++ b/roles/kubernetes-apps/cloud_controller/oci/tasks/credentials-check.yml
@@ -3,31 +3,31 @@
 - name: "OCI Cloud Controller | Credentials Check | oci_private_key"
   fail:
     msg: "oci_private_key is missing"
-  when: (oci_use_instance_principals == false) and
+  when: (not oci_use_instance_principals) and
         (oci_private_key is not defined or oci_private_key == "")
 
 - name: "OCI Cloud Controller | Credentials Check | oci_region_id"
   fail:
     msg: "oci_region_id is missing"
-  when: (oci_use_instance_principals == false) and
+  when: (not oci_use_instance_principals) and
         (oci_region_id is not defined or oci_region_id == "")
 
 - name: "OCI Cloud Controller | Credentials Check | oci_tenancy_id"
   fail:
     msg: "oci_tenancy_id is missing"
-  when: (oci_use_instance_principals == false) and
+  when: (not oci_use_instance_principals) and
         (oci_tenancy_id is not defined or oci_tenancy_id == "")
 
 - name: "OCI Cloud Controller | Credentials Check | oci_user_id"
   fail:
     msg: "oci_user_id is missing"
-  when: (oci_use_instance_principals == false) and
+  when: (not oci_use_instance_principals) and
         (oci_user_id is not defined or oci_user_id == "")
 
 - name: "OCI Cloud Controller | Credentials Check | oci_user_fingerprint"
   fail:
     msg: "oci_user_fingerprint is missing"
-  when: (oci_use_instance_principals == false) and
+  when: (not oci_use_instance_principals) and
         (oci_user_fingerprint is not defined or oci_user_fingerprint == "")
 
 - name: "OCI Cloud Controller | Credentials Check | oci_compartment_id"

--- a/roles/kubernetes-apps/cloud_controller/oci/tasks/main.yml
+++ b/roles/kubernetes-apps/cloud_controller/oci/tasks/main.yml
@@ -34,7 +34,7 @@
 
 - name: "OCI Cloud Controller | Download Controller Manifest"
   get_url:
-    url: "https://raw.githubusercontent.com/oracle/oci-cloud-controller-manager/{{oci_cloud_controller_version}}/manifests/oci-cloud-controller-manager.yaml"
+    url: "https://raw.githubusercontent.com/oracle/oci-cloud-controller-manager/{{ oci_cloud_controller_version }}/manifests/oci-cloud-controller-manager.yaml"
     dest: "/tmp/oci-cloud-controller-manager.yml"
     force: yes
   register: result

--- a/roles/kubernetes-apps/cluster_roles/tasks/main.yml
+++ b/roles/kubernetes-apps/cluster_roles/tasks/main.yml
@@ -41,10 +41,10 @@
 
 - name: Kubernetes Apps | Add policies, roles, bindings for PodSecurityPolicy
   kube:
-    name: "{{item.item.name}}"
-    kubectl: "{{bin_dir}}/kubectl"
-    resource: "{{item.item.type}}"
-    filename: "{{kube_config_dir}}/{{item.item.file}}"
+    name: "{{ item.item.name }}"
+    kubectl: "{{ bin_dir }}/kubectl"
+    resource: "{{ item.item.type }}"
+    filename: "{{ kube_config_dir }}/{{ item.item.file }}"
     state: "latest"
   with_items: "{{ psp_manifests.results }}"
   when:
@@ -65,7 +65,7 @@
 - name: Apply workaround to allow all nodes with cert O=system:nodes to register
   kube:
     name: "kubespray:system:node"
-    kubectl: "{{bin_dir}}/kubectl"
+    kubectl: "{{ bin_dir }}/kubectl"
     resource: "clusterrolebinding"
     filename: "{{ kube_config_dir }}/node-crb.yml"
     state: latest
@@ -88,7 +88,7 @@
 - name: Apply webhook ClusterRole
   kube:
     name: "system:node-webhook"
-    kubectl: "{{bin_dir}}/kubectl"
+    kubectl: "{{ bin_dir }}/kubectl"
     resource: "clusterrole"
     filename: "{{ kube_config_dir }}/node-webhook-cr.yml"
     state: latest
@@ -113,7 +113,7 @@
 - name: Grant system:nodes the webhook ClusterRole
   kube:
     name: "system:node-webhook"
-    kubectl: "{{bin_dir}}/kubectl"
+    kubectl: "{{ bin_dir }}/kubectl"
     resource: "clusterrolebinding"
     filename: "{{ kube_config_dir }}/node-webhook-crb.yml"
     state: latest
@@ -156,7 +156,7 @@
 - name: Apply vsphere-cloud-provider ClusterRole
   kube:
     name: "system:vsphere-cloud-provider"
-    kubectl: "{{bin_dir}}/kubectl"
+    kubectl: "{{ bin_dir }}/kubectl"
     resource: "clusterrolebinding"
     filename: "{{ kube_config_dir }}/vsphere-rbac.yml"
     state: latest
@@ -186,7 +186,7 @@
 - name: PriorityClass | Create k8s-cluster-critical
   kube:
     name: k8s-cluster-critical
-    kubectl: "{{bin_dir}}/kubectl"
+    kubectl: "{{ bin_dir }}/kubectl"
     resource: "PriorityClass"
     filename: "{{ kube_config_dir }}/k8s-cluster-critical-pc.yml"
     state: latest

--- a/roles/kubernetes-apps/cluster_roles/tasks/oci.yml
+++ b/roles/kubernetes-apps/cluster_roles/tasks/oci.yml
@@ -1,7 +1,7 @@
 ---
 - name: Get OCI ClusterRole, and ClusterRoleBinding
   get_url:
-    url: "https://raw.githubusercontent.com/oracle/oci-cloud-controller-manager/{{oci_cloud_controller_version}}/manifests/oci-cloud-controller-manager-rbac.yaml"
+    url: "https://raw.githubusercontent.com/oracle/oci-cloud-controller-manager/{{ oci_cloud_controller_version }}/manifests/oci-cloud-controller-manager-rbac.yaml"
     dest: "/tmp/oci-cloud-controller-manager-rbac.yaml"
     force: yes
   register: result
@@ -15,7 +15,7 @@
 
 - name: Apply OCI ClusterRole, and ClusterRoleBinding
   kube:
-    kubectl: "{{bin_dir}}/kubectl"
+    kubectl: "{{ bin_dir }}/kubectl"
     filename: "/tmp/oci-cloud-controller-manager-rbac.yaml"
   when:
     - cloud_provider is defined

--- a/roles/kubernetes-apps/container_engine_accelerator/nvidia_gpu/defaults/main.yml
+++ b/roles/kubernetes-apps/container_engine_accelerator/nvidia_gpu/defaults/main.yml
@@ -4,7 +4,7 @@ nvidia_driver_version: "390.87"
 nvidia_gpu_tesla_base_url: https://us.download.nvidia.com/tesla/
 nvidia_gpu_gtx_base_url: http://us.download.nvidia.com/XFree86/Linux-x86_64/
 nvidia_gpu_flavor: tesla
-nvidia_url_end: "{{nvidia_driver_version}}/NVIDIA-Linux-x86_64-{{nvidia_driver_version}}.run"
+nvidia_url_end: "{{ nvidia_driver_version }}/NVIDIA-Linux-x86_64-{{ nvidia_driver_version }}.run"
 nvidia_driver_install_container: false
 nvidia_driver_install_supported: false
 nvidia_gpu_nodes: []

--- a/roles/kubernetes-apps/container_engine_accelerator/nvidia_gpu/tasks/main.yml
+++ b/roles/kubernetes-apps/container_engine_accelerator/nvidia_gpu/tasks/main.yml
@@ -13,12 +13,12 @@
 
 - name: Container Engine Acceleration Nvidia GPU | Set fact of download url Tesla
   set_fact:
-    nvidia_driver_download_url_default: "{{nvidia_gpu_tesla_base_url}}{{nvidia_url_end}}"
+    nvidia_driver_download_url_default: "{{ nvidia_gpu_tesla_base_url }}{{ nvidia_url_end }}"
   when: nvidia_gpu_flavor|lower == "tesla"
 
 - name: Container Engine Acceleration Nvidia GPU | Set fact of download url GTX
   set_fact:
-    nvidia_driver_download_url_default: "{{nvidia_gpu_gtx_base_url}}{{nvidia_url_end}}"
+    nvidia_driver_download_url_default: "{{ nvidia_gpu_gtx_base_url }}{{ nvidia_url_end }}"
   when: nvidia_gpu_flavor|lower == "gtx"
 
 - name: Container Engine Acceleration Nvidia GPU | Create addon dir
@@ -49,6 +49,6 @@
     filename: "{{ kube_config_dir }}/addons/container_engine_accelerator/{{ item.item.file }}"
     state: "latest"
   with_items:
-    - "{{container_engine_accelerator_manifests.results}}"
+    - "{{ container_engine_accelerator_manifests.results }}"
   when:
     - inventory_hostname == groups['kube-master'][0] and nvidia_driver_install_container and nvidia_driver_install_supported

--- a/roles/kubernetes-apps/helm/tasks/gen_helm_tiller_certs.yml
+++ b/roles/kubernetes-apps/helm/tasks/gen_helm_tiller_certs.yml
@@ -1,15 +1,15 @@
 ---
-- name: "Gen_helm_tiller_certs | Create helm config directory (on {{groups['kube-master'][0]}})"
+- name: "Gen_helm_tiller_certs | Create helm config directory (on {{ groups['kube-master'][0] }})"
   run_once: yes
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ groups['kube-master'][0] }}"
   file:
     path: "{{ helm_config_dir }}"
     state: directory
     owner: kube
 
-- name: "Gen_helm_tiller_certs | Create helm script directory (on {{groups['kube-master'][0]}})"
+- name: "Gen_helm_tiller_certs | Create helm script directory (on {{ groups['kube-master'][0] }})"
   run_once: yes
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ groups['kube-master'][0] }}"
   file:
     path: "{{ helm_script_dir }}"
     state: directory
@@ -17,27 +17,28 @@
 
 - name: Gen_helm_tiller_certs | Copy certs generation script
   run_once: yes
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ groups['kube-master'][0] }}"
   template:
     src: "helm-make-ssl.sh.j2"
     dest: "{{ helm_script_dir }}/helm-make-ssl.sh"
     mode: 0700
 
-- name: "Check_helm_certs | check if helm client certs have already been generated on first master (on {{groups['kube-master'][0]}})"
+- name: "Check_helm_certs | check if helm client certs have already been generated on first master (on {{ groups['kube-master'][0] }})"
   find:
     paths: "{{ helm_home_dir }}"
     patterns: "*.pem"
     get_checksum: true
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ groups['kube-master'][0] }}"
   register: helmcert_master
   run_once: true
 
 - name: Gen_helm_tiller_certs | run cert generation script
   run_once: yes
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ groups['kube-master'][0] }}"
   command: "{{ helm_script_dir }}/helm-make-ssl.sh -e {{ helm_home_dir }} -d {{ helm_tiller_cert_dir }}"
 
-- set_fact:
+- name: set helm_client_certs
+  set_fact:
     helm_client_certs: ['ca.pem', 'cert.pem', 'key.pem']
 
 - name: "Check_helm_client_certs | check if a cert already exists on master node"
@@ -51,9 +52,10 @@
 - name: "Check_helm_client_certs | Set 'sync_helm_certs' to true on masters"
   set_fact:
     sync_helm_certs: true
-  when: inventory_hostname != groups['kube-master'][0] and
-      (not item in helmcert_node.files | map(attribute='path') | map("basename") | list or
-      helmcert_node.files | selectattr("path", "equalto", "{{ helm_home_dir }}/{{ item }}") | map(attribute="checksum")|first|default('') != helmcert_master.files | selectattr("path", "equalto", "{{ helm_home_dir }}/{{ item }}") | map(attribute="checksum")|first|default(''))
+  when:
+    - inventory_hostname != groups['kube-master'][0]
+    - (not item in helmcert_node.files | map(attribute='path') | map("basename") | list or
+      helmcert_node.files | selectattr("path", "equalto", "{{ helm_home_dir }}/{{ item }}") | map(attribute="checksum")|first|default('') != helmcert_master.files | selectattr("path", "equalto", "{{ helm_home_dir }}/{{ item }}") | map(attribute="checksum")|first|default(''))  # noqa: E102
   with_items:
     - "{{ helm_client_certs }}"
 
@@ -64,7 +66,7 @@
   no_log: true
   register: helm_client_cert_data
   check_mode: no
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ groups['kube-master'][0] }}"
   when: sync_helm_certs|default(false) and inventory_hostname != groups['kube-master'][0]
 
 - name: Gen_helm_tiller_certs | Use tempfile for unpacking certs on masters
@@ -78,8 +80,8 @@
 
 - name: Gen_helm_tiller_certs | Write helm client certs to tempfile
   copy:
-    content: "{{helm_client_cert_data.stdout}}"
-    dest: "{{helm_cert_tempfile.path}}"
+    content: "{{ helm_client_cert_data.stdout }}"
+    dest: "{{ helm_cert_tempfile.path }}"
     owner: root
     mode: "0600"
   when: sync_helm_certs|default(false) and inventory_hostname != groups['kube-master'][0]
@@ -93,7 +95,7 @@
 
 - name: Gen_helm_tiller_certs | Cleanup tempfile on masters
   file:
-    path: "{{helm_cert_tempfile.path}}"
+    path: "{{ helm_cert_tempfile.path }}"
     state: absent
   when: sync_helm_certs|default(false) and inventory_hostname != groups['kube-master'][0]
 

--- a/roles/kubernetes-apps/helm/tasks/main.yml
+++ b/roles/kubernetes-apps/helm/tasks/main.yml
@@ -7,8 +7,8 @@
 
 - name: Helm | Lay Down Helm Manifests (RBAC)
   template:
-    src: "{{item.file}}.j2"
-    dest: "{{kube_config_dir}}/{{item.file}}"
+    src: "{{ item.file }}.j2"
+    dest: "{{ kube_config_dir }}/{{ item.file }}"
   with_items:
     - {name: tiller, file: tiller-namespace.yml, type: namespace}
     - {name: tiller, file: tiller-sa.yml, type: sa}
@@ -20,11 +20,11 @@
 
 - name: Helm | Apply Helm Manifests (RBAC)
   kube:
-    name: "{{item.item.name}}"
+    name: "{{ item.item.name }}"
     namespace: "{{ tiller_namespace }}"
-    kubectl: "{{bin_dir}}/kubectl"
-    resource: "{{item.item.type}}"
-    filename: "{{kube_config_dir}}/{{item.item.file}}"
+    kubectl: "{{ bin_dir }}/kubectl"
+    resource: "{{ item.item.type }}"
+    filename: "{{ kube_config_dir }}/{{ item.item.file }}"
     state: "latest"
   with_items: "{{ manifests.results }}"
   when:
@@ -55,7 +55,7 @@
     {% endif %}
   register: install_helm
   changed_when: false
-  environment: "{{proxy_env}}"
+  environment: "{{ proxy_env }}"
 
 # FIXME: https://github.com/helm/helm/issues/4063
 - name: Helm | Force apply tiller overrides if necessary
@@ -71,12 +71,12 @@
     {% if tiller_enable_tls %} --tiller-tls --tiller-tls-verify --tiller-tls-cert={{ tiller_tls_cert }} --tiller-tls-key={{ tiller_tls_key }} --tls-ca-cert={{ tiller_tls_ca_cert }} {% endif %}
     {% if tiller_secure_release_info %} --override 'spec.template.spec.containers[0].command'='{/tiller,--storage=secret}' {% endif %}
     --output yaml
-    | {{bin_dir}}/kubectl apply -f -
+    | {{ bin_dir }}/kubectl apply -f -
   changed_when: false
   when:
     - (tiller_override is defined and tiller_override != "") or (kube_version is version('v1.11.1', '>='))
     - inventory_hostname == groups['kube-master'][0]
-  environment: "{{proxy_env}}"
+  environment: "{{ proxy_env }}"
 
 - name: Helm | Set up bash completion
   shell: "umask 022 && {{ bin_dir }}/helm completion bash >/etc/bash_completion.d/helm.sh"

--- a/roles/kubernetes-apps/network_plugin/calico/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/calico/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 - name: Start Calico resources
   kube:
-    name: "{{item.item.name}}"
+    name: "{{ item.item.name }}"
     namespace: "kube-system"
-    kubectl: "{{bin_dir}}/kubectl"
-    resource: "{{item.item.type}}"
-    filename: "{{kube_config_dir}}/{{item.item.file}}"
+    kubectl: "{{ bin_dir }}/kubectl"
+    resource: "{{ item.item.type }}"
+    filename: "{{ kube_config_dir }}/{{ item.item.file }}"
     state: "latest"
   with_items:
     - "{{ calico_node_manifests.results }}"

--- a/roles/kubernetes-apps/network_plugin/canal/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/canal/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 - name: Canal | Start Resources
   kube:
-    name: "{{item.item.name}}"
+    name: "{{ item.item.name }}"
     namespace: "kube-system"
-    kubectl: "{{bin_dir}}/kubectl"
-    resource: "{{item.item.type}}"
-    filename: "{{kube_config_dir}}/{{item.item.file}}"
+    kubectl: "{{ bin_dir }}/kubectl"
+    resource: "{{ item.item.type }}"
+    filename: "{{ kube_config_dir }}/{{ item.item.file }}"
     state: "latest"
   with_items: "{{ canal_manifests.results }}"
   when: inventory_hostname == groups['kube-master'][0] and not item is skipped

--- a/roles/kubernetes-apps/network_plugin/flannel/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/flannel/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 - name: Flannel | Start Resources
   kube:
-    name: "{{item.item.name}}"
+    name: "{{ item.item.name }}"
     namespace: "kube-system"
-    kubectl: "{{bin_dir}}/kubectl"
-    resource: "{{item.item.type}}"
-    filename: "{{kube_config_dir}}/{{item.item.file}}"
+    kubectl: "{{ bin_dir }}/kubectl"
+    resource: "{{ item.item.type }}"
+    filename: "{{ kube_config_dir }}/{{ item.item.file }}"
     state: "latest"
   with_items: "{{ flannel_node_manifests.results }}"
   when: inventory_hostname == groups['kube-master'][0] and not item is skipped

--- a/roles/kubernetes-apps/network_plugin/multus/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/multus/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 - name: Multus | Start resources
   kube:
-    name: "{{item.item.name}}"
+    name: "{{ item.item.name }}"
     namespace: "kube-system"
-    kubectl: "{{bin_dir}}/kubectl"
-    resource: "{{item.item.type}}"
-    filename: "{{kube_config_dir}}/{{item.item.file}}"
+    kubectl: "{{ bin_dir }}/kubectl"
+    resource: "{{ item.item.type }}"
+    filename: "{{ kube_config_dir }}/{{ item.item.file }}"
     state: "latest"
-  with_items: "{{ multus_manifest_1.results }} + {{multus_manifest_2.results }}"
+  with_items: "{{ multus_manifest_1.results }} + {{ multus_manifest_2.results }}"
   when: inventory_hostname == groups['kube-master'][0] and not item|skipped

--- a/roles/kubernetes-apps/persistent_volumes/openstack/tasks/main.yml
+++ b/roles/kubernetes-apps/persistent_volumes/openstack/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Kubernetes Persistent Volumes | Lay down OpenStack Cinder Storage Class template
   template:
     src: "openstack-storage-class.yml.j2"
-    dest: "{{kube_config_dir}}/openstack-storage-class.yml"
+    dest: "{{ kube_config_dir }}/openstack-storage-class.yml"
   register: manifests
   when:
     - inventory_hostname == groups['kube-master'][0]
@@ -10,9 +10,9 @@
 - name: Kubernetes Persistent Volumes | Add OpenStack Cinder Storage Class
   kube:
     name: storage-class
-    kubectl: "{{bin_dir}}/kubectl"
+    kubectl: "{{ bin_dir }}/kubectl"
     resource: StorageClass
-    filename: "{{kube_config_dir}}/openstack-storage-class.yml"
+    filename: "{{ kube_config_dir }}/openstack-storage-class.yml"
     state: "latest"
   when:
     - inventory_hostname == groups['kube-master'][0]

--- a/roles/kubernetes-apps/policy_controller/calico/tasks/main.yml
+++ b/roles/kubernetes-apps/policy_controller/calico/tasks/main.yml
@@ -10,8 +10,8 @@
 
 - name: Create calico-kube-controllers manifests
   template:
-    src: "{{item.file}}.j2"
-    dest: "{{kube_config_dir}}/{{item.file}}"
+    src: "{{ item.file }}.j2"
+    dest: "{{ kube_config_dir }}/{{ item.file }}"
   with_items:
     - {name: calico-kube-controllers, file: calico-kube-controllers.yml, type: deployment}
     - {name: calico-kube-controllers, file: calico-kube-sa.yml, type: sa}
@@ -24,11 +24,11 @@
 
 - name: Start of Calico kube controllers
   kube:
-    name: "{{item.item.name}}"
+    name: "{{ item.item.name }}"
     namespace: "kube-system"
-    kubectl: "{{bin_dir}}/kubectl"
-    resource: "{{item.item.type}}"
-    filename: "{{kube_config_dir}}/{{item.item.file}}"
+    kubectl: "{{ bin_dir }}/kubectl"
+    resource: "{{ item.item.type }}"
+    filename: "{{ kube_config_dir }}/{{ item.item.file }}"
     state: "latest"
   with_items:
     - "{{ calico_kube_manifests.results }}"

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -67,7 +67,7 @@
 - name: Join to cluster if needed
   command: >-
     {{ bin_dir }}/kubeadm join
-    --config {{ kube_config_dir}}/kubeadm-client.conf
+    --config {{ kube_config_dir }}/kubeadm-client.conf
     --ignore-preflight-errors=all
   register: kubeadm_join
   when: not is_kube_master and (not kubelet_conf.stat.exists)
@@ -107,7 +107,7 @@
 # is fixed
 - name: Delete kube-proxy daemonset if kube_proxy_remove set, e.g. kube_network_plugin providing proxy services
   shell: "{{ bin_dir }}/kubectl --kubeconfig /etc/kubernetes/admin.conf delete daemonset -n kube-system kube-proxy"
-  delegate_to: "{{groups['kube-master']|first}}"
+  delegate_to: "{{ groups['kube-master']|first }}"
   run_once: true
   when:
     - kube_proxy_remove

--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -3,7 +3,7 @@
   stat:
     path: "{{ kube_cert_dir }}/apiserver.pem"
   register: old_apiserver_cert
-  delegate_to: "{{groups['kube-master']|first}}"
+  delegate_to: "{{ groups['kube-master']|first }}"
   run_once: true
 
 - name: kubeadm | Migrate old certs if necessary
@@ -14,7 +14,7 @@
   stat:
     path: "{{ kube_cert_dir }}/apiserver.key"
   register: apiserver_key_before
-  delegate_to: "{{groups['kube-master']|first}}"
+  delegate_to: "{{ groups['kube-master']|first }}"
   run_once: true
 
 - name: kubeadm | Check if kubeadm has already run
@@ -31,14 +31,14 @@
 
 - name: kubeadm | Delete old static pods
   file:
-    path: "{{ kube_config_dir }}/manifests/{{item}}.manifest"
+    path: "{{ kube_config_dir }}/manifests/{{ item }}.manifest"
     state: absent
   with_items: ["kube-apiserver", "kube-controller-manager", "kube-scheduler", "kube-proxy"]
   when:
     - old_apiserver_cert.stat.exists
 
 - name: kubeadm | Forcefully delete old static pods
-  shell: "docker ps -f name=k8s_{{item}} -q | xargs --no-run-if-empty docker rm -f"
+  shell: "docker ps -f name=k8s_{{ item }} -q | xargs --no-run-if-empty docker rm -f"
   with_items: ["kube-apiserver", "kube-controller-manager", "kube-scheduler"]
   when:
     - old_apiserver_cert.stat.exists
@@ -169,7 +169,7 @@
   stat:
     path: "{{ kube_cert_dir }}/apiserver.key"
   register: apiserver_key_after
-  delegate_to: "{{groups['kube-master']|first}}"
+  delegate_to: "{{ groups['kube-master']|first }}"
   run_once: true
 
 - name: kubeadm | Set secret_changed if service account key was updated
@@ -184,6 +184,6 @@
 
 - name: kubeadm | Remove taint for master with node role
   command: "{{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf taint node {{ inventory_hostname }} node-role.kubernetes.io/master:NoSchedule-"
-  delegate_to: "{{groups['kube-master']|first}}"
+  delegate_to: "{{ groups['kube-master']|first }}"
   when: inventory_hostname in groups['kube-node']
   failed_when: false

--- a/roles/kubernetes/master/tasks/pre-upgrade.yml
+++ b/roles/kubernetes/master/tasks/pre-upgrade.yml
@@ -6,7 +6,7 @@
     ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem"
     ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem"
   register: old_data_exists
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{ groups['etcd'][0] }}"
   changed_when: false
   when: kube_apiserver_storage_backend == "etcd3"
   failed_when: false
@@ -18,7 +18,7 @@
 
 - name: "Pre-upgrade | Delete master manifests"
   file:
-    path: "/etc/kubernetes/manifests/{{item}}.manifest"
+    path: "/etc/kubernetes/manifests/{{ item }}.manifest"
     state: absent
   with_items:
     - ["kube-apiserver", "kube-controller-manager", "kube-scheduler"]
@@ -26,7 +26,7 @@
   when: (secret_changed|default(false) or etcd_secret_changed|default(false))
 
 - name: "Pre-upgrade | Delete master containers forcefully"
-  shell: "docker ps -af name=k8s_{{item}}* -q | xargs --no-run-if-empty docker rm -f"
+  shell: "docker ps -af name=k8s_{{ item }}* -q | xargs --no-run-if-empty docker rm -f"
   with_items:
     - ["kube-apiserver", "kube-controller-manager", "kube-scheduler"]
   when: kube_apiserver_manifest_replaced.changed

--- a/roles/kubernetes/node/tasks/nginx-proxy.yml
+++ b/roles/kubernetes/node/tasks/nginx-proxy.yml
@@ -2,7 +2,7 @@
 - name: nginx-proxy | Write static pod
   template:
     src: manifests/nginx-proxy.manifest.j2
-    dest: "{{kube_manifest_dir}}/nginx-proxy.yml"
+    dest: "{{ kube_manifest_dir }}/nginx-proxy.yml"
 
 - name: nginx-proxy | Make nginx directory
   file:

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -41,7 +41,7 @@
 - name: "Stop if known booleans are set as strings (Use JSON format on CLI: -e \"{'key': true }\")"
   assert:
     that: item.value|type_debug == 'bool'
-    msg: "{{item.value}} isn't a bool"
+    msg: "{{ item.value }} isn't a bool"
   run_once: yes
   with_items:
     - { name: download_run_once, value: "{{ download_run_once }}" }

--- a/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
@@ -8,9 +8,9 @@
   set_fact:
     host_architecture: >-
       {%- if ansible_architecture in architecture_groups -%}
-      {{architecture_groups[ansible_architecture]}}
+      {{ architecture_groups[ansible_architecture] }}
       {%- else -%}
-       {{ansible_architecture}}
+       {{ ansible_architecture }}
       {% endif %}
 
 - name: Force binaries directory for Container Linux by CoreOS
@@ -46,7 +46,7 @@
 - set_fact:
     bogus_domains: |-
       {% for d in [ 'default.svc.' + dns_domain, 'svc.' + dns_domain ] + searchdomains|default([]) -%}
-      {{dns_domain}}.{{d}}./{{d}}.{{d}}./com.{{d}}./
+      {{ dns_domain }}.{{ d }}./{{ d }}.{{ d }}./com.{{ d }}./
       {%- endfor %}
     cloud_resolver: >-
       {%- if cloud_provider is defined and cloud_provider == 'gce' -%}
@@ -141,9 +141,9 @@
 - name: generate nameservers to resolvconf
   set_fact:
     nameserverentries:
-      nameserver {{( dnsmasq_server + nameservers|d([]) + cloud_resolver|d([])) | join(',nameserver ')}}
+      nameserver {{ ( dnsmasq_server + nameservers|d([]) + cloud_resolver|d([])) | join(',nameserver ') }}
     supersede_nameserver:
-      supersede domain-name-servers {{( dnsmasq_server + nameservers|d([]) + cloud_resolver|d([])) | join(', ') }};
+      supersede domain-name-servers {{ ( dnsmasq_server + nameservers|d([]) + cloud_resolver|d([])) | join(', ') }};
 
 - name: gather os specific variables
   include_vars: "{{ item }}"

--- a/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
+++ b/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
@@ -17,7 +17,7 @@
     - master
     - node
   with_items:
-    - "{{bin_dir}}"
+    - "{{ bin_dir }}"
     - "{{ kube_config_dir }}"
     - "{{ kube_cert_dir }}"
     - "{{ kube_manifest_dir }}"

--- a/roles/kubernetes/preinstall/tasks/0060-resolvconf.yml
+++ b/roles/kubernetes/preinstall/tasks/0060-resolvconf.yml
@@ -5,7 +5,7 @@
 
 - name: Add domain/search/nameservers/options to resolv.conf
   blockinfile:
-    path: "{{resolvconffile}}"
+    path: "{{ resolvconffile }}"
     block: |-
       {% for item in [domainentry] + [searchentries] + nameserverentries.split(',') -%}
       {{ item }}
@@ -22,7 +22,7 @@
 
 - name: Remove search/domain/nameserver options before block
   replace:
-    dest: "{{item[0]}}"
+    dest: "{{ item[0] }}"
     regexp: '^{{ item[1] }}[^#]*(?=# Ansible entries BEGIN)'
     backup: yes
     follow: yes
@@ -33,7 +33,7 @@
 
 - name: Remove search/domain/nameserver options after block
   replace:
-    dest: "{{item[0]}}"
+    dest: "{{ item[0] }}"
     regexp: '(# Ansible entries END\n(?:(?!^{{ item[1] }}).*\n)*)(?:^{{ item[1] }}.*\n?)+'
     replace: '\1'
     backup: yes
@@ -51,7 +51,7 @@
 
 - name: persist resolvconf cloud init file
   template:
-    dest: "{{resolveconf_cloud_init_conf}}"
+    dest: "{{ resolveconf_cloud_init_conf }}"
     src: resolvconf.j2
     owner: root
     mode: 0644

--- a/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
+++ b/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
@@ -12,7 +12,7 @@
     state: "{{ preinstall_selinux_state }}"
   when:
     - ansible_os_family == "RedHat"
-    - slc.stat.exists == True
+    - slc.stat.exists
   changed_when: False
   tags:
     - bootstrap-os
@@ -31,14 +31,14 @@
 
 - name: Stat sysctl file configuration
   stat:
-    path: "{{sysctl_file_path}}"
+    path: "{{ sysctl_file_path }}"
   register: sysctl_file_stat
   tags:
     - bootstrap-os
 
 - name: Change sysctl file path to link source if linked
   set_fact:
-    sysctl_file_path: "{{sysctl_file_stat.stat.lnk_source}}"
+    sysctl_file_path: "{{ sysctl_file_stat.stat.lnk_source }}"
   when:
     - sysctl_file_stat.stat.islnk is defined
     - sysctl_file_stat.stat.islnk
@@ -52,7 +52,7 @@
 
 - name: Enable ip forwarding
   sysctl:
-    sysctl_file: "{{sysctl_file_path}}"
+    sysctl_file: "{{ sysctl_file_path }}"
     name: net.ipv4.ip_forward
     value: 1
     state: present

--- a/roles/kubernetes/preinstall/tasks/0100-dhclient-hooks.yml
+++ b/roles/kubernetes/preinstall/tasks/0100-dhclient-hooks.yml
@@ -5,7 +5,7 @@
       {% for item in [ supersede_domain, supersede_search, supersede_nameserver ] -%}
       {{ item }}
       {% endfor %}
-    path: "{{dhclientconffile}}"
+    path: "{{ dhclientconffile }}"
     create: yes
     state: present
     insertbefore: BOF

--- a/roles/kubernetes/preinstall/tasks/0110-dhclient-hooks-undo.yml
+++ b/roles/kubernetes/preinstall/tasks/0110-dhclient-hooks-undo.yml
@@ -5,7 +5,7 @@
 
 - name: Remove kubespray specific config from dhclient config
   blockinfile:
-    path: "{{dhclientconffile}}"
+    path: "{{ dhclientconffile }}"
     state: absent
     backup: yes
     marker: "# Ansible entries {mark}"

--- a/roles/kubernetes/tokens/tasks/check-tokens.yml
+++ b/roles/kubernetes/tokens/tasks/check-tokens.yml
@@ -2,7 +2,7 @@
 - name: "Check_tokens | check if the tokens have already been generated on first master"
   stat:
     path: "{{ kube_token_dir }}/known_tokens.csv"
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ groups['kube-master'][0] }}"
   register: known_tokens_master
   run_once: true
 

--- a/roles/kubernetes/tokens/tasks/gen_tokens.yml
+++ b/roles/kubernetes/tokens/tasks/gen_tokens.yml
@@ -5,7 +5,7 @@
     dest: "{{ kube_script_dir }}/kube-gen-token.sh"
     mode: 0700
   run_once: yes
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ groups['kube-master'][0] }}"
   when: gen_tokens|default(false)
 
 - name: Gen_tokens | generate tokens for master components
@@ -18,7 +18,7 @@
   register: gentoken_master
   changed_when: "'Added' in gentoken_master.stdout"
   run_once: yes
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ groups['kube-master'][0] }}"
   when: gen_tokens|default(false)
 
 - name: Gen_tokens | generate tokens for node components
@@ -31,14 +31,14 @@
   register: gentoken_node
   changed_when: "'Added' in gentoken_node.stdout"
   run_once: yes
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ groups['kube-master'][0] }}"
   when: gen_tokens|default(false)
 
 - name: Gen_tokens | Get list of tokens from first master
   shell: "(find {{ kube_token_dir }} -maxdepth 1 -type f)"
   register: tokens_list
   check_mode: no
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ groups['kube-master'][0] }}"
   run_once: true
   when: sync_tokens|default(false)
 
@@ -48,7 +48,7 @@
     warn: false
   register: tokens_data
   check_mode: no
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ groups['kube-master'][0] }}"
   run_once: true
   when: sync_tokens|default(false)
 

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -72,13 +72,13 @@ skydns_server_secondary: "{{ kube_service_addresses|ipaddr('net')|ipaddr(4)|ipad
 dnsmasq_dns_server: "{{ kube_service_addresses|ipaddr('net')|ipaddr(2)|ipaddr('address') }}"
 dns_domain: "{{ cluster_name }}"
 kube_dns_servers:
-  kubedns: ["{{skydns_server}}"]
-  coredns: ["{{skydns_server}}"]
-  coredns_dual: "{{[skydns_server] + [ skydns_server_secondary ]}}"
-  manual: ["{{manual_dns_server}}"]
-  dnsmasq_kubedns: ["{{dnsmasq_dns_server}}"]
+  kubedns: ["{{ skydns_server }}"]
+  coredns: ["{{ skydns_server }}"]
+  coredns_dual: "{{ [skydns_server] + [ skydns_server_secondary ] }}"
+  manual: ["{{ manual_dns_server }}"]
+  dnsmasq_kubedns: ["{{ dnsmasq_dns_server }}"]
 
-dns_servers: "{{kube_dns_servers[dns_mode]}}"
+dns_servers: "{{ kube_dns_servers[dns_mode] }}"
 
 # Kubernetes configuration dirs and system namespace.
 # Those are where all the additional config stuff goes
@@ -110,7 +110,7 @@ kube_log_level: 2
 kube_api_pwd: "changeme"
 kube_users:
   kube:
-    pass: "{{kube_api_pwd}}"
+    pass: "{{ kube_api_pwd }}"
     role: admin
 
 # Choose network plugin (cilium, calico, weave or flannel)
@@ -439,8 +439,8 @@ etcd_events_access_addresses_list: |-
     'https://{{ hostvars[item]['access_ip'] | default(hostvars[item]['ip'] | default(hostvars[item]['ansible_default_ipv4']['address'])) }}:2381'{% if not loop.last %},{% endif %}
   {%- endfor %}
   ]
-etcd_events_access_addresses: "{{etcd_events_access_addresses_list | join(',')}}"
-etcd_events_access_addresses_semicolon: "{{etcd_events_access_addresses_list | join(';')}}"
+etcd_events_access_addresses: "{{ etcd_events_access_addresses_list | join(',') }}"
+etcd_events_access_addresses_semicolon: "{{ etcd_events_access_addresses_list | join(';') }}"
 # user should set etcd_member_name in inventory/mycluster/hosts.ini
 etcd_member_name: |-
   {% for host in groups['etcd'] %}

--- a/roles/network_plugin/calico/rr/tasks/main.yml
+++ b/roles/network_plugin/calico/rr/tasks/main.yml
@@ -61,7 +61,7 @@
     ETCDCTL_KEY: "{{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}-key.pem"
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{ groups['etcd'][0] }}"
   when:
     - calico_version is version("v3.0.0", ">=")
 
@@ -79,7 +79,7 @@
     ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}-key.pem"
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{ groups['etcd'][0] }}"
   when:
     - calico_version is version("v3.0.0", "<")
 

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -153,7 +153,7 @@
     - calico_version is version('v3.0.0', '>=')
 
 - name: Calico | Set global as_num (legacy)
-  command: "{{ bin_dir}}/calicoctl config set asNumber {{ global_as_num }}"
+  command: "{{ bin_dir }}/calicoctl config set asNumber {{ global_as_num }}"
   run_once: true
   when:
     - calico_version is version('v3.0.0', '<')
@@ -299,7 +299,7 @@
       "name": "{{ inventory_hostname }}-{{ hostvars[item]["calico_rr_ip"]|default(hostvars[item]["ip"])|default(hostvars[item]["ansible_default_ipv4"]["address"]) }}"
    },
    "spec": {
-      "asNumber": "{{ local_as | default(global_as_num)}}",
+      "asNumber": "{{ local_as | default(global_as_num) }}",
       "node": "{{ inventory_hostname }}",
       "peerIP": "{{ hostvars[item]["calico_rr_ip"]|default(hostvars[item]["ip"])|default(hostvars[item]["ansible_default_ipv4"]["address"]) }}"
    }}' | {{ bin_dir }}/calicoctl create --skip-exists -f -
@@ -317,7 +317,7 @@
   shell: >
    echo '{
    "kind": "bgpPeer",
-   "spec": {"asNumber": "{{ local_as | default(global_as_num)}}"},
+   "spec": {"asNumber": "{{ local_as | default(global_as_num) }}"},
    "apiVersion": "v1",
    "metadata": {"node": "{{ inventory_hostname }}",
      "scope": "node",
@@ -336,8 +336,8 @@
 
 - name: Calico | Create calico manifests
   template:
-    src: "{{item.file}}.j2"
-    dest: "{{kube_config_dir}}/{{item.file}}"
+    src: "{{ item.file }}.j2"
+    dest: "{{ kube_config_dir }}/{{ item.file }}"
   with_items:
     - {name: calico-config, file: calico-config.yml, type: cm}
     - {name: calico-node, file: calico-node.yml, type: ds}

--- a/roles/network_plugin/calico/tasks/upgrade.yml
+++ b/roles/network_plugin/calico/tasks/upgrade.yml
@@ -7,7 +7,7 @@
     owner: root
     group: root
     force: yes
-  environment: "{{proxy_env}}"
+  environment: "{{ proxy_env }}"
 - name: "Create etcdv2 and etcdv3 calicoApiConfig"
   template:
     src: "{{ item }}-store.yml.j2"
@@ -17,10 +17,10 @@
     - "etcdv3"
 
 - name: "Tests data migration (dry-run)"
-  shell: "{{ bin_dir }}/calico-upgrade dry-run --output-dir=/tmp --apiconfigv1 /etc/calico/etcdv2.yml --apiconfigv3 /etc/calico/etcdv3.yml"
+  command: "{{ bin_dir }}/calico-upgrade dry-run --output-dir=/tmp --apiconfigv1 /etc/calico/etcdv2.yml --apiconfigv3 /etc/calico/etcdv3.yml"
   register: calico_upgrade_test_data
   failed_when: '"Successfully" not in calico_upgrade_test_data.stdout'
 
 - name: "If test migration is success continue with calico data real migration"
-  shell: "{{ bin_dir }}/calico-upgrade start --no-prompts --apiconfigv1 /etc/calico/etcdv2.yml --apiconfigv3 /etc/calico/etcdv3.yml --output-dir=/tmp/calico_upgrade"
+  command: "{{ bin_dir }}/calico-upgrade start --no-prompts --apiconfigv1 /etc/calico/etcdv2.yml --apiconfigv3 /etc/calico/etcdv3.yml --output-dir=/tmp/calico_upgrade"
   register: calico_upgrade_migration_data

--- a/roles/network_plugin/canal/tasks/main.yml
+++ b/roles/network_plugin/canal/tasks/main.yml
@@ -31,7 +31,7 @@
     '{ "Network": "{{ kube_pods_subnet }}", "SubnetLen": {{ kube_network_node_prefix }}, "Backend": { "Type": "{{ flannel_backend_type }}" } }'
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{ groups['etcd'][0] }}"
   changed_when: false
   run_once: true
   environment:
@@ -40,8 +40,8 @@
 
 - name: Canal | Create canal node manifests
   template:
-    src: "{{item.file}}.j2"
-    dest: "{{kube_config_dir}}/{{item.file}}"
+    src: "{{ item.file }}.j2"
+    dest: "{{ kube_config_dir }}/{{ item.file }}"
   with_items:
     - {name: canal-config, file: canal-config.yaml, type: cm}
     - {name: canal-node, file: canal-node.yaml, type: ds}

--- a/roles/network_plugin/cilium/tasks/main.yml
+++ b/roles/network_plugin/cilium/tasks/main.yml
@@ -27,8 +27,8 @@
 
 - name: Cilium | Create Cilium node manifests
   template:
-    src: "{{item.file}}.j2"
-    dest: "{{kube_config_dir}}/{{item.file}}"
+    src: "{{ item.file }}.j2"
+    dest: "{{ kube_config_dir }}/{{ item.file }}"
   with_items:
     - {name: cilium, file: cilium-config.yml, type: cm}
     - {name: cilium, file: cilium-crb.yml, type: clusterrolebinding}

--- a/roles/network_plugin/contiv/tasks/main.yml
+++ b/roles/network_plugin/contiv/tasks/main.yml
@@ -56,7 +56,8 @@
       - {name: contiv-netplugin, file: contiv-netplugin.yml, type: daemonset}
   when: inventory_hostname in groups['kube-master']
 
-- set_fact:
+- name: set contiv_manifests fact
+  set_fact:
     contiv_manifests: |-
       {% set _ = contiv_manifests.append({"name": "contiv-api-proxy", "file": "contiv-api-proxy.yml", "type": "daemonset"}) %}
       {{ contiv_manifests }}

--- a/roles/network_plugin/flannel/tasks/main.yml
+++ b/roles/network_plugin/flannel/tasks/main.yml
@@ -3,8 +3,8 @@
 
 - name: Flannel | Create Flannel manifests
   template:
-    src: "{{item.file}}.j2"
-    dest: "{{kube_config_dir}}/{{item.file}}"
+    src: "{{ item.file }}.j2"
+    dest: "{{ kube_config_dir }}/{{ item.file }}"
   with_items:
     - {name: flannel, file: cni-flannel-rbac.yml, type: sa}
     - {name: kube-flannel, file: cni-flannel.yml, type: ds}

--- a/roles/network_plugin/kube-router/tasks/annotate.yml
+++ b/roles/network_plugin/kube-router/tasks/annotate.yml
@@ -1,21 +1,21 @@
 ---
 - name: kube-router | Add annotations on kube-master
-  command: "{{bin_dir}}/kubectl annotate --overwrite node {{ ansible_hostname }} {{ item }}"
+  command: "{{ bin_dir }}/kubectl annotate --overwrite node {{ ansible_hostname }} {{ item }}"
   with_items:
   - "{{ kube_router_annotations_master }}"
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ groups['kube-master'][0] }}"
   when: kube_router_annotations_master is defined and inventory_hostname in groups['kube-master']
 
 - name: kube-router | Add annotations on kube-node
-  command: "{{bin_dir}}/kubectl annotate --overwrite node {{ ansible_hostname }} {{ item }}"
+  command: "{{ bin_dir }}/kubectl annotate --overwrite node {{ ansible_hostname }} {{ item }}"
   with_items:
   - "{{ kube_router_annotations_node }}"
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ groups['kube-master'][0] }}"
   when: kube_router_annotations_node is defined and inventory_hostname in groups['kube-node']
 
 - name: kube-router | Add common annotations on all servers
-  command: "{{bin_dir}}/kubectl annotate --overwrite node {{ ansible_hostname }} {{ item }}"
+  command: "{{ bin_dir }}/kubectl annotate --overwrite node {{ ansible_hostname }} {{ item }}"
   with_items:
   - "{{ kube_router_annotations_all }}"
-  delegate_to: "{{groups['kube-master'][0]}}"
+  delegate_to: "{{ groups['kube-master'][0] }}"
   when: kube_router_annotations_all is defined and inventory_hostname in groups['all']

--- a/roles/remove-node/post-remove/tasks/main.yml
+++ b/roles/remove-node/post-remove/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Delete node
-  command: "{{ bin_dir}}/kubectl delete node {{ item }}"
+  command: "{{ bin_dir }}/kubectl delete node {{ item }}"
   with_items:
     - "{{ node.split(',') | default(groups['kube-node']) }}"
   delegate_to: "{{ groups['kube-master']|first }}"

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -117,7 +117,7 @@
     - mounts
 
 - name: reset | unmount kubelet dirs
-  command: umount -f {{item}}
+  command: umount -f {{ item }}
   with_items: '{{ mounted_dirs.stdout_lines }}'
   register: umount_dir
   retries: 4
@@ -158,7 +158,7 @@
     path: "{{ item }}"
     state: absent
   with_items:
-    - "{{kube_config_dir}}"
+    - "{{ kube_config_dir }}"
     - /var/lib/kubelet
     - /root/.kube
     - /root/.helm

--- a/roles/win_nodes/kubernetes_patch/tasks/main.yml
+++ b/roles/win_nodes/kubernetes_patch/tasks/main.yml
@@ -16,11 +16,11 @@
 
     # Due to https://github.com/kubernetes/kubernetes/issues/58212 we cannot rely on exit code for "kubectl patch"
     - name: Check current nodeselector for kube-proxy daemonset
-      shell: "{{bin_dir}}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf get ds kube-proxy --namespace=kube-system -o jsonpath='{.spec.template.spec.nodeSelector.beta.kubernetes.io/os}'"
+      shell: "{{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf get ds kube-proxy --namespace=kube-system -o jsonpath='{.spec.template.spec.nodeSelector.beta.kubernetes.io/os}'"
       register: current_kube_proxy_state
 
     - name: Apply nodeselector patch for kube-proxy daemonset
-      shell: "{{bin_dir}}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf patch ds kube-proxy --namespace=kube-system --type=strategic -p \"$(cat nodeselector-os-linux-patch.json)\""
+      shell: "{{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf patch ds kube-proxy --namespace=kube-system --type=strategic -p \"$(cat nodeselector-os-linux-patch.json)\""
       args:
         chdir: "{{ kubernetes_user_manifests_path }}"
       register: patch_kube_proxy_state

--- a/tests/testcases/020_check-create-pod.yml
+++ b/tests/testcases/020_check-create-pod.yml
@@ -17,13 +17,13 @@
     when: not ansible_os_family in ["CoreOS", "Container Linux by CoreOS"]
 
   - name: Create test namespace
-    shell: "{{bin_dir}}/kubectl create namespace test"
+    shell: "{{ bin_dir }}/kubectl create namespace test"
 
   - name: Run a replica controller composed of 2 pods in test ns
-    shell: "{{bin_dir}}/kubectl run test --image={{test_image_repo}}:{{test_image_tag}} --namespace test --replicas=2 --command -- tail -f /dev/null"
+    shell: "{{ bin_dir }}/kubectl run test --image={{test_image_repo}}:{{test_image_tag}} --namespace test --replicas=2 --command -- tail -f /dev/null"
 
   - name: Pods are running
-    shell: "{{bin_dir}}/kubectl get pods --namespace test --no-headers -o json"
+    shell: "{{ bin_dir }}/kubectl get pods --namespace test --no-headers -o json"
     register: run_pods_log
     until: [ '(run_pods_log.stdout | from_json)["items"] | map(attribute = "status.phase") | join(",") == "Running,Running"' ]
     retries: 18

--- a/tests/testcases/030_check-network.yml
+++ b/tests/testcases/030_check-network.yml
@@ -14,7 +14,7 @@
 
 
   - name: Wait for pods to be ready
-    shell: "{{bin_dir}}/kubectl get pods -n test"
+    shell: "{{ bin_dir }}/kubectl get pods -n test"
     register: pods
     until:
       - '"ContainerCreating" not in pods.stdout'
@@ -25,24 +25,24 @@
     no_log: true
 
   - name: Get pod names
-    shell: "{{bin_dir}}/kubectl get pods -n test -o json"
+    shell: "{{ bin_dir }}/kubectl get pods -n test -o json"
     register: pods
     no_log: true
 
   - name: Get hostnet pods
-    command: "{{bin_dir}}/kubectl get pods -n test -o
+    command: "{{ bin_dir }}/kubectl get pods -n test -o
              jsonpath='{range .items[?(.spec.hostNetwork)]}{.metadata.name} {.status.podIP} {.status.containerStatuses} {end}'"
     register: hostnet_pods
     no_log: true
 
   - name: Get running pods
-    command: "{{bin_dir}}/kubectl get pods -n test -o
+    command: "{{ bin_dir }}/kubectl get pods -n test -o
              jsonpath='{range .items[?(.status.phase==\"Running\")]}{.metadata.name} {.status.podIP} {.status.containerStatuses} {end}'"
     register: running_pods
     no_log: true
 
   - name: Check kubectl output
-    shell: "{{bin_dir}}/kubectl get pods --all-namespaces -owide"
+    shell: "{{ bin_dir }}/kubectl get pods --all-namespaces -owide"
     register: get_pods
     no_log: true
 
@@ -66,14 +66,14 @@
     with_items: "{{pod_ips}}"
 
   - name: Ping between pods is working
-    shell: "{{bin_dir}}/kubectl exec {{item[0]}} -- ping -c 4 {{ item[1] }}"
+    shell: "{{ bin_dir }}/kubectl exec {{item[0]}} -- ping -c 4 {{ item[1] }}"
     when: not item[0] in pods_hostnet and not item[1] in pods_hostnet
     with_nested:
       - "{{pod_names}}"
       - "{{pod_ips}}"
 
   - name: Ping between hostnet pods is working
-    shell: "{{bin_dir}}/kubectl exec {{item[0]}} -- ping -c 4 {{ item[1] }}"
+    shell: "{{ bin_dir }}/kubectl exec {{item[0]}} -- ping -c 4 {{ item[1] }}"
     when: item[0] in pods_hostnet and item[1] in pods_hostnet
     with_nested:
       - "{{pod_names}}"

--- a/tests/testcases/040_check-network-adv.yml
+++ b/tests/testcases/040_check-network-adv.yml
@@ -100,7 +100,7 @@
       delegate_to: "{{groups['kube-master'][0]}}"
       no_log: false
 
-    - command: "{{ bin_dir }}/kubectl -n kube-system logs -l k8s-app={{item}} --all-containers"
+    - command: "{{ bin_dir }}/kubectl -n kube-system logs -l k8s-app={{ item }} --all-containers"
       run_once: true
       when: not result is success
       delegate_to: "{{groups['kube-master'][0]}}"

--- a/upgrade-cluster.yml
+++ b/upgrade-cluster.yml
@@ -38,7 +38,7 @@
   pre_tasks:
     - name: gather facts from all instances
       setup:
-      delegate_to: "{{item}}"
+      delegate_to: "{{ item }}"
       delegate_facts: True
       with_items: "{{ groups['k8s-cluster'] + groups['etcd'] + groups['calico-rr']|default([]) }}"
 


### PR DESCRIPTION
Preparatory change for introduction of ansible-lint, this fixes most
numerous and simple issues:

- {{ var }} instead of {{var}}
- all tasks mush have names

This was split in order to make it easier to review, it will follow-up
by another one introduction of ansible-lint.