### PR TITLE
add calico VXLAN mode, update docs and vars in sample inventory

### DIFF
--- a/docs/calico.md
+++ b/docs/calico.md
@@ -12,55 +12,55 @@ Check if the calico-node container is running
 docker ps | grep calico
 ```
 
-The **calicoctl** command allows to check the status of the network workloads.
+The **calicoctl.sh** is wrap script with configured acces credentials for command calicoctl allows to check the status of the network workloads.
 
 * Check the status of Calico nodes
 
 ```ShellSession
-calicoctl node status
+calicoctl.sh node status
 ```
 
 or for versions prior to *v1.0.0*:
 
 ```ShellSession
-calicoctl status
+calicoctl.sh status
 ```
 
 * Show the configured network subnet for containers
 
 ```ShellSession
-calicoctl get ippool -o wide
+calicoctl.sh get ippool -o wide
 ```
 
 or for versions prior to *v1.0.0*:
 
 ```ShellSession
-calicoctl pool show
+calicoctl.sh pool show
 ```
 
 * Show the workloads (ip addresses of containers and their located)
 
 ```ShellSession
-calicoctl get workloadEndpoint -o wide
+calicoctl.sh get workloadEndpoint -o wide
 ```
 
 and
 
 ```ShellSession
-calicoctl get hostEndpoint -o wide
+calicoctl.sh get hostEndpoint -o wide
 ```
 
 or for versions prior *v1.0.0*:
 
 ```ShellSession
-calicoctl endpoint show --detail
+calicoctl.sh endpoint show --detail
 ```
 
 ## Configuration
 
 ### Optional : Define network backend
 
-In some cases you may want to define Calico network backend. Allowed values are 'bird', 'gobgp' or 'none'. Bird is a default value.
+In some cases you may want to define Calico network backend. Allowed values are `bird`, `vxlan` or `none`. Bird is a default value.
 
 To re-define you need to edit the inventory and add a group variable `calico_network_backend`
 
@@ -199,9 +199,29 @@ To re-define health host please set the following variable in your inventory:
 calico_healthhost: "0.0.0.0"
 ```
 
