### PR TITLE
robust handling of API server SANs

### DIFF
--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -55,7 +55,7 @@
       - "{{ kube_apiserver_ip }}"
       - "localhost"
       - "127.0.0.1"
-    sans_lb: "{{ [apiserver_loadbalancer_domain_name] if loadbalancer_apiserver is defined else [] }}"
+    sans_lb: "{{ [apiserver_loadbalancer_domain_name] if apiserver_loadbalancer_domain_name is defined else [] }}"
     sans_supp: "{{ supplementary_addresses_in_ssl_keys if supplementary_addresses_in_ssl_keys is defined else [] }}"
     sans_access_ip: "{{ groups['kube-master'] | map('extract', hostvars, 'access_ip') | list | select('defined') | list }}"
     sans_ip: "{{ groups['kube-master'] | map('extract', hostvars, 'ip') | list | select('defined') | list }}"

--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -45,29 +45,21 @@
 
 - name: kubeadm | aggregate all SANs
   set_fact:
-    apiserver_sans: >-
-      kubernetes
-      kubernetes.default
-      kubernetes.default.svc
-      kubernetes.default.svc.{{ dns_domain }}
-      {{ kube_apiserver_ip }}
-      localhost
-      127.0.0.1
-      {{ ' '.join(groups['kube-master']) }}
-      {%- if loadbalancer_apiserver is defined %}
-      {{ apiserver_loadbalancer_domain_name }}
-      {% endif %}
-      {% for host in groups['kube-master'] -%}
-      {%- if hostvars[host]['access_ip'] is defined %}
-      {{ hostvars[host]['access_ip'] }}
-      {% endif %}
-      {{ hostvars[host]['ip'] | default(fallback_ips[host]) }}
-      {%- endfor %}
-      {% if supplementary_addresses_in_ssl_keys is defined -%}
-      {% for addr in supplementary_addresses_in_ssl_keys %}
-      {{ addr }}
-      {% endfor %}
-      {%- endif %}
+    apiserver_sans: "{{ (sans_base + groups['kube-master'] + sans_lb + sans_supp + sans_access_ip + sans_ip + sans_address) | unique }}"
+  vars:
+    sans_base:
+      - "kubernetes"
+      - "kubernetes.default"
+      - "kubernetes.default.svc"
+      - "kubernetes.default.svc.{{ dns_domain }}"
+      - "{{ kube_apiserver_ip }}"
+      - "localhost"
+      - "127.0.0.1"
+    sans_lb: "{{ [apiserver_loadbalancer_domain_name] if loadbalancer_apiserver is defined else [] }}"
+    sans_supp: "{{ supplementary_addresses_in_ssl_keys if supplementary_addresses_in_ssl_keys is defined else [] }}"
+    sans_access_ip: "{{ groups['kube-master'] | map('extract', hostvars, 'access_ip') | list | select('defined') | list }}"
+    sans_ip: "{{ groups['kube-master'] | map('extract', hostvars, 'ip') | list | select('defined') | list }}"
+    sans_address: "{{ groups['kube-master'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | list | select('defined') | list }}"
   tags: facts
 
 - name: kubeadm | Copy etcd cert dir under k8s cert dir

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
@@ -193,7 +193,7 @@ apiServerExtraVolumes:
 {% endif %}
 {% endif %}
 apiServerCertSANs:
-{% for san in  apiserver_sans.split() | unique %}
+{% for san in apiserver_sans %}
   - {{ san }}
 {% endfor %}
 certificatesDir: {{ kube_cert_dir }}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
@@ -211,7 +211,7 @@ schedulerExtraArgs:
 {% endfor %}
 {% endif %}
 apiServerCertSANs:
-{% for san in apiserver_sans.split() | unique %}
+{% for san in apiserver_sans %}
   - {{ san }}
 {% endfor %}
 certificatesDir: {{ kube_cert_dir }}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
@@ -43,7 +43,7 @@ controlPlaneEndpoint: {{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.po
 controlPlaneEndpoint: {{ ip | default(fallback_ips[inventory_hostname]) }}:{{ kube_apiserver_port }}
 {% endif %}
 apiServerCertSANs:
-{% for san in apiserver_sans.split() | unique %}
+{% for san in apiserver_sans %}
   - {{ san }}
 {% endfor %}
 certificatesDir: {{ kube_cert_dir }}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
@@ -176,7 +176,7 @@ apiServer:
 {% endif %}
 {% endif %}
   certSANs:
-{% for san in apiserver_sans.split() | unique %}
+{% for san in apiserver_sans %}
   - {{ san }}
 {% endfor %}
   timeoutForControlPlane: 5m0s


### PR DESCRIPTION
The construction of the apiserver_sans fact is currently rather fragile - it is one very long string literal that is put together with a bunch of jinja statements, in a way that is particularly sensitive to white space. The current implementation sometimes works if the whitespace stripping in each of the jinja pieces happens to work out depending on which variables are defined, but multi-master deployments can break in several different ways. (issues #4120 , #3957 , #4140 )

This pull request solves this class of issues. It decomposes the monolithic construction of the apiserver_sans fact into several subcomponents, each of which uses suitable ansible design patterns to construct a list of strings, and excludes undefined elements. They are concatenated and then the unique filter is applied, so  in each template file that uses apiserver_sans, you only need a standard for loop over the list, rather than further text manipulation such as splitting or filters.

The contents of the fact are the same as before:
```
      kubernetes
      kubernetes.default
      kubernetes.default.svc
      kubernetes.default.svc.{{ dns_domain }}
      {{ kube_apiserver_ip }}
      localhost
      127.0.0.1
```
These are moved into "sans_base".

```
      {{ ' '.join(groups['kube-master']) }}
```
This is replaced with `groups['kube-master']` .

```
      {%- if loadbalancer_apiserver is defined %}
      {{ apiserver_loadbalancer_domain_name }}
      {%- endif %}
```
This is replaced with sans_lb. (Update: see https://github.com/kubernetes-sigs/kubespray/pull/4435#issuecomment-480387768 )

```
      {% for host in groups['kube-master'] -%}
      {%- if hostvars[host]['access_ip'] is defined -%}
      {{ hostvars[host]['access_ip'] }}
      {%- endif %}
      {{ hostvars[host]['ip'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}
      {%- endfor %}
```
This is replaced by sans_access_ip, sans_ip and sans_address. There is a minor change in logic here: the ipv4 address is now always included, _if it is defined_. Previously, the ipv4 address was included, _even if it was not defined_, as long as ip was not defined.

```
      {%- if supplementary_addresses_in_ssl_keys is defined -%}
      {% for addr in supplementary_addresses_in_ssl_keys -%}
      {{ addr }}
      {%- endfor %}
```
This is replaced by sans_supp.
