### PR TITLE
Reduce jinja2 filters in coredns templates

### DIFF
--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -7,6 +7,7 @@ dns_min_replicas: 2
 dns_nodes_per_replica: 16
 dns_cores_per_replica: 256
 dns_prevent_single_point_failure: "{{ 'true' if dns_min_replicas|int > 1 else 'false' }}"
+coredns_ordinal_suffix: ""
 
 # nodelocaldns
 nodelocaldns_cpu_requests: 100m

--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -14,7 +14,7 @@ data:
         kubernetes {{ dns_domain }} in-addr.arpa ip6.arpa {
           pods insecure
 {% if resolvconf_mode == 'host_resolvconf' and upstream_dns_servers is defined and upstream_dns_servers|length > 0 %}
-          upstream {{ upstream_dns_servers|join(' ') }}
+          upstream {{ upstream_dns_servers.join(' ') }}
 {% else %}
           upstream /etc/resolv.conf
 {% endif %}
@@ -22,7 +22,7 @@ data:
         }
         prometheus :9153
 {% if resolvconf_mode == 'host_resolvconf' and upstream_dns_servers is defined and upstream_dns_servers|length > 0 %}
-        proxy . {{ upstream_dns_servers|join(' ') }}
+        proxy . {{ upstream_dns_servers.join(' ') }}
 {% else %}
         proxy . /etc/resolv.conf
 {% endif %}

--- a/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
@@ -2,13 +2,13 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: "coredns{{ coredns_ordinal_suffix | default('') }}"
+  name: "coredns{{ coredns_ordinal_suffix }}"
   namespace: kube-system
   labels:
-    k8s-app: "coredns{{ coredns_ordinal_suffix | default('') }}"
+    k8s-app: "coredns{{ coredns_ordinal_suffix }}"
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    kubernetes.io/name: "coredns{{ coredns_ordinal_suffix | default('') }}"
+    kubernetes.io/name: "coredns{{ coredns_ordinal_suffix }}"
 spec:
   strategy:
     type: RollingUpdate
@@ -17,17 +17,15 @@ spec:
       maxSurge: 10%
   selector:
     matchLabels:
-      k8s-app: coredns{{ coredns_ordinal_suffix | default('') }}
+      k8s-app: coredns{{ coredns_ordinal_suffix }}
   template:
     metadata:
       labels:
-        k8s-app: coredns{{ coredns_ordinal_suffix | default('') }}
+        k8s-app: coredns{{ coredns_ordinal_suffix }}
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
-{% if kube_version is version('v1.11.1', '>=') %}
       priorityClassName: system-cluster-critical
-{% endif %}
       nodeSelector:
         beta.kubernetes.io/os: linux
       serviceAccountName: coredns
@@ -42,7 +40,7 @@ spec:
           - topologyKey: "kubernetes.io/hostname"
             labelSelector:
               matchLabels:
-                k8s-app: coredns{{ coredns_ordinal_suffix | default('') }}
+                k8s-app: coredns{{ coredns_ordinal_suffix }}
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100

--- a/roles/kubernetes-apps/ansible/templates/coredns-svc.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-svc.yml.j2
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: coredns{{ coredns_ordinal_suffix | default('') }}
+  name: coredns{{ coredns_ordinal_suffix }}
   namespace: kube-system
   labels:
-    k8s-app: coredns{{ coredns_ordinal_suffix | default('') }}
+    k8s-app: coredns{{ coredns_ordinal_suffix }}
     kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "coredns{{ coredns_ordinal_suffix | default('') }}"
+    kubernetes.io/name: "coredns{{ coredns_ordinal_suffix }}"
     addonmanager.kubernetes.io/mode: Reconcile
   annotations:
     prometheus.io/path: /metrics
@@ -15,7 +15,7 @@ metadata:
     prometheus.io/scrape: "true"
 spec:
   selector:
-    k8s-app: coredns{{ coredns_ordinal_suffix | default('') }}
+    k8s-app: coredns{{ coredns_ordinal_suffix }}
   clusterIP: {{ clusterIP }}
   ports:
     - name: dns

--- a/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
@@ -16,20 +16,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: dns-autoscaler{{ coredns_ordinal_suffix | default('') }}
+  name: dns-autoscaler{{ coredns_ordinal_suffix }}
   namespace: kube-system
   labels:
-    k8s-app: dns-autoscaler{{ coredns_ordinal_suffix | default('') }}
+    k8s-app: dns-autoscaler{{ coredns_ordinal_suffix }}
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   selector:
     matchLabels:
-      k8s-app: dns-autoscaler{{ coredns_ordinal_suffix | default('') }}
+      k8s-app: dns-autoscaler{{ coredns_ordinal_suffix }}
   template:
     metadata:
       labels:
-        k8s-app: dns-autoscaler{{ coredns_ordinal_suffix | default('') }}
+        k8s-app: dns-autoscaler{{ coredns_ordinal_suffix }}
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
@@ -48,7 +48,7 @@ spec:
           - topologyKey: "kubernetes.io/hostname"
             labelSelector:
               matchLabels:
-                k8s-app: dns-autoscaler{{ coredns_ordinal_suffix | default('') }}
+                k8s-app: dns-autoscaler{{ coredns_ordinal_suffix }}
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
@@ -71,9 +71,9 @@ spec:
         - --default-params={"linear":{"preventSinglePointFailure":{{ dns_prevent_single_point_failure }},"coresPerReplica":{{ dns_cores_per_replica }},"nodesPerReplica":{{ dns_nodes_per_replica }},"min":{{ dns_min_replicas }}}}
         - --logtostderr=true
         - --v=2
-        - --configmap=dns-autoscaler{{ coredns_ordinal_suffix | default('') }}
+        - --configmap=dns-autoscaler{{ coredns_ordinal_suffix }}
 {% if dns_mode in ['coredns', 'coredns_dual'] %}
-        - --target=Deployment/coredns{{ coredns_ordinal_suffix | default('') }}
+        - --target=Deployment/coredns{{ coredns_ordinal_suffix }}
 {% endif %}
 {% if dns_mode in ['kubedns', 'dnsmasq_kubedns'] %}
         - --target=Deployment/kube-dns


### PR DESCRIPTION
After tests, it should reduce time it takes to template out coredns templates by 20-25%