### PR TITLE
Revert "Move from /etc/kubernetes/ssl to /etc/kubernetes/pki dir for k8s certs"

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -412,13 +412,13 @@ sudo route add -net [internal-subnet]/24 gw [router-ip]
 ```
 3. List Kubernetes certificates & keys:
 ```
-ssh [os-user]@[master-ip] sudo ls /etc/kubernetes/pki/
+ssh [os-user]@[master-ip] sudo ls /etc/kubernetes/ssl/
 ```
 4. Get `admin`'s certificates and keys:
 ```
-ssh [os-user]@[master-ip] sudo cat /etc/kubernetes/pki/admin-kube-master-k8s-master-1-key.pem > admin-key.pem
-ssh [os-user]@[master-ip] sudo cat /etc/kubernetes/pki/admin-kube-master-k8s-master-1.pem > admin.pem
-ssh [os-user]@[master-ip] sudo cat /etc/kubernetes/pki/ca.pem > ca.pem
+ssh [os-user]@[master-ip] sudo cat /etc/kubernetes/ssl/admin-kube-master-1-key.pem > admin-key.pem
+ssh [os-user]@[master-ip] sudo cat /etc/kubernetes/ssl/admin-kube-master-1.pem > admin.pem
+ssh [os-user]@[master-ip] sudo cat /etc/kubernetes/ssl/ca.pem > ca.pem
 ```
 5. Configure kubectl:
 ```ShellSession

--- a/contrib/vault/roles/vault/defaults/main.yml
+++ b/contrib/vault/roles/vault/defaults/main.yml
@@ -114,7 +114,7 @@ vault_client_headers:
   Content-Type: "application/json"
 
 etcd_cert_dir: /etc/ssl/etcd/ssl
-kube_cert_dir: /etc/kubernetes/pki
+kube_cert_dir: /etc/kubernetes/ssl
 
 vault_pki_mounts:
   userpass:

--- a/contrib/vault/vault.md
+++ b/contrib/vault/vault.md
@@ -76,8 +76,8 @@ generated elsewhere, you'll need to copy the certificate and key to the hosts in
   * ``/etc/ssl/etcd/ssl/ca.pem``
   * ``/etc/ssl/etcd/ssl/ca-key.pem``
 * kubernetes:
-  * ``/etc/kubernetes/pki/ca.pem``
-  * ``/etc/kubernetes/pki/ca-key.pem``
+  * ``/etc/kubernetes/ssl/ca.pem``
+  * ``/etc/kubernetes/ssl/ca-key.pem``
 
 Additional Notes:
 

--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -8,9 +8,7 @@ kube_script_dir: "{{ bin_dir }}/kubernetes-scripts"
 kube_manifest_dir: "{{ kube_config_dir }}/manifests"
 
 # This is where all the cert scripts and certs will be located
-# For old version of k8s next line should be used instead
-# kube_cert_dir: "{{ kube_config_dir }}/ssl"
-kube_cert_dir: "{{ kube_config_dir }}/pki"
+kube_cert_dir: "{{ kube_config_dir }}/ssl"
 
 # This is where all of the bearer tokens will be stored
 kube_token_dir: "{{ kube_config_dir }}/tokens"

--- a/roles/kubernetes/client/defaults/main.yml
+++ b/roles/kubernetes/client/defaults/main.yml
@@ -4,5 +4,4 @@ kubectl_localhost: false
 artifacts_dir: "{{ inventory_dir }}/artifacts"
 
 kube_config_dir: "/etc/kubernetes"
-kube_cert_dir: "{{ kube_config_dir }}/pki"
 kube_apiserver_port: "6443"

--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -49,7 +49,7 @@
     kubeconfig user
     --client-name kubernetes-admin
     --org system:masters
-    --cert-dir {{ kube_cert_dir }}
+    --cert-dir {{ kube_config_dir }}/ssl
     --apiserver-advertise-address {{ external_apiserver_address }}
     --apiserver-bind-port {{ external_apiserver_port }}
   run_once: yes

--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -71,7 +71,7 @@
   tags: facts
 
 - name: kubeadm | Copy etcd cert dir under k8s cert dir
-  command: "cp -TR {{ etcd_cert_dir }} {{ kube_cert_dir }}/etcd"
+  command: "cp -TR {{ etcd_cert_dir }} {{ kube_config_dir }}/ssl/etcd"
   changed_when: false
 
 - name: Create audit-policy directory

--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -25,7 +25,6 @@ disable_ipv6_dns: false
 
 kube_cert_group: kube-cert
 kube_config_dir: /etc/kubernetes
-kube_cert_dir: "{{ kube_config_dir }}/pki"
 
 # Container Linux by CoreOS cloud init config file to define /etc/resolv.conf content
 # for hostnet pods and infra needs

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -93,7 +93,7 @@ kube_script_dir: "{{ bin_dir }}/kubernetes-scripts"
 kube_manifest_dir: "{{ kube_config_dir }}/manifests"
 
 # This is where all the cert scripts and certs will be located
-kube_cert_dir: "{{ kube_config_dir }}/pki"
+kube_cert_dir: "{{ kube_config_dir }}/ssl"
 
 # This is where all of the bearer tokens will be stored
 kube_token_dir: "{{ kube_config_dir }}/tokens"


### PR DESCRIPTION
Reverts kubernetes-sigs/kubespray#4354

This change modified the certs dir for Kubernetes, but did not move the directories for existing clusters.