### PR TITLE
Add k8s_external plugin to CoreDNS configuration

### DIFF
--- a/docs/vars.md
+++ b/docs/vars.md
@@ -61,6 +61,10 @@ following default cluster parameters:
   bits in kube_pods_subnet dictates how many kube-nodes can be in cluster.
 * *skydns_server* - Cluster IP for DNS (default is 10.233.0.3)
 * *skydns_server_secondary* - Secondary Cluster IP for CoreDNS used with coredns_dual deployment (default is 10.233.0.4)
+* *enable_coredns_k8s_external* - If enabled, it configures the [k8s_external plugin](https://coredns.io/plugins/k8s_external/)
+  on the CoreDNS service.
+* *coredns_k8s_external_zone* - Zone that will be used when CoreDNS k8s_external plugin is enabled
+  (default is k8s_external.local)
 * *cloud_provider* - Enable extra Kubelet option if operating inside GCE or
   OpenStack (default is unset)
 * *kube_hostpath_dynamic_provisioner* - Required for use of PetSets type in

--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -135,6 +135,9 @@ dns_mode: coredns
 enable_nodelocaldns: true
 nodelocaldns_ip: 169.254.25.10
 nodelocaldns_health_port: 9254
+# Enable k8s_external plugin for CoreDNS
+enable_coredns_k8s_external: false
+coredns_k8s_external_zone: k8s_external.local
 
 # Can be docker_dns, host_resolvconf or none
 resolvconf_mode: docker_dns

--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -31,6 +31,9 @@ data:
           prefer_udp
         }
 {% endif %}
+{% if enable_coredns_k8s_external %}
+        k8s_external {{ coredns_k8s_external_zone }}
+{% endif %}
         cache 30
         loop
         reload

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -89,6 +89,8 @@ kube_dns_servers:
 
 dns_servers: "{{kube_dns_servers[dns_mode]}}"
 
+enable_coredns_k8s_external: false
+coredns_k8s_external_zone: k8s_external.local
 
 # Kubernetes configuration dirs and system namespace.
 # Those are where all the additional config stuff goes


### PR DESCRIPTION
/kind feature

There is a [k8s_external plugin](https://coredns.io/plugins/k8s_external/) for CoreDNS which, in my scenario (I am self-hosting with MetalLB) is very handy.

It makes sense to configure that at orchestration, with kubespray, while deploying the cluster. Given that the basic configuration (which should suit almost all scenarios) is very small, the changes required are minimal.

This PR introduces a user-facing change, which is explained in the `docs/vars.md`.