### PR TITLE
fix duplicates when scheduler_extra_volumes defined

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta1.yaml.j2
@@ -280,7 +280,6 @@ scheduler:
     {{ key }}: "{{ kube_kubeadm_scheduler_extra_args[key] }}"
 {% endfor %}
 {% endif %}
-  extraVolumes:
 {% if scheduler_extra_volumes %}
   extraVolumes:
 {% for volume in scheduler_extra_volumes %}

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
@@ -283,7 +283,6 @@ scheduler:
     {{ key }}: "{{ kube_kubeadm_scheduler_extra_args[key] }}"
 {% endfor %}
 {% endif %}
-  extraVolumes:
 {% if scheduler_extra_volumes %}
   extraVolumes:
 {% for volume in scheduler_extra_volumes %}


### PR DESCRIPTION
What type of PR is this?
/kind bug

**What this PR does / why we need it**:
if scheduler_extra_volumes defined, duplicate key is generated. 
```
  extraVolumes:
  extraVolumes:
  - name: tz-config
    hostPath: /etc/localtime
    mountPath: /etc/localtime
    readOnly: True
```

**Which issue(s) this PR fixes**:
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
