### PR TITLE
Add nginx stub metrics if health check enabled

### DIFF
--- a/roles/kubernetes/node/templates/loadbalancer/nginx.conf.j2
+++ b/roles/kubernetes/node/templates/loadbalancer/nginx.conf.j2
@@ -45,6 +45,10 @@ http {
       access_log off;
       return 200;
     }
+    location /stub_status {
+      stub_status on;
+      access_log off;
+    }
   }
   {% endif %}
 }


### PR DESCRIPTION
These stub metrics can be useful with some external exporters for nginx to pass metrics to prometheus.