### PR TITLE
fix using systemd cgroup driver for containerd

### DIFF
--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -19,6 +19,7 @@ disabled_plugins = ["restart"]
   stream_server_address = "127.0.0.1"
   max_container_log_line_size = {{ containerd_config.max_container_log_line_size }}
   sandbox_image = "{{ pod_infra_image_repo }}:{{ pod_infra_image_tag }}"
+  systemd_cgroup = {{ containerd_use_systemd_cgroup|lower }}
 
 [plugins.cri.cni]
   bin_dir = "/opt/cni/bin"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
when you are forcing cgroup driver to systemd with

`containerd_use_systemd_cgroup: true`

and using `containerd`, it's still not configured to use it as expected.

**Which issue(s) this PR fixes**:

Fixes #5219

**Does this PR introduce a user-facing change?**:

```release-note
Use systemd as a cgroup driver when using containerd and setting it with containerd_use_systemd_cgroup: true
```
