### PR TITLE
remove unused var 'kube_apiserver_admission_control' (#5648)

### DIFF
--- a/roles/kubernetes/master/defaults/main/main.yml
+++ b/roles/kubernetes/master/defaults/main/main.yml
@@ -95,17 +95,6 @@ kube_apiserver_memory_requests: 256M
 kube_apiserver_cpu_requests: 100m
 kube_apiserver_request_timeout: "1m0s"
 
-# 1.9 and below Admission control plug-ins
-kube_apiserver_admission_control:
-  - NamespaceLifecycle
-  - LimitRanger
-  - ServiceAccount
-  - DefaultStorageClass
-  - PersistentVolumeClaimResize
-  - MutatingAdmissionWebhook
-  - ValidatingAdmissionWebhook
-  - ResourceQuota
-
 # 1.10+ admission plugins
 kube_apiserver_enable_admission_plugins: []
 

--- a/roles/kubernetes/master/tasks/main.yml
+++ b/roles/kubernetes/master/tasks/main.yml
@@ -61,7 +61,6 @@
 
 - name: Disable SecurityContextDeny admission-controller and enable PodSecurityPolicy
   set_fact:
-    kube_apiserver_admission_control: "{{ kube_apiserver_admission_control | default([]) | difference(['SecurityContextDeny']) | union(['PodSecurityPolicy']) | unique }}"
     kube_apiserver_enable_admission_plugins: "{{ kube_apiserver_enable_admission_plugins | difference(['SecurityContextDeny']) | union(['PodSecurityPolicy']) | unique }}"
   when: podsecuritypolicy_enabled
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Code cleanup : unused var 'kube_apiserver_admission_control'

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
