### PR TITLE
Set dnsPolicy to ClusterFirstWithHostNet when hostNetwork is true

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-ds.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-ds.yml.j2
@@ -12,12 +12,10 @@ spec:
       labels:
         app: netchecker-agent-hostnet
     spec:
-      hostNetwork: True
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       nodeSelector:
         beta.kubernetes.io/os: linux
-{% if kube_version is version('v1.6', '>=') %}
-      dnsPolicy: ClusterFirstWithHostNet
-{% endif %}
 {% if kube_version is version('v1.11.1', '>=') %}
       priorityClassName: {% if netcheck_namespace == 'kube-system' %}system-node-critical{% else %}k8s-cluster-critical{% endif %}{{''}}
 {% endif %}

--- a/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-psp.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-psp.yml.j2
@@ -26,6 +26,7 @@ spec:
     - 'downwardAPI'
     - 'persistentVolumeClaim'
   hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
   hostIPC: false
   hostPID: false
   runAsUser:

--- a/roles/kubernetes-apps/cloud_controller/oci/templates/oci-cloud-provider.yml.j2
+++ b/roles/kubernetes-apps/cloud_controller/oci/templates/oci-cloud-provider.yml.j2
@@ -34,6 +34,7 @@ spec:
 {% endif %}
       serviceAccountName: cloud-controller-manager
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:

--- a/roles/kubernetes-apps/cluster_roles/templates/psp.yml.j2
+++ b/roles/kubernetes-apps/cluster_roles/templates/psp.yml.j2
@@ -65,6 +65,7 @@ spec:
   volumes:
   - '*'
   hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
   hostPorts:
   - min: 0
     max: 65535

--- a/roles/kubernetes-apps/container_engine_accelerator/nvidia_gpu/templates/k8s-device-plugin-nvidia-daemonset.yml.j2
+++ b/roles/kubernetes-apps/container_engine_accelerator/nvidia_gpu/templates/k8s-device-plugin-nvidia-daemonset.yml.j2
@@ -29,6 +29,7 @@ spec:
       - operator: "Exists"
         effect: "NoSchedule"
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       volumes:
       - name: device-plugin

--- a/roles/kubernetes-apps/container_engine_accelerator/nvidia_gpu/templates/nvidia-driver-install-daemonset.yml.j2
+++ b/roles/kubernetes-apps/container_engine_accelerator/nvidia_gpu/templates/nvidia-driver-install-daemonset.yml.j2
@@ -36,6 +36,7 @@ spec:
         effect: "NoSchedule"
         operator: "Exists"
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       volumes:
       - name: dev

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
@@ -24,6 +24,7 @@ spec:
       serviceAccountName: ingress-nginx
 {% if ingress_nginx_host_network %}
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
 {% endif %}
 {% if ingress_nginx_nodeselector %}
       nodeSelector:

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/psp-ingress-nginx.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/psp-ingress-nginx.yml.j2
@@ -26,6 +26,9 @@ spec:
     - 'downwardAPI'
     - 'persistentVolumeClaim'
   hostNetwork: {{ ingress_nginx_host_network|bool }}
+{%% if ingress_nginx_host_network %}  
+  dnsPolicy: ClusterFirstWithHostNet
+{% endif %}
   hostPorts:
   - min: 0
     max: 65535

--- a/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-controllers.yml.j2
+++ b/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-controllers.yml.j2
@@ -25,6 +25,7 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: calico-kube-controllers
       tolerations:
         - key: CriticalAddonsOnly

--- a/roles/kubernetes-apps/registry/templates/registry-proxy-psp.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-proxy-psp.yml.j2
@@ -35,6 +35,7 @@ spec:
     - 'downwardAPI'
     - 'persistentVolumeClaim'
   hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
   hostPorts:
   - min: 5000
     max: 5000

--- a/roles/kubernetes/node/templates/manifests/haproxy.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/haproxy.manifest.j2
@@ -8,6 +8,7 @@ metadata:
     k8s-app: kube-haproxy
 spec:
   hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
   nodeSelector:
     beta.kubernetes.io/os: linux
 {% if kube_version is version('v1.11.1', '>=') %}

--- a/roles/kubernetes/node/templates/manifests/nginx-proxy.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/nginx-proxy.manifest.j2
@@ -8,6 +8,7 @@ metadata:
     k8s-app: kube-nginx
 spec:
   hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
   nodeSelector:
     beta.kubernetes.io/os: linux
 {% if kube_version is version('v1.11.1', '>=') %}

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -29,6 +29,7 @@ spec:
       priorityClassName: system-node-critical
 {% endif %}
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: calico-node
       tolerations:
         - effect: NoExecute

