### PR TITLE
Remove Terraform v0.12 warnings from contrib/terraform/aws

### DIFF
--- a/contrib/terraform/aws/create-infrastructure.tf
+++ b/contrib/terraform/aws/create-infrastructure.tf
@@ -3,9 +3,9 @@ terraform {
 }
 
 provider "aws" {
-  access_key = "${var.AWS_ACCESS_KEY_ID}"
-  secret_key = "${var.AWS_SECRET_ACCESS_KEY}"
-  region     = "${var.AWS_DEFAULT_REGION}"
+  access_key = var.AWS_ACCESS_KEY_ID
+  secret_key = var.AWS_SECRET_ACCESS_KEY
+  region     = var.AWS_DEFAULT_REGION
 }
 
 data "aws_availability_zones" "available" {}
@@ -18,30 +18,30 @@ data "aws_availability_zones" "available" {}
 module "aws-vpc" {
   source = "./modules/vpc"
 
-  aws_cluster_name         = "${var.aws_cluster_name}"
-  aws_vpc_cidr_block       = "${var.aws_vpc_cidr_block}"
-  aws_avail_zones          = "${slice(data.aws_availability_zones.available.names, 0, 2)}"
-  aws_cidr_subnets_private = "${var.aws_cidr_subnets_private}"
-  aws_cidr_subnets_public  = "${var.aws_cidr_subnets_public}"
-  default_tags             = "${var.default_tags}"
+  aws_cluster_name         = var.aws_cluster_name
+  aws_vpc_cidr_block       = var.aws_vpc_cidr_block
+  aws_avail_zones          = slice(data.aws_availability_zones.available.names, 0, 2)
+  aws_cidr_subnets_private = var.aws_cidr_subnets_private
+  aws_cidr_subnets_public  = var.aws_cidr_subnets_public
+  default_tags             = var.default_tags
 }
 
 module "aws-elb" {
   source = "./modules/elb"
 
-  aws_cluster_name      = "${var.aws_cluster_name}"
-  aws_vpc_id            = "${module.aws-vpc.aws_vpc_id}"
-  aws_avail_zones       = "${slice(data.aws_availability_zones.available.names, 0, 2)}"
-  aws_subnet_ids_public = "${module.aws-vpc.aws_subnet_ids_public}"
-  aws_elb_api_port      = "${var.aws_elb_api_port}"
-  k8s_secure_api_port   = "${var.k8s_secure_api_port}"
-  default_tags          = "${var.default_tags}"
+  aws_cluster_name      = var.aws_cluster_name
+  aws_vpc_id            = module.aws-vpc.aws_vpc_id
+  aws_avail_zones       = slice(data.aws_availability_zones.available.names, 0, 2)
+  aws_subnet_ids_public = module.aws-vpc.aws_subnet_ids_public
+  aws_elb_api_port      = var.aws_elb_api_port
+  k8s_secure_api_port   = var.k8s_secure_api_port
+  default_tags          = var.default_tags
 }
 
 module "aws-iam" {
   source = "./modules/iam"
 
-  aws_cluster_name = "${var.aws_cluster_name}"
+  aws_cluster_name = var.aws_cluster_name
 }
 
 /*
@@ -50,22 +50,22 @@ module "aws-iam" {
 */
 
 resource "aws_instance" "bastion-server" {
-  ami                         = "${data.aws_ami.distro.id}"
-  instance_type               = "${var.aws_bastion_size}"
-  count                       = "${length(var.aws_cidr_subnets_public)}"
+  ami                         = data.aws_ami.distro.id
+  instance_type               = var.aws_bastion_size
+  count                       = length(var.aws_cidr_subnets_public)
   associate_public_ip_address = true
-  availability_zone           = "${element(slice(data.aws_availability_zones.available.names, 0, 2), count.index)}"
-  subnet_id                   = "${element(module.aws-vpc.aws_subnet_ids_public, count.index)}"
+  availability_zone           = element(slice(data.aws_availability_zones.available.names, 0, 2), count.index)
+  subnet_id                   = element(module.aws-vpc.aws_subnet_ids_public, count.index)
 
-  vpc_security_group_ids = "${module.aws-vpc.aws_security_group}"
+  vpc_security_group_ids = module.aws-vpc.aws_security_group
 
-  key_name = "${var.AWS_SSH_KEY_NAME}"
+  key_name = var.AWS_SSH_KEY_NAME
 
-  tags = "${merge(var.default_tags, map(
+  tags = merge(var.default_tags, map(
     "Name", "kubernetes-${var.aws_cluster_name}-bastion-${count.index}",
     "Cluster", "${var.aws_cluster_name}",
     "Role", "bastion-${var.aws_cluster_name}-${count.index}"
-  ))}"
+  ))
 }
 
 /*
@@ -74,71 +74,71 @@ resource "aws_instance" "bastion-server" {
 */
 
 resource "aws_instance" "k8s-master" {
-  ami           = "${data.aws_ami.distro.id}"
-  instance_type = "${var.aws_kube_master_size}"
+  ami           = data.aws_ami.distro.id
+  instance_type = var.aws_kube_master_size
 
-  count = "${var.aws_kube_master_num}"
+  count = var.aws_kube_master_num
 
-  availability_zone = "${element(slice(data.aws_availability_zones.available.names, 0, 2), count.index)}"
-  subnet_id         = "${element(module.aws-vpc.aws_subnet_ids_private, count.index)}"
+  availability_zone = element(slice(data.aws_availability_zones.available.names, 0, 2), count.index)
+  subnet_id         = element(module.aws-vpc.aws_subnet_ids_private, count.index)
 
-  vpc_security_group_ids = "${module.aws-vpc.aws_security_group}"
+  vpc_security_group_ids = module.aws-vpc.aws_security_group
 
-  iam_instance_profile = "${module.aws-iam.kube-master-profile}"
-  key_name             = "${var.AWS_SSH_KEY_NAME}"
+  iam_instance_profile = module.aws-iam.kube-master-profile
+  key_name             = var.AWS_SSH_KEY_NAME
 
-  tags = "${merge(var.default_tags, map(
+  tags = merge(var.default_tags, map(
     "Name", "kubernetes-${var.aws_cluster_name}-master${count.index}",
     "kubernetes.io/cluster/${var.aws_cluster_name}", "member",
     "Role", "master"
-  ))}"
+  ))
 }
 
 resource "aws_elb_attachment" "attach_master_nodes" {
-  count    = "${var.aws_kube_master_num}"
-  elb      = "${module.aws-elb.aws_elb_api_id}"
-  instance = "${element(aws_instance.k8s-master.*.id, count.index)}"
+  count    = var.aws_kube_master_num
+  elb      = module.aws-elb.aws_elb_api_id
+  instance = element(aws_instance.k8s-master.*.id, count.index)
 }
 
 resource "aws_instance" "k8s-etcd" {
-  ami           = "${data.aws_ami.distro.id}"
-  instance_type = "${var.aws_etcd_size}"
+  ami           = data.aws_ami.distro.id
+  instance_type = var.aws_etcd_size
 
-  count = "${var.aws_etcd_num}"
+  count = var.aws_etcd_num
 
-  availability_zone = "${element(slice(data.aws_availability_zones.available.names, 0, 2), count.index)}"
-  subnet_id         = "${element(module.aws-vpc.aws_subnet_ids_private, count.index)}"
+  availability_zone = element(slice(data.aws_availability_zones.available.names, 0, 2), count.index)
+  subnet_id         = element(module.aws-vpc.aws_subnet_ids_private, count.index)
 
-  vpc_security_group_ids = "${module.aws-vpc.aws_security_group}"
+  vpc_security_group_ids = module.aws-vpc.aws_security_group
 
-  key_name = "${var.AWS_SSH_KEY_NAME}"
+  key_name = var.AWS_SSH_KEY_NAME
 
-  tags = "${merge(var.default_tags, map(
+  tags = merge(var.default_tags, map(
     "Name", "kubernetes-${var.aws_cluster_name}-etcd${count.index}",
     "kubernetes.io/cluster/${var.aws_cluster_name}", "member",
     "Role", "etcd"
-  ))}"
+  ))
 }
 
 resource "aws_instance" "k8s-worker" {
-  ami           = "${data.aws_ami.distro.id}"
-  instance_type = "${var.aws_kube_worker_size}"
+  ami           = data.aws_ami.distro.id
+  instance_type = var.aws_kube_worker_size
 
-  count = "${var.aws_kube_worker_num}"
+  count = var.aws_kube_worker_num
 
-  availability_zone = "${element(slice(data.aws_availability_zones.available.names, 0, 2), count.index)}"
-  subnet_id         = "${element(module.aws-vpc.aws_subnet_ids_private, count.index)}"
+  availability_zone = element(slice(data.aws_availability_zones.available.names, 0, 2), count.index)
+  subnet_id         = element(module.aws-vpc.aws_subnet_ids_private, count.index)
 
-  vpc_security_group_ids = "${module.aws-vpc.aws_security_group}"
+  vpc_security_group_ids = module.aws-vpc.aws_security_group
 
-  iam_instance_profile = "${module.aws-iam.kube-worker-profile}"
-  key_name             = "${var.AWS_SSH_KEY_NAME}"
+  iam_instance_profile = module.aws-iam.kube-worker-profile
+  key_name             = var.AWS_SSH_KEY_NAME
 
-  tags = "${merge(var.default_tags, map(
+  tags = merge(var.default_tags, map(
     "Name", "kubernetes-${var.aws_cluster_name}-worker${count.index}",
     "kubernetes.io/cluster/${var.aws_cluster_name}", "member",
     "Role", "worker"
-  ))}"
+  ))
 }
 
 /*
@@ -146,16 +146,16 @@ resource "aws_instance" "k8s-worker" {
 *
 */
 data "template_file" "inventory" {
-  template = "${file("${path.module}/templates/inventory.tpl")}"
+  template = file("${path.module}/templates/inventory.tpl")
 
   vars = {
-    public_ip_address_bastion = "${join("\n", formatlist("bastion ansible_host=%s", aws_instance.bastion-server.*.public_ip))}"
-    connection_strings_master = "${join("\n", formatlist("%s ansible_host=%s", aws_instance.k8s-master.*.private_dns, aws_instance.k8s-master.*.private_ip))}"
-    connection_strings_node   = "${join("\n", formatlist("%s ansible_host=%s", aws_instance.k8s-worker.*.private_dns, aws_instance.k8s-worker.*.private_ip))}"
-    connection_strings_etcd   = "${join("\n", formatlist("%s ansible_host=%s", aws_instance.k8s-etcd.*.private_dns, aws_instance.k8s-etcd.*.private_ip))}"
-    list_master               = "${join("\n", aws_instance.k8s-master.*.private_dns)}"
-    list_node                 = "${join("\n", aws_instance.k8s-worker.*.private_dns)}"
-    list_etcd                 = "${join("\n", aws_instance.k8s-etcd.*.private_dns)}"
+    public_ip_address_bastion = join("\n", formatlist("bastion ansible_host=%s", aws_instance.bastion-server.*.public_ip))
+    connection_strings_master = join("\n", formatlist("%s ansible_host=%s", aws_instance.k8s-master.*.private_dns, aws_instance.k8s-master.*.private_ip))
+    connection_strings_node   = join("\n", formatlist("%s ansible_host=%s", aws_instance.k8s-worker.*.private_dns, aws_instance.k8s-worker.*.private_ip))
+    connection_strings_etcd   = join("\n", formatlist("%s ansible_host=%s", aws_instance.k8s-etcd.*.private_dns, aws_instance.k8s-etcd.*.private_ip))
+    list_master               = join("\n", aws_instance.k8s-master.*.private_dns)
+    list_node                 = join("\n", aws_instance.k8s-worker.*.private_dns)
+    list_etcd                 = join("\n", aws_instance.k8s-etcd.*.private_dns)
     elb_api_fqdn              = "apiserver_loadbalancer_domain_name=\"${module.aws-elb.aws_elb_api_fqdn}\""
   }
 }
