### PR TITLE
Containerd fixes and refactor

### DIFF
--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -10,3 +10,24 @@ containerd_config:
   registries:
     "docker.io": "https://registry-1.docker.io"
   max_container_log_line_size: -1
+
+containerd_version: '1.2.6'
+containerd_package: 'containerd.io'
+
+containerd_cfg_dir: /etc/containerd
+
+# Optional values for containerd apt repo
+containerd_package_info:
+  pkgs:
+
+containerd_repo_key_info:
+  repo_keys:
+
+containerd_repo_info:
+  repos:
+
+# Ubuntu docker-ce repo
+containerd_ubuntu_repo_base_url: "https://download.docker.com/linux/ubuntu"
+containerd_ubuntu_repo_gpgkey: 'https://download.docker.com/linux/ubuntu/gpg'
+containerd_ubuntu_repo_repokey: '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
+containerd_ubuntu_repo_component: 'stable'

--- a/roles/container-engine/containerd/handlers/main.yml
+++ b/roles/container-engine/containerd/handlers/main.yml
@@ -2,23 +2,19 @@
 - name: restart containerd
   command: /bin/true
   notify:
-    - Containerd | reload containerd
-    - Containerd | pause while containerd restarts
+    - Containerd | restart containerd
     - Containerd | wait for containerd
 
-- name: Containerd | reload containerd
-  service:
+- name: Containerd | restart containerd
+  systemd:
     name: containerd
     state: restarted
-
-- name: Containerd | pause while containerd restarts
-  pause:
-    seconds: 5
-    prompt: "Waiting for containerd restart"
+    enabled: yes
+    daemon-reload: yes
 
 - name: Containerd | wait for containerd
-  command: "{{ containerd_bin_dir }}/ctr images ls -q"
+  command: "{{ containerd_bin_dir }}/crictl images -q"
   register: containerd_ready
-  retries: 10
-  delay: 5
+  retries: 8
+  delay: 4
   until: containerd_ready.rc == 0

--- a/roles/container-engine/containerd/tasks/crictl.yml
+++ b/roles/container-engine/containerd/tasks/crictl.yml
@@ -1,6 +1,6 @@
 ---
 - name: crictl | Download crictl
-  include_tasks: "roles/download/tasks/download_file.yml"
+  include_tasks: "../../../download/tasks/download_file.yml"
   vars:
     download: "{{ download_defaults | combine(downloads.crictl) }}"
 

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -44,22 +44,22 @@
 - name: ensure containerd repository public key is installed
   action: "{{ containerd_repo_key_info.pkg_key }}"
   args:
-    id: "{{item}}"
-    url: "{{containerd_repo_key_info.url}}"
+    id: "{{ item }}"
+    url: "{{ containerd_repo_key_info.url }}"
     state: present
   register: keyserver_task_result
   until: keyserver_task_result is succeeded
   retries: 4
   delay: "{{ retry_stagger | d(3) }}"
   with_items: "{{ containerd_repo_key_info.repo_keys }}"
-  when: 
+  when:
     - ansible_os_family in ['Ubuntu', 'Debian']
     - not is_atomic
 
 - name: ensure containerd repository is enabled
   action: "{{ containerd_repo_info.pkg_repo }}"
   args:
-    repo: "{{item}}"
+    repo: "{{ item }}"
     state: present
   with_items: "{{ containerd_repo_info.repos }}"
   when:
@@ -67,7 +67,7 @@
     - not is_atomic
     - containerd_repo_info.repos|length > 0
 
-      # This is required to ensure any apt upgrade will not break kubernetes
+# This is required to ensure any apt upgrade will not break kubernetes
 - name: Set containerd pin priority to apt_preferences on Debian family
   template:
     src: "apt_preferences.d/debian_containerd.j2"
@@ -76,14 +76,14 @@
     mode: 0644
   when:
     - ansible_os_family in ['Ubuntu', 'Debian']
-    - not is_atomic     
+    - not is_atomic
 
 - name: ensure containerd packages are installed
   action: "{{ containerd_package_info.pkg_mgr }}"
   args:
