### PR TITLE
Cleanup Vagrant VMs before molecule and vagrant CI

### DIFF
--- a/.gitlab-ci/vagrant.yml
+++ b/.gitlab-ci/vagrant.yml
@@ -12,6 +12,7 @@ molecule_tests:
     - apt-get update && apt-get install -y python3-pip
     - update-alternatives --install /usr/bin/python python /usr/bin/python3 10
     - python -m pip install -r tests/requirements.txt
+    - ./tests/scripts/vagrant_clean.sh
   script:
     - ./tests/scripts/molecule_run.sh
 
@@ -26,6 +27,11 @@ molecule_tests:
   except: ['triggers']
   image: quay.io/kubespray/vagrant:$KUBESPRAY_VERSION
   services: []
+  before_script:
+    - apt-get update && apt-get install -y python3-pip
+    - update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+    - python -m pip install -r tests/requirements.txt
+    - ./tests/scripts/vagrant_clean.sh
   script:
     - vagrant up
   after_script:

--- a/tests/scripts/vagrant_clean.sh
+++ b/tests/scripts/vagrant_clean.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Cleanup vagrant VMs to avoid name conflicts
+
+for i in $(virsh list --name)
+do
+    virsh destroy "$i"
+    virsh undefine "$i"
+done


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind flake

**What this PR does / why we need it**:
When a Vagrant based CI job is cancelled or interrupted the VMs are left hanging, which can cause problems for subsequent jobs (virsh domain name already used).