### PR TITLE
define clusterIP variable before using it

### DIFF
--- a/roles/kubernetes-apps/ansible/tasks/nodelocaldns.yml
+++ b/roles/kubernetes-apps/ansible/tasks/nodelocaldns.yml
@@ -19,6 +19,7 @@
     - { name: nodelocaldns, file: nodelocaldns-daemonset.yml, type: daemonset }
   register: nodelocaldns_manifests
   vars:
+    clusterIP: "{{ skydns_server }}"
     forwardTarget: >-
       {%- if secondaryclusterIP is defined and dns_mode == 'coredns_dual' -%}
       {{ clusterIP }} {{ secondaryclusterIP }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
/kind bug

**What this PR does / why we need it**:
tag `coredns` doesn't work because variable `clusterIP` is not defined in `Kubernetes Apps | Lay Down` nodelocaldns Template when using that tag (and when enable_nodelocaldns=true)
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5017 

**Special notes for your reviewer**:
Previous fix only fixes the first variable not this one.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
