### PR TITLE
Fix Cinder CSI bugs

### DIFF
--- a/roles/kubernetes-apps/csi_driver/cinder/defaults/main.yml
+++ b/roles/kubernetes-apps/csi_driver/cinder/defaults/main.yml
@@ -2,15 +2,16 @@
 # To access Cinder, the CSI controller will need credentials to access
 # openstack apis. Per default this values will be
 # read from the environment.
-cinder_auth_url: "{{ lookup('env','OS_AUTH_URL')  }}"
-cinder_username: "{{ lookup('env','OS_USERNAME')  }}"
-cinder_password: "{{ lookup('env','OS_PASSWORD')  }}"
-cinder_region: "{{ lookup('env','OS_REGION_NAME')  }}"
-cinder_tenant_id: "{{ lookup('env','OS_TENANT_ID')| default(lookup('env','OS_PROJECT_ID')|default(lookup('env','OS_PROJECT_NAME'),true),true) }}"
-cinder_tenant_name: "{{ lookup('env','OS_TENANT_NAME') }}"
+cinder_auth_url: "{{ lookup('env','OS_AUTH_URL') }}"
+cinder_username: "{{ lookup('env','OS_USERNAME') }}"
+cinder_password: "{{ lookup('env','OS_PASSWORD') }}"
+cinder_region: "{{ lookup('env','OS_REGION_NAME') }}"
+cinder_tenant_id: "{{ lookup('env','OS_TENANT_ID')| default(lookup('env','OS_PROJECT_ID'),true) }}"
+cinder_tenant_name: "{{ lookup('env','OS_TENANT_NAME')| default(lookup('env','OS_PROJECT_NAME'),true) }}"
 cinder_domain_name: "{{ lookup('env','OS_USER_DOMAIN_NAME') }}"
 cinder_domain_id: "{{ lookup('env','OS_USER_DOMAIN_ID') }}"
 cinder_cacert: "{{ lookup('env','OS_CACERT') }}"
+
 # For now, only Cinder v3 is supported in Cinder CSI driver
 cinder_blockstorage_version: "v3"
 cinder_csi_controller_replicas: 1

--- a/roles/kubernetes-apps/csi_driver/cinder/tasks/cinder-credential-check.yml
+++ b/roles/kubernetes-apps/csi_driver/cinder/tasks/cinder-credential-check.yml
@@ -21,14 +21,14 @@
 
 - name: Cinder CSI Driver | check cinder_tenant_id value
   fail:
-    msg: "one of cinder_tenant_id or cinder_trust_id must be specified"
+    msg: "one of cinder_tenant_id or cinder_tenant_name must be specified"
   when:
     - cinder_tenant_id is not defined or not cinder_tenant_id
-    - cinder_trust_id is not defined
+    - cinder_tenant_name is not defined
 
-- name: Cinder CSI Driver | check cinder_trust_id value
+- name: Cinder CSI Driver | check cinder_tenant_name value
   fail:
-    msg: "one of cinder_tenant_id or cinder_trust_id must be specified"
+    msg: "one of cinder_tenant_id or cinder_tenant_name must be specified"
   when:
-    - cinder_trust_id is not defined or not cinder_trust_id
+    - cinder_tenant_name is not defined or not cinder_tenant_name
     - cinder_tenant_id is not defined

--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-cloud-config.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-cloud-config.j2
@@ -3,9 +3,7 @@ auth-url="{{ cinder_auth_url }}"
 username="{{ cinder_username }}"
 password="{{ cinder_password }}"
 region="{{ cinder_region }}"
-{% if cinder_trust_id is defined and cinder_trust_id != "" %}
-trust-id="{{ cinder_trust_id }}"
-{% else %}
+{% if cinder_tenant_id is defined and cinder_tenant_id != "" %}
 tenant-id="{{ cinder_tenant_id }}"
 {% endif %}
 {% if cinder_tenant_name is defined and cinder_tenant_name != "" %}

--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin.yml.j2
@@ -90,7 +90,7 @@ spec:
             - name: secret-cinderplugin
               mountPath: /etc/config
               readOnly: true
-{% if cinder_cacert is defined %}
+{% if cinder_cacert is defined and cinder_cacert != "" %}
             - name: cinder-cacert
               mountPath: {{ kube_config_dir }}/cinder-cacert.pem
               readOnly: true
@@ -101,7 +101,7 @@ spec:
         - name: secret-cinderplugin
           secret:
             secretName: cloud-config
-{% if cinder_cacert is defined %}
+{% if cinder_cacert is defined and cinder_cacert != "" %}
         - name: cinder-cacert
           hostPath:
             path: {{ kube_config_dir }}/cinder-cacert.pem


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This fixes some issues with the Cinder CSI implementation I didn't notice until I've made external OpenStack CCM: https://github.com/kubernetes-sigs/kubespray/pull/5491

**Special notes for your reviewer**:
The problems were:
- OS_PROJECT_NAME env variable can't be used for the tenant_id of the cloud controller, this was inherited from the in-tree implementation
- The user must define either tenant_id or tenant_name to identify against OpenStack APIs
- os_cacert shouldn't be mounted if it is empty