### PR TITLE
Allow calico settings to be modified

### DIFF
--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -113,7 +113,7 @@
         "spec": {
           "cidr": "{{ calico_pool_cidr | default(kube_pods_subnet) }}",
           "ipipMode": "{{ ipip_mode }}",
-          "natOutgoing": {{ nat_outgoing|default(false) and not peer_with_router|default(false) }} }} " | {{ bin_dir }}/calicoctl.sh create -f -
+          "natOutgoing": {{ nat_outgoing|default(false) and not peer_with_router|default(false) }} }} " | {{ bin_dir }}/calicoctl.sh apply -f -
   when:
     - inventory_hostname == groups['kube-master'][0]
     - 'calico_conf.stdout == "0"'
@@ -131,7 +131,7 @@
           "blockSize": "{{ kube_network_node_prefix }}",
           "cidr": "{{ calico_pool_cidr | default(kube_pods_subnet) }}",
           "ipipMode": "{{ ipip_mode }}",
-          "natOutgoing": {{ nat_outgoing|default(false) and not peer_with_router|default(false) }} }} " | {{ bin_dir }}/calicoctl.sh create -f -
+          "natOutgoing": {{ nat_outgoing|default(false) and not peer_with_router|default(false) }} }} " | {{ bin_dir }}/calicoctl.sh apply -f -
   when:
     - inventory_hostname == groups['kube-master'][0]
     - 'calico_conf.stdout == "0"'
@@ -156,7 +156,7 @@
     "spec": {
         "logSeverityScreen": "Info",
         "nodeToNodeMeshEnabled": {{ nodeToNodeMeshEnabled|default('true') }} ,
-        "asNumber": {{ global_as_num }} }} ' | {{ bin_dir }}/calicoctl.sh create --skip-exists -f -
+        "asNumber": {{ global_as_num }} }} ' | {{ bin_dir }}/calicoctl.sh apply -f -
   changed_when: false
   when:
     - inventory_hostname == groups['kube-master'][0]
@@ -172,7 +172,7 @@
     "spec": {
        "asNumber": "{{ item.as }}",
        "peerIP": "{{ item.router_id }}"
-    }}' | {{ bin_dir }}/calicoctl.sh create --skip-exists -f -
+    }}' | {{ bin_dir }}/calicoctl.sh apply -f -
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   with_items:
@@ -192,7 +192,7 @@
     "spec": {
        "nodeSelector": "!has(i-am-a-route-reflector)",
        "peerSelector": "has(i-am-a-route-reflector)"
-    }}' | {{ bin_dir }}/calicoctl.sh create --skip-exists -f -
+    }}' | {{ bin_dir }}/calicoctl.sh apply -f -
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   with_items:
@@ -212,7 +212,7 @@
     "spec": {
        "nodeSelector": "has(i-am-a-route-reflector)",
        "peerSelector": "has(i-am-a-route-reflector)"
-    }}' | {{ bin_dir }}/calicoctl.sh create --skip-exists -f -
+    }}' | {{ bin_dir }}/calicoctl.sh apply -f -
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   with_items:
@@ -285,7 +285,7 @@
          "asNumber": "{{ local_as }}"
        },
        "orchRefs":[{"nodeName":"{{ inventory_hostname }}","orchestrator":"k8s"}]
-    }}' | {{ bin_dir }}/calicoctl.sh {{ 'apply -f -' if calico_datastore == "kdd" else 'create --skip-exists -f -' }}
+    }}' | {{ bin_dir }}/calicoctl.sh apply -f -
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   when:
@@ -306,7 +306,7 @@
        "asNumber": "{{ item.as }}",
        "node": "{{ inventory_hostname }}",
        "peerIP": "{{ item.router_id }}"
-    }}' | {{ bin_dir }}/calicoctl.sh create --skip-exists -f -
+    }}' | {{ bin_dir }}/calicoctl.sh apply -f -
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   with_items:


### PR DESCRIPTION
Previous logic used calicoctl.sh create --skip-exists, which
allowed setting initial values, but not permitting changes.

This was previously not possible because of legacy calico 2.6 support