### PR TITLE
Fixup etcdctl download for etcd kubeadm mode

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -314,13 +314,15 @@ downloads:
 
   etcd:
     container: "{{ etcd_deployment_type != 'host' }}"
-    file: "{{ etcd_deployment_type == 'host' }}"
+    file: "{{ etcd_deployment_type == 'host' or etcd_kubeadm_enabled }}"
     enabled: true
     version: "{{ etcd_version }}"
     dest: "{{local_release_dir}}/etcd-{{ etcd_version }}-linux-amd64.tar.gz"
     repo: "{{ etcd_image_repo }}"
     tag: "{{ etcd_image_tag }}"
-    sha256: "{{ etcd_binary_checksum if etcd_deployment_type == 'host' else etcd_digest_checksum|d(None) }}"
+    sha256: >-
+     {{ etcd_binary_checksum if (etcd_deployment_type == 'host' or etcd_kubeadm_enabled)
+     else etcd_digest_checksum|d(None) }}
     url: "{{ etcd_download_url }}"
     unarchive: true
     owner: "root"


### PR DESCRIPTION
etcd kubeadm mode requires etcdctl binary, so it needs to be downloaded