### PR TITLE
Remove downloading deprecated calico-rr image

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -69,7 +69,6 @@ calico_version: "v3.11.1"
 calico_ctl_version: "v3.11.1"
 calico_cni_version: "v3.11.1"
 calico_policy_version: "v3.11.1"
-calico_rr_version: "v0.6.3"
 calico_typha_version: "v3.11.1"
 typha_enabled: false
 
@@ -310,8 +309,6 @@ calico_cni_image_repo: "{{ docker_image_repo }}/calico/cni"
 calico_cni_image_tag: "{{ calico_cni_version }}"
 calico_policy_image_repo: "{{ docker_image_repo }}/calico/kube-controllers"
 calico_policy_image_tag: "{{ calico_policy_version }}"
-calico_rr_image_repo: "{{ docker_image_repo }}/calico/routereflector"
-calico_rr_image_tag: "{{ calico_rr_version }}"
 calico_typha_image_repo: "{{ docker_image_repo }}/calico/typha"
 calico_typha_image_tag: "{{ calico_typha_version }}"
 pod_infra_image_repo: "{{ gcr_image_repo }}/google_containers/pause-{{ image_arch }}"
@@ -607,15 +604,6 @@ downloads:
     sha256: "{{ calico_policy_digest_checksum|default(None) }}"
     groups:
       - k8s-cluster
-
-  calico_rr:
-    enabled: "{{ peer_with_calico_rr is defined and peer_with_calico_rr and kube_network_plugin == 'calico' }}"
-    container: true
-    repo: "{{ calico_rr_image_repo }}"
-    tag: "{{ calico_rr_image_tag }}"
-    sha256: "{{ calico_rr_digest_checksum|default(None) }}"
-    groups:
-      - calico-rr
 
   calico_typha:
     enabled: "{{ typha_enabled }}"


### PR DESCRIPTION
This is no longer necessary for calico-rr mode, which was recently refactored to do route reflection using calico/node image