### PR TITLE
Fix TF inventory script

### DIFF
--- a/contrib/terraform/terraform.py
+++ b/contrib/terraform/terraform.py
@@ -346,7 +346,7 @@ def iter_host_ips(hosts, ips):
     '''Update hosts that have an entry in the floating IP list'''
     for host in hosts:
         host_id = host[1]['id']
-        use_access_ip = host[1]['metadata']['use_access_ip']
+
         if host_id in ips:
             ip = ips[host_id]
 
@@ -357,8 +357,9 @@ def iter_host_ips(hosts, ips):
                 'ansible_ssh_host': ip,
             })
 
-            if use_access_ip == "0":
+        if 'use_access_ip' in host[1]['metadata'] and ihost[1]['metadata']['use_access_ip'] == "0":
                 host[1].pop('access_ip')
+
         yield host
 
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Fixes a bug when `use_access_ip` is not defined.

```
Traceback (most recent call last):
  File "./hosts", line 462, in <module>
    main()
  File "./hosts", line 447, in main
    output = query_list(hosts)
  File "./hosts", line 378, in query_list
    for name, attrs, hostgroups in hosts:
  File "./hosts", line 349, in iter_host_ips
    use_access_ip = host[1]['metadata']['use_access_ip']
KeyError: 'use_access_ip'
```

**Special notes for your reviewer**:

