### PR TITLE
Fix ipip: false in calico v3

### DIFF
--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -8,7 +8,7 @@ calico_ipv4pool_ipip: "Off"
 
 # Use IP-over-IP encapsulation across hosts
 ipip: true
-ipip_mode: Always  # change to "CrossSubnet" if you only want ipip encapsulation on traffic going across subnets
+ipip_mode: "{{ 'Always' if ipip else 'Never' }}"  # change to "CrossSubnet" if you only want ipip encapsulation on traffic going across subnets
 
 calico_cert_dir: /etc/calico/certs
 


### PR DESCRIPTION
As of #3086 `ipip` is set but never used.
```
"spec": {
          "cidr": "{{ calico_pool_cidr | default(kube_pods_subnet) }}",
          "ipipMode": "{{ ipip_mode if ipip else 'Never' }}",
          "natOutgoing": {{ nat_outgoing|default(false) and not peer_with_router|default(false) }} }} "
```
Release notes don't mention this, so we can consider this a bug.

For example if you had `ipip: false` but left `ipip_mode` to its default value, it used to be enough to disable IP-in-IP encapsulation, but that's not the case anymore.