### PR TITLE
Remove docker-engine repository no longer active (#5542)

### DIFF
--- a/roles/container-engine/containerd/templates/rh_containerd.repo.j2
+++ b/roles/container-engine/containerd/templates/rh_containerd.repo.j2
@@ -7,13 +7,3 @@ keepcache={{ docker_rpm_keepcache | default('1') }}
 gpgkey={{ docker_rh_repo_gpgkey }}
 {% if http_proxy is defined %}proxy={{ http_proxy }}{% endif %}
 {% if ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 8 %}module_hotfixes=True{% endif %}
-
-[docker-engine]
-name=Docker-Engine Repository
-baseurl={{ dockerproject_rh_repo_base_url }}
-enabled=1
-gpgcheck=1
-keepcache={{ docker_rpm_keepcache | default('1') }}
-gpgkey={{ dockerproject_rh_repo_gpgkey }}
-{% if http_proxy is defined %}proxy={{ http_proxy }}{% endif %}
-{% if ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 8 %}module_hotfixes=True{% endif %}

--- a/roles/container-engine/docker/defaults/main.yml
+++ b/roles/container-engine/docker/defaults/main.yml
@@ -38,15 +38,11 @@ docker_ubuntu_repo_gpgkey: 'https://download.docker.com/linux/ubuntu/gpg'
 # Debian docker-ce repo
 docker_debian_repo_base_url: "https://download.docker.com/linux/debian"
 docker_debian_repo_gpgkey: 'https://download.docker.com/linux/debian/gpg'
-# dockerproject repo
-dockerproject_rh_repo_base_url: 'https://yum.dockerproject.org/repo/main/centos/7'
-dockerproject_rh_repo_gpgkey: 'https://yum.dockerproject.org/gpg'
-dockerproject_apt_repo_base_url: 'https://apt.dockerproject.org/repo'
-dockerproject_apt_repo_gpgkey: 'https://apt.dockerproject.org/gpg'
-docker_bin_dir: "/usr/bin"
 # CentOS/RedHat Extras repo
 extras_rh_repo_base_url: "http://mirror.centos.org/centos/$releasever/extras/$basearch/"
 extras_rh_repo_gpgkey: "http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-7"
+# Docker binary directory
+docker_bin_dir: "/usr/bin"
 
 # flag to enable/disable docker cleanup
 docker_orphan_clean_up: false

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -27,8 +27,8 @@
   tags:
     - facts
 
-# https://yum.dockerproject.org/repo/main/opensuse/ contains packages for an EOL
-# openSUSE version so we can't use it. The only alternative is to use the docker
+# https://yum.dockerproject.org/repo/main/opensuse/ is no longer valid
+# so we can't use it. The only alternative is to use the docker
 # packages from the distribution repositories.
 - name: Warn about Docker version on SUSE
   debug:

--- a/roles/container-engine/docker/templates/rh_docker.repo.j2
+++ b/roles/container-engine/docker/templates/rh_docker.repo.j2
@@ -7,13 +7,3 @@ keepcache={{ docker_rpm_keepcache | default('1') }}
 gpgkey={{ docker_rh_repo_gpgkey }}
 {% if http_proxy is defined %}proxy={{ http_proxy }}{% endif %}
 {% if ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 8 %}module_hotfixes=True{% endif %}
-
-[docker-engine]
-name=Docker-Engine Repository
-baseurl={{ dockerproject_rh_repo_base_url }}
-enabled=1
-gpgcheck=1
-keepcache={{ docker_rpm_keepcache | default('1') }}
-gpgkey={{ dockerproject_rh_repo_gpgkey }}
-{% if http_proxy is defined %}proxy={{ http_proxy }}{% endif %}
-{% if ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 8 %}module_hotfixes=True{% endif %}

--- a/roles/container-engine/docker/vars/debian.yml
+++ b/roles/container-engine/docker/vars/debian.yml
@@ -35,17 +35,3 @@ docker_repo_info:
        deb {{ docker_debian_repo_base_url }}
        {{ ansible_distribution_release|lower }}
        stable
-
-dockerproject_repo_key_info:
-  pkg_key: apt_key
-  url: '{{ dockerproject_apt_repo_gpgkey }}'
-  repo_keys:
-    - 58118E89F3A912897C070ADBF76221572C52609D
-
-dockerproject_repo_info:
-  pkg_repo: apt_repository
-  repos:
-    - >
-       deb {{ dockerproject_apt_repo_base_url }}
-       {{ ansible_distribution|lower }}-{{ ansible_distribution_release|lower }}
-       main

--- a/roles/container-engine/docker/vars/redhat.yml
+++ b/roles/container-engine/docker/vars/redhat.yml
@@ -3,7 +3,6 @@ docker_kernel_min_version: '0'
 
 # https://docs.docker.com/engine/installation/linux/centos/#install-from-a-package
 # https://download.docker.com/linux/centos/7/x86_64/stable/Packages/
-# https://yum.dockerproject.org/repo/main/centos/7
 # or do 'yum --showduplicates list docker-engine'
 docker_versioned_pkg:
   'latest': docker-ce

--- a/roles/container-engine/docker/vars/ubuntu-amd64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-amd64.yml
@@ -34,17 +34,3 @@ docker_repo_info:
        deb {{ docker_ubuntu_repo_base_url }}
        {{ ansible_distribution_release|lower }}
        stable
-
-dockerproject_repo_key_info:
-  pkg_key: apt_key
-  url: '{{ dockerproject_apt_repo_gpgkey }}'
-  repo_keys:
-    - 58118E89F3A912897C070ADBF76221572C52609D
-
-dockerproject_repo_info:
-  pkg_repo: apt_repository
-  repos:
-    - >
-       deb {{ dockerproject_apt_repo_base_url }}
-       {{ ansible_distribution|lower }}-{{ ansible_distribution_release|lower }}
-       main

--- a/roles/container-engine/docker/vars/ubuntu-arm64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-arm64.yml
@@ -30,17 +30,3 @@ docker_repo_info:
        deb {{ docker_ubuntu_repo_base_url }}
        {{ ansible_distribution_release|lower }}
        stable
-
-dockerproject_repo_key_info:
-  pkg_key: apt_key
-  url: '{{ dockerproject_apt_repo_gpgkey }}'
-  repo_keys:
-    - 58118E89F3A912897C070ADBF76221572C52609D
-
-dockerproject_repo_info:
-  pkg_repo: apt_repository
-  repos:
-    - >
-       deb {{ dockerproject_apt_repo_base_url }}
-       {{ ansible_distribution|lower }}-{{ ansible_distribution_release|lower }}
-       main


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Removal of docker-engine repositories, deprecated for a long time and finally removed last night!

**Which issue(s) this PR fixes**:
Fixes #5542

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
