### PR TITLE
fix bug: run Copy image to ansible host cache on download_delegate host

### DIFF
--- a/roles/download/tasks/download_container.yml
+++ b/roles/download/tasks/download_container.yml
@@ -118,10 +118,10 @@
         use_ssh_args: "{{ has_bastion | default(false) }}"
         mode: pull
       delegate_facts: no
-      run_once: true
       when:
         - download_force_cache
         - not download_localhost
+        - download_delegate == inventory_hostname
         - not image_is_cached or (image_changed | default(true))
         - ansible_os_family not in ["CoreOS", "Container Linux by CoreOS"]
 

--- a/roles/download/tasks/download_file.yml
+++ b/roles/download/tasks/download_file.yml
@@ -111,7 +111,6 @@
       dest: "{{ file_path_cached }}"
       use_ssh_args: "{{ has_bastion | default(false) }}"
       mode: pull
-    run_once: true
     when:
     - download_force_cache
     - not file_is_cached or get_url_result.changed


### PR DESCRIPTION
/kind bug
when set
download_run_once: true
download_localhost: false

task in roles/download/tasks/download_container.yml `download_container | Save and compress image` runned in download_delegate host, but next task `name: download_container | Copy image to ansible host cache` which should copy the saved image to ansible host running on random host and only once time.

I change the behavior so that the task is executed on download_delegate host
Also remove run_once from `download_file | Copy file back to ansible host file cache`, with run_once task launch on random host only once and skipped when not `download_delegate == inventory_hostname`