### PR TITLE
Allow docker and containerd package to be overridden

### DIFF
--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -14,6 +14,11 @@ containerd_config:
 containerd_version: '1.2.10'
 containerd_package: 'containerd.io'
 
+# Override the package name and version of the containerd installation
+# containerd_package_override:
+# - name: "containerd.io-1.2.4-3.1.el7"
+#   yum_conf: "{{ containerd_yum_conf }}"
+
 containerd_cfg_dir: /etc/containerd
 
 # Path to runc binary

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -77,7 +77,7 @@
   until: containerd_task_result is succeeded
   retries: 4
   delay: "{{ retry_stagger | d(3) }}"
-  with_items: "{{ containerd_package_info.pkgs }}"
+  with_items: "{{ containerd_package_override if containerd_package_override is defined else containerd_package_info.pkgs }}"
   notify: restart containerd
   when:
     - not is_atomic

--- a/roles/container-engine/docker/defaults/main.yml
+++ b/roles/container-engine/docker/defaults/main.yml
@@ -2,6 +2,11 @@
 docker_version: '18.09'
 docker_selinux_version: '17.03'
 
+# Override the package name and version of the docker installation
+# docker_package_override:
+# - name: "docker-engine-1.13.1-1.el7.centos"
+#   yum_conf: "{{ docker_yum_conf }}"
+
 docker_package_info:
   pkgs:
 

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -160,7 +160,7 @@
   until: docker_task_result is succeeded
   retries: 4
   delay: "{{ retry_stagger | d(3) }}"
-  with_items: "{{ docker_package_info.pkgs }}"
+  with_items: "{{ docker_package_override if docker_package_override is defined else docker_package_info.pkgs }}"
   notify: restart docker
   when: not (ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk", "ClearLinux"] or is_atomic) and (docker_package_info.pkgs|length > 0)
   ignore_errors: true
@@ -170,7 +170,7 @@
   args:
     name: "{{ item.name }}"
     state: "{{ item.state | default('present') }}"
-  with_items: "{{ docker_package_info.pkgs }}"
+  with_items: "{{ docker_package_override if docker_package_override is defined else docker_package_info.pkgs }}"
   register: docker_task_result
   until: docker_task_result is succeeded
   retries: 4

--- a/roles/container-engine/docker/templates/docker.service.j2
+++ b/roles/container-engine/docker/templates/docker.service.j2
@@ -3,15 +3,15 @@ Description=Docker Application Container Engine
 Documentation=http://docs.docker.com
 {% if ansible_os_family == "RedHat" %}
 After=network.target {{ ' docker-storage-setup.service' if docker_container_storage_setup else '' }}{{ ' containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') else '' }}
-{{ 'BindsTo=containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') }}
+{{ 'BindsTo=containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') else '' }}
 {{ 'Wants=docker-storage-setup.service' if docker_container_storage_setup else '' }}
 {% elif ansible_os_family == "Debian" %}
 After=network.target docker.socket{{ ' containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') else '' }}
-{{ 'BindsTo=containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') }}
+{{ 'BindsTo=containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') else '' }}
 Wants=docker.socket
 {% elif ansible_os_family == "Suse" %}
 After=network.target{{ ' containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') else '' }}
-{{ 'BindsTo=containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') }}
+{{ 'BindsTo=containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') else '' }}
 {% endif %}
 
 [Service]


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR adds a way to override the package installed when running the docker/containerd container-engine roles.

I need a way to specify alternative docker/containerd versions, which is not easily accomplished with the current method of using `include_vars` to load the os-specific variables. We often end up using patch releases of Docker and resort to modifying kubespray.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
