### PR TITLE
Move moderator between part1 and part2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,8 @@
 ---
 stages:
   - unit-tests
-  - moderator
   - deploy-part1
+  - moderator
   - deploy-part2
   - deploy-gce
   - deploy-special


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
The `ci check this` moderator is intended as a gatekeeper for costs associated with some CI jobs. Now that the part1 jobs are less cost related we could trigger them all the time.

**Special notes for your reviewer**:
PR following on a Slack discussion. We were talking about removing the moderator. Maybe a first step is to move it between part1 and 2.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