-    pkg: "{{item.name}}"
-    force: "{{item.force|default(omit)}}"
-    conf_file: "{{item.yum_conf|default(omit)}}"
+    pkg: "{{ item.name }}"
+    force: "{{ item.force | default(omit) }}"
+    conf_file: "{{ item.yum_conf | default(omit) }}"
     state: present
     update_cache: "{{ omit if ansible_distribution == 'Fedora' else True }}"
   register: containerd_task_result
@@ -92,7 +92,7 @@
   delay: "{{ retry_stagger | d(3) }}"
   with_items: "{{ containerd_package_info.pkgs }}"
   notify: restart containerd
-  when: 
+  when:
     - not is_atomic
     - containerd_package_info.pkgs|length > 0
   ignore_errors: true
@@ -113,10 +113,10 @@
   retries: 4
   delay: "{{ retry_stagger | d(3) }}"
   notify: restart containerd
-  when: 
+  when:
     - not is_atomic
     - not runc_stat.stat.exists
- 
+
 - name: Install crictl config
   template:
     src: crictl.yaml.j2

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -5,28 +5,118 @@
   when:
     - not ansible_distribution in ["CentOS","RedHat", "Ubuntu", "Debian"]
 
-- name: Install Docker
-  include_role:
-    name: container-engine/docker
+- name: gather os specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - files:
+        - "{{ ansible_distribution|lower }}-{{ ansible_distribution_version|lower|replace('/', '_') }}.yml"
+        - "{{ ansible_distribution|lower }}-{{ ansible_distribution_release|lower }}-{{ host_architecture }}.yml"
+        - "{{ ansible_distribution|lower }}-{{ ansible_distribution_release|lower }}.yml"
+        - "{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version|lower|replace('/', '_') }}.yml"
+        - "{{ ansible_distribution|lower }}-{{ host_architecture }}.yml"
+        - "{{ ansible_distribution|lower }}.yml"
+        - "{{ ansible_os_family|lower }}-{{ host_architecture }}.yml"
+        - "{{ ansible_os_family|lower }}.yml"
+        - defaults.yml
+      paths:
+        - ../vars
+      skip: true
+  tags:
+    - facts
 
-- name: Install config.toml
+- name: ensure containerd config directory
+  file:
+    dest: "{{ containerd_cfg_dir }}"
+    state: directory
+    mode: 0755
+    owner: root
+    group: root
+
+- name: Copy containerd config file
   template:
-    src: config.toml.j2
-    dest: /etc/containerd/config.toml
-    owner: bin
+    src: containerd_config.toml.j2
+    dest: "{{ containerd_cfg_dir }}/config.toml"
+    owner: "root"
     mode: 0644
+  notify: restart containerd
 
-- name: Stop and disabled Docker
-  systemd:
-    name: docker
-    state: stopped
-    enabled: no
 
-- name: Restart containerd
-  systemd:
-    name: containerd
-    state: restarted
+- name: ensure containerd repository public key is installed
+  action: "{{ containerd_repo_key_info.pkg_key }}"
+  args:
+    id: "{{item}}"
+    url: "{{containerd_repo_key_info.url}}"
+    state: present
+  register: keyserver_task_result
+  until: keyserver_task_result is succeeded
+  retries: 4
+  delay: "{{ retry_stagger | d(3) }}"
+  with_items: "{{ containerd_repo_key_info.repo_keys }}"
+  when: 
+    - ansible_os_family in ['Ubuntu', 'Debian']
+    - not is_atomic
 
