### PR TITLE
Ignore assertion comparison for kube_network_node_prefix when using calico

### DIFF
--- a/docs/vars.md
+++ b/docs/vars.md
@@ -57,7 +57,10 @@ following default cluster parameters:
 * *kube_pods_subnet* - Subnet for Pod IPs (default is 10.233.64.0/18). Must not
   overlap with kube_service_addresses.
 * *kube_network_node_prefix* - Subnet allocated per-node for pod IPs. Remaining
-  bits in kube_pods_subnet dictates how many kube-nodes can be in cluster.
+  bits in kube_pods_subnet dictates how many kube-nodes can be in cluster. Setting this > 25 will 
+  raise an assertion in playbooks if the `kubelet_max_pods` var also isn't adjusted accordingly 
+  (assertion not applicable to calico which doesn't use this as a hard limit, see 
+  [Calico IP block sizes](https://docs.projectcalico.org/reference/resources/ippool#block-sizes).
 * *skydns_server* - Cluster IP for DNS (default is 10.233.0.3)
 * *skydns_server_secondary* - Secondary Cluster IP for CoreDNS used with coredns_dual deployment (default is 10.233.0.4)
 * *enable_coredns_k8s_external* - If enabled, it configures the [k8s_external plugin](https://coredns.io/plugins/k8s_external/)

--- a/docs/vars.md
+++ b/docs/vars.md
@@ -57,9 +57,9 @@ following default cluster parameters:
 * *kube_pods_subnet* - Subnet for Pod IPs (default is 10.233.64.0/18). Must not
   overlap with kube_service_addresses.
 * *kube_network_node_prefix* - Subnet allocated per-node for pod IPs. Remaining
-  bits in kube_pods_subnet dictates how many kube-nodes can be in cluster. Setting this > 25 will 
-  raise an assertion in playbooks if the `kubelet_max_pods` var also isn't adjusted accordingly 
-  (assertion not applicable to calico which doesn't use this as a hard limit, see 
+  bits in kube_pods_subnet dictates how many kube-nodes can be in cluster. Setting this > 25 will
+  raise an assertion in playbooks if the `kubelet_max_pods` var also isn't adjusted accordingly
+  (assertion not applicable to calico which doesn't use this as a hard limit, see
   [Calico IP block sizes](https://docs.projectcalico.org/reference/resources/ippool#block-sizes).
 * *skydns_server* - Cluster IP for DNS (default is 10.233.0.3)
 * *skydns_server_secondary* - Secondary Cluster IP for CoreDNS used with coredns_dual deployment (default is 10.233.0.4)

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -79,12 +79,13 @@
 # NOTICE: the check blatantly ignores the inet6-case
 - name: Guarantee that enough network address space is available for all pods
   assert:
-    that: "{{ (kubelet_max_pods | default(110)) | int >= (2 ** (32 - kube_network_node_prefix | int)) - 2 }}"
+    that: "{{ (kubelet_max_pods | default(110)) | int <= (2 ** (32 - kube_network_node_prefix | int)) - 2 }}"
     msg: "Do not schedule more pods on a node than inet addresses are available."
   ignore_errors: "{{ ignore_assert_errors }}"
   when:
     - inventory_hostname in groups['k8s-cluster']
     - kube_network_node_prefix is defined
+    - kube_network_plugin != 'calico'
 
 - name: Stop if ip var does not match local ips
   assert:

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -79,7 +79,7 @@
 # NOTICE: the check blatantly ignores the inet6-case
 - name: Guarantee that enough network address space is available for all pods
   assert:
-    that: "{{ (kubelet_max_pods | default(110)) | int <= (2 ** (32 - kube_network_node_prefix | int)) - 2 }}"
+    that: "{{ (kubelet_max_pods | default(110)) | int >= (2 ** (32 - kube_network_node_prefix | int)) - 2 }}"
     msg: "Do not schedule more pods on a node than inet addresses are available."
   ignore_errors: "{{ ignore_assert_errors }}"
   when:


### PR DESCRIPTION
Fixes #5631 