### PR TITLE
Fix chicken and egg problem with proxy_env not defined on the first …

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -13,29 +13,37 @@
   vars:
     ansible_connection: local
 
-# FIXME(alexcross): quick&dirty solution for chicken&egg problem of proxy_env not defined, but used on the first environment keyword faced below.
 - hosts: all
   gather_facts: false
-  roles:
-    - { role: kubespray-defaults }
+  tasks:
+    - name: "Set up proxy environment"
+      set_fact:
+        proxy_env:
+          http_proxy: "{{ http_proxy | default ('') }}"
+          HTTP_PROXY: "{{ http_proxy | default ('') }}"
+          https_proxy: "{{ https_proxy | default ('') }}"
+          HTTPS_PROXY: "{{ https_proxy | default ('') }}"
+          no_proxy: "{{ no_proxy | default ('') }}"
+          NO_PROXY: "{{ no_proxy | default ('') }}"
+      no_log: true
 
 - hosts: bastion[0]
   gather_facts: False
   roles:
-    - { role: kubespray-defaults}
-    - { role: bastion-ssh-config, tags: ["localhost", "bastion"]}
+    - { role: kubespray-defaults }
+    - { role: bastion-ssh-config, tags: ["localhost", "bastion"] }
 
 - hosts: k8s-cluster:etcd
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   gather_facts: false
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - { role: bootstrap-os, tags: bootstrap-os}
 
 - hosts: k8s-cluster:etcd
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - { role: kubernetes/preinstall, tags: preinstall }
     - { role: "container-engine", tags: "container-engine", when: deploy_container_engine|default(true) }
     - { role: download, tags: download, when: "not skip_downloads" }
@@ -44,7 +52,7 @@
 - hosts: etcd
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - role: etcd
       tags: etcd
       vars:
@@ -55,7 +63,7 @@
 - hosts: k8s-cluster
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - role: etcd
       tags: etcd
       vars:
@@ -66,14 +74,14 @@
 - hosts: k8s-cluster
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - { role: kubernetes/node, tags: node }
   environment: "{{ proxy_env }}"
 
 - hosts: kube-master
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - { role: kubernetes/master, tags: master }
     - { role: kubernetes/client, tags: client }
     - { role: kubernetes-apps/cluster_roles, tags: cluster-roles }
@@ -81,7 +89,7 @@
 - hosts: k8s-cluster
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - { role: kubernetes/kubeadm, tags: kubeadm}
     - { role: network_plugin, tags: network }
     - { role: kubernetes/node-label, tags: node-label }
@@ -89,20 +97,20 @@
 - hosts: calico-rr
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
-    - { role: kubespray-defaults}
-    - { role: network_plugin/calico/rr, tags: ['network', 'calico_rr']}
+    - { role: kubespray-defaults }
+    - { role: network_plugin/calico/rr, tags: ['network', 'calico_rr'] }
 
 - hosts: kube-master[0]
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - { role: kubernetes-apps/rotate_tokens, tags: rotate_tokens, when: "secret_changed|default(false)" }
-    - { role: win_nodes/kubernetes_patch, tags: ["master", "win_nodes"]}
+    - { role: win_nodes/kubernetes_patch, tags: ["master", "win_nodes"] }
 
 - hosts: kube-master
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - { role: kubernetes-apps/external_cloud_controller, tags: external-cloud-controller }
     - { role: kubernetes-apps/network_plugin, tags: network }
     - { role: kubernetes-apps/policy_controller, tags: policy-controller }
@@ -112,12 +120,12 @@
 - hosts: kube-master
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - { role: kubernetes-apps, tags: apps }
   environment: "{{ proxy_env }}"
 
 - hosts: k8s-cluster
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - { role: kubernetes/preinstall, when: "dns_mode != 'none' and resolvconf_mode == 'host_resolvconf'", tags: resolvconf, dns_late: true }

--- a/cluster.yml
+++ b/cluster.yml
@@ -15,6 +15,7 @@
 
 # FIXME(alexcross): quick&dirty solution for chicken&egg problem of proxy_env not defined, but used on the first environment keyword faced below.
 - hosts: all
+  gather_facts: false
   roles:
     - { role: kubespray-defaults }
 

--- a/cluster.yml
+++ b/cluster.yml
@@ -13,6 +13,11 @@
   vars:
     ansible_connection: local
 
