### PR TITLE
Remove 1.16.x hook on test packet_centos7-weave-kubeadm-sep and upgrade weave to 2.6.2

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -77,7 +77,7 @@ flannel_cni_version: "v0.3.0"
 
 cni_version: "v0.8.5"
 
-weave_version: 2.5.2
+weave_version: 2.6.2
 pod_infra_version: 3.1
 contiv_version: 1.2.1
 cilium_version: "v1.7.1"

--- a/tests/files/packet_centos7-weave-kubeadm-sep.yml
+++ b/tests/files/packet_centos7-weave-kubeadm-sep.yml
@@ -9,5 +9,5 @@ deploy_netchecker: true
 kubernetes_audit: true
 dns_min_replicas: 1
 
-# Temp set k8s ver to 1.16.7 (due to bug with 1.16.8)
-kube_version: v1.16.7
+# Needed to upgrade from 1.16 to 1.17, otherwise upgrade is partial and bug followed
+upgrade_cluster_setup: true


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Remove hook as weave is working, the only thing that was making it fail was #5910 
/hold until 5910 is merged in master and rebased on this branch

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
