### PR TITLE
Update cni plugins when flannel is ready.

### DIFF
--- a/roles/kubernetes-apps/network_plugin/flannel/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/flannel/tasks/main.yml
@@ -15,3 +15,22 @@
     path: /run/flannel/subnet.env
     delay: 5
     timeout: 600
+
+- name: Flannel | wait for Flannel pods become ready
+  shell: "kubectl wait --namespace=kube-system --for=condition=Ready pods --selector k8s-app=flannel --timeout=600s"
+  register: flannel_pods_ready
+
+- name: Flannel | make sure /opt/cni/bin exists
+  file:
+    path: /opt/cni/bin
+    state: directory
+    mode: 0755
+    owner: root
+    group: root
+
+- name: Flannel | Copy cni plugins
+  unarchive:
+    src: "{{ local_release_dir }}/cni-plugins-linux-{{ image_arch }}-{{ cni_version }}.tgz"
+    dest: "/opt/cni/bin"
+    mode: 0755
+    remote_src: yes


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR will update cni plugins when flannel pod is ready.
Before this PR, when installation k8s using kubespray with flannel, the cni plugins will stick on a certain old version. And not the new version as it claimed to be in kubespray document.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5562

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
