### PR TITLE
Move long running jobs into separate CI stage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,7 @@ stages:
   - deploy-part1
   - moderator
   - deploy-part2
+  - deploy-part3
   - deploy-special
 
 variables:

--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -78,13 +78,6 @@ packet_debian9-macvlan-sep:
   extends: .packet
   when: manual
 
-packet_debian9-calico-upgrade:
-  stage: deploy-part2
-  extends: .packet
-  when: on_success
-  variables:
-    UPGRADE_TEST: graceful
-
 packet_debian9-calico-upgrade-once:
   stage: deploy-part2
   extends: .packet
@@ -142,8 +135,18 @@ packet_amazon-linux-2-aio:
   extends: .packet
   when: manual
 
+# ### PR JOBS PART3
+# Long jobs (45min+)
+
+packet_debian9-calico-upgrade:
+  stage: deploy-part3
+  extends: .packet
+  when: on_success
+  variables:
+    UPGRADE_TEST: graceful
+
 packet_ubuntu18-calico-ha-recover:
-  stage: deploy-part2
+  stage: deploy-part3
   extends: .packet
   when: on_success
   variables:
@@ -151,7 +154,7 @@ packet_ubuntu18-calico-ha-recover:
     RECOVER_CONTROL_PLANE_TEST_GROUPS: "etcd[2:],kube-master[1:]"
 
 packet_ubuntu18-calico-ha-recover-noquorum:
-  stage: deploy-part2
+  stage: deploy-part3
   extends: .packet
   when: on_success
   variables:


### PR DESCRIPTION
**What this PR does / why we need it**:
Moves long running CI jobs to a CI stage 3.

**Special notes for your reviewer**:
Some CI jobs (like upgrade tests) take a long time. Therefore I suggest to move them to a separate CI stage to run them only if all other tests are green.

This will also reduce the number parallel tests for a given PR.
On the downside it might increase the total pipeline time of each PR.
