### PR TITLE
Fix calico when kube_override_hostname is set

### DIFF
--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -61,7 +61,7 @@ calico_healthhost: "localhost"
 # see https://docs.projectcalico.org/v3.0/reference/node/configuration#ip-autodetection-methods
 # calico_ip_auto_method: "interface=eth.*"
 
-calico_baremetal_nodename: "{{ inventory_hostname }}"
+calico_baremetal_nodename: "{{ kube_override_hostname | default(inventory_hostname) }}"
 
 ### do not enable this, this is detected in scope of tasks, this is just a default value
 calico_upgrade_needed: false

--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
-- include_tasks: check.yml
+- import_tasks: check.yml
 
-- include_tasks: pre.yml
+- import_tasks: pre.yml
 
 - import_tasks: upgrade.yml
   when:


### PR DESCRIPTION
This fixes an issue where the `nodename` in calico's cni config json can fall out of sync with the k8s node name used by the calico pod if `kube_override_hostname` is set