### PR TITLE
Use k8s.gcr.io for kubernetes related images

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -23,7 +23,7 @@ kube_api_anonymous_auth: true
 kube_version: v1.16.6
 
 # kubernetes image repo define
-kube_image_repo: "{{ gcr_image_repo }}/google-containers"
+kube_image_repo: "k8s.gcr.io"
 
 # Where the binaries will be downloaded.
 # Note: ensure that you've enough disk space (about 1G)

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -55,7 +55,7 @@ etcd_version: v3.3.12
 
 # gcr and kubernetes image repo define
 gcr_image_repo: "gcr.io"
-kube_image_repo: "{{ gcr_image_repo }}/google-containers"
+kube_image_repo: "k8s.gcr.io"
 
 # docker image repo define
 docker_image_repo: "docker.io"
@@ -364,7 +364,7 @@ calico_policy_image_repo: "{{ docker_image_repo }}/calico/kube-controllers"
 calico_policy_image_tag: "{{ calico_policy_version }}"
 calico_typha_image_repo: "{{ docker_image_repo }}/calico/typha"
 calico_typha_image_tag: "{{ calico_typha_version }}"
-pod_infra_image_repo: "{{ gcr_image_repo }}/google_containers/pause-{{ image_arch }}"
+pod_infra_image_repo: "{{ kube_image_repo }}/pause"
 pod_infra_image_tag: "{{ pod_infra_version }}"
 install_socat_image_repo: "{{ docker_image_repo }}/xueshanf/install-socat"
 install_socat_image_tag: "latest"
@@ -434,10 +434,10 @@ tiller_image_tag: "{{ helm_version }}"
 
 registry_image_repo: "{{ docker_image_repo }}/library/registry"
 registry_image_tag: "2.6"
-registry_proxy_image_repo: "{{ gcr_image_repo }}/google_containers/kube-registry-proxy"
+registry_proxy_image_repo: "{{ kube_image_repo }}/kube-registry-proxy"
 registry_proxy_image_tag: "0.4"
 metrics_server_version: "v0.3.6"
-metrics_server_image_repo: "{{ gcr_image_repo }}/google_containers/metrics-server-amd64"
+metrics_server_image_repo: "{{ kube_image_repo }}/metrics-server-{{ image_arch }}"
 metrics_server_image_tag: "{{ metrics_server_version }}"
 local_volume_provisioner_image_repo: "{{ quay_image_repo }}/external_storage/local-volume-provisioner"
 local_volume_provisioner_image_tag: "v2.3.2"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
`gcr.io/google-containers` will be replaced by `gcr.io/k8s-artifacts-prod` soon (early April). Using k8s.gcr.io should be safe until the cutoff is done and even after.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5711

**Special notes for your reviewer**:
I didn't address the dashboard image as they moved it to dockerhub for the latest releases. Current version is actually not compatible with 1.16.x. It should be addressed in a separate PR.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
