### PR TITLE
[SECURITY] Docker patches for CVE-2019-5736 Ubuntu Bionic

### DIFF
--- a/roles/container-engine/docker/vars/ubuntu-bionic.yml
+++ b/roles/container-engine/docker/vars/ubuntu-bionic.yml
@@ -6,9 +6,9 @@ use_docker_engine: false
 docker_versioned_pkg:
   'latest': docker-ce
   '18.03': docker-ce=18.03.1~ce-3-0~ubuntu
-  '18.06': docker-ce=18.06.1~ce~3-0~ubuntu
-  'stable': docker-ce=18.06.1~ce~3-0~ubuntu
-  'edge': docker-ce=18.06.1~ce~3-0~ubuntu
+  '18.06': docker-ce=18.06.2~ce~3-0~ubuntu
+  'stable': docker-ce=18.06.2~ce~3-0~ubuntu
+  'edge': docker-ce=18.06.2~ce~3-0~ubuntu
 
 docker_package_info:
   pkg_mgr: apt


### PR DESCRIPTION
From #4223, adding also ubuntu bionic patches.  
Details here:
https://kubernetes.io/blog/2019/02/11/runc-and-cve-2019-5736/