### PR TITLE
Fixing and issue where if the pids in the orphan list no longer exist…

### DIFF
--- a/roles/container-engine/docker/files/cleanup-docker-orphans.sh
+++ b/roles/container-engine/docker/files/cleanup-docker-orphans.sh
@@ -9,13 +9,8 @@ list_descendants ()
   [[ -n "$children" ]] && echo "$children"
 }
 
-shim_search="^docker-containerd-shim"
+shim_search="^docker-containerd-shim|^containerd-shim"
 count_shim_processes=$(pgrep -f $shim_search | wc -l)
-
-if [ ${count_shim_processes} -eq 0 ]; then
-        shim_search="^containerd-shim"
-        count_shim_processes=$(pgrep -f $shim_search | wc -l)
-fi
 
 if [ ${count_shim_processes} -gt 0 ]; then
         # Find all container pids from shims
@@ -23,7 +18,7 @@ if [ ${count_shim_processes} -gt 0 ]; then
         # Filter out valid docker pids, leaving the orphans
         egrep -v $(docker ps -q | xargs docker inspect --format '{{.State.Pid}}' | awk '{printf "%s%s",sep,$1; sep="|"}'))
 
-        if [[ -n "$orphans" ]]
+        if [[ -n "$orphans" && -n "$(ps -o ppid= $orphans)" ]]
         then
                 # Get shim pids of orphans
                 orphan_shim_pids=$(ps -o pid= $(ps -o ppid= $orphans))


### PR DESCRIPTION
… then all systemd child processes would be killed.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
>
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Currently if any of the pids in the orphan list no longer exist, the $(ps -o ppid= $orphans) subshell returns an empty string. That empty string causes and orphan_shim_pids var to be set to the systemd pid (since it was invoked by it). In turn that causes everything to be killed  as the script descends down the pid tree from the init proc.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

NONE

```
