### PR TITLE
Release 2.8 robust san handling

### DIFF
--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -42,29 +42,21 @@
 
 - name: kubeadm | aggregate all SANs
   set_fact:
-    apiserver_sans: >-
-      kubernetes
-      kubernetes.default
-      kubernetes.default.svc
-      kubernetes.default.svc.{{ dns_domain }}
-      {{ kube_apiserver_ip }}
-      localhost
-      127.0.0.1
-      {{ ' '.join(groups['kube-master']) }}
-      {%- if loadbalancer_apiserver is defined %}
-      {{ apiserver_loadbalancer_domain_name }}
-      {%- endif %}
-      {% for host in groups['kube-master'] -%}
-      {%- if hostvars[host]['access_ip'] is defined -%}
-      {{ hostvars[host]['access_ip'] }}
-      {%- endif %}
-      {{ hostvars[host]['ip'] | default(hostvars[host]['ansible_default_ipv4']['address']) }}
-      {%- endfor %}
-      {%- if supplementary_addresses_in_ssl_keys is defined -%}
-      {% for addr in supplementary_addresses_in_ssl_keys -%}
-      {{ addr }}
-      {%- endfor %}
-      {%- endif %}
+    apiserver_sans: "{{ (sans_base + groups['kube-master'] + sans_lb + sans_supp + sans_access_ip + sans_ip + sans_address) | unique }}"
+  vars:
+    sans_base:
+      - "kubernetes"
+      - "kubernetes.default"
+      - "kubernetes.default.svc"
+      - "kubernetes.default.svc.{{ dns_domain }}"
+      - "{{ kube_apiserver_ip }}"
+      - "localhost"
+      - "127.0.0.1"
+    sans_lb: "{{ [apiserver_loadbalancer_domain_name] if loadbalancer_apiserver is defined else [] }}"
+    sans_supp: "{{ supplementary_addresses_in_ssl_keys if supplementary_addresses_in_ssl_keys is defined else [] }}"
+    sans_access_ip: "{{ groups['kube-master'] | map('extract', hostvars, 'access_ip') | list | select('defined') | list }}"
+    sans_ip: "{{ groups['kube-master'] | map('extract', hostvars, 'ip') | list | select('defined') | list }}"
+    sans_address: "{{ groups['kube-master'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | list | select('defined') | list }}"
   tags: facts
 
 - name: kubeadm | Copy etcd cert dir under k8s cert dir

--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -52,7 +52,7 @@
       - "{{ kube_apiserver_ip }}"
       - "localhost"
       - "127.0.0.1"
-    sans_lb: "{{ [apiserver_loadbalancer_domain_name] if loadbalancer_apiserver is defined else [] }}"
+    sans_lb: "{{ [apiserver_loadbalancer_domain_name] if apiserver_loadbalancer_domain_name is defined else [] }}"
     sans_supp: "{{ supplementary_addresses_in_ssl_keys if supplementary_addresses_in_ssl_keys is defined else [] }}"
     sans_access_ip: "{{ groups['kube-master'] | map('extract', hostvars, 'access_ip') | list | select('defined') | list }}"
     sans_ip: "{{ groups['kube-master'] | map('extract', hostvars, 'ip') | list | select('defined') | list }}"

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha1.yaml.j2
@@ -177,7 +177,7 @@ apiServerExtraVolumes:
 {% endif %}
 {% endif %}
 apiServerCertSANs:
-{% for san in  apiserver_sans.split() | unique %}
+{% for san in apiserver_sans %}
   - {{ san }}
 {% endfor %}
 certificatesDir: {{ kube_config_dir }}/ssl

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
@@ -206,7 +206,7 @@ schedulerExtraArgs:
 {% endfor %}
 {% endif %}
 apiServerCertSANs:
-{% for san in apiserver_sans.split() | unique %}
+{% for san in apiserver_sans %}
   - {{ san }}
 {% endfor %}
 certificatesDir: {{ kube_config_dir }}/ssl

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
@@ -43,7 +43,7 @@ controlPlaneEndpoint: {{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.po
 controlPlaneEndpoint: {{ ip | default(ansible_default_ipv4.address) }}:{{ kube_apiserver_port }}
 {% endif %}
 apiServerCertSANs:
-{% for san in apiserver_sans.split() | unique %}
+{% for san in apiserver_sans %}
   - {{ san }}
 {% endfor %}
 certificatesDir: {{ kube_config_dir }}/ssl


### PR DESCRIPTION
This PR applies the robust san handling (described in PR #4435) to the release-2.8 branch, based on discussion here:

https://github.com/kubernetes-sigs/kubespray/pull/4394#issuecomment-481151897
https://github.com/kubernetes-sigs/kubespray/pull/4435#issuecomment-481158007


