### PR TITLE
switch default container_manager to containerd

### DIFF
--- a/inventory/sample/group_vars/etcd.yml
+++ b/inventory/sample/group_vars/etcd.yml
@@ -19,4 +19,4 @@
 # etcd_peer_client_auth: true
 
 ## Settings for etcd deployment type
-etcd_deployment_type: docker
+etcd_deployment_type: host

--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -156,7 +156,7 @@ dns_domain: "{{ cluster_name }}"
 
 ## Container runtime
 ## docker for docker, crio for cri-o and containerd for containerd.
-container_manager: docker
+container_manager: containerd
 
 ## Settings for containerized control plane (kubelet/secrets)
 kubelet_deployment_type: host

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -199,7 +199,7 @@ kube_api_aggregator_routing: false
 kube_profiling: false
 
 # Container for runtime
-container_manager: docker
+container_manager: containerd
 
 # Container on localhost (download images when download_localhost is true)
 container_manager_on_localhost: "{{ container_manager }}"
@@ -273,7 +273,7 @@ containerd_use_systemd_cgroup: false
 
 # Settings for containerized control plane (etcd/kubelet/secrets)
 # deployment type for legacy etcd mode
-etcd_deployment_type: docker
+etcd_deployment_type: host
 cert_management: script
 
 helm_deployment_type: host


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:
Switch default container_manager from docker to containerd
https://kubernetes.io/blog/2018/05/24/kubernetes-containerd-integration-goes-ga/
containerd seems to be faster, with less intermediates (docker-shim / dockerd),
better integration, ...

**Which issue(s) this PR fixes**:
Fixes https://github.com/rook/rook/issues/2517

**Special notes for your reviewer**:
This is more to start a discussion, it was only tested on CentOS7

**Does this PR introduce a user-facing change?**:

```release-note
switch default container_manager to containerd / etcd_deployment_type to host
```
