### PR TITLE
remove support for calico v2.x

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -137,6 +137,14 @@
     - cloud-provider
     - facts
 
+- name: Ensure minimum calico version
+  assert:
+    that: calico_version is version('v3.0.0', '>=')
+    msg: "calico_version is too low. Minimum version v3.0.0"
+  run_once: yes
+  when:
+    - kube_network_plugin == 'calico'
+
 - name: "Get current version of calico cluster version"
   shell: "{{ bin_dir }}/calicoctl.sh version  | grep 'Cluster Version:' | awk '{ print $3}'"
   register: calico_version_on_server

--- a/roles/network_plugin/calico/rr/tasks/main.yml
+++ b/roles/network_plugin/calico/rr/tasks/main.yml
@@ -72,7 +72,6 @@
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   delegate_to: "{{ groups['etcd'][0] }}"
-  when:
 
 - meta: flush_handlers
 

--- a/roles/network_plugin/calico/rr/tasks/main.yml
+++ b/roles/network_plugin/calico/rr/tasks/main.yml
@@ -73,25 +73,6 @@
   delay: "{{ retry_stagger | random + 3 }}"
   delegate_to: "{{ groups['etcd'][0] }}"
   when:
-    - calico_version is version("v3.0.0", ">=")
-
-- name: Calico-rr | Configure route reflector (legacy)
-  command: |-
-    {{ bin_dir }}/etcdctl \
-    --peers={{ etcd_access_addresses }} \
-    set /calico/bgp/v1/rr_v4/{{ rr_ip }} \
-    '{
-       "ip": "{{ rr_ip }}",
-       "cluster_id": "{{ cluster_id }}"
-     }'
-  environment:
-    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}.pem"
-    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}-key.pem"
-  retries: 4
-  delay: "{{ retry_stagger | random + 3 }}"
-  delegate_to: "{{ groups['etcd'][0] }}"
-  when:
-    - calico_version is version("v3.0.0", "<")
 
 - meta: flush_handlers
 

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -102,7 +102,7 @@
   loop_control:
     label: "{{ item.item.file }}"
 
-- name: Calico | Configure calico network pool (v3.0.0 <= version < v3.3.0)
+- name: Calico | Configure calico network pool (version < v3.3.0)
   shell: >
     echo "
       { "kind": "IPPool",
@@ -117,7 +117,6 @@
   when:
     - inventory_hostname == groups['kube-master'][0]
     - 'calico_conf.stdout == "0"'
-    - calico_version is version("v3.0.0", ">=")
     - calico_version is version("v3.3.0", "<")
 
 - name: Calico | Configure calico network pool (version >= v3.3.0)
@@ -137,22 +136,6 @@
     - inventory_hostname == groups['kube-master'][0]
     - 'calico_conf.stdout == "0"'
     - calico_version is version("v3.3.0", ">=")
-
-- name: Calico | Configure calico network pool (legacy)
-  shell: >
-    echo '
-      { "kind": "ipPool",
-        "spec": {"disabled": false, "ipip": {"enabled": {{ ipip }}, "mode": "{{ ipip_mode|lower }}"},
-                 "nat-outgoing": {{ nat_outgoing|default(false) and not peer_with_router|default(false) }}},
-        "apiVersion": "v1",
-        "metadata": {"cidr": "{{ calico_pool_cidr | default(kube_pods_subnet) }}"}
-      }' | {{ bin_dir }}/calicoctl.sh apply -f -
-  environment:
-    NO_DEFAULT_POOLS: true
-  when:
-    - inventory_hostname == groups['kube-master'][0]
-    - 'calico_conf.stdout == "0"'
-    - calico_version is version("v3.0.0", "<")
 
 - name: "Determine nodeToNodeMesh needed state"
   set_fact:
@@ -177,20 +160,6 @@
   changed_when: false
   when:
     - inventory_hostname == groups['kube-master'][0]
-    - calico_version is version('v3.0.0', '>=')
-
-- name: Calico | Set global as_num (legacy)
-  command: "{{ bin_dir }}/calicoctl.sh config set asNumber {{ global_as_num }}"
-  when:
-    - inventory_hostname == groups['kube-master'][0]
-    - calico_version is version('v3.0.0', '<')
-
-- name: Calico | Disable node mesh (legacy)
-  command: "{{ bin_dir }}/calicoctl.sh config set nodeToNodeMesh off"
-  when:
-    - inventory_hostname == groups['kube-master'][0]
-    - calico_version is version('v3.0.0', '<')
-    - nodeToMeshEnabled|default(True)
 
 - name: Calico | Configure peering with router(s) at global scope
   shell: >
@@ -210,24 +179,6 @@
     - "{{ peers|selectattr('scope','defined')|selectattr('scope','equalto', 'global')|list|default([]) }}"
   when:
     - inventory_hostname == groups['kube-master'][0]
-    - calico_version | version_compare('v3.0.0', '>=')
-    - peer_with_router|default(false)
-
-- name: Calico | Configure peering with router(s) at global scope (legacy)
-  shell: >
-   echo '{
-   "kind": "bgpPeer",
-   "spec": {"asNumber": "{{ item.as }}"},
-   "apiVersion": "v1",
-   "metadata": {"scope": "global", "peerIP": "{{ item.router_id }}"}
-   }'
-   | {{ bin_dir }}/calicoctl.sh create --skip-exists -f -
-  retries: 4
-  delay: "{{ retry_stagger | random + 3 }}"
-  with_items: "{{ peers|selectattr('scope','defined')|selectattr('scope','equalto', 'global')|default([]) }}"
-  when:
-    - inventory_hostname == groups['kube-master'][0]
-    - calico_version is version('v3.0.0', '<')
     - peer_with_router|default(false)
 
 - name: Calico | Create calico manifests
