### PR TITLE
Update deprecated command in azure script

### DIFF
--- a/contrib/azurerm/apply-rg_2.sh
+++ b/contrib/azurerm/apply-rg_2.sh
@@ -11,9 +11,9 @@ fi
 
 ansible-playbook generate-templates.yml
 
-az group deployment create --template-file ./.generated/network.json -g $AZURE_RESOURCE_GROUP
-az group deployment create --template-file ./.generated/storage.json -g $AZURE_RESOURCE_GROUP
-az group deployment create --template-file ./.generated/availability-sets.json -g $AZURE_RESOURCE_GROUP
-az group deployment create --template-file ./.generated/bastion.json -g $AZURE_RESOURCE_GROUP
-az group deployment create --template-file ./.generated/masters.json -g $AZURE_RESOURCE_GROUP
-az group deployment create --template-file ./.generated/minions.json -g $AZURE_RESOURCE_GROUP
+az deployment group create --template-file ./.generated/network.json -g $AZURE_RESOURCE_GROUP
+az deployment group create --template-file ./.generated/storage.json -g $AZURE_RESOURCE_GROUP
+az deployment group create --template-file ./.generated/availability-sets.json -g $AZURE_RESOURCE_GROUP
+az deployment group create --template-file ./.generated/bastion.json -g $AZURE_RESOURCE_GROUP
+az deployment group create --template-file ./.generated/masters.json -g $AZURE_RESOURCE_GROUP
+az deployment group create --template-file ./.generated/minions.json -g $AZURE_RESOURCE_GROUP


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

apply-rg_2.sh uses 'az group deployment' command but the command is
deprecated like the following warning message:

```
This command is implicitly deprecated because command group 'group deployment' is deprecated
and will be removed in a future release. Use 'deployment group' instead.
```

This updates these deprecated commands.

FYI: The command has been deprecated since [1] on azure-cli side.
[1]: https://github.com/Azure/azure-cli/commit/991cb7cc7c9e577d8bec3b78e0316dfb5d39fe10#diff-2057bbb8441166e4910b34b09d22b58cR222

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
