### PR TITLE
add default routing to canal and disable bird checks

### DIFF
--- a/roles/network_plugin/canal/templates/canal-node.yaml.j2
+++ b/roles/network_plugin/canal/templates/canal-node.yaml.j2
@@ -263,7 +263,6 @@ spec:
             exec:
               command:
               - /bin/calico-node
-              - -bird-ready
               - -felix-ready
 {% endif %}
             periodSeconds: 10

--- a/roles/network_plugin/canal/templates/cni-canal.conflist.j2
+++ b/roles/network_plugin/canal/templates/cni-canal.conflist.j2
@@ -6,6 +6,7 @@
       "type": "flannel",
       "delegate": {
         "type": "calico",
+	"include_default_routes": true,
         "etcd_endpoints": "{{ etcd_access_addresses }}",
         "etcd_key_file": "{{ canal_cert_dir }}/key.pem",
         "etcd_cert_file": "{{ canal_cert_dir }}/cert.crt",


### PR DESCRIPTION
Few fixes for canal

* removed `bird` check. Canal uses flannel for networking so bird is not used (calico uses bird for bgp networking). Currently this check causes pod to be "not ready" all the time
* added default routing - currently by default only routing to container network was added, so there was no way for app in pod to connect to k8s services or outside of the cluster

@mattymo PTAL 