### PR TITLE
Fix etcd deployment type variable location

### DIFF
--- a/docs/cri-o.md
+++ b/docs/cri-o.md
@@ -19,9 +19,14 @@ skip_downloads: false
 ## k8s-cluster.yml
 
 ```yaml
-etcd_deployment_type: host
 kubelet_deployment_type: host
 container_manager: crio
+```
+
+## etcd.yml
+
+```yaml
+etcd_deployment_type: host
 ```
 
 [CRI-O]: https://cri-o.io/

--- a/inventory/sample/group_vars/etcd.yml
+++ b/inventory/sample/group_vars/etcd.yml
@@ -1,3 +1,4 @@
+---
 ## Etcd auto compaction retention for mvcc key value store in hour
 # etcd_compaction_retention: 0
 
@@ -16,3 +17,6 @@
 ### ETCD: disable peer client cert authentication.
 # This affects ETCD_PEER_CLIENT_CERT_AUTH variable
 # etcd_peer_client_auth: true
+
+## Settings for etcd deployment type
+etcd_deployment_type: docker

--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -158,8 +158,7 @@ dns_domain: "{{ cluster_name }}"
 ## docker for docker, crio for cri-o and containerd for containerd.
 container_manager: docker
 
-## Settings for containerized control plane (etcd/kubelet/secrets)
-etcd_deployment_type: docker
+## Settings for containerized control plane (kubelet/secrets)
 kubelet_deployment_type: host
 helm_deployment_type: host
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
On deployments types where etcd server is splitted from Kube Master, the deployment fails since it cannot find the variable.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5434

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
