### PR TITLE
[Openstack] Install Cinder-CSI before first node is schedulable again

### DIFF
--- a/upgrade-cluster.yml
+++ b/upgrade-cluster.yml
@@ -92,7 +92,7 @@
     - { role: kubernetes/client, tags: client }
     - { role: kubernetes/node-label, tags: node-label }
     - { role: kubernetes-apps/cluster_roles, tags: cluster-roles }
-    - { role: kubernetes-apps/csi_driver/cinder }
+    - { role: kubernetes-apps, tags: cinder-csi-driver }
     - { role: upgrade/post-upgrade, tags: post-upgrade }
   environment: "{{ proxy_env }}"
 

--- a/upgrade-cluster.yml
+++ b/upgrade-cluster.yml
@@ -92,6 +92,7 @@
     - { role: kubernetes/client, tags: client }
     - { role: kubernetes/node-label, tags: node-label }
     - { role: kubernetes-apps/cluster_roles, tags: cluster-roles }
+    - { role: kubernetes-apps/csi_driver/cinder }
     - { role: upgrade/post-upgrade, tags: post-upgrade }
   environment: "{{ proxy_env }}"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
If upgrading from Kubespray 2.12.X and migrating to the new external openstack cloud provider pods with volume(s) won't start since there is no provider to mount the cinder volume since the old openstack provider is removed and cinder CSI is installed after all nodes are drained.

This is just to avoid downtime when replacing/migration from the old Openastck in tree cloud provider with Cinder CSI

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kubespray/issues/5736

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
