### PR TITLE
Tell git to ignore .terraform directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ temp
 *.bak
 *.tfstate
 *.tfstate.backup
+.terraform/
 contrib/terraform/aws/credentials.tfvars
 /ssh-bastion.conf
 **/*.sw[pon]


### PR DESCRIPTION
The .terraform directory is populated when modules are downloaded:
https://www.terraform.io/docs/commands/get.html
"The modules are downloaded into a local .terraform folder. This folder should not be committed to version control."