### PR TITLE
Fixing mandatory check of docker_version that breaks bastion host

### DIFF
--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -213,7 +213,7 @@ docker_options: >-
   {% if docker_registry_mirrors is defined %}
   {{ docker_registry_mirrors | map('regex_replace', '^(.*)$', '--registry-mirror=\1' ) | list | join(' ') }}
   {%- endif %}
-  {%- if docker_version is version('17.05', '<') %}
+  {%- if docker_version is defined and docker_version is version('17.05', '<') %}
   --graph={{ docker_daemon_graph }} {{ docker_log_opts }}
   {%- else %}
   --data-root={{ docker_daemon_graph }} {{ docker_log_opts }}


### PR DESCRIPTION
If `docker_version` is not defined in additional `vars.yaml`, getting the below error -

```
TASK [download : Sync container] ***********************************************
Monday 18 March 2019  06:11:48 +0000 (0:00:00.353)       0:00:01.182 ********** 
skipping: [bastion-1]

TASK [kubespray-defaults : Configure defaults] *********************************
Monday 18 March 2019  06:11:49 +0000 (0:00:00.317)       0:00:01.499 ********** 
ok: [bastion-1] => {
    "msg": "Check roles/kubespray-defaults/defaults/main.yml"
}

TASK [bastion-ssh-config : set_fact] *******************************************
Monday 18 March 2019  06:11:49 +0000 (0:00:00.397)       0:00:01.897 ********** 
fatal: [bastion-1]: FAILED! => {"msg": "Version comparison: 'docker_version' is undefined"}

```