### PR TITLE
Enable retries on SSH error during CI

### DIFF
--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,6 +1,7 @@
 [ssh_connection]
 pipelining=True
 ansible_ssh_common_args = -o ControlMaster=auto -o ControlPersist=30m -o ConnectionAttempts=100
+retries=2
 [defaults]
 forks = 20
 host_key_checking=False


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
Tests sometimes fail due to an SSH timeout ([example](https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/467682244)). An automatic retry should mitigate those failures.