### PR TITLE
upgrade to containerd 1.2.10

### DIFF
--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -9,7 +9,7 @@ containerd_config:
     "docker.io": "https://registry-1.docker.io"
   max_container_log_line_size: -1
 
-containerd_version: '1.2.6'
+containerd_version: '1.2.10'
 containerd_package: 'containerd.io'
 
 containerd_cfg_dir: /etc/containerd

--- a/roles/container-engine/containerd/vars/ubuntu-amd64.yml
+++ b/roles/container-engine/containerd/vars/ubuntu-amd64.yml
@@ -5,6 +5,7 @@ containerd_versioned_pkg:
   '1.2.4': "{{ containerd_package }}=1.2.4-1"
   '1.2.5': "{{ containerd_package }}=1.2.5-1"
   '1.2.6': "{{ containerd_package }}=1.2.6-3"
+  '1.2.10': "{{ containerd_package }}=1.2.10-3"
   'stable': "{{ containerd_package }}=1.2.4-1"
   'edge': "{{ containerd_package }}=1.2.4-1"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
Upgrades containerd.io on Ubuntu to 1.2.10 [changelog](https://github.com/containerd/containerd/releases) which contains a number of important fixes (fd leaks, memory leaks, etc).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
No open issues as far as I can find, but highly used containerd powered systems typically crash due to excessive memory / cpu usage.

**Special notes for your reviewer**:
1.2.10 is the stable branch - 1.3.0 is already a month old, so 1.2.10 seems fairly safe. I'm still testing this internally - so perhaps this PR should just add the option and not change the default `containerd_version` for now. It appears to work extremely well so far and has resolved my file descriptor leak issue (causes nodes to NotReady due to context-deadline-exceeded from containerd)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Upgrade `containerd.io` package on Ubuntu systems from 1.2.6 to 1.2.10
```
