### PR TITLE
always download docker image on download_host when download_run_once

### DIFF
--- a/roles/download/tasks/download_container.yml
+++ b/roles/download/tasks/download_container.yml
@@ -59,7 +59,7 @@
       retries: 4
       become: "{{ user_can_become_root | default(false) or not download_localhost }}"
       when:
-        - pull_required
+        - pull_required or download_run_once
         - not image_is_cached
 
     - name: download_container | Save and compress image


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
download_run_once: true
download_localhost: true

image exists on nodes, but not exists on download_delegate (localhost) host.

so task with docker save is failed.

fix by always download images to cache when download_run_once=true
