### PR TITLE
Move k8s certs from old dir to new dir

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -412,13 +412,13 @@ sudo route add -net [internal-subnet]/24 gw [router-ip]
 ```
 3. List Kubernetes certificates & keys:
 ```
-ssh [os-user]@[master-ip] sudo ls /etc/kubernetes/ssl/
+ssh [os-user]@[master-ip] sudo ls /etc/kubernetes/pki/
 ```
 4. Get `admin`'s certificates and keys:
 ```
-ssh [os-user]@[master-ip] sudo cat /etc/kubernetes/ssl/admin-kube-master-1-key.pem > admin-key.pem
-ssh [os-user]@[master-ip] sudo cat /etc/kubernetes/ssl/admin-kube-master-1.pem > admin.pem
-ssh [os-user]@[master-ip] sudo cat /etc/kubernetes/ssl/ca.pem > ca.pem
+ssh [os-user]@[master-ip] sudo cat /etc/kubernetes/pki/admin-kube-master-k8s-master-1-key.pem > admin-key.pem
+ssh [os-user]@[master-ip] sudo cat /etc/kubernetes/pki/admin-kube-master-k8s-master-1.pem > admin.pem
+ssh [os-user]@[master-ip] sudo cat /etc/kubernetes/pki/ca.pem > ca.pem
 ```
 5. Configure kubectl:
 ```ShellSession

--- a/contrib/vault/roles/vault/defaults/main.yml
+++ b/contrib/vault/roles/vault/defaults/main.yml
@@ -114,7 +114,7 @@ vault_client_headers:
   Content-Type: "application/json"
 
 etcd_cert_dir: /etc/ssl/etcd/ssl
-kube_cert_dir: /etc/kubernetes/ssl
+kube_cert_dir: /etc/kubernetes/pki
 
 vault_pki_mounts:
   userpass:

--- a/contrib/vault/vault.md
+++ b/contrib/vault/vault.md
@@ -76,8 +76,8 @@ generated elsewhere, you'll need to copy the certificate and key to the hosts in
   * ``/etc/ssl/etcd/ssl/ca.pem``
   * ``/etc/ssl/etcd/ssl/ca-key.pem``
 * kubernetes:
-  * ``/etc/kubernetes/ssl/ca.pem``
-  * ``/etc/kubernetes/ssl/ca-key.pem``
+  * ``/etc/kubernetes/pki/ca.pem``
+  * ``/etc/kubernetes/pki/ca-key.pem``
 
 Additional Notes:
 

--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -8,7 +8,9 @@ kube_script_dir: "{{ bin_dir }}/kubernetes-scripts"
 kube_manifest_dir: "{{ kube_config_dir }}/manifests"
 
 # This is where all the cert scripts and certs will be located
-kube_cert_dir: "{{ kube_config_dir }}/ssl"
+# For old version of k8s next line should be used instead
+# kube_cert_dir: "{{ kube_config_dir }}/ssl"
+kube_cert_dir: "{{ kube_config_dir }}/pki"
 
 # This is where all of the bearer tokens will be stored
 kube_token_dir: "{{ kube_config_dir }}/tokens"

--- a/roles/kubernetes/client/defaults/main.yml
+++ b/roles/kubernetes/client/defaults/main.yml
@@ -4,4 +4,5 @@ kubectl_localhost: false
 artifacts_dir: "{{ inventory_dir }}/artifacts"
 
 kube_config_dir: "/etc/kubernetes"
+kube_cert_dir: "{{ kube_config_dir }}/pki"
 kube_apiserver_port: "6443"

--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -49,7 +49,7 @@
     kubeconfig user
     --client-name kubernetes-admin
     --org system:masters
-    --cert-dir {{ kube_config_dir }}/ssl
+    --cert-dir {{ kube_cert_dir }}
     --apiserver-advertise-address {{ external_apiserver_address }}
     --apiserver-bind-port {{ external_apiserver_port }}
   environment: "{{ proxy_env }}"

--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -71,7 +71,7 @@
   tags: facts
 
 - name: kubeadm | Copy etcd cert dir under k8s cert dir
-  command: "cp -TR {{ etcd_cert_dir }} {{ kube_config_dir }}/ssl/etcd"
+  command: "cp -TR {{ etcd_cert_dir }} {{ kube_cert_dir }}/etcd"
   changed_when: false
 
 - name: Create audit-policy directory

--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -25,6 +25,7 @@ disable_ipv6_dns: false
 
 kube_cert_group: kube-cert
 kube_config_dir: /etc/kubernetes
+kube_cert_dir: "{{ kube_config_dir }}/pki"
 
 # Container Linux by CoreOS cloud init config file to define /etc/resolv.conf content
 # for hostnet pods and infra needs

--- a/roles/kubernetes/preinstall/tasks/0030-pre_upgrade.yml
+++ b/roles/kubernetes/preinstall/tasks/0030-pre_upgrade.yml
@@ -38,7 +38,7 @@
   when: old_certificate_dir.stat.exists
 
 - name: "Pre-upgrade | move data from old certificate dir to new"
-  command: mv {{ kube_config_dir }}/ssl {{ kube_cert_dir }}
+  command: cp -r {{ kube_config_dir }}/ssl {{ kube_cert_dir }}
   args:
     creates: "{{ kube_cert_dir }}"
   become: yes

--- a/roles/kubernetes/preinstall/tasks/0030-pre_upgrade.yml
+++ b/roles/kubernetes/preinstall/tasks/0030-pre_upgrade.yml
@@ -23,3 +23,25 @@
   when:
     - old_credential_dir.stat.exists
     - not new_credential_dir.stat.exists
+
+- name: "Pre-upgrade | check if old certificate dir exists"
+  stat:
+    path: "{{ kube_config_dir }}/ssl"
+  register: old_certificate_dir
+  become: yes
+
+- name: "Pre-upgrade | check if new certificate dir exists"
+  stat:
+    path: "{{ kube_cert_dir }}"
+  register: new_certificate_dir
+  become: yes
+  when: old_certificate_dir.stat.exists
+
+- name: "Pre-upgrade | move data from old certificate dir to new"
+  command: mv {{ kube_config_dir }}/ssl {{ kube_cert_dir }}
+  args:
+    creates: "{{ kube_cert_dir }}"
+  become: yes
+  when:
+    - old_certificate_dir.stat.exists
+    - not new_certificate_dir.stat.exists

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -93,7 +93,7 @@ kube_script_dir: "{{ bin_dir }}/kubernetes-scripts"
 kube_manifest_dir: "{{ kube_config_dir }}/manifests"
 
 # This is where all the cert scripts and certs will be located
-kube_cert_dir: "{{ kube_config_dir }}/ssl"
+kube_cert_dir: "{{ kube_config_dir }}/pki"
 
 # This is where all of the bearer tokens will be stored
 kube_token_dir: "{{ kube_config_dir }}/tokens"


### PR DESCRIPTION
Added renaming old certificates directory ( `{{ kube_conf_dir }}/ssl` = `/etc/kubernetes/ssl` by default)  to new name ( `{{ kube_cert_dir }`} = /etc/kubernetes/pki) if it was found.

This change was discussed [here](https://github.com/kubernetes-sigs/kubespray/pull/4354#issuecomment-473895300)