### PR TITLE
Fixes #4459 - changed python 3 to python command in usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To deploy the cluster you can use :
 
     # Update Ansible inventory file with inventory builder
     declare -a IPS=(10.10.1.3 10.10.1.4 10.10.1.5)
-    CONFIG_FILE=inventory/mycluster/hosts.yml python3 contrib/inventory_builder/inventory.py ${IPS[@]}
+    CONFIG_FILE=inventory/mycluster/hosts.yml python contrib/inventory_builder/inventory.py ${IPS[@]}
 
     # Review and change parameters under ``inventory/mycluster/group_vars``
     cat inventory/mycluster/group_vars/all/all.yml


### PR DESCRIPTION
 /kind documentation

**What this PR does / why we need it**:
Example is using pip and python3. Below python 2.7 is mentioned as exampled. This brings confusions. So the command has been adapted for easier copy paste usage.

**Which issue(s) this PR fixes**:
Fixes #4459 - changed python 3 to python command in usage docs

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Documentation adapted for "Usage" example with ansible to use python 2.x
```