### PR TITLE
generate flannel manifest only on first master

### DIFF
--- a/roles/network_plugin/flannel/tasks/main.yml
+++ b/roles/network_plugin/flannel/tasks/main.yml
@@ -8,4 +8,4 @@
     - {name: kube-flannel, file: cni-flannel.yml, type: ds}
   register: flannel_node_manifests
   when:
-    - inventory_hostname in groups['kube-master']
+    - inventory_hostname == groups['kube-master'][0]


### PR DESCRIPTION

 /kind bug

**What this PR does / why we need it**:
when psp enabled generate flannel manifests on master-2 and master-3 faile with error
```2020-04-18 17:41:47,568 p=11046 u=root |  TASK [network_plugin/flannel : Flannel | Create Flannel manifests] 
(item={u'type': u'sa', u'name': u'flannel', u'file': u'cni-flannel-rbac.yml'}) =
> {"ansible_loop_var": "item", "changed": false, "item": {"file": "cni-flannel-rbac.yml", "name": "flannel", "type": "sa"}, "msg": "AnsibleUndefinedVariable:
'apparmor_enabled' is undefined"}
```

