### PR TITLE
fix OWNERS syntax

### DIFF
--- a/roles/network_plugin/kube-ovn/OWNERS
+++ b/roles/network_plugin/kube-ovn/OWNERS
@@ -1,6 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
- approvers:
-  - oilbeater
-reviewers:
-  - oilbeater
+emeritus_approvers:
+- oilbeater


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

fixes OWNERS file syntax

```
$ yamllint roles/network_plugin/kube-ovn/OWNERS
roles/network_plugin/kube-ovn/OWNERS
  1:1       warning  comment not indented like content  (comments-indentation)
  3:1       warning  missing document start "---"  (document-start)
  3:2       error    wrong indentation: expected 0 but found 1  (indentation)
  4:3       error    wrong indentation: expected 3 but found 2  (indentation)
  5:1       error    syntax error: expected '<document start>', but found '<block mapping start>'
```

this is throwing off some python-based scripts I'm using to report on
OWNERS files across the project

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```