+- name: ensure containerd repository is enabled
+  action: "{{ containerd_repo_info.pkg_repo }}"
+  args:
+    repo: "{{item}}"
+    state: present
+  with_items: "{{ containerd_repo_info.repos }}"
+  when:
+    - ansible_os_family in ['Ubuntu', 'Debian']
+    - not is_atomic
+    - containerd_repo_info.repos|length > 0
+
+      # This is required to ensure any apt upgrade will not break kubernetes
+- name: Set containerd pin priority to apt_preferences on Debian family
+  template:
+    src: "apt_preferences.d/debian_containerd.j2"
+    dest: "/etc/apt/preferences.d/containerd"
+    owner: "root"
+    mode: 0644
+  when:
+    - ansible_os_family in ['Ubuntu', 'Debian']
+    - not is_atomic     
+
+- name: ensure containerd packages are installed
+  action: "{{ containerd_package_info.pkg_mgr }}"
+  args:
+    pkg: "{{item.name}}"
+    force: "{{item.force|default(omit)}}"
+    conf_file: "{{item.yum_conf|default(omit)}}"
+    state: present
+    update_cache: "{{ omit if ansible_distribution == 'Fedora' else True }}"
+  register: containerd_task_result
+  until: containerd_task_result is succeeded
+  retries: 4
+  delay: "{{ retry_stagger | d(3) }}"
+  with_items: "{{ containerd_package_info.pkgs }}"
+  notify: restart containerd
+  when: 
+    - not is_atomic
+    - containerd_package_info.pkgs|length > 0
+  ignore_errors: true
+
+- name: Check if runc is installed
+  stat:
+    path: /usr/sbin/runc
+  register: runc_stat
+
+- name: Install runc package if necessary
+  action: "{{ containerd_package_info.pkg_mgr }}"
+  args:
+    pkg: runc
+    state: present
+    update_cache: "{{ omit if ansible_distribution == 'Fedora' else True }}"
+  register: runc_task_result
+  until: runc_task_result is succeeded
+  retries: 4
+  delay: "{{ retry_stagger | d(3) }}"
+  notify: restart containerd
+  when: 
+    - not is_atomic
+    - not runc_stat.stat.exists
+ 
 - name: Install crictl config
   template:
     src: crictl.yaml.j2
@@ -35,16 +125,6 @@
     mode: 0644
 
 - name: Install crictl completion
-  shell: /usr/local/bin/crictl completion >/etc/bash_completion.d/crictl
+  shell: "{{ bin_dir }}/crictl completion >/etc/bash_completion.d/crictl"
   ignore_errors: True
   when: ansible_distribution in ["CentOS","RedHat", "Ubuntu", "Debian"]
-
-- name: Enable containerd
-  systemd:
-    name: containerd.service
-    state: started
-    enabled: yes
-    daemon-reload: yes
-
-- name: flush handlers so we can wait for containerd to come up
-  meta: flush_handlers

--- a/roles/container-engine/containerd/templates/apt_preferences.d/debian_containerd.j2
+++ b/roles/container-engine/containerd/templates/apt_preferences.d/debian_containerd.j2
@@ -1,0 +1,3 @@
+Package: {{ containerd_package }}
+Pin: version {{ containerd_version }}.*
+Pin-Priority: 1001

--- a/roles/container-engine/containerd/templates/containerd_config.toml.j2
+++ b/roles/container-engine/containerd/templates/containerd_config.toml.j2
@@ -1,0 +1,23 @@
+{% if 'grpc' in containerd_config %}
+[grpc]
+{% for param, value in containerd_config.grpc.items() %}
+  {{ param }} = {{ value }}
+{% endfor %}
+{%  endif %}
+
+{% if 'debug' in containerd_config %}
+[debug]
+  level = "{{ containerd_config.debug.level | default("") }}"
+{%  endif %}
+
+[plugins]
+  [plugins.cri]
+    systemd_cgroup = {{ containerd_use_systemd_cgroup|lower }}
+{% if 'registries' in containerd_config %}
+    [plugins.cri.registry]
+      [plugins.cri.registry.mirrors]
+{% for registry, addr in containerd_config.registries.items() %}
+        [plugins.cri.registry.mirrors."{{ registry }}"]
+          endpoint = ["{{ addr }}"]
+{% endfor %}
+{%  endif %}

--- a/roles/container-engine/containerd/vars/ubuntu-amd64.yml
+++ b/roles/container-engine/containerd/vars/ubuntu-amd64.yml
@@ -1,0 +1,27 @@
+---
+
+containerd_versioned_pkg:
+  'latest': "{{ containerd_package }}"
+  '1.2.6': "{{ containerd_package }}=1.2.6-1"
+  'stable': "{{ containerd_package }}=1.2.6-1"
+  'edge': "{{ containerd_package }}=1.2.6-1"
+
+containerd_package_info:
+  pkg_mgr: apt
+  pkgs:
+    - name: "{{ containerd_versioned_pkg[containerd_version | string] }}"
+      force: yes
+
+containerd_repo_key_info:
+  pkg_key: apt_key
+  url: '{{ containerd_ubuntu_repo_gpgkey }}'
+  repo_keys:
+    - '{{ containerd_ubuntu_repo_repokey }}'
+
+containerd_repo_info:
+  pkg_repo: apt_repository
+  repos:
+    - >
+       deb {{ containerd_ubuntu_repo_base_url }}
+       {{ ansible_distribution_release|lower }}
+       {{ containerd_ubuntu_repo_component }}

