### PR TITLE
Adjust endpoints for kube-proxy,controller,scheduler to proper ip

### DIFF
--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -104,10 +104,12 @@
     - kubeadm_discovery_address != kube_apiserver_endpoint | replace("https://", "")
   notify: restart kubelet
 
+# FIXME(mattymo): Need to point to localhost, otherwise masters will all point
+#                 incorrectly to first master, creating SPoF.
 - name: Update server field in kube-proxy kubeconfig
   shell: >-
     {{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf get configmap kube-proxy -n kube-system -o yaml
-    | sed 's#server:.*#server:\ {{ kube_apiserver_endpoint }}#g'
+    | sed 's#server:.*#server: https://127.0.0.1:{{ kube_apiserver_port }}#g'
     | {{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf replace -f -
   run_once: true
   when:

--- a/roles/kubernetes/master/tasks/kubeadm-fix-apiserver.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-fix-apiserver.yml
@@ -1,0 +1,13 @@
+---
+- name: Update server field in component kubeconfigs
+  lineinfile:
+    dest: "{{ kube_config_dir }}/{{ item }}.conf"
+    regexp: 'server:'
+    line: '    server: {{ kube_apiserver_endpoint }}'
+    backup: yes
+  with_items:
+    - controller-manager
+    - scheduler
+  when:
+    - not loadbalancer_apiserver is defined
+  notify: "Master | Restart kube-{{ item }}"

--- a/roles/kubernetes/master/tasks/main.yml
+++ b/roles/kubernetes/master/tasks/main.yml
@@ -73,3 +73,6 @@
 - name: Include kubeadm etcd extra tasks
   include_tasks: kubeadm-etcd.yml
   when: etcd_kubeadm_enabled
+
+- name: Include kubeadm secondary server apiserver fixes
+  include_tasks: kubeadm-fix-apiserver.yml


### PR DESCRIPTION
Fixes current single point of failure where kube-proxy, kube-controller-manager, and kube-scheduler all point to the first master IP, not to localhost loadbalancer. The control plane component issue only affects kubeadm control plane mode.