@@ -166,6 +166,6 @@ resource "null_resource" "inventories" {
   }
 
   triggers = {
-    template = "${data.template_file.inventory.rendered}"
+    template = data.template_file.inventory.rendered
   }
 }

--- a/contrib/terraform/aws/modules/elb/main.tf
+++ b/contrib/terraform/aws/modules/elb/main.tf
@@ -1,19 +1,19 @@
 resource "aws_security_group" "aws-elb" {
   name   = "kubernetes-${var.aws_cluster_name}-securitygroup-elb"
-  vpc_id = "${var.aws_vpc_id}"
+  vpc_id = var.aws_vpc_id
 
-  tags = "${merge(var.default_tags, map(
+  tags = merge(var.default_tags, map(
       "Name", "kubernetes-${var.aws_cluster_name}-securitygroup-elb"
-    ))}"
+    ))
 }
 
 resource "aws_security_group_rule" "aws-allow-api-access" {
   type              = "ingress"
-  from_port         = "${var.aws_elb_api_port}"
-  to_port           = "${var.k8s_secure_api_port}"
+  from_port         = var.aws_elb_api_port
+  to_port           = var.k8s_secure_api_port
   protocol          = "TCP"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.aws-elb.id}"
+  security_group_id = aws_security_group.aws-elb.id
 }
 
 resource "aws_security_group_rule" "aws-allow-api-egress" {
@@ -22,19 +22,19 @@ resource "aws_security_group_rule" "aws-allow-api-egress" {
   to_port           = 65535
   protocol          = "TCP"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.aws-elb.id}"
+  security_group_id = aws_security_group.aws-elb.id
 }
 
 # Create a new AWS ELB for K8S API
 resource "aws_elb" "aws-elb-api" {
   name            = "kubernetes-elb-${var.aws_cluster_name}"
   subnets         = var.aws_subnet_ids_public
-  security_groups = ["${aws_security_group.aws-elb.id}"]
+  security_groups = [aws_security_group.aws-elb.id]
 
   listener {
-    instance_port     = "${var.k8s_secure_api_port}"
+    instance_port     = var.k8s_secure_api_port
     instance_protocol = "tcp"
-    lb_port           = "${var.aws_elb_api_port}"
+    lb_port           = var.aws_elb_api_port
     lb_protocol       = "tcp"
   }
 
@@ -51,7 +51,7 @@ resource "aws_elb" "aws-elb-api" {
   connection_draining         = true
   connection_draining_timeout = 400
 
-  tags = "${merge(var.default_tags, map(
+  tags = merge(var.default_tags, map(
     "Name", "kubernetes-${var.aws_cluster_name}-elb-api"
-  ))}"
+  ))
 }

