### PR TITLE
Use standard testcases job for TF CI

### DIFF
--- a/.gitlab-ci/terraform.yml
+++ b/.gitlab-ci/terraform.yml
@@ -36,10 +36,7 @@
     ANSIBLE_INVENTORY: hosts
     CI_PLATFORM: tf
   script:
-    - cd tests && make create-${CI_PLATFORM} -s ; cd -
-    - ansible-playbook tests/cloud_playbooks/wait-for-ssh.yml
-    - ansible-playbook cluster.yml --become
-    # - tests/scripts/testcases_prepare.sh
+    - tests/scripts/testcases_run.sh
   after_script:
     # Cleanup regardless of exit code
     - ./tests/scripts/testcases_cleanup.sh
@@ -106,7 +103,7 @@ tf-packet-ubuntu18-default:
   OS_INTERFACE: public
   OS_IDENTITY_API_VERSION: "3"
 
-tf-apply-ovh:
+tf-ovh_ubuntu18-calico:
   extends: .terraform_apply
   when: on_success
   variables:
@@ -115,6 +112,7 @@ tf-apply-ovh:
     PROVIDER: openstack
     CLUSTER: $CI_COMMIT_REF_NAME
     ANSIBLE_TIMEOUT: "60"
+    SSH_USER: ubuntu
     TF_VAR_cluster_name: $CI_COMMIT_REF_SLUG
     TF_VAR_number_of_k8s_masters: "0"
     TF_VAR_number_of_k8s_masters_no_floating_ip: "1"

--- a/tests/files/tf-ovh_ubuntu18-calico.yml
+++ b/tests/files/tf-ovh_ubuntu18-calico.yml
@@ -1,0 +1,3 @@
+---
+dns_min_replicas: 1
+deploy_netchecker: true

--- a/tests/testcases/010_check-apiserver.yml
+++ b/tests/testcases/010_check-apiserver.yml
@@ -4,8 +4,8 @@
   tasks:
   - name: Check the API servers are responding
     uri:
-      url: "https://{{ access_ip | default(ansible_default_ipv4.address) }}:{{ kube_apiserver_port }}/api/v1"
+      url: "https://{{ access_ip | default(ansible_default_ipv4.address) }}:{{ kube_apiserver_port | default(6443) }}/api/v1"
       user: kube
-      password: "{{ lookup('password', credentials_dir + '/kube_user.creds length=15 chars=ascii_letters,digits') }}"
+      password: "{{ lookup('password', credentials_dir | default(inventory_dir + '/credentials') + '/kube_user.creds length=15 chars=ascii_letters,digits') }}"
       validate_certs: no
       status_code: 200,401,403


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Use standard testcases scripts for TF based CI jobs to reduce code duplication.

**Special notes for your reviewer**:
In the long run the idea is to replace `gce_coreos` by a OVH+Terraform CI job since we have problems to run CoreOS in KubeVirt