### PR TITLE
Mark "Calico | Set global as_num" as "unchanged"

### DIFF
--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -148,6 +148,7 @@
         "asNumber": {{ global_as_num }} }} ' | {{ bin_dir }}/calicoctl.sh create --skip-exists -f -
   run_once: true
   delegate_to: "{{ groups['kube-master'][0] }}"
+  changed_when: false
   when:
     - calico_version is version('v3.0.0', '>=')
 


### PR DESCRIPTION
This command executes with "--skip-exists" parameter, so it is idempotent
and should not be marked as "changed".

/kind cleanup

```release-note
NONE
```
