### PR TITLE
Fix kube-proxy server replacement and kube-proxy pods restart

### DIFF
--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -111,8 +111,8 @@
     | sed 's#server:.*#server: https://127.0.0.1:{{ kube_apiserver_port }}#g'
     | {{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf replace -f -
   run_once: true
+  delegate_to: "{{ groups['kube-master']|first }}"
   when:
-    - inventory_hostname == groups['kube-master']|first
     - kubeadm_config_api_fqdn is not defined
     - kubeadm_discovery_address != kube_apiserver_endpoint | replace("https://", "")
     - not kube_proxy_remove
@@ -129,8 +129,8 @@
 - name: Restart all kube-proxy pods to ensure that they load the new configmap
   shell: "{{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf delete pod -n kube-system -l k8s-app=kube-proxy --force --grace-period=0"
   run_once: true
+  delegate_to: "{{ groups['kube-master']|first }}"
   when:
-    - inventory_hostname == groups['kube-master']|first
     - kubeadm_config_api_fqdn is not defined
     - kubeadm_discovery_address != kube_apiserver_endpoint | replace("https://", "")
     - not kube_proxy_remove


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Tested with `ansible 2.7.12` but most probably applies to other version as well: ansible does not guarantee the order of the inventory hosts.

**When running ansible-playbook in debug mode (-v,-vv,-vvv) , the first server in the list that ends up running this task** https://github.com/kubernetes-sigs/kubespray/blob/f0f8379e1b7fc86f76b86ce9cd7c13a12525867b/roles/kubernetes/kubeadm/tasks/main.yml#L108 and this one https://github.com/kubernetes-sigs/kubespray/blob/f0f8379e1b7fc86f76b86ce9cd7c13a12525867b/roles/kubernetes/kubeadm/tasks/main.yml#L129 **is almost `NEVER` one of the kubernetes masters, thus these tasks are skipped** (due to the wrong combination of `run_once: true` with `when: inventory_hostname == groups['kube-master']|first`.

I did notice that _running ansible 2.7.x without debug mode always picks the first kube-master if the inventory is structured as the example_, so probably this is the reason it was not caught earlier.

Still, the correct way is to do `run_once: true` with `delegate_to: "{{ groups['kube-master']|first }}"`; this way, regardless of the server in the inventory that ends up running this, it will always be run on the first k8s-master .

**Special notes for your reviewer**:
```
NONE
```
**Does this PR introduce a user-facing change?**:

```
NONE
```