### PR TITLE
Install python-setuptools (#4776)

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-debian.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-debian.yml
@@ -67,7 +67,7 @@
 - name: Install python
   raw:
     apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y python-minimal
+    DEBIAN_FRONTEND=noninteractive apt-get install -y python-minimal python-setuptools
   become: true
   environment: {}
   when:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR allows Kubespray to install the correct dependencies to use with some providers such as Hetzner Cloud

**Which issue(s) this PR fixes**:
Fixes #4776 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
