### PR TITLE
ansible-lint: Don't use bare variables [E104]

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,7 +4,6 @@ skip_list:
   # see https://docs.ansible.com/ansible-lint/rules/default_rules.html for a list of all default rules
   # The following rules throw errors.
   # These either still need to be corrected in the repository and the rules re-enabled or they are skipped on purpose.
-  - '104'
   - '201'
   - '204'
   - '206'

--- a/roles/etcd/tasks/check_certs.yml
+++ b/roles/etcd/tasks/check_certs.yml
@@ -22,20 +22,20 @@
     - ca.pem
     - node-{{ inventory_hostname }}-key.pem
 
-
 - name: "Check_certs | Set 'gen_certs' to true"
   set_fact:
     gen_certs: true
   when: not item in etcdcert_master.files|map(attribute='path') | list
   run_once: true
-  with_items: >-
+  with_items: "{{ expected_files }}"
+  vars:
+    expected_files: >-
        ['{{etcd_cert_dir}}/ca.pem',
        {% set all_etcd_hosts = groups['k8s-cluster']|union(groups['etcd'])|union(groups['calico-rr']|default([]))|unique|sort %}
        {% for host in all_etcd_hosts %}
        '{{etcd_cert_dir}}/node-{{ host }}-key.pem'
        {% if not loop.last %}{{','}}{% endif %}
        {% endfor %}]
-
 
 - name: "Check_certs | Set 'gen_node_certs' to true"
   set_fact:

--- a/roles/kubernetes/preinstall/tasks/0090-etchosts.yml
+++ b/roles/kubernetes/preinstall/tasks/0090-etchosts.yml
@@ -38,7 +38,7 @@
     etc_hosts_localhosts_dict: >-
        {%- set splitted = (item | regex_replace('[ \t]+', ' ')|regex_replace('#.*$')|trim).split( ' ') -%}
        {{ etc_hosts_localhosts_dict|default({}) | combine({splitted[0]: splitted[1::] }) }}
-  with_items: "{{ (etc_hosts_content['content'] | b64decode).split('\n') }}"
+  with_items: "{{ (etc_hosts_content['content'] | b64decode).splitlines() }}"
   when:
     - etc_hosts_content.content is defined
     - (item is match('^::1 .*') or item is match('^127.0.0.1 .*'))


### PR DESCRIPTION
* Circumvented one false positive from ansible-lint
* Moved a block of jinja magic into its own variable

/kind cleanup

**Special notes for your reviewer**:

One "fix" seems to be a false positive (https://github.com/ansible/ansible-lint/issues/508), I just switched to `.splitlines()` instead of `.split('\n)`.

The other "fix" is just a mess of jinja that's probably something for another day to take a proper look.

I moved it to its own, task-local variable and hopefully that's enough for both Ansible and ansible-lint.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
