### PR TITLE
Use proxy_env with kubeadm phase commands

### DIFF
--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -52,6 +52,7 @@
     --cert-dir {{ kube_config_dir }}/ssl
     --apiserver-advertise-address {{ external_apiserver_address }}
     --apiserver-bind-port {{ external_apiserver_port }}
+  environment: "{{ proxy_env }}"
   run_once: yes
   register: admin_kubeconfig
 

--- a/roles/kubernetes/master/tasks/kubeadm-certificate.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-certificate.yml
@@ -27,6 +27,7 @@
 
 - name: Generate new certs and keys
   command: "{{ bin_dir }}/kubeadm init phase certs {{ item }} --config={{ kube_config_dir }}/kubeadm-config.yaml"
+  environment: "{{ proxy_env }}"
   with_items:
     - apiserver
     - apiserver-kubelet-client
@@ -35,6 +36,7 @@
 
 - name: Generate new certs and keys
   command: "{{ bin_dir }}/kubeadm alpha phase certs {{ item }} --config={{ kube_config_dir }}/kubeadm-config.yaml"
+  environment: "{{ proxy_env }}"
   with_items:
     - apiserver
     - apiserver-kubelet-client

--- a/roles/kubernetes/master/tasks/kubeadm-kubeconfig.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-kubeconfig.yml
@@ -23,10 +23,12 @@
 
 - name: Generate new configuration files
   command: "{{ bin_dir }}/kubeadm init phase kubeconfig all --config={{ kube_config_dir }}/kubeadm-config.yaml"
+  environment: "{{ proxy_env }}"
   when: kubeadm_version is version('v1.13.0', '>=')
   ignore_errors: yes
 
 - name: Generate new configuration files
   command: "{{ bin_dir }}/kubeadm alpha phase kubeconfig all --config={{ kube_config_dir }}/kubeadm-config.yaml"
+  environment: "{{ proxy_env }}"
   when: kubeadm_version is version('v1.13.0', '<')
   ignore_errors: yes


### PR DESCRIPTION
The `kubeadm init phase` and `kubeadm alpha phase` commands make a request to https://dl.k8s.io in order to get the latest minor version. These changes introduce `proxy_env` as environment variables in order to have the request proxied.