### PR TITLE
Remove unused kubeadm_enabled variable

### DIFF
--- a/tests/files/packet_centos7-weave-kubeadm-sep.yml
+++ b/tests/files/packet_centos7-weave-kubeadm-sep.yml
@@ -5,7 +5,6 @@ mode: ha
 
 # Kubespray settings
 kube_network_plugin: weave
-kubeadm_enabled: true
 deploy_netchecker: true
 kubernetes_audit: true
 dns_min_replicas: 1

--- a/tests/files/packet_oracle7-canal.yml
+++ b/tests/files/packet_oracle7-canal.yml
@@ -5,7 +5,6 @@ mode: ha
 
 # Kubespray settings
 kube_network_plugin: canal
-kubeadm_enabled: true
 dynamic_kubelet_configuration: true
 deploy_netchecker: true
 dns_min_replicas: 1

--- a/tests/files/packet_ubuntu16-canal-kubeadm.yml
+++ b/tests/files/packet_ubuntu16-canal-kubeadm.yml
@@ -5,7 +5,6 @@ mode: ha
 
 # Kubespray settings
 kube_network_plugin: canal
-kubeadm_enabled: true
 dynamic_kubelet_configuration: true
 deploy_netchecker: true
 dns_min_replicas: 1

--- a/tests/files/packet_ubuntu16-flannel-ha.yml
+++ b/tests/files/packet_ubuntu16-flannel-ha.yml
@@ -5,7 +5,6 @@ mode: ha
 
 # Kubespray settings
 kube_network_plugin: flannel
-kubeadm_enabled: true
 etcd_kubeadm_enabled: true
 kubeadm_control_plane: true
 kubeadm_certificate_key: 3998c58db6497dd17d909394e62d515368c06ec617710d02edea31c06d741085


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
`kubeadm_enabled` var has been removed a while back, so it shouldn't be needed in the tests files anymore.