### PR TITLE
Support Cilium from version 1.5

### DIFF
--- a/roles/network_plugin/cilium/templates/cilium-cr.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-cr.yml.j2
@@ -35,6 +35,9 @@ rules:
   - endpoints
   # to check apiserver connectivity
   - namespaces
+{% if cilium_version | regex_replace('v') is version('1.7', '<') %}
+  - componentstatuses
+{% endif %}
   verbs:
   - get
   - list
@@ -48,10 +51,12 @@ rules:
   - ciliumclusterwidenetworkpolicies/status
   - ciliumendpoints
   - ciliumendpoints/status
+{% if cilium_version | regex_replace('v') is version('1.6', '>=') %}
   - ciliumnodes
   - ciliumnodes/status
   - ciliumidentities
   - ciliumidentities/status
+{% endif %}
   verbs:
   - '*'
 ---
@@ -63,6 +68,9 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
+{% if cilium_version | regex_replace('v') is version('1.7', '<') %}
+  - ingresses
+{% endif %}
   - networkpolicies
   verbs:
   - get
@@ -83,10 +91,24 @@ rules:
   - services
   - nodes
   - endpoints
+{% if cilium_version | regex_replace('v') is version('1.7', '<') %}
+  - componentstatuses
+{% endif %}
   verbs:
   - get
   - list
   - watch
+{% if cilium_version | regex_replace('v') is version('1.7', '<') %}
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+{% endif %}
 - apiGroups:
   - ""
   resources:
@@ -119,13 +141,17 @@ rules:
   resources:
   - ciliumnetworkpolicies
   - ciliumnetworkpolicies/status
+{% if cilium_version | regex_replace('v') is version('1.7', '>=') %}
   - ciliumclusterwidenetworkpolicies
   - ciliumclusterwidenetworkpolicies/status
+{% endif %}
   - ciliumendpoints
   - ciliumendpoints/status
+{% if cilium_version | regex_replace('v') is version('1.6', '>=') %}
   - ciliumnodes
   - ciliumnodes/status
   - ciliumidentities
   - ciliumidentities/status
+{% endif %}
   verbs:
   - '*'


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: There is an issue with NetworkPolicy and Cilium 1.7

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
This PR let the user to install Cilium from version 1.5 with the inventory variable `cilium_version`, adapting the K8S templates to the given version.
This is a workaround for issue #6005.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
