### PR TITLE
rename handler to fix ansible 2.8 issue

### DIFF
--- a/roles/kubernetes/kubeadm/handlers/main.yml
+++ b/roles/kubernetes/kubeadm/handlers/main.yml
@@ -1,5 +1,15 @@
 ---
-- name: restart kubelet
+- name: Kubeadm | restart kubelet
+  command: /bin/true
+  notify:
+    - Kubeadm | reload systemd
+    - Kubeadm | reload kubelet
+
+- name: Kubeadm | reload systemd
+  systemd:
+    daemon_reload: true
+
+- name: Kubeadm | reload kubelet
   service:
     name: kubelet
     state: restarted

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -101,7 +101,7 @@
     - kubeadm_config_api_fqdn is not defined
     - not is_kube_master
     - kubeadm_discovery_address != kube_apiserver_endpoint | replace("https://", "")
-  notify: restart kubelet
+  notify: Kubeadm | restart kubelet
 
 # FIXME(mattymo): Need to point to localhost, otherwise masters will all point
 #                 incorrectly to first master, creating SPoF.

--- a/roles/kubernetes/node/handlers/main.yml
+++ b/roles/kubernetes/node/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: restart kubelet
+- name: Node | restart kubelet
   command: /bin/true
   notify:
     - Kubelet | reload systemd

--- a/roles/kubernetes/node/tasks/install.yml
+++ b/roles/kubernetes/node/tasks/install.yml
@@ -35,7 +35,7 @@
   tags:
     - kubelet
     - upgrade
-  notify: restart kubelet
+  notify: Node | restart kubelet
 
 - name: install | Set kubelet binary permissions
   file:

--- a/roles/kubernetes/node/tasks/kubelet.yml
+++ b/roles/kubernetes/node/tasks/kubelet.yml
@@ -23,7 +23,7 @@
     src: "kubelet.env.{{ kubeadmConfig_api_version }}.j2"
     dest: "{{ kube_config_dir }}/kubelet.env"
     backup: yes
-  notify: restart kubelet
+  notify: Node | restart kubelet
   when: kubeadm_output.stdout is version('v1.13.0', '>=')
   tags:
     - kubelet
@@ -43,7 +43,7 @@
     src: "kubelet.service.j2"
     dest: "/etc/systemd/system/kubelet.service"
     backup: "yes"
-  notify: restart kubelet
+  notify: Node | restart kubelet
   tags:
     - kubelet
     - kubeadm

--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -221,7 +221,7 @@
   when:
     - cloud_provider is defined
     - cloud_provider in [ 'openstack', 'azure', 'vsphere', 'aws' ]
-  notify: restart kubelet
+  notify: Node | restart kubelet
   tags:
     - cloud-provider
 


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
with ansible 2.8 and play upgrade_cluster.yml kubelet on worker nodes is not restarted
Because to restart the handler `restart kubelet` is called

Handler with this name is in two roles
all playbook handlers in the ensemble are in the same space, and out of two handlers with the same name only one will be executed - https://github.com/ansible/ansible/issues/8553

In ansible 2.7, this is the handler from the first role in the playbook list
and in ansible 2.8 it’s the handle from the LAST role in list !!!

Rename handlers to a unique name
