### PR TITLE
Reduce VM size for Packet CI

### DIFF
--- a/tests/cloud_playbooks/roles/packet-ci/defaults/main.yml
+++ b/tests/cloud_playbooks/roles/packet-ci/defaults/main.yml
@@ -4,7 +4,7 @@
 vm_cpu_cores: 2
 vm_cpu_sockets: 1
 vm_cpu_threads: 2
-vm_memory: 4096Mi
+vm_memory: 2048Mi
 
 # Request/Limit allocation settings
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind flake

**What this PR does / why we need it**:
Some CI jobs have a lot of unallocated CPU or RAM resources, so we might as well reduce the VM size and allow for more parallel jobs.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
