### PR TITLE
ansible-lint: when lines should not include Jinja2 variables

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,7 +4,6 @@ skip_list:
   # see https://docs.ansible.com/ansible-lint/rules/default_rules.html for a list of all default rules
   # The following rules throw errors.
   # These either still need to be corrected in the repository and the rules re-enabled or they are skipped on purpose.
-  - '102'
   - '103'
   - '104'
   - '201'

--- a/roles/kubernetes-apps/helm/tasks/gen_helm_tiller_certs.yml
+++ b/roles/kubernetes-apps/helm/tasks/gen_helm_tiller_certs.yml
@@ -50,10 +50,9 @@
 
 - name: "Check_helm_client_certs | Set 'sync_helm_certs' to true on masters"
   set_fact:
-    sync_helm_certs: true
-  when: inventory_hostname != groups['kube-master'][0] and
-      (not item in helmcert_node.files | map(attribute='path') | map("basename") | list or
-      helmcert_node.files | selectattr("path", "equalto", "{{ helm_home_dir }}/{{ item }}") | map(attribute="checksum")|first|default('') != helmcert_master.files | selectattr("path", "equalto", "{{ helm_home_dir }}/{{ item }}") | map(attribute="checksum")|first|default(''))
+    sync_helm_certs: (not item in helmcert_node.files | map(attribute='path') | map("basename") | list or helmcert_node.files | selectattr("path", "equalto", "{{ helm_home_dir }}/{{ item }}") | map(attribute="checksum")|first|default('') != helmcert_master.files | selectattr("path", "equalto", "{{ helm_home_dir }}/{{ item }}") | map(attribute="checksum")|first|default(''))
+  when:
+    - inventory_hostname != groups['kube-master'][0]
   with_items:
     - "{{ helm_client_certs }}"
 


### PR DESCRIPTION
Fix ansible-lint rule e102: when lines should not include Jinja2 variables