### PR TITLE
Disable unused gather_facts in remove-node.yml

### DIFF
--- a/remove-node.yml
+++ b/remove-node.yml
@@ -41,7 +41,7 @@
 
 # Currently cannot remove first master or etcd
 - hosts: "{{ node | default('kube-master[1:]:etcd[:1]') }}"
-  gather_facts: yes
+  gather_facts: no
   roles:
     - { role: kubespray-defaults }
     - { role: remove-node/post-remove, tags: post-remove }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
https://github.com/kubernetes-sigs/kubespray/pull/5171#issuecomment-531248698
As mention @mjlshen, last gather_facts don't need to "yes".

**Does this PR introduce a user-facing change?:**
No

**Which issue(s) this PR fixes:**
https://github.com/kubernetes-sigs/kubespray/issues/5160


