### PR TITLE
Fix contrib/terraform formatting

### DIFF
--- a/contrib/terraform/aws/modules/elb/main.tf
+++ b/contrib/terraform/aws/modules/elb/main.tf
@@ -3,8 +3,8 @@ resource "aws_security_group" "aws-elb" {
   vpc_id = "${var.aws_vpc_id}"
 
   tags = "${merge(var.default_tags, map(
-      "Name", "kubernetes-${var.aws_cluster_name}-securitygroup-elb"
-    ))}"
+    "Name", "kubernetes-${var.aws_cluster_name}-securitygroup-elb"
+  ))}"
 }
 
 resource "aws_security_group_rule" "aws-allow-api-access" {

--- a/contrib/terraform/aws/modules/iam/outputs.tf
+++ b/contrib/terraform/aws/modules/iam/outputs.tf
@@ -1,7 +1,7 @@
 output "kube-master-profile" {
-  value = "${aws_iam_instance_profile.kube-master.name }"
+  value = "${aws_iam_instance_profile.kube-master.name}"
 }
 
 output "kube-worker-profile" {
-  value = "${aws_iam_instance_profile.kube-worker.name }"
+  value = "${aws_iam_instance_profile.kube-worker.name}"
 }

--- a/contrib/terraform/aws/modules/vpc/main.tf
+++ b/contrib/terraform/aws/modules/vpc/main.tf
@@ -6,8 +6,8 @@ resource "aws_vpc" "cluster-vpc" {
   enable_dns_hostnames = true
 
   tags = "${merge(var.default_tags, map(
-      "Name", "kubernetes-${var.aws_cluster_name}-vpc"
-    ))}"
+    "Name", "kubernetes-${var.aws_cluster_name}-vpc"
+  ))}"
 }
 
 resource "aws_eip" "cluster-nat-eip" {
@@ -30,9 +30,9 @@ resource "aws_subnet" "cluster-vpc-subnets-public" {
   cidr_block        = "${element(var.aws_cidr_subnets_public, count.index)}"
 
   tags = "${merge(var.default_tags, map(
-      "Name", "kubernetes-${var.aws_cluster_name}-${element(var.aws_avail_zones, count.index)}-public",
-      "kubernetes.io/cluster/${var.aws_cluster_name}", "member"
-    ))}"
+    "Name", "kubernetes-${var.aws_cluster_name}-${element(var.aws_avail_zones, count.index)}-public",
+    "kubernetes.io/cluster/${var.aws_cluster_name}", "member"
+  ))}"
 }
 
 resource "aws_nat_gateway" "cluster-nat-gateway" {
@@ -48,8 +48,8 @@ resource "aws_subnet" "cluster-vpc-subnets-private" {
   cidr_block        = "${element(var.aws_cidr_subnets_private, count.index)}"
 
   tags = "${merge(var.default_tags, map(
-      "Name", "kubernetes-${var.aws_cluster_name}-${element(var.aws_avail_zones, count.index)}-private"
-    ))}"
+    "Name", "kubernetes-${var.aws_cluster_name}-${element(var.aws_avail_zones, count.index)}-private"
+  ))}"
 }
 
 #Routing in VPC
@@ -65,8 +65,8 @@ resource "aws_route_table" "kubernetes-public" {
   }
 
   tags = "${merge(var.default_tags, map(
