### PR TITLE
Skip coredns image when evaluating kubeadm images

### DIFF
--- a/roles/download/tasks/prep_kubeadm_images.yml
+++ b/roles/download/tasks/prep_kubeadm_images.yml
@@ -41,7 +41,7 @@
     state: file
 
 - name: prep_kubeadm_images | Generate list of required images
-  command: "{{ bin_dir }}/kubeadm config images list --config={{ kube_config_dir }}/kubeadm-images.yaml"
+  shell: "{{ bin_dir }}/kubeadm config images list --config={{ kube_config_dir }}/kubeadm-images.yaml | grep -v coredns"
   register: kubeadm_images_raw
   run_once: true
   changed_when: false


### PR DESCRIPTION
It will be enabled correctly in downloads