### PR TITLE
check on all cluster node - kubelet_max_pods vs kube_network_node_prefix

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -81,7 +81,7 @@
     msg: "Do not schedule more pods on a node than inet addresses are available."
   ignore_errors: "{{ ignore_assert_errors }}"
   when:
-    - inventory_hostname in groups['kube-node']
+    - inventory_hostname in groups['k8s-cluster']
     - kube_network_node_prefix is defined
 
 - name: Stop if ip var does not match local ips


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`any_errors_fatal: true` broken in ansible for two years https://github.com/ansible/ansible/issues/46447

Assert `Guarantee that enough network address space is available for all pods` should be performed for all nodes of the cluster, and not just on worker node

```release-note
NONE
```
