### PR TITLE
fix useradd etcd

### DIFF
--- a/roles/adduser/defaults/main.yml
+++ b/roles/adduser/defaults/main.yml
@@ -6,8 +6,7 @@ addusers:
   etcd:
     name: etcd
     comment: "Etcd user"
-    createhome: yes
-    home: "{{ etcd_data_dir }}"
+    createhome: no
     system: yes
     shell: /bin/nologin
   kube:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**


 /kind bug


**What this PR does / why we need it**:
The useradd code calls a mkdir library function to (attempt to) create the specified directory. Creation failed when I specified multiple directories for the etcd_data_dir variable.As a nologin user, there is no need to create a home directory.
```shell
variable:
etcd_data_dir: /data/apps/etcd/data
-------
TASK [User | Create User] **********************************************************************************************************************************
Friday 18 October 2019  12:11:03 +0800 (0:00:00.355)       0:00:00.450 ********
fatal: [cn-hz-wl-test-k8s-00]: FAILED! => {"changed": false, "msg": "useradd: cannot create directory /data/apps/etcd/data\n", "name": "etcdtest", "rc": 12}
```

