### PR TITLE
Fix variable naming bug in OpenStack CCM

### DIFF
--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
@@ -43,5 +43,5 @@ floating-subnet-id={{ external_openstack_lbaas_floating_subnet_id }}
 manage-security-groups={{ external_openstack_lbaas_manage_security_groups }}
 {% endif %}
 {% if external_openstack_lbaas_internal_lb is defined %}
-internal-lb={{ external_openstack_internal_lb }}
+internal-lb={{ external_openstack_lbaas_internal_lb }}
 {% endif %}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This fixes a small error in the variable naming of the `internal_lb` parameter for the OpenStack CCM.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

Thanks to @klippo for letting me know of this bug.