### PR TITLE
Added bastion host_group for bastion host

### DIFF
--- a/inventory/sample/hosts.ini
+++ b/inventory/sample/hosts.ini
@@ -10,6 +10,7 @@
 # node6 ansible_host=95.54.0.17  # ip=10.3.0.6 etcd_member_name=etcd6
 
 # ## configure a bastion host if your nodes are not directly reachable
+# [bastion]
 # bastion ansible_host=x.x.x.x ansible_user=some_user
 
 [kube-master]


### PR DESCRIPTION
Resolves #4360 

I see two ways to solve this problem:
1. Add to inventory `bastion` group. - this PR
2. Fix all places where used similar construction (`hostvars[groups['bastion'][0]]`) to something else. - #4362

P.S. This PR and #4362 are mutually exclusive