### PR TITLE
Make nginx and haproxy client timeout configurable

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -46,6 +46,8 @@ kubelet_status_update_frequency: 10s
 loadbalancer_apiserver_memory_requests: 32M
 loadbalancer_apiserver_cpu_requests: 25m
 
+loadbalancer_apiserver_keepalive_timeout: 5m
+
 # kube_api_runtime_config:
 #   - extensions/v1beta1/daemonsets=true
 #   - extensions/v1beta1/deployments=true

--- a/roles/kubernetes/node/templates/loadbalancer/haproxy.cfg.j2
+++ b/roles/kubernetes/node/templates/loadbalancer/haproxy.cfg.j2
@@ -13,7 +13,7 @@ defaults
     timeout http-request    5m
     timeout queue           5m
     timeout connect         30s
-    timeout client          15m
+    timeout client          {{ loadbalancer_apiserver_keepalive_timeout }}
     timeout server          15m
     timeout http-keep-alive 30s
     timeout check           30s

--- a/roles/kubernetes/node/templates/loadbalancer/nginx.conf.j2
+++ b/roles/kubernetes/node/templates/loadbalancer/nginx.conf.j2
@@ -32,7 +32,7 @@ http {
   tcp_nopush on;
   tcp_nodelay on;
 
-  keepalive_timeout 75s;
+  keepalive_timeout {{ loadbalancer_apiserver_keepalive_timeout }};
   keepalive_requests 100;
   reset_timedout_connection on;
   server_tokens off;


### PR DESCRIPTION
This might need tweaking for use cases where kubectl logs takes more than 75s.