### PR TITLE
Azure vmss - kubelet: failed to get instance ID from cloud provider: instance not found #5824

### DIFF
--- a/docs/azure.md
+++ b/docs/azure.md
@@ -29,7 +29,7 @@ The name of the resource group your instances are in, can be retrieved via `azur
 
 ### azure\_vmtype
 
-The type of the vm. Supported values are `standard` or `vmss`. If vm is type of `Virtal Machines` then value is `standard`. If vm is part of `Virtaul Machine Scale Sets` then value `vmss`
+The type of the vm. Supported values are `standard` or `vmss`. If vm is type of `Virtal Machines` then value is `standard`. If vm is part of `Virtaul Machine Scale Sets` then value is `vmss`
 
 ### azure\_vnet\_name
 

--- a/docs/azure.md
+++ b/docs/azure.md
@@ -27,6 +27,10 @@ The region your instances are located, can be something like `westeurope` or `we
 
 The name of the resource group your instances are in, can be retrieved via `azure group list`
 
+### azure\_vmtype
+
+The type of the vm. Supported values are `standard` or `vmss`. If vm is type of `Virtal Machines` then value is `standard`. If vm is part of `Virtaul Machine Scale Sets` then value `vmss`
+
 ### azure\_vnet\_name
 
 The name of the virtual network your instances are in, can be retrieved via `azure network vnet list`

--- a/inventory/sample/group_vars/all/azure.yml
+++ b/inventory/sample/group_vars/all/azure.yml
@@ -12,4 +12,5 @@
 # azure_vnet_name:
 # azure_vnet_resource_group:
 # azure_route_table_name:
-# azure_vmtype:
+# supported values are 'standard' or 'vmss'
+# azure_vmtype: standard

--- a/inventory/sample/group_vars/all/azure.yml
+++ b/inventory/sample/group_vars/all/azure.yml
@@ -12,3 +12,4 @@
 # azure_vnet_name:
 # azure_vnet_resource_group:
 # azure_route_table_name:
+# azure_vmtype: 

--- a/inventory/sample/group_vars/all/azure.yml
+++ b/inventory/sample/group_vars/all/azure.yml
@@ -12,4 +12,4 @@
 # azure_vnet_name:
 # azure_vnet_resource_group:
 # azure_route_table_name:
-# azure_vmtype: 
+# azure_vmtype:

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -141,7 +141,8 @@ vsphere_public_network: "{{ lookup('env', 'VSPHERE_PUBLIC_NETWORK')|default('') 
 # azure_security_group_name:
 # azure_vnet_name:
 # azure_route_table_name:
-# azure_vmtype:
+# supported values are 'standard' or 'vmss'
+# azure_vmtype: standard
 # Sku of Load Balancer and Public IP. Candidate values are: basic and standard.
 azure_loadbalancer_sku: basic
 # excludes master nodes from standard load balancer.

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -141,6 +141,7 @@ vsphere_public_network: "{{ lookup('env', 'VSPHERE_PUBLIC_NETWORK')|default('') 
 # azure_security_group_name:
 # azure_vnet_name:
 # azure_route_table_name:
+# azure_vmtype:
 # Sku of Load Balancer and Public IP. Candidate values are: basic and standard.
 azure_loadbalancer_sku: basic
 # excludes master nodes from standard load balancer.

--- a/roles/kubernetes/node/tasks/cloud-credentials/azure-credential-check.yml
+++ b/roles/kubernetes/node/tasks/cloud-credentials/azure-credential-check.yml
@@ -70,3 +70,8 @@
 - name: "check azure_use_instance_metadata is a bool"
   assert:
     that: azure_use_instance_metadata |type_debug == 'bool'
+
+- name: check azure_vmtype value
+  fail:
+    msg: "azure_vmtype is missing. Supported values are 'standard' or 'vmss'"
+  when: azure_vmtype is not defined or not azure_vmtype

--- a/roles/kubernetes/node/templates/cloud-configs/azure-cloud-config.j2
+++ b/roles/kubernetes/node/templates/cloud-configs/azure-cloud-config.j2
@@ -10,7 +10,7 @@
   "vnetName": "{{ azure_vnet_name }}",
   "vnetResourceGroup": "{{ azure_vnet_resource_group }}",
   "routeTableName": "{{ azure_route_table_name }}",
-  "vmType": "${{ azure_vmtype }}",
+  "vmType": "{{ azure_vmtype }}",
 {% if azure_primary_availability_set_name is defined %}
   "primaryAvailabilitySetName": "{{ azure_primary_availability_set_name }}",
 {%endif%}

--- a/roles/kubernetes/node/templates/cloud-configs/azure-cloud-config.j2
+++ b/roles/kubernetes/node/templates/cloud-configs/azure-cloud-config.j2
@@ -10,6 +10,7 @@
   "vnetName": "{{ azure_vnet_name }}",
   "vnetResourceGroup": "{{ azure_vnet_resource_group }}",
   "routeTableName": "{{ azure_route_table_name }}",
+  "vmType": "${{ azure_vmtype }}",
 {% if azure_primary_availability_set_name is defined %}
   "primaryAvailabilitySetName": "{{ azure_primary_availability_set_name }}",
 {%endif%}


### PR DESCRIPTION
Added support nodes which are part of Virtual Machine Scale Sets(VMSS)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?** : /kind bug


**What this PR does / why we need it**: This PR helps to setup cluster with cloud_provider=azure, and if the nodes are part of Virtual Machine Scale Sets(VMSS). There was no support for the nodes which were part of VMSS. 

**Which issue(s) this PR fixes**: 
Fixes #5824 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: No
```release-note

```
