### PR TITLE
fix broken scale procedure:

### DIFF
--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-kubelet_cgroup_driver: systemd
-
 containerd_config:
   grpc:
     max_recv_message_size: 16777216

--- a/scale.yml
+++ b/scale.yml
@@ -42,7 +42,7 @@
     - { role: kubernetes/preinstall, tags: preinstall }
     - { role: container-engine, tags: "container-engine", when: deploy_container_engine|default(true) }
     - { role: download, tags: download, when: "not skip_downloads" }
-    - { role: etcd, tags: etcd, etcd_cluster_setup: false }
+    - { role: etcd, tags: etcd, etcd_cluster_setup: false, when: "not etcd_kubeadm_enabled|default(false)" }
     - { role: kubernetes/node, tags: node }
     - { role: kubernetes/kubeadm, tags: kubeadm }
     - { role: network_plugin, tags: network }


### PR DESCRIPTION
/kind bug

Playbook scale.yml broken when etcd_kubeadm_enabled == true on task etcd/tasks/install_host.yml
kublet not started with docker because the wrong cgroup_driver: systemd in config 

- do not run etcd role when etcd_kubeadm_enabled == true
- remove default value 'systemd' for cgroup driver in containerd role.
  this value override autodetect in kubelet_cgroup_driver_detected from docker info

ps: may be need autotest for scale.yml playbook ?

