### PR TITLE
Fixed cleanup-docker-orphans.sh to use docker-containerd-shim and con…

### DIFF
--- a/roles/container-engine/docker/files/cleanup-docker-orphans.sh
+++ b/roles/container-engine/docker/files/cleanup-docker-orphans.sh
@@ -9,12 +9,17 @@ list_descendants ()
   [[ -n "$children" ]] && echo "$children"
 }
 
-count_shim_processes=$(pgrep -f ^docker-containerd-shim | wc -l)
+shim_search="^docker-containerd-shim"
+count_shim_processes=$(pgrep -f $shim_search | wc -l)
 
+if [ ${count_shim_processes} -eq 0 ]; then
+        shim_search="^containerd-shim"
+        count_shim_processes=$(pgrep -f $shim_search | wc -l)
+fi
 
 if [ ${count_shim_processes} -gt 0 ]; then
         # Find all container pids from shims
-        orphans=$(pgrep -P $(pgrep -d ',' -f ^docker-containerd-shim) |\
+        orphans=$(pgrep -P $(pgrep -d ',' -f $shim_search) |\
         # Filter out valid docker pids, leaving the orphans
         egrep -v $(docker ps -q | xargs docker inspect --format '{{.State.Pid}}' | awk '{printf "%s%s",sep,$1; sep="|"}'))
 


### PR DESCRIPTION
The cleanup-docker-orphans.sh script uses the docker-containerd-shim search string to get a list of shim processes. For docker 18.09 the process is containerd-shim. The script has been changed to recognize docker-containerd-shim and containerd-shim processes.