### PR TITLE
Add a test to check that nodes are Ready

### DIFF
--- a/tests/scripts/testcases_run.sh
+++ b/tests/scripts/testcases_run.sh
@@ -60,6 +60,9 @@ ansible-playbook -e ansible_python_interpreter=${PYPATH} --limit "all:!fake_host
 ## Test that all pods are Running
 ansible-playbook -e ansible_python_interpreter=${PYPATH} --limit "all:!fake_hosts" tests/testcases/015_check-pods-running.yml $LOG_LEVEL
 
+## Test that all nodes are Ready
+ansible-playbook -e ansible_python_interpreter=${PYPATH} --limit "all:!fake_hosts" tests/testcases/020_check-nodes-ready.yml $LOG_LEVEL
+
 ## Test pod creation and ping between them
 ansible-playbook -e ansible_python_interpreter=${PYPATH} --limit "all:!fake_hosts" tests/testcases/030_check-network.yml $LOG_LEVEL
 

--- a/tests/testcases/020_check-nodes-ready.yml
+++ b/tests/testcases/020_check-nodes-ready.yml
@@ -1,0 +1,30 @@
+---
+- hosts: kube-master[0]
+  tasks:
+
+  - name: Force binaries directory for Container Linux by CoreOS and Flatcar
+    set_fact:
+      bin_dir: "/opt/bin"
+    when: ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+
+  - name: Force binaries directory for other hosts
+    set_fact:
+      bin_dir: "/usr/local/bin"
+    when: not ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+
+  - name: Check kubectl output
+    shell: "{{ bin_dir }}/kubectl get nodes"
+    register: get_nodes
+    no_log: true
+
+  - debug:
+      msg: "{{ get_nodes.stdout.split('\n') }}"
+
+  - name: Check that all nodes are running and ready
+    shell: "{{ bin_dir }}/kubectl get nodes --no-headers -o yaml"
+    register: get_nodes_yaml
+    until:
+    # Check that all nodes are Status=Ready
+    - '(get_nodes_yaml.stdout | from_yaml)["items"] | map(attribute = "status.conditions") | map("items2dict", key_name="type", value_name="status") | map(attribute="Ready") | list | min'
+    retries: 30
+    delay: 10


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test
/kind feature

**What this PR does / why we need it**:
Tests might fail with complex error messages because nodes are not in Ready state. Therefore we should check that all nodes are in Ready status early and give an appropriate error message.