### PR TITLE
Move tf-ovh to part2

### DIFF
--- a/.gitlab-ci/terraform.yml
+++ b/.gitlab-ci/terraform.yml
@@ -135,7 +135,6 @@ tf-ovh_ubuntu18-calico:
 
 tf-ovh_coreos-calico:
   extends: .terraform_apply
-  stage: unit-tests
   when: on_success
   variables:
     <<: *ovh_variables


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
tf-ovh has nothing to do in unit-tests, it should go in part2, just like other tf-(ovh|packet) jobs.