### PR TITLE
use swapon -s

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0010-swapoff.yml
+++ b/roles/kubernetes/preinstall/tasks/0010-swapoff.yml
@@ -8,6 +8,11 @@
     - swap
     - none
 
+# kubelet fails even if ansible_swaptotal_mb = 0
+- name: check swap
+  command: /sbin/swapon -s
+  register: swapon
+  changed_when: no
 - name: Disable swap
-  command: swapoff -a
-  when: ansible_swaptotal_mb > 0
+  command: /sbin/swapoff -a
+  when: swapon.stdout != ""


### PR DESCRIPTION
In CentOS 7, kubelet fails even if ansible_swaptotal_mb = 0 .
Or my ansible might failed to gather fact of swaptotal.

This commit avoid such a failure story.