### PR TITLE
Additional uppercase proxy env variables

### DIFF
--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -411,8 +411,11 @@ no_proxy: >-
 
 proxy_env:
   http_proxy: "{{ http_proxy| default ('') }}"
+  HTTP_PROXY: "{{ http_proxy| default ('') }}"
   https_proxy: "{{ https_proxy| default ('') }}"
+  HTTPS_PROXY: "{{ https_proxy| default ('') }}"
   no_proxy: "{{ no_proxy| default ('') }}"
+  NO_PROXY: "{{ no_proxy| default ('') }}"
 
 ssl_ca_dirs: >-
   [


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Some applications consume proxy parameters from uppercase variants (ex. instead of `http_proxy` they use `HTTP_PROXY`). One example where it causes problems is mentioned in issue #4351. In this PR new proxy environment variables are added with values matching their lowercase counterparts: `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY`.

**Which issue(s) this PR fixes**:
Fixes #4351

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
