### PR TITLE
Respect cri-tool supported version matrix

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -86,7 +86,12 @@ kube_ovn_version: "v0.6.0"
 kube_router_version: "v0.2.5"
 multus_version: "v3.2.1"
 
-crictl_version: "v1.16.1"
+# Get kubernetes major version (i.e. 1.15.4 => 1.15)
+kube_major_version: "{{ kube_version | regex_replace('^v([0-9])+\\.([0-9]+)\\.[0-9]+', 'v\\1.\\2') }}"
+crictl_supported_versions:
+  v1.16: "v1.16.1"
+  v1.15: "v1.15.0"
+crictl_version: "{{ crictl_supported_versions[kube_major_version] }}"
 
 # Download URLs
 kubeadm_download_url: "https://storage.googleapis.com/kubernetes-release/release/{{ kubeadm_version }}/bin/linux/{{ image_arch }}/kubeadm"
@@ -101,17 +106,14 @@ crictl_checksums:
     v1.16.1: 367826f3eb06c4d923f3174d23141ddacef9ffcb0c902502bd922dbad86d08dd
     v1.16.0: 331c49bd9196009b8230f7a36ec272924a7bcf4c1614ecddf0eb9598c787da0e
     v1.15.0: f31f8c3b4791608a48d030d1aa1a694a73849ae057b23a90ce4ef17e5afde9e8
-    v1.14.0: 9910cecfd6558239ba015323066c7233d8371af359b9ddd0b2a35d5223bcf945
   arm64:
     v1.16.1: 62b60ab7046b788df892a1b746bd602c520a59c38232febc0580692c9805f641
     v1.16.0: aa118c31d6f6fd2d24bb2de4a33598a14a5952e1d01f93d5c3267c2b5334743b
     v1.15.0: 785c3da7e058f6fd00b0a48de24b9199eb6bae940d13f509c44ea6dd7ad9ffcd
-    v1.14.0: f76b3d00a272c8d210e9a45f77d07d3770bee310d99c4fd9a72d6f55278882e5
   amd64:
     v1.16.1: 19fed421710fccfe58f5573383bb137c19438a9056355556f1a15da8d23b3ad1
     v1.16.0: a3eefa10a483c643ad85aee3d7832a720976ef7e80dde46b212eaaacd7d09512
     v1.15.0: c3b71be1f363e16078b51334967348aab4f72f46ef64a61fe7754e029779d45a
-    v1.14.0: 483c90a9fe679590df4332ba807991c49232e8cd326c307c575ecef7fe22327b
 
 # Checksums
 hyperkube_checksums:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR enforces to respect cri-ctool version based [support matrix](https://github.com/kubernetes-sigs/cri-tools#current-status) instead of being statically defined separately from the kubernetes version.

| Kubernetes Version | cri-tools Version |
|--------------------|-------------------|
| 1.16.x             | v1.16.0           |
| 1.15.X             | v1.15.0           |
| 1.14.X             | v1.14.0           |
| 1.13.X             | v1.13.0           |
| 1.12.X             | v1.12.0           |
| 1.11.X             | v1.11.1           |

If installing kubernetes 1.15.x, it will use cri-tool 1.15.0 instead of the current default to cri-tool 1.16.0.
I cleaned up the old sha of the cri-tool versions that match the kubernetes version kubespray deprecated (only keeping 1.15+ as `kube_version_min_required: v1.15.0`)

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
No need anymore for the user to keep track of crictl_version

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
