### PR TITLE
Enable kubeadm etcd mode

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -57,7 +57,7 @@
       vars:
         etcd_cluster_setup: true
         etcd_events_cluster_setup: "{{ etcd_events_cluster_enabled }}"
-      when: etcd_mode|default('legacy') == "legacy"
+      when: not etcd_kubeadm_enabled| default(false)
 
 - hosts: k8s-cluster:calico-rr
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
@@ -66,9 +66,9 @@
     - role: etcd
       tags: etcd
       vars:
-        etcd_cluster_setup: false,
-        etcd_events_cluster_setup: false,
-      when: etcd_mode|default('legacy') == "legacy"
+        etcd_cluster_setup: false
+        etcd_events_cluster_setup: false
+      when: not etcd_kubeadm_enabled| default(false)
 
 - hosts: k8s-cluster
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"

--- a/cluster.yml
+++ b/cluster.yml
@@ -52,13 +52,23 @@
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
     - { role: kubespray-defaults}
-    - { role: etcd, tags: etcd, etcd_cluster_setup: true, etcd_events_cluster_setup: "{{ etcd_events_cluster_enabled }}" }
+    - role: etcd
+      tags: etcd
+      vars:
+        etcd_cluster_setup: true
+        etcd_events_cluster_setup: "{{ etcd_events_cluster_enabled }}"
+      when: etcd_mode|default('legacy') == "legacy"
 
 - hosts: k8s-cluster:calico-rr
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
     - { role: kubespray-defaults}
-    - { role: etcd, tags: etcd, etcd_cluster_setup: false, etcd_events_cluster_setup: false }
+    - role: etcd
+      tags: etcd
+      vars:
+        etcd_cluster_setup: false,
+        etcd_events_cluster_setup: false,
+      when: etcd_mode|default('legacy') == "legacy"
 
 - hosts: k8s-cluster
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"

--- a/inventory/sample/group_vars/all/all.yml
+++ b/inventory/sample/group_vars/all/all.yml
@@ -2,8 +2,8 @@
 ## Directory where etcd data stored
 etcd_data_dir: /var/lib/etcd
 
-## etcd deployment mode. Choices are legacy or kubeadm
-etcd_mode: legacy
+## Experimental kubeadm etcd deployment mode. Available only for new deployment
+etcd_kubeadm_enabled: false
 
 ## Directory where the binaries will be installed
 bin_dir: /usr/local/bin

--- a/inventory/sample/group_vars/all/all.yml
+++ b/inventory/sample/group_vars/all/all.yml
@@ -2,6 +2,9 @@
 ## Directory where etcd data stored
 etcd_data_dir: /var/lib/etcd
 
+## etcd deployment mode. Choices are legacy or kubeadm
+etcd_mode: legacy
+
 ## Directory where the binaries will be installed
 bin_dir: /usr/local/bin
 

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -79,3 +79,10 @@
 # state instead of `new`.
 - include_tasks: refresh_config.yml
   when: is_etcd_master
+
+- name: Install etcdctl binary from etcd role
+  include_tasks: "{{ role_path }}/../../etcd/tasks/install_host.yml"
+  vars:
+    etcd_cluster_setup: true
+  when:
+    - etcd_mode == "kubeadm"

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -85,4 +85,4 @@
   vars:
     etcd_cluster_setup: true
   when:
-    - etcd_mode == "kubeadm"
+    - etcd_kubeadm_enabled

--- a/roles/kubernetes/kubeadm/defaults/main.yml
+++ b/roles/kubernetes/kubeadm/defaults/main.yml
@@ -13,3 +13,6 @@ kube_override_hostname: >-
 
 # Requests a fresh upload of certificates from first master
 kubeadm_etcd_refresh_cert_key: false
+
+# Experimental kubeadm etcd deployment mode. Available only for new deployment
+etcd_kubeadm_enabled: false

--- a/roles/kubernetes/kubeadm/defaults/main.yml
+++ b/roles/kubernetes/kubeadm/defaults/main.yml
@@ -10,3 +10,6 @@ kube_override_hostname: >-
   {%- else -%}
   {{ inventory_hostname }}
   {%- endif -%}
