### PR TITLE
 changing from service to systemd module

### DIFF
--- a/roles/kubernetes/node/tasks/kubelet.yml
+++ b/roles/kubernetes/node/tasks/kubelet.yml
@@ -63,9 +63,10 @@
   meta: flush_handlers
 
 - name: Enable kubelet
-  service:
+  systemd:
     name: kubelet
     enabled: yes
     state: started
+    daemon_reload: yes
   tags:
     - kubelet


### PR DESCRIPTION
changing from service to systemd module for adding parameter daemon_reload. Is better way for reload systemd to adding and remove service from SO.