### PR TITLE
fix crictl install fail

### DIFF
--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -30,19 +30,6 @@
     state: present
   when: ansible_distribution in ["Ubuntu"]
 
-- name: Add CRI-O PPA
-  apt_repository:
-    repo: ppa:projectatomic/ppa
-    state: present
-  when: ansible_distribution in ["Ubuntu"]
-
-- name: Install crictl
-  unarchive:
-    src: "{{ local_release_dir }}/crictl-{{ crictl_version }}-linux-{{ image_arch }}.tar.gz"
-    dest: "/usr/local/bin"
-    mode: 0755
-    remote_src: yes
-
 - name: Make sure needed folders exist in the system
   with_items:
     - /etc/crio


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes the crictl installation fail.
The first deleted task `Add CRI-O PPA` is an exact duplicate of the previous task.
And the second deleted task `Install crictl` which provokes the error, can never work, as it tries to unarchive crictl which is only downloaded in the role `download` that is executed after the current role `container-engine` where the failure occurs.
And there is no need to install crictl anyway as the role `download` already does it by extracting the archive and copying it to bin folder.

**Which issue(s) this PR fixes**:
Fixes #5143

**Special notes for your reviewer**:
This goes deeper. This should fix #5143 which is over CentOS, but using cri-o on Ubuntu still fails as I identified a conf error in roles/container-engine/cri-o/vars/ubuntu.yml and the service doesn't start because of a missing file maybe due to the ppa package used to install cri-o.

**Does this PR introduce a user-facing change?**:
NONE