### PR TITLE
Add etcd role dependency on kube user to avoid etcd role failure when running scale.yml (fixes #3240)

### DIFF
--- a/roles/etcd/meta/main.yml
+++ b/roles/etcd/meta/main.yml
@@ -3,3 +3,6 @@ dependencies:
   - role: adduser
     user: "{{ addusers.etcd }}"
     when: not (ansible_os_family in ['CoreOS', 'Container Linux by CoreOS', "ClearLinux"] or is_atomic)
+  - role: adduser
+    user: "{{ addusers.kube }}"
+    when: not (ansible_os_family in ['CoreOS', 'Container Linux by CoreOS', "ClearLinux"] or is_atomic)


### PR DESCRIPTION
 Add etcd role dependency on kube user to avoid etcd role failure when running scale.yml with a fresh node. (fixes #3240)