### PR TITLE
Add cert and key files for ETCD cluster-health check

### DIFF
--- a/roles/etcd/tasks/configure.yml
+++ b/roles/etcd/tasks/configure.yml
@@ -1,6 +1,7 @@
 ---
 - name: Configure | Check if etcd cluster is healthy
-  shell: "{{ bin_dir }}/etcdctl --endpoints={{ etcd_access_addresses }} cluster-health | grep -q 'cluster is healthy'"
+  become: yes
+  shell: "{{ bin_dir }}/etcdctl --endpoints={{ etcd_access_addresses }} --cert-file {{ etcd_cert_dir }}/ca.pem --key-file {{ etcd_cert_dir }}/ca-key.pem cluster-health | grep -q 'cluster is healthy'"
   register: etcd_cluster_is_healthy
   ignore_errors: true
   changed_when: false
@@ -14,7 +15,8 @@
     ETCDCTL_CA_FILE: "{{ etcd_cert_dir }}/ca.pem"
 
 - name: Configure | Check if etcd-events cluster is healthy
-  shell: "{{ bin_dir }}/etcdctl --endpoints={{ etcd_events_access_addresses }} cluster-health | grep -q 'cluster is healthy'"
+  become: yes
+  shell: "{{ bin_dir }}/etcdctl --endpoints={{ etcd_events_access_addresses }} --cert-file {{ etcd_cert_dir }}/ca.pem --key-file {{ etcd_cert_dir }}/ca-key.pem cluster-health | grep -q 'cluster is healthy'"
   register: etcd_events_cluster_is_healthy
   ignore_errors: true
   changed_when: false
@@ -64,7 +66,8 @@
   when: is_etcd_master and etcd_events_cluster_setup
 
 - name: Configure | Check if etcd cluster is healthy
-  shell: "{{ bin_dir }}/etcdctl --no-sync --endpoints={{ etcd_client_url }} cluster-health | grep -q 'cluster is healthy'"
+  become: yes
+  shell: "{{ bin_dir }}/etcdctl --no-sync --endpoints={{ etcd_client_url }} --cert-file {{ etcd_cert_dir }}/ca.pem --key-file {{ etcd_cert_dir }}/ca-key.pem cluster-health | grep -q 'cluster is healthy'"
   register: etcd_cluster_is_healthy
   until: etcd_cluster_is_healthy.rc == 0
   retries: "{{ etcd_retries }}"
@@ -85,7 +88,8 @@
     ETCDCTL_CA_FILE: "{{ etcd_cert_dir }}/ca.pem"
 
 - name: Configure | Check if etcd-events cluster is healthy
-  shell: "{{ bin_dir }}/etcdctl --no-sync --endpoints={{ etcd_events_client_url }} cluster-health | grep -q 'cluster is healthy'"
+  become: yes
+  shell: "{{ bin_dir }}/etcdctl --no-sync --endpoints={{ etcd_events_client_url }} --cert-file {{ etcd_cert_dir }}/ca.pem --key-file {{ etcd_cert_dir }}/ca-key.pem cluster-health | grep -q 'cluster is healthy'"
   register: etcd_events_cluster_is_healthy
   until: etcd_events_cluster_is_healthy.rc == 0
   retries: "{{ etcd_retries }}"


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This change improves the method which validates the healthiness of the ETCD cluster providing an absolute path for its certs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
This change can helps to improve the validation of the ETCD's certs when they're located in different folder other than *etcd_cert_dir* ansible config value

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
