### PR TITLE
Fix download delegate and check for rsync

### DIFF
--- a/roles/download/tasks/download_prep.yml
+++ b/roles/download/tasks/download_prep.yml
@@ -23,7 +23,7 @@
     path: "{{local_release_dir}}/containers"
     state: directory
     recurse: yes
-  delegate_to: localhost
+  delegate_to: "{{ download_delegate }}"
   delegate_facts: false
   become: false
   run_once: true

--- a/roles/download/tasks/sync_container.yml
+++ b/roles/download/tasks/sync_container.yml
@@ -74,7 +74,7 @@
   file:
     state: directory
     path: "{{ fname | dirname }}"
-  delegate_to: localhost
+  delegate_to: "{{ download_delegate }}"
   delegate_facts: no
   run_once: true
   become: false
@@ -94,7 +94,7 @@
     use_ssh_args: "{{ has_bastion | default(false) }}"
     mode: pull
     private_key: "{{ ansible_ssh_private_key_file }}"
-  delegate_to: localhost
+  delegate_to: "{{ download_delegate }}"
   delegate_facts: no
   run_once: true
   become: false
@@ -113,7 +113,7 @@
     dest: "{{ fname }}"
     use_ssh_args: "{{ has_bastion | default(false) }}"
     mode: push
-  delegate_to: localhost
+  delegate_to: "{{ download_delegate }}"
   delegate_facts: no
   become: true
   register: get_task

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -206,6 +206,7 @@
   run_once: true
 
 - name: "Stop if rsync is not installed on {{ download_delegate }}"
+  # noqa 303 - We need to check for the rsync command here
   command: rsync --version
   delegate_to: "{{ download_delegate }}"
   become: true

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -204,3 +204,14 @@
     msg: "resolvconf_mode can only be 'docker_dns', 'host_resolvconf' or 'none'"
   when: resolvconf_mode is defined
   run_once: true
+
+- name: "Stop if rsync is not installed on {{ download_delegate }}"
+  command: rsync --version
+  delegate_to: "{{ download_delegate }}"
+  become: true
+  run_once: true
+  when:
+    - not skip_downloads|default(false)
+    - (ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"] and
+      inventory_hostname != download_delegate or
+      download_delegate == "localhost")


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Download delegate was hardcoded to localhost.
Synchronize module used in downloads are required on the download delegate host to work so add a pre-check for it.

**Which issue(s) this PR fixes**:
Fixes #4683
