### PR TITLE
Update downloads role to download to correct group

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -531,7 +531,7 @@ downloads:
     tag: "{{ coredns_image_tag }}"
     sha256: "{{ coredns_digest_checksum|default(None) }}"
     groups:
-      - kube-node
+      - kube-master
 
   nodelocaldns:
     enabled: "{{ enable_nodelocaldns }}"
@@ -540,7 +540,7 @@ downloads:
     tag: "{{ nodelocaldns_image_tag }}"
     sha256: "{{ nodelocaldns_digest_checksum|default(None) }}"
     groups:
-      - kube-node
+      - k8s-cluster
 
   dnsautoscaler:
     enabled: "{{ dns_mode in ['coredns', 'coredns_dual'] }}"
@@ -549,7 +549,7 @@ downloads:
     tag: "{{ dnsautoscaler_image_tag }}"
     sha256: "{{ dnsautoscaler_digest_checksum|default(None) }}"
     groups:
-      - kube-node
+      - kube-master
 
   busybox:
     enabled: "{{ kube_network_plugin in ['kube-router'] }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
CoreDNS is running on masters but is downloaded on nodes.
Nodelocaldns runs on all hosts but is only downloaded on nodes.
DNSautoscaler runs on masters but is downloaded on nodes.

**Which issue(s) this PR fixes**:
Fixes #4637
