### PR TITLE
Fix typo in Multus plugin

### DIFF
--- a/roles/kubernetes-apps/network_plugin/multus/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/multus/tasks/main.yml
@@ -8,4 +8,4 @@
     filename: "{{ kube_config_dir }}/{{ item.item.file }}"
     state: "latest"
   with_items: "{{ multus_manifest_1.results }} + {{ multus_manifest_2.results }}"
-  when: inventory_hostname == groups['kube-master'][0] and not item|skipped
+  when: inventory_hostname == groups['kube-master'][0] and not item is skipped


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
Fix typo in task for Multus

```release-note
NONE
```
