### PR TITLE
Terraform dynamic inventory 0.12.12

### DIFF
--- a/.gitlab-ci/terraform.yml
+++ b/.gitlab-ci/terraform.yml
@@ -10,9 +10,9 @@
     - cp ansible.cfg ~/.ansible.cfg
     # Prepare inventory
     - if [ "$PROVIDER" == "openstack" ]; then VARIABLEFILE="cluster.tfvars"; else VARIABLEFILE="cluster.tf"; fi
-    - cp contrib/terraform/$PROVIDER/sample-inventory/$VARIABLEFILE .
     - ln -s contrib/terraform/$PROVIDER/hosts
     - terraform init contrib/terraform/$PROVIDER
+    - cp contrib/terraform/$PROVIDER/sample-inventory/$VARIABLEFILE .
     # Copy SSH keypair
     - mkdir -p ~/.ssh
     - echo "$PACKET_PRIVATE_KEY" | base64 -d > ~/.ssh/id_rsa

--- a/.gitlab-ci/terraform.yml
+++ b/.gitlab-ci/terraform.yml
@@ -55,7 +55,7 @@ tf-validate-openstack:
 tf-validate-packet:
   extends: .terraform_validate
   variables:
-    TF_VERSION: 0.11.11
+    TF_VERSION: 0.12.12
     PROVIDER: packet
     CLUSTER: $CI_COMMIT_REF_NAME
 

--- a/contrib/terraform/packet/kubespray.tf
+++ b/contrib/terraform/packet/kubespray.tf
@@ -4,59 +4,60 @@ provider "packet" {
 }
 
 resource "packet_ssh_key" "k8s" {
-  count      = "${var.public_key_path != "" ? 1 : 0}"
+  count      = var.public_key_path != "" ? 1 : 0
   name       = "kubernetes-${var.cluster_name}"
-  public_key = "${chomp(file(var.public_key_path))}"
+  public_key = chomp(file(var.public_key_path))
 }
 
 resource "packet_device" "k8s_master" {
-  depends_on = ["packet_ssh_key.k8s"]
+  depends_on = [packet_ssh_key.k8s]
 
-  count            = "${var.number_of_k8s_masters}"
-  hostname         = "${var.cluster_name}-k8s-master-${count.index+1}"
-  plan             = "${var.plan_k8s_masters}"
-  facilities       = ["${var.facility}"]
-  operating_system = "${var.operating_system}"
-  billing_cycle    = "${var.billing_cycle}"
-  project_id       = "${var.packet_project_id}"
+  count            = var.number_of_k8s_masters
+  hostname         = "${var.cluster_name}-k8s-master-${count.index + 1}"
+  plan             = var.plan_k8s_masters
+  facilities       = [var.facility]
+  operating_system = var.operating_system
+  billing_cycle    = var.billing_cycle
+  project_id       = var.packet_project_id
   tags             = ["cluster-${var.cluster_name}", "k8s-cluster", "kube-master", "etcd", "kube-node"]
 }
 
 resource "packet_device" "k8s_master_no_etcd" {
-  depends_on = ["packet_ssh_key.k8s"]
+  depends_on = [packet_ssh_key.k8s]
 
-  count            = "${var.number_of_k8s_masters_no_etcd}"
-  hostname         = "${var.cluster_name}-k8s-master-${count.index+1}"
-  plan             = "${var.plan_k8s_masters_no_etcd}"
-  facilities       = ["${var.facility}"]
-  operating_system = "${var.operating_system}"
-  billing_cycle    = "${var.billing_cycle}"
-  project_id       = "${var.packet_project_id}"
+  count            = var.number_of_k8s_masters_no_etcd
+  hostname         = "${var.cluster_name}-k8s-master-${count.index + 1}"
+  plan             = var.plan_k8s_masters_no_etcd
+  facilities       = [var.facility]
+  operating_system = var.operating_system
+  billing_cycle    = var.billing_cycle
+  project_id       = var.packet_project_id
   tags             = ["cluster-${var.cluster_name}", "k8s-cluster", "kube-master"]
 }
 
 resource "packet_device" "k8s_etcd" {
-  depends_on = ["packet_ssh_key.k8s"]
+  depends_on = [packet_ssh_key.k8s]
 
-  count            = "${var.number_of_etcd}"
-  hostname         = "${var.cluster_name}-etcd-${count.index+1}"
-  plan             = "${var.plan_etcd}"
-  facilities       = ["${var.facility}"]
-  operating_system = "${var.operating_system}"
-  billing_cycle    = "${var.billing_cycle}"
-  project_id       = "${var.packet_project_id}"
+  count            = var.number_of_etcd
+  hostname         = "${var.cluster_name}-etcd-${count.index + 1}"
+  plan             = var.plan_etcd
+  facilities       = [var.facility]
+  operating_system = var.operating_system
+  billing_cycle    = var.billing_cycle
+  project_id       = var.packet_project_id
   tags             = ["cluster-${var.cluster_name}", "etcd"]
 }
 
 resource "packet_device" "k8s_node" {
-  depends_on = ["packet_ssh_key.k8s"]
+  depends_on = [packet_ssh_key.k8s]
 
-  count            = "${var.number_of_k8s_nodes}"
-  hostname         = "${var.cluster_name}-k8s-node-${count.index+1}"
-  plan             = "${var.plan_k8s_nodes}"
-  facilities       = ["${var.facility}"]
-  operating_system = "${var.operating_system}"
-  billing_cycle    = "${var.billing_cycle}"
-  project_id       = "${var.packet_project_id}"
+  count            = var.number_of_k8s_nodes
+  hostname         = "${var.cluster_name}-k8s-node-${count.index + 1}"
+  plan             = var.plan_k8s_nodes
+  facilities       = [var.facility]
+  operating_system = var.operating_system
+  billing_cycle    = var.billing_cycle
+  project_id       = var.packet_project_id
   tags             = ["cluster-${var.cluster_name}", "k8s-cluster", "kube-node"]
 }
