### PR TITLE
Fix CoreDNS upstream servers bogus jinja filters

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -14,7 +14,7 @@ data:
         kubernetes {{ dns_domain }} in-addr.arpa ip6.arpa {
           pods insecure
 {% if resolvconf_mode == 'host_resolvconf' and upstream_dns_servers is defined and upstream_dns_servers|length > 0 %}
-          upstream {{ upstream_dns_servers.join(' ') }}
+          upstream {{ upstream_dns_servers|join(' ') }}
 {% else %}
           upstream /etc/resolv.conf
 {% endif %}
@@ -22,7 +22,7 @@ data:
         }
         prometheus :9153
 {% if resolvconf_mode == 'host_resolvconf' and upstream_dns_servers is defined and upstream_dns_servers|length > 0 %}
-        forward . {{ upstream_dns_servers.join(' ') }}
+        forward . {{ upstream_dns_servers|join(' ') }}
 {% else %}
         forward . /etc/resolv.conf
 {% endif %}


### PR DESCRIPTION
Fixes bug introduced in #4390

See https://github.com/kubernetes-sigs/kubespray/pull/4390#discussion_r273354044