### PR TITLE
use dpkg_selections module to hold docker-ce on Debian family hosts

### DIFF
--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -191,13 +191,11 @@
     - ansible_distribution == 'Ubuntu'
 
 # This is required to ensure any apt upgrade will not break kubernetes
-- name: Set docker pin priority to apt_preferences on Debian family
-  template:
-    src: "apt_preferences.d/debian_docker.j2"
-    dest: "/etc/apt/preferences.d/docker"
-    owner: "root"
-    mode: 0644
-  when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS", "ClearLinux", "RedHat", "Suse"] or is_atomic)
+- name: Tell Debian hosts not to change the docker version with apt upgrade
+  dpkg_selections:
+    name: docker-ce
+    selection: hold
+  when: ansible_os_family in ["Debian"]
 
 - name: ensure docker started, remove our config if docker start failed and try again
   block:

--- a/roles/container-engine/docker/templates/apt_preferences.d/debian_docker.j2
+++ b/roles/container-engine/docker/templates/apt_preferences.d/debian_docker.j2
@@ -1,3 +1,0 @@
-Package: docker-ce
-Pin: version {{ docker_version }}.*
-Pin-Priority: 1001


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
A better way of telling Ubuntu and Debian not to change the docker-ce package version because it's handled by kubespray

**Which issue(s) this PR fixes**:
Fixes #4819
