### PR TITLE
ansible-lint: Add exception for invocation of "rm" [E302, 201]

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,11 +4,9 @@ skip_list:
   # see https://docs.ansible.com/ansible-lint/rules/default_rules.html for a list of all default rules
   # The following rules throw errors.
   # These either still need to be corrected in the repository and the rules re-enabled or they are skipped on purpose.
-  - '201'
   - '204'
   - '206'
   - '301'
-  - '302'
   - '305'
   - '306'
   - '404'

--- a/contrib/dind/roles/dind-host/tasks/main.yaml
+++ b/contrib/dind/roles/dind-host/tasks/main.yaml
@@ -79,6 +79,7 @@
   with_items: "{{ containers.results }}"
 
 - name: Early hack image install to adapt for DIND
+  # noqa 302 - this task uses the raw module intentionally
   raw: |
     rm -fv /usr/bin/udevadm /usr/sbin/udevadm
   delegate_to: "{{ item._ansible_item_label|default(item.item) }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Creates an exception for the single occurrence of the ansible-lint rule 302.

**Special notes for your reviewer**:

Also enables rule 201 because it doesn't get triggered any more.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
