### PR TITLE
Pass `ingress_nginx_extra_args` when deploying the nginx-ingress addon

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s-cluster/addons.yml
@@ -98,6 +98,8 @@ ingress_publish_status_address: ""
 #   9000: "default/example-go:8080"
 # ingress_nginx_configmap_udp_services:
 #   53: "kube-system/coredns:53"
+# ingress_nginx_extra_args:
+#   - --default-ssl-certificate=default/foo-tls
 
 # Cert manager deployment
 cert_manager_enabled: false

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
@@ -10,3 +10,4 @@ ingress_nginx_secure_port: 443
 ingress_nginx_configmap: {}
 ingress_nginx_configmap_tcp_services: {}
 ingress_nginx_configmap_udp_services: {}
+ingress_nginx_extra_args: []

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
@@ -51,6 +51,9 @@ spec:
 {% if ingress_publish_status_address != "" %}
             - --publish-status-address={{ ingress_publish_status_address }}
 {% endif %}
+{% for extra_arg in ingress_nginx_extra_args %}
+            - {{ extra_arg }}
+{% endfor %}
           securityContext:
             capabilities:
                 drop:


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR allows to configure a new `ingress_nginx_extra_args` attribute (defaulting to `[]`) that translates to custom arguments (such as `--default-ssl-certificate=default/foo-tls`) passed to the nginx-ingress-controller binary.

**Which issue(s) this PR fixes**:

Fixes #5320 

**Special notes for your reviewer**:

By allowing to pass extra args rather than passing only the name of a certificate to use as `default-ssl-certificate`, we have a generic solution for feature #5320 .

**Does this PR introduce a user-facing change?**:

NONE