### PR TITLE
Add containerd cri 20 04 2019

### DIFF
--- a/inventory/sample/group_vars/all/all.yml
+++ b/inventory/sample/group_vars/all/all.yml
@@ -81,7 +81,7 @@ loadbalancer_apiserver_healthcheck_port: 8081
 # kube_read_only_port: 10255
 
 ## Set true to download and cache container
-# download_container: true
+download_container: false
 
 ## Deploy container engine
 # Set false if you want to deploy container engine manually.

--- a/inventory/sample/group_vars/all/all.yml
+++ b/inventory/sample/group_vars/all/all.yml
@@ -81,7 +81,7 @@ loadbalancer_apiserver_healthcheck_port: 8081
 # kube_read_only_port: 10255
 
 ## Set true to download and cache container
-download_container: false
+# download_container: true
 
 ## Deploy container engine
 # Set false if you want to deploy container engine manually.

--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -145,11 +145,11 @@ skydns_server_secondary: "{{ kube_service_addresses|ipaddr('net')|ipaddr(4)|ipad
 dns_domain: "{{ cluster_name }}"
 
 ## Container runtime
-## docker for docker and crio for cri-o.
-container_manager: docker
+## docker for docker and crio for cri-o and containerd for cri-containerd.
+container_manager: containerd
 
 ## Settings for containerized control plane (etcd/kubelet/secrets)
-etcd_deployment_type: docker
+etcd_deployment_type: host
 kubelet_deployment_type: host
 helm_deployment_type: host
 

--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -146,10 +146,10 @@ dns_domain: "{{ cluster_name }}"
 
 ## Container runtime
 ## docker for docker and crio for cri-o and containerd for cri-containerd.
-container_manager: containerd
+container_manager: docker
 
 ## Settings for containerized control plane (etcd/kubelet/secrets)
-etcd_deployment_type: host
+etcd_deployment_type: docker
 kubelet_deployment_type: host
 helm_deployment_type: host
 

--- a/roles/container-engine/cri-containerd/files/disco.pref
+++ b/roles/container-engine/cri-containerd/files/disco.pref
@@ -1,0 +1,11 @@
+Package: *
+Pin: release n=disco
+Pin-Priority: -10
+
+Package: containerd
+Pin: release n=disco
+Pin-Priority: 500
+
+Package: runc
+Pin: release n=disco
+Pin-Priority: 500

--- a/roles/container-engine/cri-containerd/tasks/main.yaml
+++ b/roles/container-engine/cri-containerd/tasks/main.yaml
@@ -16,15 +16,14 @@
   tags:
     - facts
 
-- name: Add Disco Ubuntu repository
+- name: Add Disco Ubuntu repository for Containerd
   apt_repository:
-    name: disco
-    description: Deb packages repo for containerd
-    baseurl: "deb http://ports.ubuntu.com/ubuntu-ports disco universe"
-    gpgcheck: no
+    filename: disco
+    repo: "deb http://ports.ubuntu.com/ubuntu-ports disco universe"
+    state: present
   when: ansible_distribution == "Ubuntu" and not is_atomic
 
-- name: Copy mounts.conf
+- name: Copy disco.pref with pinning for containerd and runc
   copy:
     src: disco.pref
     dest: /etc/apt/preferences.d/disco.pref
@@ -36,8 +35,8 @@
     state: present
   with_items: "{{ containerd_packages }}"
 
-- name: Install cri-o service
+- name: Install containerd service
   service:
-    name: "{{ crio_service }}"
+    name: "{{ containerd_service }}"
     enabled: yes
     state: restarted

--- a/roles/container-engine/cri-containerd/tasks/main.yaml
+++ b/roles/container-engine/cri-containerd/tasks/main.yaml
@@ -21,13 +21,13 @@
     filename: disco
     repo: "deb http://ports.ubuntu.com/ubuntu-ports disco universe"
     state: present
