### PR TITLE
Enable Kube-Router on Packet CI

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -82,9 +82,9 @@ packet_centos7-calico-ha:
   when: on_success
 
 packet_centos7-kube-router:
-  stage: deploy-special
+  stage: deploy-part2
   <<: *packet
-  when: manual
+  when: on_success
 
 packet_centos7-multus-calico:
   stage: deploy-part2
@@ -97,6 +97,6 @@ packet_opensuse-canal:
   when: manual
 
 packet_ubuntu-kube-router-sep:
-  stage: deploy-special
+  stage: deploy-part2
   <<: *packet
-  when: manual
+  when: on_success


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Enable packet_ubuntu-kube-router-sep now that is working in Packet CI.

**Special notes for your reviewer**:
The 2.9 release took a long time because there was a couple of regressions on manual jobs that were not identified until we wanted to release and had to solve the problems ASAP. Reducing the number of manual jobs should help Kubespray to release faster.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
