### PR TITLE
Update Kube-Router version to v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [cilium](https://github.com/cilium/cilium) v1.5.5
   - [contiv](https://github.com/contiv/install) v1.2.1
   - [flanneld](https://github.com/coreos/flannel) v0.11.0
-  - [kube-router](https://github.com/cloudnativelabs/kube-router) v0.2.5
+  - [kube-router](https://github.com/cloudnativelabs/kube-router) v0.4.0
   - [multus](https://github.com/intel/multus-cni) v3.4
   - [weave](https://github.com/weaveworks/weave) v2.5.2
 - Application

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -82,7 +82,7 @@ pod_infra_version: 3.1
 contiv_version: 1.2.1
 cilium_version: "v1.7.1"
 kube_ovn_version: "v0.6.0"
-kube_router_version: "v0.2.5"
+kube_router_version: "v0.4.0"
 multus_version: "v3.4"
 
 # Get kubernetes major version (i.e. 1.15.4 => 1.15)

--- a/roles/network_plugin/kube-router/tasks/main.yml
+++ b/roles/network_plugin/kube-router/tasks/main.yml
@@ -37,7 +37,7 @@
 
 - name: kube-router | Slurp cni config
   slurp:
-    src: /etc/cni/net.d/10-kuberouter.conf
+    src: /etc/cni/net.d/10-kuberouter.conflist
   register: cni_config_slurp
   ignore_errors: true
 
@@ -49,29 +49,23 @@
 
 - name: kube-router | Set host_subnet variable
   set_fact:
-    host_subnet: "{{ cni_config.ipam.subnet }}"
+    host_subnet: "{{ cni_config | json_query('plugins[?bridge==`kube-bridge`].ipam.subnet') | first }}"
   when:
     - cni_config is defined
-    - cni_config.ipam is defined
-    - cni_config.ipam.subnet is defined
-
-- name: kube-router | Set wanted cni config variable
-  set_fact:
-    wanted_cni_config: "{{ lookup('template', 'cni-conf.json.j2') }}"
-
-- name: kube-router | Set wanted_cni_config variable
-  set_fact:
-    wanted_cni_config: "{{ wanted_cni_config | combine({ 'ipam': { 'subnet': host_subnet }}, recursive=True) }}"
-  when: host_subnet is defined
+    - cni_config | json_query('plugins[?bridge==`kube-bridge`].ipam.subnet') | length > 0
 
 - name: kube-router | Create cni config
-  copy:
-    content: "{{ wanted_cni_config | to_nice_json }}"
-    dest: /etc/cni/net.d/10-kuberouter.conf
+  template:
+    src: cni-conf.json.j2
+    dest: /etc/cni/net.d/10-kuberouter.conflist
     owner: kube
-  changed_when: wanted_cni_config != cni_config
   notify:
     - reset_kube_router
+
+- name: kube-router | Delete old configuration
+  file:
+    path: /etc/cni/net.d/10-kuberouter.conf
+    state: absent
 
 - name: kube-router | Create manifest
   template:

--- a/roles/network_plugin/kube-router/templates/cni-conf.json.j2
+++ b/roles/network_plugin/kube-router/templates/cni-conf.json.j2
@@ -1,13 +1,21 @@
 {
-  "name":"kubernetes",
-  "cniVersion": "0.2.0",
-  "type":"bridge",
-  "bridge":"kube-bridge",
-  "isDefaultGateway":true,
+   "cniVersion":"0.3.0",
+   "name":"kubernetes",
+   "plugins":[
+      {
+         "name":"kubernetes",
+         "type":"bridge",
+         "bridge":"kube-bridge",
+         "isDefaultGateway":true,
 {% if kube_router_support_hairpin_mode %}
-  "hairpinMode":true,
+          "hairpinMode":true,
 {% endif %}
-  "ipam": {
-    "type":"host-local"
-  }
+         "ipam":{
+{% if host_subnet is defined %}
+            "subnet": "{{ host_subnet }}",
+{% endif %}
+            "type":"host-local"
+         }
+      }
+   ]
 }

--- a/roles/network_plugin/kube-router/templates/kube-router.yml.j2
+++ b/roles/network_plugin/kube-router/templates/kube-router.yml.j2
@@ -69,6 +69,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: KUBE_ROUTER_CNI_CONF_FILE
+          value: /etc/cni/net.d/10-kuberouter.conflist
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

Update default Kube-Router version to `v0.4.0`. Update also CNI version.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update default Kube-Router version to `v0.4.0`
```
