### PR TITLE
keep compatibility as it was before

### DIFF
--- a/roles/kubernetes/master/defaults/main/kube-proxy.yml
+++ b/roles/kubernetes/master/defaults/main/kube-proxy.yml
@@ -87,7 +87,12 @@ kube_proxy_metrics_bind_address: 127.0.0.1:10249
 # A string slice of values which specify the addresses to use for NodePorts.
 # Values may be valid IP blocks (e.g. 1.2.3.0/24, 1.2.3.4/32).
 # The default empty string slice ([]) means to use all local addresses.
-kube_proxy_nodeport_addresses: '[]'
+kube_proxy_nodeport_addresses: >-
+  {%- if kube_proxy_nodeport_addresses_cidr is defined -%}
+  [{{ kube_proxy_nodeport_addresses_cidr }}]
+  {%- else -%}
+  []
+  {%- endif -%}
 
 # oom-score-adj value for kube-proxy process. Values must be within the range [-1000, 1000]
 kube_proxy_oom_score_adj: -999


### PR DESCRIPTION
kube_proxy_nodeport_addresses must be emtpy list, not string '[]'
also return compatibility with kube_proxy_nodeport_addresses_cidr 