### PR TITLE
Fix syntax of yaml in .gitlab-ci.yml file

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -222,12 +222,8 @@ before_script:
 
 .gce: &gce
   <<: *testcases
-  variables:
-    <<: *gce_variables
 
 .do: &do
-  variables:
-    <<: *do_variables
   <<: *testcases
 
 # Test matrix. Leave the comments for markup scripts.
@@ -329,11 +325,10 @@ before_script:
 
 gce_ubuntu18-flannel-aio:
   stage: deploy-part1
-  <<: *job
   <<: *gce
   variables:
-    <<: *ubuntu18_flannel_aio_variables
     <<: *gce_variables
+    <<: *ubuntu18_flannel_aio_variables
   when: on_success
   except: ['triggers']
   only: [/^pr-.*$/]
@@ -342,18 +337,16 @@ gce_ubuntu18-flannel-aio:
 
 gce_coreos-calico-aio:
   stage: deploy-part2
-  <<: *job
   <<: *gce
   variables:
-    <<: *coreos_calico_aio_variables
     <<: *gce_variables
+    <<: *coreos_calico_aio_variables
   when: on_success
   except: ['triggers']
   only: [/^pr-.*$/]
 
 gce_centos7-flannel-addons:
   stage: deploy-part2
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -366,7 +359,6 @@ gce_centos7-flannel-addons:
 
 gce_centos-weave-kubeadm-sep:
   stage: deploy-part2
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -376,7 +368,6 @@ gce_centos-weave-kubeadm-sep:
 
 gce_ubuntu-weave-sep:
   stage: deploy-part2
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -386,7 +377,6 @@ gce_ubuntu-weave-sep:
 
 gce_coreos-calico-sep-triggers:
   stage: deploy-part2
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -396,7 +386,6 @@ gce_coreos-calico-sep-triggers:
 
 gce_ubuntu-canal-ha-triggers:
   stage: deploy-special
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -406,7 +395,6 @@ gce_ubuntu-canal-ha-triggers:
 
 gce_centos7-flannel-addons-triggers:
   stage: deploy-part2
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -416,7 +404,6 @@ gce_centos7-flannel-addons-triggers:
 
 gce_ubuntu-weave-sep-triggers:
   stage: deploy-part2
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -427,7 +414,6 @@ gce_ubuntu-weave-sep-triggers:
 # More builds for PRs/merges (manual) and triggers (auto)
 do_ubuntu-canal-ha:
   stage: deploy-part2
-  <<: *job
   <<: *do
   variables:
     <<: *do_variables
@@ -437,7 +423,6 @@ do_ubuntu-canal-ha:
 
 gce_ubuntu-canal-ha:
   stage: deploy-special
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -448,7 +433,6 @@ gce_ubuntu-canal-ha:
 
 gce_ubuntu-canal-kubeadm:
   stage: deploy-part2
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -459,7 +443,6 @@ gce_ubuntu-canal-kubeadm:
 
 gce_ubuntu-canal-kubeadm-triggers:
   stage: deploy-part2
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -469,7 +452,6 @@ gce_ubuntu-canal-kubeadm-triggers:
 
 gce_ubuntu-flannel-ha:
   stage: deploy-part2
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -479,7 +461,6 @@ gce_ubuntu-flannel-ha:
 
 gce_centos-weave-kubeadm-triggers:
   stage: deploy-part2
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -489,7 +470,6 @@ gce_centos-weave-kubeadm-triggers:
 
 gce_ubuntu-contiv-sep:
   stage: deploy-special
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -500,7 +480,6 @@ gce_ubuntu-contiv-sep:
 
 gce_coreos-cilium:
   stage: deploy-special
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -511,7 +490,6 @@ gce_coreos-cilium:
 
 gce_ubuntu-cilium-sep:
   stage: deploy-special
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -522,7 +500,6 @@ gce_ubuntu-cilium-sep:
 
 gce_rhel7-weave:
   stage: deploy-part2
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -533,7 +510,6 @@ gce_rhel7-weave:
 
 gce_rhel7-weave-triggers:
   stage: deploy-part2
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -543,7 +519,6 @@ gce_rhel7-weave-triggers:
 
 gce_debian9-calico-upgrade:
   stage: deploy-part2
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -554,7 +529,6 @@ gce_debian9-calico-upgrade:
 
 gce_debian9-calico-triggers:
   stage: deploy-part2
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -564,7 +538,6 @@ gce_debian9-calico-triggers:
 
 gce_coreos-canal:
   stage: deploy-part2
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -575,7 +548,6 @@ gce_coreos-canal:
 
 gce_coreos-canal-triggers:
   stage: deploy-part2
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -585,7 +557,6 @@ gce_coreos-canal-triggers:
 
 gce_rhel7-canal-sep:
   stage: deploy-special
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -596,7 +567,6 @@ gce_rhel7-canal-sep:
 
 gce_rhel7-canal-sep-triggers:
   stage: deploy-part2
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -606,7 +576,6 @@ gce_rhel7-canal-sep-triggers:
 
 gce_centos7-calico-ha:
   stage: deploy-special
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -617,7 +586,6 @@ gce_centos7-calico-ha:
 
 gce_centos7-calico-ha-triggers:
   stage: deploy-part2
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -627,7 +595,6 @@ gce_centos7-calico-ha-triggers:
 
 gce_centos7-kube-router:
   stage: deploy-special
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -638,7 +605,6 @@ gce_centos7-kube-router:
 
 gce_centos7-multus-calico:
   stage: deploy-part2
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -649,7 +615,6 @@ gce_centos7-multus-calico:
 
 gce_opensuse-canal:
   stage: deploy-part2
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -661,7 +626,6 @@ gce_opensuse-canal:
 # no triggers yet https://github.com/kubernetes-incubator/kargo/issues/613
 gce_coreos-alpha-weave-ha:
   stage: deploy-special
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -672,7 +636,6 @@ gce_coreos-alpha-weave-ha:
 
 gce_coreos-kube-router:
   stage: deploy-special
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -683,7 +646,6 @@ gce_coreos-kube-router:
 
 gce_ubuntu-rkt-sep:
   stage: deploy-part2
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables
@@ -694,7 +656,6 @@ gce_ubuntu-rkt-sep:
 
 gce_ubuntu-kube-router-sep:
   stage: deploy-special
-  <<: *job
   <<: *gce
   variables:
     <<: *gce_variables


### PR DESCRIPTION
The GCE and DO variables were included in line 225/229 and they also were (probably) overwritten each time in each individual job (since it would create a duplicate dictionary key named `variables`).

Unfortunately yamllint doesn't catch this case (https://github.com/adrienverge/yamllint/issues/175).

Similarly the `*job` alias is not actually needed in most cases (`gce` and `do` contain `testcases` which in turn also includes the `*job alias`).

I'm not sure about removing the `&gce` and `&do` anchors alltogether (they both do the same and are just a different name for `&testcases`), but they might be useful to know at a glance what is run.