### PR TITLE
remove our config if docker start failed

### DIFF
--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -199,11 +199,26 @@
     mode: 0644
   when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS", "ClearLinux", "RedHat", "Suse"] or is_atomic)
 
-- name: ensure service is started if docker packages are already present
-  service:
-    name: docker
-    state: started
-  when: docker_task_result is not changed
+- name: ensure docker started, remove our config if docker start failed and try again
+  block:
+    - name: ensure service is started if docker packages are already present
+      service:
+        name: docker
+        state: started
+      when: docker_task_result is not changed
+  rescue:
+    - debug:
+        msg: "Docker start failed. Try to remove our config"
+    - name: remove kubespray generated config
+      file:
+        path: "{{ item }}"
+        state: absent
+      with_items:
+        - /etc/systemd/system/docker.service.d/http-proxy.conf
+        - /etc/systemd/system/docker.service.d/docker-options.conf
+        - /etc/systemd/system/docker.service.d/docker-dns.conf
+        - /etc/systemd/system/docker.service.d/docker-orphan-cleanup.conf
+      notify: restart docker
 
 - name: flush handlers so we can wait for docker to come up
   meta: flush_handlers


### PR DESCRIPTION
If, due to a configuration error, the docker does not start, then after the restart of kubespray, it will stop the docker start task, which is before kubespray changes the docker configs

Thus, if the kubespray has damaged the configs, the docker will no longer start.

Add block-rescue to remove almost all modified docker configs to give kubespray the ability to create new ones without errors


This alternate for PR https://github.com/kubernetes-sigs/kubespray/pull/4179