### PR TITLE
Fix broken Octavia integration in OpenStack External Cloud Provider

### DIFF
--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
@@ -19,7 +19,7 @@ ca-file="{{ kube_config_dir }}/external-openstack-cacert.pem"
 {% endif %}
 
 [LoadBalancer]
-use-octavia={{ external_openstack_lbaas_use_octavia }}
+use-octavia={{ external_openstack_lbaas_use_octavia | string | lower }}
 create-monitor={{ external_openstack_lbaas_create_monitor }}
 monitor-delay={{ external_openstack_lbaas_monitor_delay }}
 monitor-timeout={{ external_openstack_lbaas_monitor_timeout }}
@@ -44,4 +44,7 @@ manage-security-groups={{ external_openstack_lbaas_manage_security_groups }}
 {% endif %}
 {% if external_openstack_lbaas_internal_lb is defined %}
 internal-lb={{ external_openstack_lbaas_internal_lb }}
+{% endif %}
+{% if external_openstack_lbaas_use_octavia is defined and external_openstack_lbaas_use_octavia %}
+lb-provider=octavia
 {% endif %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Because the Octavia Loadbalancer integration breaks without it
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
