### PR TITLE
Add several issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,16 +1,11 @@
-<!-- Thanks for filing an issue! Before hitting the button, please answer these questions.-->
+---
+name: Bug Report
+about: Report a bug encountered while operating Kubernetes
+labels: kind/bug
 
-**Is this a BUG REPORT or FEATURE REQUEST?** (choose one):
-
+---
 <!--
-If this is a BUG REPORT, please:
-  - Fill in as much of the template below as you can.  If you leave out
-    information, we can't help you as well.
-
-If this is a FEATURE REQUEST, please:
-  - Describe *in detail* the feature/behavior/change you'd like to see.
-
-In both cases, be ready for followup questions, and please respond in a timely
+Please, be ready for followup questions, and please respond in a timely
 manner.  If we can't reproduce a bug or think a feature already exists, we
 might close your issue.  If we're wrong, PLEASE feel free to reopen it and
 explain why.

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,11 @@
+---
+name: Enhancement Request
+about: Suggest an enhancement to the Kubespray project
+labels: kind/feature
+
+---
+<!-- Please only use this template for submitting enhancement requests -->
+
+**What would you like to be added**:
+
+**Why is this needed**:

--- a/.github/ISSUE_TEMPLATE/failing-test.md
+++ b/.github/ISSUE_TEMPLATE/failing-test.md
@@ -1,0 +1,20 @@
+---
+name: Failing Test
+about: Report test failures in Kubespray CI jobs
+labels: kind/failing-test
+
+---
+
+<!-- Please only use this template for submitting reports about failing tests in Kubespray CI jobs -->
+
+**Which jobs are failing**:
+
+**Which test(s) are failing**:
+
+**Since when has it been failing**:
+
+**Testgrid link**:
+
+**Reason for failure**:
+
+**Anything else we need to know**:

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,0 +1,18 @@
+---
+name: Support Request
+about: Support request or question relating to Kubespray
+labels: triage/support
+
+---
+
+<!--
+STOP -- PLEASE READ!
+
+GitHub is not the right place for support requests.
+
+If you're looking for help, check [Stack Overflow](https://stackoverflow.com/questions/tagged/kubespray) and the [troubleshooting guide](https://kubernetes.io/docs/tasks/debug-application-cluster/troubleshooting/).
+
+You can also post your question on the [Kubernetes Slack](http://slack.k8s.io/) or the [Discuss Kubernetes](https://discuss.kubernetes.io/) forum.
+
+If the matter is security related, please disclose it privately via https://kubernetes.io/security/.
+-->


### PR DESCRIPTION
Similar to #4491 this is inspired from https://github.com/kubernetes/kubernetes/tree/master/.github/ISSUE_TEMPLATE

Using issue template should help with auto labeling of issues.