### PR TITLE
Added CRI-O support for ubuntu

### DIFF
--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -30,6 +30,19 @@
     state: present
   when: ansible_distribution in ["Ubuntu"]
 
+- name: Add CRI-O PPA
+  apt_repository:
+    repo: ppa:projectatomic/ppa
+    state: present
+  when: ansible_distribution in ["Ubuntu"] and not is_atomic
+
+- name: Install crictl
+  unarchive:
+    src: "{{local_release_dir}}/crictl-{{ crictl_version }}-linux-{{ image_arch }}.tar.gz"
+    dest: "/usr/local/bin"
+    mode: 0755
+    remote_src: yes
+
 - name: Make sure needed folders exist in the system
   with_items:
     - /etc/crio

--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -38,7 +38,7 @@
 
 - name: Install crictl
   unarchive:
-    src: "{{local_release_dir}}/crictl-{{ crictl_version }}-linux-{{ image_arch }}.tar.gz"
+    src: "{{ local_release_dir }}/crictl-{{ crictl_version }}-linux-{{ image_arch }}.tar.gz"
     dest: "/usr/local/bin"
     mode: 0755
     remote_src: yes

--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -34,7 +34,7 @@
   apt_repository:
     repo: ppa:projectatomic/ppa
     state: present
-  when: ansible_distribution in ["Ubuntu"] and not is_atomic
+  when: ansible_distribution in ["Ubuntu"]
 
 - name: Install crictl
   unarchive:

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -333,7 +333,7 @@ downloads:
   crictl:
     container: false
     file: true
-    enabled: true
+    enabled: "{{ container_manager in ['crio', 'cri', 'containerd'] }}"
     version: "{{ crictl_version }}"
     dest: "{{local_release_dir}}/crictl-{{ crictl_version }}-linux-{{ image_arch }}.tar.gz"
     sha256: "{{ crictl_binary_checksum }}"
@@ -342,7 +342,7 @@ downloads:
     owner: "root"
     mode: "0755"
     groups:
-      - kube-node
+      - k8s-cluster
 
   netcheck_server:
     enabled: "{{ deploy_netchecker }}"

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -77,6 +77,7 @@ cilium_version: "v1.5.5"
 kube_ovn_version: "v0.6.0"
 kube_router_version: "v0.2.5"
 multus_version: "v3.2.1"
+crictl_version: "{{ kube_version | regex_replace('^v(?P<major>\\d+).(?P<minor>\\d+).(?P<patch>\\d+)$', 'v\\g<major>.\\g<minor>.0') }}"
 
 crictl_version: "v1.15.0"
 
@@ -329,6 +330,20 @@ image_pull_command: "{{ docker_bin_dir }}/docker pull"
 image_info_command: "{{ docker_bin_dir }}/docker images -q | xargs {{ docker_bin_dir }}/docker inspect -f \"{{ '{{' }} if .RepoTags {{ '}}' }}{{ '{{' }} (index .RepoTags 0) {{ '}}' }}{{ '{{' }} end {{ '}}' }}{{ '{{' }} if .RepoDigests {{ '}}' }},{{ '{{' }} (index .RepoDigests 0) {{ '}}' }}{{ '{{' }} end {{ '}}' }}\" | tr '\n' ','"
 
 downloads:
+  crictl:
+    container: false
+    file: true
+    enabled: true
+    version: "{{ crictl_version }}"
+    dest: "{{local_release_dir}}/crictl-{{ crictl_version }}-linux-{{ image_arch }}.tar.gz"
+    sha256: "{{ crictl_binary_checksum }}"
+    url: "{{ crictl_download_url }}"
+    unarchive: false
+    owner: "root"
+    mode: "0755"
+    groups:
+      - kube-node
+
   netcheck_server:
     enabled: "{{ deploy_netchecker }}"
     container: true

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -76,8 +76,7 @@ contiv_version: 1.2.1
 cilium_version: "v1.5.5"
 kube_ovn_version: "v0.6.0"
 kube_router_version: "v0.2.5"
-crictl_version: "v1.14.0"
-multus_version: "v3.1.autoconf"
+multus_version: "v3.2.1"
 
 crictl_version: "v1.15.0"
 

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -329,20 +329,6 @@ image_pull_command: "{{ docker_bin_dir }}/docker pull"
 image_info_command: "{{ docker_bin_dir }}/docker images -q | xargs {{ docker_bin_dir }}/docker inspect -f \"{{ '{{' }} if .RepoTags {{ '}}' }}{{ '{{' }} (index .RepoTags 0) {{ '}}' }}{{ '{{' }} end {{ '}}' }}{{ '{{' }} if .RepoDigests {{ '}}' }},{{ '{{' }} (index .RepoDigests 0) {{ '}}' }}{{ '{{' }} end {{ '}}' }}\" | tr '\n' ','"
 
 downloads:
-  crictl:
-    container: false
-    file: true
-    enabled: "{{ container_manager in ['crio', 'cri', 'containerd'] }}"
-    version: "{{ crictl_version }}"
-    dest: "{{local_release_dir}}/crictl-{{ crictl_version }}-linux-{{ image_arch }}.tar.gz"
-    sha256: "{{ crictl_binary_checksum }}"
-    url: "{{ crictl_download_url }}"
-    unarchive: false
-    owner: "root"
-    mode: "0755"
-    groups:
-      - k8s-cluster
-
   netcheck_server:
     enabled: "{{ deploy_netchecker }}"
     container: true

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -76,8 +76,8 @@ contiv_version: 1.2.1
 cilium_version: "v1.5.5"
 kube_ovn_version: "v0.6.0"
 kube_router_version: "v0.2.5"
-multus_version: "v3.2.1"
-crictl_version: "{{ kube_version | regex_replace('^v(?P<major>\\d+).(?P<minor>\\d+).(?P<patch>\\d+)$', 'v\\g<major>.\\g<minor>.0') }}"
+crictl_version: "v1.14.0"
+multus_version: "v3.1.autoconf"
 
 crictl_version: "v1.15.0"
 


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
It adds CRI-O support for ubuntu linux.
It also adds `crictl` as a download option

**Which issue(s) this PR fixes**:
Related to #4570 since it's also extracting `crictl` download into downloads role

**Special notes for your reviewer**:
https://launchpad.net/~projectatomic/+archive/ubuntu/ppa

They only have ubuntu 18 LTS in their distribution, just FYI

**Does this PR introduce a user-facing change?**:
NONE

```release-note
Added CRI-O support for Ubuntu 18
```
