### PR TITLE
Fix download_run_once in packet_ubuntu18-flannel-containerd-once

### DIFF
--- a/tests/files/packet_ubuntu18-flannel-containerd-once.yml
+++ b/tests/files/packet_ubuntu18-flannel-containerd-once.yml
@@ -26,4 +26,3 @@ metrics_server_kubelet_insecure_tls: true
 kube_token_auth: true
 kube_basic_auth: true
 enable_nodelocaldns: false
-download_run_once: true


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
That CI job fails with `download_run_once support only for docker. See https://github.com/containerd/containerd/issues/4075 for details`

See [example](https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/491992413)