### PR TITLE
Add support for HA deployment of OpenStack Cinder CSI plugin

### DIFF
--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin.yml.j2
@@ -24,6 +24,11 @@ spec:
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
+{% if cinder_csi_controller_replicas is defined and cinder_csi_controller_replicas > 1 %}
+            - --leader-election
+            - --leader-election-type=leases
+            - --leader-election-namespace=kube-system
+{% endif %}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -38,6 +43,11 @@ spec:
 {% if cinder_topology is defined and cinder_topology %}
             - --feature-gates=Topology=true
 {% endif %}
+{% if cinder_csi_controller_replicas is defined and cinder_csi_controller_replicas > 1 %}
+            - --enable-leader-election
+            - --leader-election-type=leases
+            - --leader-election-namespace=kube-system
+{% endif %}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -49,6 +59,10 @@ spec:
           image: {{ cinder_csi_snapshotter_image_repo }}:{{ cinder_csi_snapshotter_image_tag }}
           args:
             - "--csi-address=$(ADDRESS)"
+{% if cinder_csi_controller_replicas is defined and cinder_csi_controller_replicas > 1 %}
+            - --leader-election
+            - --leader-election-namespace=kube-system
+{% endif %}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -60,6 +74,10 @@ spec:
           image: {{ cinder_csi_resizer_image_repo }}:{{ cinder_csi_resizer_image_tag }}
           args:
             - "--csi-address=$(ADDRESS)"
+{% if cinder_csi_controller_replicas is defined and cinder_csi_controller_replicas > 1 %}
+            - --leader-election
+            - --leader-election-namespace=kube-system
+{% endif %}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When the OpenStack Cinder CSI plugin is deployed with `replicas > 1` there is no leader election. Thus, every replica assumes they're the leader and will respond to volume attach, provision, snapshot and resize events. This means that creating a PersistentVolumeClaim effectively creates N volumes in OpenStack and attaches these volumes N times to a node.

This PR fixes this bug by enabling leader election for all CSI sidecars when `replicas > 1`.

**Special notes for your reviewer**:
The flags that are needed to enable leader election differ per sidecar.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
