### PR TITLE
Increase CPU flavor for CI

### DIFF
--- a/tests/files/gce_centos7-multus-calico.yml
+++ b/tests/files/gce_centos7-multus-calico.yml
@@ -1,7 +1,7 @@
 # Instance settings
 cloud_image_family: centos-7
 cloud_region: us-central1-c
-cloud_machine_type: "n1-standard-1"
+cloud_machine_type: "n1-standard-2"
 mode: default
 
 # Deployment settings

--- a/tests/files/gce_coreos-kube-router.yml
+++ b/tests/files/gce_coreos-kube-router.yml
@@ -1,6 +1,7 @@
 # Instance settings
 cloud_image_family: coreos-stable
 cloud_region: us-central1-c
+cloud_machine_type: "n1-standard-2"
 mode: default
 startup_script: 'systemctl disable locksmithd && systemctl stop locksmithd'
 

--- a/tests/files/gce_ubuntu-flannel-ha.yml
+++ b/tests/files/gce_ubuntu-flannel-ha.yml
@@ -1,7 +1,7 @@
 # Instance settings
 cloud_image_family: ubuntu-1604-lts
 cloud_region: us-central1-b
-cloud_machine_type: "n1-standard-1"
+cloud_machine_type: "n1-standard-2"
 mode: ha
 
 # Deployment settings

--- a/tests/files/gce_ubuntu-kube-router-sep.yml
+++ b/tests/files/gce_ubuntu-kube-router-sep.yml
@@ -1,6 +1,7 @@
 # Instance settings
 cloud_image_family: ubuntu-1604-lts
 cloud_region: us-central1-c
+cloud_machine_type: "n1-standard-2"
 mode: separate
 
 # Deployment settings


### PR DESCRIPTION
As seen in [CI](https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/pipelines/53368163) some jobs fail because netchecker pods are stuck with "Pending" state because of "Insufficient CPU".

I have noticed this for `gce_ubuntu-flannel-ha`, `gce_coreos-kube-router` and `gce_ubuntu-kube-router-sep`