### PR TITLE
Preinstall fails on checking etcd group length

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -50,6 +50,7 @@
   assert:
     that: groups.etcd|length is not divisibleby 2
   ignore_errors: "{{ ignore_assert_errors }}"
+  when: inventory_hostname in groups['etcd']
 
 - name: Stop if memory is too small for masters
   assert:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Given the below inventory file and the code from master branch

```

[kube-master]
dani-k8s-control-plane-1
dani-k8s-control-plane-2
dani-k8s-control-plane-3

[etcd]
dani-k8s-control-plane-1
dani-k8s-control-plane-2
dani-k8s-control-plane-3

[kube-node]
dani-k8s-node-1
# dani-k8s-3
# dani-k8s-4
# dani-k8s-5
# dani-k8s-6

[k8s-cluster:children]
kube-master
kube-node

```
i hit the below issue
```
2019-06-04 17:02:28,297 p=1944 u=root |  TASK [kubernetes/preinstall : Stop if even number of etcd hosts] *************************************************************************************************************************************************************************************************************
2019-06-04 17:02:28,297 p=1944 u=root |  task path: /root/kubespray/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml:49
2019-06-04 17:02:28,297 p=1944 u=root |  Tuesday 04 June 2019  17:02:28 +0000 (0:00:00.248)       0:00:28.666 **********
2019-06-04 17:02:28,485 p=1944 u=root |  fatal: [dani-k8s-control-plane-1]: FAILED! => {"msg": "The conditional check 'groups.etcd | length is not divisible by 2' failed. The error was: template error while templating string: expected token 'end of statement block', got 'integer'. String: {% if groups.etcd | length is not divisible by 2 %} True {% else %} False {% endif %}"}
2019-06-04 17:02:28,522 p=1944 u=root |  fatal: [dani-k8s-control-plane-3]: FAILED! => {"msg": "The conditional check 'groups.etcd | length is not divisible by 2' failed. The error was: template error while templating string: expected token 'end of statement block', got 'integer'. String: {% if groups.etcd | length is not divisible by 2 %} True {% else %} False {% endif %}"}
2019-06-04 17:02:28,533 p=1944 u=root |  fatal: [dani-k8s-control-plane-2]: FAILED! => {"msg": "The conditional check 'groups.etcd | length is not divisible by 2' failed. The error was: template error while templating string: expected token 'end of statement block', got 'integer'. String: {% if groups.etcd | length is not divisible by 2 %} True {% else %} False {% endif %}"}
2019-06-04 17:02:28,578 p=1944 u=root |  fatal: [dani-k8s-node-1]: FAILED! => {"msg": "The conditional check 'groups.etcd | length is not divisible by 2' failed. The error was: template error while templating string: expected token 'end of statement block', got 'integer'. String: {% if groups.etcd | length is not divisible by 2 %} True {% else %} False {% endif %}"}

```
and the group_names do look okay
```
 ansible all -u centos -b -i inventory/dani-inv-kubespray/inventory.ini -m debug -a "var=group_names"
dani-k8s-node-1 | SUCCESS => {
    "group_names": [
        "k8s-cluster",
        "kube-node"
    ]
}
dani-k8s-control-plane-1 | SUCCESS => {
    "group_names": [
        "etcd",
        "k8s-cluster",
        "kube-master"
    ]
}
dani-k8s-control-plane-2 | SUCCESS => {
    "group_names": [
        "etcd",
        "k8s-cluster",
        "kube-master"
    ]
}
dani-k8s-control-plane-3 | SUCCESS => {
    "group_names": [
        "etcd",
        "k8s-cluster",
        "kube-master"
    ]
}


```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
