### PR TITLE
Fix default value for standalone tests

### DIFF
--- a/tests/testcases/040_check-network-adv.yml
+++ b/tests/testcases/040_check-network-adv.yml
@@ -4,8 +4,8 @@
     - name: Test tunl0 routes
       shell: "! /sbin/ip ro | grep '/26 via' | grep -v tunl0"
       when:
-        - (ipip|default(false) or cloud_provider is defined)
-        - kube_network_plugin == 'calico'
+        - (ipip|default(true) or cloud_provider is defined)
+        - kube_network_plugin|default('calico') == 'calico'
 
 - hosts: k8s-cluster
   vars:
@@ -18,7 +18,7 @@
       shell: "ethtool --offload flannel.1 rx off tx off"
       ignore_errors: true
       when:
-        - kube_network_plugin == 'flannel'
+        - kube_network_plugin|default('calico') == 'flannel'
 
     - name: Force binaries directory for Container Linux by CoreOS and Flatcar
       set_fact:


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Default value for tests are needed (ipip was wrong and should default to true, network_plugin might not be set)

**Which issue(s) this PR fixes**:
Error in CI
> fatal: [530113196-k8s-node-nf-1]: FAILED! => {"msg": "The conditional check 'kube_network_plugin == 'flannel'' failed. The error was: error while evaluating conditional (kube_network_plugin == 'flannel'): 'kube_network_plugin' is undefined\n\nThe error appears to be in '/builds/kargo-ci/kubernetes-sigs-kubespray/tests/testcases/040_check-network-adv.yml': line 17, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n  tasks:\n    - name: Flannel | Disable tx and rx offloading on VXLAN interfaces (see https://github.com/coreos/flannel/pull/1282)\n      ^ here\n"}
 ...ignoring

**Special notes for your reviewer**:
roles\network_plugin\calico\defaults\main.yml:10 -> `ipip: true`

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