+# FIXME(alexcross): quick&dirty solution for chicken&egg problem of proxy_env not defined, but used on the first environment keyword faced below.
+- hosts: all
+  roles:
+    - { role: kubespray-defaults }
+
 - hosts: bastion[0]
   gather_facts: False
   roles:

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -437,14 +437,6 @@ no_proxy: >-
   127.0.0.1,localhost,{{kube_service_addresses}},{{kube_pods_subnet}}
   {%- endif %}
 
-proxy_env:
-  http_proxy: "{{ http_proxy| default ('') }}"
-  HTTP_PROXY: "{{ http_proxy| default ('') }}"
-  https_proxy: "{{ https_proxy| default ('') }}"
-  HTTPS_PROXY: "{{ https_proxy| default ('') }}"
-  no_proxy: "{{ no_proxy| default ('') }}"
-  NO_PROXY: "{{ no_proxy| default ('') }}"
-
 ssl_ca_dirs: >-
   [
   {% if ansible_os_family in ['CoreOS', 'Container Linux by CoreOS', 'Flatcar', 'Flatcar Container Linux by Kinvolk'] -%}

--- a/scale.yml
+++ b/scale.yml
@@ -13,25 +13,39 @@
   vars:
     ansible_connection: local
 
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: "Set up proxy environment"
+      set_fact:
+        proxy_env:
+          http_proxy: "{{ http_proxy | default ('') }}"
+          HTTP_PROXY: "{{ http_proxy | default ('') }}"
+          https_proxy: "{{ https_proxy | default ('') }}"
+          HTTPS_PROXY: "{{ https_proxy | default ('') }}"
+          no_proxy: "{{ no_proxy | default ('') }}"
+          NO_PROXY: "{{ no_proxy | default ('') }}"
+      no_log: true
+
 - hosts: bastion[0]
   gather_facts: False
   roles:
-    - { role: kubespray-defaults}
-    - { role: bastion-ssh-config, tags: ["localhost", "bastion"]}
+    - { role: kubespray-defaults }
+    - { role: bastion-ssh-config, tags: ["localhost", "bastion"] }
 
 - name: Bootstrap any new workers
   hosts: kube-node
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   gather_facts: false
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - { role: bootstrap-os, tags: bootstrap-os}
 
 - name: Generate the etcd certificates beforehand
   hosts: etcd
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - { role: etcd, tags: etcd, etcd_cluster_setup: false }
 
 - name: Download images to ansible host cache via first kube-master node
@@ -46,7 +60,7 @@
   hosts: kube-node
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - { role: kubernetes/preinstall, tags: preinstall }
     - { role: container-engine, tags: "container-engine", when: deploy_container_engine|default(true) }
     - { role: download, tags: download, when: "not skip_downloads" }

--- a/upgrade-cluster.yml
+++ b/upgrade-cluster.yml
@@ -13,11 +13,25 @@
   vars:
     ansible_connection: local
 
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: "Set up proxy environment"
+      set_fact:
+        proxy_env:
+          http_proxy: "{{ http_proxy | default ('') }}"
+          HTTP_PROXY: "{{ http_proxy | default ('') }}"
+          https_proxy: "{{ https_proxy | default ('') }}"
+          HTTPS_PROXY: "{{ https_proxy | default ('') }}"
+          no_proxy: "{{ no_proxy | default ('') }}"
+          NO_PROXY: "{{ no_proxy | default ('') }}"
+      no_log: true
+
 - hosts: bastion[0]
   gather_facts: False
   roles:
-    - { role: kubespray-defaults}
-    - { role: bastion-ssh-config, tags: ["localhost", "bastion"]}
+    - { role: kubespray-defaults }
+    - { role: bastion-ssh-config, tags: ["localhost", "bastion"] }
 
 - hosts: k8s-cluster:etcd:calico-rr
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
@@ -27,7 +41,7 @@
     # fail. bootstrap-os fixes this on these systems, so in later plays it can be enabled.
     ansible_ssh_pipelining: false
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - { role: bootstrap-os, tags: bootstrap-os}
 
 - name: Download images to ansible host cache via first kube-master node
@@ -43,7 +57,7 @@
   hosts: k8s-cluster:etcd:calico-rr
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - { role: kubernetes/preinstall, tags: preinstall }
     - { role: download, tags: download, when: "not skip_downloads" }
   environment: "{{ proxy_env }}"
@@ -53,14 +67,14 @@
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   serial: "{{ serial | default('20%') }}"
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - { role: container-engine, tags: "container-engine", when: deploy_container_engine|default(true) }
   environment: "{{ proxy_env }}"
 
 - hosts: etcd
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - role: etcd
       tags: etcd
       vars:
@@ -71,7 +85,7 @@
 - hosts: k8s-cluster
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - role: etcd
       tags: etcd
       vars:
@@ -84,7 +98,7 @@
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   serial: 1
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - { role: upgrade/pre-upgrade, tags: pre-upgrade }
     - { role: container-engine, tags: "container-engine", when: deploy_container_engine|default(true) }
     - { role: kubernetes/node, tags: node }
@@ -101,7 +115,7 @@
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   serial: "{{ serial | default('20%') }}"
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - { role: kubernetes-apps/external_cloud_controller, tags: external-cloud-controller }
     - { role: network_plugin, tags: network }
     - { role: kubernetes-apps/network_plugin, tags: network }
@@ -112,7 +126,7 @@
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   serial: "{{ serial | default('20%') }}"
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - { role: upgrade/pre-upgrade, tags: pre-upgrade }
     - { role: container-engine, tags: "container-engine", when: deploy_container_engine|default(true) }
     - { role: kubernetes/node, tags: node }
@@ -124,26 +138,26 @@
 - hosts: kube-master[0]
   any_errors_fatal: true
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - { role: kubernetes-apps/rotate_tokens, tags: rotate_tokens, when: "secret_changed|default(false)" }
-    - { role: win_nodes/kubernetes_patch, tags: ["master", "win_nodes"]}
+    - { role: win_nodes/kubernetes_patch, tags: ["master", "win_nodes"] }
 
 - hosts: calico-rr
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - { role: network_plugin/calico/rr, tags: network }
   environment: "{{ proxy_env }}"
 
 - hosts: kube-master
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - { role: kubernetes-apps, tags: apps }
   environment: "{{ proxy_env }}"
 
 - hosts: k8s-cluster
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
-    - { role: kubespray-defaults}
+    - { role: kubespray-defaults }
     - { role: kubernetes/preinstall, when: "dns_mode != 'none' and resolvconf_mode == 'host_resolvconf'", tags: resolvconf }


### PR DESCRIPTION
…envinronment usage.

**What type of PR is this?**
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Confguration with proxy defined fails.

**Which issue(s) this PR fixes**:
Errors on the first task that uses `role: kubespray-defaults` and have `environment: "{{ proxy_env }}`. Messages are meaningless:
```
PLAY [k8s-cluster:etcd] *****************************************************************************************************************************************************
Tuesday 07 April 2020  08:51:31 +0300 (0:00:01.332)       0:04:03.124 *********

TASK [Gathering Facts] ******************************************************************************************************************************************************
fatal: [i9kv1]: FAILED! => {"msg": "The field 'environment' has an invalid value, which includes an undefined variable. The error was: 'None' has no attribute 'get'"}
fatal: [i0k8s1-11]: FAILED! => {"msg": "The field 'environment' has an invalid value, which includes an undefined variable. The error was: 'None' has no attribute 'get'"}
fatal: [i0k8s1-12]: FAILED! => {"msg": "The field 'environment' has an invalid value, which includes an undefined variable. The error was: 'None' has no attribute 'get'"}
fatal: [i0k8s1-13]: FAILED! => {"msg": "The field 'environment' has an invalid value, which includes an undefined variable. The error was: 'None' has no attribute 'get'"}
fatal: [i0k8s1-15]: FAILED! => {"msg": "The field 'environment' has an invalid value, which includes an undefined variable. The error was: 'None' has no attribute 'get'"}
fatal: [i0k8s1-14]: FAILED! => {"msg": "The field 'environment' has an invalid value, which includes an undefined variable. The error was: 'None' has no attribute 'get'"}
fatal: [i0k8s1-16]: FAILED! => {"msg": "The field 'environment' has an invalid value, which includes an undefined variable. The error was: 'None' has no attribute 'get'"}
```

Fixes #

**Special notes for your reviewer**:
it's not the best solution, just works.

**Does this PR introduce a user-facing change?**:
NONE