### PR TITLE
Remove GCE tests as CNCF funding ended

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,7 +64,6 @@ ci-authorized:
 include:
   - .gitlab-ci/lint.yml
   - .gitlab-ci/shellcheck.yml
-  - .gitlab-ci/gce.yml
   - .gitlab-ci/digital-ocean.yml
   - .gitlab-ci/terraform.yml
   - .gitlab-ci/packet.yml


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind failing-test

**What this PR does / why we need it**:
Remove all CI jobs from GCE as CNCF funding ended. Missing tests must now run on either Packet or OVH.