### PR TITLE
Configure http proxies for crio-o container engine

### DIFF
--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -72,6 +72,17 @@
     owner: root
     mode: 0755
 
+- name: Create cri-o service systemd directory if it doesn't exist
+  file:
+    path: /etc/systemd/system/{{ crio_service }}.service.d
+    state: directory
+
+- name: Write cri-o proxy drop-in
+  template:
+    src: http-proxy.conf.j2
+    dest: /etc/systemd/system/{{ crio_service }}.service.d/http-proxy.conf
+  when: http_proxy is defined or https_proxy is defined
+
 - name: Reload systemd daemon
   systemd:
     daemon_reload: yes

--- a/roles/container-engine/cri-o/templates/http-proxy.conf.j2
+++ b/roles/container-engine/cri-o/templates/http-proxy.conf.j2
@@ -1,0 +1,2 @@
+[Service]
+Environment={% if http_proxy is defined %}"http_proxy={{ http_proxy }}"{% endif %} {% if https_proxy is defined %}"https_proxy={{ https_proxy }}"{% endif %} {% if no_proxy is defined %}"no_proxy={{ no_proxy }}"{% endif %}


### PR DESCRIPTION
**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:

This PR makes the cri-o daemon aware of http/https proxies.
This is required in restricted environments where the only way to pull external images is by using a provided http/https proxy.

**Which issue(s) this PR fixes**:

Fixes #5485 

**Special notes for your reviewer**:

This PR implements the feature using a systemd drop-in, similar to how http proxy is implemented with the docker container engine. No new attributes are required, we use http_proxy, https_proxy and no_proxy which already exist.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```