### PR TITLE
Remove bash-completion

### DIFF
--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -12,7 +12,6 @@ common_required_pkgs:
   - "{{ (ansible_distribution == 'openSUSE Tumbleweed') | ternary('openssl-1_1', 'openssl') }}"
   - curl
   - rsync
-  - bash-completion
   - socat
   - unzip
   - e2fsprogs


### PR DESCRIPTION
The installation of `bash-completion` package on Suse triggers a prompt:
```
$ zypper install bash-completion
Loading repository data...
Reading installed packages...
Resolving package dependencies...

Problem: conflicting requests
 Solution 1: remove lock to allow installation of bash-completion-2.1-10.12.1.noarch[openSUSE-Leap-42.2-Update]
 Solution 2: do not ask to install a solvable providing bash-completion.noarch = 2.1-10.12.1

Choose from above solutions by number or cancel [1/2/c] (c):
```

That package is probably not necessary for Kubernetes to work properly in the first place, so we might as well remove it for all OS.