### PR TITLE
add allowVolumeExpansion option

### DIFF
--- a/roles/kubernetes-apps/persistent_volumes/openstack/templates/openstack-storage-class.yml.j2
+++ b/roles/kubernetes-apps/persistent_volumes/openstack/templates/openstack-storage-class.yml.j2
@@ -11,4 +11,5 @@ parameters:
 {% for key, value in (class.parameters | default({})).items() %}
   "{{ key }}": "{{ value }}"
 {% endfor %}
+allowVolumeExpansion: {{ expand_persistent_volumes }}
 {% endfor %}

--- a/roles/kubernetes/master/defaults/main/main.yml
+++ b/roles/kubernetes/master/defaults/main/main.yml
@@ -83,6 +83,7 @@ kube_apiserver_admission_control:
   - LimitRanger
   - ServiceAccount
   - DefaultStorageClass
+  - PersistentVolumeClaimResize
   - >-
       {%- if kube_version is version('v1.9', '<') -%}
       GenericAdmissionWebhook

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -278,6 +278,7 @@ persistent_volumes_enabled: false
 cephfs_provisioner_enabled: false
 ingress_nginx_enabled: false
 cert_manager_enabled: false
+expand_persistent_volumes: false
 
 ## When OpenStack is used, Cinder version can be explicitly specified if autodetection fails (Fixed in 1.9: https://github.com/kubernetes/kubernetes/issues/50461)
 # openstack_blockstorage_version: "v1/v2/auto (default)"


### PR DESCRIPTION
PR based on #2929 by @wideklev

Add allowVolumeExpansion to Openstack Storage Class to allow resizing persistent volumes  
References:
- https://kubernetes.io/docs/concepts/storage/persistent-volumes/#expanding-persistent-volumes-claims
- https://kubernetes.io/blog/2018/07/12/resizing-persistent-volumes-using-kubernetes/
