### PR TITLE
Make etcdctl connect to localhost out of the box

### DIFF
--- a/roles/etcd/templates/etcd.env.j2
+++ b/roles/etcd/templates/etcd.env.j2
@@ -42,3 +42,9 @@ ETCD_PEER_CLIENT_CERT_AUTH={{ etcd_peer_client_auth }}
 {% if host_architecture != "amd64" -%}
 ETCD_UNSUPPORTED_ARCH={{host_architecture}}
 {%- endif %}
+
+# CLI settings
+ETCDCTL_ENDPOINTS=https://127.0.0.1:2379
+ETCDCTL_CA_FILE={{ etcd_cert_dir }}/ca.pem
+ETCDCTL_KEY_FILE={{ etcd_cert_dir }}/member-{{ inventory_hostname }}-key.pem
+ETCDCTL_CERT_FILE={{ etcd_cert_dir }}/member-{{ inventory_hostname }}.pem

--- a/roles/etcd/templates/etcd.env.j2
+++ b/roles/etcd/templates/etcd.env.j2
@@ -46,5 +46,5 @@ ETCD_UNSUPPORTED_ARCH={{host_architecture}}
 # CLI settings
 ETCDCTL_ENDPOINTS=https://127.0.0.1:2379
 ETCDCTL_CA_FILE={{ etcd_cert_dir }}/ca.pem
-ETCDCTL_KEY_FILE={{ etcd_cert_dir }}/member-{{ inventory_hostname }}-key.pem
-ETCDCTL_CERT_FILE={{ etcd_cert_dir }}/member-{{ inventory_hostname }}.pem
+ETCDCTL_KEY_FILE={{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem
+ETCDCTL_CERT_FILE={{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds ETCDCTL_ env vars that point `etcdctl` to local node by default, so when you run it (in docker container or locally, with some additional effort) it works out of the box and you don't need to think about setting four additional arguments to specify endpoint and TLS settings. That is handy in stressful situations, when manually recovering a broken etcd cluster, for examlpe.

Usage with local etcd install:
```
# export $(grep -v '^#' /etc/etcd.env)
# etcdctl member list
3ac8d61071f7b1c6: name=etcd_hkf1 peerURLs=https://10.0.11.2:2380 clientURLs=https://10.92.11.2:2379 isLeader=true
```

**Does this PR introduce a user-facing change?**:

Besides better UX it can also wrongly assume that you want to connect to local etcd instance.