### PR TITLE
Fix variable for rbd_provisioner_user_secret

### DIFF
--- a/contrib/metallb/README.md
+++ b/contrib/metallb/README.md
@@ -2,7 +2,7 @@
 ```
 MetalLB hooks into your Kubernetes cluster, and provides a network load-balancer implementation. In short, it allows you to create Kubernetes services of type “LoadBalancer” in clusters that don’t run on a cloud provider, and thus cannot simply hook into paid products to provide load-balancers.
 ```
-This playbook aims to automate [this](https://metallb.universe.tf/tutorial/layer2/tutorial). It deploys MetalLB into kubernetes and sets up a layer 2 loadbalancer.
+This playbook aims to automate [this](https://metallb.universe.tf/concepts/layer2/). It deploys MetalLB into kubernetes and sets up a layer 2 loadbalancer.
 
 ## Install
 ```

--- a/roles/kubernetes-apps/external_provisioner/rbd_provisioner/defaults/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/rbd_provisioner/defaults/main.yml
@@ -8,7 +8,7 @@ rbd_provisioner_secret_name: ceph-secret-admin
 rbd_provisioner_secret_token: ceph-key-admin
 rbd_provisioner_user_id: kube
 rbd_provisioner_user_secret_name: ceph-secret-user
-rbd_provisioner_user_secret_token: ceph-key-user
+rbd_provisioner_user_secret: ceph-key-user
 rbd_provisioner_user_secret_namespace: rbd-provisioner
 rbd_provisioner_fs_type: ext4
 rbd_provisioner_image_format: "2"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**


> /kind bug

**What this PR does / why we need it**:
Rbd_provisioner_user_secret_token is incorrect in defaults/main.yml, the correct one should correspond to the field in [yml](https://github.com/kubernetes-sigs/kubespray/blob/4132cee6870cc09e5dff670b536979314f433dd4/roles/kubernetes-apps/external_provisioner/rbd_provisioner/templates/secret-rbd-provisioner.yml.j2#L9)
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Rename rbd_provisioner_user_secret_token to rbd_provisioner_user_secret

```
