### PR TITLE
Disable warning about group names with dash or dot

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,6 +4,8 @@ ssh_args = -o ControlMaster=auto -o ControlPersist=30m -o ConnectionAttempts=100
 #control_path = ~/.ssh/ansible-%%r@%%h:%%p
 [defaults]
 strategy_plugins = plugins/mitogen/ansible_mitogen/plugins/strategy
+# https://github.com/ansible/ansible/issues/56930 (to ignore group names with - and .)
+force_valid_group_names = ignore
 
 host_key_checking=False
 gathering = smart


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Disables warning about group names with dash and dot in them as per: https://github.com/ansible/ansible/issues/56930

**Which issue(s) this PR fixes**:
Fixes #4830
