### PR TITLE
Enable packet_ubuntu-contiv-sep

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -62,9 +62,9 @@ packet_ubuntu-flannel-ha:
   when: on_success
 
 packet_ubuntu-contiv-sep:
-  stage: deploy-special
+  stage: deploy-part2
   <<: *packet
-  when: manual
+  when: on_success
 
 packet_ubuntu18-cilium-sep:
   stage: deploy-special


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Enable packet_ubuntu-contiv-sep now that is working in Packet CI.

**Special notes for your reviewer**:
The 2.9 release took a long time because there was a couple of regressions on manual jobs that were not identified until we wanted to release and had to solve the problems ASAP. Reducing the number of manual jobs should help Kubespray to release faster.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
