### PR TITLE
Fix opensuse support

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -126,7 +126,7 @@ packet_centos7-multus-calico:
 packet_opensuse-canal:
   stage: deploy-part2
   extends: .packet
-  when: manual
+  when: on_success
 
 packet_oracle7-canal:
   stage: deploy-part2

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,8 +26,8 @@ SUPPORTED_OS = {
   "centos8"             => {box: "centos/8",           user: "vagrant"},
   "centos8-bento"       => {box: "bento/centos-8",           user: "vagrant"},
   "fedora"              => {box: "fedora/28-cloud-base",                user: "vagrant"},
-  "opensuse"            => {box: "opensuse/openSUSE-15.0-x86_64",       user: "vagrant"},
-  "opensuse-tumbleweed" => {box: "opensuse/openSUSE-Tumbleweed-x86_64", user: "vagrant"},
+  "opensuse"            => {box: "bento/opensuse-leap-15.1",       user: "vagrant"},
+  "opensuse-tumbleweed" => {box: "opensuse/Tumbleweed.x86_64", user: "vagrant"},
   "oraclelinux"         => {box: "generic/oracle7", user: "vagrant"},
 }
 

--- a/roles/bootstrap-os/tasks/bootstrap-opensuse.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-opensuse.yml
@@ -28,6 +28,14 @@
   when:
     - http_proxy is defined or https_proxy is defined
 
+# Required for zypper module
+- name: Install python-xml
+  shell: zypper refresh && zypper --non-interactive install python-xml
+  changed_when: false
+  become: true
+  tags:
+    - facts
+
 # Without this package, the get_url module fails when trying to handle https
 - name: Install python-cryptography
   zypper:

--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -56,6 +56,7 @@
 - name: Assign inventory name to unconfigured hostnames (CoreOS, non-Flatcar, Suse and ClearLinux only)
   command: "hostnamectl set-hostname {{ inventory_hostname }}"
   register: hostname_changed
+  become: true
   changed_when: false
   when:
     - override_system_hostname

--- a/roles/container-engine/docker/templates/docker.service.j2
+++ b/roles/container-engine/docker/templates/docker.service.j2
@@ -10,8 +10,9 @@ After=network.target docker.socket{{ ' containerd.service' if installed_docker_v
 {{ 'BindsTo=containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') }}
 Wants=docker.socket
 {% elif ansible_os_family == "Suse" %}
-After=network.target{{ ' containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') else '' }}
-{{ 'BindsTo=containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') }}
+After=network.target lvm2-monitor.service SuSEfirewall2.service
+# After=network.target{{ ' containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') else '' }}
+# {{ 'BindsTo=containerd.service' if installed_docker_version.stdout is version('18.09.1', '>=') }}
 {% endif %}
 
 [Service]

--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -15,7 +15,7 @@ common_required_pkgs:
   - unzip
   - e2fsprogs
   - xfsprogs
-  - conntrack
+  - ebtables
 
 # Set to true if your network does not support IPv6
 # This maybe necessary for pulling Docker images from

--- a/roles/kubernetes/preinstall/vars/centos.yml
+++ b/roles/kubernetes/preinstall/vars/centos.yml
@@ -2,5 +2,5 @@
 required_pkgs:
   - "{{ ( (ansible_distribution_major_version | int) < 8) | ternary('libselinux-python','python3-libselinux') }}"
   - device-mapper-libs
-  - ebtables
   - nss
+  - conntrack

--- a/roles/kubernetes/preinstall/vars/debian.yml
+++ b/roles/kubernetes/preinstall/vars/debian.yml
@@ -4,4 +4,4 @@ required_pkgs:
   - aufs-tools
   - apt-transport-https
   - software-properties-common
-  - ebtables
+  - conntrack

--- a/roles/kubernetes/preinstall/vars/fedora.yml
+++ b/roles/kubernetes/preinstall/vars/fedora.yml
@@ -2,4 +2,4 @@
 required_pkgs:
   - libselinux-python
   - device-mapper-libs
-  - ebtables
+  - conntrack

--- a/roles/kubernetes/preinstall/vars/redhat.yml
+++ b/roles/kubernetes/preinstall/vars/redhat.yml
@@ -2,5 +2,5 @@
 required_pkgs:
   - "{{ ( (ansible_distribution_major_version | int) < 8) | ternary('libselinux-python','python3-libselinux') }}"
   - device-mapper-libs
-  - ebtables
   - nss
+  - conntrack

--- a/roles/kubernetes/preinstall/vars/suse.yml
+++ b/roles/kubernetes/preinstall/vars/suse.yml
@@ -1,4 +1,4 @@
 ---
 required_pkgs:
   - device-mapper
-  - ebtables
+  - conntrack-tools

--- a/roles/kubernetes/preinstall/vars/ubuntu.yml
+++ b/roles/kubernetes/preinstall/vars/ubuntu.yml
@@ -4,4 +4,4 @@ required_pkgs:
   - aufs-tools
   - apt-transport-https
   - software-properties-common
-  - ebtables
+  - conntrack


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
- Conntrack package is called `conntrack-tools` in opensuse (vs `conntrack` for all other distros).
- opensuse uses distro packages for Docker, the latest version has significant changes in the systemd file
- opensuse tumbleweed does not ship with python-xml which is a requirement for the zypper module
- some opensuse Vagrant images have moved

[packet_opensuse-canal](https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/496676348) is now green ✅ 

Since opensuse is often broken which is time consuming thing to fix every release, I propose to enable the opensuse CI job for all PRs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5865

**Special notes for your reviewer**:
Since `ebtables` is in all `required_pkgs`, then we can move it to the `common_ required_pkgs`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
