### PR TITLE
Remove wasteful extra gather facts step

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -28,19 +28,6 @@
 
 - hosts: k8s-cluster:etcd:calico-rr
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
-  vars:
-    ansible_ssh_pipelining: true
-  gather_facts: false
-  pre_tasks:
-    - name: gather facts from all instances
-      setup:
-      delegate_to: "{{ item }}"
-      delegate_facts: true
-      with_items: "{{ groups['k8s-cluster'] + groups['etcd'] + groups['calico-rr']|default([]) }}"
-      run_once: true
-
-- hosts: k8s-cluster:etcd:calico-rr
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
     - { role: kubespray-defaults}
     - { role: kubernetes/preinstall, tags: preinstall }

--- a/extra_playbooks/upgrade-only-k8s.yml
+++ b/extra_playbooks/upgrade-only-k8s.yml
@@ -29,12 +29,6 @@
 
 - hosts: k8s-cluster:etcd:calico-rr
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
-  vars:
-    ansible_ssh_pipelining: true
-  gather_facts: true
-
-- hosts: k8s-cluster:etcd:calico-rr
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
     - { role: kubespray-defaults}
     - { role: kubernetes/preinstall, tags: preinstall }

--- a/scale.yml
+++ b/scale.yml
@@ -27,13 +27,6 @@
     - { role: kubespray-defaults}
     - { role: bootstrap-os, tags: bootstrap-os}
 
-- name: Gather facts about our masters and etcd nodes
-  hosts: k8s-cluster:etcd:calico-rr
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
-  vars:
-    ansible_ssh_pipelining: true
-  gather_facts: true
-
 - name: Generate the etcd certificates beforehand
   hosts: etcd
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"

--- a/upgrade-cluster.yml
+++ b/upgrade-cluster.yml
@@ -32,18 +32,6 @@
 
 - hosts: k8s-cluster:etcd:calico-rr
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
-  vars:
-    ansible_ssh_pipelining: true
-  gather_facts: true
-  pre_tasks:
-    - name: gather facts from all instances
-      setup:
-      delegate_to: "{{ item }}"
-      delegate_facts: True
-      with_items: "{{ groups['k8s-cluster'] + groups['etcd'] + groups['calico-rr']|default([]) }}"
-
-- hosts: k8s-cluster:etcd:calico-rr
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   serial: "{{ serial | default('20%') }}"
   roles:
     - { role: kubespray-defaults}


### PR DESCRIPTION
Ansible will gather facts on the preinstall/download role
automatically at the start of that play.
