### PR TITLE
fix references to sample files in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,12 +33,18 @@ data_files =
         LICENSE
         README.md
     usr/share/doc/kubespray/inventory/ =
-        inventory/sample/hosts.ini
+        inventory/sample/inventory.ini
     etc/kubespray/ =
         ansible.cfg
     etc/kubespray/inventory/sample/group_vars/ =
-        inventory/sample/group_vars/all.yml
-        inventory/sample/group_vars/k8s-cluster.yml
+        inventory/sample/group_vars/etcd.yml
+    etc/kubespray/inventory/sample/group_vars/all/ =
+        inventory/sample/group_vars/all/all.yml
+        inventory/sample/group_vars/all/azure.yml
+        inventory/sample/group_vars/all/coreos.yml
+        inventory/sample/group_vars/all/docker.yml
+        inventory/sample/group_vars/all/oci.yml
+        inventory/sample/group_vars/all/openstack.yml
 
 [wheel]
 universal = 1


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> 
/kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Resolving issue #4881, which made it so that a wheel could not be built.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4881 

**Special notes for your reviewer**:

To test before/after, simply checkout and run this command to try to build the wheel:

```python3 setup.py sdist bdist_wheel```

It used to fail and now it works.  There is no change to actual Kubespray playbooks or dependencies, so this should be easy to accept, I hope.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```