### PR TITLE
Add CI for 16x ubuntu servers

### DIFF
--- a/.gitlab-ci/vagrant.yml
+++ b/.gitlab-ci/vagrant.yml
@@ -1,7 +1,7 @@
 ---
 
 molecule_tests:
-  tags: [vagrant]
+  tags: [c3.small.x86]
   only: [/^pr-.*$/]
   except: ['triggers']
   image: quay.io/kubespray/vagrant:$KUBESPRAY_VERSION
@@ -22,7 +22,8 @@ molecule_tests:
     CI_PLATFORM: "vagrant"
     SSH_USER: "kubespray"
     VAGRANT_DEFAULT_PROVIDER: "libvirt"
-  tags: [vagrant]
+    KUBESPRAY_VAGRANT_CONFIG: tests/files/${CI_JOB_NAME}.rb
+  tags: [c3.small.x86]
   only: [/^pr-.*$/]
   except: ['triggers']
   image: quay.io/kubespray/vagrant:$KUBESPRAY_VERSION
@@ -41,3 +42,8 @@ vagrant_ubuntu18-flannel:
   stage: deploy-part2
   extends: .vagrant
   when: on_success
+
+vagrant_ubuntu18-weave-medium:
+  stage: deploy-part2
+  extends: .vagrant
+  when: manual

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ require 'fileutils'
 
 Vagrant.require_version ">= 2.0.0"
 
-CONFIG = File.join(File.dirname(__FILE__), "vagrant/config.rb")
+CONFIG = File.join(File.dirname(__FILE__), ENV['KUBESPRAY_VAGRANT_CONFIG'] || 'vagrant/config.rb')
 
 COREOS_URL_TEMPLATE = "https://storage.googleapis.com/%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json"
 FLATCAR_URL_TEMPLATE = "https://%s.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vagrant.json"

--- a/tests/files/vagrant_ubuntu18-weave-medium.rb
+++ b/tests/files/vagrant_ubuntu18-weave-medium.rb
@@ -1,0 +1,6 @@
+$num_instances = 16
+$vm_memory ||= 1600
+$os = "ubuntu1804"
+$network_plugin = "weave"
+$kube_master_instances = 1
+$etcd_instances = 1

--- a/tests/scripts/vagrant_clean.sh
+++ b/tests/scripts/vagrant_clean.sh
@@ -3,6 +3,8 @@ set -euxo pipefail
 
 # Cleanup vagrant VMs to avoid name conflicts
 
+apt-get install -y libvirt-clients
+
 for i in $(virsh list --name)
 do
     virsh destroy "$i"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Some PRs affect scalability of Kubespray, it can be useful to have an *optional* job to deploy a larger cluster (16 servers).

**Special notes for your reviewer**:
I'm also updating the CI job tags to be more explicit (the runner has `c3.small.x86, small, vagrant`, but `c3.small.x86` is the more explicit since it's the [machine name](https://www.packet.com/cloud/servers/c3-small/)

Also fixing lack of virsh.