### PR TITLE
Add config coredns_external_zones

### DIFF
--- a/docs/dns-stack.md
+++ b/docs/dns-stack.md
@@ -42,6 +42,36 @@ DNS servers in early cluster deployment when no cluster DNS is available yet.
 
 ## DNS modes supported by Kubespray
 
+### coredns_external_zones
+
+Array of optional external zones to coredns forward queries to. It's  injected into
+`coredns`' config file before default kubernetes zone. Use it as an optimization for well-known zones and/or internal-only
+domains, i.e. VPN for internal networks (default is unset)
+
+Example:
+
+```yaml
+coredns_external_zones:
+- zones:
+  - example.com
+  - example.io:1053
+  nameservers:
+  - 1.1.1.1
+  - 2.2.2.2
+  cache: 5
+- zones:
+  - https://mycompany.local:4453
+  nameservers:
+  - 192.168.0.53
+  cache: 0
+```
+
+or as INI
+
+```ini
+coredns_external_zones=[{"cache": 30,"zones":["example.com","example.io:453"],"nameservers":["1.1.1.1","2.2.2.2"]}]'
+```
+
 You can modify how Kubespray sets up DNS for your cluster with the variables ``dns_mode`` and ``resolvconf_mode``.
 
 ### dns_mode

--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -8,6 +8,18 @@ metadata:
       addonmanager.kubernetes.io/mode: EnsureExists
 data:
   Corefile: |
+{% if coredns_external_zones is defined and coredns_external_zones|length > 0 %}
+{%   for block in coredns_external_zones %}
+    {{ block['zones'] | join(' ') }} {
+        log
+        errors
+        forward . {{ block['nameservers'] | join(' ') }}
+        loadbalance
+        cache {{ block['cache'] | default(5) }}
+        reload
+    }
+{%   endfor %}
+{% endif %}
     .:53 {
         errors
         health


### PR DESCRIPTION
Allows to add custom zone resolving servers

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

Some private environments need to use custom resolvers for specific domains. This PR adds the ability to set custom resolvers for custom domains directly into coredns withou messing with host's /etc/resolv.conf or default coredns behavior.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Thanks for your time ;)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
