### PR TITLE
Add moreutils in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir /kubespray
 WORKDIR /kubespray
 RUN apt update -y && \
     apt install -y \
-    libssl-dev python3-dev sshpass apt-transport-https jq \
+    libssl-dev python3-dev sshpass apt-transport-https jq moreutils \
     ca-certificates curl gnupg2 software-properties-common python3-pip rsync
 RUN  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
      add-apt-repository \


### PR DESCRIPTION
Adds moreutils package in Dockerfile to later use the `chrony` command in CI.

Will need to be backported in `release-2.12` as well.