### PR TITLE
Remove dockerproject_.+_repo_.+ variables

### DIFF
--- a/roles/container-engine/containerd/templates/rh_containerd.repo.j2
+++ b/roles/container-engine/containerd/templates/rh_containerd.repo.j2
@@ -7,13 +7,3 @@ keepcache={{ docker_rpm_keepcache | default('1') }}
 gpgkey={{ docker_rh_repo_gpgkey }}
 {% if http_proxy is defined %}proxy={{ http_proxy }}{% endif %}
 {% if ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 8 %}module_hotfixes=True{% endif %}
-
-[docker-engine]
-name=Docker-Engine Repository
-baseurl={{ dockerproject_rh_repo_base_url }}
-enabled=1
-gpgcheck=1
-keepcache={{ docker_rpm_keepcache | default('1') }}
-gpgkey={{ dockerproject_rh_repo_gpgkey }}
-{% if http_proxy is defined %}proxy={{ http_proxy }}{% endif %}
-{% if ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 8 %}module_hotfixes=True{% endif %}

--- a/roles/container-engine/containerd/templates/rh_docker.repo.j2
+++ b/roles/container-engine/containerd/templates/rh_docker.repo.j2
@@ -7,13 +7,3 @@ keepcache={{ docker_rpm_keepcache | default('1') }}
 gpgkey={{ docker_rh_repo_gpgkey }}
 {% if http_proxy is defined %}proxy={{ http_proxy }}{% endif %}
 {% if ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 8 %}module_hotfixes=True{% endif %}
-
-[docker-engine]
-name=Docker-Engine Repository
-baseurl={{ dockerproject_rh_repo_base_url }}
-enabled=1
-gpgcheck=1
-keepcache={{ docker_rpm_keepcache | default('1') }}
-gpgkey={{ dockerproject_rh_repo_gpgkey }}
-{% if http_proxy is defined %}proxy={{ http_proxy }}{% endif %}
-{% if ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 8 %}module_hotfixes=True{% endif %}

--- a/roles/container-engine/docker/defaults/main.yml
+++ b/roles/container-engine/docker/defaults/main.yml
@@ -38,11 +38,6 @@ docker_ubuntu_repo_gpgkey: 'https://download.docker.com/linux/ubuntu/gpg'
 # Debian docker-ce repo
 docker_debian_repo_base_url: "https://download.docker.com/linux/debian"
 docker_debian_repo_gpgkey: 'https://download.docker.com/linux/debian/gpg'
-# dockerproject repo
-dockerproject_rh_repo_base_url: 'https://download.docker.com/linux/centos/7/$basearch/stable'
-dockerproject_rh_repo_gpgkey: 'https://download.docker.com/linux/centos/gpg'
-dockerproject_apt_repo_base_url: 'https://download.docker.com/linux/debian'
-dockerproject_apt_repo_gpgkey: 'https://download.docker.com/linux/debian/gpg'
 docker_bin_dir: "/usr/bin"
 # CentOS/RedHat Extras repo
 extras_rh_repo_base_url: "http://mirror.centos.org/centos/$releasever/extras/$basearch/"

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -104,10 +104,10 @@
 - name: Configure docker repository on RedHat/CentOS/Oracle Linux
   yum_repository:
     name: docker-ce
-    baseurl: "{{ dockerproject_rh_repo_base_url }}"
+    baseurl: "{{ docker_rh_repo_base_url }}"
     description: "Docker CE Stable - $basearch"
     gpgcheck: yes
-    gpgkey: "{{ dockerproject_rh_repo_gpgkey }}"
+    gpgkey: "{{ docker_rh_repo_gpgkey }}"
     keepcache: "{{ docker_rpm_keepcache | default('1') }}"
     proxy: " {{ http_proxy | default('_none_') }}"
   when: ansible_distribution in ["CentOS","RedHat","OracleLinux"] and not is_atomic

--- a/roles/container-engine/docker/vars/debian.yml
+++ b/roles/container-engine/docker/vars/debian.yml
@@ -37,7 +37,7 @@ docker_repo_info:
 
 dockerproject_repo_key_info:
   pkg_key: apt_key
-  url: '{{ dockerproject_apt_repo_gpgkey }}'
+  url: '{{ docker_debian_repo_gpgkey }}'
   repo_keys:
     - 58118E89F3A912897C070ADBF76221572C52609D
 
@@ -45,6 +45,6 @@ dockerproject_repo_info:
   pkg_repo: apt_repository
   repos:
     - >
-       deb {{ dockerproject_apt_repo_base_url }}
+       deb {{ docker_debian_repo_base_url }}
        {{ ansible_distribution|lower }}-{{ ansible_distribution_release|lower }}
        main

--- a/roles/container-engine/docker/vars/ubuntu-amd64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-amd64.yml
@@ -37,7 +37,7 @@ docker_repo_info:
 
 dockerproject_repo_key_info:
   pkg_key: apt_key
-  url: '{{ dockerproject_apt_repo_gpgkey }}'
+  url: '{{ docker_debian_repo_gpgkey }}'
   repo_keys:
     - 58118E89F3A912897C070ADBF76221572C52609D
 
@@ -45,6 +45,6 @@ dockerproject_repo_info:
   pkg_repo: apt_repository
   repos:
     - >
-       deb {{ dockerproject_apt_repo_base_url }}
+       deb {{ docker_debian_repo_base_url }}
        {{ ansible_distribution|lower }}-{{ ansible_distribution_release|lower }}
        main

--- a/roles/container-engine/docker/vars/ubuntu-arm64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-arm64.yml
@@ -33,7 +33,7 @@ docker_repo_info:
 
 dockerproject_repo_key_info:
   pkg_key: apt_key
-  url: '{{ dockerproject_apt_repo_gpgkey }}'
+  url: '{{ docker_debian_repo_gpgkey }}'
   repo_keys:
     - 58118E89F3A912897C070ADBF76221572C52609D
 
@@ -41,6 +41,6 @@ dockerproject_repo_info:
   pkg_repo: apt_repository
   repos:
     - >
-       deb {{ dockerproject_apt_repo_base_url }}
+       deb {{ docker_debian_repo_base_url }}
        {{ ansible_distribution|lower }}-{{ ansible_distribution_release|lower }}
        main


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This change removes the dockerproject_.+_repo_.+ docker variables in favor of the older
ones.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
