### PR TITLE
Reenable set_facts task for dns_late

### DIFF
--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -20,8 +20,6 @@
     - upgrade
 
 - import_tasks: 0040-set_facts.yml
-  when:
-    - not dns_late
   tags:
     - resolvconf
     - facts


### PR DESCRIPTION
This is necessary to configure the script zdnsupdate which will inhibit dhcp from changing /etc/resolv.conf