### PR TITLE
[contrib/terraform/openstack] Add k8s_allowed_remote_ips variable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -837,3 +837,4 @@ tf-apply-ovh:
     TF_VAR_flavor_k8s_master: "defa64c3-bd46-43b4-858a-d93bbae0a229" #s1-8
     TF_VAR_flavor_k8s_node: "defa64c3-bd46-43b4-858a-d93bbae0a229" #s1-8
     TF_VAR_image: "Ubuntu 18.04"
+    TF_VAR_k8s_allowed_remote_ips: '["0.0.0.0/0"]'

--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -243,6 +243,7 @@ For your cluster, edit `inventory/$CLUSTER/cluster.tf`.
 |`supplementary_master_groups` | To add ansible groups to the masters, such as `kube-node` for tainting them as nodes, empty by default. |
 |`supplementary_node_groups` | To add ansible groups to the nodes, such as `kube-ingress` for running ingress controller pods, empty by default. |
 |`bastion_allowed_remote_ips` | List of CIDR allowed to initiate a SSH connection, `["0.0.0.0/0"]` by default |
+|`k8s_allowed_remote_ips` | List of CIDR allowed to initiate a SSH connection, empty by default |
 |`worker_allowed_ports` | List of ports to open on worker nodes, `[{ "protocol" = "tcp", "port_range_min" = 30000, "port_range_max" = 32767, "remote_ip_prefix" = "0.0.0.0/0"}]` by default |
 
 #### Terraform state files

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -52,6 +52,7 @@ module "compute" {
   k8s_node_fips                                = "${module.ips.k8s_node_fips}"
   bastion_fips                                 = "${module.ips.bastion_fips}"
   bastion_allowed_remote_ips                   = "${var.bastion_allowed_remote_ips}"
+  k8s_allowed_remote_ips                       = "${var.k8s_allowed_remote_ips}"
   supplementary_master_groups                  = "${var.supplementary_master_groups}"
   supplementary_node_groups                    = "${var.supplementary_node_groups}"
   worker_allowed_ports                         = "${var.worker_allowed_ports}"

--- a/contrib/terraform/openstack/modules/compute/variables.tf
+++ b/contrib/terraform/openstack/modules/compute/variables.tf
@@ -66,6 +66,10 @@ variable "bastion_allowed_remote_ips" {
   type = "list"
 }
 
+variable "k8s_allowed_remote_ips" {
+  type = "list"
+}
+
 variable "supplementary_master_groups" {
   default = ""
 }

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -145,6 +145,12 @@ variable "bastion_allowed_remote_ips" {
   default     = ["0.0.0.0/0"]
 }
 
+variable "k8s_allowed_remote_ips" {
+  description = "An array of CIDRs allowed to SSH to hosts"
+  type        = "list"
+  default     = []
+}
+
 variable "worker_allowed_ports" {
   type = "list"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
#4291 introduced a way to dynamically create security groups. This change caused in effect that the bastion security group is only created if you deploy a bastion node. However this security group was added to other nodes as well, to provide SSH access from outside the cluster even if no bastion was created.

This PR introduce a new variable for defining rules of remote sources allowed to SSH. The rules are added to the `k8s` security group which exist for all nodes.

**Which issue(s) this PR fixes**:
Fixes #4487

**Does this PR introduce a user-facing change?**:
yes
```release-note
New variable for `contrib/terraform/openstack`: `k8s_allowed_remote_ips`
Used for defining a list of CIDRs allowed to initiate a SSH connection when you don't want to use a bastion.
```
