### PR TITLE
Update CI to use v2.12.0 image and update release process

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,7 @@ before_script:
   tags:
     - packet
   variables:
-    KUBESPRAY_VERSION: v2.11.0
+    KUBESPRAY_VERSION: v2.12.0
   image: quay.io/kubespray/kubespray:$KUBESPRAY_VERSION
 
 .testcases: &testcases

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,11 +5,12 @@ The Kubespray Project is released on an as-needed basis. The process is as follo
 1. An issue is proposing a new release with a changelog since the last release
 2. At least one of the [approvers](OWNERS_ALIASES) must approve this release
 3. An approver creates [new release in GitHub](https://github.com/kubernetes-sigs/kubespray/releases/new) using a version and tag name like `vX.Y.Z` and attaching the release notes
-4. An approver creates a release branch in the form `release-vX.Y`
+4. An approver creates a release branch in the form `release-X.Y`
 5. The corresponding version of [quay.io/kubespray/kubespray:vX.Y.Z](https://quay.io/repository/kubespray/kubespray) docker image is built and tagged
 6. The `KUBESPRAY_VERSION` variable is updated in `.gitlab-ci.yml`
 7. The release issue is closed
 8. An announcement email is sent to `kubernetes-dev@googlegroups.com` with the subject `[ANNOUNCE] Kubespray $VERSION is released`
+9. The topic of the #kubespray channel is updated with `vX.Y.Z is released! | ...`
 
 ## Major/minor releases, merge freezes and milestones
 


### PR DESCRIPTION
**What this PR does / why we need it**:
As par of the [release process](https://github.com/kubernetes-sigs/kubespray/blob/master/RELEASE.md) we need to update the `KUBESPRAY_VERSION` variable.

I also take this opportunity to fix small things in that process doc.