### PR TITLE
Update default kubernetes version to 1.18.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Note: Upstart/SysV init based OS types are not supported.
 ## Supported Components
 
 - Core
-  - [kubernetes](https://github.com/kubernetes/kubernetes) v1.17.5
+  - [kubernetes](https://github.com/kubernetes/kubernetes) v1.18.2
   - [etcd](https://github.com/coreos/etcd) v3.3.12
   - [docker](https://www.docker.com/) v18.06 (see note)
   - [containerd](https://containerd.io/) v1.2.13

--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -20,7 +20,7 @@ kube_users_dir: "{{ kube_config_dir }}/users"
 kube_api_anonymous_auth: true
 
 ## Change this to use another Kubernetes version, e.g. a current beta release
-kube_version: v1.17.5
+kube_version: v1.18.2
 
 # kubernetes image repo define
 kube_image_repo: "k8s.gcr.io"

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -49,7 +49,7 @@ download_delegate: "{% if download_localhost %}localhost{% else %}{{ groups['kub
 image_arch: "{{host_architecture | default('amd64')}}"
 
 # Versions
-kube_version: v1.17.5
+kube_version: v1.18.2
 kubeadm_version: "{{ kube_version }}"
 etcd_version: v3.3.12
 

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -15,7 +15,7 @@ is_fedora_coreos: false
 disable_swap: true
 
 ## Change this to use another Kubernetes version, e.g. a current beta release
-kube_version: v1.17.5
+kube_version: v1.18.2
 
 ## The minimum version working
 kube_version_min_required: v1.16.0


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Update default kubernetes version to 1.18.2

**Which issue(s) this PR fixes**:
Fixes #5859

**Special notes for your reviewer**:
Let's see what CI is thinking and not wait as long as we did with 2.13 :) 

**Does this PR introduce a user-facing change?**:
```release-note
Update default kubernetes version to 1.18.2
```
