### PR TITLE
fix incorrect documentation of use_access_ip

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -264,6 +264,7 @@ For your cluster, edit `inventory/$CLUSTER/cluster.tfvars`.
 |`etcd_root_volume_size_in_gb` | Size of the root volume for etcd nodes, 0 to use ephemeral storage |
 |`bastion_root_volume_size_in_gb` | Size of the root volume for bastions, 0 to use ephemeral storage |
 |`use_server_group` | Create and use openstack nova servergroups, default: false |
+|`use_access_ip` | If 1, nodes with floating IPs will transmit internal cluster traffic via floating IPs; if 0 private IPs will be used instead. Default value is 1. |
 |`k8s_nodes` | Map containing worker node definition, see explanation below |
 
 ##### k8s_nodes
@@ -537,10 +538,6 @@ resolvconf_mode: host_resolvconf
 - Set max amount of attached cinder volume per host (default 256)
 ```
 node_volume_attach_limit: 26
-```
-- Disable access_ip, this will make all innternal cluster traffic to be sent over local network when a floating IP is attached (default this value is set to 1)
-```
-use_access_ip: 0
 ```
 
 ### Deploy Kubernetes


### PR DESCRIPTION
AFAICT the use_access_ip variable was documented as if it were an Ansible variable, but it is a Terraform variable.
This also means the colon syntax was incorrect. TF variables are assigned with an equals sign.

/kind documentation


**Does this PR introduce a user-facing change?**:
no