### PR TITLE
Terraform wait for floating IP instance has been associated

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -16,12 +16,13 @@ most modern installs of OpenStack that support the basic services.
 - [ELASTX](https://elastx.se/)
 - [EnterCloudSuite](https://www.entercloudsuite.com/)
 - [FugaCloud](https://fuga.cloud/)
+- [Open Telekom Cloud](https://cloud.telekom.de/) : requires to set the variable `wait_for_floatingip = "true"` in your cluster.tf
 - [OVH](https://www.ovh.com/)
 - [Rackspace](https://www.rackspace.com/)
 - [Ultimum](https://ultimum.io/)
 - [VexxHost](https://vexxhost.com/)
 - [Zetta](https://www.zetta.io/)
-- [Open Telekom Cloud](https://cloud.telekom.de/) : requires to set the variable `wait_for_floatingip = "true"` in your cluster.tf
+
 
 ## Approach
 The terraform configuration inspects variables found in

--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -21,9 +21,7 @@ most modern installs of OpenStack that support the basic services.
 - [Ultimum](https://ultimum.io/)
 - [VexxHost](https://vexxhost.com/)
 - [Zetta](https://www.zetta.io/)
-
-### Known incompatible public clouds
-- T-Systems / Open Telekom Cloud: requires `wait_until_associated`
+- [Open Telekom Cloud](https://cloud.telekom.de/) : requires to set the variable `wait_for_floatingip = "true"` in your cluster.tf
 
 ## Approach
 The terraform configuration inspects variables found in
@@ -246,6 +244,7 @@ For your cluster, edit `inventory/$CLUSTER/cluster.tf`.
 |`master_allowed_remote_ips` | List of CIDR blocks allowed to initiate an API connection, `["0.0.0.0/0"]` by default |
 |`k8s_allowed_remote_ips` | List of CIDR allowed to initiate a SSH connection, empty by default |
 |`worker_allowed_ports` | List of ports to open on worker nodes, `[{ "protocol" = "tcp", "port_range_min" = 30000, "port_range_max" = 32767, "remote_ip_prefix" = "0.0.0.0/0"}]` by default |
+|`wait_for_floatingip` | Let Terraform poll the instance until the floating IP has been associated, `false` by default. |
 
 #### Terraform state files
 

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -63,6 +63,7 @@ module "compute" {
   supplementary_master_groups                  = "${var.supplementary_master_groups}"
   supplementary_node_groups                    = "${var.supplementary_node_groups}"
   worker_allowed_ports                         = "${var.worker_allowed_ports}"
+  wait_for_floatingip                          = "${var.wait_for_floatingip}"
 
   network_id = "${module.network.router_id}"
 }

--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -285,16 +285,16 @@ resource "openstack_compute_instance_v2" "k8s_node_no_floating_ip" {
 }
 
 resource "openstack_compute_floatingip_associate_v2" "bastion" {
-  count       = "${var.number_of_bastions}"
-  floating_ip = "${var.bastion_fips[count.index]}"
-  instance_id = "${element(openstack_compute_instance_v2.bastion.*.id, count.index)}"
+  count                 = "${var.number_of_bastions}"
+  floating_ip           = "${var.bastion_fips[count.index]}"
+  instance_id           = "${element(openstack_compute_instance_v2.bastion.*.id, count.index)}"
   wait_until_associated = "${var.wait_for_floatingip}"
 }
 
 resource "openstack_compute_floatingip_associate_v2" "k8s_master" {
-  count       = "${var.number_of_k8s_masters}"
-  instance_id = "${element(openstack_compute_instance_v2.k8s_master.*.id, count.index)}"
-  floating_ip = "${var.k8s_master_fips[count.index]}"
+  count                 = "${var.number_of_k8s_masters}"
+  instance_id           = "${element(openstack_compute_instance_v2.k8s_master.*.id, count.index)}"
+  floating_ip           = "${var.k8s_master_fips[count.index]}"
   wait_until_associated = "${var.wait_for_floatingip}"
 }
 
@@ -305,9 +305,9 @@ resource "openstack_compute_floatingip_associate_v2" "k8s_master_no_etcd" {
 }
 
 resource "openstack_compute_floatingip_associate_v2" "k8s_node" {
-  count       = "${var.number_of_k8s_nodes}"
-  floating_ip = "${var.k8s_node_fips[count.index]}"
-  instance_id = "${element(openstack_compute_instance_v2.k8s_node.*.id, count.index)}"
+  count                 = "${var.number_of_k8s_nodes}"
+  floating_ip           = "${var.k8s_node_fips[count.index]}"
+  instance_id           = "${element(openstack_compute_instance_v2.k8s_node.*.id, count.index)}"
   wait_until_associated = "${var.wait_for_floatingip}"
 }
 

--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -288,12 +288,14 @@ resource "openstack_compute_floatingip_associate_v2" "bastion" {
   count       = "${var.number_of_bastions}"
   floating_ip = "${var.bastion_fips[count.index]}"
   instance_id = "${element(openstack_compute_instance_v2.bastion.*.id, count.index)}"
+  wait_until_associated = "${var.wait_for_floatingip}"
 }
 
 resource "openstack_compute_floatingip_associate_v2" "k8s_master" {
   count       = "${var.number_of_k8s_masters}"
   instance_id = "${element(openstack_compute_instance_v2.k8s_master.*.id, count.index)}"
   floating_ip = "${var.k8s_master_fips[count.index]}"
+  wait_until_associated = "${var.wait_for_floatingip}"
 }
 
 resource "openstack_compute_floatingip_associate_v2" "k8s_master_no_etcd" {
@@ -306,6 +308,7 @@ resource "openstack_compute_floatingip_associate_v2" "k8s_node" {
   count       = "${var.number_of_k8s_nodes}"
   floating_ip = "${var.k8s_node_fips[count.index]}"
   instance_id = "${element(openstack_compute_instance_v2.k8s_node.*.id, count.index)}"
+  wait_until_associated = "${var.wait_for_floatingip}"
 }
 
 resource "openstack_blockstorage_volume_v2" "glusterfs_volume" {

--- a/contrib/terraform/openstack/modules/compute/variables.tf
+++ b/contrib/terraform/openstack/modules/compute/variables.tf
@@ -82,6 +82,8 @@ variable "k8s_allowed_egress_ips" {
   type = "list"
 }
 
+variable "wait_for_floatingip" {}
+
 variable "supplementary_master_groups" {
   default = ""
 }

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -125,7 +125,7 @@ variable "floatingip_pool" {
   default     = "external"
 }
 
-variable "wait_for_floatingip"{
+variable "wait_for_floatingip" {
   description = "Terraform will poll the instance until the floating IP has been associated."
   default     = "false"
 }

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -125,6 +125,11 @@ variable "floatingip_pool" {
   default     = "external"
 }
 
+variable "wait_for_floatingip"{
+  description = "Terraform will poll the instance until the floating IP has been associated."
+  default     = "false"
+}
+
 variable "external_net" {
   description = "uuid of the external/public network"
 }


### PR DESCRIPTION
This feature will give ability for the Terraform deployment to poll the instance until the floating IP has been associated. This is necessary for the use of the Open Telekom Cloud and bring it to the "Known compatible public clouds" list of Kubespray.

The user can activate the function by the variable `wait_for_floatingip = "true"` in the cluster.tf. By default the variable is set to false.