### PR TITLE
Update Docker defaults to 18.09.5 and drop deprecated

### DIFF
--- a/roles/container-engine/docker/defaults/main.yml
+++ b/roles/container-engine/docker/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-docker_version: '18.06'
+docker_version: '18.09'
 docker_selinux_version: '17.03'
 
 docker_package_info:

--- a/roles/container-engine/docker/vars/debian.yml
+++ b/roles/container-engine/docker/vars/debian.yml
@@ -5,8 +5,6 @@ docker_kernel_min_version: '3.10'
 # https://apt.dockerproject.org/repo/dists/debian-wheezy/main/filelist
 docker_versioned_pkg:
   'latest': docker-ce
-  '1.11': docker-engine=1.11.2-0~{{ ansible_distribution_release|lower }}
-  '1.12': docker-engine=1.12.6-0~debian-{{ ansible_distribution_release|lower }}
   '1.13': docker-engine=1.13.1-0~debian-{{ ansible_distribution_release|lower }}
   '17.03': docker-ce=17.03.2~ce-0~debian-{{ ansible_distribution_release|lower }}
   '17.06': docker-ce=17.06.2~ce-0~debian
@@ -14,9 +12,9 @@ docker_versioned_pkg:
   '17.12': docker-ce=17.12.1~ce-0~debian
   '18.03': docker-ce=18.03.1~ce-0~debian
   '18.06': docker-ce=18.06.2~ce~3-0~debian
-  '18.09': docker-ce=5:18.09.2~3-0~debian-{{ ansible_distribution_release|lower }}
-  'stable': docker-ce=18.06.2~ce~3-0~debian
-  'edge': docker-ce=17.12.1~ce-0~debian
+  '18.09': docker-ce=5:18.09.5~3-0~debian-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce=5:18.09.5~3-0~debian-{{ ansible_distribution_release|lower }}
+  'edge': docker-ce=5:18.09.5~3-0~debian-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkg_mgr: apt

--- a/roles/container-engine/docker/vars/fedora.yml
+++ b/roles/container-engine/docker/vars/fedora.yml
@@ -2,11 +2,13 @@
 docker_kernel_min_version: '0'
 
 # https://docs.docker.com/install/linux/docker-ce/fedora/
+# https://download.docker.com/linux/fedora/28/x86_64/stable/Packages/
 
 docker_versioned_pkg:
   'latest': docker-ce
   '18.03': docker-ce-18.03.1.ce-3.fc28
   '18.06': docker-ce-18.06.2.ce-3.fc28
+  '18.09': docker-ce-18.09.5-3.fc28
 
 #
 # This is due to the fact that the docker

--- a/roles/container-engine/docker/vars/redhat.yml
+++ b/roles/container-engine/docker/vars/redhat.yml
@@ -7,22 +7,18 @@ docker_kernel_min_version: '0'
 # or do 'yum --showduplicates list docker-engine'
 docker_versioned_pkg:
   'latest': docker-ce
-  '1.11': docker-engine-1.11.2-1.el7.centos
-  '1.12': docker-engine-1.12.6-1.el7.centos
   '1.13': docker-engine-1.13.1-1.el7.centos
   '17.03': docker-ce-17.03.2.ce-1.el7.centos
   '17.09': docker-ce-17.09.0.ce-1.el7.centos
   '17.12': docker-ce-17.12.1.ce-1.el7.centos
   '18.03': docker-ce-18.03.1.ce-1.el7.centos
   '18.06': docker-ce-18.06.2.ce-3.el7
-  '18.09': docker-ce-18.09.2-3.el7
-  'stable': docker-ce-18.06.2.ce-3.el7
-  'edge': docker-ce-18.09.2-3.el7
+  '18.09': docker-ce-18.09.5-3.el7
+  'stable': docker-ce-18.09.5-3.el7
+  'edge': docker-ce-18.09.5-3.el7
 
 docker_selinux_versioned_pkg:
   'latest': docker-ce-selinux
-  '1.11': docker-engine-selinux-1.11.2-1.el7.centos
-  '1.12': docker-engine-selinux-1.12.6-1.el7.centos
   '1.13': docker-engine-selinux-1.13.1-1.el7.centos
   '17.03': docker-ce-selinux-17.03.2.ce-1.el7.centos
   'stable': docker-ce-selinux-17.03.2.ce-1.el7.centos

--- a/roles/container-engine/docker/vars/ubuntu-amd64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-amd64.yml
@@ -11,9 +11,9 @@ docker_versioned_pkg:
   '17.09': docker-ce=17.09.0~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
   '17.12': docker-ce=17.12.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
   '18.06': docker-ce=18.06.2~ce~3-0~ubuntu
-  '18.09': docker-ce=5:18.09.2~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'stable': docker-ce=18.06.2~ce~3-0~ubuntu
-  'edge': docker-ce=5:18.09.2~ce~3-0~ubuntu
+  '18.09': docker-ce=5:18.09.5~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce=5:18.09.5~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'edge': docker-ce=5:18.09.5~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkg_mgr: apt

--- a/roles/container-engine/docker/vars/ubuntu-arm64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-arm64.yml
@@ -1,15 +1,15 @@
 ---
 docker_kernel_min_version: '3.10'
-docker_version: 18.06
+
 # https://download.docker.com/linux/ubuntu/
 docker_versioned_pkg:
   'latest': docker-ce
   '17.09': docker-ce=17.09.1~ce-0~ubuntu
   '17.12': docker-ce=17.12.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
   '18.06': docker-ce=18.06.2~ce~3-0~ubuntu
-  '18.09': docker-ce=5:18.09.2~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'stable': docker-ce=18.06.2~ce~3-0~ubuntu
-  'edge': docker-ce=5:18.09.2~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '18.09': docker-ce=5:18.09.5~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce=5:18.09.5~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'edge': docker-ce=5:18.09.5~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkg_mgr: apt


### PR DESCRIPTION
As of kubernetes v1.14, docker 18.09 is [validated for use](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md#external-dependencies). Docker 1.11 and 1.12 were dropped.

This patch:
- Updates the default docker version to 18.09
- Updates Docker packages to the latest 18.09 patch (18.09.5)
- Removes options for Docker 1.11 and 1.12