+
+# Requests a fresh upload of certificates from first master
+kubeadm_etcd_refresh_cert_key: false

--- a/roles/kubernetes/kubeadm/tasks/kubeadm_etcd_node.yml
+++ b/roles/kubernetes/kubeadm/tasks/kubeadm_etcd_node.yml
@@ -1,0 +1,74 @@
+---
+- name: Refresh certificates so they are fresh and not expired
+  command: >-
+    {{ bin_dir }}/kubeadm init phase
+    --config {{ kube_config_dir }}/kubeadm-config.yaml
+    upload-certs --experimental-upload-certs
+    {% if kubeadm_certificate_key is defined %}
+    --certificate-key={{ kubeadm_certificate_key }}
+    {% endif %}
+  register: kubeadm_upload_cert
+  delegate_to: "{{ groups['kube-master'][0] }}"
+  when: kubeadm_etcd_refresh_cert_key
+  run_once: yes
+
+- name: Parse certificate key if not set
+  set_fact:
+    kubeadm_certificate_key: "{{ hostvars[groups['kube-master'][0]]['kubeadm_upload_cert'].stdout_lines[-1] | trim }}"
+  when: kubeadm_certificate_key is undefined
+
+- name: Pull control plane certs down
+  shell: >-
+    {{ bin_dir }}/kubeadm join phase
+    control-plane-prepare download-certs
+    --certificate-key {{ kubeadm_certificate_key }}
+    --experimental-control-plane
+    --token {{ kubeadm_token }}
+    --discovery-token-unsafe-skip-ca-verification
+    {{ kubeadm_discovery_address }}
+    &&
+    {{ bin_dir }}/kubeadm join phase
+    control-plane-prepare certs
+    --experimental-control-plane
+    --token {{ kubeadm_token }}
+    --discovery-token-unsafe-skip-ca-verification
+    {{ kubeadm_discovery_address }}
+  args:
+    creates: "{{ kube_cert_dir }}/apiserver-etcd-client.key"
+
+- name: Delete unneeded certificates
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ kube_cert_dir }}/apiserver.crt"
+    - "{{ kube_cert_dir }}/apiserver.key"
+    - "{{ kube_cert_dir }}/ca.key"
+    - "{{ kube_cert_dir }}/etcd/ca.key"
+    - "{{ kube_cert_dir }}/etcd/healthcheck-client.crt"
+    - "{{ kube_cert_dir }}/etcd/healthcheck-client.key"
+    - "{{ kube_cert_dir }}/etcd/peer.crt"
+    - "{{ kube_cert_dir }}/etcd/peer.key"
+    - "{{ kube_cert_dir }}/etcd/server.crt"
+    - "{{ kube_cert_dir }}/etcd/server.key"
+    - "{{ kube_cert_dir }}/front-proxy-ca.crt"
+    - "{{ kube_cert_dir }}/front-proxy-ca.key"
+    - "{{ kube_cert_dir }}/front-proxy-client.crt"
+    - "{{ kube_cert_dir }}/front-proxy-client.key"
+    - "{{ kube_cert_dir }}/sa.key"
+    - "{{ kube_cert_dir }}/sa.pub"
+
+- name: Calculate etcd cert serial
+  command: "openssl x509 -in {{ kube_cert_dir }}/apiserver-etcd-client.crt -noout -serial"
+  register: "etcd_client_cert_serial_result"
+  changed_when: false
+  when:
+    - inventory_hostname in groups['k8s-cluster']|union(groups['calico-rr']|default([]))|unique|sort
+  tags:
+    - network
+
+- name: Set etcd_client_cert_serial
+  set_fact:
+    etcd_client_cert_serial: "{{ etcd_client_cert_serial_result.stdout.split('=')[1] }}"
+  tags:
+    - network

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -176,4 +176,5 @@
     - etcd_mode == "kubeadm"
     - kubeadm_control_plane
     - inventory_hostname not in groups['kube-master']
