### PR TITLE
Added configurable min memory assertions

### DIFF
--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -49,3 +49,7 @@ etc_hosts_localhost_entries:
     unexpected:
       - localhost
       - localhost.localdomain
+
+# Minimal memory requirement in MB for safety checks
+minimal_node_memory_mb: 1024
+minimal_master_memory_mb: 1500

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -52,13 +52,13 @@
 
 - name: Stop if memory is too small for masters
   assert:
-    that: ansible_memtotal_mb >= 1500
+    that: ansible_memtotal_mb >= minimal_master_memory_mb
   ignore_errors: "{{ ignore_assert_errors }}"
   when: inventory_hostname in groups['kube-master']
 
 - name: Stop if memory is too small for nodes
   assert:
-    that: ansible_memtotal_mb >= 1024
+    that: ansible_memtotal_mb >= minimal_node_memory_mb
   ignore_errors: "{{ ignore_assert_errors }}"
   when: inventory_hostname in groups['kube-node']
 


### PR DESCRIPTION
I'm using kubespray on low RAM devices, and this setting helps me configure minimal MB warning limit