### PR TITLE
Change bastion host reference from host group to just host

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -14,7 +14,7 @@
   vars:
     ansible_connection: local
 
-- hosts: bastion[0]
+- hosts: bastion
   gather_facts: False
   roles:
     - { role: kubespray-defaults}

--- a/reset.yml
+++ b/reset.yml
@@ -13,7 +13,7 @@
   vars:
     ansible_connection: local
 
-- hosts: bastion[0]
+- hosts: bastion
   gather_facts: False
   roles:
     - { role: kubespray-defaults}

--- a/roles/bastion-ssh-config/tasks/main.yml
+++ b/roles/bastion-ssh-config/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - set_fact:
-    bastion_ip: "{{ hostvars[groups['bastion'][0]]['ansible_host'] | d(hostvars[groups['bastion'][0]]['ansible_ssh_host']) }}"
+    bastion_ip: "{{ hostvars['bastion']['ansible_host'] | d(hostvars['bastion']['ansible_ssh_host']) }}"
   delegate_to: localhost
 
 # As we are actually running on localhost, the ansible_ssh_user is your local user when you try to use it directly

--- a/scale.yml
+++ b/scale.yml
@@ -14,7 +14,7 @@
   vars:
     ansible_connection: local
 
-- hosts: bastion[0]
+- hosts: bastion
   gather_facts: False
   roles:
     - { role: kubespray-defaults}

--- a/upgrade-cluster.yml
+++ b/upgrade-cluster.yml
@@ -14,7 +14,7 @@
   vars:
     ansible_connection: local
 
-- hosts: bastion[0]
+- hosts: bastion
   gather_facts: False
   roles:
     - { role: kubespray-defaults}


### PR DESCRIPTION
Resolves #4360 

I see two ways to solve this problem:
1. Add to inventory `bastion` group. - #4361
2. Fix all places where used similar construction (`hostvars[groups['bastion'][0]]`) to something else. - this PR


P.S. This PR and #4361 are mutually exclusive