-    - kube_network_plugin in ['calico', 'flannel', 'canal', 'cilium']
+    - kube_network_plugin in ["calico", "flannel", "canal", "cilium"]
+    - kube_network_plugin != "calico" or calico_datastore == "etcd"

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -173,7 +173,7 @@
 - name: Extract etcd certs from control plane if using etcd kubeadm mode
   include_tasks: kubeadm_etcd_node.yml
   when:
-    - etcd_mode == "kubeadm"
+    - etcd_kubeadm_enabled
     - kubeadm_control_plane
     - inventory_hostname not in groups['kube-master']
     - kube_network_plugin in ["calico", "flannel", "canal", "cilium"]

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -10,6 +10,7 @@
   tags:
     - facts
 
+
 - name: Check if kubelet.conf exists
   stat:
     path: "{{ kube_config_dir }}/kubelet.conf"
@@ -168,3 +169,11 @@
     - kubeadm_discovery_address != kube_apiserver_endpoint
   tags:
     - kube-proxy
+
+- name: Extract etcd certs from control plane if using etcd kubeadm mode
+  include_tasks: kubeadm_etcd_node.yml
+  when:
+    - etcd_mode == "kubeadm"
+    - kubeadm_control_plane
+    - inventory_hostname not in groups['kube-master']
+    - kube_network_plugin in ['calico', 'flannel', 'canal', 'cilium']

--- a/roles/kubernetes/master/defaults/main/etcd.yml
+++ b/roles/kubernetes/master/defaults/main/etcd.yml
@@ -1,0 +1,32 @@
+---
+# Note: This does not set up DNS entries. It simply adds the following DNS
+# entries to the certificate
+etcd_cert_alt_names:
+  - "etcd.kube-system.svc.{{ dns_domain }}"
+  - "etcd.kube-system.svc"
+  - "etcd.kube-system"
+  - "etcd"
+etcd_cert_alt_ips: []
+
+etcd_heartbeat_interval: "250"
+etcd_election_timeout: "5000"
+
+# etcd_snapshot_count: "10000"
+
+# Parameters for ionice
+# -c takes an integer between 0 and 3 or one of the strings none, realtime, best-effort or idle.
+# -n takes an integer between 0 (highest priority) and 7 (lowest priority)
+# etcd_ionice: "-c2 -n0"
+
+etcd_metrics: "basic"
+
+## A dictionary of extra environment variables to add to etcd.env, formatted like:
+##  etcd_extra_vars:
+##    var1: "value1"
+##    var2: "value2"
+## Note this is different from the etcd role with ETCD_ prfexi, caps, and underscores
+etcd_extra_vars: {}
+
+# etcd_quota_backend_bytes: "2G"
+
+etcd_compaction_retention: "8"

--- a/roles/kubernetes/master/defaults/main/main.yml
+++ b/roles/kubernetes/master/defaults/main/main.yml
@@ -5,8 +5,8 @@ upgrade_cluster_setup: false
 # Enable kubeadm experimental control plane
 kubeadm_control_plane: false
 
-# etcd deployment mode. Choices are legacy or kubeadm
-etcd_mode: legacy
+# Experimental kubeadm etcd deployment mode. Available only for new deployment
+etcd_kubeadm_enabled: false
 
 # An experimental dev/test only dynamic volumes provisioner,
 # for PetSets. Works for kube>=v1.3 only.

--- a/roles/kubernetes/master/defaults/main/main.yml
+++ b/roles/kubernetes/master/defaults/main/main.yml
@@ -2,6 +2,12 @@
 # disable upgrade cluster
 upgrade_cluster_setup: false
 
+# Enable kubeadm experimental control plane
+kubeadm_control_plane: false
+
+# etcd deployment mode. Choices are legacy or kubeadm
+etcd_mode: legacy
+
 # An experimental dev/test only dynamic volumes provisioner,
 # for PetSets. Works for kube>=v1.3 only.
 kube_hostpath_dynamic_provisioner: "false"

