### PR TITLE
Default to refreshing kubeadm etcd key

### DIFF
--- a/roles/kubernetes/kubeadm/defaults/main.yml
+++ b/roles/kubernetes/kubeadm/defaults/main.yml
@@ -12,7 +12,7 @@ kube_override_hostname: >-
   {%- endif -%}
 
 # Requests a fresh upload of certificates from first master
-kubeadm_etcd_refresh_cert_key: false
+kubeadm_etcd_refresh_cert_key: true
 
 # Experimental kubeadm etcd deployment mode. Available only for new deployment
 etcd_kubeadm_enabled: false


### PR DESCRIPTION
This should have been set to true by default. There are only some rare cases when refresh is not desirable.