### PR TITLE
Add default value for `bin_dir` in recover control plane

### DIFF
--- a/roles/recover_control_plane/master/defaults/main.yml
+++ b/roles/recover_control_plane/master/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+bin_dir: /usr/local/bin


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Missing default value for `bin_dir` which will fail the playbook recover-control-plane

**Which issue(s) this PR fixes**:

See above

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
