### PR TITLE
Update default (erroneous) backend value for calico

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/k8s-net-calico.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-net-calico.yml
@@ -31,8 +31,8 @@
 # Choose data store type for calico: "etcd" or "kdd" (kubernetes datastore)
 # calico_datastore: "etcd"
 
-# Choose Calico iptables backend: "Iptables" or "NFT"
-# calico_iptables_backend: "Iptables"
+# Choose Calico iptables backend: "Legacy", "Auto" or "NFT"
+# calico_iptables_backend: "Legacy"
 
 # Use typha (only with kdd)
 # typha_enabled: false

--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -53,8 +53,8 @@ calico_healthhost: "localhost"
 # Configure time in seconds that calico will wait for the iptables lock
 calico_iptables_lock_timeout_secs: 10
 
-# Choose Calico iptables backend: "Iptables" or "NFT" (FELIX_IPTABLESBACKEND)
-calico_iptables_backend: "Iptables"
+# Choose Calico iptables backend: "Legacy", "Auto" or "NFT" (FELIX_IPTABLESBACKEND)
+calico_iptables_backend: "Legacy"
 
 # If you want to use non default IP_AUTODETECTION_METHOD for calico node set this option to one of:
 # * can-reach=DESTINATION


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Current default backend value for Calico is wrong; it generates a warning message in calico pods and is replaced by "Legacy"
https://docs.projectcalico.org/reference/felix/configuration 
> This parameter controls which variant of iptables binary Felix uses. Set this to Auto for auto detection of the backend. If a specific backend is needed then use NFT for hosts using a netfilter backend or Legacy for others. [Default: Legacy]

**Which issue(s) this PR fixes**:
Fixes #5544

**Special notes for your reviewer**:
Message in pods is the follow
> 2020-04-26 20:54:23.917 [WARNING][50] config_params.go 377: Replacing invalid value with default default="legacy" error=Failed to parse config parameter IptablesBackend; value "Iptables": unknown option source=environment variable

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
