### PR TITLE
scale down coredns on each master during graceful upgrade

### DIFF
--- a/roles/kubernetes/master/tasks/kubeadm-upgrade.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-upgrade.yml
@@ -49,8 +49,8 @@
   retries: 6
   delay: 5
   until: scale_down_coredns is succeeded
+  run_once: yes
   when:
-    - inventory_hostname == groups['kube-master']|first
     - kubeadm_scale_down_coredns_enabled
     - dns_mode not in ['coredns', 'coredns_dual']
   changed_when: false


### PR DESCRIPTION
This fixes the scenario where masters are upgraded one at a time
and coredns gets improperly scaled back up to 2 replicas.