### PR TITLE
cri-o: redhat.yml - remove package cri-tools

### DIFF
--- a/roles/container-engine/cri-o/vars/redhat.yml
+++ b/roles/container-engine/cri-o/vars/redhat.yml
@@ -1,7 +1,6 @@
 ---
 crio_packages:
   - cri-o
-  - cri-tools
   - oci-systemd-hook
 
 crio_service: crio


### PR DESCRIPTION
There is no cri-tools package in CentOS/EPEL/Red Hat.
Additionally, cri-tools is provided into the installation via
roles/download/defaults/main.yml:104:crictl_download_url.


**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes # https://github.com/kubernetes-sigs/kubespray/issues/5143

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note

```
