### PR TITLE
Update CoreDNS to 1.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Supported Components
     -   [cephfs-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.0-k8s1.11
     -   [rbd-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.1-k8s1.11
     -   [cert-manager](https://github.com/jetstack/cert-manager) v0.5.2
-    -   [coredns](https://github.com/coredns/coredns) v1.5.0
+    -   [coredns](https://github.com/coredns/coredns) v1.5.2
     -   [ingress-nginx](https://github.com/kubernetes/ingress-nginx) v0.21.0
 
 Note: The list of validated [docker versions](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.13.md) was updated to 1.11.1, 1.12.1, 1.13.1, 17.03, 17.06, 17.09, 18.06. kubeadm now properly recognizes Docker 18.09.0 and newer, but still treats 18.06 as the default supported version. The kubelet might break on docker's non-standard version numbering (it no longer uses semantic versioning). To ensure auto-updates don't break your cluster look into e.g. yum versionlock plugin or apt pin).

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -242,7 +242,7 @@ nginx_image_tag: 1.15
 haproxy_image_repo: docker.io/haproxy
 haproxy_image_tag: 1.9
 
-coredns_version: "1.5.0"
+coredns_version: "1.5.2"
 coredns_image_repo: "docker.io/coredns/coredns"
 coredns_image_tag: "{{ coredns_version }}"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Updates CoreDNS to 1.5.2