### PR TITLE
Fix: overly strict hostname sanity checking.

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -121,8 +121,8 @@
 
 - name: Stop if bad hostname
   assert:
-    that: inventory_hostname is match("[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
-    msg: "Hostname must consist of lower case alphanumeric characters, '.' or '-', and must start and end with an alphanumeric character"
+    that: inventory_hostname is match("[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?)*$")
+    msg: "Hostname must consist of alphanumeric characters, '.' or '-', and must start and end with an alphanumeric character"
   ignore_errors: "{{ ignore_assert_errors }}"
 
 - name: check cloud_provider value


### PR DESCRIPTION
[hostnames with capital letters are rejected](https://github.com/kubernetes-sigs/kubespray/blob/27a99e0a3f9f879bbd887864e440a28ea61ffdbc/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml#L122-L126), but [should not be](https://tools.ietf.org/html/rfc1034#section-3.1):

> By convention, domain names can be stored with arbitrary case, but
domain name comparisons for all present domain functions are done in a
case-insensitive manner, assuming an ASCII character set, and a high
order zero bit.  This means that you are free to create a node with
label "A" or a node with label "a", but not both as brothers;  [...]

This PR re-aligns kubespray hostname checking with the standard.

I have no knowledge of kubespray, let alone its internals, so I may very well have missed something.  Please somebody double-check if this is a good idea.