### PR TITLE
Add etcd_data_dir variable to the kubeadm config

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
@@ -39,7 +39,7 @@ etcd:
   local:
     imageRepository: "{{ etcd_image_repo | regex_replace("/etcd$","") }}"
     imageTag: "{{ etcd_image_tag }}"
-    dataDir: "/var/lib/etcd"
+    dataDir: "{{ etcd_data_dir }}"
     extraArgs:
       metrics: {{ etcd_metrics }}
       election-timeout: "{{ etcd_election_timeout }}"

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
@@ -42,7 +42,7 @@ etcd:
   local:
     imageRepository: "{{ etcd_image_repo | regex_replace("/etcd$","") }}"
     imageTag: "{{ etcd_image_tag }}"
-    dataDir: "/var/lib/etcd"
+    dataDir: "{{ etcd_data_dir }}"
     extraArgs:
       metrics: {{ etcd_metrics }}
       election-timeout: "{{ etcd_election_timeout }}"


### PR DESCRIPTION


**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
 /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Support for modifying the etcd data directory by variable