-  when: ansible_distribution == "Ubuntu" and not is_atomic
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_version < 19.04 and not is_atomic
 
 - name: Copy disco.pref with pinning for containerd and runc
   copy:
     src: disco.pref
     dest: /etc/apt/preferences.d/disco.pref
-  when: ansible_distribution == "Ubuntu" and not is_atomic
+  when: ansible_distribution == "Ubuntu" and and ansible_distribution_version < 19.04 and not is_atomic
 
 - name: Install containerd packages
   package:

--- a/roles/container-engine/cri-containerd/tasks/main.yaml
+++ b/roles/container-engine/cri-containerd/tasks/main.yaml
@@ -1,0 +1,29 @@
+---
+- name: gather os specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - files:
+        - "{{ ansible_distribution|lower }}-{{ ansible_distribution_version|lower|replace('/', '_') }}.yml"
+        - "{{ ansible_distribution|lower }}-{{ ansible_distribution_release }}.yml"
+        - "{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version|lower|replace('/', '_') }}.yml"
+        - "{{ ansible_distribution|lower }}.yml"
+        - "{{ ansible_os_family|lower }}-{{ ansible_architecture }}.yml"
+        - "{{ ansible_os_family|lower }}.yml"
+        - defaults.yml
+      paths:
+        - ../vars
+      skip: true
+  tags:
+    - facts
+
+- name: Install containerd packages
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ containerd_packages }}"
+
+- name: Install cri-o service
+  service:
+    name: "{{ crio_service }}"
+    enabled: yes
+    state: restarted

--- a/roles/container-engine/cri-containerd/tasks/main.yaml
+++ b/roles/container-engine/cri-containerd/tasks/main.yaml
@@ -16,6 +16,20 @@
   tags:
     - facts
 
+- name: Add Disco Ubuntu repository
+  apt_repository:
+    name: disco
+    description: Deb packages repo for containerd
+    baseurl: "deb http://ports.ubuntu.com/ubuntu-ports disco universe"
+    gpgcheck: no
+  when: ansible_distribution == "Ubuntu" and not is_atomic
+
+- name: Copy mounts.conf
+  copy:
+    src: disco.pref
+    dest: /etc/apt/preferences.d/disco.pref
+  when: ansible_distribution == "Ubuntu" and not is_atomic
+
 - name: Install containerd packages
   package:
     name: "{{ item }}"

--- a/roles/container-engine/cri-containerd/vars/ubuntu.yml
+++ b/roles/container-engine/cri-containerd/vars/ubuntu.yml
@@ -1,0 +1,5 @@
+---
+containerd_packages:
+  - containerd
+
+crio_service: containerd

--- a/roles/container-engine/cri-containerd/vars/ubuntu.yml
+++ b/roles/container-engine/cri-containerd/vars/ubuntu.yml
@@ -2,4 +2,4 @@
 containerd_packages:
   - containerd
 
-crio_service: containerd
+containerd_service: containerd

--- a/roles/container-engine/meta/main.yml
+++ b/roles/container-engine/meta/main.yml
@@ -1,5 +1,12 @@
 ---
 dependencies:
+  - role: container-engine/cri-containerd
+    when:
+      - container_manager == 'containerd'
+    tags:
+      - container-engine
+      - containerd
+
   - role: container-engine/cri-o
     when:
       - container_manager == 'crio'

--- a/roles/download/templates/kubeadm-images.yaml.j2
+++ b/roles/download/templates/kubeadm-images.yaml.j2
@@ -7,7 +7,7 @@ apiVersion: kubeadm.k8s.io/v1beta1
 kind: InitConfiguration
 nodeRegistration:
 {% if container_manager == 'containerd' %}
-  criSocket: /run/containerd/containerd.sock
+  criSocket: /var/run/containerd/containerd.sock
 {% elif container_manager == 'crio' %}
   criSocket: /var/run/crio/crio.sock
 {% elif container_manager == 'rkt' %}
