### PR TITLE
Rollback coredns version to 1.6.5 to fix kubeadm migration failure (about half the time for weave job)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [cephfs-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.0-k8s1.11
   - [rbd-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.1-k8s1.11
   - [cert-manager](https://github.com/jetstack/cert-manager) v0.11.1
-  - [coredns](https://github.com/coredns/coredns) v1.6.9
+  - [coredns](https://github.com/coredns/coredns) v1.6.5
   - [ingress-nginx](https://github.com/kubernetes/ingress-nginx) v0.30.0
 
 Note: The list of validated [docker versions](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md) was updated to 1.13.1, 17.03, 17.06, 17.09, 18.06, 18.09. kubeadm now properly recognizes Docker 18.09.0 and newer, but still treats 18.06 as the default supported version. The kubelet might break on docker's non-standard version numbering (it no longer uses semantic versioning). To ensure auto-updates don't break your cluster look into e.g. yum versionlock plugin or apt pin).

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -511,7 +511,9 @@ nginx_image_tag: 1.17
 haproxy_image_repo: "{{ docker_image_repo }}/library/haproxy"
 haproxy_image_tag: 1.9
 
-coredns_version: "1.6.9"
+# Coredns version should be supported by corefile-migration (or at least work with)
+# bundle with kubeadm; if not 'basic' upgrade can sometimes fail
+coredns_version: "1.6.5"
 coredns_image_repo: "{{ docker_image_repo }}/coredns/coredns"
 coredns_image_tag: "{{ coredns_version }}"
 

--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -22,17 +22,14 @@ data:
 {% endif %}
     .:53 {
         errors
-        health
+        health {
+            lameduck 5s
+        }
         ready
         kubernetes {{ dns_domain }} in-addr.arpa ip6.arpa {
           pods insecure
 {% if enable_coredns_k8s_endpoint_pod_names %}
           endpoint_pod_names
-{% endif %}
-{% if resolvconf_mode == 'host_resolvconf' and upstream_dns_servers is defined and upstream_dns_servers|length > 0 %}
-          upstream {{ upstream_dns_servers|join(' ') }}
-{% else %}
-          upstream /etc/resolv.conf
 {% endif %}
           fallthrough in-addr.arpa ip6.arpa
         }


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Since kubernetes 1.16, kubeadm now does a Corefile migration https://github.com/coredns/coredns/issues/3453
> Upgrades of coredns in kubernetes are controlled by the kubernetes management software you use. For example kubeadm. Each k8s mgmt tool can handle this differently. Kubeadm uses our migration lib, in the coredns/corefile-migration repo. It migrates deprecated plugins such as proxy->forward while retaining custom configs such as stub domain configs.
I should add: 1.16 is the first version of k8s/kubeadm that does corefile migrations during upgrades. Prior to that, the existing corefile was always left untouched during an upgrade. K8s 1.16 included for the first time, a version of coredns that had introduced a k8s related backward compatibility.
As for backward compatibility between versions in coredns, we follow our deprecation policy described in the readme of this repo - maintaining backward compatibility for a limited time.
  
Kubernetes [1.17](https://github.com/kubernetes/kubernetes/blob/release-1.17/go.mod) use `corefile-migration:1.0.4` (supports 1.6.5) while [1.18](https://github.com/kubernetes/kubernetes/blob/release-1.18/go.mod) use `corefile-migration:1.0.6` (supports 1.6.7).

As far as 1.17 goes, migration sometime fail with `coredns:1.6.9` this should be retried once we set our defaut kubernetes version to 1.18.

And the fact that failing the configmap migration create a failure in the whole kubeadm upgrade may be fix in 1.19 by https://github.com/kubernetes/kubernetes/pull/88811
So we may have to wait for 1.19 not to worries about kubeadm upgrade.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
* Upgrade coredns 1.6.7 should be done with 1.18 and 1.6.9 may be retried once 1.18 is used (and corefile-migration is up to 1.0.6)

Upstream is deprecated and removed since coredns 1.5.x, lameduck need to be added to health
>$ ./corefile-tool-amd64 deprecated --corefile corefile --from 1.3.0 --to 1.6.7
Option "upstream" in plugin "kubernetes" is deprecated in 1.4.x.
Option "upstream" in plugin "kubernetes" is ignored in 1.5.x.
[...]
Option "upstream" in plugin "kubernetes" is ignored in 1.6.x.
[...]
Option "lameduck" in plugin "health" is added as a default in 1.6.5.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
