### PR TITLE
Reset between kubeadm secondary control plane join attempts

### DIFF
--- a/roles/kubernetes/master/tasks/kubeadm-secondary-experimental.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-secondary-experimental.yml
@@ -49,7 +49,10 @@
     msg: "{{ kubeadm_already_run.stat.exists }}"
 
 - name: Joining control plane node to the cluster.
-  command: >-
+  shell: >-
+    if [ -f /etc/kubernetes/manifests/kube-apiserver.yaml ]; then
+    {{ bin_dir }}/kubeadm reset -f --cert-dir {{ kube_cert_dir }};
+    fi &&
     {{ bin_dir }}/kubeadm join
     --config {{ kube_config_dir }}/kubeadm-controlplane.yaml
     --ignore-preflight-errors=all


### PR DESCRIPTION
This fixes a bug where if the first join attempt failed, the subsequent attempts fail due to etcd duplicate node errors.