### PR TITLE
Update pypy3 on CoreOS to 7.0.0

### DIFF
--- a/roles/bootstrap-os/files/bootstrap.sh
+++ b/roles/bootstrap-os/files/bootstrap.sh
@@ -11,7 +11,7 @@ if [[ -e $BINDIR/.bootstrapped ]]; then
   exit 0
 fi
 
-PYPY_VERSION=6.0.0
+PYPY_VERSION=7.0.0
 
 wget -O - https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-$PYPY_VERSION-linux_x86_64-portable.tar.bz2 | tar -xjf -
 mv -n pypy3.5-$PYPY_VERSION-linux_x86_64-portable pypy3


### PR DESCRIPTION
Not bumping to 7.1.0, since that's just the beta version for Python 3.6 support, 7.0.0 is the current stable version for using Python3 (supporting 3.5).