### PR TITLE
nodelocaldns - Do not force TCP connections to upstream DNS servers

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2
@@ -51,8 +51,6 @@ data:
         reload
         loop
         bind {{ nodelocaldns_ip }}
-        forward . {{ upstreamForwardTarget }} {
-            force_tcp
-        }
+        forward . {{ upstreamForwardTarget }}
         prometheus :9253
     }


### PR DESCRIPTION
Do not make the assumption that upstream DNS servers listen on TCP and thereby force TCP towards them. Use normal UDP.