### PR TITLE
Fix dynamic inventory parsing in contrib/tf/packet

### DIFF
--- a/.gitlab-ci/terraform.yml
+++ b/.gitlab-ci/terraform.yml
@@ -33,6 +33,8 @@
   extends: .terraform_install
   stage: deploy-part2
   when: manual
+  variables:
+    ANSIBLE_INVENTORY_UNPARSED_FAILED: "true"
   script:
     - terraform apply -auto-approve ../../contrib/terraform/$PROVIDER
     - ansible-playbook -i hosts ../../cluster.yml --become
@@ -73,7 +75,7 @@ tf-packet-ubuntu16-default:
     TF_VAR_number_of_k8s_nodes: "1"
     TF_VAR_plan_k8s_masters: t1.small.x86
     TF_VAR_plan_k8s_nodes: t1.small.x86
-    TF_VAR_facilities: '["ewr1"]'
+    TF_VAR_facility: ewr1
     TF_VAR_public_key_path: ""
     TF_VAR_operating_system: ubuntu_16_04
 
@@ -88,7 +90,7 @@ tf-packet-ubuntu18-default:
     TF_VAR_number_of_k8s_nodes: "1"
     TF_VAR_plan_k8s_masters: t1.small.x86
     TF_VAR_plan_k8s_nodes: t1.small.x86
-    TF_VAR_facilities: '["ams1"]'
+    TF_VAR_facility: ams1
     TF_VAR_public_key_path: ""
     TF_VAR_operating_system: ubuntu_18_04
 

--- a/contrib/terraform/packet/kubespray.tf
+++ b/contrib/terraform/packet/kubespray.tf
@@ -15,7 +15,7 @@ resource "packet_device" "k8s_master" {
   count            = "${var.number_of_k8s_masters}"
   hostname         = "${var.cluster_name}-k8s-master-${count.index+1}"
   plan             = "${var.plan_k8s_masters}"
-  facilities       = "${var.facilities}"
+  facilities       = ["${var.facility}"]
   operating_system = "${var.operating_system}"
   billing_cycle    = "${var.billing_cycle}"
   project_id       = "${var.packet_project_id}"
@@ -28,7 +28,7 @@ resource "packet_device" "k8s_master_no_etcd" {
   count            = "${var.number_of_k8s_masters_no_etcd}"
   hostname         = "${var.cluster_name}-k8s-master-${count.index+1}"
   plan             = "${var.plan_k8s_masters_no_etcd}"
-  facilities       = "${var.facilities}"
+  facilities       = ["${var.facility}"]
   operating_system = "${var.operating_system}"
   billing_cycle    = "${var.billing_cycle}"
   project_id       = "${var.packet_project_id}"
@@ -41,7 +41,7 @@ resource "packet_device" "k8s_etcd" {
   count            = "${var.number_of_etcd}"
   hostname         = "${var.cluster_name}-etcd-${count.index+1}"
   plan             = "${var.plan_etcd}"
-  facilities       = "${var.facilities}"
+  facilities       = ["${var.facility}"]
   operating_system = "${var.operating_system}"
   billing_cycle    = "${var.billing_cycle}"
   project_id       = "${var.packet_project_id}"
@@ -54,7 +54,7 @@ resource "packet_device" "k8s_node" {
   count            = "${var.number_of_k8s_nodes}"
   hostname         = "${var.cluster_name}-k8s-node-${count.index+1}"
   plan             = "${var.plan_k8s_nodes}"
-  facilities       = "${var.facilities}"
+  facilities       = ["${var.facility}"]
   operating_system = "${var.operating_system}"
   billing_cycle    = "${var.billing_cycle}"
   project_id       = "${var.packet_project_id}"

--- a/contrib/terraform/packet/sample-inventory/cluster.tf
+++ b/contrib/terraform/packet/sample-inventory/cluster.tf
@@ -10,7 +10,7 @@ packet_project_id = "Example-API-Token"
 public_key_path = "~/.ssh/id_rsa.pub"
 
 # cluster location
-facilities = ["ewr1"]
+facility = "ewr1"
 
 # standalone etcds
 number_of_etcd = 0

--- a/contrib/terraform/packet/variables.tf
+++ b/contrib/terraform/packet/variables.tf
@@ -19,8 +19,8 @@ variable "billing_cycle" {
   default = "hourly"
 }
 
-variable "facilities" {
-  default = ["dfw2"]
+variable "facility" {
+  default = "dfw2"
 }
 
 variable "plan_k8s_masters" {

--- a/contrib/terraform/terraform.py
+++ b/contrib/terraform/terraform.py
@@ -178,7 +178,6 @@ def packet_device(resource, tfvars=None):
     }
 
     # add groups based on attrs
-    groups.append('packet_facilities=' + attrs['facilities'])
     groups.append('packet_operating_system=' + attrs['operating_system'])
     groups.append('packet_locked=%s' % attrs['locked'])
     groups.append('packet_state=' + attrs['state'])


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind failing-test

**What this PR does / why we need it**:
This is a combination of a failing test fix and a backwards compatible variable.
#4617 introduces 2 problems:
- `tf-packet` tests fail due to a type, see [test output](https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/201838061). 
- the input variable `facility` was renamed to `facilities` which is a breaking change for existing users. Since it's not advised to do cross datacenter K8s cluster anyway, we are better off sticking to a single DC support.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
