### PR TITLE
Improve kubeadm join tasks

### DIFF
--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -65,14 +65,38 @@
     kubeadm_token: "{{ temp_token.stdout }}"
 
 - name: Join to cluster if needed
-  command: >-
-    {{ bin_dir }}/kubeadm join
-    --config {{ kube_config_dir}}/kubeadm-client.conf
-    --ignore-preflight-errors=all
-  register: kubeadm_join
-  when: not is_kube_master and (not kubelet_conf.stat.exists)
   environment:
     PATH: "{{ bin_dir }}:{{ ansible_env.PATH }}"
+  when: not is_kube_master and (not kubelet_conf.stat.exists)
+  block:
+
+    - name: Join to cluster
+      command: >-
+        {{ bin_dir }}/kubeadm join
+        --config {{ kube_config_dir}}/kubeadm-client.conf
+      register: kubeadm_join
+      async: 60
+      poll: 15
+
+  rescue:
+
+    - name: Join to cluster with ignores
+      command: >-
+        {{ bin_dir }}/kubeadm join
+        --config {{ kube_config_dir}}/kubeadm-client.conf
+        --ignore-preflight-errors=all
+      register: kubeadm_join
+      async: 60
+      poll: 15
+
+  always:
+
+    - name: Display kubeadm join stderr if any
+      when: kubeadm_join is failed
+      debug:
+        message: |
+          Joined with warnings
+          {{ kubeadm_join.stderr_lines }}
 
 - name: Wait for kubelet bootstrap to create config
   wait_for:


### PR DESCRIPTION
Fix issue where `kubeadm join` could wait forever for joining.

Fix issue where `kubeadm join` were not reaching the user, making
impossible to find the cause of the failure.

New behaviour is to first attempt to join without bypassing the
verifications checks and to display them if needed.

If this fails it still attempts to join by ignoring the check in
order to make previous behavior.

A timeout of 60 seconds is allocated for a joining.

Related-bug: #3973