@@ -42,7 +42,7 @@ etcd:
 {% if kube_version is version('v1.12.0', '<') %}
 nodeRegistration:
 {% if container_manager == 'containerd' %}
-  criSocket: /run/containerd/containerd.sock
+  criSocket: /var/run/containerd/containerd.sock
 {% elif container_manager == 'crio' %}
   criSocket: /var/run/crio/crio.sock
 {% elif container_manager == 'rkt' %}

--- a/roles/download/templates/kubeadm-images.yaml.j2
+++ b/roles/download/templates/kubeadm-images.yaml.j2
@@ -6,7 +6,9 @@ apiVersion: kubeadm.k8s.io/v1beta1
 {% endif %}
 kind: InitConfiguration
 nodeRegistration:
-{% if container_manager == 'crio' %}
+{% if container_manager == 'containerd' %}
+  criSocket: /run/containerd/containerd.sock
+{% elif container_manager == 'crio' %}
   criSocket: /var/run/crio/crio.sock
 {% elif container_manager == 'rkt' %}
   criSocket: /var/run/rkt.sock
@@ -39,7 +41,9 @@ etcd:
 {% endfor %}
 {% if kube_version is version('v1.12.0', '<') %}
 nodeRegistration:
-{% if container_manager == 'crio' %}
+{% if container_manager == 'containerd' %}
+  criSocket: /run/containerd/containerd.sock
+{% elif container_manager == 'crio' %}
   criSocket: /var/run/crio/crio.sock
 {% elif container_manager == 'rkt' %}
   criSocket: /var/run/rkt.sock

--- a/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1alpha2.j2
+++ b/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1alpha2.j2
@@ -17,7 +17,7 @@ discoveryTokenUnsafeSkipCAVerification: true
 nodeRegistration:
   name: {{ kube_override_hostname }}
 {% if container_manager == 'containerd' %}
-  criSocket: /run/containerd/containerd.sock
+  criSocket: /var/run/containerd/containerd.sock
 {% elif container_manager == 'crio' %}
   criSocket: /var/run/crio/crio.sock
 {% elif container_manager == 'rkt' %}

--- a/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1alpha2.j2
+++ b/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1alpha2.j2
@@ -16,7 +16,9 @@ discoveryTokenAPIServers:
 discoveryTokenUnsafeSkipCAVerification: true
 nodeRegistration:
   name: {{ kube_override_hostname }}
-{% if container_manager == 'crio' %}
+{% if container_manager == 'containerd' %}
+  criSocket: /run/containerd/containerd.sock
+{% elif container_manager == 'crio' %}
   criSocket: /var/run/crio/crio.sock
 {% elif container_manager == 'rkt' %}
   criSocket: /var/run/rkt.sock

--- a/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1alpha3.j2
+++ b/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1alpha3.j2
@@ -17,7 +17,7 @@ discoveryTokenUnsafeSkipCAVerification: true
 nodeRegistration:
   name: {{ kube_override_hostname }}
 {% if container_manager == 'containerd' %}
-  criSocket: /run/containerd/containerd.sock
+  criSocket: /var/run/containerd/containerd.sock
 {% elif container_manager == 'crio' %}
   criSocket: /var/run/crio/crio.sock
 {% elif container_manager == 'rkt' %}

--- a/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1alpha3.j2
+++ b/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1alpha3.j2
@@ -16,7 +16,9 @@ discoveryTokenAPIServers:
 discoveryTokenUnsafeSkipCAVerification: true
 nodeRegistration:
   name: {{ kube_override_hostname }}
-{% if container_manager == 'crio' %}
+{% if container_manager == 'containerd' %}
+  criSocket: /run/containerd/containerd.sock
+{% elif container_manager == 'crio' %}
   criSocket: /var/run/crio/crio.sock
 {% elif container_manager == 'rkt' %}
   criSocket: /var/run/rkt.sock

