### PR TITLE
Use 'private_dns' as hostname in inventory file

### DIFF
--- a/contrib/terraform/aws/create-infrastructure.tf
+++ b/contrib/terraform/aws/create-infrastructure.tf
@@ -150,12 +150,12 @@ data "template_file" "inventory" {
 
   vars = {
     public_ip_address_bastion = "${join("\n", formatlist("bastion ansible_host=%s", aws_instance.bastion-server.*.public_ip))}"
-    connection_strings_master = "${join("\n", formatlist("%s ansible_host=%s", aws_instance.k8s-master.*.tags.Name, aws_instance.k8s-master.*.private_ip))}"
-    connection_strings_node   = "${join("\n", formatlist("%s ansible_host=%s", aws_instance.k8s-worker.*.tags.Name, aws_instance.k8s-worker.*.private_ip))}"
-    connection_strings_etcd   = "${join("\n", formatlist("%s ansible_host=%s", aws_instance.k8s-etcd.*.tags.Name, aws_instance.k8s-etcd.*.private_ip))}"
-    list_master               = "${join("\n", aws_instance.k8s-master.*.tags.Name)}"
-    list_node                 = "${join("\n", aws_instance.k8s-worker.*.tags.Name)}"
-    list_etcd                 = "${join("\n", aws_instance.k8s-etcd.*.tags.Name)}"
+    connection_strings_master = "${join("\n", formatlist("%s ansible_host=%s", aws_instance.k8s-master.*.private_dns, aws_instance.k8s-master.*.private_ip))}"
+    connection_strings_node   = "${join("\n", formatlist("%s ansible_host=%s", aws_instance.k8s-worker.*.private_dns, aws_instance.k8s-worker.*.private_ip))}"
+    connection_strings_etcd   = "${join("\n", formatlist("%s ansible_host=%s", aws_instance.k8s-etcd.*.private_dns, aws_instance.k8s-etcd.*.private_ip))}"
+    list_master               = "${join("\n", aws_instance.k8s-master.*.private_dns)}"
+    list_node                 = "${join("\n", aws_instance.k8s-worker.*.private_dns)}"
+    list_etcd                 = "${join("\n", aws_instance.k8s-etcd.*.private_dns)}"
     elb_api_fqdn              = "apiserver_loadbalancer_domain_name=\"${module.aws-elb.aws_elb_api_fqdn}\""
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind flake

**What this PR does / why we need it**:
At the moment, terraform for provisioning aws infrastructure will place tags.Name into inventory file, operator need update the hostname base on https://github.com/kubernetes-sigs/kubespray/blob/master/docs/aws.md . So it's better to use 'private_dns' for inventory.

**Which issue(s) this PR fixes**:
This PR use 'private_dns' instead of 'tags.Name' for inventory file

Fixes #5462 
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
None
```
