### PR TITLE
Fix assertion in download role

### DIFF
--- a/roles/download/tasks/prep_download.yml
+++ b/roles/download/tasks/prep_download.yml
@@ -38,6 +38,7 @@
   register: test_docker
   changed_when: false
   ignore_errors: true
+  become: false
   when:
     - download_localhost
   tags:


### PR DESCRIPTION
Fix check if user can use docker without sudo.

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
I found a bug in assertion tasks on the 'download' role. If the user executing ansible doesn't have sudo on the local station and the download_localhost option is set to True, kubespray returns an error. The user unnecessarily tries to escalate permissions (this is caused by the become option in the ansible-playbook parameters). I changed the become parameter to false in this particular task and now it's work properly.

Ansible Output:
```
TASK [download : prep_download | On localhost, check if passwordless root is possible] **********************************************************************
fatal: [st-kubnode101 -> localhost]: FAILED! => {"changed": false, "module_stderr": "sudo: a password is required\n", "module_stdout": "", "msg": "MODULE FAI
LURE\nSee stdout/stderr for the exact error", "rc": 1}
...ignoring

TASK [download : prep_download | On localhost, check if user has access to docker without using sudo] *******************************************************
fatal: [st-kubnode101 -> localhost]: FAILED! => {"changed": false, "module_stderr": "sudo: a password is required\n", "module_stdout": "", "msg": "MODULE FAI
LURE\nSee stdout/stderr for the exact error", "rc": 1}
...ignoring

TASK [download : prep_download | Parse the outputs of the previous commands] ********************************************************************************
ok: [st-kubnode101]
ok: [st-kubnode102]
ok: [st-kubmaster102]
ok: [st-kubmaster101]
ok: [st-kubmaster103]

TASK [download : prep_download | Check that local user is in group or can become root] **********************************************************************
fatal: [st-kubnode101]: FAILED! => {
    "assertion": "user_in_docker_group or user_can_become_root",
    "changed": false,
    "evaluated_to": false,
    "msg": "Error: User is not in docker group and cannot become root. When download_localhost is true, at least one of these two conditions must be met."

```

**Which issue(s) this PR fixes**:
Fixes None

**Special notes for your reviewer**:
None 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
