### PR TITLE
Make container storage repository configurable

### DIFF
--- a/roles/container-engine/docker-storage/defaults/main.yml
+++ b/roles/container-engine/docker-storage/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+docker_container_storage_setup_repository: https://github.com/projectatomic/container-storage-setup.git
 docker_container_storage_setup_version: v0.6.0
 docker_container_storage_setup_profile_name: kubespray
 docker_container_storage_setup_storage_driver: devicemapper

--- a/roles/container-engine/docker-storage/files/install_container_storage_setup.sh
+++ b/roles/container-engine/docker-storage/files/install_container_storage_setup.sh
@@ -2,14 +2,15 @@
 
 set -e
 
-version=${1:-master}
-profile_name=${2:-kubespray}
+repository=${1:-https://github.com/projectatomic/container-storage-setup.git}
+version=${2:-master}
+profile_name=${3:-kubespray}
 dir=`mktemp -d`
 export GIT_DIR=$dir/.git
 export GIT_WORK_TREE=$dir
 
 git init
-git fetch --depth 1 https://github.com/projectatomic/container-storage-setup.git $version
+git fetch --depth 1 $repository $version
 git merge FETCH_HEAD
 make -C $dir install
 rm -rf /var/lib/container-storage-setup/$profile_name $dir
@@ -17,6 +18,6 @@ rm -rf /var/lib/container-storage-setup/$profile_name $dir
 set +e
 
 /usr/bin/container-storage-setup create $profile_name /etc/sysconfig/docker-storage-setup && /usr/bin/container-storage-setup activate $profile_name
-# FIXME: exit status can be 1 for both fatal and non fatal errors in current release, 
-# could be improved by matching error strings 
+# FIXME: exit status can be 1 for both fatal and non fatal errors in current release,
+# could be improved by matching error strings
 exit 0

--- a/roles/container-engine/docker-storage/tasks/main.yml
+++ b/roles/container-engine/docker-storage/tasks/main.yml
@@ -39,5 +39,9 @@
 
 - name: docker-storage-setup | install and run container-storage-setup
   become: yes
-  script: install_container_storage_setup.sh {{ docker_container_storage_setup_version }} {{ docker_container_storage_setup_profile_name }}
+  script: |
+    install_container_storage_setup.sh \
+      {{ docker_container_storage_setup_repository }} \
+      {{ docker_container_storage_setup_version }} \
+      {{ docker_container_storage_setup_profile_name }}
   notify: Docker | reload systemd


### PR DESCRIPTION
This PR introduce a new `docker_container_storage_setup_repository` variable which make it possible to configure the container storage repository url.

Close https://github.com/kubernetes-sigs/kubespray/issues/4283