### PR TITLE
Adding new registry_port* options

### DIFF
--- a/roles/kubernetes-apps/registry/defaults/main.yml
+++ b/roles/kubernetes-apps/registry/defaults/main.yml
@@ -2,3 +2,4 @@
 registry_namespace: "kube-system"
 registry_storage_class: ""
 registry_disk_size: "10Gi"
+registry_port: 5000

--- a/roles/kubernetes-apps/registry/templates/registry-proxy-ds.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-proxy-ds.yml.j2
@@ -31,8 +31,8 @@ spec:
             - name: REGISTRY_HOST
               value: registry.{{ registry_namespace }}.svc.{{ cluster_name }}
             - name: REGISTRY_PORT
-              value: "5000"
+              value: "{{ registry_port }}"
           ports:
             - name: registry
               containerPort: 80
-              hostPort: 5000
+              hostPort: {{ registry_port }}

--- a/roles/kubernetes-apps/registry/templates/registry-proxy-psp.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-proxy-psp.yml.j2
@@ -36,8 +36,8 @@ spec:
     - 'persistentVolumeClaim'
   hostNetwork: true
   hostPorts:
-  - min: 5000
-    max: 5000
+  - min: {{ registry_port }}
+    max: {{ registry_port }}
   hostIPC: false
   hostPID: false
   runAsUser:

--- a/roles/kubernetes-apps/registry/templates/registry-rs.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-rs.yml.j2
@@ -30,14 +30,14 @@ spec:
           imagePullPolicy: {{ k8s_image_pull_policy }}
           env:
             - name: REGISTRY_HTTP_ADDR
-              value: :5000
+              value: :{{ registry_port }}
             - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
               value: /var/lib/registry
           volumeMounts:
             - name: registry-pvc
               mountPath: /var/lib/registry
           ports:
-            - containerPort: 5000
+            - containerPort: {{ registry_port }}
               name: registry
               protocol: TCP
       volumes:

--- a/roles/kubernetes-apps/registry/templates/registry-svc.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-svc.yml.j2
@@ -14,5 +14,5 @@ spec:
     k8s-app: registry
   ports:
     - name: registry
-      port: 5000
+      port: {{ registry_port }}
       protocol: TCP


### PR DESCRIPTION
New overrides are added to allow installation of the registry
on different ports than ``5000``. The default port is unchanged
from previous versions

/kind feature

**What this PR does / why we need it**:

A new overrides are added to allow installation of the registry
on different ports than ``5000``. The default port is unchanged
from previous versions

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

NONE

```release-note
A new overrides are added to allow installation of the registry
on different ports than 5000. The default port is unchanged
from previous versions.

Overrides:
registry_port: 5000
registry_min_port: 5000
registry_max_port: 5000
```
