### PR TITLE
Fix calico-rr for AWS deployments

### DIFF
--- a/roles/network_plugin/calico/rr/defaults/main.yml
+++ b/roles/network_plugin/calico/rr/defaults/main.yml
@@ -3,3 +3,10 @@
 # should be the same as in calico role
 global_as_num: "64512"
 calico_baremetal_nodename: "{{ kube_override_hostname | default(inventory_hostname) }}"
+
+# If non-empty, will use this string as identification instead of the actual hostname
+kube_override_hostname: >-
+  {%- if cloud_provider is defined and cloud_provider in [ 'aws' ] -%}
+  {%- else -%}
+  {{ inventory_hostname }}
+  {%- endif -%}

--- a/roles/network_plugin/calico/rr/tasks/main.yml
+++ b/roles/network_plugin/calico/rr/tasks/main.yml
@@ -3,7 +3,7 @@
   include_tasks: pre.yml
 
 - name: Calico-rr | Fetch current node object
-  command: "{{ bin_dir }}/calicoctl.sh get node {{ inventory_hostname }} -ojson"
+  command: "{{ bin_dir }}/calicoctl.sh get node {{ kube_override_hostname }} -ojson"
   register: calico_rr_node
   until: calico_rr_node is succeeded
   delay: "{{ retry_stagger | random + 3 }}"
@@ -22,5 +22,5 @@
 
 - name: Calico-rr | Set label for route reflector
   command: >-
-    {{ bin_dir }}/calicoctl.sh label node {{ inventory_hostname }}
+    {{ bin_dir }}/calicoctl.sh label node {{ kube_override_hostname }}
     'i-am-a-route-reflector=true' --overwrite


### PR DESCRIPTION
calico node object name matches kubelet name, so this should be
set correctly when manipulatnig calico-rr node object