### PR TITLE
Improve curl invocation in download_hash.sh script

### DIFF
--- a/scripts/download_hash.sh
+++ b/scripts/download_hash.sh
@@ -19,7 +19,7 @@ for download in ${DOWNLOADS}; do
     for version in ${VERSIONS}; do
       TARGET="${DOWNLOAD_DIR}/${download}-$version-$arch"
       if [ ! -f ${TARGET} ]; then
-        curl -s -o ${TARGET} "https://storage.googleapis.com/kubernetes-release/release/${version}/bin/linux/${arch}/${download}"
+        curl -L -f -S -s -o ${TARGET} "https://storage.googleapis.com/kubernetes-release/release/${version}/bin/linux/${arch}/${download}"
       fi
       echo -e "    ${version}: $(sha256sum ${TARGET} | awk '{print $1}')"
     done


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Improve curl invocation in download_hash.sh script
- make it follow redirects
- error out if an HTTP error is encountered

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
