### PR TITLE
Make Kubeconfig uses load balancer DNS instead of IP

### DIFF
--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -2,19 +2,22 @@
 - name: Set external kube-apiserver endpoint
   set_fact:
     external_apiserver_address: >-
-      {%- if loadbalancer_apiserver is defined and loadbalancer_apiserver.address is defined -%}
+      {%- if loadbalancer_apiserver is defined and apiserver_loadbalancer_domain_name is defined -%}
+      {{ apiserver_loadbalancer_domain_name }}
+      {%- elif loadbalancer_apiserver is defined and loadbalancer_apiserver.address is defined -%}
       {{ loadbalancer_apiserver.address }}
       {%- else -%}
       {{ kube_apiserver_access_address }}
       {%- endif -%}
     external_apiserver_port: >-
       {%- if loadbalancer_apiserver is defined and loadbalancer_apiserver.address is defined and loadbalancer_apiserver.port is defined -%}
-      {{ loadbalancer_apiserver.port|default(kube_apiserver_port) }}
+      {{ loadbalancer_apiserver.port }}
       {%- else -%}
       {{ kube_apiserver_port }}
       {%- endif -%}
   tags:
     - facts
+  when: kubeadm_version is version('v1.14.0', '<')
 
 - name: Create kube config dir
   file:
@@ -57,14 +60,15 @@
     {% if kubeadm_version is version('v1.14.0', '>=') %}
     kubeconfig admin
     --kubeconfig-dir {{ kube_config_dir }}/external_kubeconfig
+    --config={{ kube_config_dir }}/kubeadm-config.yaml
     {% else %}
     kubeconfig user
     --client-name kubernetes-admin
     --org system:masters
-    {% endif %}
     --cert-dir {{ kube_cert_dir }}
     --apiserver-advertise-address {{ external_apiserver_address }}
     --apiserver-bind-port {{ external_apiserver_port }}
+    {% endif %}
     {% if kubeadm_version is version('v1.14.0', '>=') %}
     >/dev/null && cat {{ kube_config_dir }}/external_kubeconfig/admin.conf &&
     rm -rf {{ kube_config_dir }}/external_kubeconfig


### PR DESCRIPTION
In a HA setup, when generating kubeconfig on the host running ansible (`kubeconfig_localhost = true`), kubectl fails to connect to the API server because the TLS certificate of the api server doesn't include the IP of the load balancer, only the DNS:

```
Unable to connect to the server: x509: certificate is valid for 192.168.1.1, <master1-ip>, 192.168.1.1, 127.0.0.1, <master1-ip>, <master3-ip>, <master2-ip>, not <lb-ip>
```

```
[kubeconfig] Writing "admin.conf" kubeconfig file
apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: <cert base64 data>
    server: https://<lb-ip>:<lb-port>
  name: kubernetes
```

```shell
$ openssl x509 -text -noout -in /etc/kubernetes/ssl/apiserver.crt | grep DNS | sed 's/,/\n/g' | sed -e 's/^[ \t]*//'
DNS:<master1-dns>
DNS:kubernetes
DNS:kubernetes.default
DNS:kubernetes.default.svc
DNS:kubernetes.default.svc.cluster.local
DNS:<lb-dns>
DNS:kubernetes
DNS:kubernetes.default
DNS:kubernetes.default.svc
DNS:kubernetes.default.svc.cluster.local
DNS:localhost
DNS:<master1-dns>
DNS:<master2-dns>
DNS:<master3-dns>
DNS:<lb-dns>
IP Address:192.168.1.1
IP Address:<master1-ip>
IP Address:192.168.1.1
IP Address:127.0.0.1
IP Address:<master1-ip>
IP Address:<master2-ip>
IP Address:<master3-ip>
```

There are some duplicate entries in the list, they are all the same across the master nodes. The load balancer IP address is missing and its DNS is listed twice. I think there is an underlying issue.

This PR is addressing the `<lb-dns>` vs `<lb-ip>` aspect, using the former in the kubeconfig instead of the latter.

In Kubernetes 1.14, we can directly use the kubeadm-config.yaml generated in earlier tasks to generate the kubeconfig, leading on an easier workflow. I kept the current workflow intact for all the < 1.14 use cases.