### PR TITLE
Minimum required version of Kubernetes is v1.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Note: The list of validated [docker versions](https://github.com/kubernetes/kube
 
 Requirements
 ------------
--   **Minimum required version of Kubernetes is v1.14**
+-   **Minimum required version of Kubernetes is v1.15**
 -   **Ansible v2.7.8 (or newer, but [not 2.8.x](https://github.com/kubernetes-sigs/kubespray/issues/4778)) and python-netaddr is installed on the machine
     that will run Ansible commands**
 -   **Jinja 2.9 (or newer) is required to run the Ansible Playbooks**


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
After the merge of #5189 , the minimum supported kubernetes version is increased from v1.14.0 to v1.15.0. Hence, we need to update README.md accordingly.

**Does this PR introduce a user-facing change?**:
NONE
