### PR TITLE
CI: Update Terraform from 0.11.11 to 0.12.6

### DIFF
--- a/.gitlab-ci/terraform.yml
+++ b/.gitlab-ci/terraform.yml
@@ -55,21 +55,21 @@ tf-validate-openstack:
 tf-validate-packet:
   extends: .terraform_validate
   variables:
-    TF_VERSION: 0.11.11
+    TF_VERSION: 0.12.6
     PROVIDER: packet
     CLUSTER: $CI_COMMIT_REF_NAME
 
 tf-validate-aws:
   extends: .terraform_validate
   variables:
-    TF_VERSION: 0.11.11
+    TF_VERSION: 0.12.6
     PROVIDER: aws
     CLUSTER: $CI_COMMIT_REF_NAME
 
 tf-packet-ubuntu16-default:
   extends: .terraform_apply
   variables:
-    TF_VERSION: 0.11.11
+    TF_VERSION: 0.12.6
     PROVIDER: packet
     CLUSTER: $CI_COMMIT_REF_NAME
     TF_VAR_number_of_k8s_masters: "1"
@@ -83,7 +83,7 @@ tf-packet-ubuntu16-default:
 tf-packet-ubuntu18-default:
   extends: .terraform_apply
   variables:
-    TF_VERSION: 0.11.11
+    TF_VERSION: 0.12.6
     PROVIDER: packet
     CLUSTER: $CI_COMMIT_REF_NAME
     TF_VAR_number_of_k8s_masters: "1"

--- a/contrib/terraform/aws/create-infrastructure.tf
+++ b/contrib/terraform/aws/create-infrastructure.tf
@@ -16,7 +16,7 @@ data "aws_availability_zones" "available" {}
 */
 
 module "aws-vpc" {
-  source = "modules/vpc"
+  source = "./modules/vpc"
 
   aws_cluster_name         = "${var.aws_cluster_name}"
   aws_vpc_cidr_block       = "${var.aws_vpc_cidr_block}"
@@ -27,7 +27,7 @@ module "aws-vpc" {
 }
 
 module "aws-elb" {
-  source = "modules/elb"
+  source = "./modules/elb"
 
   aws_cluster_name      = "${var.aws_cluster_name}"
   aws_vpc_id            = "${module.aws-vpc.aws_vpc_id}"
@@ -39,7 +39,7 @@ module "aws-elb" {
 }
 
 module "aws-iam" {
-  source = "modules/iam"
+  source = "./modules/iam"
 
   aws_cluster_name = "${var.aws_cluster_name}"
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind cleanup
/kind failing-test

**What this PR does / why we need it**:
Update Terraform from 0.11.11 to 0.12.6 for our CI as 0.11 is outdated and makes CI fail.