### PR TITLE
The registry-proxy stuck in boot.

### DIFF
--- a/roles/kubernetes-apps/registry/templates/registry-svc.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-svc.yml.j2
@@ -10,6 +10,7 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/name: "KubeRegistry"
 spec:
+  clusterIP: None
   selector:
     k8s-app: registry
   ports:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The registry-proxy stuck in when checking if the registry is up.
To fix that is added "clusterIP: None"

**Which issue(s) this PR fixes**:
Fixes #4563 
