### PR TITLE
Fix: error converting YAML to JSON: yaml: line 36: mapping values are not allowed in this context

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
@@ -99,10 +99,10 @@ apiServerExtraArgs:
   oidc-groups-claim: {{ kube_oidc_groups_claim }}
 {%   endif %}
 {%   if kube_oidc_username_prefix is defined %}
-  oidc-username-prefix: {{ kube_oidc_username_prefix }}
+  oidc-username-prefix: "{{ kube_oidc_username_prefix }}"
 {%   endif %}
 {%   if kube_oidc_groups_prefix is defined %}
-  oidc-groups-prefix: {{ kube_oidc_groups_prefix }}
+  oidc-groups-prefix: "{{ kube_oidc_groups_prefix }}"
 {%   endif %}
 {% endif %}
 {% if kube_webhook_token_auth|default(false) %}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
@@ -84,10 +84,10 @@ apiServerExtraArgs:
   oidc-groups-claim: {{ kube_oidc_groups_claim }}
 {%   endif %}
 {%   if kube_oidc_username_prefix is defined %}
-  oidc-username-prefix: {{ kube_oidc_username_prefix }}
+  oidc-username-prefix: "{{ kube_oidc_username_prefix }}"
 {%   endif %}
 {%   if kube_oidc_groups_prefix is defined %}
-  oidc-groups-prefix: {{ kube_oidc_groups_prefix }}
+  oidc-groups-prefix: "{{ kube_oidc_groups_prefix }}"
 {%   endif %}
 {% endif %}
 {% if kube_webhook_token_auth|default(false) %}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
@@ -94,10 +94,10 @@ apiServerExtraArgs:
   oidc-groups-claim: {{ kube_oidc_groups_claim }}
 {%   endif %}
 {%   if kube_oidc_username_prefix is defined %}
-  oidc-username-prefix: {{ kube_oidc_username_prefix }}
+  oidc-username-prefix: "{{ kube_oidc_username_prefix }}"
 {%   endif %}
 {%   if kube_oidc_groups_prefix is defined %}
-  oidc-groups-prefix: {{ kube_oidc_groups_prefix }}
+  oidc-groups-prefix: "{{ kube_oidc_groups_prefix }}"
 {%   endif %}
 {% endif %}
 {% if kube_webhook_token_auth|default(false) %}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
@@ -91,10 +91,10 @@ apiServer:
     oidc-groups-claim: {{ kube_oidc_groups_claim }}
 {%   endif %}
 {%   if kube_oidc_username_prefix is defined %}
-    oidc-username-prefix: {{ kube_oidc_username_prefix }}
+    oidc-username-prefix: "{{ kube_oidc_username_prefix }}"
 {%   endif %}
 {%   if kube_oidc_groups_prefix is defined %}
-    oidc-groups-prefix: {{ kube_oidc_groups_prefix }}
+    oidc-groups-prefix: "{{ kube_oidc_groups_prefix }}"
 {%   endif %}
 {% endif %}
 {% if kube_webhook_token_auth|default(false) %}


### PR DESCRIPTION
Quote values for `kube_oidc_groups_prefix` and `kube_oidc_username_prefix` in kubeadm-config to accept colon, e.g oidc:

This will fix error: error converting YAML to JSON: yaml: line 36: mapping values are not allowed in this context

```bash
fatal: [k8s-dev-k8s-master-ne-nf-2]: FAILED! => {"changed": true, "cmd": ["timeout", "-k", "600s", "600s", "/usr/local/bin/kubeadm", "init", "--config=/etc/kubernetes/kubeadm-config.yaml", "--ignore-preflight-errors=all"], "delta": "0:00:00.781103", "end": "2019-02-27 20:57:44.305201", "failed_when_result": true, "msg": "non-zero return code", "rc": 1, "start": "2019-02-27 20:57:43.524098", "stderr": "error converting YAML to JSON: yaml: line 36: mapping values are not allowed in this context", "stderr_lines": ["error converting YAML to JSON: yaml: line 36: mapping values are not allowed in this context"], "stdout": "", "stdout_lines": []}
```

/etc/kubernetes/kubeadm-config.yaml

```yaml
certificatesDir: /etc/kubernetes/ssl
imageRepository: gcr.io/google-containers
useHyperKubeImage: false
apiServer:
  extraArgs:
    authorization-mode: Node,RBAC
    bind-address: 0.0.0.0
    insecure-port: "0"
    enable-admission-plugins: PodSecurityPolicy
    apiserver-count: "2"
    endpoint-reconciler-type: lease
    service-node-port-range: 30000-32767
    kubelet-preferred-address-types: "InternalDNS,InternalIP,Hostname,ExternalDNS,ExternalIP"
    oidc-issuer-url: https://my.cloud/auth/realms/myrelam
    oidc-client-id: k8s-client
    oidc-username-claim: preferred_username
    oidc-groups-claim: user-groups
    oidc-username-prefix: oidc:
    oidc-groups-prefix: oidc:
`