### PR TITLE
Limit registry-proxy access to localhost

### DIFF
--- a/roles/kubernetes-apps/registry/defaults/main.yml
+++ b/roles/kubernetes-apps/registry/defaults/main.yml
@@ -2,4 +2,5 @@
 registry_namespace: "kube-system"
 registry_storage_class: ""
 registry_disk_size: "10Gi"
+registry_hostip: "127.0.0.1"
 registry_port: 5000

--- a/roles/kubernetes-apps/registry/templates/registry-proxy-ds.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-proxy-ds.yml.j2
@@ -33,5 +33,5 @@ spec:
           ports:
             - name: registry
               containerPort: 80
-              hostIP: 127.0.0.1
+              hostIP: {{ registry_hostip }}
               hostPort: {{ registry_port }}

--- a/roles/kubernetes-apps/registry/templates/registry-proxy-ds.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-proxy-ds.yml.j2
@@ -33,4 +33,5 @@ spec:
           ports:
             - name: registry
               containerPort: 80
+              hostIP: 127.0.0.1
               hostPort: {{ registry_port }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Write access to the registry can trivially be escalated to Remote Code
Execution, by replacing a used image with a malicious lookalike.

The registry add-on currently publicly exposes full read/write access to the
registry for everyone at $IP_OF_ANY_NODE:5000. This isn't even mitigated by
on-node firewalls, since Kubernetes port forwarding takes precedence over both
FirewallD and UFW.

This patch locks down outside access to the registry. Note that this is still a
Privilege Escalation vulnerability with this patch, since any local user on any
node still has full read/write access. By default all pods will also have full
access to the registry, although this can be limited using a `NetworkPolicy`.

This is a breaking change, since it prevents outside access to the
registry (without APIServer proxying).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
action required: (Registry add-on) Access to registry-proxy is now limited to localhost. If you need to access the registry from inside the cluster, use the registry service instead. If you need to access the registry from outside the cluster, use some form of authenticated reverse proxy, or use the Kubernetes apiserver proxy.
```
