### PR TITLE
Add overcommitment for CPU in Packet CI playbook

### DIFF
--- a/tests/cloud_playbooks/roles/packet-ci/defaults/main.yml
+++ b/tests/cloud_playbooks/roles/packet-ci/defaults/main.yml
@@ -6,6 +6,11 @@ vm_cpu_sockets: 1
 vm_cpu_threads: 2
 vm_memory: 4096Mi
 
+# Request/Limit allocation settings
+
+cpu_allocation_ratio: 0.5
+memory_allocation_ratio: 1
+
 # Default path for inventory
 inventory_path: "/tmp/{{ test_name }}/inventory"
 

--- a/tests/cloud_playbooks/roles/packet-ci/templates/vm.yml.j2
+++ b/tests/cloud_playbooks/roles/packet-ci/templates/vm.yml.j2
@@ -34,6 +34,9 @@ spec:
             threads: {{ vm_cpu_cores }}
         resources:
           requests:
+            memory: {{ vm_memory * memory_allocation_ratio }}
+            cpu: {{ vm_cpu_cores * cpu_allocation_ratio }}
+          limits:
             memory: {{ vm_memory }}
             cpu: {{ vm_cpu_cores }}
       networks:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add overcommitment for CPU in Packet CI playbook

Packet CI is currently based on [x1.small.x86 servers](https://www.packet.com/cloud/servers/x1-small/) (8 cores/ 32 GB of RAM). The default VM size defined in tests/cloud_playbooks/roles/packet-ci/defaults/main.yml is 2 cores and 4GB of RAM, therefore we are not able to take full advantage of the servers, from the scheduler PoV they are full with 4 VMs (8 cores and 16GB of RAM allocated). 

Therefore I suggest to allow `requests.cpu < limits.cpu` to compensate.

*Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
