### PR TITLE
Ignore 2 ansible-lint rules (E204, E701) on purpose.

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,12 +3,24 @@ parseable: true
 skip_list:
   # see https://docs.ansible.com/ansible-lint/rules/default_rules.html for a list of all default rules
   # The following rules throw errors.
-  # These either still need to be corrected in the repository and the rules re-enabled or they are skipped on purpose.
-  - '204'
+  # These either still need to be corrected in the repository and the rules re-enabled or documented why they are skipped on purpose.
   - '301'
   - '305'
   - '306'
   - '404'
   - '502'
   - '503'
+
+  # These rules are intentionally skipped:
+  #
+  # [E204]: "Lines should be no longer than 160 chars"
+  # This could be re-enabled with a major rewrite in the future.
+  # For now, there's not enough value gain from strictly limiting line length.
+  # (Disabled in May 2019)
+  - '204'
+
+  # [E701]: "meta/main.yml should contain relevant info"
+  # Roles in Kubespray are not intended to be used/imported by Ansible Galaxy.
+  # While it can be useful to have these metadata available, they are also available in the existing documentation.
+  # (Disabled in May 2019)
   - '701'


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation


**What this PR does / why we need it**:

Documents why 2 of the ansible-lint checks are deactivated on purpose.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #3961 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
