### PR TITLE
[WIP] Add CI for 10x Flatcar Linux servers

### DIFF
--- a/.gitlab-ci/vagrant.yml
+++ b/.gitlab-ci/vagrant.yml
@@ -22,6 +22,7 @@ molecule_tests:
     CI_PLATFORM: "vagrant"
     SSH_USER: "kubespray"
     VAGRANT_DEFAULT_PROVIDER: "libvirt"
+    KUBESPRAY_VAGRANT_CONFIG: tests/files/${CI_JOB_NAME}.rb
   tags: [vagrant]
   only: [/^pr-.*$/]
   except: ['triggers']
@@ -39,5 +40,10 @@ molecule_tests:
 
 vagrant_ubuntu18-flannel:
   stage: deploy-part2
+  extends: .vagrant
+  when: on_success
+
+vagrant_flatcar-weave:
+  stage: unit-tests
   extends: .vagrant
   when: on_success

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ require 'fileutils'
 
 Vagrant.require_version ">= 2.0.0"
 
-CONFIG = File.join(File.dirname(__FILE__), "vagrant/config.rb")
+CONFIG = File.join(File.dirname(__FILE__), ENV['KUBESPRAY_VAGRANT_CONFIG'] || 'vagrant/config.rb')
 
 COREOS_URL_TEMPLATE = "https://storage.googleapis.com/%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json"
 FLATCAR_URL_TEMPLATE = "https://%s.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vagrant.json"
@@ -45,7 +45,7 @@ end
 $num_instances ||= 3
 $instance_name_prefix ||= "k8s"
 $vm_gui ||= false
-$vm_memory ||= 2048
+$vm_memory ||= 512
 $vm_cpus ||= 1
 $shared_folders ||= {}
 $forwarded_ports ||= {}
@@ -203,6 +203,7 @@ Vagrant.configure("2") do |config|
         "kubectl_localhost": "True",
         "local_path_provisioner_enabled": "#{$local_path_provisioner_enabled}",
         "local_path_provisioner_claim_root": "#{$local_path_provisioner_claim_root}",
+        "http_proxy": "http://192.168.1.24:8888",
         "ansible_ssh_user": SUPPORTED_OS[$os][:user]
       }
 

--- a/tests/files/vagrant_flatcar-weave.rb
+++ b/tests/files/vagrant_flatcar-weave.rb
@@ -1,0 +1,5 @@
+$num_instances = 10
+$os = "flatcar-stable"
+$network_plugin = "weave"
+$kube_master_instances = 1
+$etcd_instances = 1


### PR DESCRIPTION

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Flatcar Linux is currently not tested in CI. Since Coreros will go EOL soon, we should test Flatcar on its own.
Since I did not find any Flatcar Linux image on OVH, I propose to do it through Vagrant (thanks to #6029).

I also take that opportunity to test a 10 node cluster.