--- a/roles/network_plugin/calico/templates/calico-typha.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-typha.yml.j2
@@ -51,6 +51,7 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       tolerations:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly

--- a/roles/network_plugin/canal/templates/canal-node.yaml.j2
+++ b/roles/network_plugin/canal/templates/canal-node.yaml.j2
@@ -19,6 +19,7 @@ spec:
       priorityClassName: system-node-critical
 {% endif %}
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: canal
       tolerations:
         - operator: Exists

--- a/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
@@ -172,6 +172,7 @@ spec:
                 - "NET_ADMIN"
             privileged: true
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       volumes:
         # To keep state between restarts / upgrades
         - name: cilium-run

--- a/roles/network_plugin/contiv/templates/contiv-api-proxy.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-api-proxy.yml.j2
@@ -22,6 +22,7 @@ spec:
       # The API proxy must run in the host network namespace so that
       # it isn't governed by policy that would prevent it from working.
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/roles/network_plugin/contiv/templates/contiv-cleanup.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-cleanup.yml.j2
@@ -19,6 +19,7 @@ spec:
       priorityClassName: system-node-critical
 {% endif %}
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       tolerations:
         - operator: Exists

--- a/roles/network_plugin/contiv/templates/contiv-etcd-proxy.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-etcd-proxy.yml.j2
@@ -19,6 +19,7 @@ spec:
       priorityClassName: system-node-critical
 {% endif %}
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       affinity:
        nodeAffinity:

--- a/roles/network_plugin/contiv/templates/contiv-etcd.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-etcd.yml.j2
@@ -19,6 +19,7 @@ spec:
       priorityClassName: system-node-critical
 {% endif %}
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/roles/network_plugin/contiv/templates/contiv-netmaster.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-netmaster.yml.j2
@@ -22,6 +22,7 @@ spec:
       # The netmaster must run in the host network namespace so that
       # it isn't governed by policy that would prevent it from working.
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/roles/network_plugin/contiv/templates/contiv-netplugin.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-netplugin.yml.j2
@@ -24,6 +24,7 @@ spec:
       priorityClassName: system-node-critical
 {% endif %}
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       tolerations:
         - operator: Exists

--- a/roles/network_plugin/contiv/templates/contiv-ovs.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-ovs.yml.j2
@@ -21,6 +21,7 @@ spec:
       priorityClassName: system-node-critical
 {% endif %}
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       tolerations:
         - operator: Exists

--- a/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
+++ b/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
@@ -110,6 +110,7 @@ spec:
         - name: host-cni-bin
           mountPath: /host/opt/cni/bin/
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       tolerations:
         - operator: Exists
         # Mark pod as critical for rescheduling (Will have no effect starting with kubernetes 1.12)

--- a/roles/network_plugin/kube-router/templates/kube-router.yml.j2
+++ b/roles/network_plugin/kube-router/templates/kube-router.yml.j2
@@ -152,6 +152,7 @@ spec:
         - name: kubeconfig
           mountPath: /var/lib/kube-router
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
 {% if kube_router_enable_dsr %}
       hostIPC: true
       hostPID: true

--- a/roles/network_plugin/multus/templates/multus-daemonset.yml.j2
+++ b/roles/network_plugin/multus/templates/multus-daemonset.yml.j2
@@ -15,6 +15,7 @@ spec:
         app: multus
     spec:
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       nodeSelector:
         beta.kubernetes.io/arch: amd64
       tolerations:

--- a/roles/network_plugin/weave/templates/weave-net.yml.j2
+++ b/roles/network_plugin/weave/templates/weave-net.yml.j2
@@ -216,6 +216,7 @@ items:
                 - name: xtables-lock
                   mountPath: /run/xtables.lock
           hostNetwork: true
+          dnsPolicy: ClusterFirstWithHostNet
           hostPID: true
           restartPolicy: Always
           securityContext:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
According to the documentation here https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy

We should always use `ClusterFirstWithHostNet` as `dnsPolicy` when `HostNetwork` is `true`

**Which issue(s) this PR fixes**:
Fixes #2991

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
`dnsPolicy` is now set to `ClusterFirstWithHostNet` when `hostNetwork` is set to `true` in deployments, daemonsets etc. deployed by Kubespray