### PR TITLE
Files to archive can be passed directly when gathering etcd and tiller certs

### DIFF
--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -127,7 +127,7 @@
     - "{{ my_etcd_node_certs }}"
 
 - name: Gen_certs | Gather node certs
-  shell: "set -o pipefail && tar cfz - -C {{ etcd_cert_dir }} -T /dev/stdin <<< {{ my_etcd_node_certs|join(' ') }} | base64 --wrap=0"
+  shell: "set -o pipefail && tar cfz - -C {{ etcd_cert_dir }} {{ my_etcd_node_certs|join(' ') }} | base64 --wrap=0"
   args:
     executable: /bin/bash
     warn: false

--- a/roles/kubernetes-apps/helm/tasks/gen_helm_tiller_certs.yml
+++ b/roles/kubernetes-apps/helm/tasks/gen_helm_tiller_certs.yml
@@ -59,7 +59,7 @@
 
 - name: Gen_helm_tiller_certs | Gather helm client certs
   # noqa 303 - tar is called intentionally here, but maybe this should be done with the slurp module
-  shell: "tar cfz - -C {{ helm_home_dir }} -T /dev/stdin <<< {{ helm_client_certs|join(' ') }} | base64 --wrap=0"
+  shell: "tar cfz - -C {{ helm_home_dir }} {{ helm_client_certs|join(' ') }} | base64 --wrap=0"
   args:
     executable: /bin/bash
   no_log: true


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
While deploying in DinD, the following error occurs repeatedly.
Files to archive can be passed directly to tar, instead of using /dev/stdin
```
TASK [etcd : Gen_certs | Gather node certs] ************************************
Monday 20 January 2020  09:10:32 +0000 (0:00:00.294)       0:12:45.086 ******** 
fatal: [kube-node2 -> 172.18.0.2]: FAILED! => {"changed": true, "cmd": "set -o pipefail && tar cfz - -C /etc/ssl/etcd/ssl -T /dev/stdin <<< ca.pem node-kube-node2.pem node-kube-node2-key.pem | base64 --wrap=0", "delta": "0:00:00.021707", "end": "2020-01-20 09:10:33.606777", "msg": "non-zero return code", "rc": 2, "start": "2020-01-20 09:10:33.585070", "stderr": "tar: /dev/stdin: Cannot stat: Stale file handle\ntar: Error is not recoverable: exiting now", "stderr_lines": ["tar: /dev/stdin: Cannot stat: Stale file handle", "tar: Error is not recoverable: exiting now"], "stdout": "H4sIAIluJV4AAwMAAAAAAAAAAAA=", "stdout_lines": ["H4sIAIluJV4AAwMAAAAAAAAAAAA="]}
```

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
No