--- a/roles/kubernetes/master/tasks/kubeadm-etcd.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-etcd.yml
@@ -1,0 +1,18 @@
+---
+- name: Calculate etcd cert serial
+  command: "openssl x509 -in {{ kube_cert_dir }}/apiserver-etcd-client.crt -noout -serial"
+  register: "etcd_client_cert_serial_result"
+  changed_when: false
+  tags:
+    - network
+
+- name: Set etcd_client_cert_serial
+  set_fact:
+    etcd_client_cert_serial: "{{ etcd_client_cert_serial_result.stdout.split('=')[1] }}"
+  tags:
+    - network
+
+- name: Ensure etcdctl binary is installed
+  include_tasks: "{{ role_path }}/../../etcd/tasks/install_host.yml"
+  vars:
+    etcd_cluster_setup: true

--- a/roles/kubernetes/master/tasks/kubeadm-secondary-experimental.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-secondary-experimental.yml
@@ -43,6 +43,10 @@
     kubeadm_certificate_key: "{{ hostvars[groups['kube-master'][0]]['kubeadm_upload_cert'].stdout_lines[-1] | trim }}"
   when: kubeadm_certificate_key is undefined
 
+- name: check already run
+  debug:
+    msg: "{{ kubeadm_already_run.stat.exists }}"
+
 - name: Joining control plane node to the cluster.
   command: >-
     {{ bin_dir }}/kubeadm join
@@ -52,9 +56,11 @@
     --certificate-key={{ kubeadm_certificate_key }}
     {% endif %}
   register: kubeadm_join_control_plane
+  retries: 3
+  until: kubeadm_join_control_plane is succeeded
   when:
     - inventory_hostname != groups['kube-master']|first
-    - not kubeadm_already_run.stat.exists
+    - kubeadm_already_run is not defined or not kubeadm_already_run.stat.exists
   environment:
     PATH: "{{ bin_dir }}:{{ ansible_env.PATH }}"
 

--- a/roles/kubernetes/master/tasks/main.yml
+++ b/roles/kubernetes/master/tasks/main.yml
@@ -78,4 +78,4 @@
 
 - name: Include kubeadm etcd extra tasks
   include_tasks: kubeadm-etcd.yml
-  when: etcd_mode == "kubeadm"
+  when: etcd_kubeadm_enabled

--- a/roles/kubernetes/master/tasks/main.yml
+++ b/roles/kubernetes/master/tasks/main.yml
@@ -75,3 +75,7 @@
 
 - name: Include kubeadm setup
   import_tasks: kubeadm-setup.yml
+
+- name: Include kubeadm etcd extra tasks
+  include_tasks: kubeadm-etcd.yml
+  when: etcd_mode == "kubeadm"

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
@@ -24,7 +24,7 @@ apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration
 clusterName: {{ cluster_name }}
 etcd:
-{% if etcd_mode == "legacy" %}
+{% if not etcd_kubeadm_enabled %}
   external:
       endpoints:
 {% for endpoint in etcd_access_addresses.split(',') %}
@@ -33,9 +33,9 @@ etcd:
       caFile: {{ etcd_cert_dir }}/{{ kube_etcd_cacert_file }}
       certFile: {{ etcd_cert_dir }}/{{ kube_etcd_cert_file }}
       keyFile: {{ etcd_cert_dir }}/{{ kube_etcd_key_file }}
-{% elif etcd_mode == "kubeadm" %}
+{% elif etcd_kubeadm_enabled %}
   local:
-    imageRepository: "{{ etcd_image_repo | replace("/etcd","") }}"
+    imageRepository: "{{ etcd_image_repo | regex_replace("/etcd$","") }}"
     imageTag: "{{ etcd_image_tag }}"
     dataDir: "/var/lib/etcd"
     extraArgs:

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
@@ -24,6 +24,7 @@ apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration
 clusterName: {{ cluster_name }}
 etcd:
+{% if etcd_mode == "legacy" %}
   external:
       endpoints:
 {% for endpoint in etcd_access_addresses.split(',') %}
