### PR TITLE
kubeadm_discovery_address should not contain proto

### DIFF
--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -5,7 +5,7 @@
       {%- if "127.0.0.1" in kube_apiserver_endpoint or "localhost" in kube_apiserver_endpoint -%}
       {{ first_kube_master }}:{{ kube_apiserver_port }}
       {%- else -%}
-      {{ kube_apiserver_endpoint }}
+      {{ kube_apiserver_endpoint | replace("https://", "") }}
       {%- endif %}
   tags:
     - facts
@@ -119,7 +119,7 @@
   when:
     - kubeadm_config_api_fqdn is not defined
     - not is_kube_master
-    - kubeadm_discovery_address != kube_apiserver_endpoint
+    - kubeadm_discovery_address != kube_apiserver_endpoint | replace("https://", "")
   notify: restart kubelet
 
 - name: Update server field in kube-proxy kubeconfig
@@ -131,7 +131,7 @@
   when:
     - inventory_hostname == groups['kube-master']|first
     - kubeadm_config_api_fqdn is not defined
-    - kubeadm_discovery_address != kube_apiserver_endpoint
+    - kubeadm_discovery_address != kube_apiserver_endpoint | replace("https://", "")
     - not kube_proxy_remove
   tags:
     - kube-proxy
@@ -142,7 +142,7 @@
   when:
     - inventory_hostname == groups['kube-master']|first
     - kubeadm_config_api_fqdn is not defined
-    - kubeadm_discovery_address != kube_apiserver_endpoint
+    - kubeadm_discovery_address != kube_apiserver_endpoint | replace("https://", "")
     - not kube_proxy_remove
   tags:
     - kube-proxy
@@ -166,7 +166,7 @@
   when:
     - inventory_hostname == groups['kube-master']|first
     - kube_proxy_remove
-    - kubeadm_discovery_address != kube_apiserver_endpoint
+    - kubeadm_discovery_address != kube_apiserver_endpoint | replace("https://", "")
   tags:
     - kube-proxy
 

--- a/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1alpha1.j2
+++ b/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1alpha1.j2
@@ -6,7 +6,7 @@ discoveryTokenAPIServers:
 {% if kubeadm_config_api_fqdn is defined %}
 - {{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
 {% else %}
-- {{ kubeadm_discovery_address | replace("https://", "")}}
+- {{ kubeadm_discovery_address }}
 {% endif %}
 discoveryTokenCACertHashes:
 - sha256:{{ kubeadm_ca_hash.stdout }}

--- a/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1alpha2.j2
+++ b/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1alpha2.j2
@@ -11,7 +11,7 @@ discoveryTokenAPIServers:
 {% if kubeadm_config_api_fqdn is defined %}
 - {{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
 {% else %}
-- {{ kubeadm_discovery_address | replace("https://", "")}}
+- {{ kubeadm_discovery_address }}
 {% endif %}
 discoveryTokenUnsafeSkipCAVerification: true
 nodeRegistration:

--- a/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1alpha3.j2
+++ b/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1alpha3.j2
@@ -11,7 +11,7 @@ discoveryTokenAPIServers:
 {% if kubeadm_config_api_fqdn is defined %}
 - {{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
 {% else %}
-- {{ kubeadm_discovery_address | replace("https://", "")}}
+- {{ kubeadm_discovery_address }}
 {% endif %}
 discoveryTokenUnsafeSkipCAVerification: true
 nodeRegistration:

--- a/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1beta1.j2
+++ b/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1beta1.j2
@@ -6,7 +6,7 @@ discovery:
 {% if kubeadm_config_api_fqdn is defined %}
     apiServerEndpoint: {{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
 {% else %}
-    apiServerEndpoint: {{ kubeadm_discovery_address | replace("https://", "")}}
+    apiServerEndpoint: {{ kubeadm_discovery_address }}
 {% endif %}
     token: {{ kubeadm_token }}
     caCertHashes:

--- a/roles/kubernetes/master/templates/kubeadm-controlplane.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-controlplane.v1beta1.yaml.j2
@@ -5,7 +5,7 @@ discovery:
 {% if kubeadm_config_api_fqdn is defined %}
     apiServerEndpoint: {{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
 {% else %}
-    apiServerEndpoint: {{ kubeadm_discovery_address | replace("https://", "")}}
+    apiServerEndpoint: {{ kubeadm_discovery_address }}
 {% endif %}
     token: {{ kubeadm_token }}
     unsafeSkipCAVerification: true


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
`kubeadm_discovery_address` contains "https://" proto but it is removed everywhere it is used except in kubeadm_etcd_node.yml (cf the referenced issue).

In this PR, `kubeadm_discovery_address` is consistent with `kubeadm_discovery_address` in kubeadm-secondary-experimental.yml. The depending conditions have been modified accordingly

**Which issue(s) this PR fixes**:
Fixes #4929

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No
