### PR TITLE
WIP: Use Kubespray as an ansible collection

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,0 +1,14 @@
+---
+namespace: "kubernetes_sigs"
+name: "kubespray"
+version: "v2.11.0"
+readme: "README.md"
+license:
+  - "Apache-2.0"
+tags:
+  - kubernetes-cluster
+  - collection
+repository: "https://github.com/kubernetes-sigs/kubespray"
+documentation: "https://kubespray.io/"
+homepage: "https://kubespray.io/"
+issues: "https://github.com/kubernetes-sigs/kubespray/issues"


### PR DESCRIPTION
Related to https://github.com/kubernetes-sigs/kubespray/issues/5207

This PR add a `galaxy.yml` file to use Kubespray as an ansible collection.

See https://galaxy.ansible.com/docs/contributing/creating_collections.html

It needs a way to update the tag field with each release.

This change ensures that Kubespray can be easily used in an upstream ansible project. It also ensures the immutability of Kubespray (needed for prod stability).