### PR TITLE
Add stable repo on all masters with helm 3.x.x

### DIFF
--- a/roles/kubernetes-apps/helm/tasks/main.yml
+++ b/roles/kubernetes-apps/helm/tasks/main.yml
@@ -101,6 +101,13 @@
     - helm_version is version('v3.0.0', '<')
   environment: "{{ proxy_env }}"
 
+- name: Helm | Add/update stable repo on all masters
+  command: "{{ bin_dir }}/helm repo add stable {{ helm_stable_repo_url }}"
+  environment: "{{ proxy_env }}"
+  when:
+    - helm_version is version('v3.0.0', '>=')
+    - helm_stable_repo_url is defined
+
 - name: Make sure bash_completion.d folder exists
   file:
     name: "/etc/bash_completion.d/"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
Before Helm 3, client init optionally included addition of the stable repo.
Now that helm 3 does not require init, stable repo is not added anymore.
This PR reintroduces addition of helm stable repo for helm 3 on all masters

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
helm repo add does not fail but updates it when a repo already exists. This behviour seems fine to me. 

**Does this PR introduce a user-facing change?**:
None
