### PR TITLE
[2.11] Add proxy support to containerd, improves no_proxy (#5583)

### DIFF
--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -26,6 +26,18 @@
 
 - include_tasks: containerd_repo.yml
 
+- name: Create containerd service systemd directory if it doesn't exist
+  file:
+    path: /etc/systemd/system/containerd.service.d
+    state: directory
+
+- name: Write containerd proxy drop-in
+  template:
+    src: http-proxy.conf.j2
+    dest: /etc/systemd/system/containerd.service.d/http-proxy.conf
+  notify: restart containerd
+  when: http_proxy is defined or https_proxy is defined
+
 - name: ensure containerd config directory
   file:
     dest: "{{ containerd_cfg_dir }}"

--- a/roles/container-engine/containerd/templates/http-proxy.conf.j2
+++ b/roles/container-engine/containerd/templates/http-proxy.conf.j2
@@ -1,0 +1,2 @@
+[Service]
+Environment={% if http_proxy is defined %}"HTTP_PROXY={{ http_proxy }}"{% endif %} {% if https_proxy is defined %}"HTTPS_PROXY={{ https_proxy }}"{% endif %} {% if no_proxy is defined %}"NO_PROXY={{ no_proxy }}"{% endif %}

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -402,7 +402,7 @@ no_proxy: >-
   {%- if additional_no_proxy is defined -%}
   {{ additional_no_proxy }},
   {%- endif -%}
-  127.0.0.1,localhost
+  127.0.0.1,localhost,{{kube_service_addresses}},{{kube_pods_subnet}}
   {%- endif %}
 
 proxy_env:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR add a systemd drop-in config to containerd to setup proxy environment variables

**Which issue(s) this PR fixes**:
Fixes _

**Special notes for your reviewer**:
cherry picked from commit 9f2dd09628a11f419f394f70dae800c88b3b6959

**Does this PR introduce a user-facing change?**:
```release-note
Add proxy support to containerd, add kube_service_addresses / kube_pods_subnet to no_proxy
```