### PR TITLE
added the ability to define and deploy multiple address pools to metallb

### DIFF
--- a/contrib/metallb/README.md
+++ b/contrib/metallb/README.md
@@ -6,5 +6,7 @@ This playbook aims to automate [this](https://metallb.universe.tf/tutorial/layer
 
 ## Install
 ```
+Defaults can be found in contrib/metallb/roles/provision/defaults/main.yml. You can override the defaults by copying the contents of this file to somewhere in inventory/mycluster/group_vars such as inventory/mycluster/groups_vars/k8s-cluster/addons.yml and making any adjustments as required.
+
 ansible-playbook --ask-become -i inventory/sample/hosts.ini contrib/metallb/metallb.yml
 ```

--- a/contrib/metallb/roles/provision/defaults/main.yml
+++ b/contrib/metallb/roles/provision/defaults/main.yml
@@ -1,6 +1,12 @@
 ---
 metallb:
   ip_range: "10.5.0.50-10.5.0.99"
+  protocol: "layer2"
+  # additional_address_pools:
+  #   kube_service_pool:
+  #     ip_range: "10.5.1.50-10.5.1.99"
+  #     protocol: "layer2"
+  #     auto_assign: false
   limits:
     cpu: "100m"
     memory: "100Mi"

--- a/contrib/metallb/roles/provision/templates/metallb-config.yml.j2
+++ b/contrib/metallb/roles/provision/templates/metallb-config.yml.j2
@@ -8,6 +8,14 @@ data:
   config: |
     address-pools:
     - name: loadbalanced
-      protocol: layer2
+      protocol: {{ metallb.protocol }}
       addresses:
       - {{ metallb.ip_range }}
+{% if metallb.additional_address_pools is defined %}{% for pool in metallb.additional_address_pools %}
+    - name: {{ pool }}
+      protocol: {{ metallb.additional_address_pools[pool].protocol }}
+      addresses:
+      - {{ metallb.additional_address_pools[pool].ip_range }}
+      auto-assign: {{ metallb.additional_address_pools[pool].auto_assign }}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
Small enhancement to allow users to define additional address pools for their metallb deployment

**Which issue(s) this PR fixes**:
Fixes #4706

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```