### PR TITLE
Terraform/OpenStack: Enable usage of an existing router

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -38,6 +38,16 @@ hosts where that makes sense. You have the option of creating bastion hosts
 inside the private subnet to access the nodes there.  Alternatively, a node with
 a floating IP can be used as a jump host to nodes without.
 
+#### Using an existing router
+It is possible to use an existing router instead of creating one. To use an
+existing router set the router\_id variable to the uuid of the router you wish
+to use.
+
+For example:
+```
+router_id = "00c542e7-6f46-4535-ae95-984c7f0391a3"
+```
+
 ### Kubernetes Nodes
 You can create many different kubernetes topologies by setting the number of
 different classes of hosts. For each class there are options for allocating

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -12,6 +12,7 @@ module "network" {
   dns_nameservers    = "${var.dns_nameservers}"
   network_dns_domain = "${var.network_dns_domain}"
   use_neutron        = "${var.use_neutron}"
+  router_id          = "${var.router_id}"
 }
 
 module "ips" {

--- a/contrib/terraform/openstack/modules/network/main.tf
+++ b/contrib/terraform/openstack/modules/network/main.tf
@@ -1,8 +1,13 @@
 resource "openstack_networking_router_v2" "k8s" {
   name                = "${var.cluster_name}-router"
-  count               = "${var.use_neutron}"
+  count               = "${var.use_neutron}" == 1 && "${var.router_id}" == null ? 1 : 0
   admin_state_up      = "true"
   external_network_id = "${var.external_net}"
+}
+
+data "openstack_networking_router_v2" "k8s" {
+  router_id = "${var.router_id}"
+  count     = "${var.use_neutron}" == 1 && "${var.router_id}" != null ? 1 : 0
 }
 
 resource "openstack_networking_network_v2" "k8s" {
@@ -23,6 +28,6 @@ resource "openstack_networking_subnet_v2" "k8s" {
 
 resource "openstack_networking_router_interface_v2" "k8s" {
   count     = "${var.use_neutron}"
-  router_id = "${openstack_networking_router_v2.k8s[count.index].id}"
+  router_id = "%{if openstack_networking_router_v2.k8s != []}${openstack_networking_router_v2.k8s[count.index].id} %{else}${var.router_id} %{endif}"
   subnet_id = "${openstack_networking_subnet_v2.k8s[count.index].id}"
 }

--- a/contrib/terraform/openstack/modules/network/outputs.tf
+++ b/contrib/terraform/openstack/modules/network/outputs.tf
@@ -1,11 +1,11 @@
 output "router_id" {
-  value = "${element(concat(openstack_networking_router_v2.k8s.*.id, list("")), 0)}"
+  value = "%{if var.use_neutron == 1} ${var.router_id == null ? element(concat(openstack_networking_router_v2.k8s.*.id, [""]), 0) : var.router_id} %{else} %{endif}"
 }
 
 output "router_internal_port_id" {
-  value = "${element(concat(openstack_networking_router_interface_v2.k8s.*.id, list("")), 0)}"
+  value = "${element(concat(openstack_networking_router_interface_v2.k8s.*.id, [""]), 0)}"
 }
 
 output "subnet_id" {
-  value = "${element(concat(openstack_networking_subnet_v2.k8s.*.id, list("")), 0)}"
+  value = "${element(concat(openstack_networking_subnet_v2.k8s.*.id, [""]), 0)}"
 }

--- a/contrib/terraform/openstack/modules/network/variables.tf
+++ b/contrib/terraform/openstack/modules/network/variables.tf
@@ -13,3 +13,5 @@ variable "dns_nameservers" {
 variable "subnet_cidr" {}
 
 variable "use_neutron" {}
+
+variable "router_id" {}

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -220,3 +220,8 @@ variable "use_access_ip" {
 variable "use_server_groups" {
   default = false
 }
+
+variable "router_id" {
+  description = "uuid of an externally defined router to use"
+  default     = null
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
It allows the Terraform/OpenStack install to use an existing router
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Terraform/OpenStack: Support for using existing OpenStack routers has been added, no action needed on current installations. See documentation in contrib/terraform/openstack for instructions on how to use on a new installation.
```
