### PR TITLE
Add molecule test for bootstrap-os

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,3 +71,4 @@ include:
   - .gitlab-ci/shellcheck.yml
   - .gitlab-ci/terraform.yml
   - .gitlab-ci/packet.yml
+  - .gitlab-ci/vagrant.yml

--- a/.gitlab-ci/vagrant.yml
+++ b/.gitlab-ci/vagrant.yml
@@ -1,0 +1,16 @@
+---
+
+molecule_tests:
+  tags: [vagrant]
+  only: [/^pr-.*$/]
+  except: ['triggers']
+  image: quay.io/miouge/kubespray-vagrant
+  services: []
+  stage: deploy-part1
+  before_script:
+    - tests/scripts/rebase.sh
+    - apt-get update && apt-get install -y python3-pip
+    - update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+    - python -m pip install -r tests/requirements.txt
+  script:
+    - ./tests/scripts/molecule_run.sh

--- a/roles/bootstrap-os/defaults/main.yml
+++ b/roles/bootstrap-os/defaults/main.yml
@@ -23,3 +23,5 @@ fedora_coreos_packages:
 ## General
 # Set the hostname to inventory_hostname
 override_system_hostname: true
+
+is_fedora_coreos: false

--- a/roles/bootstrap-os/molecule/default/molecule.yml
+++ b/roles/bootstrap-os/molecule/default/molecule.yml
@@ -1,0 +1,44 @@
+---
+scenario:
+  name: default
+  test_sequence:
+    - lint
+    - destroy
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    # - idempotence # skip
+    - side_effect
+    - verify
+    - destroy
+dependency:
+  name: galaxy
+lint:
+  name: yamllint
+  options:
+    config-file: ../../.yamllint
+driver:
+  name: vagrant
+  provider:
+    name: libvirt
+platforms:
+  - name: ubuntu18
+    box: generic/ubuntu1804
+    cpus: 2
+    memory: 2048
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+  inventory:
+    group_vars:
+      all:
+        user:
+          name: foo
+          comment: My test comment
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/roles/bootstrap-os/molecule/default/playbook.yml
+++ b/roles/bootstrap-os/molecule/default/playbook.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: no
+  roles:
+    - role: bootstrap-os

--- a/roles/bootstrap-os/molecule/default/tests/test_default.py
+++ b/roles/bootstrap-os/molecule/default/tests/test_default.py
@@ -1,0 +1,11 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_python(host):
+    assert host.exists('python3') or host.exists('python')

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,3 +6,5 @@ dopy==0.3.7
 cryptography==2.8
 ansible-lint==4.2.0
 openshift==0.8.8
+molecule==2.22
+python-vagrant==0.5.15

--- a/tests/scripts/molecule_run.sh
+++ b/tests/scripts/molecule_run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euxo pipefail
+
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+
+for d in $(find roles -name molecule -type d)
+do
+    cd $(dirname $d)
+    molecule test --all
+    cd -
+done


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds molecule test with Vagrant driver and libvirt plugin.

**Special notes for your reviewer**:
Currently only testing Ubuntu 18.04, but more platforms could be added later on, we need to start somewhere.
The libvirt plugin makes this portable (KVM on Linux and VirtualBox on Mac).

The quay.io/miouge/kubespray-vagrant image could be moved to the kubespray org.

Adding `is_fedora_coreos: false` otherwise that variable is undefined.

Inspired and related to #5487, #5129 and https://github.com/kubernetes-sigs/kubespray/compare/master...MarkusTeufelberger:molecule_bootstrap_tests