@@ -32,6 +33,46 @@ etcd:
       caFile: {{ etcd_cert_dir }}/{{ kube_etcd_cacert_file }}
       certFile: {{ etcd_cert_dir }}/{{ kube_etcd_cert_file }}
       keyFile: {{ etcd_cert_dir }}/{{ kube_etcd_key_file }}
+{% elif etcd_mode == "kubeadm" %}
+  local:
+    imageRepository: "{{ etcd_image_repo | replace("/etcd","") }}"
+    imageTag: "{{ etcd_image_tag }}"
+    dataDir: "/var/lib/etcd"
+    extraArgs:
+      metrics: {{ etcd_metrics }}
+      election-timeout: "{{ etcd_election_timeout }}"
+      heartbeat-interval: "{{ etcd_heartbeat_interval }}"
+      auto-compaction-retention: "{{ etcd_compaction_retention }}"
+{% if etcd_snapshot_count is defined %}
+      snapshot-count: "{{ etcd_snapshot_count }}"
+{% endif %}
+{% if etcd_quota_backend_bytes is defined %}
+      quota-backend-bytes: "{{ etcd_quota_backend_bytes }}"
+{% endif %}
+{% if etcd_log_package_levels is defined %}
+      log-package_levels: "{{ etcd_log_package_levels }}"
+{% endif %}
+{% for key, value in etcd_extra_vars.items() %}
+      {{ key }}: "{{ value }}"
+{% endfor %}
+{% if host_architecture != "amd64" -%}
+      etcd-unsupported-arch: {{host_architecture}}
+{% endif %}
+    serverCertSANs:
+{% for san in etcd_cert_alt_names %}
+      - {{ san }}
+{% endfor %}
+{% for san in etcd_cert_alt_ips %}
+      - {{ san }}
+{% endfor %}
+    peerCertSANs:
+{% for san in etcd_cert_alt_names %}
+      - {{ san }}
+{% endfor %}
+{% for san in etcd_cert_alt_ips %}
+      - {{ san }}
+{% endfor %}
+{% endif %}
 networking:
   dnsDomain: {{ dns_domain }}
   serviceSubnet: {{ kube_service_addresses }}

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -206,3 +206,15 @@
     msg: "resolvconf_mode can only be 'docker_dns', 'host_resolvconf' or 'none'"
   when: resolvconf_mode is defined
   run_once: true
+
+- name: Stop if k8s version is too low for kubeadm etcd mode
+  assert:
+    that: kube_version is version('v1.14.0', '>=')
+    msg: "kubeadm etcd mode requires k8s version >= v1.14.0"
+  when: etcd_mode == "kubeadm"
+
+- name: Stop if kubeadm etcd mode is enabled but experimental control plane is not
+  assert:
+    that: kubeadm_control_plane
+    msg: "kubeadm etcd mode requires experimental control plane"
+  when: etcd_mode == "kubeadm"

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -211,10 +211,10 @@
   assert:
     that: kube_version is version('v1.14.0', '>=')
     msg: "kubeadm etcd mode requires k8s version >= v1.14.0"
-  when: etcd_mode == "kubeadm"
+  when: etcd_kubeadm_enabled
 
 - name: Stop if kubeadm etcd mode is enabled but experimental control plane is not
   assert:
     that: kubeadm_control_plane
     msg: "kubeadm etcd mode requires experimental control plane"
-  when: etcd_mode == "kubeadm"
+  when: etcd_kubeadm_enabled

--- a/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
@@ -177,4 +177,4 @@
     kube_etcd_key_file: "apiserver-etcd-client.key"
     etcd_deployment_type: host
   when:
-    - etcd_mode == "kubeadm"
+    - etcd_kubeadm_enabled

--- a/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
@@ -168,3 +168,13 @@
   tags:
     - facts
     - kube-proxy
