### PR TITLE
Add ready plugin for CoreDNS

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -11,6 +11,7 @@ data:
     .:53 {
         errors
         health
+        ready
         kubernetes {{ dns_domain }} in-addr.arpa ip6.arpa {
           pods insecure
 {% if resolvconf_mode == 'host_resolvconf' and upstream_dns_servers is defined and upstream_dns_servers|length > 0 %}

--- a/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
@@ -96,8 +96,8 @@ spec:
           failureThreshold: 10
         readinessProbe:
           httpGet:
-            path: /health
-            port: 8080
+            path: /ready
+            port: 8181
             scheme: HTTP
           timeoutSeconds: 5
           successThreshold: 1


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind design

**What this PR does / why we need it**:
Add and use the `ready` plugin fore CoreDNS as we use version >=1.5.0

This will soon come to nodelocaldns too. Awaiting new release where it's based on CoreDNS 1.5.0

**Does this PR introduce a user-facing change?**:
NONE