### PR TITLE
configure docker_options directly with template

### DIFF
--- a/roles/container-engine/docker/templates/docker-options.conf.j2
+++ b/roles/container-engine/docker/templates/docker-options.conf.j2
@@ -1,5 +1,15 @@
 [Service]
-Environment="DOCKER_OPTS={{ docker_options|default('') }} --iptables={{ docker_iptables_enabled | default('false') }}"
+Environment="DOCKER_OPTS={{ docker_options|default('') }} --iptables={{ docker_iptables_enabled | default('false') }} \
+{% for i in docker_insecure_registries %}--insecure-registry={{ i }} {% endfor %} \
+{% for i in docker_registry_mirrors %}--registry-mirror={{ i }} {% endfor %} \
+{% if docker_version != "latest" and docker_version is version('17.05', '<') %}--graph={% else %}--data-root={% endif %}{{ docker_daemon_graph }} \
+{% if ansible_os_family not in ["openSUSE Leap", "openSUSE Tumbleweed", "Suse"] %}{{ docker_log_opts }}{% endif %} \
+{% if ansible_architecture == "aarch64" and ansible_os_family == "RedHat" %} \
+--add-runtime docker-runc=/usr/libexec/docker/docker-runc-current \
+--default-runtime=docker-runc --exec-opt native.cgroupdriver=systemd \
+--userland-proxy-path=/usr/libexec/docker/docker-proxy-current --signature-verification=false \
+{% endif %}"
+
 {% if docker_mount_flags is defined and docker_mount_flags != "" %}
 MountFlags={{ docker_mount_flags }}
 {% endif %}

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -220,17 +220,18 @@ docker_iptables_enabled: "false"
 # Rotate container stderr/stdout logs at 50m and keep last 5
 docker_log_opts: "--log-opt max-size=50m --log-opt max-file=5"
 
-## An obvious use case is allowing insecure-registry access to self hosted registries.
-## Can be ipaddress and domain_name.
-## example define 172.19.16.11 or mirror.registry.io
+## A list of insecure docker registries (IP address or domain name), for example
+## to allow insecure-registry access to self-hosted registries. Empty by default.
 # docker_insecure_registries:
 #   - mirror.registry.io
 #   - 172.19.16.11
+docker_insecure_registries: []
 
-## Add other registry,example China registry mirror.
+## A list of additional registry mirrors, for example China registry mirror. Empty by default.
 # docker_registry_mirrors:
 #   - https://registry.docker-cn.com
 #   - https://mirror.aliyuncs.com
+docker_registry_mirrors: []
 
 ## If non-empty will override default system MounFlags value.
 ## This option takes a mount propagation flag: shared, slave
@@ -240,24 +241,7 @@ docker_log_opts: "--log-opt max-size=50m --log-opt max-file=5"
 # docker_mount_flags:
 
 ## A string of extra options to pass to the docker daemon.
-## This string should be exactly as you wish it to appear.
-docker_options: >-
-  {%- if docker_insecure_registries is defined %}
-  {{ docker_insecure_registries | map('regex_replace', '^(.*)$', '--insecure-registry=\1' ) | list | join(' ') }}
-  {%- endif %}
-  {% if docker_registry_mirrors is defined %}
-  {{ docker_registry_mirrors | map('regex_replace', '^(.*)$', '--registry-mirror=\1' ) | list | join(' ') }}
-  {%- endif %}
-  {%- if docker_version != "latest" and docker_version is version('17.05', '<') %}
-  --graph={{ docker_daemon_graph }} {% if ansible_os_family not in ["openSUSE Leap", "openSUSE Tumbleweed", "Suse"] %}{{ docker_log_opts }}{% endif %}
-  {%- else %}
-  --data-root={{ docker_daemon_graph }} {% if ansible_os_family not in ["openSUSE Leap", "openSUSE Tumbleweed", "Suse"] %}{{ docker_log_opts }}{% endif %}
-  {%- endif %}
-  {%- if ansible_architecture == "aarch64" and ansible_os_family == "RedHat" %}
-  --add-runtime docker-runc=/usr/libexec/docker/docker-runc-current
-  --default-runtime=docker-runc --exec-opt native.cgroupdriver=systemd
-  --userland-proxy-path=/usr/libexec/docker/docker-proxy-current --signature-verification=false
-  {%- endif -%}
+# docker_options: ""
 
 ## A list of plugins to install using 'docker plugin install --grant-all-permissions'
 ## Empty by default so no plugins will be installed.


### PR DESCRIPTION

**What this PR does / why we need it**:

It is difficult to actually use the docker_options variable to add customizations to your Docker 
configuration, because the current value of this very long string needs to be left as is just for the baseline Kubespray Docker config to work as expected.
This PR refactors Docker options to separate the user-provided options (parameters in the docker_options variable) from the Kubespray-managed Docker config 
(templated into the systemd docker-options.conf file directly).  This provides an easy way to customize Docker configuration.

Some regex_replace maps|list|joins are replaced by a simple jinja iterator.
A statement that was somehow duplicated in both branches of an if/else is factored out.
Sensitive whitespace control in jinja is replaced by a few lines with backslashes at the end.

**Special notes for your reviewer**:
This follows exactly the same pattern as used for docker-dns.conf.

**Does this PR introduce a user-facing change?**:
If users modified the default value of docker_options in order to customize their Docker configuration, previously 
they may have had to account for many other lines of configuration required for Kubespray to apply baseline Docker configuration and
 consolidate their own customizations with those lines. Now, users only need to specify the additional configuration they want to 
provide in docker_options and it will not overwrite any other Docker configuration applied by Kubespray.

```release-note
The docker_options variable is now used as an addon to Docker configuration rather than overwriting Docker configuration. If you were modifying the default value of this variable you should refactor your modifications accordingly.
```

/kind cleanup
/kind design