### PR TITLE
Add missing extraArgs to kubeadm-config

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
@@ -78,6 +78,8 @@ apiServerExtraArgs:
 {% endif %}
   service-node-port-range: {{ kube_apiserver_node_port_range }}
   kubelet-preferred-address-types: "{{ kubelet_preferred_address_types }}"
+  profiling: "{{ kube_profiling }}"
+  request-timeout: "{{ kube_apiserver_request_timeout }}"
 {% if kube_basic_auth|default(true) %}
   basic-auth-file: {{ kube_users_dir }}/known_users.csv
 {% endif %}
@@ -138,6 +140,9 @@ controllerManagerExtraArgs:
   node-monitor-period: {{ kube_controller_node_monitor_period }}
   pod-eviction-timeout: {{ kube_controller_pod_eviction_timeout }}
   node-cidr-mask-size: "{{ kube_network_node_prefix }}"
+  profiling: "{{ kube_profiling }}"
+  terminated-pod-gc-threshold: "{{ kube_controller_terminated_pod_gc_threshold }}"
+  enable-aggregator-routing: "{{ kube_api_aggregator_routing }}"
 {% if kube_version is version('v1.14', '<') %}
   address: {{ kube_controller_manager_bind_address }}
 {% else %}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
@@ -75,6 +75,9 @@ apiServer:
 {% endif %}
     service-node-port-range: {{ kube_apiserver_node_port_range }}
     kubelet-preferred-address-types: "{{ kubelet_preferred_address_types }}"
+    profiling: "{{ kube_profiling }}"
+    request-timeout: "{{ kube_apiserver_request_timeout }}"
+    enable-aggregator-routing: "{{ kube_api_aggregator_routing }}"
 {% if kube_basic_auth|default(true) %}
     basic-auth-file: {{ kube_users_dir }}/known_users.csv
 {% endif %}
@@ -189,6 +192,8 @@ controllerManager:
     node-monitor-period: {{ kube_controller_node_monitor_period }}
     pod-eviction-timeout: {{ kube_controller_pod_eviction_timeout }}
     node-cidr-mask-size: "{{ kube_network_node_prefix }}"
+    profiling: "{{ kube_profiling }}"
+    terminated-pod-gc-threshold: "{{ kube_controller_terminated_pod_gc_threshold }}"
 {% if kube_version is version('v1.14', '<') %}
     address: {{ kube_controller_manager_bind_address }}
 {% else %}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind cleanup

**What this PR does / why we need it**:
When we transitioned from non-kubeadm to kubeadm deployment some of the settings for kube-apiserver and kube-controller was lost. This PR will add the missing extraArgs to the config to keep the deployments in sync again.

**Does this PR introduce a user-facing change?**:
Profiling is disabled (enabled by default)
Request Timeout is set to `1m0s` for kube-apiserver
Enable Aggregator Routing is set to false
Terminated Pod GC Threshold is set to `12500` explicit