--- a/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1beta1.j2
+++ b/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1beta1.j2
@@ -15,7 +15,7 @@ caCertPath: {{ kube_cert_dir }}/ca.crt
 nodeRegistration:
   name: {{ kube_override_hostname }}
 {% if container_manager == 'containerd' %}
-  criSocket: /run/containerd/containerd.sock
+  criSocket: /var/run/containerd/containerd.sock
 {% elif container_manager == 'crio' %}
   criSocket: /var/run/crio/crio.sock
 {% elif container_manager == 'rkt' %}

--- a/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1beta1.j2
+++ b/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1beta1.j2
@@ -14,7 +14,9 @@ discovery:
 caCertPath: {{ kube_cert_dir }}/ca.crt
 nodeRegistration:
   name: {{ kube_override_hostname }}
-{% if container_manager == 'crio' %}
+{% if container_manager == 'containerd' %}
+  criSocket: /run/containerd/containerd.sock
+{% elif container_manager == 'crio' %}
   criSocket: /var/run/crio/crio.sock
 {% elif container_manager == 'rkt' %}
   criSocket: /var/run/rkt.sock

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
@@ -228,7 +228,9 @@ nodeRegistration:
 {% else %}
   taints: {}
 {% endif %}
-{% if container_manager == 'crio' %}
+{% if container_manager == 'containerd' %}
+  criSocket: /run/containerd/containerd.sock
+{% elif container_manager == 'crio' %}
   criSocket: /var/run/crio/crio.sock
 {% elif container_manager == 'rkt' %}
   criSocket: /var/run/rkt.sock

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha2.yaml.j2
@@ -229,7 +229,7 @@ nodeRegistration:
   taints: {}
 {% endif %}
 {% if container_manager == 'containerd' %}
-  criSocket: /run/containerd/containerd.sock
+  criSocket: /var/run/containerd/containerd.sock
 {% elif container_manager == 'crio' %}
   criSocket: /var/run/crio/crio.sock
 {% elif container_manager == 'rkt' %}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
@@ -14,7 +14,9 @@ nodeRegistration:
 {% else %}
   taints: {}
 {% endif %}
-{% if container_manager == 'crio' %}
+{% if container_manager == 'containerd' %}
+  criSocket: /run/containerd/containerd.sock
+{% elif container_manager == 'crio' %}
   criSocket: /var/run/crio/crio.sock
 {% elif container_manager == 'rkt' %}
   criSocket: /var/run/rkt.sock

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
@@ -15,7 +15,7 @@ nodeRegistration:
   taints: {}
 {% endif %}
 {% if container_manager == 'containerd' %}
-  criSocket: /run/containerd/containerd.sock
+  criSocket: /var/run/containerd/containerd.sock
 {% elif container_manager == 'crio' %}
   criSocket: /var/run/crio/crio.sock
 {% elif container_manager == 'rkt' %}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
@@ -14,7 +14,9 @@ nodeRegistration:
 {% else %}
   taints: []
 {% endif %}
-{% if container_manager == 'crio' %}
+{% if container_manager == 'containerd' %}
+  criSocket: /run/containerd/containerd.sock
+{% elif container_manager == 'crio' %}
   criSocket: /var/run/crio/crio.sock
 {% elif container_manager == 'rkt' %}
   criSocket: /var/run/rkt.sock

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
@@ -15,7 +15,7 @@ nodeRegistration:
   taints: []
 {% endif %}
 {% if container_manager == 'containerd' %}
-  criSocket: /run/containerd/containerd.sock
+  criSocket: /var/run/containerd/containerd.sock
 {% elif container_manager == 'crio' %}
   criSocket: /var/run/crio/crio.sock
 {% elif container_manager == 'rkt' %}

--- a/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
@@ -45,7 +45,7 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {% endif %}
 {% if container_manager == 'containerd' %}
 --container-runtime=remote \
