### PR TITLE
Add kube_override_hostname to kubeadm certs.

### DIFF
--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -55,7 +55,7 @@
 
 - name: kubeadm | aggregate all SANs
   set_fact:
-    apiserver_sans: "{{ (sans_base + groups['kube-master'] + sans_lb + sans_lb_ip + sans_supp + sans_access_ip + sans_ip + sans_address) | unique }}"
+    apiserver_sans: "{{ (sans_base + groups['kube-master'] + sans_lb + sans_lb_ip + sans_supp + sans_access_ip + sans_ip + sans_address + sans_override) | unique }}"
   vars:
     sans_base:
       - "kubernetes"
@@ -71,6 +71,7 @@
     sans_access_ip: "{{ groups['kube-master'] | map('extract', hostvars, 'access_ip') | list | select('defined') | list }}"
     sans_ip: "{{ groups['kube-master'] | map('extract', hostvars, 'ip') | list | select('defined') | list }}"
     sans_address: "{{ groups['kube-master'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | list | select('defined') | list }}"
+    sans_override: "{{ [kube_override_hostname] if kube_override_hostname is defined else [] }}"
   tags: facts
 
 - name: Create audit-policy directory

--- a/roles/kubernetes/master/templates/kubeadm-controlplane.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-controlplane.v1beta1.yaml.j2
@@ -16,7 +16,7 @@ controlPlane:
     advertiseAddress: {{ kube_apiserver_address }}
     bindPort: {{ kube_apiserver_port }}
 nodeRegistration:
-  name: {{ inventory_hostname  }}
+  name: {{ kube_override_hostname|default(inventory_hostname) }}
 {% if container_manager == 'crio' %}
   criSocket: /var/run/crio/crio.sock
 {% else %}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In case when kube_override_hostname is defined, kubeadm join command fails by timeout, because wait for node with wrong name.
This change add kube_override_hostname to allows SANs and set it in controlplane config for kubeadm.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
