### PR TITLE
Revert "Fix for unknown 'kubernetes.io' or 'k8s.io' labels specified with --node-labels"

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s-cluster/addons.yml
@@ -79,9 +79,9 @@ rbd_provisioner_enabled: false
 ingress_nginx_enabled: false
 # ingress_nginx_host_network: false
 # ingress_nginx_nodeselector:
-#   node.kubernetes.io/node: ""
+#   node-role.kubernetes.io/node: ""
 # ingress_nginx_tolerations:
-#   - key: "node.kubernetes.io/master"
+#   - key: "node-role.kubernetes.io/master"
 #     operator: "Equal"
 #     value: ""
 #     effect: "NoSchedule"

--- a/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
@@ -30,7 +30,7 @@ spec:
         beta.kubernetes.io/os: linux
       serviceAccountName: coredns
       tolerations:
-        - key: node.kubernetes.io/master
+        - key: node-role.kubernetes.io/master
           effect: NoSchedule
         - key: "CriticalAddonsOnly"
           operator: "Exists"
@@ -46,7 +46,7 @@ spec:
           - weight: 100
             preference:
               matchExpressions:
-              - key: node.kubernetes.io/master
+              - key: node-role.kubernetes.io/master
                 operator: In
                 values:
                 - ""

--- a/roles/kubernetes-apps/ansible/templates/dashboard.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dashboard.yml.j2
@@ -195,7 +195,7 @@ spec:
       serviceAccountName: kubernetes-dashboard
 {% if dashboard_master_toleration %}
       tolerations:
-      - key: node.kubernetes.io/master
+      - key: node-role.kubernetes.io/master
         effect: NoSchedule
 {% endif %}
 

--- a/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
@@ -45,7 +45,7 @@ spec:
       tolerations:
         - effect: NoSchedule
           operator: Equal
-          key: node.kubernetes.io/master
+          key: node-role.kubernetes.io/master
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -58,7 +58,7 @@ spec:
           - weight: 100
             preference:
               matchExpressions:
-              - key: node.kubernetes.io/master
+              - key: node-role.kubernetes.io/master
                 operator: In
                 values:
                 - ""

--- a/roles/kubernetes-apps/cloud_controller/oci/templates/oci-cloud-provider.yml.j2
+++ b/roles/kubernetes-apps/cloud_controller/oci/templates/oci-cloud-provider.yml.j2
@@ -35,12 +35,12 @@ spec:
       serviceAccountName: cloud-controller-manager
       hostNetwork: true
       nodeSelector:
-        node.kubernetes.io/master: ""
+        node-role.kubernetes.io/master: ""
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"
         effect: NoSchedule
-      - key: node.kubernetes.io/master
+      - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
       volumes:

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
@@ -2,7 +2,7 @@
 ingress_nginx_namespace: "ingress-nginx"
 ingress_nginx_host_network: false
 ingress_nginx_nodeselector:
-  node.kubernetes.io/node: ""
+  node-role.kubernetes.io/node: ""
 ingress_nginx_tolerations: []
 ingress_nginx_insecure_port: 80
 ingress_nginx_secure_port: 443

--- a/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
@@ -116,7 +116,7 @@ spec:
             name: metrics-server-config
 {% if not masters_are_not_tainted %}
       tolerations:
-        - key: node.kubernetes.io/master
+        - key: node-role.kubernetes.io/master
           effect: NoSchedule
         - key: "CriticalAddonsOnly"
           operator: "Exists"
@@ -127,7 +127,7 @@ spec:
           - weight: 100
             preference:
               matchExpressions:
-              - key: node.kubernetes.io/master
+              - key: node-role.kubernetes.io/master
                 operator: In
                 values:
                 - ""

--- a/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-controllers.yml.j2
+++ b/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-controllers.yml.j2
@@ -29,7 +29,7 @@ spec:
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node.kubernetes.io/master
+        - key: node-role.kubernetes.io/master
           effect: NoSchedule
 {% if kube_version is version('v1.11.1', '>=') %}
       priorityClassName: system-cluster-critical

--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -176,7 +176,7 @@
     - old_apiserver_cert.stat.exists
 
 - name: kubeadm | Remove taint for master with node role
-  command: "{{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf taint node {{ inventory_hostname }} node.kubernetes.io/master:NoSchedule-"
+  command: "{{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf taint node {{ inventory_hostname }} node-role.kubernetes.io/master:NoSchedule-"
   delegate_to: "{{groups['kube-master']|first}}"
   when: inventory_hostname in groups['kube-node']
   failed_when: false

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
@@ -224,7 +224,7 @@ nodeRegistration:
 {% if inventory_hostname in groups['kube-master'] and inventory_hostname not in groups['kube-node'] %}
   taints:
   - effect: NoSchedule
