### PR TITLE
All the SAN addresses are coming without any spaces in kubeadm config file

### DIFF
--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -56,13 +56,17 @@
       {%- endif %}
       {% for host in groups['kube-master'] -%}
       {%- if hostvars[host]['access_ip'] is defined -%}
-      {{ hostvars[host]['access_ip'] }}
+      {{ hostvars[host]['access_ip'] }}{{' '}}
       {%- endif %}
-      {{ hostvars[host]['ip'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}
+      {%- if hostvars[host]['ip'] is defined -%}
+      {{ hostvars[host]['ip'] }}
+      {% else %}
+      {{ hostvars[host]['ansible_default_ipv4']['address'] }}
+      {%- endif %}
       {%- endfor %}
       {%- if supplementary_addresses_in_ssl_keys is defined -%}
       {% for addr in supplementary_addresses_in_ssl_keys -%}
-      {{ addr }}
+      {{ addr }}{{' '}}
       {%- endfor %}
       {%- endif %}
   tags: facts


### PR DESCRIPTION
This is breaking for K8's version 1.11.8 and Kubespray 2.8 in OpenStack while generating certificates valid for all masters ip's.

**Current:**
```
apiServerCertSANs:
  - kubernetes
  - kubernetes.default
  - kubernetes.default.svc
  - kubernetes.default.svc.cluster.local
  - 10.201.0.1
  - localhost
  - 127.0.0.1
  - master-5
  - master-3
  - master-4
  - master-1
  - master-2
  - master-1-ip10.0.3.17
  - master-2-ip10.0.3.22
  - master-3-ip10.0.3.25
  - master-4-ip10.0.3.21
  - master-5-ip10.0.3.18
  - master-1-ipmaster-2-ipmaster-3-ipmaster-4-ipmaster-5-ip
```

**With this fix:**
```
apiServerCertSANs:
  - kubernetes
  - kubernetes.default
  - kubernetes.default.svc
  - kubernetes.default.svc.cluster.local
  - 10.201.0.1
  - localhost
  - 127.0.0.1
  - master-5
  - master-3
  - master-4
  - master-1
  - master-2
  - master-1-ip
  - 10.0.3.17
  - master-2-ip
  - 10.0.3.22
  - master-3-ip
  - 10.0.3.25
  - master-4-ip
  - 10.0.3.21
  - master-5-ip
  - 10.0.3.18
```