### PR TITLE
[SECURITY] Docker patches for CVE-2019-5736

### DIFF
--- a/roles/container-engine/docker/vars/debian.yml
+++ b/roles/container-engine/docker/vars/debian.yml
@@ -13,9 +13,9 @@ docker_versioned_pkg:
   '17.09': docker-ce=17.09.0~ce-0~debian
   '17.12': docker-ce=17.12.1~ce-0~debian
   '18.03': docker-ce=18.03.1~ce-0~debian
-  '18.06': docker-ce=18.06.1~ce~3-0~debian
-  '18.09': docker-ce_18.09.1~3-0~debian-{{ ansible_distribution_release|lower }}
-  'stable': docker-ce=18.06.1~ce~3-0~debian
+  '18.06': docker-ce=18.06.2~ce~3-0~debian
+  '18.09': docker-ce_18.09.2~3-0~debian-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce=18.06.2~ce~3-0~debian
   'edge': docker-ce=17.12.1~ce-0~debian
 
 docker_package_info:

--- a/roles/container-engine/docker/vars/fedora.yml
+++ b/roles/container-engine/docker/vars/fedora.yml
@@ -6,7 +6,7 @@ docker_kernel_min_version: '0'
 docker_versioned_pkg:
   'latest': docker-ce
   '18.03': docker-ce-18.03.1.ce-3.fc28
-  '18.06': docker-ce-18.06.1.ce-3.fc28
+  '18.06': docker-ce-18.06.2.ce-3.fc28
 
 #
 # This is due to the fact that the docker

--- a/roles/container-engine/docker/vars/redhat.yml
+++ b/roles/container-engine/docker/vars/redhat.yml
@@ -14,10 +14,10 @@ docker_versioned_pkg:
   '17.09': docker-ce-17.09.0.ce-1.el7.centos
   '17.12': docker-ce-17.12.1.ce-1.el7.centos
   '18.03': docker-ce-18.03.1.ce-1.el7.centos
-  '18.06': docker-ce-18.06.1.ce-3.el7
-  '18.09': docker-ce-18.09.1-3.el7
-  'stable': docker-ce-18.06.1.ce-3.el7
-  'edge': docker-ce-17.12.1.ce-1.el7.centos
+  '18.06': docker-ce-18.06.2.ce-3.el7
+  '18.09': docker-ce-18.09.2-3.el7
+  'stable': docker-ce-18.06.2.ce-3.el7
+  'edge': docker-ce-18.09.2-3.el7
 
 docker_selinux_versioned_pkg:
   'latest': docker-ce-selinux

--- a/roles/container-engine/docker/vars/ubuntu-amd64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-amd64.yml
@@ -10,10 +10,10 @@ docker_versioned_pkg:
   '17.03': docker-ce=17.03.2~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
   '17.09': docker-ce=17.09.0~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
   '17.12': docker-ce=17.12.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
-  '18.06': docker-ce=18.06.1~ce~3-0~ubuntu
-  '18.09': docker-ce_18.09.1~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'stable': docker-ce=18.06.1~ce~3-0~ubuntu
-  'edge': docker-ce=18.06.1~ce~3-0~ubuntu
+  '18.06': docker-ce=18.06.2~ce~3-0~ubuntu
+  '18.09': docker-ce_18.09.2~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce=18.06.2~ce~3-0~ubuntu
+  'edge': docker-ce=18.09.2~ce~3-0~ubuntu
 
 docker_package_info:
   pkg_mgr: apt

--- a/roles/container-engine/docker/vars/ubuntu-arm64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-arm64.yml
@@ -6,10 +6,10 @@ docker_versioned_pkg:
   'latest': docker-ce
   '17.09': docker-ce=17.09.1~ce-0~ubuntu
   '17.12': docker-ce=17.12.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
-  '18.06': docker-ce=18.06.1~ce~3-0~ubuntu
-  '18.09': docker-ce_18.09.1~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'stable': docker-ce=18.06.1~ce~3-0~ubuntu
-  'edge': docker-ce=18.06.1~ce~3-0~ubuntu
+  '18.06': docker-ce=18.06.2~ce~3-0~ubuntu
+  '18.09': docker-ce_18.09.2~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce=18.06.2~ce~3-0~ubuntu
+  'edge': docker-ce_18.09.2~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkg_mgr: apt


### PR DESCRIPTION
This updates docker 18.06 and 18.09 with the two patches released
yesterday to address the new runc exploit. Details here:
https://kubernetes.io/blog/2019/02/11/runc-and-cve-2019-5736/