### PR TITLE
Fix variable for rbd_provisioner_secret

### DIFF
--- a/roles/kubernetes-apps/external_provisioner/rbd_provisioner/defaults/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/rbd_provisioner/defaults/main.yml
@@ -5,7 +5,7 @@ rbd_provisioner_monitors: ~
 rbd_provisioner_pool: kube
 rbd_provisioner_admin_id: admin
 rbd_provisioner_secret_name: ceph-secret-admin
-rbd_provisioner_secret_token: ceph-key-admin
+rbd_provisioner_secret: ceph-key-admin
 rbd_provisioner_user_id: kube
 rbd_provisioner_user_secret_name: ceph-secret-user
 rbd_provisioner_user_secret: ceph-key-user


### PR DESCRIPTION
What type of PR is this?

/kind bug

What this PR does / why we need it:
rbd_provisioner_secret_token is incorrect in defaults/main.yml, the correct one should correspond to the field in [yml](https://github.com/kubernetes-sigs/kubespray/blob/eb40ac163f05b2909e9f7178637d89bb341f5daa/roles/kubernetes-apps/external_provisioner/rbd_provisioner/templates/secret-rbd-provisioner.yml.j2#L9)
Which issue(s) this PR fixes:

Fixes #

Does this PR introduce a user-facing change?:

Rename rbd_provisioner_secret_token to rbd_provisioner_secret

the same as #5024 