### PR TITLE
[WIP] Test v2.13 release

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -39,7 +39,7 @@ packet_ubuntu18-crio:
 # ### MANUAL JOBS
 
 packet_centos7-weave-upgrade-ha:
-  stage: deploy-part3
+  stage: deploy-part2
   extends: .packet
   when: on_success
   variables:
@@ -49,14 +49,14 @@ packet_centos7-weave-upgrade-ha:
 packet_ubuntu16-weave-sep:
   stage: deploy-part2
   extends: .packet
-  when: manual
+  when: on_success
 
 # # More builds for PRs/merges (manual) and triggers (auto)
 
 packet_ubuntu16-canal-sep:
   stage: deploy-special
   extends: .packet
-  when: manual
+  when: on_success
 
 packet_ubuntu16-canal-kubeadm-ha:
   stage: deploy-part2
@@ -64,9 +64,9 @@ packet_ubuntu16-canal-kubeadm-ha:
   when: on_success
 
 packet_ubuntu16-flannel-ha:
-  stage: deploy-part2
+  stage: deploy-part1
   extends: .packet
-  when: manual
+  when: on_success
 
 # Contiv does not work in k8s v1.16
 # packet_ubuntu16-contiv-sep:
@@ -75,27 +75,27 @@ packet_ubuntu16-flannel-ha:
 #   when: on_success
 
 packet_ubuntu18-cilium-sep:
-  stage: deploy-special
+  stage: deploy-part1
   extends: .packet
-  when: manual
+  when: on_success
 
 packet_ubuntu18-flannel-containerd-ha:
-  stage: deploy-part2
+  stage: unit-tests
   extends: .packet
-  when: manual
+  when: on_success
 
 packet_ubuntu18-flannel-containerd-ha-once:
   stage: deploy-part2
   extends: .packet
-  when: manual
+  when: on_success
 
 packet_debian9-macvlan:
   stage: deploy-part2
   extends: .packet
-  when: manual
+  when: on_success
 
 packet_debian9-calico-upgrade-once:
-  stage: deploy-part3
+  stage: deploy-part2
   extends: .packet
   when: on_success
   variables:
@@ -112,7 +112,7 @@ packet_debian10-containerd:
 packet_centos7-calico-ha:
   stage: deploy-part2
   extends: .packet
-  when: manual
+  when: on_success
 
 packet_centos7-calico-ha-once-localhost:
   stage: deploy-part2
@@ -139,14 +139,14 @@ packet_fedora31-flannel:
     MITOGEN_ENABLE: "true"
 
 packet_centos7-kube-router:
-  stage: deploy-part2
+  stage: deploy-part1
   extends: .packet
-  when: manual
+  when: on_success
 
 packet_centos7-multus-calico:
   stage: deploy-part2
   extends: .packet
-  when: manual
+  when: on_success
 
 packet_centos8-calico:
   stage: deploy-part2
@@ -154,30 +154,30 @@ packet_centos8-calico:
   when: on_success
 
 packet_opensuse-canal:
-  stage: deploy-part2
+  stage: deploy-part1
   extends: .packet
   when: on_success
 
 packet_oracle7-canal-ha:
   stage: deploy-part2
   extends: .packet
-  when: manual
+  when: on_success
 
 packet_ubuntu16-kube-router-sep:
   stage: deploy-part2
   extends: .packet
-  when: manual
+  when: on_success
 
 packet_amazon-linux-2-aio:
   stage: deploy-part2
   extends: .packet
-  when: manual
+  when: on_success
 
 # ### PR JOBS PART3
 # Long jobs (45min+)
 
 packet_debian9-calico-upgrade:
-  stage: deploy-part3
+  stage: deploy-part2
   extends: .packet
   when: on_success
   variables:
@@ -185,7 +185,7 @@ packet_debian9-calico-upgrade:
     MITOGEN_ENABLE: "false"
 
 packet_ubuntu18-calico-ha-recover:
-  stage: deploy-part3
+  stage: deploy-part2
   extends: .packet
   when: on_success
   variables:
@@ -193,7 +193,7 @@ packet_ubuntu18-calico-ha-recover:
     RECOVER_CONTROL_PLANE_TEST_GROUPS: "etcd[2:],kube-master[1:]"
 
 packet_ubuntu18-calico-ha-recover-noquorum:
-  stage: deploy-part3
+  stage: deploy-part2
   extends: .packet
   when: on_success
   variables:

--- a/README.md
+++ b/README.md
@@ -213,3 +213,5 @@ See also [Network checker](docs/netcheck.md).
 
 CI/end-to-end tests sponsored by Google (GCE)
 See the [test matrix](docs/test_cases.md) for details.
+
+TEST


### PR DESCRIPTION
Do not merge. Used only to run manual CI jobs.

| job | error |
|---|---|
| [packet_ubuntu20-calico-aio](https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/491992389) | Expected, see #5835 |
|~[packet_centos7-calico-ha-once-localhost](https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/491992424)~ | ~`Cannot connect to the Docker daemon`~, fixed in #5867 |
| ~[packet_centos7-kube-router](https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/491992428)~ | ~Failed connectivity check~, passed after rebase on latest master 🤷‍♂  |
| ~[packet_opensuse-canal](https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/491992430)~ | ~`No provider of "conntrack" found`~, fixed in #5865 |
| ~[packet_ubuntu18-flannel-containerd](https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/491992411)~ | ~Failed connectivity check, fixed in #5937~ |
| ~[packet_ubuntu18-flannel-containerd-once](httaps://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/492205803)~ | ~Failed connectivity check, fixed in #5937~ |
| ~[packet_ubuntu18-cilium-sep](https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/491992441)~ | ~Pods not ready, reported in #590,~ fixed in #5923 |