@@ -298,30 +249,6 @@
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   when:
-    - calico_version is version('v3.0.0', '>=')
-    - peer_with_router|default(false)
-    - inventory_hostname in groups['k8s-cluster']
-    - local_as is defined
-    - groups['calico-rr'] | default([]) | length == 0
-
-- name: Calico | Configure node asNumber for per node peering (legacy)
-  shell: >
-   echo '{
-   "apiVersion": "v1",
-   "kind": "node",
-   "metadata": {
-      "name": "{{ inventory_hostname }}"
-   },
-   "spec": {
-      "bgp": {
-        "asNumber": "{{ local_as }}"
-      },
-      "orchRefs":[{"nodeName":"{{ inventory_hostname }}","orchestrator":"k8s"}]
-   }}' | {{ bin_dir }}/calicoctl.sh create --skip-exists -f -
-  retries: 4
-  delay: "{{ retry_stagger | random + 3 }}"
-  when:
-    - calico_version is version('v3.0.0', '<')
     - peer_with_router|default(false)
     - inventory_hostname in groups['k8s-cluster']
     - local_as is defined
@@ -345,27 +272,8 @@
   with_items:
     - "{{ peers|selectattr('scope','undefined')|list|default([]) | union(peers|selectattr('scope','defined')|selectattr('scope','equalto', 'node')|list|default([])) }}"
   when:
-    - calico_version is version('v3.0.0', '>=')
     - peer_with_router|default(false)
     - inventory_hostname in groups['k8s-cluster']
-
-- name: Calico | Configure peering with router(s) at node scope (legacy)
-  shell: >
-   echo '{
-   "kind": "bgpPeer",
-   "spec": {"asNumber": "{{ item.as }}"},
-   "apiVersion": "v1",
-   "metadata": {"node": "{{ inventory_hostname }}", "scope": "node", "peerIP": "{{ item.router_id }}"}
-   }'
-   | {{ bin_dir }}/calicoctl.sh create --skip-exists -f -
-  retries: 4
-  delay: "{{ retry_stagger | random + 3 }}"
-  with_items: "{{ peers|selectattr('scope','undefined')|list|default([]) | union(peers|selectattr('scope','defined')|selectattr('scope','equalto', 'node')|list|default([])) }}"
-  when:
-    - calico_version | version_compare('v3.0.0', '<')
-    - peer_with_router|default(false)
-    - inventory_hostname in groups['k8s-cluster']
-
 
 - name: Calico | Configure peering with route reflectors
   shell: >
@@ -385,27 +293,6 @@
   with_items:
     - "{{ groups['calico-rr'] | default([]) }}"
   when:
-    - calico_version is version('v3.0.0', '>=')
     - peer_with_calico_rr|default(false)
     - inventory_hostname in groups['k8s-cluster']
-    - hostvars[item]['cluster_id'] == cluster_id
-
-- name: Calico | Configure peering with route reflectors (legacy)
-  shell: >
-   echo '{
-   "kind": "bgpPeer",
-   "spec": {"asNumber": "{{ local_as | default(global_as_num) }}"},
-   "apiVersion": "v1",
-   "metadata": {"node": "{{ inventory_hostname }}",
-     "scope": "node",
-     "peerIP": "{{ hostvars[item]["calico_rr_ip"]|default(hostvars[item]["ip"])|default(fallback_ips[item]) }}"}
-   }'
-   | {{ bin_dir }}/calicoctl.sh create --skip-exists -f -
-  retries: 4
-  delay: "{{ retry_stagger | random + 3 }}"
-  with_items: "{{ groups['calico-rr'] | default([]) }}"
-  when:
-    - calico_version is version('v3.0.0', '<')
-    - not calico_upgrade_enabled
-    - peer_with_calico_rr|default(false)
     - hostvars[item]['cluster_id'] == cluster_id

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -254,6 +254,29 @@
     - local_as is defined
     - groups['calico-rr'] | default([]) | length == 0
 
