### PR TITLE
Rebase on 2.12

### DIFF
--- a/tests/scripts/rebase.sh
+++ b/tests/scripts/rebase.sh
@@ -5,5 +5,5 @@ set -euxo pipefail
 if [[ $CI_COMMIT_REF_NAME == pr-* ]]; then
   git config user.email "ci@kubespray.io"
   git config user.name "CI"
-  git pull --rebase origin master
+  git pull --rebase origin release-2.12
 fi


### PR DESCRIPTION
When making a PR for `release-2.12` we should rebase on `release-2.12` instead of master.