### PR TITLE
Remove hashes only for EOL version in RELEASE cycle.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,13 +5,14 @@ The Kubespray Project is released on an as-needed basis. The process is as follo
 1. An issue is proposing a new release with a changelog since the last release
 2. At least one of the [approvers](OWNERS_ALIASES) must approve this release
 3. The `kube_version_min_required` variable is set to `n-1`
-4. An approver creates [new release in GitHub](https://github.com/kubernetes-sigs/kubespray/releases/new) using a version and tag name like `vX.Y.Z` and attaching the release notes
-5. An approver creates a release branch in the form `release-X.Y`
-6. The corresponding version of [quay.io/kubespray/kubespray:vX.Y.Z](https://quay.io/repository/kubespray/kubespray) docker image is built and tagged
-7. The `KUBESPRAY_VERSION` variable is updated in `.gitlab-ci.yml`
-8. The release issue is closed
-9. An announcement email is sent to `kubernetes-dev@googlegroups.com` with the subject `[ANNOUNCE] Kubespray $VERSION is released`
-10. The topic of the #kubespray channel is updated with `vX.Y.Z is released! | ...`
+4. Remove hashes for [EOL versions](https://github.com/kubernetes/sig-release/blob/master/releases/patch-releases.md) of kubernetes from `*_checksums` variables.
+5. An approver creates [new release in GitHub](https://github.com/kubernetes-sigs/kubespray/releases/new) using a version and tag name like `vX.Y.Z` and attaching the release notes
+6. An approver creates a release branch in the form `release-X.Y`
+7. The corresponding version of [quay.io/kubespray/kubespray:vX.Y.Z](https://quay.io/repository/kubespray/kubespray) docker image is built and tagged
+8. The `KUBESPRAY_VERSION` variable is updated in `.gitlab-ci.yml`
+9. The release issue is closed
+10. An announcement email is sent to `kubernetes-dev@googlegroups.com` with the subject `[ANNOUNCE] Kubespray $VERSION is released`
+11. The topic of the #kubespray channel is updated with `vX.Y.Z is released! | ...`
 
 ## Major/minor releases and milestones
 


### PR DESCRIPTION

/kind documentation

**What this PR does / why we need it**:
Remove hashes only for EOL version in RELEASE cycle.

Allow, but not guarantee, the installation of older but supported versions k8s