### PR TITLE
create-infrastructure.tf: create local.my_avail_zones

### DIFF
--- a/contrib/terraform/aws/create-infrastructure.tf
+++ b/contrib/terraform/aws/create-infrastructure.tf
@@ -161,6 +161,7 @@ data "template_file" "inventory" {
     list_node                 = "${join("\n",aws_instance.k8s-worker.*.tags.Name)}"
     list_etcd                 = "${join("\n",aws_instance.k8s-etcd.*.tags.Name)}"
     elb_api_fqdn              = "apiserver_loadbalancer_domain_name=\"${module.aws-elb.aws_elb_api_fqdn}\""
+    ansible_user              = "${var.ansible_user}"
   }
 }
 

--- a/contrib/terraform/aws/templates/inventory.tpl
+++ b/contrib/terraform/aws/templates/inventory.tpl
@@ -5,7 +5,7 @@ ${connection_strings_etcd}
 ${public_ip_address_bastion}
 
 [bastion]
-${public_ip_address_bastion}
+${public_ip_address_bastion} ansible_user=${ansible_user}
 
 [kube-master]
 ${list_master}

--- a/contrib/terraform/aws/terraform.tfvars
+++ b/contrib/terraform/aws/terraform.tfvars
@@ -32,5 +32,5 @@ default_tags = {
 #  Product = "kubernetes"
 }
 
-ansible_user   = "ubuntu"
+ansible_user   = "core"
 inventory_file = "../../../inventory/hosts"

--- a/contrib/terraform/aws/terraform.tfvars
+++ b/contrib/terraform/aws/terraform.tfvars
@@ -32,4 +32,5 @@ default_tags = {
 #  Product = "kubernetes"
 }
 
+ansible_user   = "ubuntu"
 inventory_file = "../../../inventory/hosts"

--- a/contrib/terraform/aws/variables.tf
+++ b/contrib/terraform/aws/variables.tf
@@ -104,6 +104,10 @@ variable "default_tags" {
   type        = "map"
 }
 
+variable "ansible_user" {
+  description = "User ansible is run under"
+}
+
 variable "inventory_file" {
   description = "Where to store the generated inventory file"
 }


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
If you want to change number of availability zones, now it's in one place instead of 6.
ie `my_avail_zones = "${slice(data.aws_availability_zones.available.names,0,2)}"` uses two availability zones. Changing this to `my_avail_zones = "${slice(data.aws_availability_zones.available.names,0,3)}"` changes it to use three availability zones.

**Does this PR introduce a user-facing change?**:
NONE

```release-note
Without this it's easy to miss one of the six hard-coded locations and have a miss-match, which happened to me and why I am submitting this.
```
