### PR TITLE
Only create kubeadm compat cert dir link if it does not exist

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
+++ b/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
@@ -23,6 +23,14 @@
     - "{{ kube_manifest_dir }}"
     - "{{ kube_script_dir }}"
 
+- name: Check if kubernetes kubeadm compat cert dir exists
+  stat:
+    path: "{{ kube_cert_compat_dir }}"
+  register: kube_cert_compat_dir_check
+  when:
+    - inventory_hostname in groups['k8s-cluster']
+    - kube_cert_dir != kube_cert_compat_dir
+
 - name: Create kubernetes kubeadm compat cert dir (kubernetes/kubeadm issue 1498)
   file:
     src: "{{ kube_cert_dir }}"
@@ -31,6 +39,7 @@
   when:
     - inventory_hostname in groups['k8s-cluster']
     - kube_cert_dir != kube_cert_compat_dir
+    - not kube_cert_compat_dir_check.stat.exists
 
 - name: Create cni directories
   file:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
If the kubernetes compat cert dir (`/etc/kubernetes/pki`) already exists and you have an older config, the symlink creation in preinstalling fails. So we do not create the symlink if it already exists.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE