### PR TITLE
Replace "replicas" option (CI tests) removed in latest k8s versions

### DIFF
--- a/tests/testcases/030_check-network.yml
+++ b/tests/testcases/030_check-network.yml
@@ -18,8 +18,11 @@
   - name: Create test namespace
     shell: "{{ bin_dir }}/kubectl create namespace test"
 
-  - name: Run a replica controller composed of 2 pods in test ns
-    shell: "{{ bin_dir }}/kubectl run test --image={{ test_image_repo }}:{{ test_image_tag }} --namespace test --replicas=2 --command -- tail -f /dev/null"
+  - name: Run 2 busybox pods in test ns
+    shell: "{{ bin_dir }}/kubectl run {{ item }} --image={{ test_image_repo }}:{{ test_image_tag }} --namespace test --command -- tail -f /dev/null"
+    loop:
+    - busybox1
+    - busybox2
 
   - import_role:
       name: cluster-dump


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
"--replicas" option in `kubectl run` no longer has effects (removed in latest kubectl version)
Because of that; test play is not fully run as it expect 2 pods in `when` statement.. so some tests are skip..

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Ouput in CI jobs is as follow
> Flag --replicas has been deprecated, has no effect and will be removed in the future.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
