### PR TITLE
Edit SecurityPolicy for cilium init container

### DIFF
--- a/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
@@ -35,6 +35,11 @@ spec:
           image: {{ cilium_init_image_repo }}:{{ cilium_init_image_tag }}
           imagePullPolicy: IfNotPresent
           command: ['sh', '-c', 'if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then rm -rf /var/run/cilium/state; rm -rf /sys/fs/bpf/tc/globals/cilium_*; fi']
+          securityContext:
+            capabilities:
+              add:
+              - NET_ADMIN
+            privileged: true
           volumeMounts:
             - name: bpf-maps
               mountPath: /sys/fs/bpf


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
Init container for cilium pods is supposed to work after setting CLEAN_CILIUM_STATE to true in cilium configmap. It needs changes in kubernetes securitypolicy, otherwise it will always fail. 
Fix has been already applied in cilium daemonset example, cilium/cilium#4994.
