### PR TITLE
Blocksize for calico default pool should be configurable

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/k8s-net-calico.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-net-calico.yml
@@ -11,6 +11,9 @@
 # add default ippool name
 # calico_pool_name: "default-pool"
 
+# add default ippool blockSize (defaults kube_network_node_prefix)
+# calico_pool_blocksize: 24
+
 # add default ippool CIDR (must be inside kube_pods_subnet, defaults to kube_pods_subnet otherwise)
 # calico_pool_cidr: 1.2.3.4/5
 

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -128,7 +128,7 @@
           "name": "{{ calico_pool_name }}",
         },
         "spec": {
-          "blockSize": "{{ kube_network_node_prefix }}",
+          "blockSize": "{{ calico_pool_blocksize | default(kube_network_node_prefix) }}",
           "cidr": "{{ calico_pool_cidr | default(kube_pods_subnet) }}",
           "ipipMode": "{{ ipip_mode }}",
           "natOutgoing": {{ nat_outgoing|default(false) and not peer_with_router|default(false) }} }} " | {{ bin_dir }}/calicoctl.sh apply -f -


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
When using multiple pools (within the podSubnet), the blocksize is not necessarily the same as the `kube_network_node_prefix`.
This PR introduces the variable `calico_pool_blocksize` (which defaults to `kube_network_node_prefix`) that is used in the calico pool definition.

**Which issue(s) this PR fixes**:
None that I found/reported

**Does this PR introduce a user-facing change?**:
No
