### PR TITLE
Cluster node scale failed with CoreOs (or OS with other python interp…

### DIFF
--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -5,6 +5,16 @@ ansible_ssh_common_args: "{% if 'bastion' in groups['all'] %} -o ProxyCommand='s
 
 kube_api_anonymous_auth: true
 
+# Set interpreter depending of OS family
+ansible_python_interpreter: |-
+  {% if ansible_os_family in ['CoreOS', 'Container Linux by CoreOS'] -%}
+  "/opt/bin/python"
+  {% elif ansible_os_family == 'RedHat' -%}
+  "/usr/bin/python"
+  {% elif ansible_os_family == 'Debian' -%}
+  "/usr/bin/python"
+  {% endif -%}
+
 # Default value, but will be set to true automatically if detected
 is_atomic: false
 

--- a/scale.yml
+++ b/scale.yml
@@ -20,7 +20,7 @@
     - { role: bastion-ssh-config, tags: ["localhost", "bastion"]}
 
 ##Bootstrap any new workers
-- hosts: kube-node
+- hosts: k8s-cluster:children
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   gather_facts: false
   vars:


### PR DESCRIPTION
…reter than /usr/bin)

because master(s) are set arbitrary with /usr/bin
-> Put interprerter detection in kubespray-defaults
-> fix scale.yml