### PR TITLE
Fix openstack_cacert conditional fail

### DIFF
--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -177,7 +177,7 @@
     - cloud_provider is defined
     - cloud_provider == 'openstack'
     - openstack_cacert is defined
-    - openstack_cacert
+    - openstack_cacert | length > 0
   tags:
     - cloud-provider
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes the failing of the condition openstack_cacert in the the task `Write cacert file` in `roles/kubernetes/node/tasks/main.yml`  

**Which issue(s) this PR fixes**:
Fixes #5077
Fixes #4851
Fixes #4960

**Special notes for your reviewer**:
This should be backported to releases 2.10 and 2.11. Should I open two separate PRs?

**Does this PR introduce a user-facing change?**:
None