### PR TITLE
Fix for bug #5116

### DIFF
--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -84,9 +84,9 @@
     content: "{{ admin_kubeconfig.stdout }}"
     dest: "{{ artifacts_dir }}/admin.conf"
     mode: 0640
-  delegate_to: localhost
   become: no
   run_once: yes
+  delegate_to: localhost
   when: kubeconfig_localhost|default(false)
 
 - name: Copy kubectl binary to ansible host
@@ -95,6 +95,7 @@
     dest: "{{ artifacts_dir }}/kubectl"
   become: no
   run_once: yes
+  delegate_to: localhost
   when: kubectl_localhost|default(false)
 
 - name: create helper script kubectl.sh on ansible host


### PR DESCRIPTION
Added delegation to `localhost` to copy `kubectl`

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind bug
> /kind cleanup 

**What this PR does / why we need it**:

It fixes copy `kubectl` to inventory directory back to host. It also move `delegate_to: localhost` to pre last line for `Write admin kubeconfig on ansible host` task in order to keep consistency of the yaml.

**Which issue(s) this PR fixes**:

#5116

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

`no`

```release-note
* bugfix for #5116 - copy `kubectl` back to host
```
