### PR TITLE
Fix empty kube_override_hostname in apiserver_sans

### DIFF
--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -71,7 +71,7 @@
     sans_access_ip: "{{ groups['kube-master'] | map('extract', hostvars, 'access_ip') | list | select('defined') | list }}"
     sans_ip: "{{ groups['kube-master'] | map('extract', hostvars, 'ip') | list | select('defined') | list }}"
     sans_address: "{{ groups['kube-master'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | list | select('defined') | list }}"
-    sans_override: "{{ [kube_override_hostname] if kube_override_hostname is defined else [] }}"
+    sans_override: "{{ [kube_override_hostname] if kube_override_hostname else [] }}"
   tags: facts
 
 - name: Create audit-policy directory


### PR DESCRIPTION
kubernetes/master role defines this value as an empty string
when using a cloud provider, not undefined. The check was updated
accordingly.