### PR TITLE
[FIX] fix match because trim removes leading/trailing whitespace

### DIFF
--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -127,7 +127,7 @@
   with_items: "{{ hostvars[groups['kube-master'][0]]['kubeadm_init'].stdout_lines | default([]) }}"
   when:
     - kubeadm_certificate_key is not defined
-    - item | trim | match('.*--certificate-key .*')
+    - item | trim | match('.*--certificate-key.*')
 
 - name: Create hardcoded kubeadm token for joining nodes with 24h expiration (if defined)
   shell: >-


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:
Match filter is failing to match on regex due to extra whitespace from the string being removed by trim

**Which issue(s) this PR fixes**:
Fixes #5355

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
