### PR TITLE
Change python crypto module from  pycrypto to cryptography

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,6 +3,6 @@ yamllint==1.19.0
 apache-libcloud==2.2.1
 tox==3.11.1
 dopy==0.3.7
-PyCrypto==2.6.1
+cryptography==2.8
 ansible-lint==4.2.0
 openshift==0.8.8


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

There  are CVEs ([CVE-2013-7459](https://github.com/advisories/GHSA-cq27-v7xp-c356) and  [CVE-2018-6594](https://github.com/advisories/GHSA-6528-wvf6-f6qg)) affecting pycrypto 2.6.1 [without a patch available](https://pypi.org/project/pycrypto/). The  [cryptography](https://pypi.org/project/pycrypto/) package is better maintained so we should probably switch  to that