### PR TITLE
Add kube-router configuration to enable metrics exposure

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/k8s-net-kube-router.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-net-kube-router.yml
@@ -47,3 +47,12 @@
 
 # Array of common annotations for every node
 # kube_router_annotations_all: []
+
+# Enables scraping kube-router metrics with Prometheus
+# kube_router_enable_metrics: false
+
+# Path to serve Prometheus metrics on
+# kube_router_metrics_path: /metrics
+
+# Prometheus metrics port to use
+# kube_router_metrics_port: 9255

--- a/roles/network_plugin/kube-router/defaults/main.yml
+++ b/roles/network_plugin/kube-router/defaults/main.yml
@@ -49,3 +49,12 @@ kube_router_annotations_node: []
 
 # Array of common annotations for every node
 kube_router_annotations_all: []
+
+# Enables scraping kube-router metrics with Prometheus
+kube_router_enable_metrics: false
+
+# Path to serve Prometheus metrics on
+kube_router_metrics_path: /metrics
+
+# Prometheus metrics port to use
+kube_router_metrics_port: 9255

--- a/roles/network_plugin/kube-router/templates/kube-router.yml.j2
+++ b/roles/network_plugin/kube-router/templates/kube-router.yml.j2
@@ -65,6 +65,12 @@ spec:
       labels:
         k8s-app: kube-router
         tier: node
+      annotations:
+{% if kube_router_enable_metrics %}
+        prometheus.io/path: {{ kube_router_metrics_path }}
+        prometheus.io/port: "{{ kube_router_metrics_port }}"
+        prometheus.io/scrape: "true"
+{% endif %}
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: kube-router
@@ -94,6 +100,10 @@ spec:
 {% endif %}
 {% if kube_router_peer_router_ports %}
         - --peer-router-ports={{ kube_router_peer_router_ports }}
+{% endif %}
+{% if kube_router_enable_metrics %}
+        - --metrics-path={{ kube_router_metrics_path }}
+        - --metrics-port={{ kube_router_metrics_port }}
 {% endif %}
 {% for arg in kube_router_extra_args %}
         - "{{ arg }}"
@@ -129,6 +139,13 @@ spec:
         - name: kubeconfig
           mountPath: /var/lib/kube-router
           readOnly: true
+{% if kube_router_enable_metrics %}
+        ports:
+        - containerPort: {{ kube_router_metrics_port }}
+          hostPort: {{ kube_router_metrics_port }}
+          name: metrics
+          protocol: TCP
+{% endif %}
       initContainers:
       - name: install-cni
         image: {{ busybox_image_repo }}:{{ busybox_image_tag }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind feature

**What this PR does / why we need it**:

This PR add the ability to enable metrics endpoint on kube-router to improve monitoring and service status check. By default, the metrics endpoint is not enabled.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add configuration to enable metrics exposure on kube-router.
```
