### PR TITLE
[doc] Add link to Kubespray.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Deploy a Production Ready Kubernetes Cluster
 ============================================
 
-If you have questions, join us on the [kubernetes slack](https://kubernetes.slack.com), channel **\#kubespray**.
+If you have questions, check the [documentation](https://kubespray.io) and join us on the [kubernetes slack](https://kubernetes.slack.com), channel **\#kubespray**.
 You can get your invite [here](http://slack.k8s.io/)
 
 -   Can be deployed on **AWS, GCE, Azure, OpenStack, vSphere, Oracle Cloud Infrastructure (Experimental), or Baremetal**


### PR DESCRIPTION
Adding a link to Kubespray.io for people to check (and search!) the documentation.