### PR TITLE
Added support for optional Ansible user

### DIFF
--- a/contrib/inventory_builder/inventory.py
+++ b/contrib/inventory_builder/inventory.py
@@ -199,7 +199,7 @@ class KubesprayInventory(object):
                                             'ip': ip,
                                             'access_ip': access_ip,
                                            'ansible_user': ANSIBLE_USER}
-                elif:
+                else:
                     all_hosts[next_host] = {'ansible_host': access_ip,
                                             'ip': ip,
                                             'access_ip': access_ip}
@@ -222,7 +222,7 @@ class KubesprayInventory(object):
                                             'ip': ip,
                                             'access_ip': access_ip,
                                            'ansible_user': ANSIBLE_USER}
-                elif:
+                else:
                     all_hosts[next_host] = {'ansible_host': access_ip,
                                             'ip': ip,
                                             'access_ip': access_ip}

--- a/contrib/inventory_builder/inventory.py
+++ b/contrib/inventory_builder/inventory.py
@@ -198,7 +198,7 @@ class KubesprayInventory(object):
                     all_hosts[next_host] = {'ansible_host': access_ip,
                                             'ip': ip,
                                             'access_ip': access_ip,
-                                           'ansible_user': ANSIBLE_USER}
+                                            'ansible_user': ANSIBLE_USER}
                 else:
                     all_hosts[next_host] = {'ansible_host': access_ip,
                                             'ip': ip,
@@ -218,14 +218,14 @@ class KubesprayInventory(object):
                     self.debug("Skipping existing host {0}.".format(ip))
                     continue
                 if ANSIBLE_USER:
-                    all_hosts[next_host] = {'ansible_host': access_ip,
-                                            'ip': ip,
-                                            'access_ip': access_ip,
+                    all_hosts[hostname] = {'ansible_host': access_ip,
+                                           'ip': ip,
+                                           'access_ip': access_ip,
                                            'ansible_user': ANSIBLE_USER}
                 else:
-                    all_hosts[next_host] = {'ansible_host': access_ip,
-                                            'ip': ip,
-                                            'access_ip': access_ip}
+                    all_hosts[hostname] = {'ansible_host': access_ip,
+                                           'ip': ip,
+                                           'access_ip': access_ip}
         return all_hosts
 
     def range2ips(self, hosts):

--- a/contrib/inventory_builder/inventory.py
+++ b/contrib/inventory_builder/inventory.py
@@ -62,10 +62,10 @@ def get_var_as_bool(name, default):
 
 
 CONFIG_FILE = os.environ.get("CONFIG_FILE", "./inventory/sample/hosts.yaml")
-KUBE_MASTERS = int(os.environ.get("KUBE_MASTERS_MASTERS", 2))
+KUBE_MASTERS = int(os.environ.get("KUBE_MASTERS_MASTERS", 3))
 # Reconfigures cluster distribution at scale
 SCALE_THRESHOLD = int(os.environ.get("SCALE_THRESHOLD", 50))
-MASSIVE_SCALE_THRESHOLD = int(os.environ.get("SCALE_THRESHOLD", 200))
+MASSIVE_SCALE_THRESHOLD = int(os.environ.get("SCALE_THRESHOLD", 3))
 
 DEBUG = get_var_as_bool("DEBUG", True)
 HOST_PREFIX = os.environ.get("HOST_PREFIX", "node")
@@ -195,7 +195,8 @@ class KubesprayInventory(object):
                 next_host_id += 1
                 all_hosts[next_host] = {'ansible_host': access_ip,
                                         'ip': ip,
-                                        'access_ip': access_ip}
+                                        'access_ip': access_ip,
+                                       'ansible_user': 'root'}
             elif host[0].isalpha():
                 if ',' in host:
                     try:
@@ -211,7 +212,8 @@ class KubesprayInventory(object):
                     continue
                 all_hosts[hostname] = {'ansible_host': access_ip,
                                        'ip': ip,
-                                       'access_ip': access_ip}
+                                       'access_ip': access_ip,
+                                       'ansible_user': 'root'}
         return all_hosts
 
     def range2ips(self, hosts):

--- a/contrib/inventory_builder/inventory.py
+++ b/contrib/inventory_builder/inventory.py
@@ -62,10 +62,11 @@ def get_var_as_bool(name, default):
 
 
 CONFIG_FILE = os.environ.get("CONFIG_FILE", "./inventory/sample/hosts.yaml")
-KUBE_MASTERS = int(os.environ.get("KUBE_MASTERS_MASTERS", 3))
+ANSIBLE_USER = os.environ.get("ANSIBLE_USER", None)
+KUBE_MASTERS = int(os.environ.get("KUBE_MASTERS_MASTERS", 2))
 # Reconfigures cluster distribution at scale
 SCALE_THRESHOLD = int(os.environ.get("SCALE_THRESHOLD", 50))
-MASSIVE_SCALE_THRESHOLD = int(os.environ.get("SCALE_THRESHOLD", 3))
+MASSIVE_SCALE_THRESHOLD = int(os.environ.get("SCALE_THRESHOLD", 200))
 
 DEBUG = get_var_as_bool("DEBUG", True)
 HOST_PREFIX = os.environ.get("HOST_PREFIX", "node")
@@ -193,10 +194,16 @@ class KubesprayInventory(object):
 
                 next_host = "{0}{1}".format(HOST_PREFIX, next_host_id)
                 next_host_id += 1
-                all_hosts[next_host] = {'ansible_host': access_ip,
-                                        'ip': ip,
-                                        'access_ip': access_ip,
-                                       'ansible_user': 'root'}
+                if ANSIBLE_USER:
+                    all_hosts[next_host] = {'ansible_host': access_ip,
+                                            'ip': ip,
+                                            'access_ip': access_ip,
+                                           'ansible_user': ANSIBLE_USER}
+                elif:
+                    all_hosts[next_host] = {'ansible_host': access_ip,
+                                            'ip': ip,
+                                            'access_ip': access_ip}
+
             elif host[0].isalpha():
                 if ',' in host:
                     try:
@@ -210,10 +217,15 @@ class KubesprayInventory(object):
                 elif self.exists_ip(all_hosts, ip):
                     self.debug("Skipping existing host {0}.".format(ip))
                     continue
-                all_hosts[hostname] = {'ansible_host': access_ip,
-                                       'ip': ip,
-                                       'access_ip': access_ip,
-                                       'ansible_user': 'root'}
+                if ANSIBLE_USER:
+                    all_hosts[next_host] = {'ansible_host': access_ip,
+                                            'ip': ip,
+                                            'access_ip': access_ip,
+                                           'ansible_user': ANSIBLE_USER}
+                elif:
+                    all_hosts[next_host] = {'ansible_host': access_ip,
+                                            'ip': ip,
+                                            'access_ip': access_ip}
         return all_hosts
 
     def range2ips(self, hosts):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
Added optional Ansible user to inventory builder so that a user doesn't have to setup accounts first on the inventory


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
