### PR TITLE
Fix retries keyword missing until instruction

### DIFF
--- a/contrib/vault/roles/vault/tasks/shared/check_vault.yml
+++ b/contrib/vault/roles/vault/tasks/shared/check_vault.yml
@@ -36,6 +36,7 @@
       {{ etcd_access_addresses.split(',') | first }}/v3alpha/kv/range
   register: vault_etcd_exists
   retries: 4
+  until: vault_etcd_exists.status == 200
   delay: "{{ retry_stagger | random + 3 }}"
   run_once: true
   when: not vault_is_running and vault_etcd_available

--- a/extra_playbooks/build-cephfs-provisioner.yml
+++ b/extra_playbooks/build-cephfs-provisioner.yml
@@ -50,6 +50,8 @@
           docker_image:
             name: quay.io/kubespray/cephfs-provisioner:06fddbe2
             push: yes
+          register: docker_image
           retries: 10
+          until: docker_image is succeeded
 
       when: check_image_result.rc != 0

--- a/roles/kubernetes/master/tasks/kubeadm-upgrade.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-upgrade.yml
@@ -24,6 +24,7 @@
   register: kubeadm_upgrade
   # Retry is because upload config sometimes fails
   retries: 3
+  until: kubeadm_upgrade.rc == 0
   when: inventory_hostname == groups['kube-master']|first
   failed_when: kubeadm_upgrade.rc != 0 and "field is immutable" not in kubeadm_upgrade.stderr
   notify: Master | restart kubelet

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -89,6 +89,7 @@
     {{ bin_dir }}/calicoctl.sh get ippool | grep -w "{{ calico_pool_cidr | default(kube_pods_subnet) }}" | wc -l
   register: calico_conf
   retries: 4
+  until: calico_conf.rc == 0
   delay: "{{ retry_stagger | random + 3 }}"
   changed_when: false
   when:
@@ -203,7 +204,9 @@
        "asNumber": "{{ item.as }}",
        "peerIP": "{{ item.router_id }}"
     }}' | {{ bin_dir }}/calicoctl.sh apply -f -
+  register: output
   retries: 4
+  until: output.rc == 0
   delay: "{{ retry_stagger | random + 3 }}"
   with_items:
     - "{{ peers|selectattr('scope','defined')|selectattr('scope','equalto', 'global')|list|default([]) }}"
@@ -223,7 +226,9 @@
        "nodeSelector": "!has(i-am-a-route-reflector)",
        "peerSelector": "has(i-am-a-route-reflector)"
     }}' | {{ bin_dir }}/calicoctl.sh apply -f -
+  register: output
   retries: 4
+  until: output.rc == 0
   delay: "{{ retry_stagger | random + 3 }}"
   with_items:
     - "{{ groups['calico-rr'] | default([]) }}"
@@ -243,7 +248,9 @@
        "nodeSelector": "has(i-am-a-route-reflector)",
        "peerSelector": "has(i-am-a-route-reflector)"
     }}' | {{ bin_dir }}/calicoctl.sh apply -f -
+  register: output
   retries: 4
+  until: output.rc == 0
   delay: "{{ retry_stagger | random + 3 }}"
   with_items:
     - "{{ groups['calico-rr'] | default([]) }}"
@@ -316,7 +323,9 @@
        },
        "orchRefs":[{"nodeName":"{{ inventory_hostname }}","orchestrator":"k8s"}]
     }}' | {{ bin_dir }}/calicoctl.sh apply -f -
+  register: output
   retries: 4
+  until: output.rc == 0
   delay: "{{ retry_stagger | random + 3 }}"
   when:
     - peer_with_router|default(false)
@@ -337,7 +346,9 @@
        "node": "{{ inventory_hostname }}",
        "peerIP": "{{ item.router_id }}"
     }}' | {{ bin_dir }}/calicoctl.sh apply -f -
+  register: output
   retries: 4
+  until: output.rc == 0
   delay: "{{ retry_stagger | random + 3 }}"
   with_items:
     - "{{ peers|selectattr('scope','undefined')|list|default([]) | union(peers|selectattr('scope','defined')|selectattr('scope','equalto', 'node')|list|default([])) }}"

--- a/roles/network_plugin/canal/tasks/main.yml
+++ b/roles/network_plugin/canal/tasks/main.yml
@@ -31,7 +31,9 @@
     {{ bin_dir }}/etcdctl --peers={{ etcd_access_addresses }} \
     set /{{ cluster_name }}/network/config \
     '{ "Network": "{{ kube_pods_subnet }}", "SubnetLen": {{ kube_network_node_prefix }}, "Backend": { "Type": "{{ flannel_backend_type }}" } }'
+  register: output
   retries: 4
+  until: output.rc == 0
   delay: "{{ retry_stagger | random + 3 }}"
   delegate_to: "{{ groups['etcd'][0] }}"
   changed_when: false

--- a/tests/cloud_playbooks/delete-gce.yml
+++ b/tests/cloud_playbooks/delete-gce.yml
@@ -31,7 +31,6 @@
         state: 'stopped'
       async: 120
       poll: 3
-      retries: 3
       register: gce
 
     - name: delete gce instances
@@ -46,5 +45,4 @@
         state: 'absent'
       async: 120
       poll: 3
-      retries: 3
       register: gce


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
>You must set the until parameter if you want a task to retry. If until is not defined, the value for the retries parameter is forced to 1.

I remove the retry on `gce:` part because I wasn't able to think of an `until` value, but feel free to comment (anyhow as there is no until as of now, it's the same as if there was no retry instruction)

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