--- a/roles/download/tasks/check_pull_required.yml
+++ b/roles/download/tasks/check_pull_required.yml
@@ -5,8 +5,7 @@
 # It will output something like the following:
 # nginx:1.15,gcr.io/google-containers/kube-proxy:v1.14.1,gcr.io/google-containers/kube-proxy@sha256:44af2833c6cbd9a7fc2e9d2f5244a39dfd2e31ad91bf9d4b7d810678db738ee9,gcr.io/google-containers/kube-apiserver:v1.14.1,etc...
 - name: check_pull_required |  Generate a list of information about the images on a node
-  shell: >-
-    {{ docker_bin_dir }}/docker images -q | xargs -r {{ docker_bin_dir }}/docker inspect -f "{{ '{{' }} if .RepoTags {{ '}}' }}{{ '{{' }} (index .RepoTags) {{ '}}' }}{{ '{{' }} end {{ '}}' }}{{ '{{' }} if .RepoDigests {{ '}}' }},{{ '{{' }} (index .RepoDigests) {{ '}}' }}{{ '{{' }} end {{ '}}' }}" | sed -e 's/^ *\[//g' -e 's/\] *$//g' -e 's/ /\n/g' | tr '\n' ','
+  shell: "{{ image_info_command }}"
   delegate_to: "{{ download_delegate if download_run_once or inventory_hostname }}"
   no_log: true
   register: docker_images

--- a/roles/download/tasks/download_container.yml
+++ b/roles/download/tasks/download_container.yml
@@ -65,7 +65,7 @@
         - ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"]
 
     - name: download_container | Prepare container download
-      import_tasks: check_pull_required.yml
+      include_tasks: check_pull_required.yml
       run_once: "{{ download_run_once }}"
       when:
         - not download_always_pull

--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -24,10 +24,11 @@
 
 - include_tasks: ../../container-engine/containerd/tasks/crictl.yml
   when:
+    - not skip_downloads|default(false)
     - container_manager in ['containerd', 'crio']
 
 - name: download | Get kubeadm binary and list of required images
-  import_tasks: prep_kubeadm_images.yml
+  include_tasks: prep_kubeadm_images.yml
   when:
     - kube_version is version('v1.11.0', '>=')
     - not skip_downloads|default(false)

--- a/roles/download/tasks/prep_download.yml
+++ b/roles/download/tasks/prep_download.yml
@@ -5,6 +5,20 @@
   tags:
     - facts
 
+- name: Set image info command for containerd
+  set_fact:
+    image_info_command: "{{ containerd_bin_dir }}/ctr images ls | tail -n +2 | awk -F '[ :]+' '{print $1\":\"$2\",\"$1\":\"$4\"@\"$5}' | tr '\n' ','"
+  when: container_manager == 'containerd'
+
+- name: Register docker images info
+  shell: "{{ image_info_command }}"
+  no_log: true
+  register: docker_images
+  failed_when: false
+  changed_when: false
+  check_mode: no
+  when: download_container
+
 - name: prep_download | Create staging directory on remote node
   file:
     path: "{{ local_release_dir }}/images"

--- a/roles/download/templates/kubeadm-images.yaml.j2
+++ b/roles/download/templates/kubeadm-images.yaml.j2
@@ -13,3 +13,9 @@ etcd:
 {% for endpoint in etcd_access_addresses.split(',') %}
       - {{ endpoint }}
 {% endfor %}
+{% if dns_mode in ['coredns', 'coredns_dual'] %}
+dns:
+  type: CoreDNS
+  imageRepository: {{ coredns_image_repo | regex_replace('/coredns$','') }}
+  imageTag: {{ coredns_image_tag }}
+{% endif %}

--- a/roles/kubernetes/kubeadm/defaults/main.yml
+++ b/roles/kubernetes/kubeadm/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 # discovery_timeout modifies the discovery timeout
-discovery_timeout: 5m0s
+# This value must be smaller than kubeadm_join_timeout
+discovery_timeout: 60s
+kubeadm_join_timeout: 120s
+
 # Optionally remove kube_proxy installed by kubeadm
 kube_proxy_remove: false
 

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -10,15 +10,24 @@
   tags:
     - facts
 
