### PR TITLE
Fix calico name resolution

### DIFF
--- a/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-controllers.yml.j2
+++ b/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-controllers.yml.j2
@@ -25,7 +25,6 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: calico-kube-controllers
       tolerations:
         - key: CriticalAddonsOnly

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -27,7 +27,6 @@ spec:
     spec:
       priorityClassName: system-node-critical
       hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: calico-node
       tolerations:
         - effect: NoExecute

--- a/roles/network_plugin/calico/templates/calico-typha.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-typha.yml.j2
@@ -54,7 +54,6 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
       tolerations:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly


### PR DESCRIPTION
dnsPolicy ClusterFirstWithHostNet creates a circular dependency with calico and dns and if i use a name for the etcd backend calico can't resolve it and kubernetes dns can't work becouse there is not cni.