### PR TITLE
Add CI var for http_proxy

### DIFF
--- a/roles/kubespray-defaults/tasks/no_proxy.yml
+++ b/roles/kubespray-defaults/tasks/no_proxy.yml
@@ -26,3 +26,6 @@
 - name: Populates no_proxy to all hosts
   set_fact:
     no_proxy: "{{ hostvars.localhost.no_proxy_prepare }}"
+    proxy_env:
+      no_proxy: "{{ hostvars.localhost.no_proxy_prepare }}"
+      NO_PROXY: "{{ hostvars.localhost.no_proxy_prepare }}"

--- a/tests/files/packet_debian10-containerd.yml
+++ b/tests/files/packet_debian10-containerd.yml
@@ -11,3 +11,7 @@ dns_min_replicas: 1
 
 helm_enabled: true
 helm_version: v3.1.0
+
+# https://gitlab.com/miouge/kubespray-ci/-/blob/a4fd5ed6857807f1c353cb60848aedebaf7d2c94/manifests/http-proxy.yml#L42
+http_proxy: http://172.30.30.30:8888
+https_proxy: http://172.30.30.30:8888


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
`http_proxy` support is not tested CI, and leads to a number of GitHub issues etc... let's add a test to it.

This does not garantee that the `http_proxy` var is used, since all VMs still have direct access to internet, but at least adding the http_proxy option will not actively break things.

**Which issue(s) this PR fixes:**
Fixes #5935
Fixes #5891

**Special notes for your reviewer**:
A `tinyproxy` forward HTTP proxy has been deployed in the CI cluster (see https://gitlab.com/miouge/kubespray-ci/-/blob/a4fd5ed6857807f1c353cb60848aedebaf7d2c94/manifests/http-proxy.yml)

`proxy_env.no_proxy` defaults to empty string, then later on the `no_proxy` facts gets generated, but not the `proxy_env.no_proxy` which means that it always was empty.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
