### PR TITLE
Derive bin_dir from the first master node to account for worker nodes…

### DIFF
--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -32,7 +32,7 @@
   run_once: true
 
 - name: Create kubeadm token for joining nodes with 24h expiration (default)
-  command: "{{ bin_dir }}/kubeadm token create"
+  command: "{{ hostvars[groups['kube-master']|first]['bin_dir'] }}/kubeadm token create"
   register: temp_token
   delegate_to: "{{ groups['kube-master'][0] }}"
   when: kubeadm_token is not defined
@@ -103,11 +103,9 @@
     - kubeadm_discovery_address != kube_apiserver_endpoint | replace("https://", "")
   notify: Kubeadm | restart kubelet
 
-# FIXME(mattymo): Need to point to localhost, otherwise masters will all point
-#                 incorrectly to first master, creating SPoF.
 - name: Update server field in kube-proxy kubeconfig
   shell: >-
-    {{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf get configmap kube-proxy -n kube-system -o yaml
+    {{ hostvars[groups['kube-master']|first]['bin_dir'] }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf get configmap kube-proxy -n kube-system -o yaml
     | sed 's#server:.*#server: https://127.0.0.1:{{ kube_apiserver_port }}#g'
     | {{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf replace -f -
   run_once: true
@@ -128,7 +126,7 @@
     mode: "0644"
 
 - name: Restart all kube-proxy pods to ensure that they load the new configmap
-  shell: "{{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf delete pod -n kube-system -l k8s-app=kube-proxy --force --grace-period=0"
+  shell: "{{ hostvars[groups['kube-master']|first]['bin_dir'] }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf delete pod -n kube-system -l k8s-app=kube-proxy --force --grace-period=0"
   run_once: true
   delegate_to: "{{ groups['kube-master']|first }}"
   when:
@@ -152,7 +150,7 @@
 # FIXME(jjo): need to post-remove kube-proxy until https://github.com/kubernetes/kubeadm/issues/776
 # is fixed
 - name: Delete kube-proxy daemonset if kube_proxy_remove set, e.g. kube_network_plugin providing proxy services
-  shell: "{{ bin_dir }}/kubectl --kubeconfig /etc/kubernetes/admin.conf delete daemonset -n kube-system kube-proxy"
+  shell: "{{ hostvars[groups['kube-master']|first]['bin_dir'] }}/kubectl --kubeconfig /etc/kubernetes/admin.conf delete daemonset -n kube-system kube-proxy"
   run_once: true
   delegate_to: "{{ groups['kube-master']|first }}"
   when:


### PR DESCRIPTION
… from different distribution.

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Install CentOS 8 worker nodes while all masters are CoreOS with different bin_dir configuration variable.

**Which issue(s) this PR fixes**:
Kind of "path not found" for kubernetes binaries when playbook is run against worker nodes, but task is delegated to a master.

Fixes #

**Special notes for your reviewer**:
Error logs are lost.
It's assumed that all masters are from the same Linux distribution, and only workers are from other.

**Does this PR introduce a user-facing change?**:
NONE