### PR TITLE
tag role kubernetes/node-label in playbooks

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -78,7 +78,7 @@
     - { role: kubespray-defaults}
     - { role: kubernetes/kubeadm, tags: kubeadm}
     - { role: network_plugin, tags: network }
-    - { role: kubernetes/node-label }
+    - { role: kubernetes/node-label, tags: node-label }
 
 - hosts: calico-rr
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"

--- a/scale.yml
+++ b/scale.yml
@@ -46,5 +46,5 @@
     - { role: kubernetes/node, tags: node }
     - { role: kubernetes/kubeadm, tags: kubeadm }
     - { role: network_plugin, tags: network }
-    - { role: kubernetes/node-label }
+    - { role: kubernetes/node-label, tags: node-label }
   environment: "{{ proxy_env }}"

--- a/upgrade-cluster.yml
+++ b/upgrade-cluster.yml
@@ -72,7 +72,7 @@
     - { role: kubernetes/node, tags: node }
     - { role: kubernetes/master, tags: master, upgrade_cluster_setup: true }
     - { role: kubernetes/client, tags: client }
-    - { role: kubernetes/node-label }
+    - { role: kubernetes/node-label, tags: node-label }
     - { role: kubernetes-apps/cluster_roles, tags: cluster-roles }
     - { role: upgrade/post-upgrade, tags: post-upgrade }
   environment: "{{ proxy_env }}"
@@ -96,7 +96,7 @@
     - { role: upgrade/pre-upgrade, tags: pre-upgrade }
     - { role: kubernetes/node, tags: node }
     - { role: kubernetes/kubeadm, tags: kubeadm }
-    - { role: kubernetes/node-label }
+    - { role: kubernetes/node-label, tags: node-label }
     - { role: upgrade/post-upgrade, tags: post-upgrade }
   environment: "{{ proxy_env }}"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds the `node-label` tag to the kubernetes/node-label role in the following playbooks: `cluster.yml`, `scale.yml`, `upgrade-cluster.yml`.
Needed to filter this role when executing playbook.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
