### PR TITLE
Fixes an issue with offline installations

### DIFF
--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -391,10 +391,13 @@ contiv_global_as: "65002"
 contiv_global_neighbor_as: "500"
 
 # Set 127.0.0.1 as fallback IP if we do not have host facts for host
+# ansible_default_ipv4 isn't what you think.
+# Thanks https://medium.com/opsops/ansible-default-ipv4-is-not-what-you-think-edb8ab154b10
 fallback_ips_base: |
   ---
   {% for item in groups['k8s-cluster'] + groups['etcd'] + groups['calico-rr']|default([])|unique %}
-  {{ item }}: "{{ hostvars[item].get('ansible_default_ipv4', {'address': '127.0.0.1'})['address'] }}"
+  {% set found = hostvars[item].get('ansible_default_ipv4') %}
+  {{ item }}: "{{ found.get('address', '127.0.0.1') }}"
   {% endfor %}
 fallback_ips: "{{ fallback_ips_base | from_yaml }}"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Better support for offline installations.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5374 #5217 

**Special notes for your reviewer**:
When 'ansible_default_ipv4' returns an empty dict, it "tells" `hostvars[item].get` that the key exists. This causes the empty dict to be used rather than `{'address': '127.0.0.1'}`. An empty dict is returned because there is no default gateway, which some offline installations don't have. [This](https://medium.com/opsops/ansible-default-ipv4-is-not-what-you-think-edb8ab154b10) helped me.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
