### PR TITLE
Remove 1.16.x hook on test tf-ovh_coreos-calico

### DIFF
--- a/tests/files/tf-ovh_coreos-calico.yml
+++ b/tests/files/tf-ovh_coreos-calico.yml
@@ -3,6 +3,3 @@ dns_min_replicas: 1
 deploy_netchecker: true
 
 # resolvconf_mode: host_resolvconf  # this is required as long as the coreos stable channel uses docker < 1.12
-
-# Temp set k8s ver to 1.16.8
-kube_version: v1.16.8


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
coreos-calico is no longer in error with 1.16.x .. just in time to see it handling 3.13.2 from #5894

**Which issue(s) this PR fixes**:
None
**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
