### PR TITLE
feat(vagrant/virtualbox): adds parameter to resize vbox disks

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,6 +50,8 @@ $kube_node_instances = $num_instances
 $kube_node_instances_with_disks = false
 $kube_node_instances_with_disks_size = "20G"
 $kube_node_instances_with_disks_number = 2
+$override_disk_size = false
+$disk_size = "20GB"
 
 $playbook = "cluster.yml"
 
@@ -96,6 +98,13 @@ Vagrant.configure("2") do |config|
 
   # always use Vagrants insecure key
   config.ssh.insert_key = false
+
+  if ($override_disk_size)
+    unless Vagrant.has_plugin?("vagrant-disksize")
+      system "vagrant plugin install vagrant-disksize"
+    end
+    config.disksize.size = $disk_size
+  end
 
   (1..$num_instances).each do |i|
     config.vm.define vm_name = "%s-%01d" % [$instance_name_prefix, i] do |node|


### PR DESCRIPTION
Useful if the default 20GB is not enough in cases where you are using
the local path provisioner of rancher for example