### PR TITLE
Use the v2.12.3 docker image for CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,7 +39,7 @@ before_script:
   tags:
     - packet
   variables:
-    KUBESPRAY_VERSION: v2.12.0
+    KUBESPRAY_VERSION: v2.12.3
   image: quay.io/kubespray/kubespray:$KUBESPRAY_VERSION
 
 .testcases: &testcases


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
dockerproject repos are offline, see [official announcement](https://www.docker.com/blog/changes-dockerproject-org-apt-yum-repositories/) 