### PR TITLE
Cinder-CSI default storageclass and volumeBindingMode

### DIFF
--- a/roles/kubernetes-apps/persistent_volumes/cinder-csi/templates/cinder-csi-storage-class.yml.j2
+++ b/roles/kubernetes-apps/persistent_volumes/cinder-csi/templates/cinder-csi-storage-class.yml.j2
@@ -5,7 +5,7 @@ apiVersion: storage.k8s.io/v1
 metadata:
   name: "{{ class.name }}"
   annotations:
-    storageclass.kubernetes.io/is-default-class: "{{ class.is_default | default(false) }}"
+    storageclass.kubernetes.io/is-default-class: "{{ class.is_default | default(false) | ternary("true","false") }}"
 provisioner: cinder.csi.openstack.org
 volumeBindingMode: WaitForFirstConsumer
 parameters:

--- a/roles/kubernetes-apps/persistent_volumes/cinder-csi/templates/cinder-csi-storage-class.yml.j2
+++ b/roles/kubernetes-apps/persistent_volumes/cinder-csi/templates/cinder-csi-storage-class.yml.j2
@@ -7,6 +7,7 @@ metadata:
   annotations:
     storageclass.kubernetes.io/is-default-class: "{{ class.is_default | default(false) }}"
 provisioner: cinder.csi.openstack.org
+volumeBindingMode: WaitForFirstConsumer
 parameters:
 {% for key, value in (class.parameters | default({})).items() %}
   "{{ key }}": "{{ value }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
* This PR fixes default storage class (currently not working when using cinder-csi)
* This pr also sets volumeBindingMode to "WaitForFirstConsumer". This allows volumes to be managed by the volume controller and affinity affects what zone volumes are created in.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
* Fixes default storage class when using cinder-csi
* Cinder-csi volumes has volumeBindingMode  set to "WaitForFirstConsumer"
```
