### PR TITLE
Honor bastion host config from inventary

### DIFF
--- a/contrib/metallb/metallb.yml
+++ b/contrib/metallb/metallb.yml
@@ -1,6 +1,12 @@
 ---
+- hosts: bastion[0]
+  gather_facts: False
+  roles:
+    - { role: kubespray-defaults}
+    - { role: bastion-ssh-config, tags: ["localhost", "bastion"]}
 - hosts: kube-master[0]
   tags:
     - "provision"
   roles:
+    - { role: kubespray-defaults}
     - { role: provision }


### PR DESCRIPTION
Before this commit, the bastion entry in the inventary was not honored,
so machines behind firewalls or with unrouted addresses were not
reachable for ansible.

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Honor bastion entry in inventary.ini

**Which issue(s) this PR fixes**:
Fixes #5521

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
NONE

```release-note

```
