### PR TITLE
Repository proxy fix

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-centos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-centos.yml
@@ -75,7 +75,7 @@
     gpgcheck: yes
     gpgkey: "{{extras_rh_repo_gpgkey}}"
     keepcache: "{{ extras_rh_rpm_keepcache | default('1') }}"
-    proxy: " {{ http_proxy | default(omit) }}"
+    proxy: " {{ http_proxy | default('_none_') }}"
   when:
     - not is_atomic
     - package_python_httplib2.results | length == 0

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -125,7 +125,7 @@
     gpgcheck: yes
     gpgkey: "{{extras_rh_repo_gpgkey}}"
     keepcache: "{{ docker_rpm_keepcache | default('1') }}"
-    proxy: " {{ http_proxy | default(omit) }}"
+    proxy: " {{ http_proxy | default('_none_') }}"
   when:
     - ansible_distribution in ["CentOS","RedHat"] and not is_atomic
     - yum_result.results | length == 0


### PR DESCRIPTION
Omit does not work in the context of yum_repository proxy. The ansible documentation specifies to use _none_ to disable the global proxy setting.