### PR TITLE
Flex volumes plugins readonly alternative path

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -244,8 +244,10 @@ podsecuritypolicy_enabled: false
 # system_master_memory_reserved: 256M
 # system_master_cpu_reserved: 250m
 
-# An alternative flexvolume plugin directory
+# The flexvolumes plugins directory
 # kubelet_flexvolumes_plugins_dir: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+# Alternative directory if the default flexvolume plugin directory is not writeable
+# kubelet_flexvolumes_plugins_ro_alt_dir: /var/lib/kubelet/volumeplugins
 
 ## Supplementary addresses that can be added in kubernetes ssl keys.
 ## That can be useful for example to setup a keepalived virtual IP

--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -27,7 +27,7 @@ kube_config_dir: /etc/kubernetes
 kube_cert_dir: "{{ kube_config_dir }}/ssl"
 kube_cert_compat_dir: /etc/kubernetes/pki
 kubelet_flexvolumes_plugins_dir: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
-# Alternate path for system where the default plugins_dir is readonly, e.g. /usr on CoreOS
+# Alternative path for systems where the default kubelet_flexvolumes_plugins_dir is readonly, e.g. CoreOS
 kubelet_flexvolumes_plugins_ro_alt_dir: /var/lib/kubelet/volumeplugins
 # Container Linux by CoreOS cloud init config file to define /etc/resolv.conf content
 # for hostnet pods and infra needs

--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -27,7 +27,8 @@ kube_config_dir: /etc/kubernetes
 kube_cert_dir: "{{ kube_config_dir }}/ssl"
 kube_cert_compat_dir: /etc/kubernetes/pki
 kubelet_flexvolumes_plugins_dir: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
-
+# Alternate path for system where the default plugins_dir is readonly, e.g. /usr on CoreOS
+kubelet_flexvolumes_plugins_ro_alt_dir: /var/lib/kubelet/volumeplugins
 # Container Linux by CoreOS cloud init config file to define /etc/resolv.conf content
 # for hostnet pods and infra needs
 resolveconf_cloud_init_conf: /etc/resolveconf_cloud_init.conf

--- a/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
@@ -198,12 +198,17 @@
   when:
     - etcd_kubeadm_enabled
 
-- name: check /usr readonly
+- name: check if the flexvolume root path is readonly
   stat:
-    path: "/usr"
-  register: usr
+    path: "{{ kubelet_flexvolumes_plugins_dir | regex_search('^/[^/]+(/|$)') }}" # matches the first directory in the path
+  register: flexvp_path
+
+- name: notify about the alternative flexvolume path
+  debug:
+    msg: "The requested flexvolumes plugins path is not writeable, using {{ kubelet_flexvolumes_plugins_ro_alt_dir }} instead of {{ kubelet_flexvolumes_plugins_dir }}."
+  when: not flexvp_path.stat.writeable
 
 - name: set alternate flexvolume path
   set_fact:
-    kubelet_flexvolumes_plugins_dir: /var/lib/kubelet/volumeplugins
-  when: not usr.stat.writeable
+    kubelet_flexvolumes_plugins_dir: "{{ kubelet_flexvolumes_plugins_ro_alt_dir }}"
+  when: not flexvp_path.stat.writeable

--- a/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
@@ -205,7 +205,7 @@
 
 - name: notify about the alternative flexvolume path
   debug:
-    msg: "The requested flexvolumes plugins path is not writeable, using {{ kubelet_flexvolumes_plugins_ro_alt_dir }} instead of {{ kubelet_flexvolumes_plugins_dir }}."
+    msg: "The flexvolumes plugins path {{ kubelet_flexvolumes_plugins_dir }} is not writeable, using {{ kubelet_flexvolumes_plugins_ro_alt_dir }}."
   when: not flexvp_path.stat.writeable
 
 - name: set alternate flexvolume path

--- a/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
@@ -200,7 +200,7 @@
 
 - name: check if the flexvolume root path is readonly
   stat:
-    path: "{{ kubelet_flexvolumes_plugins_dir | regex_search('^/[^/]+(/|$)') }}" # matches the first directory in the path
+    path: "{{ kubelet_flexvolumes_plugins_dir | regex_search('^/[^/]+(/|$)') }}"  # matches the first directory in the path
   register: flexvp_path
 
 - name: notify about the alternative flexvolume path


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes a problem in which setting the variable `kubelet_flexvolumes_plugins_dir` had no effect. Also introduces some changes to improve how the path is detected to be readonly and remove a hardcoded value from the task itself.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5786

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Users of CoreOS and other systems where the default kubelet_flexvolumes_plugins_dir is not writeable can now use an alternative one with kubelet_flexvolumes_plugins_ro_alt_dir
```
