### PR TITLE
Don't create secgroup for a bastion host on openstack, if it doesn't exist

### DIFF
--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -20,11 +20,12 @@ resource "openstack_networking_secgroup_rule_v2" "k8s_master" {
 
 resource "openstack_networking_secgroup_v2" "bastion" {
   name        = "${var.cluster_name}-bastion"
+  count       = "${var.number_of_bastions ? 1 : 0}"
   description = "${var.cluster_name} - Bastion Server"
 }
 
 resource "openstack_networking_secgroup_rule_v2" "bastion" {
-  count             = "${length(var.bastion_allowed_remote_ips)}"
+  count             = "${var.number_of_bastions ? length(var.bastion_allowed_remote_ips) : 0}"
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
@@ -101,18 +102,20 @@ resource "openstack_compute_instance_v2" "k8s_master" {
     name = "${var.network_name}"
   }
 
-  security_groups = ["${openstack_networking_secgroup_v2.k8s_master.name}",
-    "${openstack_networking_secgroup_v2.bastion.name}",
-    "${openstack_networking_secgroup_v2.k8s.name}",
-    "default",
-  ]
+  # The join() hack is described here: https://github.com/hashicorp/terraform/issues/11566
+  # As a workaround for creating "dynamic" lists (when, for example, no bastion host is created)
 
+  security_groups = ["${compact(list(
+    openstack_networking_secgroup_v2.k8s_master.name,
+    join(" ", openstack_networking_secgroup_v2.bastion.*.id),
+    openstack_networking_secgroup_v2.k8s.name,
+    "default",
+   ))}"]
   metadata = {
     ssh_user         = "${var.ssh_user}"
     kubespray_groups = "etcd,kube-master,${var.supplementary_master_groups},k8s-cluster,vault"
     depends_on       = "${var.network_id}"
   }
-
   provisioner "local-exec" {
     command = "sed s/USER/${var.ssh_user}/ contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element( concat(var.bastion_fips, var.k8s_master_fips), 0)}/ > contrib/terraform/group_vars/no-floating.yml"
   }
@@ -130,10 +133,11 @@ resource "openstack_compute_instance_v2" "k8s_master_no_etcd" {
     name = "${var.network_name}"
   }
 
-  security_groups = ["${openstack_networking_secgroup_v2.k8s_master.name}",
-    "${openstack_networking_secgroup_v2.bastion.name}",
-    "${openstack_networking_secgroup_v2.k8s.name}",
-  ]
+  security_groups = ["${compact(list(
+    openstack_networking_secgroup_v2.k8s_master.name,
+    join(" ", openstack_networking_secgroup_v2.bastion.*.id),
+    openstack_networking_secgroup_v2.k8s.name,
+   ))}"]
 
   metadata = {
     ssh_user         = "${var.ssh_user}"
@@ -226,11 +230,12 @@ resource "openstack_compute_instance_v2" "k8s_node" {
     name = "${var.network_name}"
   }
 
-  security_groups = ["${openstack_networking_secgroup_v2.k8s.name}",
-    "${openstack_networking_secgroup_v2.bastion.name}",
-    "${openstack_networking_secgroup_v2.worker.name}",
+  security_groups = ["${compact(list(
+    openstack_networking_secgroup_v2.k8s_master.name,
+    join(" ", openstack_networking_secgroup_v2.bastion.*.id),
+    openstack_networking_secgroup_v2.k8s.name,
     "default",
-  ]
+   ))}"]
 
   metadata = {
     ssh_user         = "${var.ssh_user}"


### PR DESCRIPTION
even if `number_of_bastions` var is set to 0, terraform creates a security group and rules for a non-existing bastion host. 

This PR sets these resources as conditionals, and uses the `join()` hack from: https://github.com/hashicorp/terraform/issues/11566 to set a dynamic value to the attached security groups on the instances themselves.