--- a/contrib/terraform/aws/modules/elb/outputs.tf
+++ b/contrib/terraform/aws/modules/elb/outputs.tf
@@ -1,7 +1,7 @@
 output "aws_elb_api_id" {
-  value = "${aws_elb.aws-elb-api.id}"
+  value = aws_elb.aws-elb-api.id
 }
 
 output "aws_elb_api_fqdn" {
-  value = "${aws_elb.aws-elb-api.dns_name}"
+  value = aws_elb.aws-elb-api.dns_name
 }

--- a/contrib/terraform/aws/modules/elb/variables.tf
+++ b/contrib/terraform/aws/modules/elb/variables.tf
@@ -16,15 +16,12 @@ variable "k8s_secure_api_port" {
 
 variable "aws_avail_zones" {
   description = "Availability Zones Used"
-  type        = "list"
 }
 
 variable "aws_subnet_ids_public" {
   description = "IDs of Public Subnets"
-  type        = "list"
 }
 
 variable "default_tags" {
   description = "Tags for all resources"
-  type        = "map"
 }

--- a/contrib/terraform/aws/modules/iam/main.tf
+++ b/contrib/terraform/aws/modules/iam/main.tf
@@ -42,7 +42,7 @@ EOF
 
 resource "aws_iam_role_policy" "kube-master" {
   name = "kubernetes-${var.aws_cluster_name}-master"
-  role = "${aws_iam_role.kube-master.id}"
+  role = aws_iam_role.kube-master.id
 
   policy = <<EOF
 {
@@ -77,7 +77,7 @@ EOF
 
 resource "aws_iam_role_policy" "kube-worker" {
   name = "kubernetes-${var.aws_cluster_name}-node"
-  role = "${aws_iam_role.kube-worker.id}"
+  role = aws_iam_role.kube-worker.id
 
   policy = <<EOF
 {
@@ -132,10 +132,10 @@ EOF
 
 resource "aws_iam_instance_profile" "kube-master" {
   name = "kube_${var.aws_cluster_name}_master_profile"
-  role = "${aws_iam_role.kube-master.name}"
+  role = aws_iam_role.kube-master.name
 }
 
 resource "aws_iam_instance_profile" "kube-worker" {
   name = "kube_${var.aws_cluster_name}_node_profile"
-  role = "${aws_iam_role.kube-worker.name}"
+  role = aws_iam_role.kube-worker.name
 }

--- a/contrib/terraform/aws/modules/iam/outputs.tf
+++ b/contrib/terraform/aws/modules/iam/outputs.tf
@@ -1,7 +1,7 @@
 output "kube-master-profile" {
-  value = "${aws_iam_instance_profile.kube-master.name }"
+  value = aws_iam_instance_profile.kube-master.name
 }
 
 output "kube-worker-profile" {
-  value = "${aws_iam_instance_profile.kube-worker.name }"
+  value = aws_iam_instance_profile.kube-worker.name
 }

--- a/contrib/terraform/aws/modules/vpc/main.tf
+++ b/contrib/terraform/aws/modules/vpc/main.tf
@@ -1,55 +1,55 @@
 resource "aws_vpc" "cluster-vpc" {
-  cidr_block = "${var.aws_vpc_cidr_block}"
+  cidr_block = var.aws_vpc_cidr_block
 
   #DNS Related Entries
   enable_dns_support   = true
   enable_dns_hostnames = true
 
-  tags = "${merge(var.default_tags, map(
+  tags = merge(var.default_tags, map(
       "Name", "kubernetes-${var.aws_cluster_name}-vpc"
-    ))}"
+    ))
 }
 
 resource "aws_eip" "cluster-nat-eip" {
-  count = "${length(var.aws_cidr_subnets_public)}"
+  count = length(var.aws_cidr_subnets_public)
   vpc   = true
 }
 
 resource "aws_internet_gateway" "cluster-vpc-internetgw" {
-  vpc_id = "${aws_vpc.cluster-vpc.id}"
+  vpc_id = aws_vpc.cluster-vpc.id
 
-  tags = "${merge(var.default_tags, map(
+  tags = merge(var.default_tags, map(
     "Name", "kubernetes-${var.aws_cluster_name}-internetgw"
-  ))}"
+  ))
 }
 
 resource "aws_subnet" "cluster-vpc-subnets-public" {
-  vpc_id            = "${aws_vpc.cluster-vpc.id}"
-  count             = "${length(var.aws_avail_zones)}"
-  availability_zone = "${element(var.aws_avail_zones, count.index)}"
-  cidr_block        = "${element(var.aws_cidr_subnets_public, count.index)}"
+  vpc_id            = aws_vpc.cluster-vpc.id
+  count             = length(var.aws_avail_zones)
+  availability_zone = element(var.aws_avail_zones, count.index)
+  cidr_block        = element(var.aws_cidr_subnets_public, count.index)
 
-  tags = "${merge(var.default_tags, map(
+  tags = merge(var.default_tags, map(
       "Name", "kubernetes-${var.aws_cluster_name}-${element(var.aws_avail_zones, count.index)}-public",
       "kubernetes.io/cluster/${var.aws_cluster_name}", "member"
-    ))}"
+    ))
 }
 
 resource "aws_nat_gateway" "cluster-nat-gateway" {
-  count         = "${length(var.aws_cidr_subnets_public)}"
-  allocation_id = "${element(aws_eip.cluster-nat-eip.*.id, count.index)}"
-  subnet_id     = "${element(aws_subnet.cluster-vpc-subnets-public.*.id, count.index)}"
+  count         = length(var.aws_cidr_subnets_public)
+  allocation_id = element(aws_eip.cluster-nat-eip.*.id, count.index)
+  subnet_id     = element(aws_subnet.cluster-vpc-subnets-public.*.id, count.index)
 }
 
 resource "aws_subnet" "cluster-vpc-subnets-private" {
-  vpc_id            = "${aws_vpc.cluster-vpc.id}"
-  count             = "${length(var.aws_avail_zones)}"
-  availability_zone = "${element(var.aws_avail_zones, count.index)}"
-  cidr_block        = "${element(var.aws_cidr_subnets_private, count.index)}"
+  vpc_id            = aws_vpc.cluster-vpc.id
+  count             = length(var.aws_avail_zones)
+  availability_zone = element(var.aws_avail_zones, count.index)
+  cidr_block        = element(var.aws_cidr_subnets_private, count.index)
 
-  tags = "${merge(var.default_tags, map(
+  tags = merge(var.default_tags, map(
       "Name", "kubernetes-${var.aws_cluster_name}-${element(var.aws_avail_zones, count.index)}-private"
-    ))}"
+    ))
 }
 
 #Routing in VPC
