### PR TITLE
Only check ansible_all_ipv4_addresses if it is defined

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -97,6 +97,7 @@
     that: ip in ansible_all_ipv4_addresses
   when:
     - not ignore_assert_errors
+    - ansible_all_ipv4_addresses is defined
     - ip is defined
 
 - name: Stop if access_ip is not pingable


### PR DESCRIPTION
Signed-off-by: Craig Rodrigues <craig@portworx.com>


**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:

If you define `ip=` in your hosts.ini file, then you will hit this assertion if ansible_all_ipv4_addresses is not defined.

**Which issue(s) this PR fixes**:
Fixes #2981

**Special notes for your reviewer**:

In Opencontrail, they explicitly check if `ansible_all_ipv4_addresses` exists before using it:
https://review.opencontrail.org/c/Juniper/contrail-ansible-deployer/+/47468#q,8eb7fdacab2bd66593c0d6ea591ea51b83c1ec79,n,z

I think we need to do the same

**Does this PR introduce a user-facing change?**:

```release-note

NONE
```
