### PR TITLE
Upgrade to Ansible >2.7.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,6 @@ To deploy the cluster you can use :
 
 ### Ansible
 
-#### Ansible version
-
-Ansible v2.7.0 is failing and/or produce unexpected results due to [ansible/ansible/issues/46600](https://github.com/ansible/ansible/issues/46600)
-
 #### Usage
 
     # Install dependencies from ``requirements.txt``
@@ -142,7 +138,7 @@ plugins can be deployed for a given single cluster.
 Requirements
 ------------
 
--   **Ansible v2.6 (or newer) and python-netaddr is installed on the machine
+-   **Ansible v2.7.6 (or newer) and python-netaddr is installed on the machine
     that will run Ansible commands**
 -   **Jinja 2.9 (or newer) is required to run the Ansible Playbooks**
 -   The target servers must have **access to the Internet** in order to pull docker images. Otherwise, additional configuration is required (See [Offline Environment](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/downloads.md#offline-environment))

--- a/cluster.yml
+++ b/cluster.yml
@@ -3,12 +3,11 @@
   gather_facts: false
   become: no
   tasks:
-    - name: "Check ansible version !=2.7.0"
+    - name: "Check ansible version >=2.7.6"
       assert:
-        msg: "Ansible V2.7.0 can't be used until: https://github.com/ansible/ansible/issues/46600 is fixed"
+        msg: "Ansible must be v2.7.6 or higher"
         that:
-          - ansible_version.string is version("2.7.0", "!=")
-          - ansible_version.string is version("2.6.0", ">=")
+          - ansible_version.string is version("2.7.6", ">=")
       tags:
         - check
   vars:

--- a/remove-node.yml
+++ b/remove-node.yml
@@ -2,12 +2,11 @@
 - hosts: localhost
   become: no
   tasks:
-    - name: "Check ansible version !=2.7.0"
+    - name: "Check ansible version >=2.7.6"
       assert:
-        msg: "Ansible V2.7.0 can't be used until: https://github.com/ansible/ansible/issues/46600 is fixed"
+        msg: "Ansible must be v2.7.6 or higher"
         that:
-          - ansible_version.string is version("2.7.0", "!=")
-          - ansible_version.string is version("2.6.0", ">=")
+          - ansible_version.string is version("2.7.6", ">=")
       tags:
         - check
   vars:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible>=2.6.0,!=2.7.0
+ansible>=2.7.6
 jinja2>=2.9.6
 netaddr
 pbr>=1.6

--- a/reset.yml
+++ b/reset.yml
@@ -2,12 +2,11 @@
 - hosts: localhost
   become: no
   tasks:
-    - name: "Check ansible version !=2.7.0"
+    - name: "Check ansible version >=2.7.6"
       assert:
-        msg: "Ansible V2.7.0 can't be used until: https://github.com/ansible/ansible/issues/46600 is fixed"
+        msg: "Ansible must be v2.7.6 or higher"
         that:
-          - ansible_version.string is version("2.7.0", "!=")
-          - ansible_version.string is version("2.6.0", ">=")
+          - ansible_version.string is version("2.7.6", ">=")
       tags:
         - check
   vars:

--- a/scale.yml
+++ b/scale.yml
@@ -3,12 +3,11 @@
   gather_facts: False
   become: no
   tasks:
-    - name: "Check ansible version !=2.7.0"
+    - name: "Check ansible version >=2.7.6"
       assert:
-        msg: "Ansible V2.7.0 can't be used until: https://github.com/ansible/ansible/issues/46600 is fixed"
+        msg: "Ansible must be v2.7.6 or higher"
         that:
-          - ansible_version.string is version("2.7.0", "!=")
-          - ansible_version.string is version("2.6.0", ">=")
+          - ansible_version.string is version("2.7.6", ">=")
       tags:
         - check
   vars:

--- a/upgrade-cluster.yml
+++ b/upgrade-cluster.yml
@@ -3,12 +3,11 @@
   gather_facts: false
   become: no
   tasks:
-    - name: "Check ansible version !=2.7.0"
+    - name: "Check ansible version >=2.7.6"
       assert:
-        msg: "Ansible V2.7.0 can't be used until: https://github.com/ansible/ansible/issues/46600 is fixed"
+        msg: "Ansible must be v2.7.6 or higher"
         that:
-          - ansible_version.string is version("2.7.0", "!=")
-          - ansible_version.string is version("2.6.0", ">=")
+          - ansible_version.string is version("2.7.6", ">=")
       tags:
         - check
   vars:


### PR DESCRIPTION
All CI jobs are using Ansible 2.7.10.
We already know that 2.7.0 doesn't work.
Ansible 2.6.0 doesn't work either (errors related to `kube_token_auth` and `kube_apiserver_storage_backend`).

Therefore I suggest to upgrade to `>2.7.0`