### PR TITLE
Use kubespray/kubespray:v2.11.0 for CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,14 +30,15 @@ variables:
 
 before_script:
   - ./tests/scripts/rebase.sh
-  - /usr/bin/python -m pip install -r tests/requirements.txt
+  - update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+  - python -m pip install -r tests/requirements.txt
   - mkdir -p /.ssh
 
 .job: &job
   tags:
     - packet
   variables:
-    KUBESPRAY_VERSION: v2.10.0
+    KUBESPRAY_VERSION: v2.11.0
   image: quay.io/kubespray/kubespray:$KUBESPRAY_VERSION
 
 .testcases: &testcases
@@ -45,6 +46,7 @@ before_script:
   services:
     - docker:dind
   before_script:
+    - update-alternatives --install /usr/bin/python python /usr/bin/python3 1
     - ./tests/scripts/rebase.sh
     - ./tests/scripts/testcases_prepare.sh
   script:

--- a/.gitlab-ci/lint.yml
+++ b/.gitlab-ci/lint.yml
@@ -2,6 +2,8 @@
 yamllint:
   extends: .job
   stage: unit-tests
+  variables:
+    LANG: C.UTF-8
   script:
     - yamllint --strict .
   except: ['triggers', 'master']

--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -78,9 +78,9 @@ packet_ubuntu18-flannel-containerd:
   when: manual
 
 packet_debian9-macvlan-sep:
-  stage: deploy-part2
+  stage: unit-tests
   <<: *packet
-  when: on_success
+  when: manual
 
 packet_debian9-calico-upgrade:
   stage: deploy-part2
@@ -105,7 +105,7 @@ packet_centos7-kube-ovn:
 packet_centos7-kube-router:
   stage: deploy-part2
   <<: *packet
-  when: on_success
+  when: manual
 
 packet_centos7-multus-calico:
   stage: deploy-part2

--- a/.gitlab-ci/terraform.yml
+++ b/.gitlab-ci/terraform.yml
@@ -3,6 +3,7 @@
 .terraform_install:
   extends: .job
   before_script:
+    - update-alternatives --install /usr/bin/python python /usr/bin/python3 1
     - ./tests/scripts/rebase.sh
     - ./tests/scripts/testcases_prepare.sh
     - ./tests/scripts/terraform_install.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ RUN  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && 
      stable" \
      && apt update -y && apt-get install docker-ce -y
 COPY . .
-RUN /usr/bin/python3 -m pip install pip -U && /usr/bin/python3 -m pip install -r tests/requirements.txt && python3 -m pip install -r requirements.txt
+RUN /usr/bin/python3 -m pip install pip -U && /usr/bin/python3 -m pip install -r tests/requirements.txt && python3 -m pip install -r requirements.txt && update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.14.4/bin/linux/amd64/kubectl \
     && chmod a+x kubectl && cp kubectl /usr/local/bin/kubectl


### PR DESCRIPTION
After the v2.11.0 we forgot to build and upload the appropriate Docker image for CI.

The v2.11.0 image is use Python 3 whereas the previous images were using Python 2, so there is a significant difference.