### PR TITLE
Fix crio runc path on Ubuntu

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,9 @@ Kubespray uses `yamllint` and `ansible-lint`. To run them locally use `yamllint 
 
 #### Molecule
 
-[molecule](https://github.com/ansible-community/molecule) is designed to help the development and testing of Ansible roles. In Kubespray you can run it all for all roles with `./tests/scripts/molecule_run.sh` or for a specific role (that you are working with) with `cd roles/my-role && molecule test`
+[molecule](https://github.com/ansible-community/molecule) is designed to help the development and testing of Ansible roles. In Kubespray you can run it all for all roles with `./tests/scripts/molecule_run.sh` or for a specific role (that you are working with) with `molecule test` from the role directory (`cd roles/my-role`).
+
+When developing or debugging a role it can be useful to run `molecule create` and `molecule converge` separately. Then you can use `molecule login` to SSH into the test environment.
 
 #### Vagrant
 

--- a/roles/container-engine/cri-o/molecule/default/molecule.yml
+++ b/roles/container-engine/cri-o/molecule/default/molecule.yml
@@ -8,31 +8,25 @@ lint:
   options:
     config-file: ../../../.yamllint
 platforms:
-  - name: kubespray-crio-ubuntu
+  - name: ubuntu1804
     box: generic/ubuntu1804
     cpus: 2
     memory: 1024
     groups:
       - kube-master
-  - name: kubespray-crio-centos7
+  - name: centos7
     box: centos/7
     cpus: 2
     memory: 1024
     groups:
       - kube-master
-  - name: kubespray-crio-centos8
+  - name: centos8
     box: centos/8
     cpus: 2
     memory: 1024
     groups:
       - kube-master
-  - name: kubespray-crio-debian
-    box: generic/debian10
-    cpus: 2
-    memory: 1024
-    groups:
-      - kube-master
-  - name: kubespray-crio-fedora
+  - name: fedora
     box: fedora/31-cloud-base
     cpus: 2
     memory: 1024

--- a/roles/container-engine/cri-o/vars/ubuntu.yml
+++ b/roles/container-engine/cri-o/vars/ubuntu.yml
@@ -3,4 +3,4 @@
 crio_packages:
   - "cri-o-{{ crio_version }}"
 
-crio_runc_path: /usr/lib/cri-o-runc/sbin/runc
+crio_runc_path: /usr/sbin/runc


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind failing-test

**What this PR does / why we need it**:
Tests failed with:
```
Apr 28 00:20:56 kubespray-crio-ubuntu crio[5383]: time="2020-04-28 00:20:56.476564397-07:00" level=fatal msg="runtime config: runtime validation: invalid runtime_path for runtime 'runc': \"stat /usr/lib/cri-o-runc/sbin/runc: no such file or directory\""

```

Also changing the platform names to be shorter and easier to use and including some doc about `molecule login`