### PR TITLE
Add option to enable usage reports to calico servers

### DIFF
--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -43,6 +43,9 @@ calico_upgrade_url: "https://github.com/projectcalico/calico-upgrade/releases/do
 # Set the agent log level. Can be debug, warning, info or fatal
 calico_loglevel: info
 
+# Enable or disable usage report to 'usage.projectcalico.org'
+calico_usage_reporting: false
+
 # Should calico ignore kernel's RPF check setting,
 # see https://github.com/projectcalico/felix/blob/ab8799eaea66627e5db7717e62fca61fd9c08646/python/calico/felix/config.py#L198
 calico_node_ignorelooserpf: false
@@ -84,9 +87,7 @@ typha_replicas: 1
 # Set max typha connections
 typha_max_connections_lower_limit: 300
 
-
 # Generate certifcates for typha<->calico-node communication
 typha_secure: false
-
 
 calico_feature_control: {}

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -223,6 +223,9 @@ spec:
             # Set Felix logging to "info"
             - name: FELIX_LOGSEVERITYSCREEN
               value: "{{ calico_loglevel }}"
+            # Enable or disable usage report
+            - name: FELIX_USAGEREPORTINGENABLED
+              value: "{{ calico_usage_reporting }}"
             # Set MTU for tunnel device used if ipip is enabled
 {% if calico_mtu is defined %}
             - name: FELIX_IPINIPMTU


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Disable usage report to calico servers `usage.projectcalico.org`
Allow users to enable it via configuration

**Which issue(s) this PR fixes**:
Fixes #6027

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
Usage report to calico servers is no longer enable by default
```
