### PR TITLE
force rotate control plane certifcate on master node when upgrade 

### DIFF
--- a/roles/kubernetes/master/tasks/kubeadm-upgrade.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-upgrade.yml
@@ -9,6 +9,7 @@
     --allow-experimental-upgrades
     --allow-release-candidate-upgrades
     --etcd-upgrade=false
+    {{ (kubeadm_output.stdout is version('v1.16.0', '>=')) | ternary('--certificate-renewal=true', '') }}
     --force
   register: kubeadm_upgrade
   # Retry is because upload config sometimes fails
@@ -29,6 +30,7 @@
     --allow-experimental-upgrades
     --allow-release-candidate-upgrades
     --etcd-upgrade=false
+    {{ (kubeadm_output.stdout is version('v1.16.0', '>=')) | ternary('--certificate-renewal=true', '') }}
     --force
   register: kubeadm_upgrade
   when: inventory_hostname != groups['kube-master']|first


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
workaround kubeadm bug https://github.com/kubernetes/kubeadm/issues/1818 
**Which issue(s) this PR fixes**:
Fixes #5555 

