### PR TITLE
Fix "Prevent inventory.py from configuring an even number of nodes in…

### DIFF
--- a/contrib/inventory_builder/inventory.py
+++ b/contrib/inventory_builder/inventory.py
@@ -93,14 +93,15 @@ class KubesprayInventory(object):
             self.purge_invalid_hosts(self.hosts.keys(), PROTECTED_NAMES)
             self.set_all(self.hosts)
             self.set_k8s_cluster()
-            self.set_etcd(list(self.hosts.keys())[:3])
+            etcd_hosts_count = 3 if len(self.hosts.keys()) >= 3 else 1
+            self.set_etcd(list(self.hosts.keys())[:etcd_hosts_count])
             if len(self.hosts) >= SCALE_THRESHOLD:
-                self.set_kube_master(list(self.hosts.keys())[3:5])
+                self.set_kube_master(list(self.hosts.keys())[etcd_hosts_count:5])
             else:
                 self.set_kube_master(list(self.hosts.keys())[:2])
             self.set_kube_node(self.hosts.keys())
             if len(self.hosts) >= SCALE_THRESHOLD:
-                self.set_calico_rr(list(self.hosts.keys())[:3])
+                self.set_calico_rr(list(self.hosts.keys())[:etcd_hosts_count])
         else:  # Show help if no options
             self.show_help()
             sys.exit(0)


### PR DESCRIPTION
… etcd" #439

by making clusters with fewer than 3 nodes have only 1 etcd node