### PR TITLE
Update DNS Autoscaler to 1.4.0

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -210,8 +210,8 @@ nodelocaldns_version: "1.15.1"
 nodelocaldns_image_repo: "k8s.gcr.io/k8s-dns-node-cache"
 nodelocaldns_image_tag: "{{ nodelocaldns_version }}"
 
-dnsautoscaler_version: 1.3.0
-dnsautoscaler_image_repo: "gcr.io/google_containers/cluster-proportional-autoscaler-{{ image_arch }}"
+dnsautoscaler_version: 1.4.0
+dnsautoscaler_image_repo: "k8s.gcr.io/cluster-proportional-autoscaler-{{ image_arch }}"
 dnsautoscaler_image_tag: "{{ dnsautoscaler_version }}"
 test_image_repo: busybox
 test_image_tag: latest

--- a/roles/kubernetes-apps/ansible/dns-autoscaler-clusterrole.yml
+++ b/roles/kubernetes-apps/ansible/dns-autoscaler-clusterrole.yml
@@ -26,7 +26,7 @@ rules:
   - apiGroups: [""]
     resources: ["replicationcontrollers/scale"]
     verbs: ["get", "update"]
-  - apiGroups: ["extensions","apps"]
+  - apiGroups: ["extensions", "apps"]
     resources: ["deployments/scale", "replicasets/scale"]
     verbs: ["get", "update"]
   - apiGroups: [""]

--- a/roles/kubernetes-apps/ansible/dns-autoscaler-clusterrole.yml
+++ b/roles/kubernetes-apps/ansible/dns-autoscaler-clusterrole.yml
@@ -26,7 +26,7 @@ rules:
   - apiGroups: [""]
     resources: ["replicationcontrollers/scale"]
     verbs: ["get", "update"]
-  - apiGroups: ["extensions"]
+  - apiGroups: ["extensions","apps"]
     resources: ["deployments/scale", "replicasets/scale"]
     verbs: ["get", "update"]
   - apiGroups: [""]

--- a/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
@@ -31,11 +31,15 @@ spec:
       labels:
         k8s-app: dns-autoscaler{{ coredns_ordinal_suffix }}
       annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
 {% if kube_version is version('v1.11.1', '>=') %}
       priorityClassName: system-cluster-critical
 {% endif %}
+      securityContext:
+        supplementalGroups: [ 65534 ]
+        fsGroup: 65534
       nodeSelector:
         beta.kubernetes.io/os: linux
       tolerations:

--- a/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
@@ -31,7 +31,7 @@ spec:
       labels:
         k8s-app: dns-autoscaler{{ coredns_ordinal_suffix }}
       annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/critical-pod: ""
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
 {% if kube_version is version('v1.11.1', '>=') %}


### PR DESCRIPTION
Update DNS auto scaler according to https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml