### PR TITLE
Removed deprecated label kubernetes.io/cluster-service

### DIFF
--- a/roles/kubernetes-apps/ansible/files/coredns-sa.yml
+++ b/roles/kubernetes-apps/ansible/files/coredns-sa.yml
@@ -5,5 +5,4 @@ metadata:
   name: coredns
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile

--- a/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
@@ -6,7 +6,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: "kube-dns{{ coredns_ordinal_suffix }}"
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/name: "coredns{{ coredns_ordinal_suffix }}"
 spec:

--- a/roles/kubernetes-apps/ansible/templates/coredns-svc.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-svc.yml.j2
@@ -6,7 +6,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: kube-dns{{ coredns_ordinal_suffix }}
-    kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "coredns{{ coredns_ordinal_suffix }}"
     addonmanager.kubernetes.io/mode: Reconcile
   annotations:

--- a/roles/kubernetes-apps/ansible/templates/dashboard.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dashboard.yml.j2
@@ -228,7 +228,6 @@ apiVersion: v1
 metadata:
   labels:
     k8s-app: kubernetes-dashboard
-    kubernetes.io/cluster-service: "true"
   name: kubernetes-dashboard
   namespace: kube-system
 spec:

--- a/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
@@ -20,7 +20,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: dns-autoscaler{{ coredns_ordinal_suffix }}
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   selector:

--- a/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-psp.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-psp.yml.j2
@@ -11,7 +11,6 @@ metadata:
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
 {% endif %}
   labels:
-    kubernetes.io/cluster-service: 'true'
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   privileged: false

--- a/roles/kubernetes-apps/ansible/templates/netchecker-agent-sa.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-agent-sa.yml.j2
@@ -3,5 +3,3 @@ kind: ServiceAccount
 metadata:
   name: netchecker-agent
   namespace: {{ netcheck_namespace }}
-  labels:
-    kubernetes.io/cluster-service: "true"

--- a/roles/kubernetes-apps/ansible/templates/netchecker-server-sa.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-server-sa.yml.j2
@@ -3,5 +3,3 @@ kind: ServiceAccount
 metadata:
   name: netchecker-server
   namespace: {{ netcheck_namespace }}
-  labels:
-    kubernetes.io/cluster-service: "true"

--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-daemonset.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-daemonset.yml.j2
@@ -5,7 +5,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: kube-dns
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   selector:

--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-sa.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-sa.yml.j2
@@ -4,5 +4,4 @@ metadata:
   name: nodelocaldns
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile

--- a/roles/kubernetes-apps/cluster_roles/files/oci-rbac.yml
+++ b/roles/kubernetes-apps/cluster_roles/files/oci-rbac.yml
@@ -9,8 +9,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: system:cloud-controller-manager
-  labels:
-    kubernetes.io/cluster-service: "true"
 rules:
 - apiGroups:
   - ""

--- a/roles/kubernetes-apps/cluster_roles/templates/psp-cr.yml.j2
+++ b/roles/kubernetes-apps/cluster_roles/templates/psp-cr.yml.j2
@@ -4,7 +4,6 @@ kind: ClusterRole
 metadata:
   name: psp:privileged
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
 - apiGroups:
@@ -21,7 +20,6 @@ kind: ClusterRole
 metadata:
   name: psp:restricted
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
 - apiGroups:

--- a/roles/kubernetes-apps/cluster_roles/templates/psp-crb.yml.j2
+++ b/roles/kubernetes-apps/cluster_roles/templates/psp-crb.yml.j2
@@ -40,7 +40,6 @@ metadata:
       nodes to mirror pods bound to themselves.'
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
-    kubernetes.io/cluster-service: 'true'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/roles/kubernetes-apps/cluster_roles/templates/psp.yml.j2
+++ b/roles/kubernetes-apps/cluster_roles/templates/psp.yml.j2
@@ -11,7 +11,6 @@ metadata:
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
 {% endif %}
   labels:
