### PR TITLE
[terraform/openstack] Explicitly set egress security groups

### DIFF
--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -53,6 +53,7 @@ module "compute" {
   bastion_fips                                 = "${module.ips.bastion_fips}"
   bastion_allowed_remote_ips                   = "${var.bastion_allowed_remote_ips}"
   k8s_allowed_remote_ips                       = "${var.k8s_allowed_remote_ips}"
+  k8s_allowed_egress_ips                       = "${var.k8s_allowed_egress_ips}"
   supplementary_master_groups                  = "${var.supplementary_master_groups}"
   supplementary_node_groups                    = "${var.supplementary_node_groups}"
   worker_allowed_ports                         = "${var.worker_allowed_ports}"

--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -4,8 +4,9 @@ resource "openstack_compute_keypair_v2" "k8s" {
 }
 
 resource "openstack_networking_secgroup_v2" "k8s_master" {
-  name        = "${var.cluster_name}-k8s-master"
-  description = "${var.cluster_name} - Kubernetes Master"
+  name                 = "${var.cluster_name}-k8s-master"
+  description          = "${var.cluster_name} - Kubernetes Master"
+  delete_default_rules = true
 }
 
 resource "openstack_networking_secgroup_rule_v2" "k8s_master" {
@@ -19,9 +20,10 @@ resource "openstack_networking_secgroup_rule_v2" "k8s_master" {
 }
 
 resource "openstack_networking_secgroup_v2" "bastion" {
-  name        = "${var.cluster_name}-bastion"
-  count       = "${var.number_of_bastions ? 1 : 0}"
-  description = "${var.cluster_name} - Bastion Server"
+  name                 = "${var.cluster_name}-bastion"
+  count                = "${var.number_of_bastions ? 1 : 0}"
+  description          = "${var.cluster_name} - Bastion Server"
+  delete_default_rules = true
 }
 
 resource "openstack_networking_secgroup_rule_v2" "bastion" {
@@ -36,8 +38,9 @@ resource "openstack_networking_secgroup_rule_v2" "bastion" {
 }
 
 resource "openstack_networking_secgroup_v2" "k8s" {
-  name        = "${var.cluster_name}-k8s"
-  description = "${var.cluster_name} - Kubernetes"
+  name                 = "${var.cluster_name}-k8s"
+  description          = "${var.cluster_name} - Kubernetes"
+  delete_default_rules = true
 }
 
 resource "openstack_networking_secgroup_rule_v2" "k8s" {
@@ -58,9 +61,18 @@ resource "openstack_networking_secgroup_rule_v2" "k8s_allowed_remote_ips" {
   security_group_id = "${openstack_networking_secgroup_v2.k8s.id}"
 }
 
+resource "openstack_networking_secgroup_rule_v2" "egress" {
+  count             = "${length(var.k8s_allowed_egress_ips)}"
+  direction         = "egress"
+  ethertype         = "IPv4"
+  remote_ip_prefix  = "${var.k8s_allowed_egress_ips[count.index]}"
+  security_group_id = "${openstack_networking_secgroup_v2.k8s.id}"
+}
+
 resource "openstack_networking_secgroup_v2" "worker" {
-  name        = "${var.cluster_name}-k8s-worker"
-  description = "${var.cluster_name} - Kubernetes worker nodes"
+  name                 = "${var.cluster_name}-k8s-worker"
+  description          = "${var.cluster_name} - Kubernetes worker nodes"
+  delete_default_rules = true
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker" {
@@ -87,7 +99,6 @@ resource "openstack_compute_instance_v2" "bastion" {
 
   security_groups = ["${openstack_networking_secgroup_v2.k8s.name}",
     "${openstack_networking_secgroup_v2.bastion.name}",
-    "default",
   ]
 
   metadata = {
@@ -115,7 +126,6 @@ resource "openstack_compute_instance_v2" "k8s_master" {
 
   security_groups = ["${openstack_networking_secgroup_v2.k8s_master.name}",
     "${openstack_networking_secgroup_v2.k8s.name}",
-    "default",
   ]
 
   metadata = {
@@ -143,7 +153,6 @@ resource "openstack_compute_instance_v2" "k8s_master_no_etcd" {
 
   security_groups = ["${openstack_networking_secgroup_v2.k8s_master.name}",
     "${openstack_networking_secgroup_v2.k8s.name}",
-    "default",
   ]
 
   metadata = {
@@ -192,7 +201,6 @@ resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip" {
 
   security_groups = ["${openstack_networking_secgroup_v2.k8s_master.name}",
     "${openstack_networking_secgroup_v2.k8s.name}",
-    "default",
   ]
 
   metadata = {
@@ -239,7 +247,6 @@ resource "openstack_compute_instance_v2" "k8s_node" {
 
   security_groups = ["${openstack_networking_secgroup_v2.k8s.name}",
     "${openstack_networking_secgroup_v2.worker.name}",
-    "default",
   ]
 
   metadata = {
@@ -267,7 +274,6 @@ resource "openstack_compute_instance_v2" "k8s_node_no_floating_ip" {
 
   security_groups = ["${openstack_networking_secgroup_v2.k8s.name}",
     "${openstack_networking_secgroup_v2.worker.name}",
-    "default",
   ]
 
   metadata = {
@@ -314,9 +320,7 @@ resource "openstack_compute_instance_v2" "glusterfs_node_no_floating_ip" {
     name = "${var.network_name}"
   }
 
-  security_groups = ["${openstack_networking_secgroup_v2.k8s.name}",
-    "default",
-  ]
+  security_groups = ["${openstack_networking_secgroup_v2.k8s.name}"]
 
   metadata = {
     ssh_user         = "${var.ssh_user_gfs}"

--- a/contrib/terraform/openstack/modules/compute/variables.tf
+++ b/contrib/terraform/openstack/modules/compute/variables.tf
@@ -70,6 +70,10 @@ variable "k8s_allowed_remote_ips" {
   type = "list"
 }
 
+variable "k8s_allowed_egress_ips" {
+  type = "list"
+}
+
 variable "supplementary_master_groups" {
   default = ""
 }

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -151,6 +151,12 @@ variable "k8s_allowed_remote_ips" {
   default     = []
 }
 
+variable "k8s_allowed_egress_ips" {
+  description = "An array of CIDRs allowed for egress traffic"
+  type        = "list"
+  default     = ["0.0.0.0/0"]
+}
+
 variable "worker_allowed_ports" {
   type = "list"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature
/kind flake

**What this PR does / why we need it**:
Currently contrib/terraform/openstack relias on the default security group. Since those defaults can change from one cloud provider to another (example OVH has different settings than ElastX), explicitly setting egress security groups and `delete_default_rules = true` helps with portability.

**Special notes for your reviewer**:

The OpenStack Vanilla defaults is to allow egress to `0.0.0.0/0` by default, so I think it's safe for `k8s_allowed_egress_ips` to default to that.

In the future we could CI  test the `http_proxy` settings of Kubespray, by setting `k8s_allowed_egress_ips` to the IP of a proxy.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
contrib/terraform/openstack: Ignore default security groups and add k8s_allowed_egress_ips variable
```
