### PR TITLE
Fix python syntax in Terraform dynamic inventory

### DIFF
--- a/contrib/terraform/terraform.py
+++ b/contrib/terraform/terraform.py
@@ -157,7 +157,7 @@ def packet_device(resource, tfvars=None):
 
     attrs = {
         'id': raw_attrs['id'],
-        'facilities': parse_list(raw_attrs, 'facilities']),
+        'facilities': parse_list(raw_attrs, 'facilities'),
         'hostname': raw_attrs['hostname'],
         'operating_system': raw_attrs['operating_system'],
         'locked': parse_bool(raw_attrs['locked']),


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
Bug introduced by #4617

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
