### PR TITLE
Always download coredns images with kubeadm

### DIFF
--- a/roles/download/templates/kubeadm-images.yaml.j2
+++ b/roles/download/templates/kubeadm-images.yaml.j2
@@ -13,9 +13,7 @@ etcd:
 {% for endpoint in etcd_access_addresses.split(',') %}
       - {{ endpoint }}
 {% endfor %}
-{% if dns_mode in ['coredns', 'coredns_dual'] %}
 dns:
   type: CoreDNS
   imageRepository: {{ coredns_image_repo | regex_replace('/coredns$','') }}
   imageTag: {{ coredns_image_tag }}
-{% endif %}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
@@ -69,12 +69,10 @@ etcd:
       - {{ san }}
 {% endfor %}
 {% endif %}
-{% if dns_mode in ['coredns', 'coredns_dual'] %}
 dns:
   type: CoreDNS
   imageRepository: {{ coredns_image_repo | regex_replace('/coredns$','') }}
   imageTag: {{ coredns_image_tag }}
-{% endif %}
 networking:
   dnsDomain: {{ dns_domain }}
   serviceSubnet: {{ kube_service_addresses }}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
@@ -72,13 +72,10 @@ etcd:
       - {{ san }}
 {% endfor %}
 {% endif %}
-
-{% if dns_mode in ['coredns', 'coredns_dual'] %}
 dns:
   type: CoreDNS
   imageRepository: {{ coredns_image_repo | regex_replace('/coredns$','') }}
   imageTag: {{ coredns_image_tag }}
-{% endif %}
 networking:
   dnsDomain: {{ dns_domain }}
   serviceSubnet: {{ kube_service_addresses }}


### PR DESCRIPTION
Fixes situation when using manual mode because it
tries to download coredns v1.3.1 from the same
image repository where kubernetes images are
downloaded from.