### PR TITLE
Repair kube_proxy_exclude_cidrs

### DIFF
--- a/roles/kubernetes/master/defaults/main/kube-proxy.yml
+++ b/roles/kubernetes/master/defaults/main/kube-proxy.yml
@@ -69,7 +69,7 @@ kube_proxy_min_sync_period: 0s
 kube_proxy_sync_period: 30s
 
 # A comma-separated list of CIDR's which the ipvs proxier should not touch when cleaning up IPVS rules.
-kube_proxy_exclude_cidrs: 'null'
+kube_proxy_exclude_cidrs: []
 
 # The ipvs scheduler type when proxy mode is ipvs
 # rr: round-robin

--- a/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1alpha3.yaml.j2
@@ -277,7 +277,7 @@ iptables:
  minSyncPeriod: {{ kube_proxy_min_sync_period }}
  syncPeriod: {{ kube_proxy_sync_period }}
 ipvs:
- excludeCIDRs: {{ kube_proxy_exclude_cidrs }}
+ excludeCIDRs: {{ "[]" if kube_proxy_exclude_cidrs is not defined or kube_proxy_exclude_cidrs == "null" or kube_proxy_exclude_cidrs | length == 0 else (kube_proxy_exclude_cidrs if kube_proxy_exclude_cidrs[0] == '[' else ("[" + kube_proxy_exclude_cidrs + "]" if (kube_proxy_exclude_cidrs[0] | length) == 1 else "[" + kube_proxy_exclude_cidrs | join(",") + "]")) }}
  minSyncPeriod: {{ kube_proxy_min_sync_period }}
  scheduler: {{ kube_proxy_scheduler }}
  syncPeriod: {{ kube_proxy_sync_period }}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
@@ -326,7 +326,7 @@ iptables:
  minSyncPeriod: {{ kube_proxy_min_sync_period }}
  syncPeriod: {{ kube_proxy_sync_period }}
 ipvs:
- excludeCIDRs: {{ kube_proxy_exclude_cidrs }}
+ excludeCIDRs: {{ "[]" if kube_proxy_exclude_cidrs is not defined or kube_proxy_exclude_cidrs == "null" or kube_proxy_exclude_cidrs | length == 0 else (kube_proxy_exclude_cidrs if kube_proxy_exclude_cidrs[0] == '[' else ("[" + kube_proxy_exclude_cidrs + "]" if (kube_proxy_exclude_cidrs[0] | length) == 1 else "[" + kube_proxy_exclude_cidrs | join(",") + "]")) }}
  minSyncPeriod: {{ kube_proxy_min_sync_period }}
  scheduler: {{ kube_proxy_scheduler }}
  syncPeriod: {{ kube_proxy_sync_period }}


### PR DESCRIPTION
If you currently set the kube_proxy_exclude_cidrs to a list of ip subnets, it fails without breaking the ansible pass (no error reported), you can only see it doing that on a master node:

kubeadm config upload from-file --config /etc/kubernetes/kubeadm-config.yaml 
KubeProxyConfiguration.KubeProxyIPVSConfiguration.ExcludeCidrs: Invalid value: []string{"u'10.1.0.0/22'"}: must be a valid IP block

It also does not work trying to set it as a string...

This fix is tested and works with the following inputs:

kube_proxy_exclude_cidrs: "[10.100.100.2,10.100.2.1]"
kube_proxy_exclude_cidrs: 'null'
kube_proxy_exclude_cidrs: []
kube_proxy_exclude_cidrs: [10.100.100.2,10.100.2.1]
kube_proxy_exclude_cidrs: "10.100.100.2,10.100.2.1"



**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:



<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Allow to set a list of subnets with CIDR notation to be excluded from kube proxy management (ipvs)
```
