### PR TITLE
Raise delay and retry for rotate tokens

### DIFF
--- a/roles/kubernetes-apps/rotate_tokens/tasks/main.yml
+++ b/roles/kubernetes-apps/rotate_tokens/tasks/main.yml
@@ -4,8 +4,8 @@
   register: default_token
   changed_when: false
   until: default_token.rc == 0
-  delay: 1
-  retries: 5
+  delay: 4
+  retries: 10
 
 - name: Rotate Tokens | Get default token data
   command: "{{ bin_dir }}/kubectl --kubeconfig /etc/kubernetes/admin.conf get secrets {{ default_token.stdout }} -ojson"

--- a/roles/network_plugin/calico/files/make-ssl-typha.sh
+++ b/roles/network_plugin/calico/files/make-ssl-typha.sh
@@ -59,7 +59,7 @@ tmpdir=$(mktemp -d /tmp/calico_typha_certs.XXXXXX)
 trap 'rm -rf "${tmpdir}"' EXIT
 cd "${tmpdir}"
 
-mkdir -p "${SSLDIR} ${CADIR}"
+mkdir -p ${SSLDIR} ${CADIR}
 
 # Root CA
 if [ -e "$CADIR/ca.key" ]; then


### PR DESCRIPTION
This fixes the scenario where kube_network_plugin is CNI and kube-apiserver is not quite up right away.