### PR TITLE
added missing sidebar link to Packet doc

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -20,6 +20,7 @@
   * [AWS](docs/aws.md)
   * [Azure](docs/azure.md)
   * [OpenStack](/docs/openstack.md)
+  * [Packet](/docs/packet.md)
   * [vSphere](/docs/vsphere.md)
 * Operating Systems
   * [Atomic](docs/atomic.md)


### PR DESCRIPTION
 /kind documentation

added in missing link on the sidebar to the already written Packet docs