### PR TITLE
Remove RHEL from packet deploy

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -80,24 +80,10 @@ packet_ubuntu-cilium-sep:
   except: ['triggers']
   only: ['master', /^pr-.*$/]
 
-packet_rhel7-weave:
-  stage: deploy-part2
-  <<: *packet
-  when: manual
-  except: ['triggers']
-  only: ['master', /^pr-.*$/]
-
 packet_debian9-calico-upgrade:
   stage: deploy-part2
   <<: *packet
   when: on_success
-  except: ['triggers']
-  only: ['master', /^pr-.*$/]
-
-packet_rhel7-canal-sep:
-  stage: deploy-special
-  <<: *packet
-  when: manual
   except: ['triggers']
   only: ['master', /^pr-.*$/]
 

--- a/tests/files/packet_rhel7-canal-sep.yml
+++ b/tests/files/packet_rhel7-canal-sep.yml
@@ -1,9 +1,0 @@
----
-# Instance settings
-cloud_image: rhel-server-7
-mode: separate
-
-# Kubespray settings
-kube_network_plugin: canal
-deploy_netchecker: true
-dns_min_replicas: 1

--- a/tests/files/packet_rhel7-weave.yml
+++ b/tests/files/packet_rhel7-weave.yml
@@ -1,9 +1,0 @@
----
-# Instance settings
-cloud_image: rhel-server-7
-mode: default
-
-# Kubespray settings
-kube_network_plugin: weave
-deploy_netchecker: true
-dns_min_replicas: 1


### PR DESCRIPTION
/kind bug

We can't deploy RHEL on packet. I have another PR to remove packet rhel cilium job.