### PR TITLE
[WIP] Add support for the flannel IPSec backend

### DIFF
--- a/roles/network_plugin/flannel/defaults/main.yml
+++ b/roles/network_plugin/flannel/defaults/main.yml
@@ -17,6 +17,7 @@
 # You can choose what type of flannel backend to use
 # please refer to flannel's docs : https://github.com/coreos/flannel/blob/master/README.md
 flannel_backend_type: "vxlan"
+flannel_ipsec_backend_psk: ""
 
 # Limits for apps
 flannel_memory_limit: 500M

--- a/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
+++ b/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
@@ -41,6 +41,14 @@ data:
 {% endif %}
       }
     }
+{% if flannel_backend_type == 'ipsec' %}
+  charon.conf: |
+    charon {
+        # Install routes into a separate routing table for established IPsec
+        # tunnels.
+        install_routes = yes
+    }
+{% endif %}
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
@@ -97,6 +105,9 @@ spec:
           mountPath: /etc/cni/net.d
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
+        - name: flannel-cfg
+          mountPath: /etc/strongswan.d/charon.conf
+          subPath: charon.conf
       - name: install-cni
         image: {{ flannel_cni_image_repo }}:{{ flannel_cni_image_tag }}
         command: ["/install-cni.sh"]

--- a/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
+++ b/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
@@ -33,7 +33,12 @@ data:
     {
       "Network": "{{ kube_pods_subnet }}",
       "Backend": {
+{% if flannel_backend_type == 'ipsec' %}
+        "Type": "{{ flannel_backend_type }}",
+        "PSK": "{{ flannel_ipsec_backend_psk }}"
+{% else %}
         "Type": "{{ flannel_backend_type }}"
+{% endif %}
       }
     }
 ---


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR introduces support for IPSec over flannel, which was introduced in flannel 0.11.0. 
This makes it possible to have lightweight, high-performance encryption between the cluster nodes.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
Users may now specify 'flannel_backend_type = "ipsec"' along with 'flannel_ipsec_backend_psk = "$PSK"' to instruct flannel to use the new IPSec backend.
```
