### PR TITLE
Upgrade to latest version of ubuntu-nvidia-driver-installer.

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -212,6 +212,6 @@ persistent_volumes_enabled: false
 # nvidia_gpu_flavor: gtx
 ## NVIDIA driver installer images. Change them if you have trouble accessing gcr.io.
 # nvidia_driver_install_centos_container: atzedevries/nvidia-centos-driver-installer:2
-# nvidia_driver_install_ubuntu_container: gcr.io/google-containers/ubuntu-nvidia-driver-installer@sha256:eea7309dc4fa4a5c9d716157e74b90826e0a853aa26c7219db4710ddcd1ad8bc
+# nvidia_driver_install_ubuntu_container: gcr.io/google-containers/ubuntu-nvidia-driver-installer@sha256:7df76a0f0a17294e86f691c81de6bbb7c04a1b4b3d4ea4e7e2cccdc42e1f6d63
 ## NVIDIA GPU device plugin image.
 # nvidia_gpu_device_plugin_container: "k8s.gcr.io/nvidia-gpu-device-plugin@sha256:0842734032018be107fa2490c98156992911e3e1f2a21e059ff0105b07dd8e9e"

--- a/roles/kubernetes-apps/container_engine_accelerator/nvidia_gpu/defaults/main.yml
+++ b/roles/kubernetes-apps/container_engine_accelerator/nvidia_gpu/defaults/main.yml
@@ -7,7 +7,7 @@ nvidia_gpu_flavor: tesla
 nvidia_url_end: "{{ nvidia_driver_version }}/NVIDIA-Linux-x86_64-{{ nvidia_driver_version }}.run"
 nvidia_driver_install_container: false
 nvidia_driver_install_centos_container: atzedevries/nvidia-centos-driver-installer:2
-nvidia_driver_install_ubuntu_container: gcr.io/google-containers/ubuntu-nvidia-driver-installer@sha256:eea7309dc4fa4a5c9d716157e74b90826e0a853aa26c7219db4710ddcd1ad8bc
+nvidia_driver_install_ubuntu_container: gcr.io/google-containers/ubuntu-nvidia-driver-installer@sha256:7df76a0f0a17294e86f691c81de6bbb7c04a1b4b3d4ea4e7e2cccdc42e1f6d63
 nvidia_driver_install_supported: false
 nvidia_gpu_device_plugin_container: "k8s.gcr.io/nvidia-gpu-device-plugin@sha256:0842734032018be107fa2490c98156992911e3e1f2a21e059ff0105b07dd8e9e"
 nvidia_gpu_nodes: []


### PR DESCRIPTION
The lastest version of ubuntu-nvidia-driver-installer contains a fix for
https://github.com/GoogleCloudPlatform/container-engine-accelerators/issues/90
which causes the installer pod to crash when driver is already loaded.