### PR TITLE
Fix etcd_events_cluster_enabled in CI due to wrong var used

### DIFF
--- a/tests/files/gce_centos7-flannel-addons.yml
+++ b/tests/files/gce_centos7-flannel-addons.yml
@@ -11,7 +11,7 @@ kubeadm_certificate_key: 3998c58db6497dd17d909394e62d515368c06ec617710d02edea31c
 kube_network_plugin: flannel
 helm_enabled: true
 kubernetes_audit: true
-etcd_events_cluster_setup: true
+etcd_events_cluster_enabled: true
 local_volume_provisioner_enabled: true
 etcd_deployment_type: host
 deploy_netchecker: true

--- a/tests/files/packet_centos7-flannel-addons.yml
+++ b/tests/files/packet_centos7-flannel-addons.yml
@@ -10,7 +10,7 @@ kube_proxy_mode: iptables
 kube_network_plugin: flannel
 helm_enabled: true
 kubernetes_audit: true
-etcd_events_cluster_setup: true
+etcd_events_cluster_enabled: true
 local_volume_provisioner_enabled: true
 etcd_deployment_type: host
 deploy_netchecker: true


### PR DESCRIPTION


**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
To test and validate if the PR https://github.com/kubernetes-sigs/kubespray/pull/4846#issuecomment-499460377 

Based on the result we'll review if we need to open the PR again


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
