### PR TITLE
kubelet_config_extra_args and kubelet_node_config_extra_args

### DIFF
--- a/docs/vars.md
+++ b/docs/vars.md
@@ -170,6 +170,11 @@ The possible vars are:
 * *kubelet_custom_flags*
 * *kubelet_node_custom_flags*
 
+As an alternative, these very same parameters can be set as key-value pairs of configuration parameters that will be inserted into the kubelet YAML config file:
+
+* *kubelet_config_extra_args*
+* *kubelet_node_config_extra_args*
+
 Extra flags for the API server, controller, and scheduler components can be specified using these variables,
 in the form of dicts of key-value pairs of configuration parameters that will be inserted into the kubeadm YAML config file:
 

--- a/docs/vars.md
+++ b/docs/vars.md
@@ -156,7 +156,32 @@ node_taints:
 
 ### Custom flags for Kube Components
 
-For all kube components, custom flags can be passed in. This allows for edge cases where users need changes to the default deployment that may not be applicable to all deployments. This can be done by providing a list of flags. The `kubelet_node_custom_flags` apply kubelet settings only to nodes and not masters. Example:
+For all kube components, custom flags can be passed in. This allows for edge cases where users need changes to the default deployment that may not be applicable to all deployments.
+
+Extra flags for the kubelet can be specified using these variables,
+in the form of dicts of key-value pairs of configuration parameters that will be inserted into the kubelet YAML config file. The `kubelet_node_config_extra_args` apply kubelet settings only to nodes and not masters. Example:
+
+```yml
+kubelet_config_extra_args:
+  EvictionHard:
+    memory.available: "<100Mi"
+  EvictionSoftGracePeriod:
+    memory.available: "30s"
+  EvictionSoft:
+    memory.available: "<300Mi"
+```
+
+The possible vars are:
+
+* *kubelet_config_extra_args*
+* *kubelet_node_config_extra_args*
+
+Previously, the same paramaters could be passed as flags to kubelet binary with the following vars:
+
+* *kubelet_custom_flags*
+* *kubelet_node_custom_flags*
+
+The `kubelet_node_custom_flags` apply kubelet settings only to nodes and not masters. Example:
 
 ```yml
 kubelet_custom_flags:
@@ -165,15 +190,7 @@ kubelet_custom_flags:
   - "--eviction-soft=memory.available<300Mi"
 ```
 
-The possible vars are:
-
-* *kubelet_custom_flags*
-* *kubelet_node_custom_flags*
-
-As an alternative, these very same parameters can be set as key-value pairs of configuration parameters that will be inserted into the kubelet YAML config file:
-
-* *kubelet_config_extra_args*
-* *kubelet_node_config_extra_args*
+This alternative is deprecated and will remain until the flags are completely removed from kubelet
 
 Extra flags for the API server, controller, and scheduler components can be specified using these variables,
 in the form of dicts of key-value pairs of configuration parameters that will be inserted into the kubeadm YAML config file:

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -68,6 +68,12 @@ kubelet_load_modules: false
 # default is equal to application default
 kubelet_max_pods: 110
 
+## Support parameters to be passed to kubelet via kubelet-config.yaml
+kubelet_config_extra_args: {}
+
+## Support parameters to be passed to kubelet via kubelet-config.yaml only on nodes, not masters
+kubelet_node_config_extra_args: {}
+
 ## Support custom flags to be passed to kubelet
 kubelet_custom_flags: []
 

--- a/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
@@ -70,3 +70,9 @@ systemReserved:
 {% endif %}
 {% endif %}
 resolvConf: "{{ kube_resolv_conf }}"
+{% if kubelet_config_extra_args %}
+{{ kubelet_config_extra_args | to_nice_yaml(indent=2) }}
+{% endif %}
+{% if inventory_hostname in groups['kube-node'] and kubelet_node_config_extra_args %}
+{{ kubelet_node_config_extra_args | to_nice_yaml(indent=2) }}
+{% endif %}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
Introduce `kubelet_config_extra_args` and `kubelet_node_config_extra_args` to pass params to kubelet via YAML config

These variables are meant to be used in kubelet-config.v1beta1.yaml.j2 to pass args to were previously passed via `kubelet_custom_flags` and `kubelet_node_custom_flags`

**Which issue(s) this PR fixes**:
N/A