### PR TITLE
bump minimal ansible version to 2.8.0

### DIFF
--- a/ansible_version.yml
+++ b/ansible_version.yml
@@ -1,0 +1,15 @@
+---
+- hosts: localhost
+  gather_facts: false
+  become: no
+  vars:
+    minimal_ansible_version: 2.8.0
+    ansible_connection: local
+  tasks:
+    - name: "Check ansible version >={{ minimal_ansible_version }}"
+      assert:
+        msg: "Ansible must be {{ minimal_ansible_version }} or higher"
+        that:
+          - ansible_version.string is version(minimal_ansible_version, ">=")
+      tags:
+        - check

--- a/cluster.yml
+++ b/cluster.yml
@@ -3,11 +3,11 @@
   gather_facts: false
   become: no
   tasks:
-    - name: "Check ansible version >=2.7.8"
+    - name: "Check ansible version >=2.8.0"
       assert:
-        msg: "Ansible must be v2.7.8 or higher"
+        msg: "Ansible must be v2.8.0 or higher"
         that:
-          - ansible_version.string is version("2.7.8", ">=")
+          - ansible_version.string is version("2.8.0", ">=")
       tags:
         - check
   vars:

--- a/cluster.yml
+++ b/cluster.yml
@@ -1,17 +1,6 @@
 ---
-- hosts: localhost
-  gather_facts: false
-  become: no
-  tasks:
-    - name: "Check ansible version >=2.8.0"
-      assert:
-        msg: "Ansible must be v2.8.0 or higher"
-        that:
-          - ansible_version.string is version("2.8.0", ">=")
-      tags:
-        - check
-  vars:
-    ansible_connection: local
+- name: Check ansible version
+  import_playbook: ansible_version.yml
 
 - hosts: all
   gather_facts: false

--- a/mitogen.yaml
+++ b/mitogen.yaml
@@ -4,7 +4,14 @@
   vars:
     mitogen_version: master
     mitogen_url: https://github.com/dw/mitogen/archive/{{ mitogen_version }}.zip
+    ansible_connection: local
   tasks:
+    - name: "Check ansible version >=2.8.0"
+      assert:
+        msg: "Ansible must be v2.8.0 or higher"
+        that:
+          - ansible_version.string is version("2.8.0", ">=")
+
     - name: Create mitogen plugin dir
       file:
         path: "{{ item }}"

--- a/mitogen.yaml
+++ b/mitogen.yaml
@@ -1,4 +1,7 @@
 ---
+- name: Check ansible version
+  import_playbook: ansible_version.yml
+
 - hosts: localhost
   strategy: linear
   vars:
@@ -6,12 +9,6 @@
     mitogen_url: https://github.com/dw/mitogen/archive/{{ mitogen_version }}.zip
     ansible_connection: local
   tasks:
-    - name: "Check ansible version >=2.8.0"
-      assert:
-        msg: "Ansible must be v2.8.0 or higher"
-        that:
-          - ansible_version.string is version("2.8.0", ">=")
-
     - name: Create mitogen plugin dir
       file:
         path: "{{ item }}"

--- a/recover-control-plane.yml
+++ b/recover-control-plane.yml
@@ -3,11 +3,11 @@
   gather_facts: False
   become: no
   tasks:
-    - name: "Check ansible version >=2.7.8"
+    - name: "Check ansible version >=2.8.0"
       assert:
-        msg: "Ansible must be v2.7.8 or higher"
+        msg: "Ansible must be v2.8.0 or higher"
         that:
-          - ansible_version.string is version("2.7.8", ">=")
+          - ansible_version.string is version("2.8.0", ">=")
       tags:
         - check
   vars:

--- a/recover-control-plane.yml
+++ b/recover-control-plane.yml
@@ -1,17 +1,6 @@
 ---
-- hosts: localhost
-  gather_facts: False
-  become: no
-  tasks:
-    - name: "Check ansible version >=2.8.0"
-      assert:
-        msg: "Ansible must be v2.8.0 or higher"
-        that:
-          - ansible_version.string is version("2.8.0", ">=")
-      tags:
-        - check
-  vars:
-    ansible_connection: local
+- name: Check ansible version
+  import_playbook: ansible_version.yml
 
 - hosts: bastion[0]
   gather_facts: False

--- a/remove-node.yml
+++ b/remove-node.yml
@@ -3,11 +3,11 @@
   become: no
   gather_facts: no
   tasks:
-    - name: "Check ansible version >=2.7.8"
+    - name: "Check ansible version >=2.8.0"
       assert:
-        msg: "Ansible must be v2.7.8 or higher"
+        msg: "Ansible must be v2.8.0 or higher"
         that:
-          - ansible_version.string is version("2.7.8", ">=")
+          - ansible_version.string is version("2.8.0", ">=")
       tags:
         - check
   vars:

