### PR TITLE
Speed up old docker package removal

### DIFF
--- a/roles/container-engine/docker/defaults/main.yml
+++ b/roles/container-engine/docker/defaults/main.yml
@@ -50,3 +50,21 @@ extras_rh_repo_gpgkey: "http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-7"
 
 # flag to enable/disable docker cleanup
 docker_orphan_clean_up: false
+
+# old docker package names to be removed
+docker_remove_packages_yum:
+  - docker
+  - docker-common
+  - docker-engine
+  - docker-selinux.noarch
+  - docker-client
+  - docker-client-latest
+  - docker-latest
+  - docker-latest-logrotate
+  - docker-logrotate
+  - docker-engine-selinux.noarch
+
+docker_remove_packages_apt:
+  - docker
+  - docker-engine
+  - docker.io

--- a/roles/container-engine/docker/tasks/pre-upgrade.yml
+++ b/roles/container-engine/docker/tasks/pre-upgrade.yml
@@ -1,31 +1,16 @@
 ---
 - name: Ensure old versions of Docker are not installed. | Debian
-  package:
-    name: '{{ item }}'
+  apt:
+    name: '{{ docker_remove_packages_apt }}'
     state: absent
-  with_items:
-    - docker
-    - docker-engine
-    - docker.io
   when:
     - ansible_os_family == 'Debian'
     - (docker_versioned_pkg[docker_version | string] is search('docker-ce'))
 
 - name: Ensure old versions of Docker are not installed. | RedHat
-  package:
-    name: '{{ item }}'
+  yum:
+    name: '{{ docker_remove_packages_yum }}'
     state: absent
-  with_items:
-    - docker
-    - docker-common
-    - docker-engine
-    - docker-selinux.noarch
-    - docker-client
-    - docker-client-latest
-    - docker-latest
-    - docker-latest-logrotate
-    - docker-logrotate
-    - docker-engine-selinux.noarch
   when:
     - ansible_os_family == 'RedHat'
     - (docker_versioned_pkg[docker_version | string] is search('docker-ce'))


### PR DESCRIPTION
Both the `yum` and `apt` modules support a list as input, this allows us avoid the slower `with_items` approach, which can take a long time with a large count of cluster nodes.