### PR TITLE
[WIP] Do not require upgrade_cluster_setup=true for unsafe upgrades

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,6 +1,9 @@
 ---
 extends: default
 
+ignore: |
+  .git/
+
 rules:
   braces:
     min-spaces-inside: 0

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -25,16 +25,14 @@ If you wanted to upgrade just kube_version from v1.4.3 to v1.4.6, you could
 deploy the following way:
 
 ```ShellSession
-ansible-playbook cluster.yml -i inventory/sample/hosts.ini -e kube_version=v1.4.3 -e upgrade_cluster_setup=true
+ansible-playbook cluster.yml -i inventory/sample/hosts.ini -e kube_version=v1.4.3
 ```
 
 And then repeat with v1.4.6 as kube_version:
 
 ```ShellSession
-ansible-playbook cluster.yml -i inventory/sample/hosts.ini -e kube_version=v1.4.6 -e upgrade_cluster_setup=true
+ansible-playbook cluster.yml -i inventory/sample/hosts.ini -e kube_version=v1.4.6
 ```
-
-The var ```-e upgrade_cluster_setup=true``` is needed to be set in order to migrate the deploys of e.g kube-apiserver inside the cluster immediately which is usually only done in the graceful upgrade. (Refer to [#4139](https://github.com/kubernetes-sigs/kubespray/issues/4139) and [#4736](https://github.com/kubernetes-sigs/kubespray/issues/4736))
 
 ## Graceful upgrade
 

--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -200,7 +200,6 @@
 - name: kubeadm | upgrade kubernetes cluster
   include_tasks: kubeadm-upgrade.yml
   when:
-    - upgrade_cluster_setup
     - kubeadm_already_run.stat.exists
 
 - name: kubeadm | Check serviceaccount key again


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind cleanup

**What this PR does / why we need it**:
`cluster.yml` used to be able to upgrade a cluster without drains, which is useful in some cases. Adding the `upgrade_cluster_setup=true` was introduced in #5339

**Which issue(s) this PR fixes**:

Related to #5609

**Special notes for your reviewer**:
Also exclude `.git` dir from yamlint otherwise it gets confused with branches ending in `.yml`
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
