### PR TITLE
Move cri_socket var to kubespray-defaults

### DIFF
--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -7,21 +7,6 @@
     - download
     - upload
 
-- name: Use cri-o for cri connection
-  set_fact:
-    cri_socket: /var/run/crio/crio.sock
-  when: container_manager == 'crio'
-
-- name: Use containerd for cri connection
-  set_fact:
-    cri_socket: /var/run/containerd/containerd.sock
-  when: container_manager == 'containerd'
-
-- name: Use docker for cri connection
-  set_fact:
-    cri_socket: /var/run/dockershim.sock
-  when: container_manager == 'docker'
-
 - include_tasks: ../../container-engine/containerd/tasks/crictl.yml
   when:
     - not skip_downloads|default(false)

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -198,6 +198,16 @@ kube_profiling: false
 # Container for runtime
 container_manager: docker
 
+# CRI socket path
+cri_socket: >-
+  {%- if container_manager == 'crio' -%}
+  /var/run/crio/crio.sock
+  {%- elif container_manager == 'containerd' -%}
+  /var/run/containerd/containerd.sock
+  {%- else -%}
+  /var/run/dockershim.sock
+  {%- endif -%}
+
 ## Uncomment this if you want to force overlay/overlay2 as docker storage driver
 ## Please note that overlay2 is only supported on newer kernels
 # docker_storage_options: -s overlay2


### PR DESCRIPTION
This removes a hard dependency on download role for this var to be set.