### PR TITLE
generate kubeadm download image list with options useHyperKubeImage

### DIFF
--- a/roles/download/templates/kubeadm-images.yaml.j2
+++ b/roles/download/templates/kubeadm-images.yaml.j2
@@ -7,6 +7,7 @@ apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration
 imageRepository: {{ kube_image_repo }}
 kubernetesVersion: {{ kube_version }}
+useHyperKubeImage: {{ kubeadm_use_hyperkube_image }}
 etcd:
   external:
       endpoints:

--- a/roles/kubernetes/master/defaults/main/main.yml
+++ b/roles/kubernetes/master/defaults/main/main.yml
@@ -172,6 +172,3 @@ kube_override_hostname: >-
   {%- endif -%}
 
 secrets_encryption_query: "resources[*].providers[0].{{kube_encryption_algorithm}}.keys[0].secret"
-
-# use HyperKube image to control plane containers
-kubeadm_use_hyperkube_image: False

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -17,6 +17,9 @@ kube_version: v1.15.3
 ## The minimum version working
 kube_version_min_required: v1.14.0
 
+# use HyperKube image to control plane containers
+kubeadm_use_hyperkube_image: False
+
 ## Kube Proxy mode One of ['iptables','ipvs']
 kube_proxy_mode: ipvs
 


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

we added the ability to install a cluster with kubeadm option useHyperKubeImage,
 but when preloading images, this option was not used and the image `gcr.io/google-containers/hyperkube` did not load