-    key: node.kubernetes.io/master
+    key: node-role.kubernetes.io/master
 {% endif %}
 {% if container_manager == 'crio' %}
   criSocket: /var/run/crio/crio.sock

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
@@ -10,7 +10,7 @@ nodeRegistration:
 {% if inventory_hostname in groups['kube-master'] and inventory_hostname not in groups['kube-node'] %}
   taints:
   - effect: NoSchedule
-    key: node.kubernetes.io/master
+    key: node-role.kubernetes.io/master
 {% endif %}
 {% if container_manager == 'crio' %}
   criSocket: /var/run/crio/crio.sock

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
@@ -10,7 +10,7 @@ nodeRegistration:
 {% if inventory_hostname in groups['kube-master'] and inventory_hostname not in groups['kube-node'] %}
   taints:
   - effect: NoSchedule
-    key: node.kubernetes.io/master
+    key: node-role.kubernetes.io/master
 {% endif %}
 {% if container_manager == 'crio' %}
   criSocket: /var/run/crio/crio.sock

--- a/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
@@ -85,12 +85,12 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {# Kubelet node labels #}
 {% set role_node_labels = [] %}
 {% if inventory_hostname in groups['kube-master'] %}
-{%   set dummy = role_node_labels.append("node.kubernetes.io/master=''") %}
+{%   set dummy = role_node_labels.append("node-role.kubernetes.io/master=''") %}
 {%   if not standalone_kubelet|bool %}
-{%     set dummy = role_node_labels.append("node.kubernetes.io/node=''") %}
+{%     set dummy = role_node_labels.append("node-role.kubernetes.io/node=''") %}
 {%   endif %}
 {% else %}
-{%   set dummy = role_node_labels.append("node.kubernetes.io/node=''") %}
+{%   set dummy = role_node_labels.append("node-role.kubernetes.io/node=''") %}
 {% endif %}
 {% if nvidia_gpu_nodes is defined and nvidia_accelerator_enabled|bool %}
 {%   if inventory_hostname in nvidia_gpu_nodes %}

--- a/roles/network_plugin/contiv/templates/contiv-api-proxy.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-api-proxy.yml.j2
@@ -24,7 +24,7 @@ spec:
       hostNetwork: true
       hostPID: true
       nodeSelector:
-        node.kubernetes.io/master: ""
+        node-role.kubernetes.io/master: ""
       tolerations:
         - operator: Exists
         # Mark pod as critical for rescheduling (Will have no effect starting with kubernetes 1.12)

--- a/roles/network_plugin/contiv/templates/contiv-etcd-proxy.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-etcd-proxy.yml.j2
@@ -21,7 +21,7 @@ spec:
       hostNetwork: true
       hostPID: true
       nodeSelector:
-        node.kubernetes.io/node: ""
+        node-role.kubernetes.io/node: ""
       containers:
         - name: contiv-etcd-proxy
           image: {{ contiv_etcd_image_repo }}:{{ contiv_etcd_image_tag }}

--- a/roles/network_plugin/contiv/templates/contiv-etcd.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-etcd.yml.j2
@@ -21,7 +21,7 @@ spec:
       hostNetwork: true
       hostPID: true
       nodeSelector:
-        node.kubernetes.io/master: ""
+        node-role.kubernetes.io/master: ""
       tolerations:
         - operator: Exists
         # Mark pod as critical for rescheduling (Will have no effect starting with kubernetes 1.12)

--- a/roles/network_plugin/contiv/templates/contiv-netmaster.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-netmaster.yml.j2
@@ -24,7 +24,7 @@ spec:
       hostNetwork: true
       hostPID: true
       nodeSelector:
-        node.kubernetes.io/master: ""
+        node-role.kubernetes.io/master: ""
       tolerations:
         - operator: Exists
         # Mark pod as critical for rescheduling (Will have no effect starting with kubernetes 1.12)

--- a/roles/network_plugin/multus/templates/multus-daemonset.yml.j2
+++ b/roles/network_plugin/multus/templates/multus-daemonset.yml.j2
@@ -18,7 +18,7 @@ spec:
       nodeSelector:
         beta.kubernetes.io/arch: amd64
       tolerations:
-      - key: node.kubernetes.io/master
+      - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
       serviceAccountName: multus


### PR DESCRIPTION
Reverts kubernetes-sigs/kubespray#4320

Apparently kubernetes still uses the node-role label:

https://github.com/kubernetes/kubernetes/blob/release-1.14/pkg/controller/service/service_controller.go#L66

See more at this link:

https://github.com/kubernetes/kubernetes/pull/68267#issuecomment-468503200


This also had the side-effect that CoreDNS, Nodelocaldns and others did not start on a single instance with taints