### PR TITLE
[doc] Add documentation about CPU arch compatibility

### DIFF
--- a/docs/arch.md
+++ b/docs/arch.md
@@ -1,0 +1,16 @@
+## Architecture compatibility
+
+The following table shows the impact of the CPU architecture on compatible features:
+- amd64: Cluster using only x86/amd64 CPUs
+- arm64: Cluster using only arm64 CPUs
+- amd64 + arm64: Cluster with a mix of x86/amd64 and arm64 CPUs
+
+| kube_network_plugin | amd64 | arm64 | amd64 + arm64 |
+| ------------------- | ----- | ----- | ------------- |
+| Calico              | Y     | Y     | Y             |
+| Weave               | Y     | Y     | Y             |
+| Flannel             | Y     | N     | N             |
+| Canal               | Y     | N     | N             |
+| Cilium              | Y     | N     | N             |
+| Contib              | Y     | N     | N             |
+| kube-router         | Y     | N     | N             |


### PR DESCRIPTION
Add documentation about CPU arch compatibility. Trial and error can be frustrating for users, might as well have official documentation about what is we know works vs what we know doesn't work.