### PR TITLE
[contrib/heketi]: path fix and tear down improvements

### DIFF
--- a/contrib/network-storage/heketi/README.md
+++ b/contrib/network-storage/heketi/README.md
@@ -14,3 +14,5 @@ ansible-playbook --ask-become -i inventory/sample/k8s_heketi_inventory.yml contr
 ```
 ansible-playbook --ask-become -i inventory/sample/k8s_heketi_inventory.yml contrib/network-storage/heketi/heketi-tear-down.yml
 ```
+
+Add `--extra-vars "heketi_remove_lvm=true"` to the command above to remove LVM packages from the system

--- a/contrib/network-storage/heketi/roles/provision/templates/heketi-bootstrap.json.j2
+++ b/contrib/network-storage/heketi/roles/provision/templates/heketi-bootstrap.json.j2
@@ -56,7 +56,7 @@
             "serviceAccountName": "heketi-service-account",
             "containers": [
               {
-                "image": "heketi/heketi:7",
+                "image": "heketi/heketi:9",
                 "imagePullPolicy": "Always",
                 "name": "deploy-heketi",
                 "env": [

--- a/contrib/network-storage/heketi/roles/provision/templates/heketi-deployment.json.j2
+++ b/contrib/network-storage/heketi/roles/provision/templates/heketi-deployment.json.j2
@@ -68,7 +68,7 @@
             "serviceAccountName": "heketi-service-account",
             "containers": [
               {
-                "image": "heketi/heketi:7",
+                "image": "heketi/heketi:9",
                 "imagePullPolicy": "Always",
                 "name": "heketi",
                 "env": [

--- a/contrib/network-storage/heketi/roles/tear-down-disks/defaults/main.yml
+++ b/contrib/network-storage/heketi/roles/tear-down-disks/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+heketi_remove_lvm: false

--- a/contrib/network-storage/heketi/roles/tear-down-disks/tasks/main.yml
+++ b/contrib/network-storage/heketi/roles/tear-down-disks/tasks/main.yml
@@ -14,6 +14,8 @@
   when: "ansible_os_family == 'Debian'"
 
 - name: "Get volume group information."
+  environment:
+    PATH: "{{ ansible_env.PATH }}:/sbin"  # Make sure we can workaround RH / CentOS conservative path management
   become: true
   shell: "pvs {{ disk_volume_device_1 }} --option vg_name | tail -n+2"
   register: "volume_groups"
@@ -21,12 +23,16 @@
   changed_when: false
 
 - name: "Remove volume groups."
+  environment:
+    PATH: "{{ ansible_env.PATH }}:/sbin"  # Make sure we can workaround RH / CentOS conservative path management
   become: true
   command: "vgremove {{ volume_group }} --yes"
   with_items: "{{ volume_groups.stdout_lines }}"
   loop_control: { loop_var: "volume_group" }
 
 - name: "Remove physical volume from cluster disks."
+  environment:
+    PATH: "{{ ansible_env.PATH }}:/sbin"  # Make sure we can workaround RH / CentOS conservative path management
   become: true
   command: "pvremove {{ disk_volume_device_1 }} --yes"
   ignore_errors: true
@@ -36,11 +42,11 @@
   yum:
     name: "lvm2"
     state: "absent"
-  when: "ansible_os_family == 'RedHat'"
+  when: "ansible_os_family == 'RedHat' and heketi_remove_lvm"
 
 - name: "Remove lvm utils (Debian)"
   become: true
   apt:
     name: "lvm2"
     state: "absent"
-  when: "ansible_os_family == 'Debian'"
+  when: "ansible_os_family == 'Debian' and heketi_remove_lvm"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
>
/kind feature
> /kind flake

**What this PR does / why we need it**:

* lvm packages installation is not handled by the Heketi role and thus removal during tear down should be skipped by default
* lvm utils execution PATH fixed for CentOS/RH
* Heketi updated to the latest version 9

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
* `heketi_remove_lvm` var added for the heketi-tear-down playbook
```
