### PR TITLE
Bump node local dns version to 1.15.11

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -451,7 +451,7 @@ coredns_version: "1.6.7"
 coredns_image_repo: "{{ docker_image_repo }}/coredns/coredns"
 coredns_image_tag: "{{ coredns_version }}"
 
-nodelocaldns_version: "1.15.8"
+nodelocaldns_version: "1.15.11"
 nodelocaldns_image_repo: "{{ kube_image_repo }}/k8s-dns-node-cache"
 nodelocaldns_image_tag: "{{ nodelocaldns_version }}"
 


### PR DESCRIPTION
k8s-dns-node-cache now uses debian-iptables base images
to automatically use either iptables-legacy or iptables-nft
https://github.com/kubernetes/dns/pull/355
https://github.com/kubernetes/kubernetes/pull/82966

This adds support CentOS 8

Signed-off-by: Etienne Champetier <champetier.etienne@gmail.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR adds support CentOS 8

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Bump node local dns version to 1.15.11 (add support to iptables-nft / CentOS 8)
```
