### PR TITLE
Add an ability to provide oidc cert in base64

### DIFF
--- a/roles/kubernetes/master/defaults/main/main.yml
+++ b/roles/kubernetes/master/defaults/main/main.yml
@@ -119,11 +119,14 @@ kube_webhook_token_auth: false
 # kube_oidc_url: https:// ...
 # kube_oidc_client_id: kubernetes
 ## Optional settings for OIDC
-# kube_oidc_ca_file: {{ kube_cert_dir }}/ca.pem
 # kube_oidc_username_claim: sub
 # kube_oidc_username_prefix: oidc:
 # kube_oidc_groups_claim: groups
 # kube_oidc_groups_prefix: oidc:
+# Copy oidc CA file to the following path if needed
+# kube_oidc_ca_file: {{ kube_cert_dir }}/ca.pem
+# Optionally include a base64-encoded oidc CA cert
+# kube_oidc_ca_cert: c3RhY2thYnVzZS5jb20...
 
 ## Variables for webhook token auth https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
 # kube_webhook_token_auth_url: https://...

--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -10,6 +10,17 @@
   import_tasks: kubeadm-migrate-certs.yml
   when: old_apiserver_cert.stat.exists
 
+- name: Install OIDC certificate
+  copy:
+    content: "{{ kube_oidc_ca_cert | b64decode }}"
+    dest: "{{ kube_oidc_ca_file }}"
+    owner: root
+    group: root
+    mode: "0644"
+  when:
+    - kube_oidc_auth
+    - kube_oidc_ca_cert is defined
+
 - name: kubeadm | Check serviceaccount key
   stat:
     path: "{{ kube_cert_dir }}/sa.key"


### PR DESCRIPTION
/kind feature
Make it possible to provide a certificate for OIDC in base64 format, as currently it's only possible to select a file

```release-note
NONE
```
