### PR TITLE
Update vars.md

### DIFF
--- a/docs/vars.md
+++ b/docs/vars.md
@@ -50,6 +50,7 @@ Kubernetes needs some parameters in order to get deployed. These are the
 following default cluster parameters:
 
 * *cluster_name* - Name of cluster (default is cluster.local)
+* *container_manager* - Container Runtime to install in the nodes (default is docker)
 * *dns_domain* - Name of cluster DNS domain (default is cluster.local)
 * *kube_network_plugin* - Plugin to use for container networking
 * *kube_service_addresses* - Subnet for cluster IPs (default is


### PR DESCRIPTION
**What type of PR is this?**
> /kind documentation

**What this PR does / why we need it**:
The `container_manager` cluster variable is not referenced in the global document of variables. It is a simple new line to reference the way of changing the container runtime.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
NONE
