### PR TITLE
remove duble check for run this task just one time

### DIFF
--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -68,7 +68,6 @@
   delegate_to: "{{groups['etcd'][0]}}"
   when:
     - gen_certs|default(false)
-    - inventory_hostname == groups['etcd'][0]
   notify: set etcd_secret_changed
 
 - name: Gen_certs | Gather etcd master certs


### PR DESCRIPTION
/kind bug
**What this PR does / why we need it**:
Fix problem wit certificate generation in etcd[0] when run cluster wit --limit node
Can't generate etcd certificate for calico.
**Which issue(s) this PR fixes**:
Fixes # https://github.com/kubernetes-sigs/kubespray/issues/4571