-      "Name", "kubernetes-${var.aws_cluster_name}-routetable-public"
-    ))}"
+    "Name", "kubernetes-${var.aws_cluster_name}-routetable-public"
+  ))}"
 }
 
 resource "aws_route_table" "kubernetes-private" {
@@ -79,20 +79,20 @@ resource "aws_route_table" "kubernetes-private" {
   }
 
   tags = "${merge(var.default_tags, map(
-      "Name", "kubernetes-${var.aws_cluster_name}-routetable-private-${count.index}"
-    ))}"
+    "Name", "kubernetes-${var.aws_cluster_name}-routetable-private-${count.index}"
+  ))}"
 }
 
 resource "aws_route_table_association" "kubernetes-public" {
   count          = "${length(var.aws_cidr_subnets_public)}"
-  subnet_id      = "${element(aws_subnet.cluster-vpc-subnets-public.*.id,count.index)}"
+  subnet_id      = "${element(aws_subnet.cluster-vpc-subnets-public.*.id, count.index)}"
   route_table_id = "${aws_route_table.kubernetes-public.id}"
 }
 
 resource "aws_route_table_association" "kubernetes-private" {
   count          = "${length(var.aws_cidr_subnets_private)}"
-  subnet_id      = "${element(aws_subnet.cluster-vpc-subnets-private.*.id,count.index)}"
-  route_table_id = "${element(aws_route_table.kubernetes-private.*.id,count.index)}"
+  subnet_id      = "${element(aws_subnet.cluster-vpc-subnets-private.*.id, count.index)}"
+  route_table_id = "${element(aws_route_table.kubernetes-private.*.id, count.index)}"
 }
 
 #Kubernetes Security Groups
