### PR TITLE
Ensure upgrade CI jobs are named correctly

### DIFF
--- a/tests/scripts/testcases_run.sh
+++ b/tests/scripts/testcases_run.sh
@@ -2,9 +2,19 @@
 set -euxo pipefail
 
 echo "CI_JOB_NAME is $CI_JOB_NAME"
-pwd
-ls
-echo ${PWD}
+
+if [[ "$CI_JOB_NAME" =~ "upgrade" ]]; then
+  if [ "${UPGRADE_TEST}" == "false" ]; then
+    echo "Job name contains 'upgrade', but UPGRADE_TEST='false'"
+    exit 1
+  fi
+else
+  if [ "${UPGRADE_TEST}" != "false" ]; then
+    echo "UPGRADE_TEST!='false', but job names does not contain 'upgrade'"
+    exit 1
+  fi
+fi
+
 
 export ANSIBLE_REMOTE_USER=$SSH_USER
 export ANSIBLE_BECOME=true


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Some CI jobs like [packet_centos7-weave-kubeadm-sep](https://github.com/kubernetes-sigs/kubespray/blob/master/.gitlab-ci/packet.yml#L37) have TEST_UPGRADE=basic but do not include the "upgrade" in their name, which can make it confusing for people.

Something noticed by @floryut 