### PR TITLE
Add OWNERS file for OpenStack CSI driver and cloud controller

### DIFF
--- a/roles/kubernetes-apps/csi_driver/OWNERS
+++ b/roles/kubernetes-apps/csi_driver/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+reviewers:
+  - alijahnas
+  - luckySB

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/OWNERS
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+reviewers:
+  - alijahnas
+  - luckySB


### PR DESCRIPTION
In #5432 @LuckySB and @alijahnas volunteered to give a hand to maintain the openstack csi_driver (and I assume the external cloud controller as well, since @alijahnas is the author of #5491). Since they have been also actively reviewing incoming PRs on the topic I suggest to add them to the respective OWNERS file.