### PR TITLE
support azure loadbalancer standard sku (#4150)

### DIFF
--- a/docs/azure.md
+++ b/docs/azure.md
@@ -51,6 +51,25 @@ This is the AppId from the last command
 
 azure\_aad\_client\_id must be set to the AppId, azure\_aad\_client\_secret is your choosen secret.
 
+#### azure\_loadbalancer\_sku
+Sku of Load Balancer and Public IP. Candidate values are: basic and standard.
+
+#### azure\_exclude\_master\_from\_standard\_lb
+azure\_exclude\_master\_from\_standard\_lb excludes master nodes from `standard` load balancer.
+
+#### azure\_disable\_outbound\_snat
+azure\_disable\_outbound\_snat disables the outbound SNAT for public load balancer rules. It should only be set when azure\_exclude\_master\_from\_standard\_lb is `standard`.
+ 
+#### azure\_primary\_availability\_set\_name
+(Optional) The name of the availability set that should be used as the load balancer backend .If this is set, the Azure 
+cloudprovider will only add nodes from that availability set to the load balancer backend pool. If this is not set, and 
+multiple agent pools (availability sets) are used, then the cloudprovider will try to add all nodes to a single backend 
+pool which is forbidden. In other words, if you use multiple agent pools (availability sets), you MUST set this field.
+
+#### azure\_use\_instance\_metadata
+Use instance metadata service where possible
+
+
 ## Provisioning Azure with Resource Group Templates
 
 You'll find Resource Group Templates and scripts to provision the required infrastructure to Azure in [*contrib/azurerm*](../contrib/azurerm/README.md)

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -126,3 +126,11 @@ vsphere_public_network: "{{ lookup('env', 'VSPHERE_PUBLIC_NETWORK')|default('') 
 # azure_security_group_name:
 # azure_vnet_name:
 # azure_route_table_name:
+# Sku of Load Balancer and Public IP. Candidate values are: basic and standard.
+azure_loadbalancer_sku: basic
+# excludes master nodes from standard load balancer.
+azure_exclude_master_from_standard_lb: true
+# disables the outbound SNAT for public load balancer rules
+azure_disable_outbound_snat: false
+# use instance metadata service where possible
+azure_use_instance_metadata: true

--- a/roles/kubernetes/node/tasks/azure-credential-check.yml
+++ b/roles/kubernetes/node/tasks/azure-credential-check.yml
@@ -53,3 +53,20 @@
   fail:
     msg: "azure_route_table_name is missing"
   when: azure_route_table_name is not defined or azure_route_table_name == ""
+
+- name: check azure_loadbalancer_sku value
+  fail:
+    msg: "azure_loadbalancer_sku has an invalid value '{{azure_loadbalancer_sku}}'. Supported values are 'basic', 'standard'"
+  when: azure_loadbalancer_sku not in ["basic", "standard"]
+
+- name: "check azure_exclude_master_from_standard_lb is a bool"
+  assert:
+    that: azure_exclude_master_from_standard_lb |type_debug == 'bool'
+
+- name: "check azure_disable_outbound_snat is a bool"
+  assert:
+    that: azure_disable_outbound_snat |type_debug == 'bool'
+
+- name: "check azure_use_instance_metadata is a bool"
+  assert:
+    that: azure_use_instance_metadata |type_debug == 'bool'

--- a/roles/kubernetes/node/templates/azure-cloud-config.j2
+++ b/roles/kubernetes/node/templates/azure-cloud-config.j2
@@ -9,5 +9,14 @@
   "securityGroupName": "{{ azure_security_group_name }}",
   "vnetName": "{{ azure_vnet_name }}",
   "vnetResourceGroup": "{{ azure_vnet_resource_group }}",
-  "routeTableName": "{{ azure_route_table_name }}"
+  "routeTableName": "{{ azure_route_table_name }}",
+{% if azure_primary_availability_set_name is defined %}
+  "primaryAvailabilitySetName": "{{ azure_primary_availability_set_name }}",
+{%endif%}
+  "useInstanceMetadata": {{azure_use_instance_metadata }},
+{% if azure_loadbalancer_sku == "standard" %}
+  "excludeMasterFromStandardLB": {{ azure_exclude_master_from_standard_lb }},
+  "disableOutboundSNAT": {{ azure_disable_outbound_snat }},
+{% endif%}
+  "loadBalancerSku": "{{ azure_loadbalancer_sku }}"
 }


### PR DESCRIPTION
Add the support of the following property in `azure-credential-check.yml`
  - azure_loadbalancer_sku: Sku of Load Balancer and Public IP. Candidate values are: basic and standard.
  - azure_exclude_master_from_standard_lb: excludes master nodes from standard load balancer.
  - azure_disable_outbound_snat: disables the outbound SNAT for public load balancer rules
  - useInstanceMetadata: Use instance metadata service where possible
  - azure_primary_availability_set: (Optional) The name of the availability set that should be used as the load balancer backend

for more information about the  azure cloud config: https://github.com/kubernetes/kubernetes/blob/aa740646008adcdad4c9cfb6c1c2c9144d463d17/pkg/cloudprovider/providers/azure/azure.go#L82

fix #4150

/kind feature
/sig azure