### PR TITLE
Update Calico to v3.13.2, Multus to v3.4.1. Add ConfigMap get permission…

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,13 +121,13 @@ Note: Upstart/SysV init based OS types are not supported.
   - [cri-o](http://cri-o.io/) v1.14.0 (experimental: see [CRI-O Note](docs/cri-o.md). Only on centos based OS)
 - Network Plugin
   - [cni-plugins](https://github.com/containernetworking/plugins) v0.8.5
-  - [calico](https://github.com/projectcalico/calico) v3.11.1
+  - [calico](https://github.com/projectcalico/calico) v3.13.2
   - [canal](https://github.com/projectcalico/canal) (given calico/flannel versions)
   - [cilium](https://github.com/cilium/cilium) v1.5.5
   - [contiv](https://github.com/contiv/install) v1.2.1
   - [flanneld](https://github.com/coreos/flannel) v0.11.0
   - [kube-router](https://github.com/cloudnativelabs/kube-router) v0.4.0
-  - [multus](https://github.com/intel/multus-cni) v3.4
+  - [multus](https://github.com/intel/multus-cni) v3.4.1
   - [weave](https://github.com/weaveworks/weave) v2.5.2
 - Application
   - [cephfs-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.0-k8s1.11

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -65,11 +65,11 @@ quay_image_repo: "quay.io"
 
 # TODO(mattymo): Move calico versions to roles/network_plugins/calico/defaults
 # after migration to container download
-calico_version: "v3.11.1"
-calico_ctl_version: "v3.11.1"
-calico_cni_version: "v3.11.1"
-calico_policy_version: "v3.11.1"
-calico_typha_version: "v3.11.1"
+calico_version: "v3.13.2"
+calico_ctl_version: "v3.13.2"
+calico_cni_version: "v3.13.2"
+calico_policy_version: "v3.13.2"
+calico_typha_version: "v3.13.2"
 typha_enabled: false
 
 flannel_version: "v0.11.0"
@@ -83,7 +83,7 @@ contiv_version: 1.2.1
 cilium_version: "v1.7.1"
 kube_ovn_version: "v0.6.0"
 kube_router_version: "v0.4.0"
-multus_version: "v3.4"
+multus_version: "v3.4.1"
 
 # Get kubernetes major version (i.e. 1.15.4 => 1.15)
 kube_major_version: "{{ kube_version | regex_replace('^v([0-9])+\\.([0-9]+)\\.[0-9]+', 'v\\1.\\2') }}"
@@ -382,18 +382,21 @@ cni_binary_checksums:
   amd64: bd682ffcf701e8f83283cdff7281aad0c83b02a56084d6e601216210732833f9
 calicoctl_binary_checksums:
   arm:
+    v3.13.2: 0
     v3.11.1: 0
     v3.7.3: 0
     v3.6.1: 0
     v3.5.4: 0
     v3.4.4: 0
   amd64:
+    v3.13.2: 5b0361e8935e450b1b39147d5690f75474a0ab7eb5936d65fa21a5eb8bcf66d7
     v3.11.1: 045fdbfdb30789194c499ba17c8eac6d1704fe20d05e3c10027eb570767386db
     v3.7.3: 932f68e893e80e95e10f064f1e7745e438d456f41a6ff12d11bb16ca0cab735c
     v3.6.1: 3b01336de37550e020343d62a38c96c4605d33a3ed7ddba2fe38bc172a5b42b5
     v3.5.4: 197194b838cc2a9a7455c2ebd5505a5e24f8f3d994eb75c17f5dd568944100b8
     v3.4.4: 93bd084e053cf1bf3b7fef369677bd6767c30fe7135e2c7e044e31693422ef61
   arm64:
+    v3.13.2: 7936ad0a5a40a1d50e3b9a555c101d1372bc424a98e4480e6471afd3abf92451
     v3.11.1: 770e0fce9acf1927726d64a885f8350d44a3fcbf248017d0aceec58bd41fa1b8
     v3.7.3: 7cfaab25c287f7ef93b2682d060b55bf39f76b668540de50376b5ed174209832
     v3.6.1: 60fbaeb257061647bdf12b5ede7a0d4298a5ee216f6472e5a92bb14ef5c2a5d3
@@ -734,7 +737,7 @@ downloads:
     enabled: "{{ kube_network_plugin == 'calico' or kube_network_plugin == 'canal' }}"
     file: true
     version: "{{ calico_ctl_version }}"
-    dest: "{{local_release_dir}}/calicoctl"
+    dest: "{{ local_release_dir }}/calicoctl"
     sha256: "{{ calicoctl_binary_checksum }}"
     url: "{{ calicoctl_download_url }}"
     unarchive: false

--- a/roles/network_plugin/calico/templates/calico-cr.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-cr.yml.j2
@@ -10,6 +10,7 @@ rules:
       - pods
       - nodes
       - namespaces
+      - configmaps
     verbs:
       - get
   - apiGroups: [""]


### PR DESCRIPTION
… to allow calico-node access to kubeadm config.

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
Update to the latest CNI.

**Which issue(s) this PR fixes**:
Without configmap permission on calico-node clusterrole recurring CrashLoopBackOff for all calico-node daemon sets will ocurr with container logs error like this:
`startup.go 182: failed to query kubeadm's config map error=configmaps "kubeadm-config" is forbidden: User "system:serviceaccount:kube-system:calico-node" cannot get resource "configmaps" in API group "" in the namespace "kube-system"`

Fixes #

**Special notes for your reviewer**:
Kubernetes v1.18 (and maybe previous)
Calico v3.13.2

**Does this PR introduce a user-facing change?**:
```
- Update Calico to v3.13.2
- Update Multus to v3.4.1
```