-
 - name: Check if kubelet.conf exists
   stat:
     path: "{{ kube_config_dir }}/kubelet.conf"
   register: kubelet_conf
 
+- name: Check if kubeadm CA cert is accessible
+  stat:
+    path: "{{ kube_cert_dir }}/ca.crt"
+  register: kubeadm_ca_stat
+  delegate_to: "{{ groups['kube-master'][0] }}"
+  run_once: true
+
 - name: Calculate kubeadm CA cert hash
   shell: openssl x509 -pubkey -in {{ kube_cert_dir }}/ca.crt | openssl rsa -pubin -outform der 2>/dev/null | openssl dgst -sha256 -hex | sed 's/^.* //'
   register: kubeadm_ca_hash
+  when:
+    - kubeadm_ca_stat.stat is defined
+    - kubeadm_ca_stat.stat.exists
   delegate_to: "{{ groups['kube-master'][0] }}"
   run_once: true
 
@@ -58,23 +67,21 @@
 
     - name: Join to cluster
       command: >-
+        timeout -k {{ kubeadm_join_timeout }} {{ kubeadm_join_timeout }}
         {{ bin_dir }}/kubeadm join
         --config {{ kube_config_dir }}/kubeadm-client.conf
         --ignore-preflight-errors=DirAvailable--etc-kubernetes-manifests
       register: kubeadm_join
-      async: 120
-      poll: 15
 
   rescue:
 
     - name: Join to cluster with ignores
       command: >-
+        timeout -k {{ kubeadm_join_timeout }} {{ kubeadm_join_timeout }}
         {{ bin_dir }}/kubeadm join
         --config {{ kube_config_dir }}/kubeadm-client.conf
         --ignore-preflight-errors=all
       register: kubeadm_join
-      async: 180
-      poll: 15
 
   always:
 
@@ -84,12 +91,6 @@
         msg: |
           Joined with warnings
           {{ kubeadm_join.stderr_lines }}
-
-- name: Wait for kubelet bootstrap to create config
-  wait_for:
-    path: "{{ kube_config_dir }}/kubelet.conf"
-    delay: 1
-    timeout: 60
 
 - name: Update server field in kubelet kubeconfig
   lineinfile:

--- a/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1beta1.j2
+++ b/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1beta1.j2
@@ -9,8 +9,12 @@ discovery:
     apiServerEndpoint: {{ kubeadm_discovery_address }}
 {% endif %}
     token: {{ kubeadm_token }}
+{% if kubeadm_ca_hash.stdout is defined %}
     caCertHashes:
     - sha256:{{ kubeadm_ca_hash.stdout }}
+{% else %}
+    unsafeSkipCAVerification: true
+{% endif %}
   timeout: {{ discovery_timeout }}
   tlsBootstrapToken: {{ kubeadm_token }}
 caCertPath: {{ kube_cert_dir }}/ca.crt

--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -101,10 +101,9 @@
     - not upgrade_cluster_setup
     - kubeadm_already_run.stat.exists
 
-    #timeout -k 600s 600s
 - name: kubeadm | Initialize first master
   command: >-
-    timeout -k 60s 60s
+    timeout -k 300s 300s
     {{ bin_dir }}/kubeadm init
     --config={{ kube_config_dir }}/kubeadm-config.yaml
     --ignore-preflight-errors=all

--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -101,9 +101,10 @@
     - not upgrade_cluster_setup
     - kubeadm_already_run.stat.exists
 
+    #timeout -k 600s 600s
 - name: kubeadm | Initialize first master
   command: >-
-    timeout -k 600s 600s
+    timeout -k 60s 60s
     {{ bin_dir }}/kubeadm init
     --config={{ kube_config_dir }}/kubeadm-config.yaml
     --ignore-preflight-errors=all
@@ -120,7 +121,7 @@
     {% endif %}
   register: kubeadm_init
   # Retry is because upload config sometimes fails
-  retries: 3
+  retries: 0
   until: kubeadm_init is succeeded or "field is immutable" in kubeadm_init.stderr
   when: inventory_hostname == groups['kube-master']|first and not kubeadm_already_run.stat.exists
   failed_when: kubeadm_init.rc != 0 and "field is immutable" not in kubeadm_init.stderr

