### PR TITLE
Add support for --enable-skip-login in Dashboard

### DIFF
--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -53,3 +53,4 @@ dashboard_tls_cert_file: dashboard.crt
 
 # Override dashboard default settings
 dashboard_token_ttl: 900
+dashboard_skip_login: false

--- a/roles/kubernetes-apps/ansible/templates/dashboard.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dashboard.yml.j2
@@ -164,6 +164,9 @@ spec:
 {% else %}
           - --auto-generate-certificates
 {% endif %}
+{% if dashboard_skip_login %}
+          - --enable-skip-login
+{% endif %}
           - --authentication-mode=token{% if kube_basic_auth|default(false) %},basic{% endif %}
           # Uncomment the following line to manually specify Kubernetes API server Host
           # If not specified, Dashboard will attempt to auto discover the API server and connect


### PR DESCRIPTION
Kubernetes dashboard has support for `--enable-skip-login` that is useful, therefore we have it as a flag disabled by default in order to keep the current behavior.

```
--enable-skip-login                When enabled, the skip button on the login page will be shown. Default: false.
```