### PR TITLE
Fix etcd install with docker and etcd_kubeadm_enabled

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -540,17 +540,17 @@ downloads:
 
   etcd:
     container: "{{ etcd_deployment_type != 'host' }}"
-    file: "{{ etcd_deployment_type == 'host' or etcd_kubeadm_enabled }}"
+    file: "{{ etcd_deployment_type == 'host' }}"
     enabled: true
     version: "{{ etcd_version }}"
-    dest: "{{local_release_dir}}/etcd-{{ etcd_version }}-linux-amd64.tar.gz"
+    dest: "{{ local_release_dir }}/etcd-{{ etcd_version }}-linux-amd64.tar.gz"
     repo: "{{ etcd_image_repo }}"
     tag: "{{ etcd_image_tag }}"
     sha256: >-
-     {{ etcd_binary_checksum if (etcd_deployment_type == 'host' or etcd_kubeadm_enabled)
+     {{ etcd_binary_checksum if (etcd_deployment_type == 'host')
      else etcd_digest_checksum|d(None) }}
     url: "{{ etcd_download_url }}"
-    unarchive: true
+    unarchive: "{{ etcd_deployment_type == 'host' }}"
     owner: "root"
     mode: "0755"
     groups:

--- a/roles/etcd/tasks/install_docker.yml
+++ b/roles/etcd/tasks/install_docker.yml
@@ -1,14 +1,5 @@
 ---
-- name: Install | Copy etcdctl binary from docker container
-  command: sh -c "{{ docker_bin_dir }}/docker rm -f etcdctl-binarycopy;
-           {{ docker_bin_dir }}/docker create --name etcdctl-binarycopy {{ etcd_image_repo }}:{{ etcd_image_tag }} &&
-           {{ docker_bin_dir }}/docker cp etcdctl-binarycopy:/usr/local/bin/etcdctl {{ bin_dir }}/etcdctl &&
-           {{ docker_bin_dir }}/docker rm -f etcdctl-binarycopy"
-  register: etcd_task_result
-  until: etcd_task_result.rc == 0
-  retries: "{{ etcd_retries }}"
-  delay: "{{ retry_stagger | random + 3 }}"
-  changed_when: false
+- import_tasks: install_etcdctl_docker.yml
   when: etcd_cluster_setup
 
 - name: Install etcd launch script

--- a/roles/etcd/tasks/install_etcdctl_docker.yml
+++ b/roles/etcd/tasks/install_etcdctl_docker.yml
@@ -1,0 +1,11 @@
+---
+- name: Install | Copy etcdctl binary from docker container
+  command: sh -c "{{ docker_bin_dir }}/docker rm -f etcdctl-binarycopy;
+           {{ docker_bin_dir }}/docker create --name etcdctl-binarycopy {{ etcd_image_repo }}:{{ etcd_image_tag }} &&
+           {{ docker_bin_dir }}/docker cp etcdctl-binarycopy:/usr/local/bin/etcdctl {{ bin_dir }}/etcdctl &&
+           {{ docker_bin_dir }}/docker rm -f etcdctl-binarycopy"
+  register: etcdctl_install_result
+  until: etcdctl_install_result.rc == 0
+  retries: "{{ etcd_retries }}"
+  delay: "{{ retry_stagger | random + 3 }}"
+  changed_when: false

--- a/roles/kubernetes/master/tasks/kubeadm-etcd.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-etcd.yml
@@ -16,3 +16,12 @@
   include_tasks: "{{ role_path }}/../../etcd/tasks/install_host.yml"
   vars:
     etcd_cluster_setup: true
+  when: etcd_deployment_type == "host"
+
+- name: Ensure etcdctl binary is installed
+  include_tasks: "{{ role_path }}/../../etcd/tasks/install_etcdctl_docker.yml"
+  vars:
+    etcd_cluster_setup: true
+    etcd_retries: 4
+  when:
+    - etcd_deployment_type == "docker"

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -260,6 +260,12 @@
     msg: "kubeadm etcd mode requires experimental control plane"
   when: etcd_kubeadm_enabled
 
+- name: Stop if etcd deployment type is not host or docker
+  assert:
+    that: etcd_deployment_type in ['host', 'docker']
+    msg: "The etcd deployment type, 'etcd_deployment_type', must be host or docker"
+  run_once: true
+
 - name: Stop if download_localhost is enabled but download_run_once is not
   assert:
     that: download_run_once

--- a/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
@@ -185,7 +185,6 @@
     kube_etcd_cacert_file: "etcd/ca.crt"
     kube_etcd_cert_file: "apiserver-etcd-client.crt"
     kube_etcd_key_file: "apiserver-etcd-client.key"
-    etcd_deployment_type: host
   when:
     - etcd_kubeadm_enabled
 


### PR DESCRIPTION
  - This solves issue #5721 & #5713 (dupes)
  - Provide a cleaner default usage pattern for the download role
    around etcd that supports 'host' and 'docker' properly
  - Extract the 'etcdctl' as a separate task install piece and reuse it where
    appropriate
  - Update the kubeadm-etcd task to reflect the above change

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

There might be certain situations where our cluster nodes can't reach out to the location where the etcd tarball is in order to extract etcdctl and if we've already specified docker as the deployment type, why not just leverage the local image itself in order to get etcdctl? This image would have been pulled from a private registry.  The goal of this PR is to cleanup the `download` role for `etcd` to facilitate this as easily as possible based on current variables that users are familiar with: `etcd_deployment_type` && `etcd_deployment_type`.  After looking at the original code - it appeared to me, hopefully correctly, that we were using `etcd_kubeadm_enabled` to perform conditional logic around etcd in the download role incorrectly.  This also attempts to address that issue.

**Which issue(s) this PR fixes**:

Fixes #5721 & #5713

**Special notes for your reviewer**:

Local Testing Performed:

- [x] `etcd_deployment_type: host` && ` etcd_kubeadm_enabled: false`
- [x] `etcd_deployment_type: host` && ` etcd_kubeadm_enabled: true`
- [x] `etcd_deployment_type: docker` && ` etcd_kubeadm_enabled: false`
- [x] `etcd_deployment_type: docker` && ` etcd_kubeadm_enabled: true`

