### PR TITLE
[2.12] Ensure we always fixup kube-proxy kubeconfig

### DIFF
--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -111,8 +111,8 @@
     | sed 's#server:.*#server: https://127.0.0.1:{{ kube_apiserver_port }}#g'
     | {{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf replace -f -
   run_once: true
+  delegate_to: "{{ groups['kube-master']|first }}"
   when:
-    - inventory_hostname == groups['kube-master']|first
     - kubeadm_config_api_fqdn is not defined
     - kubeadm_discovery_address != kube_apiserver_endpoint | replace("https://", "")
     - not kube_proxy_remove
@@ -129,8 +129,8 @@
 - name: Restart all kube-proxy pods to ensure that they load the new configmap
   shell: "{{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf delete pod -n kube-system -l k8s-app=kube-proxy --force --grace-period=0"
   run_once: true
+  delegate_to: "{{ groups['kube-master']|first }}"
   when:
-    - inventory_hostname == groups['kube-master']|first
     - kubeadm_config_api_fqdn is not defined
     - kubeadm_discovery_address != kube_apiserver_endpoint | replace("https://", "")
     - not kube_proxy_remove
@@ -153,8 +153,8 @@
 - name: Delete kube-proxy daemonset if kube_proxy_remove set, e.g. kube_network_plugin providing proxy services
   shell: "{{ bin_dir }}/kubectl --kubeconfig /etc/kubernetes/admin.conf delete daemonset -n kube-system kube-proxy"
   run_once: true
+  delegate_to: "{{ groups['kube-master']|first }}"
   when:
-    - inventory_hostname == groups['kube-master']|first
     - kube_proxy_remove
     - kubeadm_discovery_address != kube_apiserver_endpoint | replace("https://", "")
   # When scaling/adding nodes in the existing k8s cluster, kube-proxy wouldn't be created, as `kubeadm init` wouldn't run.


### PR DESCRIPTION
When running with serial != 100%, like upgrade_cluster.yml, we need to apply this fixup each time
Problem was introduced in 05dc2b3a097fda2ffff7a77f4ca843d0e41dec76

Signed-off-by: Etienne Champetier <champetier.etienne@gmail.com>
(cherry picked from commit 5e9479cdedc21c7a1c6b2fb3b85ad863212ff521)

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
backport 5e9479cdedc21c7a1c6b2fb3b85ad863212ff521 / #5524 to release-2.12

**Which issue(s) this PR fixes**:
Fixes #5520 for release-2.12

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Ensure we set the correct API address in kube-proxy kubeconfig when running `upgrade_cluster.yml` to have properly working HA
You can check how your cluster is currently configured `kubectl get -n kube-system configmaps kube-proxy -o yaml | grep server`
```