### PR TITLE
[WIP] Allocate 4GB of RAM for each CI job

### DIFF
--- a/tests/cloud_playbooks/roles/packet-ci/defaults/main.yml
+++ b/tests/cloud_playbooks/roles/packet-ci/defaults/main.yml
@@ -4,7 +4,7 @@
 vm_cpu_cores: 2
 vm_cpu_sockets: 1
 vm_cpu_threads: 2
-vm_memory: 2048Mi
+vm_memory: 4096Mi
 
 # Request/Limit allocation settings
 


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
CI cluster is loaded leading to flaky CI. More RAM might help.

Let's see how the CI for this PR works out.