### PR TITLE
Prefix docker-ce package versions with epoch

### DIFF
--- a/roles/container-engine/docker/vars/debian.yml
+++ b/roles/container-engine/docker/vars/debian.yml
@@ -14,7 +14,7 @@ docker_versioned_pkg:
   '17.12': docker-ce=17.12.1~ce-0~debian
   '18.03': docker-ce=18.03.1~ce-0~debian
   '18.06': docker-ce=18.06.2~ce~3-0~debian
-  '18.09': docker-ce_18.09.2~3-0~debian-{{ ansible_distribution_release|lower }}
+  '18.09': docker-ce=18.09.2~3-0~debian-{{ ansible_distribution_release|lower }}
   'stable': docker-ce=18.06.2~ce~3-0~debian
   'edge': docker-ce=17.12.1~ce-0~debian
 

--- a/roles/container-engine/docker/vars/debian.yml
+++ b/roles/container-engine/docker/vars/debian.yml
@@ -14,9 +14,9 @@ docker_versioned_pkg:
   '17.12': docker-ce=17.12.1~ce-0~debian
   '18.03': docker-ce=18.03.1~ce-0~debian
   '18.06': docker-ce=18.06.2~ce~3-0~debian
-  '18.09': docker-ce=18.09.2~3-0~debian-{{ ansible_distribution_release|lower }}
+  '18.09': docker-ce=5:18.09.2~3-0~debian-{{ ansible_distribution_release|lower }}
   'stable': docker-ce=18.06.2~ce~3-0~debian
-  'edge': docker-ce=17.12.1~ce-0~debian
+  'edge': docker-ce=5:18.09.2~3-0~debian-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkg_mgr: apt

--- a/roles/container-engine/docker/vars/ubuntu-amd64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-amd64.yml
@@ -11,7 +11,7 @@ docker_versioned_pkg:
   '17.09': docker-ce=17.09.0~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
   '17.12': docker-ce=17.12.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
   '18.06': docker-ce=18.06.2~ce~3-0~ubuntu
-  '18.09': docker-ce_18.09.2~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '18.09': docker-ce=18.09.2~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   'stable': docker-ce=18.06.2~ce~3-0~ubuntu
   'edge': docker-ce=18.09.2~ce~3-0~ubuntu
 

--- a/roles/container-engine/docker/vars/ubuntu-amd64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-amd64.yml
@@ -11,9 +11,9 @@ docker_versioned_pkg:
   '17.09': docker-ce=17.09.0~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
   '17.12': docker-ce=17.12.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
   '18.06': docker-ce=18.06.2~ce~3-0~ubuntu
-  '18.09': docker-ce=18.09.2~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '18.09': docker-ce=5:18.09.2~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   'stable': docker-ce=18.06.2~ce~3-0~ubuntu
-  'edge': docker-ce=18.09.2~ce~3-0~ubuntu
+  'edge': docker-ce=5:18.09.2~ce~3-0~ubuntu
 
 docker_package_info:
   pkg_mgr: apt

--- a/roles/container-engine/docker/vars/ubuntu-amd64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-amd64.yml
@@ -13,7 +13,7 @@ docker_versioned_pkg:
   '18.06': docker-ce=18.06.2~ce~3-0~ubuntu
   '18.09': docker-ce=5:18.09.2~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   'stable': docker-ce=18.06.2~ce~3-0~ubuntu
-  'edge': docker-ce=5:18.09.2~ce~3-0~ubuntu
+  'edge': docker-ce=5:18.09.2~ce~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkg_mgr: apt

--- a/roles/container-engine/docker/vars/ubuntu-arm64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-arm64.yml
@@ -7,9 +7,9 @@ docker_versioned_pkg:
   '17.09': docker-ce=17.09.1~ce-0~ubuntu
   '17.12': docker-ce=17.12.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
   '18.06': docker-ce=18.06.2~ce~3-0~ubuntu
-  '18.09': docker-ce_18.09.2~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '18.09': docker-ce=18.09.2~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   'stable': docker-ce=18.06.2~ce~3-0~ubuntu
-  'edge': docker-ce_18.09.2~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'edge': docker-ce=18.09.2~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkg_mgr: apt

--- a/roles/container-engine/docker/vars/ubuntu-arm64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-arm64.yml
@@ -7,9 +7,9 @@ docker_versioned_pkg:
   '17.09': docker-ce=17.09.1~ce-0~ubuntu
   '17.12': docker-ce=17.12.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
   '18.06': docker-ce=18.06.2~ce~3-0~ubuntu
-  '18.09': docker-ce=18.09.2~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '18.09': docker-ce=5:18.09.2~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   'stable': docker-ce=18.06.2~ce~3-0~ubuntu
-  'edge': docker-ce=18.09.2~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'edge': docker-ce=5:18.09.2~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkg_mgr: apt


### PR DESCRIPTION
It seems that starting with docker-ce package 18.09.0 the epoch must be specified - https://stackoverflow.com/questions/53669694/docker-version-number-18-09