### PR TITLE
Re-Add docker:dind for Packet CI and fix packet_centos7-calico-ha

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,6 +39,8 @@ before_script:
 
 .testcases: &testcases
   <<: *job
+  services:
+    - docker:dind
   before_script:
     - /usr/bin/python -m pip install -r tests/requirements.txt
     - mkdir -p /.ssh
@@ -52,6 +54,8 @@ before_script:
     - ls
     - echo ${PWD}
     - echo "${STARTUP_SCRIPT}"
+    # Docker is required on the ansible host for download_run_once and download_localhost
+    - docker info
     - cd tests && make create-${CI_PLATFORM} -s ; cd -
 
     # Check out latest tag if testing upgrade

--- a/.gitlab-ci/gce.yml
+++ b/.gitlab-ci/gce.yml
@@ -6,10 +6,6 @@
   CI_PLATFORM: "gce"
   PRIVATE_KEY: $GCE_PRIVATE_KEY
 
-.docker_service: &docker_service
-  services:
-    - docker:dind
-
 .cache: &cache
   cache:
     key: "$CI_BUILD_REF_NAME"
@@ -19,7 +15,6 @@
 
 .gce: &gce
   extends: .testcases
-  <<: *docker_service
   <<: *cache
   variables:
     <<: *gce_variables

--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -104,7 +104,7 @@ packet_rhel7-canal-sep:
 packet_centos7-calico-ha:
   stage: deploy-special
   <<: *packet
-  when: manual
+  when: on_success
   except: ['triggers']
   only: ['master', /^pr-.*$/]
 


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Some options (like download_run_once) require docker locally. This was made exclusive to GCE by #4538 and is the cause of failing jobs like: https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/198852991

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
