### PR TITLE
Fix invalid variable in host inventory script

### DIFF
--- a/contrib/terraform/terraform.py
+++ b/contrib/terraform/terraform.py
@@ -357,7 +357,7 @@ def iter_host_ips(hosts, ips):
                 'ansible_ssh_host': ip,
             })
 
-        if 'use_access_ip' in host[1]['metadata'] and ihost[1]['metadata']['use_access_ip'] == "0":
+        if 'use_access_ip' in host[1]['metadata'] and host[1]['metadata']['use_access_ip'] == "0":
                 host[1].pop('access_ip')
 
         yield host


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: actually the script for dynamic inventory (from `tfstate`) does not work due of invalid python variable ~`ihost`~ -> `host`