### PR TITLE
[2.12] Add moreutils in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir /kubespray
 WORKDIR /kubespray
 RUN apt update -y && \
     apt install -y \
-    libssl-dev python3-dev sshpass apt-transport-https jq \
+    libssl-dev python3-dev sshpass apt-transport-https jq moreutils \
     ca-certificates curl gnupg2 software-properties-common python3-pip rsync
 RUN  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
      add-apt-repository \


### PR DESCRIPTION
Backport of #5839

Thererfore the next release of v2.12.X will include `chronic` which will allow us to use it in `master` once we update the `KUBESPRAY_VERSION` in `.gitlab-ci.yml`