### PR TITLE
Custom hostname support in inventory builder

### DIFF
--- a/contrib/inventory_builder/inventory.py
+++ b/contrib/inventory_builder/inventory.py
@@ -95,7 +95,7 @@ class KubesprayInventory(object):
             try:
                 self.hosts_file = open(config_file, 'r')
                 self.yaml_config = yaml.load(self.hosts_file)
-            except FileNotFoundError:
+            except IOError:
                 pass
         if changed_hosts and changed_hosts[0] in AVAILABLE_COMMANDS:
             self.parse_command(changed_hosts[0], changed_hosts[1:])

--- a/contrib/inventory_builder/inventory.py
+++ b/contrib/inventory_builder/inventory.py
@@ -44,7 +44,7 @@ import sys
 ROLES = ['all', 'kube-master', 'kube-node', 'etcd', 'k8s-cluster',
          'calico-rr']
 PROTECTED_NAMES = ROLES
-AVAILABLE_COMMANDS = ['help', 'print_cfg', 'print_ips', 'load']
+AVAILABLE_COMMANDS = ['help', 'print_cfg', 'print_ips', 'print_hostnames', 'load']
 _boolean_states = {'1': True, 'yes': True, 'true': True, 'on': True,
                    '0': False, 'no': False, 'false': False, 'off': False}
 yaml = YAML()
@@ -348,6 +348,8 @@ class KubesprayInventory(object):
             self.print_config()
         elif command == 'print_ips':
             self.print_ips()
+        elif command == 'print_hostnames':
+            self.print_hostnames()
         elif command == 'load':
             self.load_file(args)
         else:
@@ -361,6 +363,7 @@ Available commands:
 help - Display this message
 print_cfg - Write inventory file to stdout
 print_ips - Write a space-delimited list of IPs from "all" group
+print_hostnames - Write a space-delimited list of Hostnames from "all" group
 
 Advanced usage:
 Add another host after initial creation: inventory.py 10.10.1.5
@@ -380,6 +383,9 @@ MASSIVE_SCALE_THRESHOLD Separate K8s master and ETCD if # of nodes >= 200
 
     def print_config(self):
         yaml.dump(self.yaml_config, sys.stdout)
+
+    def print_hostnames(self):
+        print(' '.join(self.yaml_config['all']['hosts'].keys()))
 
     def print_ips(self):
         ips = []

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,6 +24,15 @@ Example inventory generator usage:
 
 Then use `inventory/mycluster/hosts.yml` as inventory file.
 
+Inventory generator supports using custom hostnames.
+Example:
+
+    cp -r inventory/sample inventory/mycluster
+    declare -a IPS=(10.10.1.3 10.10.1.4 10.10.1.5)
+    declare -a HOSTNAMES=(kubemaster01 kubemaster02 worker01)
+    CUSTOM_HOSTNAMES=True CONFIG_FILE=inventory/mycluster/hosts.yml python3 contrib/inventory_builder/inventory.py ${IPS[@]} ${HOSTNAMES[@]}
+
+
 Starting custom deployment
 --------------------------
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
This PR enables the user to define custom hostnames in the inventory builder (eg kubemaster01, kubemaster02, worker01) instead of the autogenerated node1. This gives more flexibility than using the prefixes currently supported.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
New feature in contrib/inventory_builder
User can now specify custom hostnames by passing hostnames to the inventory builder. For details see the documentation

```
