### PR TITLE
Fix selector workaround for helm install

### DIFF
--- a/roles/kubernetes-apps/helm/tasks/main.yml
+++ b/roles/kubernetes-apps/helm/tasks/main.yml
@@ -51,10 +51,10 @@
     {% if tiller_max_history is defined %} --history-max={{ tiller_max_history }}{% endif %}
     {% if tiller_enable_tls %} --tiller-tls --tiller-tls-verify --tiller-tls-cert={{ tiller_tls_cert }} --tiller-tls-key={{ tiller_tls_key }} --tls-ca-cert={{ tiller_tls_ca_cert }} {% endif %}
     {% if tiller_secure_release_info %} --override 'spec.template.spec.containers[0].command'='{/tiller,--storage=secret}' {% endif %}
+    --override spec.selector.matchLabels.'name'='tiller',spec.selector.matchLabels.'app'='helm'
     {% if tiller_wait %} --wait{% endif %}
     --output yaml
     | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@'
-    | {{ bin_dir }}/kubectl patch --local -oyaml -f - -p '{"spec":{"selector": {"app":"helm","name":"tiller"} } }'
     | {{ bin_dir }}/kubectl apply -f -
     {% else %}
     --client-only
@@ -76,10 +76,10 @@
     {% if tiller_max_history is defined %} --history-max={{ tiller_max_history }}{% endif %}
     {% if tiller_enable_tls %} --tiller-tls --tiller-tls-verify --tiller-tls-cert={{ tiller_tls_cert }} --tiller-tls-key={{ tiller_tls_key }} --tls-ca-cert={{ tiller_tls_ca_cert }} {% endif %}
     {% if tiller_secure_release_info %} --override 'spec.template.spec.containers[0].command'='{/tiller,--storage=secret}' {% endif %}
+    --override spec.selector.matchLabels.'name'='tiller',spec.selector.matchLabels.'app'='helm'
     {% if tiller_wait %} --wait{% endif %}
     --output yaml
     | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@'
-    | {{ bin_dir }}/kubectl patch --local -oyaml -f - -p '{"spec":{"selector": {"app":"helm","name":"tiller"} } }'
     | {{ bin_dir }}/kubectl apply -f -
   changed_when: false
   when:


### PR DESCRIPTION
The previous workaround was not working because kubectl patch cannot handle multidocument yamls. The new --override method to set selector works better.