### PR TITLE
Vagrant fix password prompt

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -198,7 +198,7 @@ Vagrant.configure("2") do |config|
           ansible.become = true
           ansible.limit = "all"
           ansible.host_key_checking = false
-          ansible.raw_arguments = ["--forks=#{$num_instances}", "--flush-cache", "--ask-become-pass"]
+          ansible.raw_arguments = ["--forks=#{$num_instances}", "--flush-cache", "-e ansible_become_pass=vagrant"]
           ansible.host_vars = host_vars
           #ansible.tags = ['download']
           ansible.groups = {


### PR DESCRIPTION
Currently `vagrant up` asks for the sudo/become password, by convention vagrant images use "vagrant" for such password so we might as well pass it with `ansible_become_pass`

Fixes #4214