### PR TITLE
Backport v2.10.0 update local path provisioner to use variable for image pull policy

### DIFF
--- a/roles/kubernetes-apps/external_provisioner/local_path_provisioner/templates/local-path-storage.yaml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_path_provisioner/templates/local-path-storage.yaml.j2
@@ -61,7 +61,7 @@ spec:
       containers:
       - name: local-path-provisioner
         image: {{ local_path_provisioner_image_repo }}:{{ local_path_provisioner_image_tag }}
-        imagePullPolicy: {{ k8s_image_pull_policy }}
+        imagePullPolicy: Always
         command:
         - local-path-provisioner
         - start

--- a/roles/kubernetes-apps/external_provisioner/local_path_provisioner/templates/local-path-storage.yaml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_path_provisioner/templates/local-path-storage.yaml.j2
@@ -61,7 +61,7 @@ spec:
       containers:
       - name: local-path-provisioner
         image: {{ local_path_provisioner_image_repo }}:{{ local_path_provisioner_image_tag }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ k8s_image_pull_policy }}
         command:
         - local-path-provisioner
         - start


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

kind feature

> /kind flake

**What this PR does / why we need it**:
Introduces the use of a global variable for imagePullPolicy into local path provisoner. Backporting this fix from master into release 2.10

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