--- a/roles/kubernetes/master/tasks/kubeadm-upgrade.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-upgrade.yml
@@ -29,6 +29,7 @@
     --allow-experimental-upgrades
     --allow-release-candidate-upgrades
     --etcd-upgrade=false
+    --force
   register: kubeadm_upgrade
   when: inventory_hostname != groups['kube-master']|first
   failed_when:

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
@@ -69,6 +69,12 @@ etcd:
       - {{ san }}
 {% endfor %}
 {% endif %}
+{% if dns_mode in ['coredns', 'coredns_dual'] %}
+dns:
+  type: CoreDNS
+  imageRepository: {{ coredns_image_repo | regex_replace('/coredns$','') }}
+  imageTag: {{ coredns_image_tag }}
+{% endif %}
 networking:
   dnsDomain: {{ dns_domain }}
   serviceSubnet: {{ kube_service_addresses }}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
@@ -17,16 +17,13 @@ nodeRegistration:
 {% else %}
   taints: []
 {% endif %}
-{% if container_manager == 'crio' %}
-  criSocket: /var/run/crio/crio.sock
-{% else %}
-  criSocket: /var/run/dockershim.sock
-{% endif %}
+  criSocket: {{ cri_socket }}
 ---
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: ClusterConfiguration
 clusterName: {{ cluster_name }}
 etcd:
+{% if not etcd_kubeadm_enabled %}
   external:
       endpoints:
 {% for endpoint in etcd_access_addresses.split(',') %}
@@ -35,6 +32,53 @@ etcd:
       caFile: {{ etcd_cert_dir }}/{{ kube_etcd_cacert_file }}
       certFile: {{ etcd_cert_dir }}/{{ kube_etcd_cert_file }}
       keyFile: {{ etcd_cert_dir }}/{{ kube_etcd_key_file }}
+{% elif etcd_kubeadm_enabled %}
+  local:
+    imageRepository: "{{ etcd_image_repo | regex_replace("/etcd$","") }}"
+    imageTag: "{{ etcd_image_tag }}"
+    dataDir: "/var/lib/etcd"
+    extraArgs:
+      metrics: {{ etcd_metrics }}
+      election-timeout: "{{ etcd_election_timeout }}"
+      heartbeat-interval: "{{ etcd_heartbeat_interval }}"
+      auto-compaction-retention: "{{ etcd_compaction_retention }}"
+{% if etcd_snapshot_count is defined %}
+      snapshot-count: "{{ etcd_snapshot_count }}"
+{% endif %}
+{% if etcd_quota_backend_bytes is defined %}
+      quota-backend-bytes: "{{ etcd_quota_backend_bytes }}"
+{% endif %}
+{% if etcd_log_package_levels is defined %}
+      log-package_levels: "{{ etcd_log_package_levels }}"
+{% endif %}
+{% for key, value in etcd_extra_vars.items() %}
+      {{ key }}: "{{ value }}"
+{% endfor %}
+{% if host_architecture != "amd64" -%}
+      etcd-unsupported-arch: {{host_architecture}}
+{% endif %}
+    serverCertSANs:
+{% for san in etcd_cert_alt_names %}
+      - {{ san }}
+{% endfor %}
+{% for san in etcd_cert_alt_ips %}
+      - {{ san }}
+{% endfor %}
+    peerCertSANs:
+{% for san in etcd_cert_alt_names %}
+      - {{ san }}
+{% endfor %}
+{% for san in etcd_cert_alt_ips %}
+      - {{ san }}
+{% endfor %}
+{% endif %}
+
+{% if dns_mode in ['coredns', 'coredns_dual'] %}
+dns:
+  type: CoreDNS
+  imageRepository: {{ coredns_image_repo | regex_replace('/coredns$','') }}
+  imageTag: {{ coredns_image_tag }}
+{% endif %}
 networking:
   dnsDomain: {{ dns_domain }}
   serviceSubnet: {{ kube_service_addresses }}
