### PR TITLE
terraform/openstack: add network_dns_domain variable

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -225,6 +225,7 @@ For your cluster, edit `inventory/$CLUSTER/cluster.tfvars`.
 |---------|-------------|
 |`cluster_name` | All OpenStack resources will use the Terraform variable`cluster_name` (default`example`) in their name to make it easier to track. For example the first compute resource will be named`example-kubernetes-1`. |
 |`network_name` | The name to be given to the internal network that will be generated |
+|`network_dns_domain` | (Optional) The dns_domain for the internal network that will be generated |
 |`dns_nameservers`| An array of DNS name server names to be used by hosts in the internal subnet. |
 |`floatingip_pool` | Name of the pool from which floating IPs will be allocated |
 |`external_net` | UUID of the external network that will be routed to |

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -5,12 +5,13 @@ provider "openstack" {
 module "network" {
   source = "./modules/network"
 
-  external_net    = "${var.external_net}"
-  network_name    = "${var.network_name}"
-  subnet_cidr     = "${var.subnet_cidr}"
-  cluster_name    = "${var.cluster_name}"
-  dns_nameservers = "${var.dns_nameservers}"
-  use_neutron     = "${var.use_neutron}"
+  external_net       = "${var.external_net}"
+  network_name       = "${var.network_name}"
+  subnet_cidr        = "${var.subnet_cidr}"
+  cluster_name       = "${var.cluster_name}"
+  dns_nameservers    = "${var.dns_nameservers}"
+  network_dns_domain = "${var.network_dns_domain}"
+  use_neutron        = "${var.use_neutron}"
 }
 
 module "ips" {

--- a/contrib/terraform/openstack/modules/network/main.tf
+++ b/contrib/terraform/openstack/modules/network/main.tf
@@ -8,6 +8,7 @@ resource "openstack_networking_router_v2" "k8s" {
 resource "openstack_networking_network_v2" "k8s" {
   name           = "${var.network_name}"
   count          = "${var.use_neutron}"
+  dns_domain     = var.network_dns_domain != null ? "${var.network_dns_domain}" : null
   admin_state_up = "true"
 }
 

--- a/contrib/terraform/openstack/modules/network/variables.tf
+++ b/contrib/terraform/openstack/modules/network/variables.tf
@@ -2,6 +2,8 @@ variable "external_net" {}
 
 variable "network_name" {}
 
+variable "network_dns_domain" {}
+
 variable "cluster_name" {}
 
 variable "dns_nameservers" {

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -103,6 +103,12 @@ variable "network_name" {
   default     = "internal"
 }
 
+variable "network_dns_domain" {
+  description = "dns_domain for the internal network"
+  type        = "string"
+  default     = null
+}
+
 variable "use_neutron" {
   description = "Use neutron"
   default     = 1


### PR DESCRIPTION
This allows the user to optionally specify the dns_domain attribute on the
generated internal kubernetes network.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
The Designate OpenStack DNS service can be configured to dynamically generate associated DNS records when floating IPs are assigned to an instance (see https://docs.openstack.org/neutron/latest/admin/config-dns-int-ext-serv.html for a more in-depth discussion as to how this works).

For this to work the dns_domain attribute on the *internal* network must be set to the FQDN of the relevant DNS zone so that the appropriate DNS record can be automatically generated.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
An optional network_dns_domain variable can be specified in cluster.tfvars which is used to set the dns_domain attribute on the generated internal kubernetes network.
```
