### PR TITLE
Add labels to vsphere cloud config

### DIFF
--- a/docs/vsphere.md
+++ b/docs/vsphere.md
@@ -14,6 +14,9 @@ After this step you should have:
 - UUID activated for each VM where Kubernetes will be deployed
 - A vSphere account with required privileges
 
+If you intend to leverage the [zone and region node labeling](https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#failure-domain-beta-kubernetes-io-region), create a tag category for both the zone and region in vCenter.  The tags can then be applied at the host, cluster, datacenter, or folder level, and the cloud provider will walk the hierarchy to extract and apply the labels to the Kubernetes nodes.
+
+
 ## Kubespray configuration
 
 First you must define the cloud provider in `inventory/sample/group_vars/all.yml` and set it to `vsphere`.
@@ -34,9 +37,11 @@ Then, in the same file, you need to declare your vCenter credential following th
 | vsphere_datastore            | TRUE     | string  |                            |         | Datastore name to use                                                                                                                                                                         |
 | vsphere_working_dir          | TRUE     | string  |                            |         | Working directory from the view "VMs and template" in the   vCenter where VM are placed                                                                                                       |
 | vsphere_scsi_controller_type | TRUE     | string  | buslogic, pvscsi, parallel | pvscsi  | SCSI controller name. Commonly "pvscsi".                                                                                                                                                      |
-| vsphere_vm_uuid              | FALSE    | string  |                            |         | VM Instance UUID of virtual machine that host K8s master. Can be   retrieved from instanceUuid property in VmConfigInfo, or as vc.uuid in VMX   file or in `/sys/class/dmi/id/product_serial` (Optional, only used for Kubernetes <= 1.9.2) |
+| vsphere_vm_uuid              | FALSE    | string  |                            |         | VM Instance UUID of virtual machine that host K8s master. Can be retrieved from instanceUuid property in VmConfigInfo, or as vc.uuid in VMX file or in `/sys/class/dmi/id/product_serial` (Optional, only used for Kubernetes <= 1.9.2) |
 | vsphere_public_network       | FALSE    | string  |                            | Blank   | Name of the   network the VMs are joined to                                                                                                                                                   |
-| vsphere_resource_pool       | FALSE    | string  |                            | Blank   | Name of the Resource pool where the VMs are located (Optional, only used for Kubernetes >= 1.9.2)                                                                                                                                                 |
+| vsphere_resource_pool        | FALSE    | string  |                            | Blank   | Name of the Resource pool where the VMs are located (Optional, only used for Kubernetes >= 1.9.2)                                                                                                                                                 |
+| vsphere_zone_category        | FALSE    | string  |                            |         | Name of the tag category used to set the `failure-domain.beta.kubernetes.io/zone` label on nodes (Optional, only used for Kubernetes >= 1.12.0)                                                                                                                                                 |
+| vsphere_region_category      | FALSE    | string  |                            |         | Name of the tag category used to set the `failure-domain.beta.kubernetes.io/region` label on nodes (Optional, only used for Kubernetes >= 1.12.0)                                                                                                                                                 |
 
 Example configuration
 

--- a/roles/kubernetes/node/templates/vsphere-cloud-config.j2
+++ b/roles/kubernetes/node/templates/vsphere-cloud-config.j2
@@ -42,3 +42,13 @@ scsicontrollertype = {{ vsphere_scsi_controller_type }}
 [Network]
 public-network = {{ vsphere_public_network }}
 {% endif %}
+
+{% if kube_version is version('v1.12.0', '>=') %}
+[Labels]
+{% if vsphere_zone_category is defined and vsphere_zone_category != ""  %}
+zone = {{ vsphere_zone_category }}
+{% endif %}
+{% if vsphere_region_category is defined and vsphere_region_category != ""  %}
+region = {{ vsphere_region_category }}
+{% endif %}
+{% endif %}


### PR DESCRIPTION

Since k8s v1.12.0, the vSphere cloud provider can use tags in vCenter to apply fault-domain labels to kubernetes nodes.  This is enabled by setting zone and region in the Labels section of the vsphere cloud config.  I couldn't locate official docs on this, but here's the PR - https://github.com/kubernetes/kubernetes/pull/66795. 

Additionally, more recent work (https://github.com/kubernetes/kubernetes/pull/72687, https://github.com/kubernetes/kubernetes/pull/72731) will utilize zones for handling zone-local datastores in v1.14
