### PR TITLE
Add OWNERS to contrib/terraform

### DIFF
--- a/contrib/terraform/OWNERS
+++ b/contrib/terraform/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - holmsten
+  - miouge1


### PR DESCRIPTION
Following suggestion on  `#kubespray-dev` slack channel - we should add owners at more levels of the project.

This PR adds owners to `contrib/terraform`.