### PR TITLE
Use static files in KubeDNS templating task

### DIFF
--- a/roles/kubernetes-apps/ansible/tasks/kubedns.yml
+++ b/roles/kubernetes-apps/ansible/tasks/kubedns.yml
@@ -1,18 +1,19 @@
 ---
 
 - name: Kubernetes Apps | Lay Down KubeDNS Template
-  template:
-    src: "{{ item.file }}.j2"
+  action: "{{ item.module }}"
+  args:
+    src: "{{ item.file }}{% if item.module == 'template' %}.j2{% endif %}"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
   with_items:
-    - { name: kube-dns, file: kubedns-sa.yml, type: sa }
-    - { name: kube-dns, file: kubedns-config.yml, type: configmap }
-    - { name: kube-dns, file: kubedns-deploy.yml, type: deployment }
-    - { name: kube-dns, file: kubedns-svc.yml, type: svc }
-    - { name: dns-autoscaler, file: dns-autoscaler-sa.yml, type: sa }
-    - { name: dns-autoscaler, file: dns-autoscaler-clusterrole.yml, type: clusterrole }
-    - { name: dns-autoscaler, file: dns-autoscaler-clusterrolebinding.yml, type: clusterrolebinding }
-    - { name: dns-autoscaler, file: dns-autoscaler.yml, type: deployment }
+    - { name: kube-dns, module: template, file: kubedns-sa.yml, type: sa }
+    - { name: kube-dns, module: template, file: kubedns-config.yml, type: configmap }
+    - { name: kube-dns, module: template, file: kubedns-deploy.yml, type: deployment }
+    - { name: kube-dns, module: template, file: kubedns-svc.yml, type: svc }
+    - { name: dns-autoscaler, module: copy, file: dns-autoscaler-sa.yml, type: sa }
+    - { name: dns-autoscaler, module: copy, file: dns-autoscaler-clusterrole.yml, type: clusterrole }
+    - { name: dns-autoscaler, module: copy, file: dns-autoscaler-clusterrolebinding.yml, type: clusterrolebinding }
+    - { name: dns-autoscaler, module: template, file: dns-autoscaler.yml, type: deployment }
   register: kubedns_manifests
   when:
     - dns_mode in ['kubedns','dnsmasq_kubedns']


### PR DESCRIPTION
This commit adapts the "Lay Down KubeDNS Template" task to use the static
files moved by pull request https://github.com/kubernetes-sigs/kubespray/pull/4341.

Fixes: https://github.com/kubernetes-sigs/kubespray/issues/4378

Edit: Btw. I blatantly copied @mattymo's approach from https://github.com/kubernetes-sigs/kubespray/pull/4341/commits/0c32c2f8292a86c59600e0236f1a9201784d546a