### PR TITLE
Generate unique username per cluster in client kubeconfig

### DIFF
--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -84,7 +84,7 @@
 
 - name: Write admin kubeconfig on ansible host
   copy:
-    content: "{{ final_admin_kubeconfig | to_nice_yaml(indent=2)}}"
+    content: "{{ final_admin_kubeconfig | to_nice_yaml(indent=2) }}"
     dest: "{{ artifacts_dir }}/admin.conf"
     mode: 0640
   delegate_to: localhost

--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -63,9 +63,23 @@
   run_once: yes
   register: admin_kubeconfig
 
+- set_fact:
+    admin_kubeconfig: "{{ raw_admin_kubeconfig.stdout | from_yaml }}"
+- set_fact:
+    cluster_infos: "{{ admin_kubeconfig['clusters'][0]['cluster'] }}"
+    user_certs: "{{ admin_kubeconfig['users'][0]['user'] }}"
+    username: "kubernetes-admin-{{ cluster_name }}"
+    context: "kubernetes-admin-{{ cluster_name }}@{{ cluster_name }}"
+- set_fact:
+    final_admin_kubeconfig: "{{ admin_kubeconfig | combine(override_cluster_name, recursive=true) | combine(override_context, recursive=true) | combine(override_user, recursive=true) }}"
+  vars:
+    override_cluster_name: "{{ { 'clusters': [ { 'cluster': cluster_infos, 'name': cluster_name } ] } }}"
+    override_context: "{{ { 'contexts': [ { 'context': { 'user': username, 'cluster': cluster_name }, 'name': context } ], 'current-context': context } }}"
+    override_user: "{{ { 'users': [ { 'name': username, 'user': user_certs  } ] } }}"
+
 - name: Write admin kubeconfig on ansible host
   copy:
-    content: "{{ admin_kubeconfig.stdout }}"
+    content: "{{ final_admin_kubeconfig | to_nice_yaml(indent=2)}}"
     dest: "{{ artifacts_dir }}/admin.conf"
     mode: 0640
   delegate_to: localhost

--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -38,7 +38,7 @@
   delegate_to: localhost
   become: no
   run_once: yes
-  when: kubeconfig_localhost|default(false)
+  when: kubeconfig_localhost
 
 - name: Wait for k8s apiserver
   wait_for:
@@ -62,25 +62,25 @@
   environment: "{{ proxy_env }}"
   run_once: yes
   register: raw_admin_kubeconfig
+  when: kubeconfig_localhost
 
 - name: Convert kubeconfig to YAML
   set_fact:
     admin_kubeconfig: "{{ raw_admin_kubeconfig.stdout | from_yaml }}"
-
-- name: Extract current settings from kubeconfig
-  set_fact:
-    cluster_infos: "{{ admin_kubeconfig['clusters'][0]['cluster'] }}"
-    user_certs: "{{ admin_kubeconfig['users'][0]['user'] }}"
-    username: "kubernetes-admin-{{ cluster_name }}"
-    context: "kubernetes-admin-{{ cluster_name }}@{{ cluster_name }}"
+  when: kubeconfig_localhost
 
 - name: Override username in kubeconfig
   set_fact:
     final_admin_kubeconfig: "{{ admin_kubeconfig | combine(override_cluster_name, recursive=true) | combine(override_context, recursive=true) | combine(override_user, recursive=true) }}"
   vars:
+    cluster_infos: "{{ admin_kubeconfig['clusters'][0]['cluster'] }}"
+    user_certs: "{{ admin_kubeconfig['users'][0]['user'] }}"
+    username: "kubernetes-admin-{{ cluster_name }}"
+    context: "kubernetes-admin-{{ cluster_name }}@{{ cluster_name }}"
     override_cluster_name: "{{ { 'clusters': [ { 'cluster': cluster_infos, 'name': cluster_name } ] } }}"
     override_context: "{{ { 'contexts': [ { 'context': { 'user': username, 'cluster': cluster_name }, 'name': context } ], 'current-context': context } }}"
     override_user: "{{ { 'users': [ { 'name': username, 'user': user_certs  } ] } }}"
+  when: kubeconfig_localhost
 
 - name: Write admin kubeconfig on ansible host
   copy:
@@ -90,7 +90,7 @@
   delegate_to: localhost
   become: no
   run_once: yes
-  when: kubeconfig_localhost|default(false)
+  when: kubeconfig_localhost
 
 - name: Copy kubectl binary to ansible host
   fetch:
@@ -100,7 +100,7 @@
     validate_checksum: no
   become: no
   run_once: yes
-  when: kubectl_localhost|default(false)
+  when: kubectl_localhost
 
 - name: create helper script kubectl.sh on ansible host
   copy:
@@ -112,4 +112,4 @@
   become: no
   run_once: yes
   delegate_to: localhost
-  when: kubectl_localhost|default(false) and kubeconfig_localhost|default(false)
+  when: kubectl_localhost and kubeconfig_localhost

--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -61,7 +61,7 @@
     rm -rf {{ kube_config_dir }}/external_kubeconfig
   environment: "{{ proxy_env }}"
   run_once: yes
-  register: admin_kubeconfig
+  register: raw_admin_kubeconfig
 
 - set_fact:
     admin_kubeconfig: "{{ raw_admin_kubeconfig.stdout | from_yaml }}"

--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -63,14 +63,19 @@
   run_once: yes
   register: raw_admin_kubeconfig
 
-- set_fact:
+- name: Convert kubeconfig to YAML
+  set_fact:
     admin_kubeconfig: "{{ raw_admin_kubeconfig.stdout | from_yaml }}"
-- set_fact:
+
+- name: Extract current settings from kubeconfig
+  set_fact:
     cluster_infos: "{{ admin_kubeconfig['clusters'][0]['cluster'] }}"
     user_certs: "{{ admin_kubeconfig['users'][0]['user'] }}"
     username: "kubernetes-admin-{{ cluster_name }}"
     context: "kubernetes-admin-{{ cluster_name }}@{{ cluster_name }}"
-- set_fact:
+
+- name: Override username in kubeconfig
+  set_fact:
     final_admin_kubeconfig: "{{ admin_kubeconfig | combine(override_cluster_name, recursive=true) | combine(override_context, recursive=true) | combine(override_user, recursive=true) }}"
   vars:
     override_cluster_name: "{{ { 'clusters': [ { 'cluster': cluster_infos, 'name': cluster_name } ] } }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
When dealing with multiple clusters from the same ansible or bastion host, it's getting difficult to easily manage all kubeconfig files generated by kubespray. Kubectl provides a handy merge command `kubectl config view --flatten` when putting multiple kubeconfig file in KUBECONFIG environment variable but cluster, context and user values need to be unique otherwise they will overwrite each other. `cluster_name` is driven by kubespray users, so it's easy to make it unique. username is generated by kubeadm and is always set to `kubernetes-admin` which is an issue (see #5744 for more details).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5744

**Special notes for your reviewer**:
We should recommend to kubespray users to not use cluster.local as `cluster_name` default and either make it mandatory or make it different to `dns_domain` default. `kubeadm` uses `kubernetes` as default for `cluster_name`

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
