### PR TITLE
Fix getting nameserver and search for /etc/resolv.conf with comments

### DIFF
--- a/roles/container-engine/docker/tasks/set_facts_dns.yml
+++ b/roles/container-engine/docker/tasks/set_facts_dns.yml
@@ -29,13 +29,13 @@
     docker_dns_search_domains: "{{ docker_dns_search_domains + searchdomains|default([]) }}"
 
 - name: check system nameservers
-  shell: grep "^nameserver" /etc/resolv.conf | sed 's/^nameserver\s*//'
+  shell: grep "^nameserver" /etc/resolv.conf | sed -r 's/^nameserver\s*([^#\s]+)\s*(#.*)?/\1/'
   changed_when: False
   register: system_nameservers
   check_mode: no
 
 - name: check system search domains
-  shell: grep "^search" /etc/resolv.conf | sed 's/^search\s*//'
+  shell: grep "^search" /etc/resolv.conf | sed -r 's/^search\s*([^#]+)\s*(#.*)?/\1/'
   changed_when: False
   register: system_search_domains
   check_mode: no


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Provided that docker_dns is used, it fixes the retrieval of nameserver and search entries from system resolv.conf when these entries have traling comments

**Which issue(s) this PR fixes**:
None found...

**Does this PR introduce a user-facing change?**:
None