### PR TITLE
Update calico-typha deployment to address v3.7.x changes

### DIFF
--- a/roles/network_plugin/calico/templates/calico-typha.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-typha.yml.j2
@@ -97,19 +97,17 @@ spec:
           # - name: USE_POD_CIDR
           #   value: "true"
         livenessProbe:
-          exec:
-            command:
-            - calico-typha
-            - check
-            - liveness
+          httpGet:
+            path: /liveness
+            port: 9098
+            host: localhost
           periodSeconds: 30
           initialDelaySeconds: 30
         readinessProbe:
-          exec:
-            command:
-            - calico-typha
-            - check
-            - readiness
+          httpGet:
+            path: /readiness
+            port: 9098
+            host: localhost
           periodSeconds: 10
 
 ---

--- a/roles/network_plugin/calico/templates/calico-typha.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-typha.yml.j2
@@ -60,7 +60,6 @@ spec:
       # as a host-networked pod.
       serviceAccountName: calico-node
       containers:
-#      - image: calico/typha:v3.4.4
       - image: {{ calico_typha_image_repo }}:{{ calico_typha_image_tag }}
         name: calico-typha
         ports:
@@ -97,17 +96,33 @@ spec:
           # - name: USE_POD_CIDR
           #   value: "true"
         livenessProbe:
+{% if calico_version is version('v3.7.0', '<') %}
+          exec:
+            command:
+            - calico-typha
+            - check
+            - liveness
+{% else %}
           httpGet:
             path: /liveness
             port: 9098
             host: localhost
+{% endif %}
           periodSeconds: 30
           initialDelaySeconds: 30
         readinessProbe:
+{% if calico_version is version('v3.7.0', '<') %}
+          exec:
+            command:
+            - calico-typha
+            - check
+            - readiness
+{% else %}
           httpGet:
             path: /readiness
             port: 9098
             host: localhost
+{% endif %}
           periodSeconds: 10
 
 ---


### PR DESCRIPTION
Update calico-typha deployment to address v3.7.x changes (according to https://docs.projectcalico.org/v3.7/manifests/calico-typha.yaml).
So that calico-typha works for Calico v3.7.x when using KDD.

**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:

calico-typha works for Calico v3.7.x when using KDD.

**Special notes for your reviewer**:

Related change: https://github.com/kubernetes-sigs/kubespray/pull/4953

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
