### PR TITLE
Fix OpenSUSE support

### DIFF
--- a/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
@@ -41,3 +41,9 @@ images:
     url: https://storage.googleapis.com/born-images/oracle76/oracle-linux-76.qcow2
     checksum: sha256:f396c03e907fa2a0c94d6807b9f62622f23ee3499df4456ae2a15da381fbdca5
     converted: true
+
+  opensuse-leap-15:
+    filename: openSUSE-Leap-15.1-OpenStack.x86_64-0.0.4-Build6.106.qcow2
+    url: https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.1/images/openSUSE-Leap-15.1-OpenStack.x86_64-0.0.4-Build6.106.qcow2
+    checksum: sha256:e3c016a889505c5ae51dafe6eedc836a9e9546ab951fdc96f07eb35e34d12b8c
+    converted: true

--- a/tests/files/packet_opensuse-canal.yml
+++ b/tests/files/packet_opensuse-canal.yml
@@ -5,6 +5,5 @@ mode: default
 
 # Kubespray settings
 kube_network_plugin: canal
-container_manager: containerd
 deploy_netchecker: true
 dns_min_replicas: 1

--- a/tests/scripts/testcases_run.sh
+++ b/tests/scripts/testcases_run.sh
@@ -19,6 +19,16 @@ ansible-playbook tests/cloud_playbooks/wait-for-ssh.yml
 if [[ "$CI_JOB_NAME" =~ "coreos" ]]; then
   ansible all -m raw -a 'systemctl disable locksmithd'
   ansible all -m raw -a 'systemctl stop locksmithd'
+  mkdir -p /opt/bin && ln -s /usr/bin/python /opt/bin/python
+fi
+
+if [[ "$CI_JOB_NAME" =~ "opensuse" ]]; then
+  # OpenSUSE needs netconfig update to get correct resolv.conf
+  # See https://goinggnu.wordpress.com/2013/10/14/how-to-fix-the-dns-in-opensuse-13-1/
+  ansible all -m raw -a 'netconfig update -f'
+  # Auto import repo keys
+  ansible all -m raw -a 'zypper --gpg-auto-import-keys refresh'
+  PYPATH=/usr/bin/python3
 fi
 
 # Check out latest tag if testing upgrade
@@ -27,14 +37,14 @@ test "${UPGRADE_TEST}" != "false" && git fetch --all && git checkout "$KUBESPRAY
 test "${UPGRADE_TEST}" != "false" && git checkout "${CI_BUILD_REF}" tests/files/${CI_JOB_NAME}.yml
 
 # Create cluster
-ansible-playbook ${LOG_LEVEL} -e @${CI_TEST_VARS} -e local_release_dir=${PWD}/downloads --limit "all:!fake_hosts" cluster.yml
+ansible-playbook ${LOG_LEVEL} -e @${CI_TEST_VARS} -e local_release_dir=${PWD}/downloads -e ansible_python_interpreter=${PYPATH} --limit "all:!fake_hosts" cluster.yml
 
 # Repeat deployment if testing upgrade
 if [ "${UPGRADE_TEST}" != "false" ]; then
   test "${UPGRADE_TEST}" == "basic" && PLAYBOOK="cluster.yml"
   test "${UPGRADE_TEST}" == "graceful" && PLAYBOOK="upgrade-cluster.yml"
   git checkout "${CI_BUILD_REF}"
-  ansible-playbook ${LOG_LEVEL} -e @${CI_TEST_VARS} -e local_release_dir=${PWD}/downloads --limit "all:!fake_hosts" $PLAYBOOK
+  ansible-playbook ${LOG_LEVEL} -e @${CI_TEST_VARS} -e local_release_dir=${PWD}/downloads -e ansible_python_interpreter=${PYPATH} --limit "all:!fake_hosts" $PLAYBOOK
 fi
 
 # Tests Cases


### PR DESCRIPTION
Fixing problems with OpenSUSE support:

- OpenSUSE gets an empty `/etc/resolv.conf` from cloud-init, then dhclient does not put its nameserver info in there. Apparently this is a known issue with opensuse: https://goinggnu.wordpress.com/2013/10/14/how-to-fix-the-dns-in-opensuse-13-1/
- OpenSUSE 15.0 is not supported since end of November, therefore we should move to 15.1 which ships only with Python3 supported until November 2020, see https://en.opensuse.org/Lifetime
- OpenSUSE support for containerd is blocked by `Fail containerd setup if distribution is not supported` assertion


Fixes #5352