### PR TITLE
Add Vagrant CI

### DIFF
--- a/.gitlab-ci/vagrant.yml
+++ b/.gitlab-ci/vagrant.yml
@@ -14,3 +14,24 @@ molecule_tests:
     - python -m pip install -r tests/requirements.txt
   script:
     - ./tests/scripts/molecule_run.sh
+
+.vagrant:
+  extends: .testcases
+  variables:
+    CI_PLATFORM: "vagrant"
+    SSH_USER: "kubespray"
+    VAGRANT_DEFAULT_PROVIDER: "libvirt"
+  tags: [vagrant]
+  only: [/^pr-.*$/]
+  except: ['triggers']
+  image: quay.io/miouge/kubespray-vagrant
+  services: []
+  script:
+    - vagrant up
+  after_script:
+    - vagrant destroy --force
+
+vagrant_ubuntu18-flannel:
+  stage: deploy-part2
+  extends: .vagrant
+  when: on_success

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,7 +43,7 @@ $vm_memory ||= 2048
 $vm_cpus ||= 1
 $shared_folders ||= {}
 $forwarded_ports ||= {}
-$subnet ||= "172.17.8"
+$subnet ||= "172.18.8"
 $os ||= "ubuntu1804"
 $network_plugin ||= "flannel"
 # Setting multi_networking to true will install Multus: https://github.com/intel/multus-cni


### PR DESCRIPTION
The vagrant support documented in `README.md` is very useful to local tests and quick experiments with Kubespray. It can easily be broken therefore it deserves some form of CI.

This PR tests that `vagrant up` with all default settings works.

By default docker uses `172.17.0.0/16` which conflicts with `172.17.8.0/24` which was used by default in Vagrantfile.