### PR TITLE
Ability to define plugins.cri.containerd params

### DIFF
--- a/docs/vars.md
+++ b/docs/vars.md
@@ -104,6 +104,8 @@ Stack](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/dns-stack.m
 * *docker_options* - Commonly used to set
   ``--insecure-registry=myregistry.mydomain:5000``
 * *docker_plugins* - This list can be used to define [Docker plugins](https://docs.docker.com/engine/extend/) to install.
+* *containerd_config* - Controls some parameters in containerd configuration file (usually /etc/containerd/config.toml).
+  [Default config](https://github.com/kubernetes-sigs/kubespray/blob/master/roles/container-engine/containerd/defaults/main.yml) can be overriden in inventory vars.
 * *http_proxy/https_proxy/no_proxy* - Proxy variables for deploying behind a
   proxy. Note that no_proxy defaults to all internal cluster IPs and hostnames
   that correspond to each node.

--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -8,6 +8,8 @@ containerd_config:
   registries:
     "docker.io": "https://registry-1.docker.io"
   max_container_log_line_size: -1
+  # containerd:
+  #   snapshotter: native
 
 containerd_version: '1.2.10'
 containerd_package: 'containerd.io'

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -25,6 +25,12 @@ disabled_plugins = ["restart"]
   conf_dir = "/etc/cni/net.d"
   conf_template = ""
 
+{% if 'containerd' in containerd_config %}
+[plugins.cri.containerd]
+{% for param, value in containerd_config.containerd.items() %}
+  {{ param }} = {{ value }}
+{% endfor %}
+{% endif %}
 [plugins.cri.containerd.untrusted_workload_runtime]
   runtime_type = ""
   runtime_engine = ""


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Enables `containerd_config.containerd` hash as a way to tune `plugins.cri.containerd` in /etc/container/config.toml.
My use-case is deploying kubespray in DinD: Default snapshotter ("overlayfs") doesn't work in my environment, I have to override snapshotter to "native"

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**: