### PR TITLE
Create storage class for AWS provider

### DIFF
--- a/roles/kubernetes-apps/persistent_volumes/aws/defaults/main.yml
+++ b/roles/kubernetes-apps/persistent_volumes/aws/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+bin_dir: /usr/local/bin
+kube_config_dir: "/etc/kubernetes"
+persistent_volumes_enabled: false
+storage_classes:
+  - name: gp2
+    is_default: true
+    parameters:
+      type: gp2

--- a/roles/kubernetes-apps/persistent_volumes/aws/tasks/main.yml
+++ b/roles/kubernetes-apps/persistent_volumes/aws/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Kubernetes Persistent Volumes | Lay down AWS gp2 Storage Class template
+  template:
+    src: "aws-storage-class.yml.j2"
+    dest: "{{ kube_config_dir }}/aws-storage-class.yml"
+  register: manifests
+  when:
+    - inventory_hostname == groups['kube-master'][0]
+
+- name: Kubernetes Persistent Volumes | Add AWS gp2 Storage Class
+  kube:
+    name: storage-class
+    kubectl: "{{ bin_dir }}/kubectl"
+    resource: StorageClass
+    filename: "{{ kube_config_dir }}/aws-storage-class.yml"
+    state: "latest"
+  when:
+    - inventory_hostname == groups['kube-master'][0]
+    - manifests.changed

--- a/roles/kubernetes-apps/persistent_volumes/aws/templates/aws-storage-class.yml.j2
+++ b/roles/kubernetes-apps/persistent_volumes/aws/templates/aws-storage-class.yml.j2
@@ -1,0 +1,17 @@
+{% for class in storage_classes %}
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: "{{ class.name }}"
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "{{ class.is_default | default(false) | ternary("true","false") }}"
+provisioner: kubernetes.io/aws-ebs
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: EnsureExists
+parameters:
+{% for key, value in (class.parameters | default({})).items() %}
+  "{{ key }}": "{{ value }}"
+{% endfor %}
+{% endfor %}

--- a/roles/kubernetes-apps/persistent_volumes/meta/main.yml
+++ b/roles/kubernetes-apps/persistent_volumes/meta/main.yml
@@ -6,3 +6,10 @@ dependencies:
       - cloud_provider in [ 'openstack' ]
     tags:
       - persistent_volumes_openstack
+
+  - role: kubernetes-apps/persistent_volumes/aws
+    when:
+      - cloud_provider is defined
+      - cloud_provider in [ 'aws' ]
+    tags:
+      - persistent_volumes_aws


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
Currently storage class is not automatically created when the cluster is deployed on AWS. This patch creates it automatically, so users can use volumes with default storage class without additional steps.

**Does this PR introduce a user-facing change?**:
```release-note
gp2 storage class is created automatically if AWS cloud provider is used now.
```