### PR TITLE
Update premoderator to fix Github API throttle

### DIFF
--- a/scripts/premoderator.sh
+++ b/scripts/premoderator.sh
@@ -1,13 +1,20 @@
-#!/bin/sh
+#!/bin/bash
 # A naive premoderation script to allow Gitlab CI pipeline on a specific PRs' comment
 # Exits with 0, if the pipeline is good to go
+# Exits with 1, if the user is not allowed to start pipeline
+# Exits with 2, if script is unable to get issue id from $CI_BUILD_REF_NAME variable
+# Exits with 3, if missing the magic comment in the pipeline to start the pipeline
 
-#CURL_ARGS="-fs --connect-timeout 5 --max-time 5 --retry-max-time 20 --retry 4 --retry-delay 5"
 CURL_ARGS="-fs --retry 4 --retry-delay 5"
 MAGIC="${MAGIC:-ci check this}"
 
 # Get PR number from CI_BUILD_REF_NAME
 issue=$(echo ${CI_BUILD_REF_NAME} | perl -ne '/^pr-(\d+)-\S+$/ && print $1')
+
+if [ "$issue" = "" ]; then
+  echo "Unable to get issue id from: $CI_BUILD_REF_NAME"
+  exit 2
+fi
 
 echo "Checking for '$MAGIC' comment in PR $issue"
 
@@ -16,9 +23,9 @@ user=$(curl ${CURL_ARGS} "https://api.github.com/repos/kubernetes-sigs/kubespray
   | jq -M "map(select(.body | contains (\"$MAGIC\"))) | .[0] .user.login" | tr -d '"')
 
 # Check for the required user group membership to allow (exit 0) or decline (exit >0) the pipeline
-if [ "x$user" = "x" ]; then
+if [ "$user" = "" ] || [ "$user" = "null" ]; then
 	echo "Missing '$MAGIC' comment from one of the OWNERS"
-	exit 1
+	exit 3
 else
   echo "Found comment from user: $user"
 fi
@@ -33,4 +40,3 @@ else
 fi
 
 exit 0
-

--- a/scripts/premoderator.sh
+++ b/scripts/premoderator.sh
@@ -2,7 +2,7 @@
 # A naive premoderation script to allow Gitlab CI pipeline on a specific PRs' comment
 # Exits with 0, if the pipeline is good to go
 # Exits with 1, if the user is not allowed to start pipeline
-# Exits with 2, if script is unable to get issue id from $CI_BUILD_REF_NAME variable
+# Exits with 2, if script is unable to get issue id from CI_BUILD_REF_NAME variable
 # Exits with 3, if missing the magic comment in the pipeline to start the pipeline
 
 CURL_ARGS="-fs --retry 4 --retry-delay 5"
@@ -24,8 +24,8 @@ user=$(curl ${CURL_ARGS} "https://api.github.com/repos/kubernetes-sigs/kubespray
 
 # Check for the required user group membership to allow (exit 0) or decline (exit >0) the pipeline
 if [ "$user" = "" ] || [ "$user" = "null" ]; then
-	echo "Missing '$MAGIC' comment from one of the OWNERS"
-	exit 3
+  echo "Missing '$MAGIC' comment from one of the OWNERS"
+  exit 3
 else
   echo "Found comment from user: $user"
 fi
@@ -34,7 +34,7 @@ curl ${CURL_ARGS} "https://api.github.com/orgs/kubernetes-sigs/members/${user}"
 
 if [ $? -ne 0 ]; then
   echo "User does not have permissions to start CI run"
-	exit 1
+  exit 1
 else
   echo "$user has allowed CI to start"
 fi

--- a/scripts/premoderator.sh
+++ b/scripts/premoderator.sh
@@ -1,18 +1,36 @@
-#!/bin/sh -eux -o pipefail
+#!/bin/sh
 # A naive premoderation script to allow Gitlab CI pipeline on a specific PRs' comment
 # Exits with 0, if the pipeline is good to go
 
-CURL_ARGS="-fs --connect-timeout 5 --max-time 5 --retry-max-time 20 --retry 4 --retry-delay 5"
+#CURL_ARGS="-fs --connect-timeout 5 --max-time 5 --retry-max-time 20 --retry 4 --retry-delay 5"
+CURL_ARGS="-fs --retry 4 --retry-delay 5"
 MAGIC="${MAGIC:-ci check this}"
 
 # Get PR number from CI_BUILD_REF_NAME
 issue=$(echo ${CI_BUILD_REF_NAME} | perl -ne '/^pr-(\d+)-\S+$/ && print $1')
+
+echo "Checking for '$MAGIC' comment in PR $issue"
+
 # Get the user name from the PR comments with the wanted magic incantation casted
 user=$(curl ${CURL_ARGS} "https://api.github.com/repos/kubernetes-sigs/kubespray/issues/${issue}/comments" \
   | jq -M "map(select(.body | contains (\"$MAGIC\"))) | .[0] .user.login" | tr -d '"')
+
 # Check for the required user group membership to allow (exit 0) or decline (exit >0) the pipeline
-if [ "$user" = "null" ]; then
-	echo "User does not have permissions to start CI run"
+if [ "x$user" = "x" ]; then
+	echo "Missing '$MAGIC' comment from one of the OWNERS"
 	exit 1
+else
+  echo "Found comment from user: $user"
 fi
+
 curl ${CURL_ARGS} "https://api.github.com/orgs/kubernetes-sigs/members/${user}"
+
+if [ $? -ne 0 ]; then
+  echo "User does not have permissions to start CI run"
+	exit 1
+else
+  echo "$user has allowed CI to start"
+fi
+
+exit 0
+


### PR DESCRIPTION
Update the premoderator script and remove timeouts as Github API has throttle and does not always answer within the timeout causing the ci-check-this feature to fail.

Also, add some output of what is happening.