### PR TITLE
Update docker RHEL/CentOS versions to the latest patch versions avail…

### DIFF
--- a/roles/container-engine/docker/vars/redhat-aarch64.yml
+++ b/roles/container-engine/docker/vars/redhat-aarch64.yml
@@ -8,8 +8,7 @@ docker_version: '1.13'
 # or do 'yum --showduplicates list docker'
 docker_versioned_pkg:
   'latest': docker
-  '1.12': docker-1.12.6-48.git0fdc778.el7
-  '1.13': docker-1.13.1-63.git94f4240.el7
+  '1.13': docker-1.13.1-109.gitcccb291.el7.centos
 
 # https://docs.docker.com/engine/installation/linux/centos/#install-from-a-package
 # http://mirror.centos.org/altarch/7/extras/aarch64/Packages/

--- a/roles/container-engine/docker/vars/redhat.yml
+++ b/roles/container-engine/docker/vars/redhat.yml
@@ -6,23 +6,21 @@ docker_kernel_min_version: '0'
 # or do 'yum --showduplicates list docker-engine'
 docker_versioned_pkg:
   'latest': docker-ce
-  '1.13': docker-engine-1.13.1-1.el7.centos
-  '17.03': docker-ce-17.03.2.ce-1.el7.centos
-  '17.09': docker-ce-17.09.0.ce-1.el7.centos
+  '17.03': docker-ce-17.03.3.ce-1.el7
+  '17.09': docker-ce-17.09.1.ce-1.el7.centos
   '17.12': docker-ce-17.12.1.ce-1.el7.centos
   '18.03': docker-ce-18.03.1.ce-1.el7.centos
-  '18.06': docker-ce-18.06.2.ce-3.el7
-  '18.09': docker-ce-18.09.7-3.el7
-  '19.03': docker-ce-19.03.7-3.el7
-  'stable': docker-ce-18.09.7-3.el7
-  'edge': docker-ce-19.03.7-3.el7
+  '18.06': docker-ce-18.06.3.ce-3.el7
+  '18.09': docker-ce-18.09.9-3.el7
+  '19.03': docker-ce-19.03.8-3.el7
+  'stable': docker-ce-18.09.9-3.el7
+  'edge': docker-ce-19.03.8-3.el7
 
 docker_selinux_versioned_pkg:
-  'latest': docker-ce-selinux
-  '1.13': docker-engine-selinux-1.13.1-1.el7.centos
-  '17.03': docker-ce-selinux-17.03.2.ce-1.el7.centos
-  'stable': docker-ce-selinux-17.03.2.ce-1.el7.centos
-  'edge': docker-ce-selinux-17.03.2.ce-1.el7.centos
+  'latest': docker-ce-selinux-17.03.3.ce-1.el7
+  '17.03': docker-ce-selinux-17.03.3.ce-1.el7
+  'stable': docker-ce-selinux-17.03.3.ce-1.el7
+  'edge': docker-ce-selinux-17.03.3.ce-1.el7
 
 
 docker_pkgs_use_docker_ce:


### PR DESCRIPTION
**What type of PR is this?**
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
Just updates to the current available packages from:
- https://download.docker.com/linux/centos/7/x86_64/stable/Packages/
- http://mirror.centos.org/altarch/7/extras/aarch64/Packages/

**Which issue(s) this PR fixes**:
A playbook fails to fetch required packages.

Fixes #
- #5317
- #5437

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
NONE
