### PR TITLE
fix node join error because of etc-kubernetes-manifests not empty

### DIFF
--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -74,6 +74,7 @@
       command: >-
         {{ bin_dir }}/kubeadm join
         --config {{ kube_config_dir}}/kubeadm-client.conf
+        --ignore-preflight-errors=DirAvailable--etc-kubernetes-manifests
       register: kubeadm_join
       async: 60
       poll: 15


### PR DESCRIPTION
This PS is to fix the bug when workers can't join the cluster because of etc-kubernetes-manifests not empty.
The issue is here. #4252