### PR TITLE
Add support for Docker plugins

### DIFF
--- a/docs/vars.md
+++ b/docs/vars.md
@@ -98,6 +98,7 @@ Stack](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/dns-stack.m
 
 * *docker_options* - Commonly used to set
   ``--insecure-registry=myregistry.mydomain:5000``
+* *docker_plugin* - This string can be used to define a [Docker plugin](https://docs.docker.com/engine/extend/) to install. 
 * *http_proxy/https_proxy/no_proxy* - Proxy variables for deploying behind a
   proxy. Note that no_proxy defaults to all internal cluster IPs and hostnames
   that correspond to each node.

--- a/docs/vars.md
+++ b/docs/vars.md
@@ -98,7 +98,7 @@ Stack](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/dns-stack.m
 
 * *docker_options* - Commonly used to set
   ``--insecure-registry=myregistry.mydomain:5000``
-* *docker_plugin* - This string can be used to define a [Docker plugin](https://docs.docker.com/engine/extend/) to install. 
+* *docker_plugins* - This list can be used to define [Docker plugins](https://docs.docker.com/engine/extend/) to install. 
 * *http_proxy/https_proxy/no_proxy* - Proxy variables for deploying behind a
   proxy. Note that no_proxy defaults to all internal cluster IPs and hostnames
   that correspond to each node.

--- a/roles/container-engine/docker/tasks/docker_plugin.yml
+++ b/roles/container-engine/docker/tasks/docker_plugin.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Install Docker plugin
+  command: docker plugin install --grant-all-permissions {{ docker_plugin | quote }}
+  when: docker_plugin is defined
+  register: docker_plugin_status
+  failed_when:
+    - docker_plugin_status.failed
+    - '"already exists" not in docker_plugin_status.stderr'
+

--- a/roles/container-engine/docker/tasks/docker_plugin.yml
+++ b/roles/container-engine/docker/tasks/docker_plugin.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Install Docker plugin
   command: docker plugin install --grant-all-permissions {{ docker_plugin | quote }}
   when: docker_plugin is defined
@@ -7,4 +6,3 @@
   failed_when:
     - docker_plugin_status.failed
     - '"already exists" not in docker_plugin_status.stderr'
-

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -235,13 +235,11 @@
         resolvconf_mode == 'docker_dns' and
         installed_docker_version.stdout is version('1.12', '<')
 
-- name: Install Docker plugin
-  command: docker plugin install --grant-all-permissions {{ docker_plugin | quote }}
-  when: docker_plugin is defined
-  register: docker_plugin_status
-  failed_when:
-    - docker_plugin_status.failed 
-    - '"already exists" not in docker_plugin_status.stderr'
+# Install each plugin using a looped include to make error handling in the included task simpler.
+- include_tasks: docker_plugin.yml
+  loop: "{{ docker_plugins }}"
+  loop_control:
+    loop_var: docker_plugin
 
 - name: Set docker systemd config
   import_tasks: systemd.yml

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -235,6 +235,14 @@
         resolvconf_mode == 'docker_dns' and
         installed_docker_version.stdout is version('1.12', '<')
 
+- name: Install Docker plugin
+  command: docker plugin install --grant-all-permissions {{ docker_plugin | quote }}
+  when: docker_plugin is defined
+  register: docker_plugin_status
+  failed_when:
+    - docker_plugin_status.failed 
+    - '"already exists" not in docker_plugin_status.stderr'
+
 - name: Set docker systemd config
   import_tasks: systemd.yml
 

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -255,9 +255,9 @@ docker_options: >-
   --userland-proxy-path=/usr/libexec/docker/docker-proxy-current --signature-verification=false
   {%- endif -%}
 
-## A docker plugin to install using 'docker plugin install --grant-all-permissions'
-## Undefined by default so no plugin will be installed. Example:
-# docker_plugin: "cvmfs/graphdriver"
+## A list of plugins to install using 'docker plugin install --grant-all-permissions'
+## Empty by default so no plugins will be installed.
+docker_plugins: []
 
 # Experimental kubeadm etcd deployment mode. Available only for new deployment
 etcd_kubeadm_enabled: false

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -255,6 +255,10 @@ docker_options: >-
   --userland-proxy-path=/usr/libexec/docker/docker-proxy-current --signature-verification=false
   {%- endif -%}
 
+## A docker plugin to install using 'docker plugin install --grant-all-permissions'
+## Undefined by default so no plugin will be installed. Example:
+# docker_plugin: "cvmfs/graphdriver"
+
 # Experimental kubeadm etcd deployment mode. Available only for new deployment
 etcd_kubeadm_enabled: false
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Docker plugins are a useful way to extend the capabilities of Docker:
https://docs.docker.com/engine/extend/

This simple addition enables Kubespray users to benefit from the flexibility of Docker plugins in their k8s deployments.

**Special notes for your reviewer**:
See below.

**Can't you just run your own Docker customization on top of Kubespray instead of changing Kubespray?**

No. The installation of a plugin must occur after Docker is installed and running, but before the Docker configuration files are changed. This is because the Docker configuration files must be changed (e.g. via docker_storage_options) in order to tell Docker to start using the plugin, but if Docker tries to start using the plugin before the plugin is installed, Docker will be broken. Therefore the plugin installation must happen in between execution of the other Docker tasks. 

**Does this PR introduce a user-facing change?**:
No.