### PR TITLE
Specify ingress controller node

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s-cluster/addons.yml
@@ -49,7 +49,8 @@ cephfs_provisioner_enabled: false
 ingress_nginx_enabled: false
 # ingress_nginx_host_network: false
 # ingress_nginx_nodeselector:
-#   node-role.kubernetes.io/node: ""
+#   node-role.kubernetes.io/ingress: "true"
+# ingress_nginx_node_count: 1
 # ingress_nginx_tolerations:
 #   - key: "node-role.kubernetes.io/master"
 #     operator: "Equal"

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
@@ -2,7 +2,8 @@
 ingress_nginx_namespace: "ingress-nginx"
 ingress_nginx_host_network: false
 ingress_nginx_nodeselector:
-  node-role.kubernetes.io/node: ""
+  node-role.kubernetes.io/ingress: "true"
+ingress_nginx_node_count: 1
 ingress_nginx_tolerations: []
 ingress_nginx_insecure_port: 80
 ingress_nginx_secure_port: 443

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/tasks/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/tasks/main.yml
@@ -59,6 +59,30 @@
   when:
     - inventory_hostname == groups['kube-master'][0]
 
+- name: Set ingress nginx node role
+  set_fact:
+    ingress_nginx_node_role:
+      key: "{{ item.key }}"
+      value: "{{ item.value }}"
+  with_dict: "{{ ingress_nginx_nodeselector }}"
+  when:
+    - inventory_hostname == groups['kube-master'][0]
+
+- name: Set ingress nginx node list
+  set_fact:
+    ingress_nginx_node_list:
+      - "{{ groups['kube-node'][item|int] }}"
+  with_sequence: start=0 end={{ (ingress_nginx_node_count-1)|int }}
+  when:
+    - inventory_hostname == groups['kube-master'][0]
+
+- name: NGINX Ingress Controller | Set node label
+  shell: |
+    {{ bin_dir }}/kubectl label --overwrite node {{ item }} {{ ingress_nginx_node_role.key }}={{ ingress_nginx_node_role.value }}
+  loop: "{{ ingress_nginx_node_list }}"
+  when:
+    - inventory_hostname == groups['kube-master'][0]
+
 - name: NGINX Ingress Controller | Apply manifests
   kube:
     name: "{{ item.item.name }}"


### PR DESCRIPTION
Until now, when you install the ingress controller, it is installed on all nodes. The PS can run the ingress controller by specifying the number of nodes.