### PR TITLE
change API runtime config option to:   - admissionregistration.k8s.io/v1beta1

### DIFF
--- a/roles/kubernetes/master/defaults/main/main.yml
+++ b/roles/kubernetes/master/defaults/main/main.yml
@@ -100,7 +100,7 @@ kube_apiserver_disable_admission_plugins: []
 
 # extra runtime config
 kube_api_runtime_config:
-  - admissionregistration.k8s.io/v1alpha1
+  - admissionregistration.k8s.io/v1beta1
 
 ## Enable/Disable Kube API Server Authentication Methods
 kube_basic_auth: false


### PR DESCRIPTION
  - admissionregistration.k8s.io/v1beta1

https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md
The alpha Initializers feature, admissionregistration.k8s.io/v1alpha1 API version, Initializers admission plugin, and use of the metadata.initializers API field have been removed.