### PR TITLE
Set pipefail in case tar fails

### DIFF
--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -127,7 +127,7 @@
     - "{{ my_etcd_node_certs }}"
 
 - name: Gen_certs | Gather node certs
-  shell: "tar cfz - -C {{ etcd_cert_dir }} -T /dev/stdin <<< {{ my_etcd_node_certs|join(' ') }} | base64 --wrap=0"
+  shell: "set -o pipefail && tar cfz - -C {{ etcd_cert_dir }} -T /dev/stdin <<< {{ my_etcd_node_certs|join(' ') }} | base64 --wrap=0"
   args:
     executable: /bin/bash
     warn: false


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
It fixes the case when tar fails (I hit "tar: /dev/stdin: Cannot stat: Stale file handle\ntar: Error is not recoverable: exiting now" sometimes)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
