### PR TITLE
Use a separate runner for light CI jobs

### DIFF
--- a/.gitlab-ci/lint.yml
+++ b/.gitlab-ci/lint.yml
@@ -2,6 +2,7 @@
 yamllint:
   extends: .job
   stage: unit-tests
+  tags: [light]
   variables:
     LANG: C.UTF-8
   script:
@@ -11,6 +12,7 @@ yamllint:
 vagrant-validate:
   extends: .job
   stage: unit-tests
+  tags: [light]
   variables:
     VAGRANT_VERSION: 2.2.4
   script:
@@ -20,6 +22,7 @@ vagrant-validate:
 ansible-lint:
   extends: .job
   stage: unit-tests
+  tags: [light]
   # lint every yml/yaml file that looks like it contains Ansible plays
   script: |-
     grep -Rl '^- hosts: \|^  hosts: ' --include \*.yml --include \*.yaml . | xargs -P 4 -n 25 ansible-lint -v
@@ -28,6 +31,7 @@ ansible-lint:
 syntax-check:
   extends: .job
   stage: unit-tests
+  tags: [light]
   variables:
     ANSIBLE_INVENTORY: inventory/local-tests.cfg
     ANSIBLE_REMOTE_USER: root
@@ -43,6 +47,7 @@ syntax-check:
 
 tox-inventory-builder:
   stage: unit-tests
+  tags: [light]
   extends: .job
   before_script:
     - ./tests/scripts/rebase.sh
@@ -56,6 +61,7 @@ tox-inventory-builder:
 
 markdownlint:
   stage: unit-tests
+  tags: [light]
   image: node
   before_script:
     - npm install -g markdownlint-cli

--- a/.gitlab-ci/shellcheck.yml
+++ b/.gitlab-ci/shellcheck.yml
@@ -2,6 +2,7 @@
 shellcheck:
   extends: .job
   stage: unit-tests
+  tags: [light]
   variables:
     SHELLCHECK_VERSION: v0.6.0
   before_script:

--- a/.gitlab-ci/terraform.yml
+++ b/.gitlab-ci/terraform.yml
@@ -22,6 +22,7 @@
 .terraform_validate:
   extends: .terraform_install
   stage: unit-tests
+  tags: [light]
   only: ['master', /^pr-.*$/]
   script:
     - terraform validate -var-file=cluster.tfvars contrib/terraform/$PROVIDER
@@ -29,6 +30,7 @@
 
 .terraform_apply:
   extends: .terraform_install
+  tags: [light]
   stage: deploy-part2
   when: manual
   only: [/^pr-.*$/]
@@ -106,6 +108,7 @@ tf-validate-aws:
 
 tf-ovh_cleanup:
   stage: unit-tests
+  tags: [light]
   image: python
   variables:
     <<: *ovh_variables


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
CI jobs that create VMs in KubeVirt are "heavy" on the CI cluster whereas other jobs are easier on the cluster. Therefore I propose to split them in 2 runners.

This will allow light jobs to run even if all the heavy runners are busy, which happens often and it's a pain to get linting jobs queue up.

Here is. an example of this happening, kube-virt jobs are queued up, but the light jobs for this PR are able to go through, giving fast feedback to linting errors.

<img width="782" alt="Screen Shot 2020-03-13 at 17 31 52" src="https://user-images.githubusercontent.com/13647208/76640671-a055fb80-6550-11ea-9ec6-b3f6486395a8.png">
