### PR TITLE
Update api-versions to cleanup depreciated ones

### DIFF
--- a/roles/kubernetes-apps/cluster_roles/files/k8s-cluster-critical-pc.yml
+++ b/roles/kubernetes-apps/cluster_roles/files/k8s-cluster-critical-pc.yml
@@ -1,6 +1,5 @@
 ---
-
-apiVersion: scheduling.k8s.io/v1beta1
+apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: k8s-cluster-critical


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
Update API used 

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
PriorityClass resources will no longer be served from scheduling.k8s.io/v1beta1 and scheduling.k8s.io/v1alpha1 in v1.17. Migrate to the scheduling.k8s.io/v1 API, available since v1.14. Existing persisted data can be retrieved via the scheduling.k8s.io/v1 API.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
