### PR TITLE
Fix kubernetes-dashboard template identation

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/dashboard.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dashboard.yml.j2
@@ -178,7 +178,7 @@ spec:
             - --auto-generate-certificates
 {% endif %}
 {% if dashboard_skip_login %}
-          - --enable-skip-login
+            - --enable-skip-login
 {% endif %}
             - --authentication-mode=token{% if kube_basic_auth|default(false) %},basic{% endif %}
             # Uncomment the following line to manually specify Kubernetes API server Host


### PR DESCRIPTION
The 98e7a07fbae671c3651e3c687398356362ebb5cd commit udpates the
dashboard version to 2.0.0 but it enable skip login flag wasn't
updated. This change updates its identation to avoid issues when
dashboard_skip_login is enabled.

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This fixes the format of the dashboard template 
 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6065

**Special notes for your reviewer**:
Enable `dashboard_skip_login` configuration value

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
