### PR TITLE
Set INVALID_TASK_ATTRIBUTE_FAILED false

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,6 +3,7 @@ pipelining=True
 ssh_args = -o ControlMaster=auto -o ControlPersist=30m -o ConnectionAttempts=100 -o UserKnownHostsFile=/dev/null
 #control_path = ~/.ssh/ansible-%%r@%%h:%%p
 [defaults]
+invalid_task_attribute_failed=False
 strategy_plugins = plugins/mitogen/ansible_mitogen/plugins/strategy
 
 host_key_checking=False


### PR DESCRIPTION
The INVALID_TASK_ATTRIBUTE_FAILED configuration default value has been
changed[1] to `True` which results in errors during the deployment
process. This change disables that feature raising warnings instead of
errors.

[1] https://github.com/ansible/ansible/commit/509e92ef72dbce56cdce413452be2b6268c5bf6c

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Ansible 2.8 has enabled INVALID_TASK_ATTRIBUTE_FAILED by default causing errors during deployment. This change disables that configuration value in the `ansible.cfg`

**Which issue(s) this PR fixes**:
Fixes #3985

**Special notes for your reviewer**:
This requires to run kubespray with ansible 2.8

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
