### PR TITLE
[2.12] containerd: bump to 1.2.13 (#5727)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [kubernetes](https://github.com/kubernetes/kubernetes) v1.16.8
   - [etcd](https://github.com/coreos/etcd) v3.3.12
   - [docker](https://www.docker.com/) v18.06 (see note)
+  - [containerd](https://containerd.io/) v1.2.13
   - [cri-o](http://cri-o.io/) v1.14.0 (experimental: see [CRI-O Note](docs/cri-o.md). Only on centos based OS)
 - Network Plugin
   - [cni-plugins](https://github.com/containernetworking/plugins) v0.8.1

--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -9,7 +9,7 @@ containerd_config:
     "docker.io": "https://registry-1.docker.io"
   max_container_log_line_size: -1
 
-containerd_version: '1.2.10'
+containerd_version: '1.2.13'
 containerd_package: 'containerd.io'
 
 containerd_cfg_dir: /etc/containerd

--- a/roles/container-engine/containerd/vars/debian.yml
+++ b/roles/container-engine/containerd/vars/debian.yml
@@ -6,8 +6,10 @@ containerd_versioned_pkg:
   '1.2.5': "{{ containerd_package }}=1.2.5-1"
   '1.2.6': "{{ containerd_package }}=1.2.6-3"
   '1.2.10': "{{ containerd_package }}=1.2.10-3"
-  'stable': "{{ containerd_package }}=1.2.10-3"
-  'edge': "{{ containerd_package }}=1.2.10-3"
+  '1.2.12': "{{ containerd_package }}=1.2.12-1"
+  '1.2.13': "{{ containerd_package }}=1.2.13-1"
+  'stable': "{{ containerd_package }}=1.2.13-1"
+  'edge': "{{ containerd_package }}=1.2.13-1"
 
 containerd_package_info:
   pkg_mgr: apt

--- a/roles/container-engine/containerd/vars/redhat.yml
+++ b/roles/container-engine/containerd/vars/redhat.yml
@@ -6,8 +6,10 @@ containerd_versioned_pkg:
   '1.2.5': "{{ containerd_package }}-1.2.5-3.1.el7"
   '1.2.6': "{{ containerd_package }}-1.2.6-3.3.el7"
   '1.2.10': "{{ containerd_package }}-1.2.10-3.2.el7"
-  'stable': "{{ containerd_package }}-1.2.10-3.2.el7"
-  'edge': "{{ containerd_package }}-1.2.10-3.2.el7"
+  '1.2.12': "{{ containerd_package }}-1.2.12-3.1.el7"
+  '1.2.13': "{{ containerd_package }}-1.2.13-3.1.el7"
+  'stable': "{{ containerd_package }}-1.2.13-3.1.el7"
+  'edge': "{{ containerd_package }}-1.2.13-3.1.el7"
 
 containerd_package_info:
   pkg_mgr: yum

--- a/roles/container-engine/containerd/vars/ubuntu-amd64.yml
+++ b/roles/container-engine/containerd/vars/ubuntu-amd64.yml
@@ -6,8 +6,10 @@ containerd_versioned_pkg:
   '1.2.5': "{{ containerd_package }}=1.2.5-1"
   '1.2.6': "{{ containerd_package }}=1.2.6-3"
   '1.2.10': "{{ containerd_package }}=1.2.10-3"
-  'stable': "{{ containerd_package }}=1.2.10-3"
-  'edge': "{{ containerd_package }}=1.2.10-3"
+  '1.2.12': "{{ containerd_package }}=1.2.12-1"
+  '1.2.13': "{{ containerd_package }}=1.2.13-1"
+  'stable': "{{ containerd_package }}=1.2.13-1"
+  'edge': "{{ containerd_package }}=1.2.13-1"
 
 containerd_package_info:
   pkg_mgr: apt


### PR DESCRIPTION
https://github.com/containerd/containerd/releases/tag/v1.2.11
CVE-2019-16884 / CVE-2019-17596

https://github.com/containerd/containerd/releases/tag/v1.2.12
CVE-2019-19921 / CVE-2019-16884 / CVE-2019-11253

https://github.com/containerd/containerd/releases/tag/v1.2.13

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
CVE and bug fixes

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:
cherry picked from commit e2ec7c76a4ed4a23a5b3276e0cb48511b6ccd2a4

**Does this PR introduce a user-facing change?**:
```release-note
containerd: update from 1.2.10 to 1.2.13
```
