### PR TITLE
Ensure /etc/sysconfig/proxy file exists during openSUSE bootstrap

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-opensuse.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-opensuse.yml
@@ -1,6 +1,19 @@
 ---
 # OpenSUSE ships with Python installed
 
+- name: Check that /etc/sysconfig/proxy file exists
+  stat:
+    path: /etc/sysconfig/proxy
+  register: stat_result
+
+- name: Create the /etc/sysconfig/proxy empty file
+  file:
+    path: /etc/sysconfig/proxy
+    state: touch
+  when:
+    - http_proxy is defined or https_proxy is defined
+    - not stat_result.stat.exists
+
 - name: Set the http_proxy in /etc/sysconfig/proxy
   lineinfile:
     path: /etc/sysconfig/proxy


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The [bootstrap-opensuse.yml playbook](https://github.com/kubernetes-sigs/kubespray/blob/master/roles/bootstrap-os/tasks/bootstrap-opensuse.yml) configures the proxy values for openSUSE servers but it assumes that the /etc/sysconfig/proxy file exists raising the following error when it doesn't:

```
TASK [bootstrap-os : Set the http_proxy in /etc/sysconfig/proxy] ***************
Friday 13 December 2019  01:14:54 +0100 (0:00:00.078)       0:00:02.333 *******
fatal: [k8s]: FAILED! => {"changed": false, "msg": "Destination /etc/sysconfig/proxy does not exist !", "rc": 257}
```

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
This requires to execute Kubespray on a **openSUSE** server which doesn't have the `/etc/sysconfig/proxy` and define `http_proxy` and/or `https_proxy` environment variables

**Does this PR introduce a user-facing change?**:
None
