### PR TITLE
modify  resource-container default value for kube-proxy

### DIFF
--- a/roles/kubernetes/master/defaults/main/kube-proxy.yml
+++ b/roles/kubernetes/master/defaults/main/kube-proxy.yml
@@ -101,10 +101,6 @@ kube_proxy_oom_score_adj: -999
 # in order to proxy service traffic. If unspecified, 0, or (0-0) then ports will be randomly chosen.
 kube_proxy_port_range: ''
 
-# resourceContainer is the absolute name of the resource-only container to create and run
-# the Kube-proxy in (Default: /kube-proxy).
-kube_proxy_resource_container: /kube-proxy
-
 # udpIdleTimeout is how long an idle UDP connection will be kept open (e.g. '250ms', '2s').
 # Must be greater than 0. Only applicable for proxyMode=userspace.
 kube_proxy_udp_idle_timeout: 250ms

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
@@ -323,5 +323,4 @@ mode: {{ kube_proxy_mode }}
 nodePortAddresses: {{ kube_proxy_nodeport_addresses }}
 oomScoreAdj: {{ kube_proxy_oom_score_adj }}
 portRange: {{ kube_proxy_port_range }}
-resourceContainer: {{ kube_proxy_resource_container }}
 udpIdleTimeout: {{ kube_proxy_udp_idle_timeout }}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
@@ -326,5 +326,4 @@ mode: {{ kube_proxy_mode }}
 nodePortAddresses: {{ kube_proxy_nodeport_addresses }}
 oomScoreAdj: {{ kube_proxy_oom_score_adj }}
 portRange: {{ kube_proxy_port_range }}
-resourceContainer: {{ kube_proxy_resource_container }}
 udpIdleTimeout: {{ kube_proxy_udp_idle_timeout }}


### PR DESCRIPTION
related issue: https://github.com/kubernetes/kubernetes/issues/66614
related pr: https://github.com/kubernetes-sigs/kubespray/pull/3519
First resource-container has been removed in https://github.com/kubernetes/kubernetes/pull/78294 ,
Once upgrade kube-proxy which running with  `resource-container=/kube-proxy`, we will found #66614 err.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
modify  resource-container default value for kube-proxy
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #66614

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
