### PR TITLE
Make CI job packet centos7 flannel addons work

### DIFF
--- a/.gitlab-ci/gce.yml
+++ b/.gitlab-ci/gce.yml
@@ -56,7 +56,7 @@ gce_coreos-calico-aio:
 gce_centos7-flannel-addons:
   stage: deploy-part2
   <<: *gce
-  when: on_success
+  when: manual
   except: ['triggers']
   only: [/^pr-.*$/]
 

--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -26,7 +26,7 @@ packet_ubuntu18-flannel-aio:
 packet_centos7-flannel-addons:
   stage: deploy-part2
   <<: *packet
-  when: manual
+  when: on_success
   except: ['triggers']
   only: [/^pr-.*$/]
 

--- a/tests/files/packet_centos7-flannel-addons.yml
+++ b/tests/files/packet_centos7-flannel-addons.yml
@@ -18,6 +18,4 @@ cert_manager_enabled: true
 metrics_server_enabled: true
 kube_token_auth: true
 kube_basic_auth: true
-enable_nodelocaldns: true
-
-vm_memory: 6144Mi
+enable_nodelocaldns: false


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind feature

**What this PR does / why we need it**:
This will make the CI job for Packet Centos Flannel Addons work and thus remove the GCE costs further for CI tests