+- name: Calico | Configure node asNumber for per node peering
+  shell: >
+   echo '{
+   "apiVersion": "projectcalico.org/v3",
+   "kind": "Node",
+   "metadata": {
+      "name": {{ inventory_hostname }}"
+   },
+   "spec": {
+      "bgp": {
+        "asNumber": "{{ local_as }}"
+      },
+      "orchRefs":[{"nodeName":"{{ inventory_hostname }}","orchestrator":"k8s"}]
+   }}' | {{ bin_dir }}/calicoctl.sh create --skip-exists -f -
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  with_items:
+    - "{{ peers|selectattr('scope','defined')|selectattr('scope','equalto', 'global')|list|default([]) }}"
+  when:
+    - peer_with_router|default(false)
+    - inventory_hostname in groups['k8s-cluster']
+
+
 - name: Calico | Configure peering with router(s) at node scope
   shell: >
    echo '{

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -254,29 +254,6 @@
     - local_as is defined
     - groups['calico-rr'] | default([]) | length == 0
 
-- name: Calico | Configure node asNumber for per node peering
-  shell: >
-   echo '{
-   "apiVersion": "projectcalico.org/v3",
-   "kind": "Node",
-   "metadata": {
-      "name": {{ inventory_hostname }}"
-   },
-   "spec": {
-      "bgp": {
-        "asNumber": "{{ local_as }}"
-      },
-      "orchRefs":[{"nodeName":"{{ inventory_hostname }}","orchestrator":"k8s"}]
-   }}' | {{ bin_dir }}/calicoctl.sh create --skip-exists -f -
-  retries: 4
-  delay: "{{ retry_stagger | random + 3 }}"
-  with_items:
-    - "{{ peers|selectattr('scope','defined')|selectattr('scope','equalto', 'global')|list|default([]) }}"
-  when:
-    - peer_with_router|default(false)
-    - inventory_hostname in groups['k8s-cluster']
-
-
 - name: Calico | Configure peering with router(s) at node scope
   shell: >
    echo '{

--- a/roles/network_plugin/calico/tasks/pre.yml
+++ b/roles/network_plugin/calico/tasks/pre.yml
@@ -1,11 +1,4 @@
 ---
-- name: Calico | Disable calico-node service if it exists
-  service:
-    name: calico-node
-    state: stopped
-    enabled: no
-  failed_when: false
-
 - name: Calico | Get kubelet hostname
   shell: >-
     {{ bin_dir }}/kubectl get node -o custom-columns='NAME:.metadata.name,INTERNAL-IP:.status.addresses[?(@.type=="InternalIP")].address'

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -25,9 +25,7 @@ spec:
         prometheus.io/port: "{{ calico_felix_prometheusmetricsport }}"
 {% endif %}
     spec:
-{% if kube_version is version('v1.11.1', '>=') %}
       priorityClassName: system-node-critical
-{% endif %}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: calico-node

--- a/roles/network_plugin/canal/templates/canal-node.yaml.j2
+++ b/roles/network_plugin/canal/templates/canal-node.yaml.j2
@@ -257,17 +257,10 @@ spec:
             initialDelaySeconds: 5
             failureThreshold: 6
           readinessProbe:
-{% if calico_version is version('v3.3.0', '<')%}
-            httpGet:
-              host: 127.0.0.1
-              path: /readiness
-              port: 9099
-{% else %}
             exec:
               command:
               - /bin/calico-node
               - -felix-ready
-{% endif %}
             periodSeconds: 10
           volumeMounts:
             - mountPath: /lib/modules

--- a/roles/network_plugin/canal/templates/canal-node.yaml.j2
+++ b/roles/network_plugin/canal/templates/canal-node.yaml.j2
@@ -15,9 +15,7 @@ spec:
       labels:
         k8s-app: canal-node
     spec:
-{% if kube_version is version('v1.11.1', '>=') %}
       priorityClassName: system-node-critical
-{% endif %}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: canal
@@ -257,18 +255,18 @@ spec:
             initialDelaySeconds: 5
             failureThreshold: 6
           readinessProbe:
-          {% if calico_version is version('v3.3.0', '<')%}
+{% if calico_version is version('v3.3.0', '<')%}
             httpGet:
               host: 127.0.0.1
               path: /readiness
               port: 9099
-          {% else %}
+{% else %}
             exec:
               command:
               - /bin/calico-node
               - -felix-ready
+{% endif %}
             periodSeconds: 10
-          {% endif %}
           volumeMounts:
             - mountPath: /lib/modules
               name: lib-modules

--- a/roles/network_plugin/canal/templates/canal-node.yaml.j2
+++ b/roles/network_plugin/canal/templates/canal-node.yaml.j2
@@ -257,11 +257,18 @@ spec:
             initialDelaySeconds: 5
             failureThreshold: 6
           readinessProbe:
+          {% if calico_version is version('v3.3.0', '<')%}
+            httpGet:
+              host: 127.0.0.1
+              path: /readiness
+              port: 9099
+          {% else %}
             exec:
               command:
               - /bin/calico-node
               - -felix-ready
             periodSeconds: 10
+          {% endif %}
           volumeMounts:
             - mountPath: /lib/modules
               name: lib-modules


### PR DESCRIPTION
/kind cleanup

This PR depends on https://github.com/kubernetes-sigs/kubespray/pull/4956 being merged first.