### PR TITLE
modify host.yml in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To deploy the cluster you can use :
 
     # Update Ansible inventory file with inventory builder
     declare -a IPS=(10.10.1.3 10.10.1.4 10.10.1.5)
-    CONFIG_FILE=inventory/mycluster/hosts.yml python3 contrib/inventory_builder/inventory.py ${IPS[@]}
+    CONFIG_FILE=inventory/mycluster/inventory.ini python3 contrib/inventory_builder/inventory.py ${IPS[@]}
 
     # Review and change parameters under ``inventory/mycluster/group_vars``
     cat inventory/mycluster/group_vars/all/all.yml
@@ -39,7 +39,7 @@ To deploy the cluster you can use :
     # The option `--become` is required, as for example writing SSL keys in /etc/,
     # installing packages and interacting with various systemd daemons.
     # Without --become the playbook will fail to run!
-    ansible-playbook -i inventory/mycluster/hosts.yml --become --become-user=root cluster.yml
+    ansible-playbook -i inventory/mycluster/inventory.ini --become --become-user=root cluster.yml
 
 Note: When Ansible is already installed via system packages on the control machine, other python packages installed via `sudo pip install -r requirements.txt` will go to a different directory tree (e.g. `/usr/local/lib/python2.7/dist-packages` on Ubuntu) from Ansible's (e.g. `/usr/lib/python2.7/dist-packages/ansible` still on Ubuntu).
 As a consequence, `ansible-playbook` command will fail with:


### PR DESCRIPTION
There is an error about "ansible-playbook -i  inventory/mycluster/host.yaml ..." in README.md. 
There is not host.yaml in inventory/sample directory, host.yaml exists in the old version. So we should modify it to inventory.ini. 