### PR TITLE
use correct ip for checking kubeconfig kube-apiserver ip

### DIFF
--- a/roles/kubernetes/master/tasks/kubeadm-fix-apiserver.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-fix-apiserver.yml
@@ -1,11 +1,13 @@
 ---
 - name: Test if correct apiserver is set in all kubeconfigs
   shell: >-
-    grep -Fq "{{ kube_apiserver_endpoint }}" {{ kube_config_dir }}/admin.conf &&
-    grep -Fq "{{ kube_apiserver_endpoint }}" {{ kube_config_dir }}/controller-manager.conf &&
-    grep -Fq "{{ kube_apiserver_endpoint }}" {{ kube_config_dir }}/kubelet.conf &&
-    grep -Fq "{{ kube_apiserver_endpoint }}" {{ kube_config_dir }}/scheduler.conf
+    grep -Fq "{{ kubeconfig_correct_ip }}" {{ kube_config_dir }}/admin.conf &&
+    grep -Fq "{{ kubeconfig_correct_ip }}" {{ kube_config_dir }}/controller-manager.conf &&
+    grep -Fq "{{ kubeconfig_correct_ip }}" {{ kube_config_dir }}/kubelet.conf &&
+    grep -Fq "{{ kubeconfig_correct_ip }}" {{ kube_config_dir }}/scheduler.conf
   register: kubeconfig_correct_apiserver
+  vars:
+    kubeconfig_correct_ip: "{{ ip | default(fallback_ips[inventory_hostname]) }}"
   changed_when: False
   failed_when: False
 


### PR DESCRIPTION
It was using 127.0.0.1 as apiserver IP by accident, which forced restarting control plane components every run