### PR TITLE
Fix nodeselectors for contiv and nginx-ingress

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s-cluster/addons.yml
@@ -79,7 +79,7 @@ rbd_provisioner_enabled: false
 ingress_nginx_enabled: false
 # ingress_nginx_host_network: false
 # ingress_nginx_nodeselector:
-#   node-role.kubernetes.io/node: ""
+#   beta.kubernetes.io/os: "linux": ""
 # ingress_nginx_tolerations:
 #   - key: "node-role.kubernetes.io/master"
 #     operator: "Equal"

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
@@ -2,7 +2,7 @@
 ingress_nginx_namespace: "ingress-nginx"
 ingress_nginx_host_network: false
 ingress_nginx_nodeselector:
-  node-role.kubernetes.io/node: ""
+  beta.kubernetes.io/os: "linux"
 ingress_nginx_tolerations: []
 ingress_nginx_insecure_port: 80
 ingress_nginx_secure_port: 443

--- a/roles/network_plugin/contiv/templates/contiv-etcd-proxy.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-etcd-proxy.yml.j2
@@ -20,8 +20,13 @@ spec:
 {% endif %}
       hostNetwork: true
       hostPID: true
-      nodeSelector:
-        node-role.kubernetes.io/node: ""
+      affinity:
+       nodeAffinity:
+         requiredDuringSchedulingIgnoredDuringExecution:
+           nodeSelectorTerms:
+           - matchExpressions:
+             - key: node-role.kubernetes.io/master
+               operator: DoesNotExist
       containers:
         - name: contiv-etcd-proxy
           image: {{ contiv_etcd_image_repo }}:{{ contiv_etcd_image_tag }}

--- a/tests/files/packet_centos7-flannel-addons.yml
+++ b/tests/files/packet_centos7-flannel-addons.yml
@@ -6,6 +6,7 @@ mode: ha
 # Kubespray settings
 kubeadm_control_plane: true
 kubeadm_certificate_key: 3998c58db6497dd17d909394e62d515368c06ec617710d02edea31c06d741085
+kube_proxy_mode: iptables
 kube_network_plugin: flannel
 helm_enabled: true
 kubernetes_audit: true


### PR DESCRIPTION
/kind bug

Fixed contiv to use affinity rule to schedule its etcd proxy on non-masters
nginx-ingress changed its default nodeselector to use any node.