### PR TITLE
Re introduce CI for upgrades

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -1,133 +1,126 @@
 ---
-.packet_variables: &packet_variables
-  CI_PLATFORM: "packet"
-  SSH_USER: "kubespray"
-
 .packet: &packet
   extends: .testcases
   variables:
-    <<: *packet_variables
+    CI_PLATFORM: "packet"
+    SSH_USER: "kubespray"
   tags:
     - packet
   only: [/^pr-.*$/]
   except: ['triggers']
 
-.test-upgrade: &test-upgrade
-  variables:
-    UPGRADE_TEST: "graceful"
-
 packet_ubuntu18-calico-aio:
   stage: deploy-part1
-  <<: *packet
+  extends: .packet
   when: on_success
 
 # ### PR JOBS PART2
 
 packet_centos7-flannel-addons:
+  extends: .packet
   stage: deploy-part2
-  <<: *packet
   when: on_success
 
 # ### MANUAL JOBS
 
 packet_centos-weave-kubeadm-sep:
   stage: deploy-part2
-  <<: *packet
+  extends: .packet
   when: on_success
-  only: ['triggers']
-  except: []
+  variables:
+    UPGRADE_TEST: basic
 
 packet_ubuntu-weave-sep:
   stage: deploy-part2
-  <<: *packet
+  extends: .packet
   when: manual
-  only: ['triggers']
-  except: []
 
 # # More builds for PRs/merges (manual) and triggers (auto)
 
 packet_ubuntu-canal-ha:
   stage: deploy-special
-  <<: *packet
+  extends: .packet
   when: manual
 
 packet_ubuntu-canal-kubeadm:
   stage: deploy-part2
-  <<: *packet
+  extends: .packet
   when: on_success
 
 packet_ubuntu-flannel-ha:
   stage: deploy-part2
-  <<: *packet
+  extends: .packet
   when: manual
 
 # Contiv does not work in k8s v1.16
 # packet_ubuntu-contiv-sep:
 #   stage: deploy-part2
-#   <<: *packet
+#   extends: .packet
 #   when: on_success
 
 packet_ubuntu18-cilium-sep:
   stage: deploy-special
-  <<: *packet
+  extends: .packet
   when: manual
 
 packet_ubuntu18-flannel-containerd:
   stage: deploy-part2
-  <<: *packet
+  extends: .packet
   when: manual
 
 packet_debian9-macvlan-sep:
-  stage: unit-tests
-  <<: *packet
+  stage: deploy-part2
+  extends: .packet
   when: manual
 
 packet_debian9-calico-upgrade:
   stage: deploy-part2
-  <<: *packet
+  extends: .packet
   when: on_success
+  variables:
+    UPGRADE_TEST: graceful
 
 packet_debian10-containerd:
   stage: deploy-part2
-  <<: *packet
+  extends: .packet
   when: on_success
 
 packet_centos7-calico-ha:
   stage: deploy-part2
-  <<: *packet
+  extends: .packet
   when: manual
 
 packet_centos7-kube-ovn:
   stage: deploy-part2
-  <<: *packet
+  extends: .packet
   when: on_success
 
 packet_centos7-kube-router:
   stage: deploy-part2
-  <<: *packet
+  extends: .packet
   when: manual
 
 packet_centos7-multus-calico:
   stage: deploy-part2
-  <<: *packet
+  extends: .packet
   when: manual
 
 packet_opensuse-canal:
   stage: deploy-part2
-  <<: *packet
+  extends: .packet
   when: manual
 
 packet_oracle-7-canal:
   stage: deploy-part2
-  <<: *packet
+  extends: .packet
   when: manual
 
 packet_ubuntu-kube-router-sep:
   stage: deploy-part2
-  <<: *packet
+  extends: .packet
   when: manual
 
 packet_amazon-linux-2-aio:
   stage: deploy-part2
-  <<: *packet
+  extends: .packet
   when: manual


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In the 2.12 release cycle, I noticed that upgrade tests are not enabled on any job.

Also replaces YAML anchors by extends to use dict merging.

Also re-adds weave CI jobs.

Depends on #5363