--- a/remove-node.yml
+++ b/remove-node.yml
@@ -1,17 +1,6 @@
 ---
-- hosts: localhost
-  become: no
-  gather_facts: no
-  tasks:
-    - name: "Check ansible version >=2.8.0"
-      assert:
-        msg: "Ansible must be v2.8.0 or higher"
-        that:
-          - ansible_version.string is version("2.8.0", ">=")
-      tags:
-        - check
-  vars:
-    ansible_connection: local
+- name: Check ansible version
+  import_playbook: ansible_version.yml
 
 - hosts: "{{ node | default('etcd:k8s-cluster:calico-rr') }}"
   gather_facts: no

--- a/reset.yml
+++ b/reset.yml
@@ -3,11 +3,11 @@
   become: no
   gather_facts: False
   tasks:
-    - name: "Check ansible version >=2.7.8"
+    - name: "Check ansible version >=2.8.0"
       assert:
-        msg: "Ansible must be v2.7.8 or higher"
+        msg: "Ansible must be v2.8.0 or higher"
         that:
-          - ansible_version.string is version("2.7.8", ">=")
+          - ansible_version.string is version("2.8.0", ">=")
       tags:
         - check
   vars:

--- a/reset.yml
+++ b/reset.yml
@@ -1,17 +1,6 @@
 ---
-- hosts: localhost
-  become: no
-  gather_facts: False
-  tasks:
-    - name: "Check ansible version >=2.8.0"
-      assert:
-        msg: "Ansible must be v2.8.0 or higher"
-        that:
-          - ansible_version.string is version("2.8.0", ">=")
-      tags:
-        - check
-  vars:
-    ansible_connection: local
+- name: Check ansible version
+  import_playbook: ansible_version.yml
 
 - hosts: bastion[0]
   gather_facts: False

--- a/scale.yml
+++ b/scale.yml
@@ -3,11 +3,11 @@
   gather_facts: False
   become: no
   tasks:
-    - name: "Check ansible version >=2.7.8"
+    - name: "Check ansible version >=2.8.0"
       assert:
-        msg: "Ansible must be v2.7.8 or higher"
+        msg: "Ansible must be v2.8.0 or higher"
         that:
-          - ansible_version.string is version("2.7.8", ">=")
+          - ansible_version.string is version("2.8.0", ">=")
       tags:
         - check
   vars:

--- a/scale.yml
+++ b/scale.yml
@@ -1,17 +1,6 @@
 ---
-- hosts: localhost
-  gather_facts: False
-  become: no
-  tasks:
-    - name: "Check ansible version >=2.8.0"
-      assert:
-        msg: "Ansible must be v2.8.0 or higher"
-        that:
-          - ansible_version.string is version("2.8.0", ">=")
-      tags:
-        - check
-  vars:
-    ansible_connection: local
+- name: Check ansible version
+  import_playbook: ansible_version.yml
 
 - hosts: all
   gather_facts: false

--- a/upgrade-cluster.yml
+++ b/upgrade-cluster.yml
@@ -3,11 +3,11 @@
   gather_facts: false
   become: no
   tasks:
-    - name: "Check ansible version >=2.7.8"
+    - name: "Check ansible version >=2.8.0"
       assert:
-        msg: "Ansible must be v2.7.8 or higher"
+        msg: "Ansible must be v2.8.0 or higher"
         that:
-          - ansible_version.string is version("2.7.8", ">=")
+          - ansible_version.string is version("2.8.0", ">=")
       tags:
         - check
   vars:

--- a/upgrade-cluster.yml
+++ b/upgrade-cluster.yml
@@ -1,17 +1,6 @@
 ---
-- hosts: localhost
-  gather_facts: false
-  become: no
-  tasks:
-    - name: "Check ansible version >=2.8.0"
-      assert:
-        msg: "Ansible must be v2.8.0 or higher"
-        that:
-          - ansible_version.string is version("2.8.0", ">=")
-      tags:
-        - check
-  vars:
-    ansible_connection: local
+- name: Check ansible version
+  import_playbook: ansible_version.yml
 
 - hosts: all
   gather_facts: false


### PR DESCRIPTION

/kind bug

**What this PR does / why we need it**:

ansible 2.7.x fail with error 

```
 {"msg": "The conditional check '{{ 'bootstrap-os' not in ansible_play
_role_names }}' failed. The error was: error while evaluating conditional ({{ 'bootstrap-os' not in ansible_play_role_names }}): Unable to look up a name or a
ccess an attribute in template string ({{ 'bootstrap-os' not in ansible_play_role_names }}).\nMake sure your variable name does not contain invalid characters
 like '-': argument of type 'StrictUndefined' is not iterable\n\nThe error appears to have been in '/srv/kubespray/roles/kubespray-defaults/tasks/main.yaml':
line 9, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n# do not run gather facts w
hen bootstrap-os in roles\n- name: set fallback_ips\n  ^ here\n"}
```
