### PR TITLE
Use kubespray-defaults in remove-node role

### DIFF
--- a/remove-node.yml
+++ b/remove-node.yml
@@ -32,6 +32,7 @@
 
 - hosts: kube-master
   roles:
+    - { role: kubespray-defaults }
     - { role: remove-node/pre-remove, tags: pre-remove }
 
 - hosts: "{{ node | default('kube-node') }}"
@@ -41,4 +42,5 @@
 
 - hosts: kube-master
   roles:
+    - { role: kubespray-defaults }
     - { role: remove-node/post-remove, tags: post-remove }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Without this PR the playbook `remove-node` is unable to execute the tasks in `roles/remove-node/{pre/post}-remove/tasks/main.yml` as `bin_dir` is undefined.
```
TASK [remove-node/pre-remove : cordon-node | Mark all nodes as unschedulable before drain] ***************************************************
task path: /home/funke_t1/code/ansible/ansible/plays/kubernetes/kubespray/roles/remove-node/pre-remove/tasks/main.yml:2
fatal: [kubernetes-dev-6.mgmt.hss.int]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'bin_dir' is undefined\n\nThe error appears to be in '/home/funke_t1/code/ansible/ansible/plays/kubernetes/kubespray/roles/remove-node/pre-remove/tasks
/main.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: cordon-node | Mark all nodes as unschedulable before drain\n  ^ here\n"}
...ignoring

TASK [remove-node/pre-remove : remove-node | Drain node except daemonsets resource] **********************************************************
task path: /home/funke_t1/code/ansible/ansible/plays/kubernetes/kubespray/roles/remove-node/pre-remove/tasks/main.yml:12
fatal: [kubernetes-dev-6.mgmt.hss.int]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'bin_dir' is undefined\n\nThe error appears to be in '/home/funke_t1/code/ansible/ansible/plays/kubernetes/kubespray/roles/remove-node/pre-remove/tasks
/main.yml': line 12, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: remove-node | Drain node except daemonsets resource\n  ^ here\n"}
...ignoring
```
```
TASK [remove-node/post-remove : Delete node] *************************************************************************************************
task path: /home/funke_t1/code/ansible/ansible/plays/kubernetes/kubespray/roles/remove-node/post-remove/tasks/main.yml:3
fatal: [kubernetes-dev-6.mgmt.hss.int]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'bin_dir' is undefined\n\nThe error appears to be in '/home/funke_t1/code/ansible/ansible/plays/kubernetes/kubespray/roles/remove-node/post-remove/tasks/main.yml': line 3, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Delete node\n  ^ here\n"}
...ignoring
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Tested `remove-node.yml` playbook with the changes and it successfully runs with correct `bin_dir` specified.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
