### PR TITLE
disable gpgcheck if gpgkey is empty

### DIFF
--- a/roles/container-engine/containerd/tasks/containerd_repo.yml
+++ b/roles/container-engine/containerd/tasks/containerd_repo.yml
@@ -58,7 +58,7 @@
     state: present
     baseurl: "{{ extras_rh_repo_base_url }}"
     file: "extras"
-    gpgcheck: yes
+    gpgcheck: "{{ 'yes' if extras_rh_repo_gpgkey else 'no' }}"
     gpgkey: "{{ extras_rh_repo_gpgkey }}"
     keepcache: "{{ containerd_rpm_keepcache | default('1') }}"
     proxy: " {{ http_proxy | default('_none_') }}"

--- a/roles/container-engine/containerd/templates/rh_containerd.repo.j2
+++ b/roles/container-engine/containerd/templates/rh_containerd.repo.j2
@@ -2,7 +2,7 @@
 name=Docker-CE Repository
 baseurl={{ docker_rh_repo_base_url }}
 enabled=1
-gpgcheck=1
+gpgcheck={{ '1' if docker_rh_repo_gpgkey else '0' }}
 keepcache={{ docker_rpm_keepcache | default('1') }}
 gpgkey={{ docker_rh_repo_gpgkey }}
 {% if http_proxy is defined %}proxy={{ http_proxy }}{% endif %}

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -120,7 +120,7 @@
     state: present
     baseurl: "{{ extras_rh_repo_base_url }}"
     file: "extras"
-    gpgcheck: yes
+    gpgcheck: "{{ 'yes' if extras_rh_repo_gpgkey else 'no' }}"
     gpgkey: "{{ extras_rh_repo_gpgkey }}"
     keepcache: "{{ docker_rpm_keepcache | default('1') }}"
     proxy: " {{ http_proxy | default('_none_') }}"

--- a/roles/container-engine/docker/templates/fedora_docker.repo.j2
+++ b/roles/container-engine/docker/templates/fedora_docker.repo.j2
@@ -2,6 +2,6 @@
 name=Docker-CE Repository
 baseurl={{ docker_fedora_repo_base_url }}
 enabled=1
-gpgcheck=1
+gpgcheck={{ '1' if docker_fedora_repo_gpgkey else '0' }}
 gpgkey={{ docker_fedora_repo_gpgkey }}
 {% if http_proxy is defined %}proxy={{ http_proxy }}{% endif %}

--- a/roles/container-engine/docker/templates/rh_docker.repo.j2
+++ b/roles/container-engine/docker/templates/rh_docker.repo.j2
@@ -2,7 +2,7 @@
 name=Docker-CE Repository
 baseurl={{ docker_rh_repo_base_url }}
 enabled=1
-gpgcheck=1
+gpgcheck={{ '1' if docker_rh_repo_gpgkey else '0' }}
 keepcache={{ docker_rpm_keepcache | default('1') }}
 gpgkey={{ docker_rh_repo_gpgkey }}
 {% if http_proxy is defined %}proxy={{ http_proxy }}{% endif %}


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
This allows the gpgcheck for the docker repositories to be disabled if an empty gpgkey is provided

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
