### PR TITLE
Add ability to setup virtual ip for ingress-controller on bare metal

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s-cluster/addons.yml
@@ -80,6 +80,7 @@ rbd_provisioner_enabled: false
 # Nginx ingress controller deployment
 ingress_nginx_enabled: false
 # ingress_nginx_host_network: false
+ingress_publish_status_address: ""
 # ingress_nginx_nodeselector:
 #   beta.kubernetes.io/os: "linux"
 # ingress_nginx_tolerations:

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 ingress_nginx_namespace: "ingress-nginx"
 ingress_nginx_host_network: false
+ingress_publish_status_address: ""
 ingress_nginx_nodeselector:
   beta.kubernetes.io/os: "linux"
 ingress_nginx_tolerations: []

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
@@ -48,6 +48,9 @@ spec:
 {% if ingress_nginx_host_network %}
             - --report-node-internal-ip-address
 {% endif %}
+{% if ingress_publish_status_address != "" %}
+            - --publish-status-address={{ ingress_publish_status_address }}
+{% endif %}
           securityContext:
             capabilities:
                 drop:


### PR DESCRIPTION
Allows to set optional key for ingress controller
```
- --publish-status-address=<LB_VIP>
```
to define address for ingress's objects
```
$ kubectl get ingresses
NAME         HOSTS             ADDRESS         PORTS     AGE
myapp   myapp.prod.local   <LB_VIP>          80, 443     12d
```
In support with external-dns operator this option let us to create dns-records for ingress's objects use specified <LB_VIP>

/kind feature