### PR TITLE
Fix Docker in Docker CI jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,6 @@ stages:
 variables:
   FAILFASTCI_NAMESPACE: 'kargo-ci'
   GITLAB_REPOSITORY: 'kargo-ci/kubernetes-sigs-kubespray'
-  # DOCKER_HOST: tcp://localhost:2375
   ANSIBLE_FORCE_COLOR: "true"
   MAGIC: "ci check this"
   TEST_ID: "$CI_PIPELINE_ID-$CI_BUILD_ID"
@@ -45,8 +44,6 @@ before_script:
 
 .testcases: &testcases
   <<: *job
-  services:
-    - docker:dind
   before_script:
     - update-alternatives --install /usr/bin/python python /usr/bin/python3 1
     - ./tests/scripts/rebase.sh

--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -102,9 +102,11 @@ packet_centos7-calico-ha:
   when: manual
 
 packet_centos7-calico-ha-once-localhost:
-  stage: deploy-part2
+  stage: unit-tests
   extends: .packet
-  when: manual
+  when: on_success
+  services:
+    - docker:18.09.9-dind
 
 packet_centos7-kube-ovn:
   stage: deploy-part2


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
`packet_centos7-calico-ha-once-localhost` is the only (manual) job that requires docker in docker to work. Therefore we should move the `services:` block to only that job.

In v19.09 they changed the way the `docker:dind` image works (documentation available [here](https://about.gitlab.com/releases/2019/07/31/docker-in-docker-with-docker-19-dot-03/)), therefore I suggest to pin to 18.09 until we update things to support 19.03 in CI