### PR TITLE
Fix some minor issues with the Cinder CSI plugin

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -459,6 +459,19 @@ addon_resizer_version: "1.8.3"
 addon_resizer_image_repo: "{{ kube_image_repo }}/addon-resizer"
 addon_resizer_image_tag: "{{ addon_resizer_version }}"
 
+cinder_csi_attacher_image_repo: "{{ quay_image_repo }}/k8scsi/csi-attacher"
+cinder_csi_attacher_image_tag: "v1.2.1"
+cinder_csi_provisioner_image_repo: "{{ quay_image_repo }}/k8scsi/csi-provisioner"
+cinder_csi_provisioner_image_tag: "v1.3.0"
+cinder_csi_snapshotter_image_repo: "{{ quay_image_repo }}/k8scsi/csi-snapshotter"
+cinder_csi_snapshotter_image_tag: "v1.2.0"
+cinder_csi_resizer_image_repo: "{{ quay_image_repo }}/k8scsi/csi-resizer"
+cinder_csi_resizer_image_tag: "v0.2.0"
+cinder_csi_plugin_image_repo: "{{ docker_image_repo }}/k8scloudprovider/cinder-csi-plugin"
+cinder_csi_plugin_image_tag: "latest"
+cinder_csi_node_driver_registrar_image_repo: "{{ quay_image_repo }}/k8scsi/csi-node-driver-registrar"
+cinder_csi_node_driver_registrar_image_tag: "v1.1.0"
+
 dashboard_image_repo: "{{ gcr_image_repo }}/google_containers/kubernetes-dashboard-{{ image_arch }}"
 dashboard_image_tag: "v1.10.1"
 
@@ -945,6 +958,60 @@ downloads:
     repo: "{{ cert_manager_controller_image_repo }}"
     tag: "{{ cert_manager_controller_image_tag }}"
     sha256: "{{ cert_manager_controller_digest_checksum|default(None) }}"
+    groups:
+      - kube-node
+
+  cinder_csi_attacher:
+    enabled: "{{ cinder_csi_enabled }}"
+    container: true
+    repo: "{{ cinder_csi_attacher_image_repo }}"
+    tag: "{{ cinder_csi_attacher_image_tag }}"
+    sha256: "{{ cinder_csi_attacher_digest_checksum|default(None) }}"
+    groups:
+      - kube-node
+
+  cinder_csi_provisioner:
+    enabled: "{{ cinder_csi_enabled }}"
+    container: true
+    repo: "{{ cinder_csi_provisioner_image_repo }}"
+    tag: "{{ cinder_csi_provisioner_image_tag }}"
+    sha256: "{{ cinder_csi_provisioner_digest_checksum|default(None) }}"
+    groups:
+      - kube-node
+
+  cinder_csi_snapshotter:
+    enabled: "{{ cinder_csi_enabled }}"
+    container: true
+    repo: "{{ cinder_csi_snapshotter_image_repo }}"
+    tag: "{{ cinder_csi_snapshotter_image_tag }}"
+    sha256: "{{ cinder_csi_snapshotter_digest_checksum|default(None) }}"
+    groups:
+      - kube-node
+
+  cinder_csi_resizer:
+    enabled: "{{ cinder_csi_enabled }}"
+    container: true
+    repo: "{{ cinder_csi_resizer_image_repo }}"
+    tag: "{{ cinder_csi_resizer_image_tag }}"
+    sha256: "{{ cinder_csi_resizer_digest_checksum|default(None) }}"
+    groups:
+      - kube-node
+
+  cinder_csi_plugin:
+    enabled: "{{ cinder_csi_enabled }}"
+    container: true
+    repo: "{{ cinder_csi_plugin_image_repo }}"
+    tag: "{{ cinder_csi_plugin_image_tag }}"
+    sha256: "{{ cinder_csi_plugin_digest_checksum|default(None) }}"
+    groups:
+      - kube-node
+
+  cinder_csi_node_driver_registrar:
+    enabled: "{{ cinder_csi_enabled }}"
+    container: true
+    repo: "{{ cinder_csi_node_driver_registrar_image_repo }}"
+    tag: "{{ cinder_csi_node_driver_registrar_image_tag }}"
+    sha256: "{{ cinder_csi_node_driver_registrar_digest_checksum|default(None) }}"
     groups:
       - kube-node
 

