### PR TITLE
Git checkout a specific version for testing upgrades

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,7 +36,9 @@ before_script:
 .job: &job
   tags:
     - packet
-  image: quay.io/kubespray/kubespray:v2.9.0
+  variables:
+    KUBESPRAY_VERSION: v2.9.0
+  image: quay.io/kubespray/kubespray:$KUBESPRAY_VERSION
 
 .testcases: &testcases
   <<: *job

--- a/tests/scripts/testcases_run.sh
+++ b/tests/scripts/testcases_run.sh
@@ -10,7 +10,7 @@ echo ${PWD}
 cd tests && make create-${CI_PLATFORM} -s ; cd -
 
 # Check out latest tag if testing upgrade
-test "${UPGRADE_TEST}" != "false" && git fetch --all && git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
+test "${UPGRADE_TEST}" != "false" && git fetch --all && git checkout "$KUBESPRAY_VERSION"
 # Checkout the CI vars file so it is available
 test "${UPGRADE_TEST}" != "false" && git checkout "${CI_BUILD_REF}" tests/files/${CI_JOB_NAME}.yml
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind failing-test

**What this PR does / why we need it**:
Upgrade tests fail because 2.8.5 was released after 2.9.0 and the `git rev-list` snippet selects the latest release. Therefore Kubeadm fails because it doesn't want to upgrade from 1.12 to 1.14.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
