### PR TITLE
Fix when openstack_cacert starts with a slash

### DIFF
--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -178,6 +178,7 @@
     - cloud_provider == 'openstack'
     - openstack_cacert is defined
     - openstack_cacert
+    - openstack_cacert | length > 0
   tags:
     - cloud-provider
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Fix the issue that was introduced with this PR https://github.com/kubernetes-sigs/kubespray/pull/4665 When having files starting with / causing the following error:

`fatal: [kube-node-1]: FAILED! => {"msg": "The conditional check 'openstack_cacert' failed. The error was: template error while templating string: unexpected '/'. String: {% if /etc/ansible/certificate.pem %} True {% else %} False {% endif %}\n\nThe error appears to have been in '/kube-ansible/kubespray/roles/kubernetes/node/tasks/main.yml': line 186, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Write cacert file\n  ^ here\n"}`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Discovered in the 2.10.4 branch so I guess this should be backported into that branch as well and not sure about the correct order.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
