### PR TITLE
Fix typo in task description

### DIFF
--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -115,7 +115,7 @@
   register: yum_result
   when: ansible_distribution in ["CentOS","RedHat"] and not is_atomic
 
-- name: Configure extras repository on RedHat/CentOS if container-selinux not avaiable in current repos
+- name: Configure extras repository on RedHat/CentOS if container-selinux is not available in current repos
   yum_repository:
     name: extras
     description: "CentOS-7 - Extras"


### PR DESCRIPTION
Fix typo in task title

> name: Configure extras repository on RedHat/CentOS if container-selinux not **avaiable** in current repos