### PR TITLE
Set helm 3.0 as default

### DIFF
--- a/docs/vars.md
+++ b/docs/vars.md
@@ -179,7 +179,8 @@ in the form of dicts of key-value pairs of configuration parameters that will be
 
 ## App variables
 
-* *helm_version* - Defaults to v2.x, set to a v3 version (e.g. `v3.0.1` ) to install Helm 3.x (no more Tiller!). When changing this to 3 in an existing cluster, Tiller will be left alone and has to be removed manually.
+* *helm_version* - Defaults to v3.x, set to a v2 version (e.g. `v2.16.1` ) to install Helm 2.x (will install Tiller!). 
+Picking v3 for an existing cluster running Tiller will leave it alone. In that case you will have to remove Tiller manually afterwards.
 
 ## User accounts
 

--- a/docs/vars.md
+++ b/docs/vars.md
@@ -179,7 +179,7 @@ in the form of dicts of key-value pairs of configuration parameters that will be
 
 ## App variables
 
-* *helm_version* - Defaults to v3.x, set to a v2 version (e.g. `v2.16.1` ) to install Helm 2.x (will install Tiller!). 
+* *helm_version* - Defaults to v3.x, set to a v2 version (e.g. `v2.16.1` ) to install Helm 2.x (will install Tiller!).
 Picking v3 for an existing cluster running Tiller will leave it alone. In that case you will have to remove Tiller manually afterwards.
 
 ## User accounts

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -426,7 +426,7 @@ test_image_repo: "{{ docker_image_repo }}/library/busybox"
 test_image_tag: latest
 busybox_image_repo: "{{ docker_image_repo }}/library/busybox"
 busybox_image_tag: 1.29.2
-helm_version: "v2.16.1"
+helm_version: "v3.0.2"
 helm_image_repo: "{{ docker_image_repo }}/lachlanevenson/k8s-helm"
 helm_image_tag: "{{ helm_version }}"
 tiller_image_repo: "{{ gcr_image_repo }}/kubernetes-helm/tiller"

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -426,7 +426,7 @@ test_image_repo: "{{ docker_image_repo }}/library/busybox"
 test_image_tag: latest
 busybox_image_repo: "{{ docker_image_repo }}/library/busybox"
 busybox_image_tag: 1.29.2
-helm_version: "v3.0.2"
+helm_version: "v3.0.3"
 helm_image_repo: "{{ docker_image_repo }}/lachlanevenson/k8s-helm"
 helm_image_tag: "{{ helm_version }}"
 tiller_image_repo: "{{ gcr_image_repo }}/kubernetes-helm/tiller"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This changes the default helm version to v3.0. 


**Does this PR introduce a user-facing change?**:

action required!

Users will have to be made aware how they can migrate their existing v2 objects to v3 (https://helm.sh/docs/topics/v2_v3_migration/ and https://github.com/helm/helm-2to3), and be told the following:

- Upgraders will still have Tiller running, so only when they use the helm binary on their api/master nodes will they have to do something. I  think a lot of people use local helm binaries as well, which won't be impacted.
- New installs won't have a Tiller, so can only use Helm v3. They either have to change helm_version or be made aware of the namespaced scope of v3.

```release-note

Upgrading to Helm v3

This release installs Helm v3 by default. You can stop this from happening by setting `helm_version = 'v2.16.1'` for example in `group_vars/k8s-cluster/addons.yml`.

When this is an upgrade of an existing cluster, follow the steps outlined by https://helm.sh/docs/topics/v2_v3_migration/ and https://github.com/helm/helm-2to3 afterwards to convert your Helm v2 releases to v3.

After the upgrade to Helm v3, Tiller will still be running on your cluster, but the `helm` binary on the api/master nodes will be replaced by a v3 counterpart. You won't be able to access/modify/upgrade your Helm v2 releases by using the default 'helm' binary on those nodes. Please manually download a Helm v2 binary on your workstation to modify existing v2 releases, or use the 2to3 plugin to convert everything to v3.

You will have to remove Tiller from your cluster manually ( or through the 2to3 plugin cleanup action) after everything has been migrated to v3.
```
