### PR TITLE
Add terraform validate for contrib/terraform/aws

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -796,6 +796,13 @@ tf-validate-packet:
     PROVIDER: packet
     CLUSTER: $CI_COMMIT_REF_NAME
 
+tf-validate-aws:
+  <<: *terraform_validate
+  variables:
+    TF_VERSION: 0.11.11
+    PROVIDER: aws
+    CLUSTER: $CI_COMMIT_REF_NAME
+
 tf-apply-packet:
   <<: *terraform_apply
   variables:

--- a/contrib/terraform/aws/sample-inventory/cluster.tf
+++ b/contrib/terraform/aws/sample-inventory/cluster.tf
@@ -1,0 +1,45 @@
+#Global Vars
+aws_cluster_name = "devtest"
+
+#VPC Vars
+aws_vpc_cidr_block = "10.250.192.0/18"
+aws_cidr_subnets_private = ["10.250.192.0/20","10.250.208.0/20"]
+aws_cidr_subnets_public = ["10.250.224.0/20","10.250.240.0/20"]
+
+#Bastion Host
+aws_bastion_size = "t2.medium"
+
+
+#Kubernetes Cluster
+
+aws_kube_master_num = 3
+aws_kube_master_size = "t2.medium"
+
+aws_etcd_num = 3
+aws_etcd_size = "t2.medium"
+
+aws_kube_worker_num = 4
+aws_kube_worker_size = "t2.medium"
+
+#Settings AWS ELB
+
+aws_elb_api_port = 6443
+k8s_secure_api_port = 6443
+kube_insecure_apiserver_address = "0.0.0.0"
+
+default_tags = {
+#  Env = "devtest"
+#  Product = "kubernetes"
+}
+
+inventory_file = "../../../inventory/hosts"
+
+## Credentials
+#AWS Access Key
+AWS_ACCESS_KEY_ID = ""
+#AWS Secret Key
+AWS_SECRET_ACCESS_KEY = ""
+#EC2 SSH Key Name
+AWS_SSH_KEY_NAME = ""
+#AWS Region
+AWS_DEFAULT_REGION = "eu-central-1"

--- a/contrib/terraform/aws/sample-inventory/group_vars
+++ b/contrib/terraform/aws/sample-inventory/group_vars
@@ -1,0 +1,1 @@
+../../../../inventory/sample/group_vars


### PR DESCRIPTION
Adding `terraform validate` CI for contrib/terraform/aws is a good way to quicky and automatically detect issues like undefined variables etc...