### PR TITLE
install python3 instead of python2 for fedora >= 30 fixes 5056, fixes 4802

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0070-system-packages.yml
+++ b/roles/kubernetes/preinstall/tasks/0070-system-packages.yml
@@ -26,6 +26,21 @@
   when:
     - ansible_distribution == "Fedora"
     - ansible_distribution_major_version|int > 21
+    - ansible_distribution_major_version|int <= 29
+    - not is_atomic
+  changed_when: False
+  tags:
+    - bootstrap-os
+
+- name: Install python3-dnf for latest RedHat versions
+  command: dnf install -y python3-dnf
+  register: dnf_task_result
+  until: dnf_task_result is succeeded
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  when:
+    - ansible_distribution == "Fedora"
+    - ansible_distribution_major_version|int >= 30
     - not is_atomic
   changed_when: False
   tags:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
It install python3 instead of python2 for fedora 30 (python2 can't be installed using dnf anymore since EOL)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5056, Fixes 4802

**Special notes for your reviewer**:
Ansible is working on defaulting to python3 for fedora 30 (and for others...) https://github.com/nodejs/build/pull/1812 for now we need to use ansible_python_interpreter=/usr/bin/python3

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
