### PR TITLE
Ansible 2.8.x note

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Note: The list of validated [docker versions](https://github.com/kubernetes/kube
 Requirements
 ------------
 -   **Minimum required version of Kubernetes is v1.13**
--   **Ansible v2.7.8 (or newer) and python-netaddr is installed on the machine
+-   **Ansible v2.7.8 (or newer, but [not 2.8.x](https://github.com/kubernetes-sigs/kubespray/issues/4778)) and python-netaddr is installed on the machine
     that will run Ansible commands**
 -   **Jinja 2.9 (or newer) is required to run the Ansible Playbooks**
 -   The target servers must have **access to the Internet** in order to pull docker images. Otherwise, additional configuration is required (See [Offline Environment](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/downloads.md#offline-environment))


### PR DESCRIPTION
Update README.md to link to the open issue that shows Ansible 2.8.x doesn't work with Kubespray.  The requirements.txt file is already fixed to 2.7.8 so only the README needed updating, I think.

**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Clarifies the Ansible versions that will work at present.

**Which issue(s) this PR fixes**:

None - but does clarify the working position as per Issue kubernetes-sigs#4778.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
