### PR TITLE
Bump pypy to 7.3.1, verify hash

### DIFF
--- a/roles/bootstrap-os/files/bootstrap.sh
+++ b/roles/bootstrap-os/files/bootstrap.sh
@@ -2,6 +2,9 @@
 set -e
 
 BINDIR="/opt/bin"
+PYPY_VERSION=7.3.1
+PYPI_URL="https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v${PYPY_VERSION}-linux64.tar.bz2"
+PYPI_HASH=f67cf1664a336a3e939b58b3cabfe47d893356bdc01f2e17bc912aaa6605db12
 
 mkdir -p $BINDIR
 
@@ -11,10 +14,11 @@ if [[ -e $BINDIR/.bootstrapped ]]; then
   exit 0
 fi
 
-PYPY_VERSION=7.2.0
-
-wget -O - https://github.com/squeaky-pl/portable-pypy/releases/download/pypy3.6-7.2.0/pypy3.6-$PYPY_VERSION-linux_x86_64-portable.tar.bz2 | tar -xjf -
-mv -n pypy3.6-$PYPY_VERSION-linux_x86_64-portable pypy3
+TAR_FILE=pyp.tar.bz2
+wget -O "${TAR_FILE}" "${PYPI_URL}"
+echo "${PYPI_HASH} ${TAR_FILE}" | sha256sum -c -
+tar -xjf "${TAR_FILE}" && rm "${TAR_FILE}"
+mv -n "pypy3.6-v${PYPY_VERSION}-linux64" pypy3
 
 ln -s ./pypy3/bin/pypy3 python
 $BINDIR/python --version


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR does two things related to pypy bootstrap:

* Switches to the official PyPy release, which as of pypy `7.3.0`, can be pulled
  directly instead of the previously used `portable-pypy` distribution.
* Adds checksum validation - these are posted on the PyPy download pages and help
  with the integrity/security of the download process.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
No relevant issue currently exists for this

**Special notes for your reviewer**:

Tested against `Fedora CoreOS 31`

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update bootstrap PyPy version install to 7.3.1
```