### PR TITLE
Upgrade to etcd v3.2.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Supported Components
 
 -   Core
     -   [kubernetes](https://github.com/kubernetes/kubernetes) v1.13.5
-    -   [etcd](https://github.com/coreos/etcd) v3.2.24
+    -   [etcd](https://github.com/coreos/etcd) v3.2.26
     -   [docker](https://www.docker.com/) v18.06 (see note)
     -   [rkt](https://github.com/rkt/rkt) v1.21.0 (see Note 2)
     -   [cri-o](http://cri-o.io/) v1.11.5 (experimental: see [CRI-O Note](docs/cri-o.md). Only on centos based OS)

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -37,7 +37,7 @@ image_arch: "{{host_architecture | default('amd64')}}"
 # Versions
 kube_version: v1.13.5
 kubeadm_version: "{{ kube_version }}"
-etcd_version: v3.2.24
+etcd_version: v3.2.26
 
 # kubernetes image repo define
 kube_image_repo: "gcr.io/google-containers"
@@ -133,8 +133,8 @@ kubeadm_checksums:
     v1.12.0: 463fb058b7fa2591fb01f29f2451b054f6cbaa0f8a20394b4a4eb5d68473176f
 
 etcd_binary_checksums:
-  arm64: 7d3db622fb8d22a669a9351e1002ed2a7a776004a4a35888734bf39323889390
-  amd64: 947849dbcfa13927c81236fb76a7c01d587bbab42ab1e807184cd91b026ebed7
+  arm64: c219b254ece7d7e308ae41569fa240dbae2de460bed818ee39b408b73f6360ef
+  amd64: 127d4f2097c09d929beb9d3784590cc11102f4b4d4d4da7ad82d5c9e856afd38
 cni_binary_checksums:
   arm64: 016bbc989877e35e3cd49fafe11415fb2717e52c74fde6b1650411154cb91b81
   amd64: f04339a21b8edf76d415e7f17b620e63b8f37a76b2f706671587ab6464411f2d


### PR DESCRIPTION
Based on a [comment](https://github.com/kubernetes-sigs/kubespray/issues/4370#issuecomment-477998683) from @EppO v3.2.26 is recommended.