### PR TITLE
Calico felix - Fix jinja2 boolean condition

### DIFF
--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -35,10 +35,10 @@ calicoctl_memory_requests: 32M
 calicoctl_cpu_requests: 250m
 
 # Enable Prometheus Metrics endpoint for felix
-calico_felix_prometheusmetricsenabled: "false"
+calico_felix_prometheusmetricsenabled: false
 calico_felix_prometheusmetricsport: 9091
-calico_felix_prometheusgometricsenabled: "true"
-calico_felix_prometheusprocessmetricsenabled: "true"
+calico_felix_prometheusgometricsenabled: true
+calico_felix_prometheusprocessmetricsenabled: true
 
 ### check latest version https://github.com/projectcalico/calico-upgrade/releases
 calico_upgrade_enabled: true

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -20,7 +20,7 @@ spec:
       annotations:
         # Mark pod as critical for rescheduling (Will have no effect starting with kubernetes 1.12)
         kubespray.etcd-cert/serial: "{{ etcd_client_cert_serial }}"
-{% if calico_felix_prometheusmetricsenabled == 'true' %}
+{% if calico_felix_prometheusmetricsenabled %}
         prometheus.io/scrape: 'true'
         prometheus.io/port: "{{ calico_felix_prometheusmetricsport }}"
 {% endif %}

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -20,7 +20,7 @@ spec:
       annotations:
         # Mark pod as critical for rescheduling (Will have no effect starting with kubernetes 1.12)
         kubespray.etcd-cert/serial: "{{ etcd_client_cert_serial }}"
-{% if calico_felix_prometheusmetricsenabled %}
+{% if calico_felix_prometheusmetricsenabled == 'true' %}
         prometheus.io/scrape: 'true'
         prometheus.io/port: "{{ calico_felix_prometheusmetricsport }}"
 {% endif %}


### PR DESCRIPTION
`calico_felix_prometheusmetricsenabled` is by default set to `"false"` (string) and in this condition it evaluates to true.

This results in the felix prometheus metrics being disabled but Prometheus still trying to scrape since the annotations are set due to `"false"` being interpreted as true.
And of course Prometheus marks this Pod as bad since it can't scrape the metrics.