-    kubernetes.io/cluster-service: 'true'
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   privileged: false
@@ -53,7 +52,6 @@ metadata:
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   privileged: true

--- a/roles/kubernetes-apps/external_provisioner/cephfs_provisioner/templates/psp-cephfs-provisioner.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/cephfs_provisioner/templates/psp-cephfs-provisioner.yml.j2
@@ -11,7 +11,6 @@ metadata:
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
 {% endif %}
   labels:
-    kubernetes.io/cluster-service: 'true'
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   privileged: false

--- a/roles/kubernetes-apps/external_provisioner/local_path_provisioner/templates/local-path-storage-psp.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_path_provisioner/templates/local-path-storage-psp.yml.j2
@@ -11,7 +11,6 @@ metadata:
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
 {% endif %}
   labels:
-    kubernetes.io/cluster-service: 'true'
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   privileged: true

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-psp.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-psp.yml.j2
@@ -11,7 +11,6 @@ metadata:
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
 {% endif %}
   labels:
-    kubernetes.io/cluster-service: 'true'
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   privileged: true

--- a/roles/kubernetes-apps/external_provisioner/rbd_provisioner/templates/psp-rbd-provisioner.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/rbd_provisioner/templates/psp-rbd-provisioner.yml.j2
@@ -11,7 +11,6 @@ metadata:
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
 {% endif %}
   labels:
-    kubernetes.io/cluster-service: 'true'
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   privileged: false

--- a/roles/kubernetes-apps/helm/templates/tiller-sa.yml.j2
+++ b/roles/kubernetes-apps/helm/templates/tiller-sa.yml.j2
@@ -4,5 +4,3 @@ kind: ServiceAccount
 metadata:
   name: tiller
   namespace: {{ tiller_namespace }}
-  labels:
-    kubernetes.io/cluster-service: "true"

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/psp-ingress-nginx.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/psp-ingress-nginx.yml.j2
@@ -11,7 +11,6 @@ metadata:
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
 {% endif %}
   labels:
-    kubernetes.io/cluster-service: 'true'
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   privileged: false

--- a/roles/kubernetes-apps/metrics_server/templates/auth-delegator.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/auth-delegator.yaml.j2
@@ -3,7 +3,6 @@ kind: ClusterRoleBinding
 metadata:
   name: metrics-server:system:auth-delegator
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/roles/kubernetes-apps/metrics_server/templates/auth-reader.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/auth-reader.yaml.j2
@@ -4,7 +4,6 @@ metadata:
   name: metrics-server-auth-reader
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/roles/kubernetes-apps/metrics_server/templates/metrics-apiservice.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/metrics-apiservice.yaml.j2
@@ -3,7 +3,6 @@ kind: APIService
 metadata:
   name: v1beta1.metrics.k8s.io
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   service:

--- a/roles/kubernetes-apps/metrics_server/templates/metrics-server-cm.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/metrics-server-cm.yaml.j2
@@ -5,7 +5,6 @@ metadata:
   name: metrics-server-config
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: EnsureExists
 data:
   NannyConfiguration: |-

--- a/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
@@ -6,7 +6,6 @@ metadata:
   namespace: kube-system
   labels:
     app.kubernetes.io/name: metrics-server
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
     version: {{ metrics_server_version }}
 spec:

--- a/roles/kubernetes-apps/metrics_server/templates/metrics-server-sa.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/metrics-server-sa.yaml.j2
@@ -5,5 +5,4 @@ metadata:
   name: metrics-server
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile

--- a/roles/kubernetes-apps/metrics_server/templates/metrics-server-service.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/metrics-server-service.yaml.j2
@@ -5,7 +5,6 @@ metadata:
   namespace: kube-system
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
-    kubernetes.io/cluster-service: "true"
     app.kubernetes.io/name: "metrics-server"
 spec:
   selector:

