### PR TITLE
Update kube-ovn to 1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [cilium](https://github.com/cilium/cilium) v1.7.3
   - [contiv](https://github.com/contiv/install) v1.2.1
   - [flanneld](https://github.com/coreos/flannel) v0.12.0
+  - [kube-ovn](https://github.com/alauda/kube-ovn) v1.1.1
   - [kube-router](https://github.com/cloudnativelabs/kube-router) v0.4.0
   - [multus](https://github.com/intel/multus-cni) v3.4.1
   - [weave](https://github.com/weaveworks/weave) v2.6.2

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -83,7 +83,7 @@ weave_version: 2.6.2
 pod_infra_version: 3.1
 contiv_version: 1.2.1
 cilium_version: "v1.7.3"
-kube_ovn_version: "v1.1.0"
+kube_ovn_version: "v1.1.1"
 kube_router_version: "v0.4.0"
 multus_version: "v3.4.1"
 

--- a/roles/network_plugin/kube-ovn/templates/cni-kube-ovn.yml.j2
+++ b/roles/network_plugin/kube-ovn/templates/cni-kube-ovn.yml.j2
@@ -3,7 +3,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: kube-ovn-controller
-  namespace: kube-ovn
+  namespace: kube-system
   annotations:
     kubernetes.io/description: |
       kube-ovn controller
@@ -69,7 +69,7 @@ spec:
               command:
                 - sh
                 - /kube-ovn/kube-ovn-controller-healthcheck.sh
-            initialDelaySeconds: 30
+            initialDelaySeconds: 300
             periodSeconds: 7
             failureThreshold: 5
       nodeSelector:
@@ -80,7 +80,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: kube-ovn-cni
-  namespace: kube-ovn
+  namespace: kube-system
   annotations:
     kubernetes.io/description: |
       This daemon set launches the kube-ovn cni daemon.
@@ -192,7 +192,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: kube-ovn-pinger
-  namespace: kube-ovn
+  namespace: kube-system
   annotations:
     kubernetes.io/description: |
       This daemon set launches the openvswitch daemon.
@@ -294,7 +294,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: kube-ovn-pinger
-  namespace: kube-ovn
+  namespace: kube-system
   labels:
     app: kube-ovn-pinger
 spec:
@@ -308,7 +308,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: kube-ovn-controller
-  namespace: kube-ovn
+  namespace: kube-system
   labels:
     app: kube-ovn-controller
 spec:
@@ -322,7 +322,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: kube-ovn-cni
-  namespace: kube-ovn
+  namespace: kube-system
   labels:
     app: kube-ovn-cni
 spec:

--- a/roles/network_plugin/kube-ovn/templates/cni-ovn.yml.j2
+++ b/roles/network_plugin/kube-ovn/templates/cni-ovn.yml.j2
@@ -1,21 +1,16 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kube-ovn
-
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ovn-config
-  namespace: kube-ovn
+  namespace: kube-system
 
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ovn
-  namespace: kube-ovn
+  namespace: kube-system
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -31,6 +26,8 @@ rules:
       - subnets
       - subnets/status
       - ips
+      - vlans
+      - networks
     verbs:
       - "*"
   - apiGroups:
@@ -51,12 +48,14 @@ rules:
       - ""
       - networking.k8s.io
       - apps
+      - extensions
     resources:
       - networkpolicies
       - services
       - endpoints
       - statefulsets
       - daemonsets
+      - deployments
     verbs:
       - get
       - list
@@ -82,14 +81,14 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ovn
-    namespace: kube-ovn
+    namespace: kube-system
 
 ---
 kind: Service
 apiVersion: v1
 metadata:
   name: ovn-nb
-  namespace: kube-ovn
+  namespace: kube-system
 spec:
   ports:
     - name: ovn-nb
@@ -107,7 +106,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: ovn-sb
-  namespace: kube-ovn
+  namespace: kube-system
 spec:
   ports:
     - name: ovn-sb
@@ -125,7 +124,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: ovn-central
-  namespace: kube-ovn
+  namespace: kube-system
   annotations:
     kubernetes.io/description: |
       OVN components: northd, nb and sb.
@@ -197,6 +196,8 @@ spec:
               readOnly: true
             - mountPath: /etc/openvswitch
               name: host-config-openvswitch
+            - mountPath: /etc/ovn
+              name: host-config-ovn
             - mountPath: /var/log/openvswitch
               name: host-log-ovs
             - mountPath: /var/log/ovn
@@ -231,6 +232,9 @@ spec:
         - name: host-config-openvswitch
           hostPath:
             path: /etc/origin/openvswitch
+        - name: host-config-ovn
+          hostPath:
+            path: /etc/origin/ovn
         - name: host-log-ovs
           hostPath:
             path: /var/log/openvswitch
@@ -243,7 +247,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: ovs-ovn
-  namespace: kube-ovn
+  namespace: kube-system
   annotations:
     kubernetes.io/description: |
       This daemon set launches the openvswitch daemon.
@@ -293,6 +297,8 @@ spec:
               readOnly: true
             - mountPath: /etc/openvswitch
               name: host-config-openvswitch
+            - mountPath: /etc/ovn
+              name: host-config-ovn
             - mountPath: /var/log/openvswitch
               name: host-log-ovs
             - mountPath: /var/log/ovn
@@ -336,6 +342,9 @@ spec:
         - name: host-config-openvswitch
           hostPath:
             path: /etc/origin/openvswitch
+        - name: host-config-ovn
+          hostPath:
+            path: /etc/origin/ovn
         - name: host-log-ovs
           hostPath:
             path: /var/log/openvswitch


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Update kube-ovn to 1.1.1 (mainly bugfix and move to ns kube-system)

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Should we put a variable for kube-ovn ns ? and keep it in kube-ovn to not break install on existing cluster ? 
https://github.com/alauda/kube-ovn/issues/209

**Does this PR introduce a user-facing change?**:
```release-note
Maybe put a note in networking part about the ns situation.
```
