### PR TITLE
Adding ability to maintain existing Encryption Secrets at Rest.

### DIFF
--- a/roles/kubernetes/master/defaults/main/main.yml
+++ b/roles/kubernetes/master/defaults/main/main.yml
@@ -163,3 +163,5 @@ kube_override_hostname: >-
   {%- else -%}
   {{ inventory_hostname }}
   {%- endif -%}
+
+secrets_encryption_query: "resources[*].providers[0].{{kube_encryption_algorithm}}.keys[0].secret"

--- a/roles/kubernetes/master/tasks/encrypt-at-rest.yml
+++ b/roles/kubernetes/master/tasks/encrypt-at-rest.yml
@@ -1,4 +1,25 @@
 ---
+- name: Check if secret for encrypting data at rest already exist
+  stat:
+    path: "{{ kube_cert_dir }}/secrets_encryption.yaml"
+  register: secrets_encryption_file
+
+- name: Slurp secrets_encryption file if it exists
+  slurp:
+    src: "{{ kube_cert_dir }}/secrets_encryption.yaml"
+  register: secret_file_encoded
+  when: secrets_encryption_file.stat.exists
+
+- name: Base 64 Decode slurped secrets_encryption file
+  set_fact:
+    secret_file_decoded: "{{secret_file_encoded['content'] | b64decode | from_yaml}}"
+  when: secrets_encryption_file.stat.exists
+
+- name: Query for secret value
+  set_fact:
+    kube_encrypt_token: "{{ secret_file_decoded | json_query(secrets_encryption_query) | first | b64decode}}"
+  when: secrets_encryption_file.stat.exists
+
 - name: Write secrets for encrypting secret data at rest
   template:
     src: secrets_encryption.yaml.j2


### PR DESCRIPTION
If secrets_encryption.yaml is present it will not be overriten with a new kube_encrypt_token.

This should allow for it to be set ahead of a playbook running or maintain it if cluster.yml is ran on the same cluster and the ansible host does not have access to the secrets.