### PR TITLE
Replace iteritems() to items() in Jinja2 templates

### DIFF
--- a/roles/kubernetes-apps/cloud_controller/oci/templates/controller-manager-config.yml.j2
+++ b/roles/kubernetes-apps/cloud_controller/oci/templates/controller-manager-config.yml.j2
@@ -66,7 +66,7 @@ loadBalancer:
 {% if oci_security_lists is defined and oci_security_lists|length > 0 %}
   # Optional specification of which security lists to modify per subnet. This does not apply if security list management is off.
   securityLists:
-{% for subnet_ocid, list_ocid in oci_security_lists.iteritems() %}
+{% for subnet_ocid, list_ocid in oci_security_lists.items() %}
     {{ subnet_ocid }}: {{ list_ocid }}
 {% endfor %}
 {% endif %}

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-cm.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-cm.yml.j2
@@ -17,7 +17,7 @@ metadata:
   namespace: {{ local_volume_provisioner_namespace }}
 data:
   storageClassMap: |
-{% for class_name, storage_class in local_volume_provisioner_storage_classes.iteritems() %}
+{% for class_name, storage_class in local_volume_provisioner_storage_classes.items() %}
     {{ class_name }}:
       {{- convert_keys(storage_class) }}
       {{ storage_class | to_nice_yaml(indent=2) | indent(6) }}

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-ds.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-ds.yml.j2
@@ -44,7 +44,7 @@ spec:
             - name: local-volume-provisioner
               mountPath: /etc/provisioner/config
               readOnly: true
-{% for class_name, class_config in local_volume_provisioner_storage_classes.iteritems() %}
+{% for class_name, class_config in local_volume_provisioner_storage_classes.items() %}
             - name: local-volume-provisioner-hostpath-{{ class_name }}
               mountPath: {{ class_config.mount_dir }}
               mountPropagation: "HostToContainer"
@@ -53,7 +53,7 @@ spec:
         - name: local-volume-provisioner
           configMap:
             name: local-volume-provisioner
-{% for class_name, class_config in local_volume_provisioner_storage_classes.iteritems() %}
+{% for class_name, class_config in local_volume_provisioner_storage_classes.items() %}
         - name: local-volume-provisioner-hostpath-{{ class_name }}
           hostPath:
             path: {{ class_config.host_dir }}

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-psp.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-psp.yml.j2
@@ -25,7 +25,7 @@ spec:
     - 'downwardAPI'
     - 'hostPath'
   allowedHostPaths:
-{% for class_name, class_config in local_volume_provisioner_storage_classes.iteritems() %}
+{% for class_name, class_config in local_volume_provisioner_storage_classes.items() %}
     - pathPrefix: "{{ class_config.host_dir }}"
       readOnly: false
 {% endfor %}


### PR DESCRIPTION
The iteritems() dictionary's method has been removed in Python3. Using
this method in Jinja2 templates limits the execution to Python2 which
will be deprecated in 2020[1]. This change replaces that method for
the items() method as it's suggested in the official website[2].

[1] https://pythonclock.org/
[2] https://docs.ansible.com/ansible/latest/user_guide/playbooks_python_version.html#dict-iteritems