### PR TITLE
Add wait for kubectl get ds after upgrades

### DIFF
--- a/roles/win_nodes/kubernetes_patch/tasks/main.yml
+++ b/roles/win_nodes/kubernetes_patch/tasks/main.yml
@@ -18,6 +18,10 @@
     - name: Check current nodeselector for kube-proxy daemonset
       shell: "{{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf get ds kube-proxy --namespace=kube-system -o jsonpath='{.spec.template.spec.nodeSelector.beta.kubernetes.io/os}'"
       register: current_kube_proxy_state
+      retries: 60
+      delay: 5
+      until: current_kube_proxy_state is succeeded
+
 
     - name: Apply nodeselector patch for kube-proxy daemonset
       shell: "{{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf patch ds kube-proxy --namespace=kube-system --type=strategic -p \"$(cat nodeselector-os-linux-patch.json)\""


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Upgrading from v2.11 to master fails ` Error from server (NotFound): the server could not find the requested resource` with in the `win_nodes/kubernetes_patch : Check current nodeselector for kube-proxy daemonset` task. 

After 2 to 3 minutes the `kubectl get ds` command works, therefore I propose to add a retry.


**Special notes for your reviewer**:
```
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"16", ...
Server Version: version.Info{Major:"1", Minor:"16", ...
$ kubectl get ds
Error from server (NotFound): Unable to list "extensions/v1beta1, Resource=daemonsets": the server could not find the requested resource
$ kubectl get ds -n kube-system kube-proxy
Error from server (NotFound): the server could not find the requested resource
```


I tested this separately here: https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/pipelines/102329471

```
TASK [win_nodes/kubernetes_patch : Check current nodeselector for kube-proxy daemonset] ***
[1;30mtask path: /builds/kargo-ci/kubernetes-sigs-kubespray/roles/win_nodes/kubernetes_patch/tasks/main.yml:18[0m
Wednesday 11 December 2019  15:15:21 +0000 (0:00:01.040)       0:14:24.036 **** 
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (60 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (59 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (58 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (57 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (56 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (55 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (54 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (53 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (52 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (51 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (50 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (49 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (48 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (47 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (46 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (45 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (44 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (43 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (42 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (41 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (40 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (39 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (38 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (37 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (36 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (35 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (34 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (33 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (32 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (31 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (30 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (29 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (28 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (27 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (26 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (25 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (24 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (23 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (22 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (21 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (20 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (19 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (18 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (17 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (16 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (15 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (14 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (13 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (12 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (11 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (10 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (9 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (8 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (7 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (6 retries left).[0m
[1;30mFAILED - RETRYING: Check current nodeselector for kube-proxy daemonset (5 retries left).[0m
[0;33mchanged: [376255923-k8s-master-nf-1] => {"attempts": 57, "changed": true, "cmd": "/usr/local/bin/kubectl --kubeconfig /etc/kubernetes/admin.conf get ds kube-proxy --namespace=kube-system -o jsonpath='{.spec.template.spec.nodeSelector.beta.kubernetes.io/os}'", "delta": "0:00:00.378986", "end": "2019-12-11 15:20:31.256241", "rc": 0, "start": "2019-12-11 15:20:30.877255", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}[0m
```