### PR TITLE
Fix docker.service template for docker 1.13

### DIFF
--- a/roles/container-engine/docker/templates/docker.service.j2
+++ b/roles/container-engine/docker/templates/docker.service.j2
@@ -3,16 +3,16 @@ Description=Docker Application Container Engine
 Documentation=http://docs.docker.com
 {% if ansible_os_family == "RedHat" %}
 After=network.target {{ ' docker-storage-setup.service' if docker_container_storage_setup else '' }}{{ ' containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') else '' }}
-{{ 'BindsTo=containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') }}
+{{ 'BindsTo=containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') else '' }}
 {{ 'Wants=docker-storage-setup.service' if docker_container_storage_setup else '' }}
 {% elif ansible_os_family == "Debian" %}
 After=network.target docker.socket{{ ' containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') else '' }}
-{{ 'BindsTo=containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') }}
+{{ 'BindsTo=containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') else '' }}
 Wants=docker.socket
 {% elif ansible_os_family == "Suse" %}
 After=network.target lvm2-monitor.service SuSEfirewall2.service
 # After=network.target{{ ' containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') else '' }}
-# {{ 'BindsTo=containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') }}
+# {{ 'BindsTo=containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') else '' }}
 {% endif %}
 
 [Service]


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

When installing docker `1.13`, the `docker.service` template errors, prior to this change:
```
fatal: [hostname1.fqdn.net]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: the inline if-expression on line 6 evaluated to false and no else section was defined."}
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