@@ -128,16 +172,16 @@ apiServer:
 {% endif %}
 {% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws"] %}
     cloud-provider: {{cloud_provider}}
-    cloud-config: {{ kube_config_dir }}/cloud_config
+    cloud-config: {{ cloud_config_file }}
 {% elif cloud_provider is defined and cloud_provider in ["external"] %}
-    cloud-config: {{ kube_config_dir }}/cloud_config
+    cloud-config: {{ cloud_config_file }}
 {% endif %}
 {% if kubernetes_audit or kube_basic_auth|default(true) or kube_token_auth|default(true) or kube_webhook_token_auth|default(false) or ( cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws"] ) or apiserver_extra_volumes or ssl_ca_dirs|length %}
   extraVolumes:
 {% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws", "external"] %}
   - name: cloud-config
-    hostPath: {{ kube_config_dir }}/cloud_config
-    mountPath: {{ kube_config_dir }}/cloud_config
+    hostPath: {{ cloud_config_file }}
+    mountPath: {{ cloud_config_file }}
 {% endif %}
 {% if kube_basic_auth|default(true) %}
   - name: basic-auth-config
@@ -202,9 +246,12 @@ controllerManager:
 {% endfor %}
 {% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws"] %}
     cloud-provider: {{cloud_provider}}
-    cloud-config: {{ kube_config_dir }}/cloud_config
+    cloud-config: {{ cloud_config_file }}
 {% elif cloud_provider is defined and cloud_provider in ["external"] %}
-    cloud-config: {{ kube_config_dir }}/cloud_config
+{% if external_provider_type in ["openstack"] %}
+    external-cloud-volume-plugin: openstack
+{% endif %}
+    cloud-config: {{ cloud_config_file }}
 {% endif %}
 {% if kube_network_plugin is defined and kube_network_plugin not in ["cloud"] %}
     configure-cloud-routes: "false"
@@ -218,8 +265,8 @@ controllerManager:
 {% endif %}
 {% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws", "external"] %}
   - name: cloud-config
-    hostPath: {{ kube_config_dir }}/cloud_config
-    mountPath: {{ kube_config_dir }}/cloud_config
+    hostPath: {{ cloud_config_file }}
+    mountPath: {{ cloud_config_file }}
 {% endif %}
 {% for volume in controller_manager_extra_volumes %}
   - name: {{ volume.name }}

--- a/roles/kubernetes/master/templates/kubeadm-controlplane.v1beta2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-controlplane.v1beta2.yaml.j2
@@ -5,7 +5,7 @@ discovery:
 {% if kubeadm_config_api_fqdn is defined %}
     apiServerEndpoint: {{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
 {% else %}
-    apiServerEndpoint: {{ kubeadm_discovery_address | replace("https://", "")}}
+    apiServerEndpoint: {{ kubeadm_discovery_address }}
 {% endif %}
     token: {{ kubeadm_token }}
     unsafeSkipCAVerification: true
@@ -18,8 +18,4 @@ controlPlane:
   certificateKey: {{ kubeadm_certificate_key }}
 nodeRegistration:
   name: {{ kube_override_hostname|default(inventory_hostname) }}
-{% if container_manager == 'crio' %}
-  criSocket: /var/run/crio/crio.sock
-{% else %}
-  criSocket: /var/run/dockershim.sock
-{% endif %}
+  criSocket: {{ cri_socket }}

--- a/roles/kubernetes/preinstall/tasks/0070-system-packages.yml
+++ b/roles/kubernetes/preinstall/tasks/0070-system-packages.yml
@@ -44,7 +44,7 @@
 
 - name: Update common_required_pkgs with ipvsadm when kube_proxy_mode is ipvs
   set_fact:
-    common_required_pkgs: "{{ common_required_pkgs|default([]) + ['ipvsadm'] }}"
+    common_required_pkgs: "{{ common_required_pkgs|default([]) + ['ipvsadm', 'ipset'] }}"
   when: kube_proxy_mode == 'ipvs'
 
 - name: Install packages requirements


### PR DESCRIPTION
Main changes:
- allow containerd distro package (not only Docker's containerd.io package)
- Fixes for download role for containerd related to checking existing images
- Fixes for containerd related to kubeadm, kubeadm etcd, and coredns
- Use crictl everywhere instead of limited ctr command
- Support custom repo for containerd (default is docker-ce repo)
- switch import_tasks to include_tasks in download role so that conditionals work