### PR TITLE
terraform: use openstackclient instead of novaclient

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -229,7 +229,7 @@ For your cluster, edit `inventory/$CLUSTER/cluster.tf`.
 |`dns_nameservers`| An array of DNS name server names to be used by hosts in the internal subnet. |
 |`floatingip_pool` | Name of the pool from which floating IPs will be allocated |
 |`external_net` | UUID of the external network that will be routed to |
-|`flavor_k8s_master`,`flavor_k8s_node`,`flavor_etcd`, `flavor_bastion`,`flavor_gfs_node` | Flavor depends on your openstack installation, you can get available flavor IDs through`nova flavor-list` |
+|`flavor_k8s_master`,`flavor_k8s_node`,`flavor_etcd`, `flavor_bastion`,`flavor_gfs_node` | Flavor depends on your openstack installation, you can get available flavor IDs through `openstack flavor list` |
 |`image`,`image_gfs` | Name of the image to use in provisioning the compute resources. Should already be loaded into glance. |
 |`ssh_user`,`ssh_user_gfs` | The username to ssh into the image with. This usually depends on the image you have selected |
 |`public_key_path` | Path on your local workstation to the public key file you wish to use in creating the key pairs |

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -74,27 +74,27 @@ variable "ssh_user_gfs" {
 }
 
 variable "flavor_bastion" {
-  description = "Use 'nova flavor-list' command to see what your OpenStack instance uses for IDs"
+  description = "Use 'openstack flavor list' command to see what your OpenStack instance uses for IDs"
   default     = 3
 }
 
 variable "flavor_k8s_master" {
-  description = "Use 'nova flavor-list' command to see what your OpenStack instance uses for IDs"
+  description = "Use 'openstack flavor list' command to see what your OpenStack instance uses for IDs"
   default     = 3
 }
 
 variable "flavor_k8s_node" {
-  description = "Use 'nova flavor-list' command to see what your OpenStack instance uses for IDs"
+  description = "Use 'openstack flavor list' command to see what your OpenStack instance uses for IDs"
   default     = 3
 }
 
 variable "flavor_etcd" {
-  description = "Use 'nova flavor-list' command to see what your OpenStack instance uses for IDs"
+  description = "Use 'openstack flavor list' command to see what your OpenStack instance uses for IDs"
   default     = 3
 }
 
 variable "flavor_gfs_node" {
-  description = "Use 'nova flavor-list' command to see what your OpenStack instance uses for IDs"
+  description = "Use 'openstack flavor list' command to see what your OpenStack instance uses for IDs"
   default     = 3
 }
 

--- a/inventory/sample/group_vars/all/all.yml
+++ b/inventory/sample/group_vars/all/all.yml
@@ -41,7 +41,7 @@ nginx_kube_apiserver_port: 6443
 ## for instance we need to encapsulate packets with some network plugins
 ## If set the possible values are either 'gce', 'aws', 'azure', 'openstack', 'vsphere', 'oci', or 'external'
 ## When openstack is used make sure to source in the openstack credentials
-## like you would do when using nova-client before starting the playbook.
+## like you would do when using openstack-client before starting the playbook.
 ## Note: The 'external' cloud provider is not supported.
 ## TODO(riverzhang): https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager
 #cloud_provider:


### PR DESCRIPTION
The openstackclient is the preferred CLI for OpenStack
environments and should be used instead of novaclient.