### PR TITLE
Fix temp filename for debian-10 image

### DIFF
--- a/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
@@ -37,7 +37,7 @@ images:
     converted: true
 
   debian-10:
-    filename: debian-9-openstack-amd64.qcow2
+    filename: debian-10-openstack-amd64.qcow2
     url: https://cdimage.debian.org/cdimage/openstack/current-10/debian-10-openstack-amd64.qcow2
     checksum: sha512:296ad8345cb49e52464a0cb8bf4365eb0b9e4220c47ebdd73d134d51effc756d5554aee15027fffd038fef4ad5fa984c94208bce60572d58b2ab26f74bb2a5de
     converted: true


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Debian 10 should use the debian-10 temporary file name instead of debian-9.