### PR TITLE
Raise typha max connections to 300

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/k8s-net-calico.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-net-calico.yml
@@ -40,5 +40,9 @@
 # Generate TLS certs for secure typha<->calico-node communication
 # typha_secure: false
 
+# Scaling typha: 1 replica per 100 nodes is adequate
 # Number of typha replicas
 # typha_replicas: 1
+
+# Set max typha connections
+# typha_max_connections_lower_limit: 300

--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -74,8 +74,14 @@ kube_etcd_key_file: node-{{ inventory_hostname }}-key.pem
 
 # Use typha (only with kdd)
 typha_enabled: false
+
+# Scaling typha: 1 replica per 100 nodes is adequate
 # Number of typha replicas
 typha_replicas: 1
+
+# Set max typha connections
+typha_max_connections_lower_limit: 300
+
 
 # Generate certifcates for typha<->calico-node communication
 typha_secure: false

--- a/roles/network_plugin/calico/templates/calico-typha.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-typha.yml.j2
@@ -82,6 +82,8 @@ spec:
             value: "kubernetes"
           - name: TYPHA_HEALTHENABLED
             value: "true"
+          - name: TYPHA_MAXCONNECTIONSLOWERLIMIT
+            value: "{{ typha_max_connections_lower_limit }}"
 {% if typha_secure %}
           - name: TYPHA_CAFILE
             value: /etc/ca/ca.crt


### PR DESCRIPTION
Raises limit from 100 to 300 because the default is far too low
and the pod can handle 300 with the given resources.

/kind feature
