### PR TITLE
Minor cleanups of CoreDNS issues and CI job

### DIFF
--- a/docs/dns-stack.md
+++ b/docs/dns-stack.md
@@ -118,6 +118,8 @@ Setting ``enable_nodelocaldns`` to ``true`` will make pods reach out to the dns 
 
 More information on the rationale behind this implementation can be found [here](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/0030-nodelocal-dns-cache.md).
 
+**As per the 2.10 release, Nodelocal DNS cache is enabled by default.**
+
 
 Limitations
 -----------

--- a/docs/dns-stack.md
+++ b/docs/dns-stack.md
@@ -114,7 +114,7 @@ The only exception is that ``hostNetwork: true`` PODs and non-k8s managed contai
 cluster service names.
 
 ## Nodelocal DNS cache
-Setting ``enable_nodelocaldns`` to ``true`` will make pods reach out to the dns (core-dns) caching agent running on the same node, thereby avoiding iptables DNAT rules and connection tracking. The local caching agent will query kube-dns / core-dns (depending on what main DNS plugin is configured in your cluster) for cache misses of cluster hostnames(cluster.local suffix by default).
+Setting ``enable_nodelocaldns`` to ``true`` will make pods reach out to the dns (core-dns) caching agent running on the same node, thereby avoiding iptables DNAT rules and connection tracking. The local caching agent will query core-dns (depending on what main DNS plugin is configured in your cluster) for cache misses of cluster hostnames(cluster.local suffix by default).
 
 More information on the rationale behind this implementation can be found [here](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/0030-nodelocal-dns-cache.md).
 
@@ -129,9 +129,7 @@ Limitations
 
 * There is
   [no way to specify a custom value](https://github.com/kubernetes/kubernetes/issues/33554)
-  for the SkyDNS ``ndots`` param via an
-  [option for KubeDNS](https://github.com/kubernetes/kubernetes/blob/master/cmd/kube-dns/app/options/options.go)
-  add-on, while SkyDNS supports it though.
+  for the SkyDNS ``ndots`` param.
 
 * the ``searchdomains`` have a limitation of a 6 names and 256 chars
   length. Due to default ``svc, default.svc`` subdomains, the actual

--- a/inventory/sample/group_vars/k8s-cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s-cluster/addons.yml
@@ -94,7 +94,7 @@ ingress_nginx_enabled: false
 # ingress_nginx_configmap_tcp_services:
 #   9000: "default/example-go:8080"
 # ingress_nginx_configmap_udp_services:
-#   53: "kube-system/kube-dns:53"
+#   53: "kube-system/coredns:53"
 
 # Cert manager deployment
 cert_manager_enabled: false

--- a/roles/kubernetes-apps/ansible/tasks/cleanup_dns.yml
+++ b/roles/kubernetes-apps/ansible/tasks/cleanup_dns.yml
@@ -7,6 +7,16 @@
     resource: "deploy"
     state: absent
   when:
-    - kubeadm_init is defined
-    - kubeadm_init.changed|default(false)
+    - dns_mode in ['coredns', 'coredns_dual']
+    - inventory_hostname == groups['kube-master'][0]
+
+- name: Kubernetes Apps | Delete kubeadm Kube-DNS service
+  kube:
+    name: "kube-dns"
+    namespace: "kube-system"
+    kubectl: "{{ bin_dir }}/kubectl"
+    resource: "svc"
+    state: absent
+  when:
+    - dns_mode in ['coredns', 'coredns_dual']
     - inventory_hostname == groups['kube-master'][0]

--- a/roles/kubernetes-apps/rotate_tokens/tasks/main.yml
+++ b/roles/kubernetes-apps/rotate_tokens/tasks/main.yml
@@ -34,7 +34,7 @@
     {{ bin_dir }}/kubectl --kubeconfig /etc/kubernetes/admin.conf get secrets --all-namespaces
     -o 'jsonpath={range .items[*]}{"\n"}{.metadata.namespace}{" "}{.metadata.name}{" "}{.type}{end}'
     | grep kubernetes.io/service-account-token
-    | egrep 'default-token|kube-proxy|kube-dns|netchecker|weave|calico|canal|flannel|dashboard|cluster-proportional-autoscaler|tiller|local-volume-provisioner'
+    | egrep 'default-token|kube-proxy|coredns|netchecker|weave|calico|canal|flannel|dashboard|cluster-proportional-autoscaler|tiller|local-volume-provisioner'
   register: tokens_to_delete
   when: needs_rotation
 

--- a/tests/files/packet_centos7-flannel-addons.yml
+++ b/tests/files/packet_centos7-flannel-addons.yml
@@ -18,7 +18,8 @@ dns_min_replicas: 1
 kube_encrypt_secret_data: true
 ingress_nginx_enabled: true
 cert_manager_enabled: true
-metrics_server_enabled: true
+# Disable as health checks are still unstable and slow to respond.
+metrics_server_enabled: false
 metrics_server_kubelet_insecure_tls: true
 kube_token_auth: true
 kube_basic_auth: true


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind cleanup
/kind failing-test

**What this PR does / why we need it**:
- The `cleanup_dns` task was not run because of it's when conditions.
- CoreDNS deployment deleted the `kube-dns` service as it's deployed even though you skip the coredns phase as we do.
- Metrics-Server is disabled again because the health endpoint is slow to respond sometimes, so CI jobs fails.
- Rotate tokens check was checking for kube-dns and not coredns tokens.