### PR TITLE
Apply etcd_extra_vars to etcd-events.env as well.

### DIFF
--- a/roles/etcd/templates/etcd-events.env.j2
+++ b/roles/etcd/templates/etcd-events.env.j2
@@ -31,6 +31,10 @@ ETCD_PEER_CERT_FILE={{ etcd_cert_dir }}/member-{{ inventory_hostname }}.pem
 ETCD_PEER_KEY_FILE={{ etcd_cert_dir }}/member-{{ inventory_hostname }}-key.pem
 ETCD_PEER_CLIENT_CERT_AUTH={{ etcd_peer_client_auth }}
 
+{% for key, value in etcd_extra_vars.items() %}
+{{ key }}={{ value }}
+{% endfor %}
+
 {% if host_architecture != "amd64" -%}
 ETCD_UNSUPPORTED_ARCH={{host_architecture}}
 {%- endif %}


### PR DESCRIPTION
This change ensures that etcd_extra_vars variable applies
to events etcd as well.

Allows to ensure that options like cipher settings are consistent between etcd instances.