### PR TITLE
Fix GCE tests with undefined CI_PLATFORM

### DIFF
--- a/.gitlab-ci/gce.yml
+++ b/.gitlab-ci/gce.yml
@@ -59,7 +59,7 @@ gce_centos7-flannel-addons:
 
 gce_centos-weave-kubeadm-sep:
   stage: deploy-gce
-  <<: *gce
+  extends: .gce
   variables:
     <<: *centos_weave_kubeadm_variables
   when: on_success
@@ -126,7 +126,7 @@ gce_ubuntu-flannel-ha:
 
 gce_centos-weave-kubeadm-triggers:
   stage: deploy-gce
-  <<: *gce
+  extends: .gce
   variables:
     <<: *centos_weave_kubeadm_variables
   when: on_success
@@ -227,7 +227,7 @@ gce_centos7-kube-router:
 
 gce_centos7-multus-calico:
   stage: deploy-gce
-  <<: *gce
+  extends: .gce
   variables:
     <<: *centos7_multus_calico_variables
   when: manual


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind failing-test

**What this PR does / why we need it**:
Upgrade tests fail due to undefined CI_PLATFORM caused by the `variables` to be overwritten instead of being merged.

See https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/201897456

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
