### PR TITLE
contrib/heketi: use inventory node ip in topology instead of guessing it

### DIFF
--- a/contrib/network-storage/heketi/roles/provision/templates/heketi-storage.json.j2
+++ b/contrib/network-storage/heketi/roles/provision/templates/heketi-storage.json.j2
@@ -16,7 +16,7 @@
         {
           "addresses": [
             {
-              "ip": "{{ hostvars[node]['ansible_facts']['default_ipv4']['address'] }}"
+              "ip": "{{ hostvars[node].ip }}"
             }
           ],
           "ports": [

--- a/contrib/network-storage/heketi/roles/provision/templates/topology.json.j2
+++ b/contrib/network-storage/heketi/roles/provision/templates/topology.json.j2
@@ -12,7 +12,7 @@
                 "{{ node }}"
               ],
               "storage": [
-                "{{ hostvars[node]['ansible_facts']['default_ipv4']['address'] }}"
+                "{{ hostvars[node].ip }}"
               ]
             },
             "zone": 1


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:

This PR allows to apply the `contrib/network-storage/heketi` playbook
on a kubespray-provisioned cluster whose nodes use a private network interface different than the one used by the default route (such as Vagrant VMs)

Fixes #5232

**Special notes for your reviewer**:

```release-note
NONE
```