### PR TITLE
nodelocaldns: allow to set health port

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -134,6 +134,7 @@ dns_mode: coredns
 # Enable nodelocal dns cache
 enable_nodelocaldns: true
 nodelocaldns_ip: 169.254.25.10
+nodelocaldns_health_port: 9254
 
 # Can be docker_dns, host_resolvconf or none
 resolvconf_mode: docker_dns

--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2
@@ -21,7 +21,7 @@ data:
             force_tcp
         }
         prometheus :9253
-        health {{ nodelocaldns_ip }}:8080
+        health {{ nodelocaldns_ip }}:{{ nodelocaldns_health_port }}
     }
     in-addr.arpa:53 {
         errors

--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-daemonset.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-daemonset.yml.j2
@@ -58,7 +58,7 @@ spec:
           httpGet:
             host: {{ nodelocaldns_ip }}
             path: /health
-            port: 8080
+            port: {{ nodelocaldns_health_port }}
             scheme: HTTP
           timeoutSeconds: 5
           successThreshold: 1
@@ -67,7 +67,7 @@ spec:
           httpGet:
             host: {{ nodelocaldns_ip }}
             path: /health
-            port: 8080
+            port: {{ nodelocaldns_health_port }}
             scheme: HTTP
           timeoutSeconds: 5
           successThreshold: 1

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -68,6 +68,7 @@ dns_mode: coredns
 # Enable nodelocal dns cache
 enable_nodelocaldns: true
 nodelocaldns_ip: 169.254.25.10
+nodelocaldns_health_port: 9254
 
 # Should be set to a cluster IP if using a custom cluster DNS
 manual_dns_server: ""


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
8080 is a pretty common port, using nodelocaldns_ip:8080 still
prevents node processes or hostNetwork=true processes to bind to *:8080

This introduce nodelocaldns_health_port to easily be able to change this port, and use 9254 by default

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
This PR change the default nodelocaldns health port from 8080 to 9254

```release-note
Add nodelocaldns_health_port var to allow to set nodelocaldns health port, switch from 8080 to 9254 by default
```