@@ -102,8 +102,8 @@ resource "aws_security_group" "kubernetes" {
   vpc_id = "${aws_vpc.cluster-vpc.id}"
 
   tags = "${merge(var.default_tags, map(
-      "Name", "kubernetes-${var.aws_cluster_name}-securitygroup"
-    ))}"
+    "Name", "kubernetes-${var.aws_cluster_name}-securitygroup"
+  ))}"
 }
 
 resource "aws_security_group_rule" "allow-all-ingress" {

--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -96,25 +96,25 @@ resource "openstack_networking_secgroup_rule_v2" "worker" {
 }
 
 resource "openstack_compute_servergroup_v2" "k8s_master" {
-  count = "%{ if var.use_server_groups }1%{else}0%{endif}"
-  name = "k8s-master-srvgrp"
+  count    = "%{if var.use_server_groups}1%{else}0%{endif}"
+  name     = "k8s-master-srvgrp"
   policies = ["anti-affinity"]
 }
 
 resource "openstack_compute_servergroup_v2" "k8s_node" {
-  count = "%{ if var.use_server_groups }1%{else}0%{endif}"
-  name = "k8s-node-srvgrp"
+  count    = "%{if var.use_server_groups}1%{else}0%{endif}"
+  name     = "k8s-node-srvgrp"
   policies = ["anti-affinity"]
 }
 
 resource "openstack_compute_servergroup_v2" "k8s_etcd" {
-  count = "%{ if var.use_server_groups }1%{else}0%{endif}"
-  name = "k8s-etcd-srvgrp"
+  count    = "%{if var.use_server_groups}1%{else}0%{endif}"
+  name     = "k8s-etcd-srvgrp"
   policies = ["anti-affinity"]
 }
 
 resource "openstack_compute_instance_v2" "bastion" {
-  name       = "${var.cluster_name}-bastion-${count.index+1}"
+  name       = "${var.cluster_name}-bastion-${count.index + 1}"
   count      = "${var.number_of_bastions}"
   image_name = "${var.image}"
   flavor_id  = "${var.flavor_bastion}"
@@ -153,8 +153,8 @@ resource "openstack_compute_instance_v2" "bastion" {
 }
 
 resource "openstack_compute_instance_v2" "k8s_master" {
-  name              = "${var.cluster_name}-k8s-master-${count.index+1}"
-  count             = "${var.number_of_k8s_masters }"
+  name              = "${var.cluster_name}-k8s-master-${count.index + 1}"
+  count             = "${var.number_of_k8s_masters}"
   availability_zone = "${element(var.az_list, count.index)}"
   image_name        = "${var.image}"
   flavor_id         = "${var.flavor_k8s_master}"
@@ -196,13 +196,13 @@ resource "openstack_compute_instance_v2" "k8s_master" {
   }
 
   provisioner "local-exec" {
-    command = "sed s/USER/${var.ssh_user}/ ../../contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element( concat(var.bastion_fips, var.k8s_master_fips), 0)}/ > group_vars/no-floating.yml"
+    command = "sed s/USER/${var.ssh_user}/ ../../contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(concat(var.bastion_fips, var.k8s_master_fips), 0)}/ > group_vars/no-floating.yml"
   }
 }
 
 resource "openstack_compute_instance_v2" "k8s_master_no_etcd" {
-  name              = "${var.cluster_name}-k8s-master-ne-${count.index+1}"
-  count             = "${var.number_of_k8s_masters_no_etcd }"
+  name              = "${var.cluster_name}-k8s-master-ne-${count.index + 1}"
+  count             = "${var.number_of_k8s_masters_no_etcd}"
   availability_zone = "${element(var.az_list, count.index)}"
   image_name        = "${var.image}"
   flavor_id         = "${var.flavor_k8s_master}"
@@ -228,7 +228,7 @@ resource "openstack_compute_instance_v2" "k8s_master_no_etcd" {
   security_groups = ["${openstack_networking_secgroup_v2.k8s_master.name}",
     "${openstack_networking_secgroup_v2.k8s.name}",
   ]
-  
+
   dynamic "scheduler_hints" {
     for_each = var.use_server_groups ? [openstack_compute_servergroup_v2.k8s_master[0]] : []
     content {
@@ -244,18 +244,18 @@ resource "openstack_compute_instance_v2" "k8s_master_no_etcd" {
   }
 
   provisioner "local-exec" {
-    command = "sed s/USER/${var.ssh_user}/ ../../contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element( concat(var.bastion_fips, var.k8s_master_fips), 0)}/ > group_vars/no-floating.yml"
+    command = "sed s/USER/${var.ssh_user}/ ../../contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(concat(var.bastion_fips, var.k8s_master_fips), 0)}/ > group_vars/no-floating.yml"
   }
 }
 
 resource "openstack_compute_instance_v2" "etcd" {
-  name              = "${var.cluster_name}-etcd-${count.index+1}"
-  count             = "${var.number_of_etcd }"
+  name              = "${var.cluster_name}-etcd-${count.index + 1}"
+  count             = "${var.number_of_etcd}"
   availability_zone = "${element(var.az_list, count.index)}"
   image_name        = "${var.image}"
   flavor_id         = "${var.flavor_etcd}"
   key_pair          = "${openstack_compute_keypair_v2.k8s.name}"
-  
+
   dynamic "block_device" {
     for_each = var.etcd_root_volume_size_in_gb > 0 ? [var.image] : []
     content {
@@ -290,7 +290,7 @@ resource "openstack_compute_instance_v2" "etcd" {
 }
 
 resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip" {
-  name              = "${var.cluster_name}-k8s-master-nf-${count.index+1}"
+  name              = "${var.cluster_name}-k8s-master-nf-${count.index + 1}"
   count             = "${var.number_of_k8s_masters_no_floating_ip}"
   availability_zone = "${element(var.az_list, count.index)}"
   image_name        = "${var.image}"
@@ -316,7 +316,7 @@ resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip" {
   security_groups = ["${openstack_networking_secgroup_v2.k8s_master.name}",
     "${openstack_networking_secgroup_v2.k8s.name}",
   ]
-  
+
   dynamic "scheduler_hints" {
     for_each = var.use_server_groups ? [openstack_compute_servergroup_v2.k8s_master[0]] : []
     content {
@@ -333,7 +333,7 @@ resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip" {
 }
 
 resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip_no_etcd" {
-  name              = "${var.cluster_name}-k8s-master-ne-nf-${count.index+1}"
+  name              = "${var.cluster_name}-k8s-master-ne-nf-${count.index + 1}"
   count             = "${var.number_of_k8s_masters_no_floating_ip_no_etcd}"
   availability_zone = "${element(var.az_list, count.index)}"
   image_name        = "${var.image}"
@@ -359,7 +359,7 @@ resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip_no_etcd" {
   security_groups = ["${openstack_networking_secgroup_v2.k8s_master.name}",
     "${openstack_networking_secgroup_v2.k8s.name}",
   ]
-  
+
   dynamic "scheduler_hints" {
     for_each = var.use_server_groups ? [openstack_compute_servergroup_v2.k8s_master[0]] : []
     content {
@@ -376,7 +376,7 @@ resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip_no_etcd" {
 }
 
 resource "openstack_compute_instance_v2" "k8s_node" {
-  name              = "${var.cluster_name}-k8s-node-${count.index+1}"
+  name              = "${var.cluster_name}-k8s-node-${count.index + 1}"
   count             = "${var.number_of_k8s_nodes}"
   availability_zone = "${element(var.az_list_node, count.index)}"
   image_name        = "${var.image}"
@@ -418,12 +418,12 @@ resource "openstack_compute_instance_v2" "k8s_node" {
   }
 
   provisioner "local-exec" {
-    command = "sed s/USER/${var.ssh_user}/ ../../contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element( concat(var.bastion_fips, var.k8s_node_fips), 0)}/ > group_vars/no-floating.yml"
+    command = "sed s/USER/${var.ssh_user}/ ../../contrib/terraform/openstack/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(concat(var.bastion_fips, var.k8s_node_fips), 0)}/ > group_vars/no-floating.yml"
   }
 }
 
 resource "openstack_compute_instance_v2" "k8s_node_no_floating_ip" {
-  name              = "${var.cluster_name}-k8s-node-nf-${count.index+1}"
+  name              = "${var.cluster_name}-k8s-node-nf-${count.index + 1}"
   count             = "${var.number_of_k8s_nodes_no_floating_ip}"
   availability_zone = "${element(var.az_list_node, count.index)}"
   image_name        = "${var.image}"
@@ -449,7 +449,7 @@ resource "openstack_compute_instance_v2" "k8s_node_no_floating_ip" {
   security_groups = ["${openstack_networking_secgroup_v2.k8s.name}",
     "${openstack_networking_secgroup_v2.worker.name}",
   ]
-  
+
   dynamic "scheduler_hints" {
     for_each = var.use_server_groups ? [openstack_compute_servergroup_v2.k8s_node[0]] : []
     content {
@@ -466,7 +466,7 @@ resource "openstack_compute_instance_v2" "k8s_node_no_floating_ip" {
 }
 
 resource "openstack_compute_instance_v2" "glusterfs_node_no_floating_ip" {
-  name              = "${var.cluster_name}-gfs-node-nf-${count.index+1}"
+  name              = "${var.cluster_name}-gfs-node-nf-${count.index + 1}"
   count             = "${var.number_of_gfs_nodes_no_floating_ip}"
   availability_zone = "${element(var.az_list, count.index)}"
   image_name        = "${var.image_gfs}"
@@ -490,7 +490,7 @@ resource "openstack_compute_instance_v2" "glusterfs_node_no_floating_ip" {
   }
 
   security_groups = ["${openstack_networking_secgroup_v2.k8s.name}"]
-  
+
   dynamic "scheduler_hints" {
     for_each = var.use_server_groups ? [openstack_compute_servergroup_v2.k8s_node[0]] : []
     content {
@@ -535,7 +535,7 @@ resource "openstack_compute_floatingip_associate_v2" "k8s_node" {
 }
 
 resource "openstack_blockstorage_volume_v2" "glusterfs_volume" {
-  name        = "${var.cluster_name}-glusterfs_volume-${count.index+1}"
+  name        = "${var.cluster_name}-glusterfs_volume-${count.index + 1}"
   count       = "${var.gfs_root_volume_size_in_gb == 0 ? var.number_of_gfs_nodes_no_floating_ip : 0}"
   description = "Non-ephemeral volume for GlusterFS"
   size        = "${var.gfs_volume_size_in_gb}"


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
Fix the formatting of the terraform examples in contrib.

I needed this because when using kubespray with terraform, I add kubespray as a submodule of my terraform plan.
When running in my CI, I check all formatting and these pop-up

**Which issue(s) this PR fixes**:
None, it is cosmetic

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
