### PR TITLE
containerd: update to 1.2.10

### DIFF
--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -9,7 +9,7 @@ containerd_config:
     "docker.io": "https://registry-1.docker.io"
   max_container_log_line_size: -1
 
-containerd_version: '1.2.6'
+containerd_version: '1.2.10'
 containerd_package: 'containerd.io'
 
 containerd_cfg_dir: /etc/containerd

--- a/roles/container-engine/containerd/vars/debian.yml
+++ b/roles/container-engine/containerd/vars/debian.yml
@@ -5,8 +5,9 @@ containerd_versioned_pkg:
   '1.2.4': "{{ containerd_package }}=1.2.4-1"
   '1.2.5': "{{ containerd_package }}=1.2.5-1"
   '1.2.6': "{{ containerd_package }}=1.2.6-3"
-  'stable': "{{ containerd_package }}=1.2.4-1"
-  'edge': "{{ containerd_package }}=1.2.4-1"
+  '1.2.10': "{{ containerd_package }}=1.2.10-3"
+  'stable': "{{ containerd_package }}=1.2.10-3"
+  'edge': "{{ containerd_package }}=1.2.10-3"
 
 containerd_package_info:
   pkg_mgr: apt

--- a/roles/container-engine/containerd/vars/redhat.yml
+++ b/roles/container-engine/containerd/vars/redhat.yml
@@ -5,8 +5,9 @@ containerd_versioned_pkg:
   '1.2.4': "{{ containerd_package }}-1.2.4-3.1.el7"
   '1.2.5': "{{ containerd_package }}-1.2.5-3.1.el7"
   '1.2.6': "{{ containerd_package }}-1.2.6-3.3.el7"
-  'stable': "{{ containerd_package }}-1.2.6-3.3.el7"
-  'edge': "{{ containerd_package }}-1.2.6-3.3.el7"
+  '1.2.10': "{{ containerd_package }}-1.2.10-3.2.el7"
+  'stable': "{{ containerd_package }}-1.2.10-3.2.el7"
+  'edge': "{{ containerd_package }}-1.2.10-3.2.el7"
 
 containerd_package_info:
   pkg_mgr: yum

--- a/roles/container-engine/containerd/vars/ubuntu-amd64.yml
+++ b/roles/container-engine/containerd/vars/ubuntu-amd64.yml
@@ -5,8 +5,9 @@ containerd_versioned_pkg:
   '1.2.4': "{{ containerd_package }}=1.2.4-1"
   '1.2.5': "{{ containerd_package }}=1.2.5-1"
   '1.2.6': "{{ containerd_package }}=1.2.6-3"
-  'stable': "{{ containerd_package }}=1.2.4-1"
-  'edge': "{{ containerd_package }}=1.2.4-1"
+  '1.2.10': "{{ containerd_package }}=1.2.10-3"
+  'stable': "{{ containerd_package }}=1.2.10-3"
+  'edge': "{{ containerd_package }}=1.2.10-3"
 
 containerd_package_info:
   pkg_mgr: apt


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR update containerd from 1.2.6 to 1.2.10
This new version includes a lot of bugs and security fixes:
https://github.com/containerd/containerd/releases/tag/v1.2.10
CVE-2019-16884 / CVE-2019-16276
https://github.com/containerd/containerd/releases/tag/v1.2.9
CVE-2019-9512 / CVE-2019-9514 / CVE-2019-9515
https://github.com/containerd/containerd/releases/tag/v1.2.8
CVE-2019-9512 / CVE-2019-9514
https://github.com/containerd/containerd/releases/tag/v1.2.7

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Duplicate of #5296, but @erulabs doesn't seems responsive

**Does this PR introduce a user-facing change?**:
```release-note
Update containerd from 1.2.6 to 1.2.10
```