### PR TITLE
Add script to download hashes of kubeadm, hyperkube etc...

### DIFF
--- a/scripts/download_hash.sh
+++ b/scripts/download_hash.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+version=$1
+if [ -z "$version" ]
+then
+  echo "Usage: $0 <version>"
+  exit 2
+fi
+
+for arch in amd64 arm64 arm
+do
+  for file in kubectl kubelet kubeadm
+  do
+    echo -n "$version $arch $file: "
+    curl --fail -s "https://storage.googleapis.com/kubernetes-release/release/$version/bin/linux/$arch/$file" | shasum -a 256
+  done
+done


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Collecting checksums of all the components for various archs can be painful. I've been using that script for a while and figured it might be useful to others as well.

**Special notes for your reviewer**:

Sample output:
```
$ ./scripts/download_hash.sh v1.17.0
v1.17.0 amd64 kubectl: 6e0aaaffe5507a44ec6b1b8a0fb585285813b78cc045f8804e70a6aac9d1cb4c  -
v1.17.0 amd64 kubelet: c2af77f501c3164e80171903028d35c632366f53dec0c8419828d4e55d86146f  -
v1.17.0 amd64 kubeadm: 0d8443f50fb7caab2e5e7e53f9dc56d5ffe55f021ec061f2e2bcba0481df5a48  -
v1.17.0 arm64 kubectl: cba12bfe0ee447b06f00813d7d4ba3fbdbf5116eccc4d3291987044f2d6f93c2  -
v1.17.0 arm64 kubelet: b1a4a2325383854a69ec768e7dc00f69378d3ccbc554859d910bf5b582264ea2  -
v1.17.0 arm64 kubeadm: 0b94d1ace240a8f9995358ca2b66ac92072e3f3cd0543275b315dcd317798546  -
v1.17.0 arm kubectl: 594b3e2f89dca09d82b176b51bf6c8c0fa524ed209c14ec915c9b36fa876601d  -
v1.17.0 arm kubelet: 75ae6ad8f4a7f2ac3988b37a01c28093f240745d17c1781135d1844057c8ae94  -
v1.17.0 arm kubeadm: 5fcf1234d89bc2a364c53b76b36134fc57278b456138d93c278805f2c9b186f1  -
```