### PR TITLE
Remove invalid field dnsPolicy from podSecurityPolicy

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-psp.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-psp.yml.j2
@@ -26,7 +26,6 @@ spec:
     - 'downwardAPI'
     - 'persistentVolumeClaim'
   hostNetwork: true
-  dnsPolicy: ClusterFirstWithHostNet
   hostIPC: false
   hostPID: false
   runAsUser:

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/psp-ingress-nginx.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/psp-ingress-nginx.yml.j2
@@ -26,9 +26,6 @@ spec:
     - 'downwardAPI'
     - 'persistentVolumeClaim'
   hostNetwork: {{ ingress_nginx_host_network|bool }}
-{%% if ingress_nginx_host_network %}  
-  dnsPolicy: ClusterFirstWithHostNet
-{% endif %}
   hostPorts:
   - min: 0
     max: 65535

--- a/roles/kubernetes-apps/registry/templates/registry-proxy-psp.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-proxy-psp.yml.j2
@@ -35,7 +35,6 @@ spec:
     - 'downwardAPI'
     - 'persistentVolumeClaim'
   hostNetwork: true
-  dnsPolicy: ClusterFirstWithHostNet
   hostPorts:
   - min: 5000
     max: 5000


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In conjunction with #4863 

This was introduced by #4843, but `dnsPolicy` in the [PodSecurityPolicySpec ](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#podsecuritypolicyspec-v1beta1-policy) has been removed since v1.12
