### PR TITLE
Add ignore_assert_errors to "kube-master, ...

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -7,6 +7,7 @@
     - kube-node
     - etcd
   run_once: true
+  ignore_errors: "{{ ignore_assert_errors }}"
 
 - name: Stop if non systemd OS type
   assert:


### PR DESCRIPTION
... kube-node or etcd is empty" task
As a assert must be ignored if ignore_assert_errors is true

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
With this is possible to deploy master + etcd without the obligation to have worker nodes available
The scenarios can be:
- deploy master + etcd and worker nodes in different moment
- have different deploy method between master + etcd and worker nodes 
- the ansible control machine can't reach the master + etcd and worker nodes simultaneously

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
