### PR TITLE
use hyperkubeimage to run controlplane containers

### DIFF
--- a/roles/kubernetes/master/defaults/main/main.yml
+++ b/roles/kubernetes/master/defaults/main/main.yml
@@ -172,3 +172,6 @@ kube_override_hostname: >-
   {%- endif -%}
 
 secrets_encryption_query: "resources[*].providers[0].{{kube_encryption_algorithm}}.keys[0].secret"
+
+# use HyperKube image to control plane containers
+kubeadm_use_hyperkube_image: False

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
@@ -91,7 +91,7 @@ controlPlaneEndpoint: {{ ip | default(fallback_ips[inventory_hostname]) }}:{{ ku
 {% endif %}
 certificatesDir: {{ kube_cert_dir }}
 imageRepository: {{ kube_image_repo }}
-useHyperKubeImage: false
+useHyperKubeImage: {{ kubeadm_use_hyperkube_image }}
 apiServer:
   extraArgs:
 {% if kube_api_anonymous_auth is defined %}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
@@ -94,7 +94,7 @@ controlPlaneEndpoint: {{ ip | default(fallback_ips[inventory_hostname]) }}:{{ ku
 {% endif %}
 certificatesDir: {{ kube_cert_dir }}
 imageRepository: {{ kube_image_repo }}
-useHyperKubeImage: false
+useHyperKubeImage: {{ kubeadm_use_hyperkube_image }}
 apiServer:
   extraArgs:
 {% if kube_api_anonymous_auth is defined %}


### PR DESCRIPTION

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
allows to run controlplane containers from hyperkube image
in hyperkube image exists ceph binary, which need to work native rbd provisioner


