### PR TITLE
containerd installation on Debian

### DIFF
--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -40,3 +40,9 @@ containerd_ubuntu_repo_base_url: "https://download.docker.com/linux/ubuntu"
 containerd_ubuntu_repo_gpgkey: 'https://download.docker.com/linux/ubuntu/gpg'
 containerd_ubuntu_repo_repokey: '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
 containerd_ubuntu_repo_component: 'stable'
+
+# Debian docker-ce repo
+containerd_debian_repo_base_url: 'https://download.docker.com/linux/debian'
+containerd_debian_repo_gpgkey: 'https://download.docker.com/linux/debian/gpg'
+containerd_debian_repo_repokey: '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
+containerd_debian_repo_component: 'stable'

--- a/roles/container-engine/containerd/vars/debian.yml
+++ b/roles/container-engine/containerd/vars/debian.yml
@@ -1,0 +1,31 @@
+---
+
+containerd_versioned_pkg:
+  'latest': "{{ containerd_package }}"
+  '1.2.4': "{{ containerd_package }}=1.2.4-1"
+  '1.2.5': "{{ containerd_package }}=1.2.5-1"
+  '1.2.6': "{{ containerd_package }}=1.2.6-3"
+  'stable': "{{ containerd_package }}=1.2.4-1"
+  'edge': "{{ containerd_package }}=1.2.4-1"
+
+containerd_package_info:
+  pkg_mgr: apt
+  pkgs:
+    - name: "{{ containerd_versioned_pkg[containerd_version | string] }}"
+      force: false
+
+containerd_repo_key_info:
+  pkg_key: apt_key
+  url: '{{ containerd_debian_repo_gpgkey }}'
+  repo_keys:
+    - '{{ containerd_debian_repo_repokey }}'
+
+containerd_repo_info:
+  pkg_repo: apt_repository
+  repos:
+    - >
+       deb {{ containerd_debian_repo_base_url }}
+       {{ ansible_distribution_release|lower }}
+       {{ containerd_debian_repo_component }}
+
+runc_binary: /usr/bin/runc


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Kubespray already has support for containerd (container-engine role), but it doesn't support installation on Debian.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
upgrade to containerd 1.2.10 #5296

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
