### PR TITLE
Fix calico v3.4.0 scale and upgrade

### DIFF
--- a/roles/network_plugin/calico/handlers/main.yml
+++ b/roles/network_plugin/calico/handlers/main.yml
@@ -1,15 +1,14 @@
 ---
-- name: restart calico-node
+- name: reset_calico_cni
   command: /bin/true
   notify:
-    - Calico | reload systemd
-    - Calico | reload calico-node
+    - delete 10-calico.conflist
+    - delete calico-node containers
 
-- name: Calico | reload systemd
-  shell: systemctl daemon-reload
+- name: delete 10-calico.conflist
+  file:
+    path: /etc/calico/10-calico.conflist
+    state: absent
 
-- name: Calico | reload calico-node
-  service:
-    name: calico-node
-    state: restarted
-    sleep: 10
+- name: delete calico-node containers
+  shell: "docker ps -af name=k8s_POD_calico-node* -q | xargs --no-run-if-empty docker rm -f"

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -15,7 +15,6 @@
     owner: root
     group: root
 
-
 - name: Calico | Link etcd certificates for calico-node
   file:
     src: "{{ etcd_cert_dir }}/{{ item.s }}"

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -4,6 +4,8 @@
     src: "cni-calico.conflist.j2"
     dest: "/etc/cni/net.d/{% if calico_version is version('v3.3.0', '>=') %}calico.conflist.template{% else %}10-calico.conflist{% endif %}"
     owner: kube
+  register: calico_conflist
+  notify: reset_calico_cni
 
 - name: Calico | Create calico certs directory
   file:
@@ -12,6 +14,7 @@
     mode: 0750
     owner: root
     group: root
+
 
 - name: Calico | Link etcd certificates for calico-node
   file:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Restarts calico after the installation, with the current config after scaling or upgrade there's an error loading CNI config, explained in #4315
This change is introduced in #4514 but needs to be applied in 2.9

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```