### PR TITLE
weave: Upgrade to 2.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Supported Components
     -   [flanneld](https://github.com/coreos/flannel) v0.11.0
     -   [kube-router](https://github.com/cloudnativelabs/kube-router) v0.2.1
     -   [multus](https://github.com/intel/multus-cni) v3.1.autoconf
-    -   [weave](https://github.com/weaveworks/weave) v2.5.0
+    -   [weave](https://github.com/weaveworks/weave) v2.5.1
 -   Application
     -   [cephfs-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.0-k8s1.11
     -   [cert-manager](https://github.com/jetstack/cert-manager) v0.5.2

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -55,7 +55,7 @@ flannel_cni_version: "v0.3.0"
 
 cni_version: "v0.6.0"
 
-weave_version: 2.5.0
+weave_version: 2.5.1
 pod_infra_version: 3.1
 contiv_version: 1.2.1
 cilium_version: "v1.3.0"

--- a/roles/network_plugin/weave/templates/weave-net.yml.j2
+++ b/roles/network_plugin/weave/templates/weave-net.yml.j2
@@ -222,7 +222,8 @@ items:
             seLinuxOptions: {}
           serviceAccountName: weave-net
           tolerations:
-            - operator: Exists
+            - effect: NoSchedule
+              operator: Exists
             # Mark pod as critical for rescheduling (Will have no effect starting with kubernetes 1.12)
             - key: CriticalAddonsOnly
               operator: "Exists"


### PR DESCRIPTION
Upstream Changes:

  - weave 2.5.1 (https://github.com/weaveworks/weave/releases/tag/v2.5.1)

Our Changes:

  - Sync templates with upstream changes