--- a/roles/kubernetes-apps/metrics_server/templates/resource-reader-clusterrolebinding.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/resource-reader-clusterrolebinding.yaml.j2
@@ -4,7 +4,6 @@ kind: ClusterRoleBinding
 metadata:
   name: system:metrics-server
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/roles/kubernetes-apps/metrics_server/templates/resource-reader.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/resource-reader.yaml.j2
@@ -3,7 +3,6 @@ kind: ClusterRole
 metadata:
   name: system:metrics-server
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
 - apiGroups:

--- a/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-controllers.yml.j2
+++ b/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-controllers.yml.j2
@@ -5,21 +5,18 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-kube-controllers
-    kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
   strategy:
     type: Recreate
   selector:
     matchLabels:
-      kubernetes.io/cluster-service: "true"
       k8s-app: calico-kube-controllers
   template:
     metadata:
       name: calico-kube-controllers
       namespace: kube-system
       labels:
-        kubernetes.io/cluster-service: "true"
         k8s-app: calico-kube-controllers
     spec:
       nodeSelector:

--- a/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-sa.yml.j2
+++ b/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-sa.yml.j2
@@ -4,5 +4,3 @@ kind: ServiceAccount
 metadata:
   name: calico-kube-controllers
   namespace: kube-system
-  labels:
-    kubernetes.io/cluster-service: "true"

--- a/roles/kubernetes-apps/registry/README.md
+++ b/roles/kubernetes-apps/registry/README.md
@@ -38,8 +38,6 @@ kind: PersistentVolume
 apiVersion: v1
 metadata:
   name: kube-system-kube-registry-pv
-  labels:
-    kubernetes.io/cluster-service: "true"
 spec:
 {% if pillar.get('cluster_registry_disk_type', '') == 'gce' %}
   capacity:
@@ -81,8 +79,6 @@ apiVersion: v1
 metadata:
   name: kube-registry-pvc
   namespace: kube-system
-  labels:
-    kubernetes.io/cluster-service: "true"
 spec:
   accessModes:
     - ReadWriteOnce
@@ -112,7 +108,6 @@ metadata:
   labels:
     k8s-app: registry
     version: v0
-    kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
   selector:
@@ -123,7 +118,6 @@ spec:
       labels:
         k8s-app: registry
         version: v0
-        kubernetes.io/cluster-service: "true"
     spec:
       containers:
       - name: registry
@@ -165,7 +159,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: registry
-    kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "KubeRegistry"
 spec:
   selector:
@@ -193,7 +186,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: kube-registry-proxy
-    kubernetes.io/cluster-service: "true"
     version: v0.4
 spec:
   template:
@@ -201,7 +193,6 @@ spec:
       labels:
         k8s-app: kube-registry-proxy
         kubernetes.io/name: "kube-registry-proxy"
-        kubernetes.io/cluster-service: "true"
         version: v0.4
     spec:
       containers:

--- a/roles/kubernetes-apps/registry/templates/registry-proxy-ds.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-proxy-ds.yml.j2
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ registry_namespace }}
   labels:
     k8s-app: registry-proxy
-    kubernetes.io/cluster-service: "true"
     version: v{{ registry_proxy_image_tag }}
 spec:
   selector:
@@ -18,7 +17,6 @@ spec:
       labels:
         k8s-app: registry-proxy
         kubernetes.io/name: "registry-proxy"
-        kubernetes.io/cluster-service: "true"
         version: v{{ registry_proxy_image_tag }}
     spec:
       priorityClassName: {% if registry_namespace == 'kube-system' %}system-node-critical{% else %}k8s-cluster-critical{% endif %}{{''}}

--- a/roles/kubernetes-apps/registry/templates/registry-proxy-psp.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-proxy-psp.yml.j2
@@ -11,7 +11,6 @@ metadata:
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
 {% endif %}
   labels:
-    kubernetes.io/cluster-service: 'true'
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   privileged: false

