### PR TITLE
Fix pep8 warnings

### DIFF
--- a/contrib/inventory_builder/requirements.txt
+++ b/contrib/inventory_builder/requirements.txt
@@ -1,2 +1,3 @@
 configparser>=3.3.0
 ruamel.yaml>=0.15.88
+ipaddress


### PR DESCRIPTION
`master` has a couple of `pep8`/`pycodestyle` warning in CI: https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/180803333

This is an attempt at fixing them.

I added `# noqa` where lines are too long and I couldn't fix it without a major refactor.