### PR TITLE
kube-proxy/ipvs: allow to configure strict ARP

### DIFF
--- a/contrib/metallb/roles/provision/tasks/main.yml
+++ b/contrib/metallb/roles/provision/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: "Kubernetes Apps | Check cluster settings for MetalLB"
+  fail:
+    msg: "MetalLB require kube_proxy_strict_arp = true, see https://github.com/danderson/metallb/issues/153#issuecomment-518651132"
+  when:
+    - "kube_proxy_mode == 'ipvs' and not kube_proxy_strict_arp"
 - name: "Kubernetes Apps | Lay Down MetalLB"
   become: true
   template: { src: "{{ item }}.j2", dest: "{{ kube_config_dir }}/{{ item }}" }

--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -101,6 +101,10 @@ kube_apiserver_insecure_port: 0  # (disabled)
 # Can be ipvs, iptables
 kube_proxy_mode: ipvs
 
+# configure arp_ignore and arp_announce to avoid answering ARP queries from kube-ipvs0 interface
+# must be set to true for MetalLB to work
+kube_proxy_strict_arp: false
+
 # A string slice of values which specify the addresses to use for NodePorts.
 # Values may be valid IP blocks (e.g. 1.2.3.0/24, 1.2.3.4/32).
 # The default empty string slice ([]) means to use all local addresses.

--- a/roles/kubernetes/master/defaults/main/kube-proxy.yml
+++ b/roles/kubernetes/master/defaults/main/kube-proxy.yml
@@ -71,6 +71,9 @@ kube_proxy_sync_period: 30s
 # A comma-separated list of CIDR's which the ipvs proxier should not touch when cleaning up IPVS rules.
 kube_proxy_exclude_cidrs: []
 
+# configure arp_ignore and arp_announce to avoid answering ARP queries from kube-ipvs0 interface
+kube_proxy_strict_arp: false
+
 # The ipvs scheduler type when proxy mode is ipvs
 # rr: round-robin
 # lc: least connection

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
@@ -323,6 +323,7 @@ ipvs:
  excludeCIDRs: {{ kube_proxy_exclude_cidrs }}
  minSyncPeriod: {{ kube_proxy_min_sync_period }}
  scheduler: {{ kube_proxy_scheduler }}
+ strictARP: {{ kube_proxy_strict_arp }}
  syncPeriod: {{ kube_proxy_sync_period }}
 {% if kube_version is version('v1.14.2', '>=') %}
  strictARP: {{ kube_proxy_strict_arp }}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Allow to configure kube-proxy ipvs strictARP setting

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Allow to configure kube-proxy ipvs strictARP setting (needed by MetalLB)
```