### PR TITLE
Enable nodelocaldns by default

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -132,7 +132,7 @@ dns_mode: coredns
 # Set manual server if using a custom cluster DNS server
 # manual_dns_server: 10.x.x.x
 # Enable nodelocal dns cache
-enable_nodelocaldns: False
+enable_nodelocaldns: true
 nodelocaldns_ip: 169.254.25.10
 
 # Can be docker_dns, host_resolvconf or none

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -59,7 +59,7 @@ ndots: 2
 dns_mode: coredns
 
 # Enable nodelocal dns cache
-enable_nodelocaldns: False
+enable_nodelocaldns: true
 nodelocaldns_ip: 169.254.25.10
 
 # Should be set to a cluster IP if using a custom cluster DNS

--- a/tests/files/gce_centos7-flannel-addons.yml
+++ b/tests/files/gce_centos7-flannel-addons.yml
@@ -21,5 +21,4 @@ cert_manager_enabled: true
 metrics_server_enabled: true
 kube_token_auth: true
 kube_basic_auth: true
-enable_nodelocaldns: true
 local_path_provisioner_enabled: true

--- a/tests/files/gce_centos7-flannel-addons.yml
+++ b/tests/files/gce_centos7-flannel-addons.yml
@@ -21,4 +21,5 @@ cert_manager_enabled: true
 metrics_server_enabled: true
 kube_token_auth: true
 kube_basic_auth: true
+enable_nodelocaldns: false
 local_path_provisioner_enabled: true


### PR DESCRIPTION
Enable nodelocaldns by default as Kubespray is "production-ready".

Nodelocaldns prevents / mitigates racy DNS connections.

See more at:

- https://blog.quentin-machu.fr/2018/06/24/5-15s-dns-lookups-on-kubernetes/
- https://www.weave.works/blog/racy-conntrack-and-dns-lookup-timeouts
- https://tech.xing.com/a-reason-for-unexplained-connection-timeouts-on-kubernetes-docker-abd041cf7e02
- https://github.com/Quentin-M/weave-tc