### PR TITLE
Add tf-ovh_coreos CI job

### DIFF
--- a/.gitlab-ci/terraform.yml
+++ b/.gitlab-ci/terraform.yml
@@ -35,6 +35,7 @@
     ANSIBLE_INVENTORY_UNPARSED_FAILED: "true"
     ANSIBLE_INVENTORY: hosts
     CI_PLATFORM: tf
+    TF_VAR_ssh_user: $SSH_USER
   script:
     - tests/scripts/testcases_run.sh
   after_script:
@@ -113,7 +114,7 @@ tf-ovh_ubuntu18-calico:
     CLUSTER: $CI_COMMIT_REF_NAME
     ANSIBLE_TIMEOUT: "60"
     SSH_USER: ubuntu
-    TF_VAR_cluster_name: $CI_COMMIT_REF_SLUG
+    TF_VAR_cluster_name: $CI_COMMIT_REF_SLUG-$CI_JOB_ID
     TF_VAR_number_of_k8s_masters: "0"
     TF_VAR_number_of_k8s_masters_no_floating_ip: "1"
     TF_VAR_number_of_k8s_masters_no_floating_ip_no_etcd: "0"
@@ -130,4 +131,34 @@ tf-ovh_ubuntu18-calico:
     TF_VAR_flavor_k8s_master: "defa64c3-bd46-43b4-858a-d93bbae0a229"    # s1-8
     TF_VAR_flavor_k8s_node: "defa64c3-bd46-43b4-858a-d93bbae0a229"      # s1-8
     TF_VAR_image: "Ubuntu 18.04"
+    TF_VAR_k8s_allowed_remote_ips: '["0.0.0.0/0"]'
+
+tf-ovh_coreos-calico:
+  extends: .terraform_apply
+  stage: unit-tests
+  when: on_success
+  variables:
+    <<: *ovh_variables
+    TF_VERSION: 0.11.11
+    PROVIDER: openstack
+    CLUSTER: $CI_COMMIT_REF_NAME
+    ANSIBLE_TIMEOUT: "60"
+    SSH_USER: core
+    TF_VAR_cluster_name: $CI_COMMIT_REF_SLUG-$CI_JOB_ID
+    TF_VAR_number_of_k8s_masters: "0"
+    TF_VAR_number_of_k8s_masters_no_floating_ip: "1"
+    TF_VAR_number_of_k8s_masters_no_floating_ip_no_etcd: "0"
+    TF_VAR_number_of_etcd: "0"
+    TF_VAR_number_of_k8s_nodes: "0"
+    TF_VAR_number_of_k8s_nodes_no_floating_ip: "1"
+    TF_VAR_number_of_gfs_nodes_no_floating_ip: "0"
+    TF_VAR_number_of_bastions: "0"
+    TF_VAR_number_of_k8s_masters_no_etcd: "0"
+    TF_VAR_use_neutron: "0"
+    TF_VAR_floatingip_pool: "Ext-Net"
+    TF_VAR_external_net: "6011fbc9-4cbf-46a4-8452-6890a340b60b"
+    TF_VAR_network_name: "Ext-Net"
+    TF_VAR_flavor_k8s_master: "4d4fd037-9493-4f2b-9afe-b542b5248eac"    # b2-7
+    TF_VAR_flavor_k8s_node: "4d4fd037-9493-4f2b-9afe-b542b5248eac"      # b2-7
+    TF_VAR_image: "CoreOS Stable"
     TF_VAR_k8s_allowed_remote_ips: '["0.0.0.0/0"]'

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -91,7 +91,7 @@
         --config {{ kube_config_dir }}/kubeadm-client.conf
         --ignore-preflight-errors=all
       register: kubeadm_join
-      async: 60
+      async: 180
       poll: 15
 
   always:

--- a/tests/files/tf-ovh_coreos-calico.yml
+++ b/tests/files/tf-ovh_coreos-calico.yml
@@ -1,0 +1,5 @@
+---
+dns_min_replicas: 1
+deploy_netchecker: true
+
+# resolvconf_mode: host_resolvconf  # this is required as long as the coreos stable channel uses docker < 1.12


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add tf-ovh_coreos CI job to since `gce_`  jobs needs to be deprecated and we have problems with CoreOS on KubeVirt.

**Special notes for your reviewer**:
- CoreOS needs `locksmithd` to be disabled to block auto-updates while the CI job is running
- Cleaned up some of the `ansible_ssh_user=${SSH_USER}` left, since they are configured with env vars now

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
