### PR TITLE
Use install_cni init container for cni copy for calico/canal

### DIFF
--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -10,10 +10,6 @@ calico_ipv4pool_ipip: "Off"
 ipip: true
 ipip_mode: Always  # change to "CrossSubnet" if you only want ipip encapsulation on traffic going across subnets
 
-# Set to true if you want your calico cni binaries to overwrite the
-# ones from hyperkube while leaving other cni plugins intact.
-overwrite_hyperkube_cni: true
-
 calico_cert_dir: /etc/calico/certs
 
 # Global as_num (/calico/bgp/v1/global/as_num)

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -33,34 +33,6 @@
     group: root
   changed_when: false
 
-- name: Calico | Copy cni plugins
-  unarchive:
-    src: "{{ local_release_dir }}/cni-plugins-{{ image_arch }}-{{ cni_version }}.tgz"
-    dest: "/opt/cni/bin"
-    mode: 0755
-    remote_src: yes
-
-- name: Calico | Set cni directory permissions
-  file:
-    path: /opt/cni/bin
-    state: directory
-    owner: kube
-    recurse: true
-    mode: 0755
-
-- name: Calico | Copy cni plugins from calico/cni container
-  command: "{{ docker_bin_dir }}/docker run --rm -v /opt/cni/bin:/cnibindir {{ calico_cni_image_repo }}:{{ calico_cni_image_tag }} sh -c 'cp /opt/cni/bin/* /cnibindir/'"
-  register: cni_task_result
-  until: cni_task_result.rc == 0
-  retries: 4
-  delay: "{{ retry_stagger | random + 3 }}"
-  changed_when: false
-  when:
-    - "overwrite_hyperkube_cni|bool"
-  tags:
-    - hyperkube
-    - upgrade
-
 - name: Calico | wait for etcd
   uri:
     url: "{{ etcd_access_addresses.split(',') | first }}/health"

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -52,9 +52,9 @@ spec:
             # Name of the CNI config file to create.
             - name: CNI_CONF_NAME
               value: "10-calico.conflist"
-            # CNI binaries are already on the host
+            # Install CNI binaries
             - name: UPDATE_CNI_BINARIES
-              value: "false"
+              value: "true"
             # The CNI network config to install on each node.
             - name: CNI_NETWORK_CONFIG_FILE
               value: "/host/etc/cni/net.d/calico.conflist.template"
@@ -64,6 +64,8 @@ spec:
           volumeMounts:
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
 {% endif %}
       containers:
 {% if calico_version is version('v3.3.0', '>=') and calico_version is version('v3.4.0', '<') %}
@@ -74,9 +76,9 @@ spec:
             # Name of the CNI config file to create.
             - name: CNI_CONF_NAME
               value: "10-calico.conflist"
-            # CNI binaries are already on the host
+            # Install CNI binaries
             - name: UPDATE_CNI_BINARIES
-              value: "false"
+              value: "true"
             # The CNI network config to install on each node.
             - name: CNI_NETWORK_CONFIG_FILE
               value: "/host/etc/cni/net.d/calico.conflist.template"
@@ -86,6 +88,8 @@ spec:
           volumeMounts:
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
 {% endif %}
         # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and routes on each
@@ -260,6 +264,9 @@ spec:
         - name: cni-net-dir
           hostPath:
             path: /etc/cni/net.d
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
         # Mount in the etcd TLS secrets.
         - name: etcd-certs
           hostPath:

--- a/roles/network_plugin/canal/tasks/main.yml
+++ b/roles/network_plugin/canal/tasks/main.yml
@@ -54,40 +54,6 @@
   when:
     - inventory_hostname in groups['kube-master']
 
-- name: Canal | Set cni directory permissions
-  file:
-    path: /opt/cni/bin
-    state: directory
-    owner: kube
-    recurse: true
-    mode: 0755
-
-- name: Canal | Copy cni plugins
-  unarchive:
-    src: "{{ local_release_dir }}/cni-plugins-{{ image_arch }}-{{ cni_version }}.tgz"
-    dest: "/opt/cni/bin"
-    mode: 0755
-    remote_src: yes
-
-- name: Canal | Copy cni plugins from calico/cni
-  command: "{{ docker_bin_dir }}/docker run --rm -v /opt/cni/bin:/cnibindir {{ calico_cni_image_repo }}:{{ calico_cni_image_tag }} sh -c 'cp /opt/cni/bin/* /cnibindir/'"
-  register: cni_task_result
-  until: cni_task_result.rc == 0
-  retries: 4
-  delay: "{{ retry_stagger | random + 3 }}"
-  changed_when: false
-  tags:
-    - hyperkube
-    - upgrade
-
-- name: Canal | Set cni directory permissions
-  file:
-    path: /opt/cni/bin
-    state: directory
-    owner: kube
-    recurse: true
-    mode: 0755
-
 - name: Canal | Install calicoctl container script
   template:
     src: calicoctl-container.j2

--- a/roles/network_plugin/canal/templates/canal-node.yaml.j2
+++ b/roles/network_plugin/canal/templates/canal-node.yaml.j2
@@ -68,9 +68,9 @@ spec:
             # Name of the CNI config file to create.
             - name: CNI_CONF_NAME
               value: "10-canal.conflist"
-            # CNI binaries are already on the host
+            # Install CNI binaries
             - name: UPDATE_CNI_BINARIES
-              value: "false"
+              value: "true"
             # The CNI network config to install on each node.
             - name: CNI_NETWORK_CONFIG_FILE
               value: "/host/etc/cni/net.d/canal.conflist.template"
@@ -80,6 +80,8 @@ spec:
           volumeMounts:
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
 {% endif %}
       containers:
 {% if calico_version is version('v3.3.0', '>=') and calico_version is version('v3.4.0', '<') %}
@@ -90,15 +92,17 @@ spec:
             # Name of the CNI config file to create.
             - name: CNI_CONF_NAME
               value: "10-canal.conflist"
-            # CNI binaries are already on the host
+            # Install CNI binaries
             - name: UPDATE_CNI_BINARIES
-              value: "false"
+              value: "true"
             # The CNI network config to install on each node.
             - name: CNI_NETWORK_CONFIG_FILE
               value: "/host/etc/cni/net.d/canal.conflist.template"
           volumeMounts:
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
 {% endif %}
         # Runs the flannel daemon to enable vxlan networking between
         # container hosts.


### PR DESCRIPTION
Deploy should be faster because we won't waste time with extra tasks. The native daemonset can handle this task faster