### PR TITLE
MetalLB: fail if kube_proxy_strict_arp is false

### DIFF
--- a/contrib/metallb/roles/provision/tasks/main.yml
+++ b/contrib/metallb/roles/provision/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: "Kubernetes Apps | Check cluster settings for MetalLB"
+  fail:
+    msg: "MetalLB require kube_proxy_strict_arp = true, see https://github.com/danderson/metallb/issues/153#issuecomment-518651132"
+  when:
+    - "kube_proxy_mode == 'ipvs' and not kube_proxy_strict_arp"
 - name: "Kubernetes Apps | Lay Down MetalLB"
   become: true
   template: { src: "{{ item }}.j2", dest: "{{ kube_config_dir }}/{{ item }}" }

--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -101,6 +101,10 @@ kube_apiserver_insecure_port: 0  # (disabled)
 # Can be ipvs, iptables
 kube_proxy_mode: ipvs
 
+# configure arp_ignore and arp_announce to avoid answering ARP queries from kube-ipvs0 interface
+# must be set to true for MetalLB to work
+kube_proxy_strict_arp: false
+
 # A string slice of values which specify the addresses to use for NodePorts.
 # Values may be valid IP blocks (e.g. 1.2.3.0/24, 1.2.3.4/32).
 # The default empty string slice ([]) means to use all local addresses.

--- a/roles/kubernetes/master/defaults/main/kube-proxy.yml
+++ b/roles/kubernetes/master/defaults/main/kube-proxy.yml
@@ -80,6 +80,8 @@ kube_proxy_exclude_cidrs: []
 # nq: never queue
 kube_proxy_scheduler: rr
 
+# configure arp_ignore and arp_announce to avoid answering ARP queries from kube-ipvs0 interface
+# must be set to true for MetalLB to work
 kube_proxy_strict_arp: false
 
 # The IP address and port for the metrics server to serve on


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
When using IPVS, do not deploy MetalLB if kube_proxy_strict_arp is false
```