### PR TITLE
Update Kubespray CI image to v2.13.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ stages:
   - deploy-special
 
 variables:
-  KUBESPRAY_VERSION: v2.12.6
+  KUBESPRAY_VERSION: v2.13.0
   FAILFASTCI_NAMESPACE: 'kargo-ci'
   GITLAB_REPOSITORY: 'kargo-ci/kubernetes-sigs-kubespray'
   ANSIBLE_FORCE_COLOR: "true"

--- a/test-infra/vagrant-docker/Dockerfile
+++ b/test-infra/vagrant-docker/Dockerfile
@@ -1,6 +1,6 @@
 # Docker image published at quay.io/kubespray/vagrant
 
-ARG KUBESPRAY_VERSION=v2.12.6
+ARG KUBESPRAY_VERSION
 FROM quay.io/kubespray/kubespray:${KUBESPRAY_VERSION}
 
 ENV VAGRANT_VERSION=2.2.7


### PR DESCRIPTION
v2.13.0 docker image is built and pushed to quay.io, so we can now use it in CI.