### PR TITLE
Make Vagrant CI use unsafe I/O

### DIFF
--- a/tests/files/vagrant_ubuntu18-flannel.rb
+++ b/tests/files/vagrant_ubuntu18-flannel.rb
@@ -1,0 +1,6 @@
+# For CI we are not worries about data persistence across reboot
+$libvirt_volume_cache = "unsafe"
+
+# Checking for box update can trigger API rate limiting
+# https://www.vagrantup.com/docs/vagrant-cloud/request-limits.html
+$box_check_update = false


### PR DESCRIPTION
**What this PR does / why we need it**:
If the server reboots, the CI job will fail anyway, so we are not concerned with writes being persisted on disk.