### PR TITLE
Add shellcheck CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -193,6 +193,7 @@ ci-authorized:
 
 include:
   - .gitlab-ci/lint.yml
+  - .gitlab-ci/shellcheck.yml
   - .gitlab-ci/gce.yml
   - .gitlab-ci/digital-ocean.yml
   - .gitlab-ci/terraform.yml

--- a/.gitlab-ci/shellcheck.yml
+++ b/.gitlab-ci/shellcheck.yml
@@ -1,0 +1,14 @@
+# TODO(miouge1): Include
+shellcheck:
+  extends: .job
+  stage: unit-tests
+  variables:
+    SHELLCHECK_VERSION: v0.6.0
+  before_script:
+    - curl --silent "https://storage.googleapis.com/shellcheck/shellcheck-"${SHELLCHECK_VERSION}".linux.x86_64.tar.xz" | tar -xJv
+    - cp shellcheck-"${SHELLCHECK_VERSION}"/shellcheck /usr/bin/
+    - shellcheck --version
+  script:
+    # Run shellcheck for all *.sh except contrib/
+    - find . -name '*.sh' -not -path './contrib/*' | xargs shellcheck --severity error
+  except: ['triggers', 'master']


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add shellcheck CI to report potential shell problems early.

**Special notes for your reviewer**:
contrib folder is excluded because there are some errors in contrib/dind.
A couple of warning are thrown so let's use `--severity error` until those are addressed.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
