### PR TITLE
Fix certificates checking when adding etcd node to existing k8s node

### DIFF
--- a/roles/etcd/tasks/check_certs.yml
+++ b/roles/etcd/tasks/check_certs.yml
@@ -33,8 +33,8 @@
        ['{{ etcd_cert_dir }}/ca.pem',
        {% set all_etcd_hosts = groups['k8s-cluster']|union(groups['etcd'])|union(groups['calico-rr']|default([]))|unique|sort %}
        {% for host in all_etcd_hosts %}
-         '{{ etcd_cert_dir }}/node-{{ host }}-key.pem'
-         '{{ etcd_cert_dir }}/admin-{{ host }}-key.pem'
+         '{{ etcd_cert_dir }}/node-{{ host }}-key.pem',
+         '{{ etcd_cert_dir }}/admin-{{ host }}-key.pem',
          '{{ etcd_cert_dir }}/member-{{ host }}-key.pem'
          {% if not loop.last %}{{','}}{% endif %}
        {% endfor %}]

--- a/roles/etcd/tasks/check_certs.yml
+++ b/roles/etcd/tasks/check_certs.yml
@@ -34,8 +34,8 @@
        {% set all_etcd_hosts = groups['k8s-cluster']|union(groups['etcd'])|union(groups['calico-rr']|default([]))|unique|sort %}
        {% for host in all_etcd_hosts %}
          '{{ etcd_cert_dir }}/node-{{ host }}-key.pem'
-         '{{ etcd_cert_dir }}/member-{{ host }}-key.pem'
          '{{ etcd_cert_dir }}/admin-{{ host }}-key.pem'
+         '{{ etcd_cert_dir }}/member-{{ host }}-key.pem'
          {% if not loop.last %}{{','}}{% endif %}
        {% endfor %}]
 

--- a/roles/etcd/tasks/check_certs.yml
+++ b/roles/etcd/tasks/check_certs.yml
@@ -34,8 +34,27 @@
        {% set all_etcd_hosts = groups['k8s-cluster']|union(groups['etcd'])|union(groups['calico-rr']|default([]))|unique|sort %}
        {% for host in all_etcd_hosts %}
        '{{ etcd_cert_dir }}/node-{{ host }}-key.pem'
-       {% if not loop.last %}{{','}}{% endif %}
+       '{{ etcd_cert_dir }}/admin-{{ host }}-key.pem'
+       '{{ etcd_cert_dir }}/member-{{ host }}-key.pem'
+      {% if not loop.last %}{{','}}{% endif %}
        {% endfor %}]
+
+- name: "Check_certs | Set 'gen_master_certs' to true"
+  set_fact:
+    gen_master_certs: |-
+      {
+      {% set all_etcd_hosts = groups['k8s-cluster']|union(groups['etcd'])|union(groups['calico-rr']|default([]))|unique|sort -%}
+      {% set existing_certs = etcdcert_master.files|map(attribute='path')|list|sort %}
+      {% for host in all_etcd_hosts -%}
+        {% set host_cert = "%s/member-%s-key.pem"|format(etcd_cert_dir, host) %}
+        {% if host_cert in existing_certs -%}
+        "{{ host }}": False,
+        {% else -%}
+        "{{ host }}": True,
+        {% endif -%}
+      {% endfor %}
+      }
+  run_once: true
 
 - name: "Check_certs | Set 'gen_node_certs' to true"
   set_fact:
@@ -59,6 +78,7 @@
     sync_certs: true
   when:
     - gen_node_certs[inventory_hostname] or
+      gen_master_certs[inventory_hostname] or
       (not etcdcert_node.results[0].stat.exists|default(false)) or
       (not etcdcert_node.results[1].stat.exists|default(false)) or
       (etcdcert_node.results[1].stat.checksum|default('') != etcdcert_master.files|selectattr("path", "equalto", etcdcert_node.results[1].stat.path)|map(attribute="checksum")|first|default(''))

--- a/roles/etcd/tasks/check_certs.yml
+++ b/roles/etcd/tasks/check_certs.yml
@@ -33,10 +33,10 @@
        ['{{ etcd_cert_dir }}/ca.pem',
        {% set all_etcd_hosts = groups['k8s-cluster']|union(groups['etcd'])|union(groups['calico-rr']|default([]))|unique|sort %}
        {% for host in all_etcd_hosts %}
-       '{{ etcd_cert_dir }}/node-{{ host }}-key.pem'
-       '{{ etcd_cert_dir }}/member-{{ host }}-key.pem'
-       '{{ etcd_cert_dir }}/admin-{{ host }}-key.pem'
-      {% if not loop.last %}{{','}}{% endif %}
+         '{{ etcd_cert_dir }}/node-{{ host }}-key.pem'
+         '{{ etcd_cert_dir }}/member-{{ host }}-key.pem'
+         '{{ etcd_cert_dir }}/admin-{{ host }}-key.pem'
+         {% if not loop.last %}{{','}}{% endif %}
        {% endfor %}]
 
 - name: "Check_certs | Set 'gen_master_certs' to true"

--- a/roles/etcd/tasks/check_certs.yml
+++ b/roles/etcd/tasks/check_certs.yml
@@ -34,8 +34,8 @@
        {% set all_etcd_hosts = groups['k8s-cluster']|union(groups['etcd'])|union(groups['calico-rr']|default([]))|unique|sort %}
        {% for host in all_etcd_hosts %}
        '{{ etcd_cert_dir }}/node-{{ host }}-key.pem'
-       '{{ etcd_cert_dir }}/admin-{{ host }}-key.pem'
        '{{ etcd_cert_dir }}/member-{{ host }}-key.pem'
+       '{{ etcd_cert_dir }}/admin-{{ host }}-key.pem'
       {% if not loop.last %}{{','}}{% endif %}
        {% endfor %}]
 

--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -55,7 +55,7 @@
   command: "bash -x {{ etcd_script_dir }}/make-ssl-etcd.sh -f {{ etcd_config_dir }}/openssl.conf -d {{ etcd_cert_dir }}"
   environment:
     - MASTERS: "{% for m in groups['etcd'] %}
-                  {% if gen_node_certs[m] %}
+                  {% if gen_master_certs[m] %}
                     {{ m }}
                   {% endif %}
                 {% endfor %}"


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
This pull request allows to add etcd master node to existing k8s master or worker nodes without errors. Also before this PR `Gen_certs | run cert generation script` checks not related certs in `MASTERS:` block.

**Which issue(s) this PR fixes**:
Fixes #4040 

**Does this PR introduce a user-facing change?**:
```release-note
+ fix scaling etcd nodes to existing k8s node
```
