### PR TITLE
Fix the command for kube-proxy cleanup

### DIFF
--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -153,7 +153,7 @@
   set_fact:
     kube_proxy_cleanup_command: >-
       {%- if container_manager in ['docker', 'crio'] %}
-      {{ docker_bin_dir }}/docker run --rm --privileged -v /lib/modules:{{ kube_proxy_image_repo }}:{{ kube_version }} --cleanup
+      {{ docker_bin_dir }}/docker run --rm --privileged -v /lib/modules:/lib/modules {{ kube_proxy_image_repo }}:{{ kube_version }} kube-proxy --cleanup
       {%- elif container_manager == "containerd" %}
       ctr run --rm --mount type=bind,src=/lib/modules,dst=/lib/modules,options=rbind:rw {{ kube_proxy_image_repo }}:{{ kube_version }} kube-proxy --cleanup
       {%- endif %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind bug

**What this PR does / why we need it**:

Fix the command used to clean up Kube-proxy settings when `kube_proxy_remove` is set. Without this PR, the cleanup command would result in failure.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

N/A

**Special notes for your reviewer**:

Have locally tested

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
