### PR TITLE
Fix macro on local_volume_provisioner

### DIFF
--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-cm.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-cm.yml.j2
@@ -1,6 +1,6 @@
 # Macro to convert camelCase dictionary keys to snake_case keys
-{%- macro convert_keys(mydict) %}
-  {% for key in mydict.keys() -%}
+{% macro convert_keys(mydict) -%}
+  {% for key in mydict.keys()|list -%}
     {% set key_split = key.split('_') -%}
     {% set new_key = key_split[0] + key_split[1:]|map('capitalize')|join -%}
     {% set value = mydict.pop(key) -%}
@@ -21,5 +21,4 @@ data:
     {{ class_name }}:
       {{- convert_keys(storage_class) }}
       {{ storage_class | to_nice_yaml(indent=2) | indent(6) }}
-{% endfor %}
-
+{%- endfor %}

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-sc.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-sc.yml.j2
@@ -1,4 +1,4 @@
-{% for class_name in local_volume_provisioner_storage_classes.keys() %}
+{% for class_name, class_config in local_volume_provisioner_storage_classes.items() %}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -6,4 +6,7 @@ metadata:
   name: {{ class_name }}
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
+{% if class_config.reclaim_policy is defined %}
+reclaimPolicy: {{ class_config.reclaim_policy }}
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
mydict.keys() should be converted to list,
otherwise it causes errors in loop iteration.

Remove extra space after class name, which broke configmap.

Also allow set reclaimPolicy property.

/kind bug

```release-note
NONE
```
