### PR TITLE
Add rpm-ostree cleanup task

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-fedora-coreos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-fedora-coreos.yml
@@ -8,6 +8,11 @@
   tags:
     - facts
 
+- name: Clean up possible pending packages on fedora coreos
+  raw: "export http_proxy={{ http_proxy | default('') }};rpm-ostree cleanup -p }}"
+  become: true
+  when: need_bootstrap.rc != 0
+
 - name: Install required packages on fedora coreos
   raw: "export http_proxy={{ http_proxy | default('') }};rpm-ostree install {{ fedora_coreos_packages|join(' ') }}"
   become: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

On fedora coreos, when the installation of packages fails at the task `Install required packages on fedora coreos`, e.g. when a network error happened, it leaves the package manager in state were future runs will fail with:
```fatal: [a05.node.vmxon.local]: FAILED! => {"changed": true, "msg": "non-zero return code", "rc": 1, "stderr": "Shared connection to a05.node.vmxon.local closed.\r\n", "stderr_lines": ["Shared connection to a05.node.vmxon.local closed."], "stdout": "\u001b[31m\u001b[1merror: \u001b[22m\u001b[0mPackage/capability 'python' is already requested\r\n", "stdout_lines": ["\u001b[31m\u001b[1merror: \u001b[22m\u001b[0mPackage/capability 'python' is already requested"]}```

This is fixed by adding a task before it to clean up the pending packages.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