@@ -57,53 +57,53 @@ resource "aws_subnet" "cluster-vpc-subnets-private" {
 #TODO: Do we need two routing tables for each subnet for redundancy or is one enough?
 
 resource "aws_route_table" "kubernetes-public" {
-  vpc_id = "${aws_vpc.cluster-vpc.id}"
+  vpc_id = aws_vpc.cluster-vpc.id
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.cluster-vpc-internetgw.id}"
+    gateway_id = aws_internet_gateway.cluster-vpc-internetgw.id
   }
 
-  tags = "${merge(var.default_tags, map(
+  tags = merge(var.default_tags, map(
       "Name", "kubernetes-${var.aws_cluster_name}-routetable-public"
-    ))}"
+    ))
 }
 
 resource "aws_route_table" "kubernetes-private" {
-  count  = "${length(var.aws_cidr_subnets_private)}"
-  vpc_id = "${aws_vpc.cluster-vpc.id}"
+  count  = length(var.aws_cidr_subnets_private)
+  vpc_id = aws_vpc.cluster-vpc.id
 
   route {
     cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = "${element(aws_nat_gateway.cluster-nat-gateway.*.id, count.index)}"
+    nat_gateway_id = element(aws_nat_gateway.cluster-nat-gateway.*.id, count.index)
   }
 
-  tags = "${merge(var.default_tags, map(
+  tags = merge(var.default_tags, map(
       "Name", "kubernetes-${var.aws_cluster_name}-routetable-private-${count.index}"
-    ))}"
+    ))
 }
 
 resource "aws_route_table_association" "kubernetes-public" {
-  count          = "${length(var.aws_cidr_subnets_public)}"
-  subnet_id      = "${element(aws_subnet.cluster-vpc-subnets-public.*.id,count.index)}"
-  route_table_id = "${aws_route_table.kubernetes-public.id}"
+  count          = length(var.aws_cidr_subnets_public)
+  subnet_id      = element(aws_subnet.cluster-vpc-subnets-public.*.id,count.index)
+  route_table_id = aws_route_table.kubernetes-public.id
 }
 
 resource "aws_route_table_association" "kubernetes-private" {
-  count          = "${length(var.aws_cidr_subnets_private)}"
-  subnet_id      = "${element(aws_subnet.cluster-vpc-subnets-private.*.id,count.index)}"
-  route_table_id = "${element(aws_route_table.kubernetes-private.*.id,count.index)}"
+  count          = length(var.aws_cidr_subnets_private)
+  subnet_id      = element(aws_subnet.cluster-vpc-subnets-private.*.id,count.index)
+  route_table_id = element(aws_route_table.kubernetes-private.*.id,count.index)
 }
 
 #Kubernetes Security Groups
 
 resource "aws_security_group" "kubernetes" {
   name   = "kubernetes-${var.aws_cluster_name}-securitygroup"
-  vpc_id = "${aws_vpc.cluster-vpc.id}"
+  vpc_id = aws_vpc.cluster-vpc.id
 
-  tags = "${merge(var.default_tags, map(
+  tags = merge(var.default_tags, map(
       "Name", "kubernetes-${var.aws_cluster_name}-securitygroup"
-    ))}"
+    ))
 }
 
 resource "aws_security_group_rule" "allow-all-ingress" {
@@ -111,8 +111,8 @@ resource "aws_security_group_rule" "allow-all-ingress" {
   from_port         = 0
   to_port           = 65535
   protocol          = "-1"
-  cidr_blocks       = ["${var.aws_vpc_cidr_block}"]
-  security_group_id = "${aws_security_group.kubernetes.id}"
+  cidr_blocks       = [var.aws_vpc_cidr_block]
+  security_group_id = aws_security_group.kubernetes.id
 }
 
 resource "aws_security_group_rule" "allow-all-egress" {
@@ -121,7 +121,7 @@ resource "aws_security_group_rule" "allow-all-egress" {
   to_port           = 65535
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.kubernetes.id}"
+  security_group_id = aws_security_group.kubernetes.id
 }
 
 resource "aws_security_group_rule" "allow-ssh-connections" {
@@ -130,5 +130,5 @@ resource "aws_security_group_rule" "allow-ssh-connections" {
   to_port           = 22
   protocol          = "TCP"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.kubernetes.id}"
+  security_group_id = aws_security_group.kubernetes.id
 }

--- a/contrib/terraform/aws/modules/vpc/outputs.tf
+++ b/contrib/terraform/aws/modules/vpc/outputs.tf
@@ -1,5 +1,5 @@
 output "aws_vpc_id" {
-  value = "${aws_vpc.cluster-vpc.id}"
+  value = aws_vpc.cluster-vpc.id
 }
 
 output "aws_subnet_ids_private" {
@@ -15,5 +15,5 @@ output "aws_security_group" {
 }
 
 output "default_tags" {
-  value = "${var.default_tags}"
+  value = var.default_tags
 }

--- a/contrib/terraform/aws/modules/vpc/variables.tf
+++ b/contrib/terraform/aws/modules/vpc/variables.tf
@@ -8,20 +8,16 @@ variable "aws_cluster_name" {
 
 variable "aws_avail_zones" {
   description = "AWS Availability Zones Used"
-  type        = "list"
 }
 
 variable "aws_cidr_subnets_private" {
   description = "CIDR Blocks for private subnets in Availability zones"
-  type        = "list"
 }
 
 variable "aws_cidr_subnets_public" {
   description = "CIDR Blocks for public subnets in Availability zones"
-  type        = "list"
 }
 
 variable "default_tags" {
   description = "Default tags for all resources"
-  type        = "map"
 }

--- a/contrib/terraform/aws/output.tf
+++ b/contrib/terraform/aws/output.tf
@@ -1,17 +1,17 @@
 output "bastion_ip" {
-  value = "${join("\n", aws_instance.bastion-server.*.public_ip)}"
+  value = join("\n", aws_instance.bastion-server.*.public_ip)
 }
 
 output "masters" {
-  value = "${join("\n", aws_instance.k8s-master.*.private_ip)}"
+  value = join("\n", aws_instance.k8s-master.*.private_ip)
 }
 
 output "workers" {
-  value = "${join("\n", aws_instance.k8s-worker.*.private_ip)}"
+  value = join("\n", aws_instance.k8s-worker.*.private_ip)
 }
 
 output "etcd" {
-  value = "${join("\n", aws_instance.k8s-etcd.*.private_ip)}"
+  value = join("\n", aws_instance.k8s-etcd.*.private_ip)
 }
 
 output "aws_elb_api_fqdn" {
@@ -19,9 +19,9 @@ output "aws_elb_api_fqdn" {
 }
 
 output "inventory" {
-  value = "${data.template_file.inventory.rendered}"
+  value = data.template_file.inventory.rendered
 }
 
 output "default_tags" {
-  value = "${var.default_tags}"
+  value = var.default_tags
 }

--- a/contrib/terraform/aws/output.tf
+++ b/contrib/terraform/aws/output.tf
@@ -19,7 +19,7 @@ output "aws_elb_api_fqdn" {
 }
 
 output "inventory" {
-  value = data.template_file.inventory.rendered
+  value = local_file.inventory.content
 }
 
 output "default_tags" {

--- a/contrib/terraform/aws/terraform.tfvars
+++ b/contrib/terraform/aws/terraform.tfvars
@@ -7,19 +7,19 @@ aws_cidr_subnets_private = ["10.250.192.0/20", "10.250.208.0/20"]
 aws_cidr_subnets_public  = ["10.250.224.0/20", "10.250.240.0/20"]
 
 #Bastion Host
-aws_bastion_size = "t2.medium"
+aws_bastion_size = "t2.micro"
 
 
 #Kubernetes Cluster
 
 aws_kube_master_num  = 3
-aws_kube_master_size = "t2.medium"
+aws_kube_master_size = "t3a.small"
 
 aws_etcd_num  = 3
-aws_etcd_size = "t2.medium"
+aws_etcd_size = "t3a.small"
 
 aws_kube_worker_num  = 4
-aws_kube_worker_size = "t2.medium"
+aws_kube_worker_size = "t3a.small"
 
 #Settings AWS ELB
 
@@ -32,4 +32,4 @@ default_tags = {
   #  Product = "kubernetes"
 }
 
-inventory_file = "../../../inventory/hosts"
+inventory_file = "inventory"

--- a/contrib/terraform/aws/variables.tf
+++ b/contrib/terraform/aws/variables.tf
@@ -44,12 +44,10 @@ variable "aws_vpc_cidr_block" {
 
 variable "aws_cidr_subnets_private" {
   description = "CIDR Blocks for private subnets in Availability Zones"
-  type        = "list"
 }
 
 variable "aws_cidr_subnets_public" {
   description = "CIDR Blocks for public subnets in Availability Zones"
-  type        = "list"
 }
 
 //AWS EC2 Settings
@@ -101,7 +99,6 @@ variable "k8s_secure_api_port" {
 
 variable "default_tags" {
   description = "Default tags for all resources"
-  type        = "map"
 }
 
 variable "inventory_file" {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Removed all terraform interpolation-only expressions because they are deprecated, causing unnecessary warnings, and that makes the code cleaner and a bit easier to read.
I also did a separate commit to use the new terraform templatefile function to create the inventory file, it is a more compact (but forces run the terraform init command to download the local_file plugin)

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE