### PR TITLE
Documenting Terraform variable `az_list` explicitly

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -224,6 +224,7 @@ For your cluster, edit `inventory/$CLUSTER/cluster.tfvars`.
 |Variable | Description |
 |---------|-------------|
 |`cluster_name` | All OpenStack resources will use the Terraform variable`cluster_name` (default`example`) in their name to make it easier to track. For example the first compute resource will be named`example-kubernetes-1`. |
+|`az_list` | List of Availability Zones available in your OpenStack cluster. |
 |`network_name` | The name to be given to the internal network that will be generated |
 |`network_dns_domain` | (Optional) The dns_domain for the internal network that will be generated |
 |`dns_nameservers`| An array of DNS name server names to be used by hosts in the internal subnet. |

--- a/contrib/terraform/openstack/sample-inventory/cluster.tfvars
+++ b/contrib/terraform/openstack/sample-inventory/cluster.tfvars
@@ -1,6 +1,9 @@
 # your Kubernetes cluster name here
 cluster_name = "i-didnt-read-the-docs"
 
+# list of availability zones available in your OpenStack cluster
+#az_list = ["nova"]
+
 # SSH key to use for access to nodes
 public_key_path = "~/.ssh/id_rsa.pub"
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

When setting up [Kubernetes on OpenStack with Terraform](https://github.com/kubernetes-sigs/kubespray/tree/master/contrib/terraform/openstack), Terraform variable `az_list` will be explicitly set in [cluster.tfvars](https://github.com/kubernetes-sigs/kubespray/blob/master/contrib/terraform/openstack/sample-inventory/cluster.tfvars) as well as explicitly documented in the [associated README section](https://github.com/kubernetes-sigs/kubespray/blob/master/contrib/terraform/openstack/README.md#cluster-variables). This will save the hassle of looking into [variables.tf](https://github.com/kubernetes-sigs/kubespray/blob/master/contrib/terraform/openstack/variables.tf).

**Which issue(s) this PR fixes**:

Fixes #5130 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Yes, but this change will be self-explanatory and requires no further actions as it is an improvement of documentation.
```