### PR TITLE
[FIX] fix incorrect link to downloads documentation

### DIFF
--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -26,7 +26,7 @@ The supported operating systems for vagrant are defined in the `SUPPORTED_OS` co
 File and image caching
 ======================
 
-Kubespray can take quite a while to start on a laptop. To improve provisioning speed, the variable 'download_run_once' is set. This will make kubespray download all files and containers just once and then redistributes them to the other nodes and as a bonus, also cache all downloads locally and re-use them on the next provisioning run. For more information on download settings see [download documentation](docs/downloads.md).
+Kubespray can take quite a while to start on a laptop. To improve provisioning speed, the variable 'download_run_once' is set. This will make kubespray download all files and containers just once and then redistributes them to the other nodes and as a bonus, also cache all downloads locally and re-use them on the next provisioning run. For more information on download settings see [download documentation](downloads.md).
 
 Example use of Vagrant
 ======================


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:
Fixes an incorrect relative link in the documentation, Vagrant --> Documentation

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