+

--- a/contrib/terraform/packet/output.tf
+++ b/contrib/terraform/packet/output.tf
@@ -1,15 +1,16 @@
 output "k8s_masters" {
-  value = "${packet_device.k8s_master.*.access_public_ipv4}"
+  value = packet_device.k8s_master.*.access_public_ipv4
 }
 
 output "k8s_masters_no_etc" {
-  value = "${packet_device.k8s_master_no_etcd.*.access_public_ipv4}"
+  value = packet_device.k8s_master_no_etcd.*.access_public_ipv4
 }
 
 output "k8s_etcds" {
-  value = "${packet_device.k8s_etcd.*.access_public_ipv4}"
+  value = packet_device.k8s_etcd.*.access_public_ipv4
 }
 
 output "k8s_nodes" {
-  value = "${packet_device.k8s_node.*.access_public_ipv4}"
+  value = packet_device.k8s_node.*.access_public_ipv4
 }
+

--- a/contrib/terraform/packet/variables.tf
+++ b/contrib/terraform/packet/variables.tf
@@ -54,3 +54,4 @@ variable "number_of_etcd" {
 variable "number_of_k8s_nodes" {
   default = 0
 }
+

--- a/contrib/terraform/packet/versions.tf
+++ b/contrib/terraform/packet/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/contrib/terraform/terraform.py
+++ b/contrib/terraform/terraform.py
@@ -213,6 +213,7 @@ def packet_device(resource, tfvars=None):
         'state': raw_attrs['state'],
         # ansible
         'ansible_ssh_host': raw_attrs['network.0.address'],
+        'ansible_ssh_user': 'root',  # Use root by default in packet
         # generic
         'ipv4_address': raw_attrs['network.0.address'],
         'public_ipv4': raw_attrs['network.0.address'],
@@ -221,6 +222,10 @@ def packet_device(resource, tfvars=None):
         'private_ipv4': raw_attrs['network.2.address'],
         'provider': 'packet',
     }
+
+    if raw_attrs['operating_system'] == 'coreos_stable':
+        # For CoreOS set the ssh_user to core
+        attrs.update({'ansible_ssh_user': 'core'})
 
     # add groups based on attrs
     groups.append('packet_operating_system=' + attrs['operating_system'])

--- a/contrib/terraform/terraform.py
+++ b/contrib/terraform/terraform.py
@@ -73,7 +73,7 @@ def iterresources(filenames):
                 # In version 4 the structure changes so we need to iterate
                 # each instance inside the resource branch.
                 for resource in state['resources']:
-                    name = resource['module'].split('.')[-1]
+                    name = resource['provider'].split('.')[-1]
                     for instance in resource['instances']:
                         key = "{}.{}".format(resource['type'], resource['name'])
                         if 'index_key' in instance:
@@ -182,6 +182,9 @@ def parse_list(source, prefix, sep='.'):
 
 
 def parse_bool(string_form):
+    if type(string_form) is bool:
+        return string_form
+
     token = string_form.lower()[0]
 
     if token == 't':
@@ -342,7 +345,7 @@ def iter_host_ips(hosts, ips):
         use_access_ip = host[1]['metadata']['use_access_ip']
         if host_id in ips:
             ip = ips[host_id]
-            
+
             host[1].update({
                 'access_ip_v4': ip,
                 'access_ip': ip,

--- a/contrib/terraform/terraform.py
+++ b/contrib/terraform/terraform.py
@@ -213,7 +213,6 @@ def packet_device(resource, tfvars=None):
         'state': raw_attrs['state'],
         # ansible
         'ansible_ssh_host': raw_attrs['network.0.address'],
-        'ansible_ssh_user': 'root',  # it's always "root" on Packet
         # generic
         'ipv4_address': raw_attrs['network.0.address'],
         'public_ipv4': raw_attrs['network.0.address'],


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Updates the terraform.py dynamic inventory script to work with terraform 0.12.12.

**Which issue(s) this PR fixes**:
Fixes #5297

**Special notes for your reviewer**:
In my local testing after updating to terraform 0.12.12 I was getting the following error.

```
Traceback (most recent call last):
  File "./terraform.py", line 401, in <module>
    main()
  File "./terraform.py", line 380, in main
    ips = dict(iterips(iterresources(tfstates(args.root))))
  File "./terraform.py", line 75, in iterips
    for module_name, key, resource in resources:
  File "./terraform.py", line 46, in iterresources
    for module in state['modules']:
KeyError: u'modules'
```

After addressing that I was seeing this also:

```
Traceback (most recent call last):
  File "./terraform.py", line 455, in <module>
    main()
  File "./terraform.py", line 440, in main
    output = query_list(hosts)
  File "./terraform.py", line 371, in query_list
    for name, attrs, hostgroups in hosts:
  File "./terraform.py", line 113, in iterhosts
    yield parser(resource, module_name)
  File "./terraform.py", line 206, in packet_device
    'locked': parse_bool(raw_attrs['locked']),
  File "./terraform.py", line 185, in parse_bool
    token = string_form.lower()[0]
AttributeError: 'bool' object has no attribute 'lower'
```

This PR seems to address both of those.

Lastly defaulting to root for all systems in packet breaks the ability to connect to CoreOS servers by default.

**Does this PR introduce a user-facing change?**:
NONE

