### PR TITLE
kubeadmn init: add 'until' to make 'retries' effective

### DIFF
--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -106,6 +106,7 @@
   register: kubeadm_init
   # Retry is because upload config sometimes fails
   retries: 3
+  until: kubeadm_init is succeeded or "field is immutable" in kubeadm_init.stderr
   when: inventory_hostname == groups['kube-master']|first and not kubeadm_already_run.stat.exists
   failed_when: kubeadm_init.rc != 0 and "field is immutable" not in kubeadm_init.stderr
   environment:


### PR DESCRIPTION
Rebased version of #4346

Since we need this for the 2.9.0 release, I figured I might as well open another PR to fix the rebase.