### PR TITLE
CI inventory should start at 1 instead of 0

### DIFF
--- a/tests/cloud_playbooks/roles/packet-ci/tasks/create-vms.yml
+++ b/tests/cloud_playbooks/roles/packet-ci/tasks/create-vms.yml
@@ -17,7 +17,7 @@
   template:
     src: "vm.yml.j2"
     dest: "/tmp/{{ test_name }}/instance-{{ vm_id }}.yml"
-  loop: "{{ range(0, vm_count|int, 1) | list }}"
+  loop: "{{ range(1, vm_count|int + 1, 1) | list }}"
   loop_control:
     index_var: vm_id
 
@@ -25,14 +25,14 @@
   k8s:
     state: present
     src: "/tmp/{{ test_name }}/instance-{{ vm_id }}.yml"
-  loop: "{{ range(0, vm_count|int, 1) | list }}"
+  loop: "{{ range(1, vm_count|int + 1, 1) | list }}"
   loop_control:
     index_var: vm_id
 
 - name: Wait for vms to have ipaddress assigned
   shell: "kubectl get vmis -n {{ test_name }} instance-{{ vm_id }} -o json | jq '.status.interfaces[].ipAddress' | tr -d '\"'"
   register: vm_ips
-  loop: "{{ range(0, vm_count|int, 1) | list }}"
+  loop: "{{ range(1, vm_count|int + 1, 1) | list }}"
   loop_control:
     index_var: vm_id
   retries: 20


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
In tests/cloud_playbooks/roles/packet-ci/templates/inventory.j2 the inventory starts at instance-1 but in create-vms.yml it starts from 0. Which makes a mismatch between the kube-virt resource name, hostname and inventory.