### PR TITLE
Add CI for Ubuntu 18.04 on Packet

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -821,7 +821,7 @@ tf-validate-aws:
     PROVIDER: aws
     CLUSTER: $CI_COMMIT_REF_NAME
 
-tf-apply-packet:
+tf-packet-ubuntu16-default:
   <<: *terraform_apply
   variables:
     TF_VERSION: 0.11.11
@@ -834,6 +834,22 @@ tf-apply-packet:
     TF_VAR_plan_k8s_nodes: t1.small.x86
     TF_VAR_facility: "ewr1"
     TF_VAR_public_key_path: ""
+    TF_VAR_operating_system: ubuntu_16_04
+
+tf-packet-ubuntu18-default:
+  <<: *terraform_apply
+  variables:
+    TF_VERSION: 0.11.11
+    PROVIDER: packet
+    CLUSTER: $CI_COMMIT_REF_NAME
+    TF_VAR_cluster_name: $CI_COMMIT_REF_NAME
+    TF_VAR_number_of_k8s_masters: "1"
+    TF_VAR_number_of_k8s_nodes: "1"
+    TF_VAR_plan_k8s_masters: t1.small.x86
+    TF_VAR_plan_k8s_nodes: t1.small.x86
+    TF_VAR_facility: "ams1"
+    TF_VAR_public_key_path: ""
+    TF_VAR_operating_system: ubuntu_18_04
 
 tf-apply-ovh:
   <<: *terraform_apply


### PR DESCRIPTION
Add CI for Ubuntu 18.04 on Packet with all default settings from Kubespray