### PR TITLE
Remove inline shell in YAML for vagrant-validate

### DIFF
--- a/.gitlab-ci/lint.yml
+++ b/.gitlab-ci/lint.yml
@@ -11,10 +11,10 @@ yamllint:
 vagrant-validate:
   extends: .job
   stage: unit-tests
+  variables:
+    VAGRANT_VERSION: 2.2.4
   script:
-    - curl -sL https://releases.hashicorp.com/vagrant/2.2.4/vagrant_2.2.4_x86_64.deb -o /tmp/vagrant_2.2.4_x86_64.deb
-    - dpkg -i /tmp/vagrant_2.2.4_x86_64.deb
-    - vagrant validate --ignore-provider
+    - ./tests/scripts/vagrant-validate.sh
   except: ['triggers', 'master']
 
 ansible-lint:

--- a/tests/scripts/vagrant-validate.sh
+++ b/tests/scripts/vagrant-validate.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euxo pipefail
+
+curl -sL "https://releases.hashicorp.com/vagrant/2.2.4/vagrant_${VAGRANT_VERSION}_x86_64.deb" -o "/tmp/vagrant_${VAGRANT_VERSION}_x86_64.deb"
+dpkg -i "/tmp/vagrant_${VAGRANT_VERSION}_x86_64.deb"
+vagrant validate --ignore-provider


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
**What this PR does / why we need it**:
Shell in-line in YAML quickly becomes messy, therefore this PR moves that to a dedicated script.

Also uses a variable for the vagrant version