### PR TITLE
fix broken ubuntu containerd engine

### DIFF
--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -101,7 +101,7 @@
 
 - name: Check if runc is installed
   stat:
-    path: /usr/sbin/runc
+    path: "{{ runc_binary }}"
   register: runc_stat
 
 - name: Install runc package if necessary

--- a/roles/container-engine/containerd/vars/ubuntu-amd64.yml
+++ b/roles/container-engine/containerd/vars/ubuntu-amd64.yml
@@ -3,6 +3,7 @@
 containerd_versioned_pkg:
   'latest': "{{ containerd_package }}"
   '1.2.4': "{{ containerd_package }}=1.2.4-1"
+  '1.2.6': "{{ containerd_package }}=1.2.6-3"
   'stable': "{{ containerd_package }}=1.2.4-1"
   'edge': "{{ containerd_package }}=1.2.4-1"
 
@@ -25,3 +26,5 @@ containerd_repo_info:
        deb {{ containerd_ubuntu_repo_base_url }}
        {{ ansible_distribution_release|lower }}
        {{ containerd_ubuntu_repo_component }}
+
+runc_binary: /usr/bin/runc


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
containerd is not working with Ubuntu. Causes are:

* installing runc package remove containerd.io package.
*  runc's path is difference

**Does this PR introduce a user-facing change?**:

NONE

