### PR TITLE
Return the ability to start control plain from the hyperkube image

### DIFF
--- a/roles/download/templates/kubeadm-images.yaml.j2
+++ b/roles/download/templates/kubeadm-images.yaml.j2
@@ -7,6 +7,7 @@ apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration
 imageRepository: {{ kube_image_repo }}
 kubernetesVersion: {{ kube_version }}
+useHyperKubeImage: {{ kubeadm_use_hyperkube_image }}
 etcd:
   external:
       endpoints:

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
@@ -95,6 +95,7 @@ controlPlaneEndpoint: {{ ip | default(fallback_ips[inventory_hostname]) }}:{{ ku
 {% endif %}
 certificatesDir: {{ kube_cert_dir }}
 imageRepository: {{ kube_image_repo }}
+useHyperKubeImage: {{ kubeadm_use_hyperkube_image }}
 apiServer:
   extraArgs:
 {% if kube_api_anonymous_auth is defined %}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
@@ -98,6 +98,7 @@ controlPlaneEndpoint: {{ ip | default(fallback_ips[inventory_hostname]) }}:{{ ku
 {% endif %}
 certificatesDir: {{ kube_cert_dir }}
 imageRepository: {{ kube_image_repo }}
+useHyperKubeImage: {{ kubeadm_use_hyperkube_image }}
 apiServer:
   extraArgs:
 {% if kube_api_anonymous_auth is defined %}

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -17,6 +17,9 @@ kube_version: v1.16.6
 ## The minimum version working
 kube_version_min_required: v1.15.0
 
+# use HyperKube image to control plane containers
+kubeadm_use_hyperkube_image: False
+
 ## Kube Proxy mode One of ['iptables','ipvs']
 kube_proxy_mode: ipvs
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Return the ability to start control plain from the hyperkube image.
Hyperkube docker image still exists in gcr.io:
https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/hyperkube-amd64

Hyperkube image need to work built-in CEPH RBD provisioner

mileston to remove hyperkube changed to 1.18

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
