### PR TITLE
Cache facts for 2 hours

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -11,6 +11,7 @@ host_key_checking=False
 gathering = smart
 fact_caching = jsonfile
 fact_caching_connection = /tmp
+fact_caching_timeout = 7200
 stdout_callback = skippy
 library = ./library
 callback_whitelist = profile_tasks


### PR DESCRIPTION
Sets a 2 hour timeout value for facts caching.

 Some users managed to re-use the same names (e.g. "node1, node2") for their hosts which can confuse Ansible.

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Cache host facts for 2 hours by default instead of indefinitely.
```
