### PR TITLE
Fix helm for Kubernetes 1.16.2

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -297,7 +297,7 @@ test_image_repo: "{{ docker_image_repo }}/library/busybox"
 test_image_tag: latest
 busybox_image_repo: "{{ docker_image_repo }}/library/busybox"
 busybox_image_tag: 1.29.2
-helm_version: "v2.14.3"
+helm_version: "v2.16.0"
 helm_image_repo: "{{ docker_image_repo }}/lachlanevenson/k8s-helm"
 helm_image_tag: "{{ helm_version }}"
 tiller_image_repo: "{{ gcr_image_repo }}/kubernetes-helm/tiller"


### PR DESCRIPTION
Since upgrading k8s beyond 1.16.0 version, helm init does
no longer work with helm < 2.16.0 due to
https://github.com/helm/helm/issues/6374

This PR closes issue #5331

/kind bug


```release-note
Helm is upgraded to v2.16.0 to fix a helm init issue since Kubernetes 1.16.0
```
