### PR TITLE
openSUSE: Use Leap 15.0 instead of 42.3

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ SUPPORTED_OS = {
   "centos"              => {box: "centos/7",           user: "vagrant"},
   "centos-bento"        => {box: "bento/centos-7.5",   user: "vagrant"},
   "fedora"              => {box: "fedora/28-cloud-base",                user: "vagrant"},
-  "opensuse"            => {box: "opensuse/openSUSE-42.3-x86_64",       user: "vagrant"},
+  "opensuse"            => {box: "opensuse/openSUSE-15.0-x86_64",       user: "vagrant"},
   "opensuse-tumbleweed" => {box: "opensuse/openSUSE-Tumbleweed-x86_64", user: "vagrant"},
 }
 

--- a/docs/opensuse.md
+++ b/docs/opensuse.md
@@ -1,4 +1,4 @@
-openSUSE Leap 42.3 and Tumbleweed
+openSUSE Leap 15.0 and Tumbleweed
 ===============
 
 openSUSE Leap installation Notes:

--- a/inventory/sample/group_vars/all/docker.yml
+++ b/inventory/sample/group_vars/all/docker.yml
@@ -59,9 +59,9 @@ docker_options: >-
   {{ docker_registry_mirrors | map('regex_replace', '^(.*)$', '--registry-mirror=\1' ) | list | join(' ') }}
   {%- endif %}
   {%- if docker_version != "latest" and docker_version is version('17.05', '<') %}
-  --graph={{ docker_daemon_graph }} {{ docker_log_opts }}
+  --graph={{ docker_daemon_graph }} {% if ansible_os_family not in ["openSUSE Leap", "openSUSE Tumbleweed", "Suse"] %}{{ docker_log_opts }}{% endif %}
   {%- else %}
-  --data-root={{ docker_daemon_graph }} {{ docker_log_opts }}
+  --data-root={{ docker_daemon_graph }} {% if ansible_os_family not in ["openSUSE Leap", "openSUSE Tumbleweed", "Suse"] %}{{ docker_log_opts }}{% endif %}
   {%- endif %}
   {%- if ansible_architecture == "aarch64" and ansible_os_family == "RedHat" %}
   --add-runtime docker-runc=/usr/libexec/docker/docker-runc-current

--- a/roles/bootstrap-os/tasks/bootstrap-opensuse.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-opensuse.yml
@@ -1,4 +1,9 @@
 ---
+- name: Ensure zypper cache is updated (SUSE)
+  zypper_repository:
+    repo: "*"
+    runrefresh: yes
+
 - name: Install required packages (SUSE)
   package:
     name: "{{ item }}"

--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -23,7 +23,7 @@
   when: '"CentOS" in os_release.stdout or "Red Hat Enterprise Linux" in os_release.stdout'
 
 - include_tasks: bootstrap-opensuse.yml
-  when: '"OpenSUSE" in os_release.stdout'
+  when: '"openSUSE" in os_release.stdout'
 
 - include_tasks: bootstrap-clearlinux.yml
   when: '"Clear Linux OS" in os_release.stdout'

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -151,7 +151,7 @@
     pkg: "{{item.name}}"
     force: "{{item.force|default(omit)}}"
     conf_file: "{{item.yum_conf|default(omit)}}"
-    state: present
+    state: "{{item.state | default('present')}}"
     update_cache: "{{ omit if ansible_distribution == 'Fedora' else True }}"
   register: docker_task_result
   until: docker_task_result is succeeded
@@ -166,7 +166,7 @@
   action: "{{ docker_package_info.pkg_mgr }}"
   args:
     name: "{{ item.name }}"
-    state: present
+    state: "{{item.state | default('present')}}"
   with_items: "{{ docker_package_info.pkgs }}"
   register: docker_task_result
   until: docker_task_result is succeeded

--- a/roles/container-engine/docker/vars/suse.yml
+++ b/roles/container-engine/docker/vars/suse.yml
@@ -5,6 +5,8 @@ docker_package_info:
   pkg_mgr: zypper
   pkgs:
     - name: docker
+    - name: containerd
+      state: latest
 
 docker_repo_key_info:
   pkg_key: ''

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -236,9 +236,9 @@ docker_options: >-
   {{ docker_registry_mirrors | map('regex_replace', '^(.*)$', '--registry-mirror=\1' ) | list | join(' ') }}
   {%- endif %}
   {%- if docker_version != "latest" and docker_version is version('17.05', '<') %}
-  --graph={{ docker_daemon_graph }} {{ docker_log_opts }}
+  --graph={{ docker_daemon_graph }} {% if ansible_os_family not in ["openSUSE Leap", "openSUSE Tumbleweed", "Suse"] %}{{ docker_log_opts }}{% endif %}
   {%- else %}
-  --data-root={{ docker_daemon_graph }} {{ docker_log_opts }}
+  --data-root={{ docker_daemon_graph }} {% if ansible_os_family not in ["openSUSE Leap", "openSUSE Tumbleweed", "Suse"] %}{{ docker_log_opts }}{% endif %}
   {%- endif %}
   {%- if ansible_architecture == "aarch64" and ansible_os_family == "RedHat" %}
   --add-runtime docker-runc=/usr/libexec/docker/docker-runc-current


### PR DESCRIPTION
Use openSUSE Leap 15.0 which is the latest openSUSE version

This has been tested with `vagrant up` and the following `inventory/sample/hosts.ini` file

Fixes: #4440 

```
[all]
ansible_ssh_private_key_file=.vagrant/machines/default/virtualbox/private_key
ansible_become=true ansible_timeout=60
k8s-1 ansible_port=2222 ansible_user=vagrant ansible_host=127.0.0.1 ip=172.17.8.101
k8s-2 ansible_port=2200 ansible_user=vagrant ansible_host=127.0.0.1 ip=172.17.8.102
k8s-3 ansible_port=2201 ansible_user=vagrant ansible_host=127.0.0.1 ip=172.17.8.103
[kube-master]
k8s-1
[etcd]
k8s-1
[kube-node]
k8s-2
k8s-3
[k8s-cluster:children]
kube-master
kube-node
```