### PR TITLE
Always create bash_completion.d folder

### DIFF
--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -72,3 +72,11 @@
       - ceph-common
     state: present
   when: rbd_provisioner_enabled|default(false)
+
+- name: Ensure bash_completion.d folder exists
+  file:
+    name: /etc/bash_completion.d/
+    state: directory
+    owner: root
+    group: root
+    mode: 0755

--- a/roles/kubernetes/master/tasks/main.yml
+++ b/roles/kubernetes/master/tasks/main.yml
@@ -42,21 +42,14 @@
     - kubectl
     - upgrade
 
-- name: Make sure bash_completion.d folder exists
-  file:
-    name: "/etc/bash_completion.d/"
-    state: directory
-  when: ansible_os_family in ["ClearLinux"]
-  tags:
-    - kubectl
-
 - name: Install kubectl bash completion
   shell: "{{ bin_dir }}/kubectl completion bash >/etc/bash_completion.d/kubectl.sh"
   when: ansible_os_family in ["Debian","RedHat"]
   tags:
     - kubectl
+  ignore_errors: True
 
-- name: Set kubectl bash completion file
+- name: Set kubectl bash completion file permissions
   file:
     path: /etc/bash_completion.d/kubectl.sh
     owner: root
@@ -66,6 +59,7 @@
   tags:
     - kubectl
     - upgrade
+  ignore_errors: True
 
 - name: Disable SecurityContextDeny admission-controller and enable PodSecurityPolicy
   set_fact:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes a fatal error when installing kubectl with the containerd container engine on Ubuntu 18.04:
```
TASK [kubernetes/master : Install kubectl bash completion]
task path: /home/mark/git/kubernetes-sigs/kubespray/roles/kubernetes/master/tasks/main.yml:54
fatal: [k8s-master]: FAILED! => {"changed": true, "cmd": "/usr/local/bin/kubectl completion bash >/etc/bash_completion.d/kubectl.sh", "delta": "0:00:00.002043", "end": "2019-08-03 20:54:10.686498", "msg": "non-zero return code", "rc": 2, "start": "2019-08-03 20:54:10.684455", "stderr": "/bin/sh: 1: cannot create /etc/bash_completion.d/kubectl.sh: Directory nonexistent", "stderr_lines": ["/bin/sh: 1: cannot create /etc/bash_completion.d/kubectl.sh: Directory nonexistent"], "stdout": "", "stdout_lines": []}
```

When the Docker container engine is used, the `docker-ce` package has `Recommends: git` which installs `/etc/bash_completion.d/git-prompt` and thus ensures the directory exists before this task is called.

This PR also fixes the following ignored error during crictl installation:

```
TASK [container-engine/containerd : Install crictl completion]
task path: /home/mark/git/kubernetes-sigs/kubespray/roles/container-engine/containerd/tasks/main.yml:129
fatal: [k8s-master]: FAILED! => {"changed": true, "cmd": "/usr/local/bin/crictl completion >/etc/bash_completion.d/crictl", "delta": "0:00:00.001735", "end": "2019-08-03 21:05:42.075376", "msg": "non-zero return code", "rc": 2, "start": "2019-08-03 21:05:42.073641", "stderr": "/bin/sh: 1: cannot create /etc/bash_completion.d/crictl: Directory nonexistent", "stderr_lines": ["/bin/sh: 1: cannot create /etc/bash_completion.d/crictl: Directory nonexistent"], "stdout": "", "stdout_lines": []}
...ignoring
```

**Does this PR introduce a user-facing change?**:

```release-note
Always create bash_completion.d folder
```