### PR TITLE
use the locally deployed kubectl binary within the kubectl.sh helper …

### DIFF
--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -79,7 +79,7 @@
   copy:
     content: |
       #!/bin/bash
-      kubectl --kubeconfig=${BASH_SOURCE%/*}/admin.conf $@
+      ./kubectl --kubeconfig=${BASH_SOURCE%/*}/admin.conf $@
     dest: "{{ artifacts_dir }}/kubectl.sh"
     mode: 0755
   become: no


### PR DESCRIPTION
The helper script kubectl.sh uses kubectl without a relative/absolute path which leads to an error if kubectl is not installed or in the PATH. The helper script should use ./kubectl to use the kubectl binary kubespray-ansible deployed to the artifacts folder.