### PR TITLE
Add Ansible-lint CI step

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,25 @@
+---
+parseable: true
+skip_list:
+  # see https://docs.ansible.com/ansible-lint/rules/default_rules.html for a list of all default rules
+  # The following rules throw errors.
+  # These either still need to be corrected in the repository and the rules re-enabled or they are skipped on purpose.
+  - '102'
+  - '103'
+  - '104'
+  - '201'
+  - '204'
+  - '206'
+  - '301'
+  - '302'
+  - '303'
+  - '305'
+  - '306'
+  - '403'
+  - '404'
+  - '502'
+  - '503'
+  - '504'
+  - '601'
+  - '602'
+  - '701'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -735,7 +735,7 @@ ansible-lint:
   stage: unit-tests
   # lint every yml/yaml file that looks like it contains Ansible plays
   script: |-
-    grep -Rl '^- hosts: \|^  hosts: \|^- name: ' --include \*.yml --include \*.yaml . | xargs ansible-lint
+    grep -Rl '^- hosts: \|^  hosts: \|^- name: ' --include \*.yml --include \*.yaml . | xargs ansible-lint -v
   except: ['triggers', 'master']
 
 tox-inventory-builder:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -733,9 +733,9 @@ yamllint:
 ansible-lint:
   <<: *job
   stage: unit-tests
-  script:
-    # lint every yml/yaml file that looks like it contains Ansible plays
-    - "grep -Rl '^- hosts: \|^  hosts: \|^- name: ' --include \*.yml --include \*.yaml . | xargs ansible-lint"
+  # lint every yml/yaml file that looks like it contains Ansible plays
+  script: |-
+    grep -Rl '^- hosts: \|^  hosts: \|^- name: ' --include \*.yml --include \*.yaml . | xargs ansible-lint
   except: ['triggers', 'master']
 
 tox-inventory-builder:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -730,6 +730,14 @@ yamllint:
     - yamllint roles
   except: ['triggers', 'master']
 
+ansible-lint:
+  <<: *job
+  stage: unit-tests
+  script:
+    # lint every yml/yaml file that looks like it contains Ansible plays
+    - "grep -Rl '^- hosts: \|^  hosts: \|^- name: ' --include \*.yml --include \*.yaml . | xargs ansible-lint"
+  except: ['triggers', 'master']
+
 tox-inventory-builder:
   stage: unit-tests
   <<: *job

--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -4,9 +4,10 @@
     - not skip_downloads|default(false)
 
 - name: "Download items"
-  include_tasks: "download_{% if download.container %}container{% else %}file{% endif %}.yml"
+  include_tasks: "{{ include_file }}"
   vars:
     download: "{{ download_defaults | combine(item.value) }}"
+    include_file: "download_{% if download.container %}container{% else %}file{% endif %}.yml"
   with_dict: "{{ downloads }}"
   when:
     - not skip_downloads|default(false)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,3 +5,4 @@ boto==2.9.0
 tox
 dopy
 PyCrypto
+ansible-lint==4.1.0


### PR DESCRIPTION
This is a more limited version of #4177 which just runs `ansible-lint` in CI with all rules disabled that are causing errors anywhere. It stops regressions within these rules and allows follow-up PRs to fix the code base and enable further rules, such as #4201.

The second commit is to get `ansible-lint` to run at all (it seems to fail on a "clever" jinja2 expression in an `include_tasks` task).

There are also multiple warnings about not being able to open certain files, this is usually caused by roles importing tasks from different roles using relative paths (which are sometimes wrong). Since I don't have the means currently to verify if fixing these relative paths to make `ansible-lint` work correctly doesn't introduce regressions, I left them out for now. I can add them if needed/requested.