+
+- name: set etcd vars if using kubeadm mode
+  set_fact:
+    etcd_cert_dir: "{{ kube_cert_dir }}"
+    kube_etcd_cacert_file: "etcd/ca.crt"
+    kube_etcd_cert_file: "apiserver-etcd-client.crt"
+    kube_etcd_key_file: "apiserver-etcd-client.key"
+    etcd_deployment_type: host
+  when:
+    - etcd_mode == "kubeadm"

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -252,7 +252,11 @@ docker_options: >-
   --userland-proxy-path=/usr/libexec/docker/docker-proxy-current --signature-verification=false
   {%- endif -%}
 
+# etcd deployment mode. Choices are legacy or kubeadm
+etcd_mode: legacy
+
 # Settings for containerized control plane (etcd/kubelet/secrets)
+# deployment type for legacy etcd mode
 etcd_deployment_type: docker
 cert_management: script
 
@@ -304,6 +308,8 @@ openstack_lbaas_monitor_timeout: "30s"
 openstack_lbaas_monitor_max_retries: "3"
 openstack_cacert: "{{ lookup('env','OS_CACERT') }}"
 
+cloud_config_file: "{{ kube_config_dir }}/cloud_config"
+
 ## List of authorization modes that must be configured for
 ## the k8s cluster. Only 'AlwaysAllow', 'AlwaysDeny', 'Node' and
 ## 'RBAC' modes are tested. Order is important.
@@ -314,7 +320,7 @@ rbac_enabled: "{{ 'RBAC' in authorization_modes }}"
 kubelet_authentication_token_webhook: true
 
 # When enabled, access to the kubelet API requires authorization by delegation to the API server
-kubelet_authorization_mode_webhook: true
+kubelet_authorization_mode_webhook: false
 
 # kubelet uses certificates for authenticating to the Kubernetes API
 # Automatically generate a new key and request a new certificate from the Kubernetes API as the current certificate approaches expiration
@@ -501,5 +507,3 @@ pip_extra_args: |-
 
 etcd_config_dir: /etc/ssl/etcd
 etcd_cert_dir: "{{ etcd_config_dir }}/ssl"
-
-typha_enabled: false

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -252,8 +252,8 @@ docker_options: >-
   --userland-proxy-path=/usr/libexec/docker/docker-proxy-current --signature-verification=false
   {%- endif -%}
 
-# etcd deployment mode. Choices are legacy or kubeadm
-etcd_mode: legacy
+# Experimental kubeadm etcd deployment mode. Available only for new deployment
+etcd_kubeadm_enabled: false
 
 # Settings for containerized control plane (etcd/kubelet/secrets)
 # deployment type for legacy etcd mode
@@ -307,8 +307,6 @@ openstack_lbaas_monitor_delay: "1m"
 openstack_lbaas_monitor_timeout: "30s"
 openstack_lbaas_monitor_max_retries: "3"
 openstack_cacert: "{{ lookup('env','OS_CACERT') }}"
-
-cloud_config_file: "{{ kube_config_dir }}/cloud_config"
 
 ## List of authorization modes that must be configured for
 ## the k8s cluster. Only 'AlwaysAllow', 'AlwaysDeny', 'Node' and

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -320,7 +320,7 @@ rbac_enabled: "{{ 'RBAC' in authorization_modes }}"
 kubelet_authentication_token_webhook: true
 
 # When enabled, access to the kubelet API requires authorization by delegation to the API server
-kubelet_authorization_mode_webhook: false
+kubelet_authorization_mode_webhook: true
 
 # kubelet uses certificates for authenticating to the Kubernetes API
 # Automatically generate a new key and request a new certificate from the Kubernetes API as the current certificate approaches expiration
@@ -507,3 +507,5 @@ pip_extra_args: |-
 
 etcd_config_dir: /etc/ssl/etcd
 etcd_cert_dir: "{{ etcd_config_dir }}/ssl"
+
+typha_enabled: false

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -45,8 +45,8 @@
   uri:
     url: "{{ etcd_access_addresses.split(',') | first }}/health"
     validate_certs: no
-    client_cert: "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem"
-    client_key: "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem"
+    client_cert: "{{ calico_cert_dir }}/cert.crt"
+    client_key: "{{ calico_cert_dir }}/key.pem"
   register: result
   until: result.status == 200 or result.status == 401
   retries: 10

