### PR TITLE
Add OIDC to CI

### DIFF
--- a/tests/files/packet_centos7-flannel-addons.yml
+++ b/tests/files/packet_centos7-flannel-addons.yml
@@ -25,3 +25,6 @@ metrics_server_kubelet_insecure_tls: true
 kube_token_auth: true
 kube_basic_auth: true
 enable_nodelocaldns: false
+
+kube_oidc_url: https://accounts.google.com/.well-known/openid-configuration
+kube_oidc_client_id: kubespray-example


### PR DESCRIPTION
**What this PR does / why we need it**:
OIDC auth is one of the most common way to authenticate in Kubernetes API. The recent PR #5406 showed some bug with it, therefore I suggest to add it to CI coverage.


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
