### PR TITLE
contrib/terraform: resolve openstack's external network ID from network name

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -228,8 +228,8 @@ For your cluster, edit `inventory/$CLUSTER/cluster.tf`.
 |`network_name` | The name to be given to the internal network that will be generated |
 |`dns_nameservers`| An array of DNS name server names to be used by hosts in the internal subnet. |
 |`floatingip_pool` | Name of the pool from which floating IPs will be allocated |
-|`external_net` | UUID of the external network that will be routed to |
 |`flavor_k8s_master`,`flavor_k8s_node`,`flavor_etcd`, `flavor_bastion`,`flavor_gfs_node` | Flavor depends on your openstack installation, you can get available flavor IDs through `openstack flavor list` |
+|`external_network_name` | Name of the external network that will be routed to |
 |`image`,`image_gfs` | Name of the image to use in provisioning the compute resources. Should already be loaded into glance. |
 |`ssh_user`,`ssh_user_gfs` | The username to ssh into the image with. This usually depends on the image you have selected |
 |`public_key_path` | Path on your local workstation to the public key file you wish to use in creating the key pairs |

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -4,7 +4,8 @@ provider "openstack" {
 
 # query external network details
 data "openstack_networking_network_v2" "extnet" {
-  name = "${var.external_network_name}"
+  network_id = "${var.external_network_id != "" ? var.external_network_id : ""}"
+  name       = "${var.external_network_name}"
 }
 
 module "network" {

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -2,15 +2,20 @@ provider "openstack" {
   version = "~> 1.17"
 }
 
+# query external network details
+data "openstack_networking_network_v2" "extnet" {
+  name = "${var.external_network_name}"
+}
+
 module "network" {
   source = "modules/network"
 
-  external_net    = "${var.external_net}"
-  network_name    = "${var.network_name}"
-  subnet_cidr     = "${var.subnet_cidr}"
-  cluster_name    = "${var.cluster_name}"
-  dns_nameservers = "${var.dns_nameservers}"
-  use_neutron     = "${var.use_neutron}"
+  network_name        = "${var.network_name}"
+  external_network_id = "${data.openstack_networking_network_v2.extnet.id}"
+  subnet_cidr         = "${var.subnet_cidr}"
+  cluster_name        = "${var.cluster_name}"
+  dns_nameservers     = "${var.dns_nameservers}"
+  use_neutron         = "${var.use_neutron}"
 }
 
 module "ips" {
@@ -21,7 +26,7 @@ module "ips" {
   number_of_k8s_nodes           = "${var.number_of_k8s_nodes}"
   floatingip_pool               = "${var.floatingip_pool}"
   number_of_bastions            = "${var.number_of_bastions}"
-  external_net                  = "${var.external_net}"
+  external_network_id           = "${data.openstack_networking_network_v2.extnet.id}"
   network_name                  = "${var.network_name}"
   router_id                     = "${module.network.router_id}"
 }
@@ -71,7 +76,7 @@ output "private_subnet_id" {
 }
 
 output "floating_network_id" {
-  value = "${var.external_net}"
+  value = "${data.openstack_networking_network_v2.extnet.id}"
 }
 
 output "router_id" {

--- a/contrib/terraform/openstack/modules/ips/variables.tf
+++ b/contrib/terraform/openstack/modules/ips/variables.tf
@@ -8,7 +8,7 @@ variable "floatingip_pool" {}
 
 variable "number_of_bastions" {}
 
-variable "external_net" {}
+variable "external_network_id" {}
 
 variable "network_name" {}
 

--- a/contrib/terraform/openstack/modules/network/main.tf
+++ b/contrib/terraform/openstack/modules/network/main.tf
@@ -2,7 +2,7 @@ resource "openstack_networking_router_v2" "k8s" {
   name                = "${var.cluster_name}-router"
   count               = "${var.use_neutron}"
   admin_state_up      = "true"
-  external_network_id = "${var.external_net}"
+  external_network_id = "${var.external_network_id}"
 }
 
 resource "openstack_networking_network_v2" "k8s" {

--- a/contrib/terraform/openstack/modules/network/variables.tf
+++ b/contrib/terraform/openstack/modules/network/variables.tf
@@ -1,4 +1,4 @@
-variable "external_net" {}
+variable "external_network_id" {}
 
 variable "network_name" {}
 

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -103,6 +103,10 @@ variable "network_name" {
   default     = "internal"
 }
 
+variable "external_network_name" {
+  description = "name of the external network to use"
+}
+
 variable "use_neutron" {
   description = "Use neutron"
   default     = 1
@@ -123,10 +127,6 @@ variable "dns_nameservers" {
 variable "floatingip_pool" {
   description = "name of the floating ip pool to use"
   default     = "external"
-}
-
-variable "external_net" {
-  description = "uuid of the external/public network"
 }
 
 variable "supplementary_master_groups" {

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -103,8 +103,22 @@ variable "network_name" {
   default     = "internal"
 }
 
+variable "external_network_id" {
+  description = <<EOF
+ID of the external network to use. If no ID is provided,
+the UUID would be resolved from the external_network_name variable.
+EOF
+
+  default = ""
+}
+
 variable "external_network_name" {
-  description = "name of the external network to use"
+  description = <<EOF
+Name of the external network to use. If this variable is empty, then
+external_network_id MUST be set.
+EOF
+
+  default = ""
 }
 
 variable "use_neutron" {


### PR DESCRIPTION
This PR adds an `openstack_networking_network_v2` data source that aims to resolve the network UUID. for backward compatibility, this data source also filters per given ID, so that if the ID is already set in the var file, it will fetch the appropriate network details per that UUID.