### PR TITLE
Add OWNERS file for recover_control_plane

### DIFF
--- a/roles/recover_control_plane/OWNERS
+++ b/roles/recover_control_plane/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - qvicksilver
+  - yujunz
+reviewers:
+  - qvicksilver
+  - yujunz


### PR DESCRIPTION
Related to #5432

**What type of PR is this?**

> /kind documentation

**What this PR does / why we need it**:

Offering helps on #5432 

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

Volunteer to help maintaining the role `recover_control_plane`

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