--- a/roles/kubernetes-apps/registry/templates/registry-proxy-sa.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-proxy-sa.yml.j2
@@ -3,5 +3,3 @@ kind: ServiceAccount
 metadata:
   name: registry-proxy
   namespace: {{ registry_namespace }}
-  labels:
-    kubernetes.io/cluster-service: "true"

--- a/roles/kubernetes-apps/registry/templates/registry-psp.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-psp.yml.j2
@@ -11,7 +11,6 @@ metadata:
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
 {% endif %}
   labels:
-    kubernetes.io/cluster-service: 'true'
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   privileged: false

--- a/roles/kubernetes-apps/registry/templates/registry-pvc.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-pvc.yml.j2
@@ -5,7 +5,6 @@ metadata:
   name: registry-pvc
   namespace: {{ registry_namespace }}
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   accessModes:

--- a/roles/kubernetes-apps/registry/templates/registry-rs.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-rs.yml.j2
@@ -7,7 +7,6 @@ metadata:
   labels:
     k8s-app: registry
     version: v{{ registry_image_tag }}
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   replicas: 1
@@ -20,7 +19,6 @@ spec:
       labels:
         k8s-app: registry
         version: v{{ registry_image_tag }}
-        kubernetes.io/cluster-service: "true"
     spec:
       priorityClassName: {% if registry_namespace == 'kube-system' %}system-cluster-critical{% else %}k8s-cluster-critical{% endif %}{{''}}
       serviceAccountName: registry

--- a/roles/kubernetes-apps/registry/templates/registry-sa.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-sa.yml.j2
@@ -3,5 +3,3 @@ kind: ServiceAccount
 metadata:
   name: registry
   namespace: {{ registry_namespace }}
-  labels:
-    kubernetes.io/cluster-service: "true"

--- a/roles/kubernetes-apps/registry/templates/registry-svc.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-svc.yml.j2
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ registry_namespace }}
   labels:
     k8s-app: registry
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/name: "KubeRegistry"
 spec:

--- a/roles/network_plugin/calico/templates/calico-node-sa.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node-sa.yml.j2
@@ -4,5 +4,3 @@ kind: ServiceAccount
 metadata:
   name: calico-node
   namespace: kube-system
-  labels:
-    kubernetes.io/cluster-service: "true"

--- a/roles/network_plugin/canal/templates/canal-node-sa.yml.j2
+++ b/roles/network_plugin/canal/templates/canal-node-sa.yml.j2
@@ -4,6 +4,3 @@ kind: ServiceAccount
 metadata:
   name: canal
   namespace: kube-system
-  labels:
-    kubernetes.io/cluster-service: "true"
-

--- a/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
@@ -3,14 +3,12 @@ kind: DaemonSet
 metadata:
   labels:
     k8s-app: cilium
-    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
   selector:
     matchLabels:
       k8s-app: cilium
-      kubernetes.io/cluster-service: "true"
   template:
     metadata:
       annotations:
@@ -26,7 +24,6 @@ spec:
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
       labels:
         k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
     spec:
       containers:
       - args:

--- a/roles/network_plugin/contiv/templates/contiv-netmaster-serviceaccount.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-netmaster-serviceaccount.yml.j2
@@ -3,5 +3,3 @@ kind: ServiceAccount
 metadata:
   name: contiv-netmaster
   namespace: kube-system
-  labels:
-    kubernetes.io/cluster-service: "true"

--- a/roles/network_plugin/contiv/templates/contiv-netplugin-serviceaccount.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-netplugin-serviceaccount.yml.j2
@@ -3,5 +3,3 @@ kind: ServiceAccount
 metadata:
   name: contiv-netplugin
   namespace: kube-system
-  labels:
-    kubernetes.io/cluster-service: "true"


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
Removes deprecated labels in kuberenetes add-ons

Which issue(s) this PR fixes:

Remove deprecated label kubernetes.io/cluster-service in yaml files of kubernetes add-ons. Ref https://github.com/kubernetes/kubernetes/pull/75638
https://github.com/kubernetes/kubernetes/issues/72757