### PR TITLE
jmespath is required when re-running cluster.yml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ jinja2>=2.9.6
 netaddr
 pbr>=1.6
 hvac
+jmespath


### PR DESCRIPTION
Otherwise, this happens:
```
TASK [kubernetes/master : Extract secret value from secrets_encryption.yaml] ***
Wednesday 03 April 2019  13:08:36 +0000 (0:00:00.569)       0:15:35.523 ******* 
[0;31mfatal: [node001]: FAILED! => {"msg": "You need to install \"jmespath\" prior to running json_query filter"}[0m
[0;31mfatal: [node002]: FAILED! => {"msg": "You need to install \"jmespath\" prior to running json_query filter"}[0m
[0;31mfatal: [node003]: FAILED! => {"msg": "You need to install \"jmespath\" prior to running json_query filter"}[0m
```