### PR TITLE
Disable cloud-routes for non-cloud plugin

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
@@ -203,6 +203,9 @@ controllerManager:
 {% elif cloud_provider is defined and cloud_provider in ["external"] %}
     cloud-config: {{ kube_config_dir }}/cloud_config
 {% endif %}
+{% if kube_network_plugin is defined and kube_network_plugin not in ["cloud"] %}
+    configure-cloud-routes: "false"
+{% endif %}
 {% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws", "external"] or controller_manager_extra_volumes %}
   extraVolumes:
 {% if cloud_provider is defined and cloud_provider in ["openstack"] and openstack_cacert is defined %}


### PR DESCRIPTION
With `cloud_provider` aws I was see constant spamming in my logs regarding controller not able to create routes in aws route table. Since I am running non-cloud `kube_network_plugin` in this case `flannel` I would expect controller not to create these routes.

I believe we had something like this before but not sure why it was removed!  