### PR TITLE
Clean kubectl cache after upgrade on first master

### DIFF
--- a/roles/kubernetes/master/tasks/kubeadm-upgrade.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-upgrade.yml
@@ -38,6 +38,14 @@
     - kubeadm_upgrade.stdout_lines | length > 1
   notify: Master | restart kubelet
 
+- name: kubeadm | clean kubectl cache to refresh api types
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - /root/.kube/cache
+    - /root/.kube/http-cache
+
 # FIXME: https://github.com/kubernetes/kubeadm/issues/1318
 - name: kubeadm | scale down coredns replicas to 0 if not using coredns dns_mode
   command: >-


### PR DESCRIPTION
Resolves issue where kubectl cache of <v1.16 api schema
interferes with interacting with daemonsets and deployments.