### PR TITLE
Make calico iptables lock timeout configurable

### DIFF
--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -51,6 +51,9 @@ calico_node_ignorelooserpf: false
 # Define address on which Felix will respond to health requests
 calico_healthhost: "localhost"
 
+# Configure time in seconds that calico will wait for the iptables lock
+calico_iptables_lock_timeout_secs: 10
+
 # Choose Calico iptables backend: "Iptables" or "NFT" (FELIX_IPTABLESBACKEND)
 calico_iptables_backend: "Iptables"
 

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -209,12 +209,8 @@ spec:
             - name: FELIX_IPTABLESBACKEND
               value: "{{ calico_iptables_backend }}"
 {% endif %}
-            # Prior to v3.2.1 iptables didn't acquire the lock, so Calico's own implementation of the lock should be used,
-            # this is not required in later versions https://github.com/projectcalico/calico/issues/2179
-{% if calico_version is version('v3.2.1', '<') %}
             - name: FELIX_IPTABLESLOCKTIMEOUTSECS
-              value: "10"
-{% endif %}
+              value: "{{ calico_iptables_lock_timeout_secs }}"
 # should be set in etcd before deployment
 #            # Configure the IP Pool from which Pod IPs will be chosen.
 #            - name: CALICO_IPV4POOL_CIDR


### PR DESCRIPTION
Adds `calico_iptables_lock_timeout_secs` variable to calico DS yaml.