### PR TITLE
Adding centos 7 extras repo if it is missing

### DIFF
--- a/roles/bootstrap-os/defaults/main.yml
+++ b/roles/bootstrap-os/defaults/main.yml
@@ -8,3 +8,9 @@ coreos_auto_upgrade: true
 
 # Install epel repo on Centos/RHEL
 epel_enabled: false
+
+# CentOS/RedHat Extras repo
+extras_rh_repo_base_url: "http://mirror.centos.org/centos/$releasever/extras/$basearch/"
+extras_rh_repo_gpgkey: "http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-7"
+# Caching extras packages after installation
+extras_rh_rpm_keepcache: 0

--- a/roles/bootstrap-os/tasks/bootstrap-centos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-centos.yml
@@ -56,6 +56,28 @@
     - not is_atomic
     - package_python_pip.results | length != 0
 
+- name: check python-httplib2 package
+  yum:
+    list: "python-httplib2"
+  register: package_python_httplib2
+  when:
+    - not is_atomic
+
+- name: Configure extras repository if python-httplib2 not avaiable in current repos
+  yum_repository:
+    name: extras
+    description: "CentOS-7 - Extras"
+    state: present
+    baseurl: "{{ extras_rh_repo_base_url }}"
+    file: "extras"
+    gpgcheck: yes
+    gpgkey: "{{extras_rh_repo_gpgkey}}"
+    keepcache: "{{ extras_rh_rpm_keepcache | default('1') }}"
+    proxy: " {{ http_proxy | default(omit) }}"
+  when:
+    - not is_atomic
+    - package_python_httplib2.results | length == 0
+
 - name: Install pip for bootstrap
   yum:
     name: python-pip


### PR DESCRIPTION
If a centos or rhel node is not configured with the extras repo installation of required packages (python-httplib2 in particular) will fail later on.