### PR TITLE
Update nginx to 1.15. Update manifest and performance optimize

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -200,7 +200,7 @@ kube_router_image_tag: "{{ kube_router_version }}"
 multus_image_repo: "docker.io/nfvpe/multus"
 multus_image_tag: "{{ multus_version }}"
 nginx_image_repo: nginx
-nginx_image_tag: 1.13
+nginx_image_tag: 1.15
 
 coredns_version: "1.4.0"
 coredns_image_repo: "coredns/coredns"

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -42,9 +42,7 @@ kube_master_cpu_reserved: 200m
 
 kubelet_status_update_frequency: 10s
 
-# Limits for nginx load balancer app
-nginx_memory_limit: 512M
-nginx_cpu_limit: 300m
+# Requests for nginx load balancer app
 nginx_memory_requests: 32M
 nginx_cpu_requests: 25m
 

--- a/roles/kubernetes/node/templates/manifests/nginx-proxy.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/nginx-proxy.manifest.j2
@@ -4,6 +4,7 @@ metadata:
   name: nginx-proxy
   namespace: kube-system
   labels:
+    addonmanager.kubernetes.io/mode: Reconcile
     k8s-app: kube-nginx
 spec:
   hostNetwork: true
@@ -17,9 +18,6 @@ spec:
     image: {{ nginx_image_repo }}:{{ nginx_image_tag }}
     imagePullPolicy: {{ k8s_image_pull_policy }}
     resources:
-      limits:
-        cpu: {{ nginx_cpu_limit }}
-        memory: {{ nginx_memory_limit }}
       requests:
         cpu: {{ nginx_cpu_requests }}
         memory: {{ nginx_memory_requests }}
@@ -27,6 +25,10 @@ spec:
       privileged: true
     {% if nginx_kube_apiserver_healthcheck_port is defined -%}
     livenessProbe:
+      httpGet:
+        path: /healthz
+        port: {{ nginx_kube_apiserver_healthcheck_port }}
+    readinessProbe:
       httpGet:
         path: /healthz
         port: {{ nginx_kube_apiserver_healthcheck_port }}

--- a/roles/kubernetes/node/templates/nginx.conf.j2
+++ b/roles/kubernetes/node/templates/nginx.conf.j2
@@ -1,37 +1,50 @@
 error_log stderr notice;
 
-worker_processes 1;
+worker_processes 2;
+worker_rlimit_nofile 130048;
+worker_shutdown_timeout 10s;
+
 events {
   multi_accept on;
   use epoll;
-  worker_connections 1024;
+  worker_connections 16384;
 }
 
 stream {
-        upstream kube_apiserver {
-            least_conn;
-            {% for host in groups['kube-master'] -%}
-            server {{ hostvars[host]['access_ip'] | default(hostvars[host]['ip'] | default(fallback_ips[host])) }}:{{ kube_apiserver_port }};
-            {% endfor -%}
-        }
+  upstream kube_apiserver {
+    least_conn;
+    {% for host in groups['kube-master'] -%}
+    server {{ hostvars[host]['access_ip'] | default(hostvars[host]['ip'] | default(fallback_ips[host])) }}:{{ kube_apiserver_port }};
+    {% endfor -%}
+  }
 
-        server {
-            listen        127.0.0.1:{{ nginx_kube_apiserver_port|default(kube_apiserver_port) }};
-            proxy_pass    kube_apiserver;
-            proxy_timeout 10m;
-            proxy_connect_timeout 1s;
-
-        }
+  server {
+    listen        127.0.0.1:{{ nginx_kube_apiserver_port|default(kube_apiserver_port) }};
+    proxy_pass    kube_apiserver;
+    proxy_timeout 10m;
+    proxy_connect_timeout 1s;
+  }
 }
 
 http {
-        {% if nginx_kube_apiserver_healthcheck_port is defined -%}
-        server {
-            listen {{ nginx_kube_apiserver_healthcheck_port }};
-            location /healthz {
-              access_log off;
-              return 200;
-            }
-        }
-        {% endif -%}  
+  aio threads;
+  aio_write on;
+  tcp_nopush on;
+  tcp_nodelay on;
+
+  keepalive_timeout 75s;
+  keepalive_requests 100;
+  reset_timedout_connection on;
+  server_tokens off;
+  autoindex off;
+
+  {% if nginx_kube_apiserver_healthcheck_port is defined -%}
+  server {
+    listen {{ nginx_kube_apiserver_healthcheck_port }};
+    location /healthz {
+      access_log off;
+      return 200;
+    }
+  }
+  {% endif -%}
 }


### PR DESCRIPTION
- Upgrade nginx to 1.15
- Remove limits on deployment. If we limit the loadbalancer towards our masters from the node, this could result in unexpected behavior under load. The node should always be able to get in touch with the masters.
- Add readiness check
- Performance optimize the nginx configuration

Currently the kube-nginx deployment does not do health checks towards the masters. This requires nginx plus, custom module or switching to another loadbalancer ([gobetween](http://gobetween.io/) maybe?)