--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin.yml.j2
@@ -20,7 +20,7 @@ spec:
       serviceAccount: csi-cinder-controller-sa
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v1.2.1
+          image: {{ cinder_csi_attacher_image_repo }}:{{ cinder_csi_attacher_image_tag }}
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -32,7 +32,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.3.0
+          image: {{ cinder_csi_provisioner_image_repo }}:{{ cinder_csi_provisioner_image_tag }}
           args:
             - "--csi-address=$(ADDRESS)"
           env:
@@ -43,7 +43,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v1.2.0
+          image: {{ cinder_csi_snapshotter_image_repo }}:{{ cinder_csi_snapshotter_image_tag }}
           args:
             - "--csi-address=$(ADDRESS)"
           env:
@@ -54,7 +54,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v0.2.0
+          image: {{ cinder_csi_resizer_image_repo }}:{{ cinder_csi_resizer_image_tag }}
           args:
             - "--csi-address=$(ADDRESS)"
           env:
@@ -65,7 +65,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: cinder-csi-plugin
-          image: docker.io/k8scloudprovider/cinder-csi-plugin:latest
+          image: {{ cinder_csi_plugin_image_repo }}:{{ cinder_csi_plugin_image_tag }}
           args :
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"
@@ -90,6 +90,9 @@ spec:
             - name: secret-cinderplugin
               mountPath: /etc/config
               readOnly: true
+            - name: ca-certs
+              mountPath: /etc/ssl/certs
+              readOnly: true
 {% if cinder_cacert is defined and cinder_cacert != "" %}
             - name: cinder-cacert
               mountPath: {{ kube_config_dir }}/cinder-cacert.pem
@@ -101,6 +104,10 @@ spec:
         - name: secret-cinderplugin
           secret:
             secretName: cloud-config
+        - name: ca-certs
+          hostPath:
+            path: /etc/ssl/certs
+            type: DirectoryOrCreate
 {% if cinder_cacert is defined and cinder_cacert != "" %}
         - name: cinder-cacert
           hostPath:

--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-driver.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-driver.yml.j2
@@ -4,4 +4,4 @@ metadata:
   name: cinder.csi.openstack.org
 spec:
   attachRequired: true
-  podInfoOnMount: false
+  podInfoOnMount: true

--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-nodeplugin.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-nodeplugin.yml.j2
@@ -19,7 +19,7 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: {{ cinder_csi_node_driver_registrar_image_repo }}:{{ cinder_csi_node_driver_registrar_image_tag }}
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
@@ -48,7 +48,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: docker.io/k8scloudprovider/cinder-csi-plugin:latest
+          image: {{ cinder_csi_plugin_image_repo }}:{{ cinder_csi_plugin_image_tag }}
           args :
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"
@@ -79,7 +79,10 @@ spec:
             - name: secret-cinderplugin
               mountPath: /etc/config
               readOnly: true
-{% if cinder_cacert is defined %}
+            - name: ca-certs
+              mountPath: /etc/ssl/certs
+              readOnly: true
+{% if cinder_cacert is defined and cinder_cacert != "" %}
             - name: cinder-cacert
               mountPath: {{ kube_config_dir }}/cinder-cacert.pem
               readOnly: true
@@ -108,7 +111,11 @@ spec:
         - name: secret-cinderplugin
           secret:
             secretName: cloud-config
-{% if cinder_cacert is defined %}
+        - name: ca-certs
+          hostPath:
+            path: /etc/ssl/certs
+            type: DirectoryOrCreate
+{% if cinder_cacert is defined and cinder_cacert != "" %}
         - name: cinder-cacert
           hostPath:
             path: {{ kube_config_dir }}/cinder-cacert.pem

--- a/roles/kubernetes-apps/persistent_volumes/cinder-csi/defaults/main.yml
+++ b/roles/kubernetes-apps/persistent_volumes/cinder-csi/defaults/main.yml
@@ -4,3 +4,4 @@ storage_classes:
     is_default: false
     parameters:
       availability: nova
+      allowVolumeExpansion: false


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR fixes some minor issues with the Cinder CSI implementation.

**Special notes for your reviewer:**
- Change the hardcoded `quay.io` and `docker.io` URLs to the `quay_image_repo` and `docker_image_repo` variables
- Mount the host's CA certificates in the Cinder CSI plugin container (this also happens in the OpenStack controller manager and is very convenient)
- Set `podInfoOnMount` to true. This is the default when using Kubernetes as the orchestrator. See https://kubernetes-csi.github.io/docs/pod-info.html
- Add the `allowVolumeExpansion` option to the default arguments for clarity (same defaults).