### PR TITLE
Tidy up coredns_server var and set proper priority in systemd-resolved

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
@@ -137,11 +137,11 @@
   set_fact:
     coredns_server: |-
       {%- if dns_mode == 'coredns' and not dns_early|bool -%}
-        {{ [ skydns_server ] + upstream_dns_servers|default([]) }}
+        {{ [ skydns_server ] }}
       {%- elif dns_mode == 'coredns_dual' and not dns_early|bool -%}
-        {{ [ skydns_server ] + [ skydns_server_secondary ] + upstream_dns_servers|default([]) }}
+        {{ [ skydns_server ] + [ skydns_server_secondary ] }}
       {%- elif dns_mode == 'manual' and not dns_early|bool -%}
-        {{ ( manual_dns_server.split(',') | list) + upstream_dns_servers|default([]) }}
+        {{ ( manual_dns_server.split(',') | list) }}
       {%- elif dns_early|bool -%}
         {{ upstream_dns_servers|default([]) }}
       {%- endif -%}

--- a/roles/kubernetes/preinstall/templates/resolved.conf.j2
+++ b/roles/kubernetes/preinstall/templates/resolved.conf.j2
@@ -1,10 +1,6 @@
 [Resolve]
-{% if dns_late %}
-DNS={{ ( coredns_server + nameservers|d([]) + cloud_resolver|d([])) | unique | join(' ') }}
-{% else %}
-DNS={{ ( nameservers|d([]) + cloud_resolver|d([])) | unique | join(' ') }}
-{% endif %}
-#FallbackDNS=
+DNS={{ coredns_server | list | join(' ') }}
+FallbackDNS={{ ( nameservers|d([]) + cloud_resolver|d([])) | unique | join(' ') }}
 Domains={{ ([ 'default.svc.' + dns_domain, 'svc.' + dns_domain ] + searchdomains|default([])) | join(' ') }}
 #LLMNR=no
 #MulticastDNS=no


### PR DESCRIPTION
Upstream servers don't belong in coredns_server var. Just actual coredns (or manual) servers.

systemd-resolved will fail over to other primary DNS servers if the first one doesn't respond, but never flip back. As a result, upstream servers should be in the Secondary field in config.