### PR TITLE
Add ConfigMap get permission to allow calico-node …

### DIFF
--- a/roles/network_plugin/calico/templates/calico-cr.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-cr.yml.j2
@@ -10,6 +10,7 @@ rules:
       - pods
       - nodes
       - namespaces
+      - configmaps
     verbs:
       - get
   - apiGroups: [""]


### PR DESCRIPTION
… (startup.go:182) access to kubeadm config.

**What type of PR is this?**
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Recurring CrashLoopBackOff for all calico-node daemon sets.
A container logs error:
`startup.go 182: failed to query kubeadm's config map error=configmaps "kubeadm-config" is forbidden: User "system:serviceaccount:kube-system:calico-node" cannot get resource "configmaps" in API group "" in the namespace "kube-system"`

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
Kubernetes v1.18
Calico v3.13.2

**Does this PR introduce a user-facing change?**:
NONE