### PR TITLE
Fix youtube url

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ See also [Network checker](docs/netcheck.md).
 - [kubernetes.io/docs/setup/production-environment/tools/kubespray/](https://kubernetes.io/docs/setup/production-environment/tools/kubespray/)
 - [kubespray, monitoring and logging](https://github.com/gregbkr/kubernetes-kargo-logging-monitoring) by @gregbkr
 - [Deploy Kubernetes w/ Ansible & Terraform](https://rsmitty.github.io/Terraform-Ansible-Kubernetes/) by @rsmitty
-- [Deploy a Kubernetes Cluster with Kubespray (video)](https://www.youtube.com/watch?v=N9q51JgbWu8)
+- [Deploy a Kubernetes Cluster with Kubespray (video)](https://www.youtube.com/watch?v=CJ5G4GpqDy0)
 
 ## Tools and projects on top of Kubespray
 


### PR DESCRIPTION
It's an outdated link in README: [Deploy a Kubernetes Cluster with Kargo](https://www.youtube.com/watch?v=N9q51JgbWu8)