### PR TITLE
Fixing deprecated `failed` filter which was removed in Ansible 2.9

### DIFF
--- a/roles/download/tasks/download_container.yml
+++ b/roles/download/tasks/download_container.yml
@@ -57,7 +57,7 @@
       delegate_to: "{{ download_delegate if download_run_once else inventory_hostname }}"
       run_once: "{{ download_run_once }}"
       register: container_load_status
-      failed_when: container_load_status | failed
+      failed_when: container_load_status is failed
       become: "{{ user_can_become_root | default(false) or not (download_run_once and download_localhost) }}"
       when:
         - download_force_cache


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
(Don't consider this as a feature, but the issue #5635 is marked that way, so I kept it.

Updates the deprecated Ansible filter `failed` as described in the [Ansible 1.5 porting guide](https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.5.html).

**What this PR does / why we need it**:

Ansible playbook fails without this fix, as Ansible >=2.9 removed the filter completely.

**Which issue(s) this PR fixes**:

Fixes #5635 

**Special notes for your reviewer**:

Reran the whole playbook on a Vagrant box and verified the cluster is up and running.

**Does this PR introduce a user-facing change?**:

No.
