### PR TITLE
Fixing Vagrant cluster provisioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -185,6 +185,7 @@ Vagrant.configure("2") do |config|
         "download_localhost": "False",
         "local_path_provisioner_enabled": "#{$local_path_provisioner_enabled}",
         "local_path_provisioner_claim_root": "#{$local_path_provisioner_claim_root}"
+        "ansible_ssh_user": SUPPORTED_OS[$os][:user]
       }
 
       # Only execute the Ansible provisioner once, when all the machines are up and ready.

--- a/roles/download/tasks/sync_container.yml
+++ b/roles/download/tasks/sync_container.yml
@@ -93,6 +93,7 @@
     dest: "{{ fname }}"
     use_ssh_args: "{{ has_bastion | default(false) }}"
     mode: pull
+    private_key: "{{ ansible_ssh_private_key_file }}"
   delegate_to: localhost
   delegate_facts: no
   run_once: true

--- a/roles/download/tasks/sync_container.yml
+++ b/roles/download/tasks/sync_container.yml
@@ -70,6 +70,23 @@
     - (ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"] or download_delegate == "localhost")
     - (container_changed or not img.stat.exists)
 
+- name: container_download | create container images directory on ansible host
+  file:
+    state: directory
+    path: "{{ fname | dirname }}"
+  delegate_to: localhost
+  delegate_facts: no
+  run_once: true
+  become: false
+  when:
+    - download.enabled
+    - download.container
+    - download_run_once
+    - ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"]
+    - inventory_hostname == download_delegate
+    - download_delegate != "localhost"
+    - saved.changed
+
 - name: container_download | copy container images to ansible host
   synchronize:
     src: "{{ fname }}"


### PR DESCRIPTION
See: #3749.

We have attempted to create a single-node Vagrant cluster for development purposes. We were not able to set up the cluster as expected, because:
* `delegate_to` is causing local username being used instead of `ansible_user`; setting `ansible_ssh_user` fixes the issue.
* `delagate_to` prevents expected private key from being uses; setting synchronization task `private_key` argument fixes the issue.
* `/tmp/releases/containers` directory does not exist on ansible host; it is being created now.