---container-runtime-endpoint=/run/containerd/containerd.sock \
+--container-runtime-endpoint=/var/run/containerd/containerd.sock \
 {% endif %}
 {% if container_manager == 'crio' %}
 --container-runtime=remote \

--- a/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.kubeadm.env.j2
@@ -43,6 +43,10 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {% if container_manager == 'docker' and kube_version is version('v1.12.0', '<') %}
 --docker-disable-shared-pid={{ kubelet_disable_shared_pid }} \
 {% endif %}
+{% if container_manager == 'containerd' %}
+--container-runtime=remote \
+--container-runtime-endpoint=/run/containerd/containerd.sock \
+{% endif %}
 {% if container_manager == 'crio' %}
 --container-runtime=remote \
 --container-runtime-endpoint=/var/run/crio/crio.sock \

--- a/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
@@ -156,7 +156,7 @@ spec:
               mountPath: /host/etc/cni/net.d
 {% if container_manager == 'containerd' %}
             - name: containerd-socket
-              mountPath: /run/containerd/containerd.sock
+              mountPath: /var/run/containerd/containerd.sock
               readOnly: true
 {% elif container_manager == 'crio' %}
             - name: crio-socket
@@ -192,7 +192,7 @@ spec:
         # To read cri-containerd events from the node
         - name: containerd-socket
           hostPath:
-            path: /run/containerd/containerd.sock
+            path: /var/run/containerd/containerd.sock
 {% elif container_manager == 'crio' %}
         # To read crio events from the node
         - name: crio-socket

--- a/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
@@ -154,7 +154,11 @@ spec:
               mountPath: /host/opt/cni/bin
             - name: etc-cni-netd
               mountPath: /host/etc/cni/net.d
-{% if container_manager == 'crio' %}
+{% if container_manager == 'containerd' %}
+            - name: containerd-socket
+              mountPath: /run/containerd/containerd.sock
+              readOnly: true
+{% elif container_manager == 'crio' %}
             - name: crio-socket
               mountPath: /var/run/crio.sock
               readOnly: true
@@ -184,7 +188,12 @@ spec:
         - name: bpf-maps
           hostPath:
             path: /sys/fs/bpf
-{% if container_manager == 'crio' %}
+{% if container_manager == 'containerd' %}
+        # To read cri-containerd events from the node
+        - name: containerd-socket
+          hostPath:
+            path: /run/containerd/containerd.sock
+{% elif container_manager == 'crio' %}
         # To read crio events from the node
         - name: crio-socket
           hostPath:

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -75,7 +75,7 @@
   delay: 5
   tags:
     - crio
-  when: container_manager == 'crio'
+  when: container_manager == 'crio' or container_manager == 'containerd'
 
 
 - name: reset | remove all cri-o containers
@@ -86,7 +86,7 @@
   delay: 5
   tags:
     - crio
-  when: container_manager == 'crio' and deploy_container_engine|default(true)
+  when: (container_manager == 'crio' or container_manager == 'containerd') and deploy_container_engine|default(true)
 
 - name: reset | stop all cri-o pods
   shell: "crictl pods -q | xargs -r crictl stopp"
@@ -96,7 +96,7 @@
   delay: 5
   tags:
     - crio
-  when: container_manager == 'crio'
+  when: container_manager == 'crio' or container_manager == 'containerd'
 
 - name: reset | remove all cri-o pods
   shell: "crictl pods -q | xargs -r crictl rmp"
@@ -106,7 +106,7 @@
   delay: 5
   tags:
     - crio
-  when: container_manager == 'crio'
+  when: container_manager == 'crio' or container_manager == 'containerd'
 - name: reset | gather mounted kubelet dirs
   shell: mount | grep /var/lib/kubelet/ | awk '{print $3}' | tac
   args:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Adds containerd CRI. Also adds Ubuntu Disco repository to install dockerd and runc from it for Ubuntu case.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
