### PR TITLE
Fix kube-proxy ds win nodeselector check for 1.17

### DIFF
--- a/roles/win_nodes/kubernetes_patch/defaults/main.yml
+++ b/roles/win_nodes/kubernetes_patch/defaults/main.yml
@@ -3,3 +3,5 @@
 kubernetes_user_manifests_path: "{{ ansible_env.HOME }}/kube-manifests"
 # Optionally remove kube_proxy installed by kubeadm
 kube_proxy_remove: false
+# nodeselector for kube-proxy ds is beta until 1.18
+kube_proxy_nodeselector: "{{ 'kubernetes.io/os' if kube_version is version('v1.18.0', '>=') else 'beta.kubernetes.io/os' }}"

--- a/roles/win_nodes/kubernetes_patch/files/nodeselector-os-linux-patch.json
+++ b/roles/win_nodes/kubernetes_patch/files/nodeselector-os-linux-patch.json
@@ -1,1 +1,0 @@
-{"spec":{"template":{"spec":{"nodeSelector":{"kubernetes.io/os":"linux"}}}}}

--- a/roles/win_nodes/kubernetes_patch/tasks/main.yml
+++ b/roles/win_nodes/kubernetes_patch/tasks/main.yml
@@ -9,17 +9,12 @@
 
 - name: Apply kube-proxy nodeselector
   block:
-    - name: Copy kube-proxy daemonset nodeselector patch
-      copy:
-        src: nodeselector-os-linux-patch.json
-        dest: "{{ kubernetes_user_manifests_path }}/nodeselector-os-linux-patch.json"
-
     # Due to https://github.com/kubernetes/kubernetes/issues/58212 we cannot rely on exit code for "kubectl patch"
     - name: Check current nodeselector for kube-proxy daemonset
       command: >-
         {{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf
         get ds kube-proxy --namespace=kube-system
-        -o jsonpath='{.spec.template.spec.nodeSelector.kubernetes\.io/os}'
+        -o jsonpath='{.spec.template.spec.nodeSelector.{{ kube_proxy_nodeselector | regex_replace('\.', '\\.') }}}'
       register: current_kube_proxy_state
       retries: 60
       delay: 5
@@ -30,9 +25,7 @@
       shell: >-
         {{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf
         patch ds kube-proxy --namespace=kube-system --type=strategic -p
-        "$(cat nodeselector-os-linux-patch.json)"
-      args:
-        chdir: "{{ kubernetes_user_manifests_path }}"
+        '{"spec":{"template":{"spec":{"nodeSelector":{"{{ kube_proxy_nodeselector }}":"linux"}}}}}'
       register: patch_kube_proxy_state
       when: current_kube_proxy_state.stdout | trim | lower != "linux"
 

--- a/roles/win_nodes/kubernetes_patch/tasks/main.yml
+++ b/roles/win_nodes/kubernetes_patch/tasks/main.yml
@@ -25,7 +25,7 @@
       shell: >-
         {{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf
         patch ds kube-proxy --namespace=kube-system --type=strategic -p
-        '{"spec":{"template":{"spec":{"nodeSelector":{"{{ kube_proxy_nodeselector }}":"linux"}}}}}'
+        '{"spec":{"template":{"spec":{"nodeSelector":{"{{ kube_proxy_nodeselector }}":"linux"} }}}}'
       register: patch_kube_proxy_state
       when: current_kube_proxy_state.stdout | trim | lower != "linux"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Before 1.18, kubeadm created kube-proxy daemonset with nodeselector [containing](https://github.com/kubernetes/kubernetes/blob/release-1.17/cluster/addons/kube-proxy/kube-proxy-ds.yaml#L28) deprecated label `beta.kubernetes.io/os`. After #5974 the check on 1.17 does not find GA label it looks for and applies it resulting in duplicate nodeselector labels (regardless of the os).
As 1.16 and 1.17 are still supported, this PR uses the required label depending on the kubernetes version. Additionally, it cleans up the patch from file to inline increasing readability.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
