### PR TITLE
Missing ruamel.yaml from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ netaddr
 pbr>=1.6
 hvac
 jmespath
+ruamel.yaml


### PR DESCRIPTION
This is noticed when trying to run inventory.py