### PR TITLE
Fixup recover_control_plane with Ansible 2.9

### DIFF
--- a/roles/recover_control_plane/etcd/tasks/main.yml
+++ b/roles/recover_control_plane/etcd/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Set healthy fact
   set_fact:
-    healthy: "{{ etcd_endpoint_health.stderr | match('Error: unhealthy cluster') }}"
+    healthy: "{{ etcd_endpoint_health.stderr is match('Error: unhealthy cluster') }}"
   when:
     - groups['broken_etcd']
 


### PR DESCRIPTION
Tests as filters support is removed as of Ansible 2.9
https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.5.html#jinja-tests-used-as-filters


**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixup issue with Ansible 2.9

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
