### PR TITLE
Update path of all.yml on Azure README

### DIFF
--- a/docs/azure.md
+++ b/docs/azure.md
@@ -1,6 +1,6 @@
 # Azure
 
-To deploy Kubernetes on [Azure](https://azure.microsoft.com) uncomment the `cloud_provider` option in `group_vars/all.yml` and set it to `'azure'`.
+To deploy Kubernetes on [Azure](https://azure.microsoft.com) uncomment the `cloud_provider` option in `group_vars/all/all.yml` and set it to `'azure'`.
 
 All your instances are required to run in a resource group and a routing table has to be attached to the subnet your instances are in.
 
@@ -8,7 +8,7 @@ Not all features are supported yet though, for a list of the current status have
 
 ## Parameters
 
-Before creating the instances you must first set the `azure_` variables in the `group_vars/all.yml` file.
+Before creating the instances you must first set the `azure_` variables in the `group_vars/all/all.yml` file.
 
 All of the values can be retrieved using the azure cli tool which can be downloaded here: <https://docs.microsoft.com/en-gb/azure/xplat-cli-install>
 After installation you have to run `azure login` to get access to your account.


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup
/kind documentation

**What this PR does / why we need it**:

cloud_provider option exists in ./inventory/sample/group_vars/all/all.yml
In addition, the quick start shows to create configuration by copying
./inventory/sample. So this updates path of all.yml for fitting the above.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
