### PR TITLE
Add additional configuration options to external Openstack CCM

### DIFF
--- a/inventory/sample/group_vars/all/openstack.yml
+++ b/inventory/sample/group_vars/all/openstack.yml
@@ -26,6 +26,8 @@
 # external_openstack_lbaas_monitor_delay: "1m"
 # external_openstack_lbaas_monitor_timeout: "30s"
 # external_openstack_lbaas_monitor_max_retries: "3"
+# external_openstack_lbaas_manage_security_groups: false
+# external_openstack_lbaas_internal_lb: false
 
 ## The tag of the external OpenStack Cloud Controller image
 # external_openstack_cloud_controller_image_tag: "latest"

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
@@ -36,6 +36,12 @@ subnet-id={{ external_openstack_lbaas_subnet_id }}
 {% if external_openstack_lbaas_floating_network_id is defined %}
 floating-network-id={{ external_openstack_lbaas_floating_network_id }}
 {% endif %}
-{% if external_openstack_lbaas_flaoting_subnet_id is defined %}
+{% if external_openstack_lbaas_floating_subnet_id is defined %}
 floating-subnet-id={{ external_openstack_lbaas_floating_subnet_id }}
+{% endif %}
+{% if external_openstack_lbaas_manage_security_groups is defined %}
+manage-security-groups={{ external_openstack_lbaas_manage_security_groups }}
+{% endif %}
+{% if external_openstack_lbaas_internal_lb is defined %}
+internal-lb={{ external_openstack_internal_lb }}
 {% endif %}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Additional configuration options for external OpenStack CCM

- The `manage-security-groups` flag was missing from the previous PR and is needed to make automated security groups for Neutron LBaaS v2 work.
- Added support for the `internal-lb` flag.
- Fixed a typo in the `external_openstack_lbaas_floating_subnet_id` variable.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
