### PR TITLE
Set LANG in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,6 @@ COPY . .
 RUN /usr/bin/python3 -m pip install pip -U && /usr/bin/python3 -m pip install -r tests/requirements.txt && python3 -m pip install -r requirements.txt && update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.14.4/bin/linux/amd64/kubectl \
     && chmod a+x kubectl && cp kubectl /usr/local/bin/kubectl
+
+# Some tools like yamllint need this
+ENV LANG=C.UTF-8


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind failing-test

**What this PR does / why we need it**:
`yamllint` needs the LANG to be set, which we usually set in https://github.com/kubernetes-sigs/kubespray/blob/221c6a8eef35217267a96a6c0bf75aecd20986f3/.gitlab-ci/lint.yml#L7 and https://github.com/kubernetes-sigs/kubespray/blob/ded58d3b6604bbda618c2b5cb119d6edac1aad43/tests/scripts/molecule_run.sh#L5, but it would be better to set that directly in the Docker image, t.ex for Prow (https://github.com/kubernetes/test-infra/pull/17051)