+## Config encapsulation for cross server traffic
+
+Calico supports two types of encapsulation: [VXLAN and IP in IP](https://docs.projectcalico.org/v3.11/networking/vxlan-ipip). VXLAN is supported in some environments where IP in IP is not (for example, Azure).
+
+*IP in IP* and *VXLAN* is mutualy exclusive modes.
+
+Configure Ip in Ip mode. Possible values is `Always`, `CrossSubnet`, `Never`.
+
+```yml
+calico_ipip_mode: 'Always'
+```
+
+Configure VXLAN mode. Possible values is `Always`, `CrossSubnet`, `Never`.
+
+```yml
+calico_vxlan_mode: 'Never'
+```
+
+If you use VXLAN mode, BGP networking is not required. You can disable BGP to reduce the moving parts in your cluster by `calico_network_backend: vxlan`
+
 ## Cloud providers configuration
 
-Please refer to the official documentation, for example [GCE configuration](http://docs.projectcalico.org/v1.5/getting-started/docker/installation/gce) requires a security rule for calico ip-ip tunnels. Note, calico is always configured with ``ipip: true`` if the cloud provider was defined.
+Please refer to the official documentation, for example [GCE configuration](http://docs.projectcalico.org/v1.5/getting-started/docker/installation/gce) requires a security rule for calico ip-ip tunnels. Note, calico is always configured with ``calico_ipip_mode: Always`` if the cloud provider was defined.
 
 ### Optional : Ignore kernel's RPF check setting
 

--- a/inventory/sample/group_vars/k8s-cluster/k8s-net-calico.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-net-calico.yml
@@ -47,6 +47,17 @@
 # Set max typha connections
 # typha_max_connections_lower_limit: 300
 
+# Set calico network backend: "bird", "vxlan" or "none"
+# bird enable BGP routing, required for ipip mode.
+# calico_network_backend: bird
+
+# IP in IP and VXLAN is mutualy exclusive modes.
+# set IP in IP encapsulation mode: "Always", "CrossSubnet", "Never"
+# calico_ipip_mode: 'Always'
+
+# set VXLAN encapsulation mode: "Always", "CrossSubnet", "Never"
+# calico_vxlan_mode: 'Never'
+
 # If you want to use non default IP_AUTODETECTION_METHOD for calico node set this option to one of:
 # * can-reach=DESTINATION
 # * interface=INTERFACE-REGEX

--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -9,6 +9,8 @@ calico_ipv4pool_ipip: "Off"
 # Use IP-over-IP encapsulation across hosts
 ipip: true
 ipip_mode: "{{ 'Always' if ipip else 'Never' }}"  # change to "CrossSubnet" if you only want ipip encapsulation on traffic going across subnets
+calico_ipip_mode: "{{ ipip_mode }}"
+calico_vxlan_mode: 'Never'
 
 calico_cert_dir: /etc/calico/certs
 

--- a/roles/network_plugin/calico/tasks/check.yml
+++ b/roles/network_plugin/calico/tasks/check.yml
@@ -6,13 +6,15 @@
       - "calico_pool_name is match('^[a-zA-Z0-9-_\\\\.]{2,63}$')"
     msg: "calico_pool_name contains invalid characters"
 
-- name: "Check vars defined correctly"
+- name: "Check calico network backend defined correctly"
   assert:
     that:
       - "calico_network_backend in ['bird', 'vxlan', 'none']"
     msg: "calico network backend is not 'bird', 'vxlan' or 'none'"
+  when:
+    - calico_network_backend is defined
 
-- name: "Check vars defined correctly"
+- name: "Check ipip and vxlan mode defined correctly"
   assert:
     that:
       - "calico_ipip_mode in ['Always', 'CrossSubnet', 'Never']"

--- a/roles/network_plugin/calico/tasks/check.yml
+++ b/roles/network_plugin/calico/tasks/check.yml
@@ -4,10 +4,36 @@
     that:
       - "calico_pool_name is defined"
       - "calico_pool_name is match('^[a-zA-Z0-9-_\\\\.]{2,63}$')"
-      - "ipip_mode is defined"
-      - "ipip_mode in ['Always', 'CrossSubnet', 'Never']"
-    msg: "Check variable definitions seems something is wrong"
-  run_once: yes
+    msg: "calico_pool_name contains invalid characters"
+
+- name: "Check vars defined correctly"
+  assert:
+    that:
+      - "calico_network_backend in ['bird', 'vxlan', 'none']"
+    msg: "calico network backend is not 'bird', 'vxlan' or 'none'"
+
+- name: "Check vars defined correctly"
+  assert:
+    that:
+      - "calico_ipip_mode in ['Always', 'CrossSubnet', 'Never']"
+      - "calico_vxlan_mode in ['Always', 'CrossSubnet', 'Never']"
+    msg: "calico inter host encapsulation mode is not 'Always', 'CrossSubnet' or 'Never'"
+
+- name: "Check ipip and vxlan mode if simultaneously enabled"
+  assert:
+    that:
+      - "calico_vxlan_mode in ['Never']"
+    msg: "IP in IP and VXLAN mode is mutualy exclusive modes"
+  when:
+    - "calico_ipip_mode in ['Always', 'CrossSubnet']"
+
+- name: "Check ipip and vxlan mode if simultaneously enabled"
+  assert:
+    that:
+      - "calico_ipip_mode in ['Never']"
+    msg: "IP in IP and VXLAN mode is mutualy exclusive modes"
+  when:
+    - "calico_vxlan_mode in ['Always', 'CrossSubnet']"
 
 - name: "Get current version of calico cluster version"
   shell: "{{ bin_dir }}/calicoctl.sh version  | grep 'Cluster Version:' | awk '{ print $3}'"

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -140,7 +140,8 @@
         },
         "spec": {
           "cidr": "{{ calico_pool_cidr | default(kube_pods_subnet) }}",
-          "ipipMode": "{{ ipip_mode }}",
+          "ipipMode": "{{ calico_ipip_mode }}",
+          "vxlanMode": "{{ calico_vxlan_mode }}",
           "natOutgoing": {{ nat_outgoing|default(false) and not peer_with_router|default(false) }} }} " | {{ bin_dir }}/calicoctl.sh apply -f -
   when:
     - inventory_hostname == groups['kube-master'][0]
@@ -158,7 +159,8 @@
         "spec": {
           "blockSize": "{{ calico_pool_blocksize | default(kube_network_node_prefix) }}",
           "cidr": "{{ calico_pool_cidr | default(kube_pods_subnet) }}",
-          "ipipMode": "{{ ipip_mode }}",
+          "ipipMode": "{{ calico_ipip_mode }}",
+          "vxlanMode": "{{ calico_vxlan_mode }}",
           "natOutgoing": {{ nat_outgoing|default(false) and not peer_with_router|default(false) }} }} " | {{ bin_dir }}/calicoctl.sh apply -f -
   when:
     - inventory_hostname == groups['kube-master'][0]

--- a/roles/network_plugin/calico/templates/calico-config.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-config.yml.j2
@@ -15,9 +15,9 @@ data:
   # essential.
   typha_service_name: "calico-typha"
 {% endif %}
-{% if calico_network_backend is defined and calico_network_backend == 'none' %}
+{% if calico_network_backend is defined %}
   cluster_type: "kubespray"
-  calico_backend: "none"
+  calico_backend: "{{ calico_network_backend }}"
 {% else %}
   cluster_type: "kubespray,bgp"
   calico_backend: "bird"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

enable calico VXLAN tunneling, updated documentation a bit
introduced two new variables:
`calico_ipip_mode:`
`calico_vxlan_mode:`
leaving compatibility with the old `ipip:` and `ipip_mode:`
