### PR TITLE
Update premoderator to fix Github API throttle

### DIFF
--- a/scripts/premoderator.sh
+++ b/scripts/premoderator.sh
@@ -1,18 +1,35 @@
-#!/bin/sh -eux -o pipefail
+#!/bin/sh
 # A naive premoderation script to allow Gitlab CI pipeline on a specific PRs' comment
 # Exits with 0, if the pipeline is good to go
 
-CURL_ARGS="-fs --connect-timeout 5 --max-time 5 --retry-max-time 20 --retry 4 --retry-delay 5"
+#CURL_ARGS="-fs --connect-timeout 5 --max-time 5 --retry-max-time 20 --retry 4 --retry-delay 5"
+CURL_ARGS="-fs --retry 4 --retry-delay 5"
 MAGIC="${MAGIC:-ci check this}"
 
 # Get PR number from CI_BUILD_REF_NAME
 issue=$(echo ${CI_BUILD_REF_NAME} | perl -ne '/^pr-(\d+)-\S+$/ && print $1')
+
+echo "Checking for '$MAGIC' comment in PR $issue"
+
 # Get the user name from the PR comments with the wanted magic incantation casted
 user=$(curl ${CURL_ARGS} "https://api.github.com/repos/kubernetes-sigs/kubespray/issues/${issue}/comments" \
   | jq -M "map(select(.body | contains (\"$MAGIC\"))) | .[0] .user.login" | tr -d '"')
+
 # Check for the required user group membership to allow (exit 0) or decline (exit >0) the pipeline
-if [ "$user" = "null" ]; then
-	echo "User does not have permissions to start CI run"
+if [ "x$user" = "x" ]; then
+	echo "Missing '$MAGIC' comment from one of the OWNERS"
 	exit 1
+else
+  echo "Found comment from user: $user"
 fi
+
 curl ${CURL_ARGS} "https://api.github.com/orgs/kubernetes-sigs/members/${user}"
+
+if [ $? -ne 0 ]; then
+  echo "User does not have permissions to start CI run"
+	exit 1
+else
+  echo "$user has allowed CI to start"
+fi
+
+exit 0


### PR DESCRIPTION
Update the premoderator script and remove timeouts as Github API has throttle and does not always answer within the timeout causing the ci-check-this feature to fail.

Also, add some output of what is happening.