### PR TITLE
Missing reset.yml

### DIFF
--- a/roles/network_plugin/calico/tasks/reset.yml
+++ b/roles/network_plugin/calico/tasks/reset.yml
@@ -1,0 +1,19 @@
+---
+- name: reset | check dummy0 network device
+  stat:
+    path: /sys/class/net/dummy0
+  register: dummy0
+
+- name: reset | remove the network device created by calico
+  command: ip link del dummy0
+  when: dummy0.stat.exists
+
+- name: reset | get remaining routes set by bird
+  command: ip route show proto bird
+  register: bird_routes
+
+- name: reset | remove remaining routes set by bird
+  command: "ip route del {{ bird_route }} proto bird"
+  with_items: "{{ bird_routes.stdout_lines }}"
+  loop_control:
+    loop_var: bird_route


### PR DESCRIPTION
Taken from https://github.com/kubernetes-sigs/kubespray/blob/master/roles/network_plugin/calico/tasks/reset.yml