### PR TITLE
add local-path-provosioner helper image defenition for non-internet deployment

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s-cluster/addons.yml
@@ -27,6 +27,8 @@ local_path_provisioner_enabled: false
 # local_path_provisioner_debug: false
 # local_path_provisioner_image_repo: "rancher/local-path-provisioner"
 # local_path_provisioner_image_tag: "v0.0.2"
+# local_path_provisioner_helper_image_repo: "busybox"
+# local_path_provisioner_helper_image_tag: "latest"
 
 # Local volume provisioner deployment
 local_volume_provisioner_enabled: false

--- a/roles/kubernetes-apps/external_provisioner/local_path_provisioner/defaults/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/local_path_provisioner/defaults/main.yml
@@ -6,3 +6,4 @@ local_path_provisioner_reclaim_policy: Delete
 local_path_provisioner_claim_root: /opt/local-path-provisioner/
 local_path_provisioner_is_default_storageclass: "true"
 local_path_provisioner_debug: false
+local_path_provisioner_helper_image_tag: "latest"

--- a/roles/kubernetes-apps/external_provisioner/local_path_provisioner/templates/local-path-storage-deployment.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_path_provisioner/templates/local-path-storage-deployment.yml.j2
@@ -27,6 +27,10 @@ spec:
 {% if local_path_provisioner_debug|default(false) %}
         - --debug
 {% endif %}
+{{ if local_path_provisioner_helper_image is defined }}
+        - --helper-image
+        - {{local_path_provisioner_helper_image_repo}}:{{local_path_provisioner_helper_image_tag}}
+{% endif %}
         volumeMounts:
         - name: config-volume
           mountPath: /etc/config/


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
Local-path-provisioner uses busybox container for create PV. In non-internet deployment it caused to unable to creaton PV. To prevent this, you can specify busybox container in your own local registry.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
