### PR TITLE
update ansible due to paramiko error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.7.8
+ansible==2.8.1
 jinja2==2.10.1
 netaddr==0.7.19
 pbr==5.2.0


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes a bug Paramiko error due probably to a paramiko update. To get working, we have to change the ansible version to latest, or do :  
pip install -r requirements.txt
pip uninstall ansible
pip install ansible


