### PR TITLE
Use short cluster_name for TF CI

### DIFF
--- a/.gitlab-ci/terraform.yml
+++ b/.gitlab-ci/terraform.yml
@@ -36,6 +36,7 @@
     ANSIBLE_INVENTORY: hosts
     CI_PLATFORM: tf
     TF_VAR_ssh_user: $SSH_USER
+    TF_VAR_cluster_name: $CI_JOB_ID
   script:
     - tests/scripts/testcases_run.sh
   after_script:
@@ -69,7 +70,6 @@ tf-packet-ubuntu16-default:
     TF_VERSION: 0.11.11
     PROVIDER: packet
     CLUSTER: $CI_COMMIT_REF_NAME
-    TF_VAR_cluster_name: $CI_COMMIT_REF_SLUG
     TF_VAR_number_of_k8s_masters: "1"
     TF_VAR_number_of_k8s_nodes: "1"
     TF_VAR_plan_k8s_masters: t1.small.x86
@@ -84,7 +84,6 @@ tf-packet-ubuntu18-default:
     TF_VERSION: 0.11.11
     PROVIDER: packet
     CLUSTER: $CI_COMMIT_REF_NAME
-    TF_VAR_cluster_name: $CI_COMMIT_REF_SLUG
     TF_VAR_number_of_k8s_masters: "1"
     TF_VAR_number_of_k8s_nodes: "1"
     TF_VAR_plan_k8s_masters: t1.small.x86
@@ -114,7 +113,6 @@ tf-ovh_ubuntu18-calico:
     CLUSTER: $CI_COMMIT_REF_NAME
     ANSIBLE_TIMEOUT: "60"
     SSH_USER: ubuntu
-    TF_VAR_cluster_name: $CI_COMMIT_REF_SLUG-$CI_JOB_ID
     TF_VAR_number_of_k8s_masters: "0"
     TF_VAR_number_of_k8s_masters_no_floating_ip: "1"
     TF_VAR_number_of_k8s_masters_no_floating_ip_no_etcd: "0"
@@ -143,7 +141,6 @@ tf-ovh_coreos-calico:
     CLUSTER: $CI_COMMIT_REF_NAME
     ANSIBLE_TIMEOUT: "60"
     SSH_USER: core
-    TF_VAR_cluster_name: $CI_COMMIT_REF_SLUG-$CI_JOB_ID
     TF_VAR_number_of_k8s_masters: "0"
     TF_VAR_number_of_k8s_masters_no_floating_ip: "1"
     TF_VAR_number_of_k8s_masters_no_floating_ip_no_etcd: "0"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind failing-test

**What this PR does / why we need it**:
A PR with a long branch name can cause TF CI to fail due to too long hostname:
```
name cannot be longer than 64 characters on systemd servers, try a shorter name 
```