### PR TITLE
Set host_architecture for docker & containerd

### DIFF
--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -5,6 +5,22 @@
   when:
     - not ansible_distribution in ["CentOS","RedHat", "Ubuntu", "Debian"]
 
+- name: set architecture_groups
+  set_fact:
+    architecture_groups:
+      x86_64: amd64
+      aarch64: arm64
+      armv7l: arm
+
+- name: ansible_architecture_rename
+  set_fact:
+    host_architecture: >-
+      {%- if ansible_architecture in architecture_groups -%}
+      {{ architecture_groups[ansible_architecture] }}
+      {%- else -%}
+      {{ ansible_architecture }}
+      {% endif %}
+
 - name: gather os specific variables
   include_vars: "{{ item }}"
   with_first_found:

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -8,6 +8,22 @@
   set_fact:
     is_atomic: "{{ ostree.stat.exists }}"
 
+- name: set architecture_groups
+  set_fact:
+    architecture_groups:
+      x86_64: amd64
+      aarch64: arm64
+      armv7l: arm
+
+- name: ansible_architecture_rename
+  set_fact:
+    host_architecture: >-
+      {%- if ansible_architecture in architecture_groups -%}
+      {{ architecture_groups[ansible_architecture] }}
+      {%- else -%}
+      {{ ansible_architecture }}
+      {% endif %}
+
 - name: gather os specific variables
   include_vars: "{{ item }}"
   with_first_found:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
When `cluster.yml` is run with `--tags docker` as documented in [`docs/upgrades.md`](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/upgrades.md), it will fail (at least for Ubuntu) to find `vars/<dist>_<arch>.yml` since [`host_architecture` is not set](https://github.com/kubernetes-sigs/kubespray/blob/986c46c2b6cfcc83c5a9257839247016abb1d87a/roles/container-engine/docker/tasks/main.yml#L19).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
This variable is originally set in `kubernetes/preinstall`, but [the same method](https://github.com/kubernetes-sigs/kubespray/blob/986c46c2b6cfcc83c5a9257839247016abb1d87a/roles/etcd/tasks/main.yml#L2-L15) is also used in `etcd` role.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
