### PR TITLE
Optionally refresh kubeadm token every time

### DIFF
--- a/roles/kubernetes/master/defaults/main/main.yml
+++ b/roles/kubernetes/master/defaults/main/main.yml
@@ -41,6 +41,9 @@ kube_scheduler_bind_address: 0.0.0.0
 # discovery_timeout modifies the discovery timeout
 discovery_timeout: 5m0s
 
+# Instruct first master to refresh kubeadm token
+kubeadm_refresh_token: true
+
 # audit support
 kubernetes_audit: false
 # path to audit log file

--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -146,6 +146,7 @@
   when:
     - inventory_hostname == groups['kube-master']|first
     - kubeadm_token is defined
+    - kubeadm_refresh_token
   tags:
     - kubeadm_token
 


### PR DESCRIPTION
Allows to set kubeadm_token_refresh=false if the deployer has an external tool to reset kubeadm tokens.