### PR TITLE
Fixed missing meta for generic CNI network plugin

### DIFF
--- a/roles/network_plugin/meta/main.yml
+++ b/roles/network_plugin/meta/main.yml
@@ -25,6 +25,11 @@ dependencies:
     tags:
       - canal
 
+  - role: network_plugin/cni
+    when: kube_network_plugin == 'cni'
+    tags:
+      - cni
+
   - role: network_plugin/contiv
     when: kube_network_plugin == 'contiv'
     tags:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
While evaluating Kubespray for cluster provisioning on AWS we encountered a problem where advertised ability to use 'generic CNI plugins' didn't work as expected.
CNI plugin binaries were only installed on a master node. This resulted in pods being stuck in ContainerCreating state with messages like this:

```NetworkPlugin cni failed to set up pod "kube-dns-autoscaler-6c4b786f5-zvjwl_kube-system" network: failed to find plugin "loopback" in path [/opt/cni/bin]```

**Special notes for your reviewer**:
Properly rebased from master since #4816 got messed up.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```