### PR TITLE
Bump minimum K8S version to 1.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Note: The list of validated [docker versions](https://github.com/kubernetes/kube
 
 Requirements
 ------------
--   **Minimum required version of Kubernetes is v1.13**
+-   **Minimum required version of Kubernetes is v1.14**
 -   **Ansible v2.7.8 (or newer, but [not 2.8.x](https://github.com/kubernetes-sigs/kubespray/issues/4778)) and python-netaddr is installed on the machine
     that will run Ansible commands**
 -   **Jinja 2.9 (or newer) is required to run the Ansible Playbooks**


### PR DESCRIPTION
Signed-off-by: Craig Rodrigues <craig@portworx.com>

**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

NONE
```
