### PR TITLE
remove legacy docker repo in kubernetes/preinstall before install pkg

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0070-system-packages.yml
+++ b/roles/kubernetes/preinstall/tasks/0070-system-packages.yml
@@ -17,6 +17,14 @@
   tags:
     - bootstrap-os
 
+- name: Remove legacy docker repo file
+  file:
+    path: "{{ yum_repo_dir }}/docker.repo"
+    state: absent
+  when:
+    - ansible_distribution in ["CentOS","RedHat","OracleLinux"]
+    - not is_atomic
+
 - name: Install python-dnf for latest RedHat versions
   command: dnf install -y python-dnf yum
   register: dnf_task_result


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
stale repos broke yum install. need to remove before install any pakages

**Which issue(s) this PR fixes**:
Fixes #5638

