### PR TITLE
Enable openstack_cacert to be either file or base64 string

### DIFF
--- a/docs/openstack.md
+++ b/docs/openstack.md
@@ -5,6 +5,9 @@ To deploy kubespray on [OpenStack](https://www.openstack.org/) uncomment the `cl
 
 After that make sure to source in your OpenStack credentials like you would do when using `nova-client` or `neutron-client` by using `source path/to/your/openstack-rc` or `. path/to/your/openstack-rc`.
 
+For those who prefer to pass the OpenStack CA certificate as a string, one can
+base64 encode the cacert file and store it in the variable `openstack_cacert`.
+
 The next step is to make sure the hostnames in your `inventory` file are identical to your instance names in OpenStack.
 Otherwise [cinder](https://wiki.openstack.org/wiki/Cinder) won't work as expected.
 

--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -166,14 +166,24 @@
     - cloud-provider
     - facts
 
+- name: Test if openstack_cacert is a base64 string
+  set_fact:
+    openstack_cacert_is_base64: "{% if openstack_cacert | b64decode %}true{% else %}false{% endif %}"
+  when:
+    - cloud_provider is defined
+    - cloud_provider == 'openstack'
+    - openstack_cacert is defined
+    - openstack_cacert | length > 0
+
+
 - name: Write cacert file
   copy:
-    src: "{{ openstack_cacert }}"
+    src: "{{ openstack_cacert if not openstack_cacert_is_base64 else omit }}"
+    content: "{{ openstack_cacert | b64decode if openstack_cacert_is_base64 else omit }}"
     dest: "{{ kube_config_dir }}/openstack-cacert.pem"
     group: "{{ kube_cert_group }}"
     mode: 0640
   when:
-    - inventory_hostname in groups['k8s-cluster']
     - cloud_provider is defined
     - cloud_provider == 'openstack'
     - openstack_cacert is defined


### PR DESCRIPTION
This is helpful for users who do not want to write the openstack cacert file to disk on the deployment host.