### PR TITLE
download container always been on download_delegate host

### DIFF
--- a/roles/download/tasks/check_pull_required.yml
+++ b/roles/download/tasks/check_pull_required.yml
@@ -6,7 +6,7 @@
 # nginx:1.15,gcr.io/google-containers/kube-proxy:v1.14.1,gcr.io/google-containers/kube-proxy@sha256:44af2833c6cbd9a7fc2e9d2f5244a39dfd2e31ad91bf9d4b7d810678db738ee9,gcr.io/google-containers/kube-apiserver:v1.14.1,etc...
 - name: check_pull_required |  Generate a list of information about the images on a node
   shell: "{{ image_info_command }}"
-  delegate_to: "{{ download_delegate if download_run_once or inventory_hostname }}"
+  delegate_to: "{{ download_delegate if download_run_once else inventory_hostname }}"
   no_log: true
   register: docker_images
   failed_when: false

--- a/roles/download/tasks/download_container.yml
+++ b/roles/download/tasks/download_container.yml
@@ -54,7 +54,7 @@
 
     - name: download_container | Load image into docker
       shell: "{{ docker_bin_dir }}/docker load < {{ image_path_cached if download_localhost else image_path_final }}"
-      delegate_to: "{{ download_delegate if download_run_once or inventory_hostname }}"
+      delegate_to: "{{ download_delegate if download_run_once else inventory_hostname }}"
       run_once: "{{ download_run_once }}"
       register: container_load_status
       failed_when: container_load_status | failed
@@ -77,7 +77,7 @@
     # if a pull is forced. This is a known issue with docker. See https://github.com/moby/moby/issues/23684
     - name: download_container | Download image if required
       command: "{{ image_pull_command }} {{ image_reponame }}"
-      delegate_to: "{{ download_delegate if download_run_once or inventory_hostname }}"
+      delegate_to: "{{ download_delegate if download_run_once else inventory_hostname }}"
       delegate_facts: yes
       run_once: "{{ download_run_once }}"
       register: pull_task_result
@@ -100,7 +100,7 @@
 
     - name: download_container | Save and compress image
       shell: "{{ docker_bin_dir }}/docker save {{ image_reponame }} | gzip -{{ download_compress }} > {{ image_path_cached if download_localhost else image_path_final }}"
-      delegate_to: "{{ download_delegate if download_run_once or inventory_hostname }}"
+      delegate_to: "{{ download_delegate if download_run_once else inventory_hostname }}"
       delegate_facts: no
       register: container_save_status
       failed_when: container_save_status.stderr


### PR DESCRIPTION
/kind bug

**Which issue(s) this PR fixes**:
docker images always download on download_delegate host

