### PR TITLE
Fix broken containerd pinning on Ubuntu

### DIFF
--- a/roles/container-engine/containerd/templates/apt_preferences.d/debian_containerd.j2
+++ b/roles/container-engine/containerd/templates/apt_preferences.d/debian_containerd.j2
@@ -1,3 +1,3 @@
 Package: {{ containerd_package }}
-Pin: version {{ containerd_version }}.*
+Pin: version {{ containerd_version }}*
 Pin-Priority: 1001


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
Remove the unneeded dot in pinning configuration which prevents it from working

```release-note
NONE
```
