### PR TITLE
remove namespace from ClusterRole

### DIFF
--- a/roles/kubernetes-apps/cluster_roles/templates/psp-cr.yml.j2
+++ b/roles/kubernetes-apps/cluster_roles/templates/psp-cr.yml.j2
@@ -20,7 +20,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: psp:restricted
-  namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile


### PR DESCRIPTION
I may be mistaken, but as far as I can tell from the documentation, specifying a namespace has no meaning in a ClusterRole, so it should be removed.
https://kubernetes.io/docs/reference/access-authn-authz/rbac/

I have tested this in v1.12.7. I create a ClusterRole like this:
```
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: test-cr
  namespace: development
  labels:
    kubernetes.io/cluster-service: "true"
    addonmanager.kubernetes.io/mode: Reconcile
rules:
- apiGroups:
  - policy
  resourceNames:
  - restricted
  resources:
  - podsecuritypolicies
  verbs:
  - use
```

I first do `kubectl apply -f test.yml ` to create this ClusterRole, then change the test.yaml file in each of 3 ways: remove namespace from the definition, add namespace back to the definition, change namespace to something that doesn't exist. For each of those changes, I ` kubectl apply -f test.yml` again. In each case, the result is `clusterrole.rbac.authorization.k8s.io/test-cr unchanged` , demonstrating that the presence of the "namespace" field has no effect on the ClusterRole.

Besides, it seems like it might be problematic if the restricted PSP was applied to the kube-system namespace. Maybe this line was just left in accidentally?

