### PR TITLE
re-run kubeadm init when kubeadm_config_changed

### DIFF
--- a/roles/kubernetes/master/tasks/kubeadm-secondary-legacy.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-secondary-legacy.yml
@@ -37,7 +37,7 @@
   until: kubeadm_init is succeeded or "field is immutable" in kubeadm_init.stderr
   when:
     - inventory_hostname != groups['kube-master']|first
-    - not kubeadm_already_run.stat.exists
+    - not kubeadm_already_run.stat.exists or kubeadm_config.changed
   failed_when: kubeadm_init.rc != 0 and "field is immutable" not in kubeadm_init.stderr
   environment:
     PATH: "{{ bin_dir }}:{{ ansible_env.PATH }}"

--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -124,7 +124,9 @@
   # Retry is because upload config sometimes fails
   retries: 3
   until: kubeadm_init is succeeded or "field is immutable" in kubeadm_init.stderr
-  when: inventory_hostname == groups['kube-master']|first and not kubeadm_already_run.stat.exists
+  when:
+    - inventory_hostname == groups['kube-master']|first
+    - not kubeadm_already_run.stat.exists or kubeadm_config.changed
   failed_when: kubeadm_init.rc != 0 and "field is immutable" not in kubeadm_init.stderr
   environment:
     PATH: "{{ bin_dir }}:{{ ansible_env.PATH }}"
@@ -175,10 +177,6 @@
 - name: kubeadm | Initialize other masters (experimental control plane)
   include: kubeadm-secondary-legacy.yml
   when: not kubeadm_control_plane
-
-- name: kubeadm | upgrade kubernetes cluster
-  import_tasks: kubeadm-upgrade.yml
-  when: upgrade_cluster_setup
 
 - name: kubeadm | Check serviceaccount key again
   stat:

--- a/roles/kubernetes/master/tasks/kubeadm-version.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-version.yml
@@ -17,3 +17,4 @@
   template:
     src: "kubeadm-config.{{ kubeadmConfig_api_version }}.yaml.j2"
     dest: "{{ kube_config_dir }}/kubeadm-config.yaml"
+  register: kubeadm_config


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug

**What this PR does / why we need it**:
`kubeadm upgrade` not work because it start CoreDNS, and `kubeadm upgrade` do not support `--skip-phases=addon/coredns` like `kubeadm init`, so re-run `kubeadm init` instead of `kubeadm upgrade`, and sometimes we want modify k8s master ( ex. kube-apiserver ) parameters, we also need re-run `kubeadm init`.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4894

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
