### PR TITLE
Add an option for helm init --wait

### DIFF
--- a/roles/kubernetes-apps/helm/defaults/main.yml
+++ b/roles/kubernetes-apps/helm/defaults/main.yml
@@ -7,6 +7,9 @@ helm_home_dir: "/root/.helm"
 # Deployment mode: host or docker
 helm_deployment_type: host
 
+# Wait until Tiller is running and ready to receive requests
+tiller_wait: false
+
 # Do not download the local repository cache on helm init
 helm_skip_refresh: false
 

--- a/roles/kubernetes-apps/helm/tasks/main.yml
+++ b/roles/kubernetes-apps/helm/tasks/main.yml
@@ -50,6 +50,7 @@
     {% if tiller_max_history is defined %} --history-max={{ tiller_max_history }}{% endif %}
     {% if tiller_enable_tls %} --tiller-tls --tiller-tls-verify --tiller-tls-cert={{ tiller_tls_cert }} --tiller-tls-key={{ tiller_tls_key }} --tls-ca-cert={{ tiller_tls_ca_cert }} {% endif %}
     {% if tiller_secure_release_info %} --override 'spec.template.spec.containers[0].command'='{/tiller,--storage=secret}' {% endif %}
+    {% if tiller_wait %} --wait{% endif %}
     {% else %}
     --client-only
     {% endif %}
@@ -70,6 +71,7 @@
     {% if tiller_max_history is defined %} --history-max={{ tiller_max_history }}{% endif %}
     {% if tiller_enable_tls %} --tiller-tls --tiller-tls-verify --tiller-tls-cert={{ tiller_tls_cert }} --tiller-tls-key={{ tiller_tls_key }} --tls-ca-cert={{ tiller_tls_ca_cert }} {% endif %}
     {% if tiller_secure_release_info %} --override 'spec.template.spec.containers[0].command'='{/tiller,--storage=secret}' {% endif %}
+    {% if tiller_wait %} --wait{% endif %}
     --output yaml
     | {{bin_dir}}/kubectl apply -f -
   changed_when: false


### PR DESCRIPTION
Closes #4109 

I'm occasionally running into situations where the post-Kubespray tasks fail because Tiller is not ready.