### PR TITLE
Run TF tests from repo root

### DIFF
--- a/.gitlab-ci/terraform.yml
+++ b/.gitlab-ci/terraform.yml
@@ -9,10 +9,9 @@
     # Set Ansible config
     - cp ansible.cfg ~/.ansible.cfg
     # Prepare inventory
-    - cp -LRp contrib/terraform/$PROVIDER/sample-inventory inventory/$CLUSTER
-    - cd inventory/$CLUSTER
-    - ln -s ../../contrib/terraform/$PROVIDER/hosts
-    - terraform init ../../contrib/terraform/$PROVIDER
+    - cp contrib/terraform/$PROVIDER/sample-inventory/cluster.tf .
+    - ln -s contrib/terraform/$PROVIDER/hosts
+    - terraform init contrib/terraform/$PROVIDER
     # Copy SSH keypair
     - mkdir -p ~/.ssh
     - echo "$PACKET_PRIVATE_KEY" | base64 -d > ~/.ssh/id_rsa
@@ -24,8 +23,8 @@
   stage: unit-tests
   only: ['master', /^pr-.*$/]
   script:
-    - terraform validate -var-file=cluster.tf ../../contrib/terraform/$PROVIDER
-    - terraform fmt -check -diff ../../contrib/terraform/$PROVIDER
+    - terraform validate -var-file=cluster.tf contrib/terraform/$PROVIDER
+    - terraform fmt -check -diff contrib/terraform/$PROVIDER
 
 .terraform_apply:
   extends: .terraform_install
@@ -37,8 +36,9 @@
     ANSIBLE_INVENTORY: hosts
     CI_PLATFORM: tf
   script:
-    - cd ../../tests && make create-${CI_PLATFORM} -s ; cd -
-    - ansible-playbook ../../cluster.yml --become
+    - cd tests && make create-${CI_PLATFORM} -s ; cd -
+    - ansible-playbook cluster.yml --become
+    # - tests/scripts/testcases_prepare.sh
   after_script:
     # Cleanup regardless of exit code
     - ./tests/scripts/testcases_cleanup.sh

--- a/tests/scripts/create-tf.sh
+++ b/tests/scripts/create-tf.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -euxo pipefail
 
-cd "../inventory/$CLUSTER"
-terraform apply -auto-approve "../../contrib/terraform/$PROVIDER"
+cd ..
+terraform apply -auto-approve "contrib/terraform/$PROVIDER"

--- a/tests/scripts/delete-tf.sh
+++ b/tests/scripts/delete-tf.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -euxo pipefail
 
-cd "../inventory/$CLUSTER"
-terraform destroy -auto-approve "../../contrib/terraform/$PROVIDER"
+cd ..
+terraform destroy -auto-approve "contrib/terraform/$PROVIDER"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Running TF tests from the repo root instead of `inventory/` folder makes CI more consistent and standardized.