### PR TITLE
Add proxy support to CRI-O service

### DIFF
--- a/roles/container-engine/cri-o/handlers/main.yml
+++ b/roles/container-engine/cri-o/handlers/main.yml
@@ -1,0 +1,15 @@
+---
+- name: restart crio
+  command: /bin/true
+  notify:
+    - CRI-O | reload systemd
+    - CRI-O | reload crio
+
+- name: CRI-O | reload systemd
+  systemd:
+    daemon_reload: true
+
+- name: CRI-O | reload crio
+  service:
+    name: crio
+    state: restarted

--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -54,6 +54,7 @@
   with_items:
     - /etc/crio
     - /etc/containers
+    - /etc/systemd/system/crio.service.d
   file:
     path: "{{ item }}"
     state: directory
@@ -121,6 +122,13 @@
 - name: Reload systemd daemon
   systemd:
     daemon_reload: yes
+
+- name: Write cri-o proxy drop-in
+  template:
+    src: http-proxy.conf.j2
+    dest: /etc/systemd/system/crio.service.d/http-proxy.conf
+  notify: restart crio
+  when: http_proxy is defined or https_proxy is defined
 
 - name: Install cri-o service
   service:

--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -65,6 +65,7 @@
     state: present
   when: not is_ostree
   with_items: "{{ crio_packages }}"
+  notify: restart crio
 
 - name: Check if already installed
   stat:
@@ -111,6 +112,7 @@
     dest: /etc/containers/mounts.conf
   when:
     - ansible_os_family == 'RedHat'
+  notify: restart crio
 
 - name: Create directory for oci hooks
   file:
@@ -119,19 +121,9 @@
     owner: root
     mode: 0755
 
-- name: Reload systemd daemon
-  systemd:
-    daemon_reload: yes
-
 - name: Write cri-o proxy drop-in
   template:
     src: http-proxy.conf.j2
     dest: /etc/systemd/system/crio.service.d/http-proxy.conf
   notify: restart crio
   when: http_proxy is defined or https_proxy is defined
-
-- name: Install cri-o service
-  service:
-    name: "{{ crio_service }}"
-    enabled: yes
-    state: restarted

--- a/roles/container-engine/cri-o/templates/http-proxy.conf.j2
+++ b/roles/container-engine/cri-o/templates/http-proxy.conf.j2
@@ -1,0 +1,2 @@
+[Service]
+Environment={% if http_proxy is defined %}"HTTP_PROXY={{ http_proxy }}"{% endif %} {% if https_proxy is defined %}"HTTPS_PROXY={{ https_proxy }}"{% endif %} {% if no_proxy is defined %}"NO_PROXY={{ no_proxy }}"{% endif %}

--- a/roles/container-engine/cri-o/vars/clearlinux.yml
+++ b/roles/container-engine/cri-o/vars/clearlinux.yml
@@ -2,7 +2,6 @@
 crio_packages:
   - containers-basic
 
-crio_service: crio
 crio_conmon: /usr/libexec/crio/conmon
 crio_seccomp_profile: /usr/share/defaults/crio/seccomp.json
 crio_runc_path: /usr/bin/runc

--- a/roles/container-engine/cri-o/vars/fedora.yml
+++ b/roles/container-engine/cri-o/vars/fedora.yml
@@ -3,6 +3,5 @@ crio_packages:
   - cri-o
   - cri-tools
 
-crio_service: cri-o
 crio_conmon: /usr/libexec/crio/conmon
 crio_seccomp_profile: ""

--- a/roles/container-engine/cri-o/vars/redhat.yml
+++ b/roles/container-engine/cri-o/vars/redhat.yml
@@ -3,6 +3,5 @@ crio_packages:
   - cri-o
   - oci-systemd-hook
 
-crio_service: crio
 crio_conmon: /usr/libexec/crio/conmon
 crio_runc_path: /usr/bin/runc

--- a/roles/container-engine/cri-o/vars/ubuntu.yml
+++ b/roles/container-engine/cri-o/vars/ubuntu.yml
@@ -2,7 +2,6 @@
 crio_packages:
   - "cri-o-{{ kube_version | regex_replace('^v(?P<major>\\d+).(?P<minor>\\d+).(?P<patch>\\d+)$', '\\g<major>.\\g<minor>') }}"
 
-crio_service: crio
 crio_conmon: /usr/libexec/podman/conmon
 crio_seccomp_profile: ""
 crio_runc_path: /usr/lib/cri-o-runc/sbin/runc


### PR DESCRIPTION
The crio.service requires proxy environment variables when it's
deployed behind a corporated network. This change creates a systemd
configuration file when the proxy variables are defined.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This change deals with deployments inside of the corporate networks

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Enable CRI-O container engine

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