--- a/tests/files/packet_centos7-flannel-addons.yml
+++ b/tests/files/packet_centos7-flannel-addons.yml
@@ -6,6 +6,7 @@ mode: ha
 # Kubespray settings
 kubeadm_control_plane: true
 kubeadm_certificate_key: 3998c58db6497dd17d909394e62d515368c06ec617710d02edea31c06d741085
+etcd_mode: kubeadm
 kube_proxy_mode: iptables
 kube_network_plugin: flannel
 helm_enabled: true

--- a/tests/files/packet_centos7-flannel-addons.yml
+++ b/tests/files/packet_centos7-flannel-addons.yml
@@ -6,7 +6,6 @@ mode: ha
 # Kubespray settings
 kubeadm_control_plane: true
 kubeadm_certificate_key: 3998c58db6497dd17d909394e62d515368c06ec617710d02edea31c06d741085
-etcd_mode: kubeadm
 kube_proxy_mode: iptables
 kube_network_plugin: flannel
 helm_enabled: true

--- a/tests/files/packet_ubuntu-flannel-ha.yml
+++ b/tests/files/packet_ubuntu-flannel-ha.yml
@@ -6,9 +6,9 @@ mode: ha
 # Kubespray settings
 kube_network_plugin: flannel
 kubeadm_enabled: true
+etcd_kubeadm_enabled: true
 kubeadm_control_plane: true
 kubeadm_certificate_key: 3998c58db6497dd17d909394e62d515368c06ec617710d02edea31c06d741085
-etcd_mode: true
 skip_non_kubeadm_warning: true
 deploy_netchecker: true
 dns_min_replicas: 1

--- a/tests/files/packet_ubuntu-flannel-ha.yml
+++ b/tests/files/packet_ubuntu-flannel-ha.yml
@@ -6,6 +6,9 @@ mode: ha
 # Kubespray settings
 kube_network_plugin: flannel
 kubeadm_enabled: true
+kubeadm_control_plane: true
+kubeadm_certificate_key: 3998c58db6497dd17d909394e62d515368c06ec617710d02edea31c06d741085
+etcd_mode: true
 skip_non_kubeadm_warning: true
 deploy_netchecker: true
 dns_min_replicas: 1

--- a/upgrade-cluster.yml
+++ b/upgrade-cluster.yml
@@ -56,13 +56,23 @@
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
     - { role: kubespray-defaults}
-    - { role: etcd, tags: etcd, etcd_cluster_setup: true }
+    - role: etcd
+      tags: etcd
+      vars:
+        etcd_cluster_setup: true
+        etcd_events_cluster_setup: false
+      when: etcd_mode|default('legacy') == "legacy"
 
 - hosts: k8s-cluster
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
     - { role: kubespray-defaults}
-    - { role: etcd, tags: etcd, etcd_cluster_setup: false }
+    - role: etcd
+      tags: etcd
+      vars:
+        etcd_cluster_setup: false
+        etcd_events_cluster_setup: false
+      when: etcd_mode|default('legacy') == "legacy"
 
 - name: Handle upgrades to master components first to maintain backwards compat.
   hosts: kube-master

--- a/upgrade-cluster.yml
+++ b/upgrade-cluster.yml
@@ -61,7 +61,7 @@
       vars:
         etcd_cluster_setup: true
         etcd_events_cluster_setup: false
-      when: etcd_mode|default('legacy') == "legacy"
+      when: not etcd_kubeadm_enabled | default(false)
 
 - hosts: k8s-cluster
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
@@ -72,7 +72,7 @@
       vars:
         etcd_cluster_setup: false
         etcd_events_cluster_setup: false
-      when: etcd_mode|default('legacy') == "legacy"
+      when: not etcd_kubeadm_enabled | default(false)
 
 - name: Handle upgrades to master components first to maintain backwards compat.
   hosts: kube-master


### PR DESCRIPTION
/kind feature

Uses cert commands from kubeadm experimental control plane to
enable non-master nodes to obtain etcd certs.

Non-backward compatible change. Only new clusters can use this feature.