### PR TITLE
fix pip requirements version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To deploy the cluster you can use :
 
 ```ShellSession
 # Install dependencies from ``requirements.txt``
-sudo pip install -r requirements.txt
+sudo pip3 install -r requirements.txt
 
 # Copy ``inventory/sample`` as ``inventory/mycluster``
 cp -rfp inventory/sample inventory/mycluster


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation


**What this PR does / why we need it**:

When we were using python Program create inventory, it will happen this error.

```python
Traceback (most recent call last):
  File "contrib/inventory_builder/inventory.py", line 38, in <module>
    from ruamel.yaml import YAML
ModuleNotFoundError: No module named 'ruamel'
```

thus I change python pip version to install kubespray requirements

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
NONE