### PR TITLE
remove duplicate ppa step and replace with circtl package download

### DIFF
--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -30,11 +30,10 @@
     state: present
   when: ansible_distribution in ["Ubuntu"]
 
-- name: Add CRI-O PPA
-  apt_repository:
-    repo: ppa:projectatomic/ppa
-    state: present
-  when: ansible_distribution in ["Ubuntu"]
+- name: crictl | Download crictl
+  include_tasks: "../../../download/tasks/download_file.yml"
+  vars:
+    download: "{{ download_defaults | combine(downloads.crictl) }}"
 
 - name: Install crictl
   unarchive:


### PR DESCRIPTION
fix error that crictl package not downloaded before install.
```
TASK [container-engine/cri-o : Install crictl] *********************************
fatal: [more-crab]: FAILED! => {"changed": false, "msg": "Source '/tmp/releases/crictl-v1.16.1-linux-amd64.tar.gz' does not exist"}
```


**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
fix crictl install bug

**Which issue(s) this PR fixes**:
fix error that crictl package not downloaded before install.

**Special notes for your reviewer**:
crio version 1.16 's not available on ppa yet, so the ansible tasks of this version of crio installation will still fail until package available on ppa.

**Does this PR introduce a user-facing change?**:
No

```release-note

```
