### PR TITLE
backport cve-2019-5736 for Ubuntu Bionic to release-2.8

### DIFF
--- a/roles/container-engine/docker/vars/ubuntu-bionic.yml
+++ b/roles/container-engine/docker/vars/ubuntu-bionic.yml
@@ -6,9 +6,9 @@ use_docker_engine: false
 docker_versioned_pkg:
   'latest': docker-ce
   '18.03': docker-ce=18.03.1~ce-3-0~ubuntu
-  '18.06': docker-ce=18.06.1~ce~3-0~ubuntu
-  'stable': docker-ce=18.06.1~ce~3-0~ubuntu
-  'edge': docker-ce=18.06.1~ce~3-0~ubuntu
+  '18.06': docker-ce=18.06.2~ce~3-0~ubuntu
+  'stable': docker-ce=18.06.2~ce~3-0~ubuntu
+  'edge': docker-ce=18.06.2~ce~3-0~ubuntu
 
 docker_package_info:
   pkg_mgr: apt


### PR DESCRIPTION
After the commit 85b77f7c2243bb6fcfbb5bab917d4af0c5efc30d the file `roles/container-engine/docker/vars/ubuntu-bionic.yml` for Ubuntu Bionic no longer exists, but for release 2.8 is still needed to update Docker.