### PR TITLE
set calico_datastore default value in role kubespray-default

### DIFF
--- a/roles/kubernetes-apps/policy_controller/calico/defaults/main.yml
+++ b/roles/kubernetes-apps/policy_controller/calico/defaults/main.yml
@@ -8,6 +8,3 @@ calico_policy_controller_memory_requests: 64M
 # SSL
 calico_cert_dir: "/etc/calico/certs"
 canal_cert_dir: "/etc/canal/certs"
-
-# Datastore type
-calico_datastore: "etcd"

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -144,6 +144,9 @@ peer_with_calico_rr: "{{ 'calico-rr' in groups and groups['calico-rr']|length > 
 # Set to false to disable calico-upgrade
 calico_upgrade_enabled: true
 
+# Choose data store type for calico: "etcd" or "kdd" (kubernetes datastore)
+calico_datastore: "etcd"
+
 # Kubernetes internal network for services, unused block of space.
 kube_service_addresses: 10.233.0.0/18
 

--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -67,7 +67,8 @@ kube_etcd_cert_file: node-{{ inventory_hostname }}.pem
 kube_etcd_key_file: node-{{ inventory_hostname }}-key.pem
 
 # Choose data store type for calico: "etcd" or "kdd" (kubernetes datastore)
-calico_datastore: "etcd"
+# The default value calico_datastore: "etcd" is set in role kubespray-default
+
 # Use typha (only with kdd)
 typha_enabled: false
 # Number of typha replicas


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
i get error on upgrade_cluster.yml wtih kubeadm_enable_etcd
```
fatal: [node-1]: FAILED! => {"msg": "The conditional check 'kube_network_plugin != \"calico\" or calico_datastore == \"etcd\"' failed. The error was: error while evaluating conditional (kube_network_plugin != \"calico\" or calico_datastore == \"etcd\"): 'calico_datastore' is undefined\n\nThe error appears to have been in '/srv/kubespray/roles/kubernetes/kubeadm/tasks/main.yml': line 156, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Extract etcd certs from control plane if using etcd kubeadm mode\n  ^ here\n"}```

```release-note
NONE
```
