### PR TITLE
update oidc to contain quotes

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
@@ -128,16 +128,16 @@ apiServer:
     token-auth-file: {{ kube_token_dir }}/known_tokens.csv
 {% endif %}
 {% if kube_oidc_auth|default(false) and kube_oidc_url is defined and kube_oidc_client_id is defined %}
-    oidc-issuer-url: {{ kube_oidc_url }}
-    oidc-client-id: {{ kube_oidc_client_id }}
+    oidc-issuer-url: "{{ kube_oidc_url }}"
+    oidc-client-id: "{{ kube_oidc_client_id }}"
 {%   if kube_oidc_ca_file is defined %}
-    oidc-ca-file: {{ kube_oidc_ca_file }}
+    oidc-ca-file: "{{ kube_oidc_ca_file }}"
 {%   endif %}
 {%   if kube_oidc_username_claim is defined %}
-    oidc-username-claim: {{ kube_oidc_username_claim }}
+    oidc-username-claim: "{{ kube_oidc_username_claim }}"
 {%   endif %}
 {%   if kube_oidc_groups_claim is defined %}
-    oidc-groups-claim: {{ kube_oidc_groups_claim }}
+    oidc-groups-claim: "{{ kube_oidc_groups_claim }}"
 {%   endif %}
 {%   if kube_oidc_username_prefix is defined %}
     oidc-username-prefix: "{{ kube_oidc_username_prefix }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Currently when trying to configure the OpenID provider kubeadm fails to init the cluster and outputs an error saying "unmarshaling JSON" 

The complete error can be seen below:
```
["W1202 13:09:37.856538    3494 strict.go:54] error unmarshaling configuration schema.GroupVersionKind{Group:\"kubeadm.k8s.io\", Version:\"v1beta2\", Kind:\"ClusterConfiguration\"}: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal number into Go struct field APIServer.extraArgs of type string", "v1beta2.ClusterConfiguration.APIServer: v1beta2.APIServer.ControlPlaneComponent: ExtraArgs: ReadString: expects \" or n, but found 1, error found in #10 byte of ...|ient-id\":**************,\"|..., bigger context ...|ostname,ExternalDNS,ExternalIP\",\"oidc-client-id\":123456789,\"oidc-issuer-url\":\"********"], "stdout": "", "stdout_lines": []}
````
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
