### PR TITLE
Use wide for netchecker debug output

### DIFF
--- a/tests/testcases/040_check-network-adv.yml
+++ b/tests/testcases/040_check-network-adv.yml
@@ -24,7 +24,7 @@
       when: not ansible_os_family in ["CoreOS", "Container Linux by CoreOS"]
 
     - name: Wait for netchecker server
-      shell: "{{ bin_dir }}/kubectl get pods --namespace {{netcheck_namespace}} | grep ^netchecker-server"
+      shell: "{{ bin_dir }}/kubectl get pods -o wide --namespace {{netcheck_namespace}} | grep ^netchecker-server"
       delegate_to: "{{groups['kube-master'][0]}}"
       run_once: true
       register: ncs_pod
@@ -33,7 +33,7 @@
       delay: 10
 
     - name: Wait for netchecker agents
-      shell: "{{ bin_dir }}/kubectl get pods --namespace {{netcheck_namespace}} | grep '^netchecker-agent-.*Running'"
+      shell: "{{ bin_dir }}/kubectl get pods -o wide --namespace {{netcheck_namespace}} | grep '^netchecker-agent-.*Running'"
       run_once: true
       delegate_to: "{{groups['kube-master'][0]}}"
       register: nca_pod


### PR DESCRIPTION
Netchecker issues would be easier to debug with `-o wide`