### PR TITLE
Make vagrant CI normal

### DIFF
--- a/.gitlab-ci/vagrant.yml
+++ b/.gitlab-ci/vagrant.yml
@@ -20,7 +20,7 @@ molecule_tests:
   extends: .testcases
   variables:
     CI_PLATFORM: "vagrant"
-    SSH_USER: "kubespray"
+    SSH_USER: "vagrant"
     VAGRANT_DEFAULT_PROVIDER: "libvirt"
     KUBESPRAY_VAGRANT_CONFIG: tests/files/${CI_JOB_NAME}.rb
   tags: [c3.small.x86]
@@ -34,9 +34,9 @@ molecule_tests:
     - python -m pip install -r tests/requirements.txt
     - ./tests/scripts/vagrant_clean.sh
   script:
-    - vagrant up
+    - ./tests/scripts/testcases_run.sh
   after_script:
-    - vagrant destroy --force
+    - chronic ./tests/scripts/testcases_cleanup.sh
 
 vagrant_ubuntu18-flannel:
   stage: deploy-part2

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,7 +69,7 @@ $disk_size ||= "20GB"
 $local_path_provisioner_enabled ||= false
 $local_path_provisioner_claim_root ||= "/opt/local-path-provisioner/"
 
-$playbook = "cluster.yml"
+$playbook ||= "cluster.yml"
 
 host_vars = {}
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -16,7 +16,7 @@ fedora31 |  :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: |
 opensuse |  :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 oracle7 |  :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 ubuntu16 |  :x: | :white_check_mark: | :x: | :white_check_mark: | :white_check_mark: | :x: | :white_check_mark: | :x: | :white_check_mark: |
-ubuntu18 |  :white_check_mark: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
+ubuntu18 |  :white_check_mark: | :x: | :white_check_mark: | :x: | :white_check_mark: | :x: | :x: | :x: | :white_check_mark: |
 ubuntu20 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 
 ## crio

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -72,3 +72,11 @@ delete-packet:
 	-e @"files/${CI_JOB_NAME}.yml" \
 	-e test_id=$(TEST_ID) \
 	-e inventory_path=$(INVENTORY)
+
+create-vagrant:
+	vagrant up
+	find / -name vagrant_ansible_inventory
+	cp  /builds/kargo-ci/kubernetes-sigs-kubespray/inventory/sample/vagrant_ansible_inventory $(INVENTORY)
+
+delete-vagrant:
+	vagrant destroy -f

--- a/tests/files/vagrant_ubuntu18-flannel.rb
+++ b/tests/files/vagrant_ubuntu18-flannel.rb
@@ -4,3 +4,4 @@ $libvirt_volume_cache = "unsafe"
 # Checking for box update can trigger API rate limiting
 # https://www.vagrantup.com/docs/vagrant-cloud/request-limits.html
 $box_check_update = false
+$vm_cpus = 2

--- a/tests/files/vagrant_ubuntu18-flannel.yml
+++ b/tests/files/vagrant_ubuntu18-flannel.yml
@@ -1,0 +1,7 @@
+---
+# Kubespray settings
+
+kube_network_plugin: flannel
+
+deploy_netchecker: true
+dns_min_replicas: 1

--- a/tests/files/vagrant_ubuntu18-weave-medium.rb
+++ b/tests/files/vagrant_ubuntu18-weave-medium.rb
@@ -4,3 +4,4 @@ $os = "ubuntu1804"
 $network_plugin = "weave"
 $kube_master_instances = 1
 $etcd_instances = 1
+$playbook = "tests/cloud_playbooks/wait-for-ssh.yml"

--- a/tests/files/vagrant_ubuntu18-weave-medium.yml
+++ b/tests/files/vagrant_ubuntu18-weave-medium.yml
@@ -1,0 +1,7 @@
+---
+# Kubespray settings
+
+kube_network_plugin: weave
+
+deploy_netchecker: true
+dns_min_replicas: 1

--- a/tests/testcases/040_check-network-adv.yml
+++ b/tests/testcases/040_check-network-adv.yml
@@ -188,7 +188,7 @@
           EOF
       when:
         - inventory_hostname == groups['kube-master'][0]
-        - kube_network_plugin_multus|default(false)
+        - kube_network_plugin_multus|bool|default(false)
 
     - name: Annotate pod with macvlan network
       # We cannot use only shell: below because Ansible will render the text
@@ -212,7 +212,7 @@
           EOF
       when:
         - inventory_hostname == groups['kube-master'][0]
-        - kube_network_plugin_multus|default(false)
+        - kube_network_plugin_multus|bool|default(false)
 
     - name: Check secondary macvlan interface
       shell: "{{ bin_dir }}/kubectl exec samplepod -- ip addr show dev net1"
@@ -222,4 +222,4 @@
       changed_when: false
       when:
         - inventory_hostname == groups['kube-master'][0]
-        - kube_network_plugin_multus|default(false)
+        - kube_network_plugin_multus|bool|default(false)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Until now Vagrant CI was not running the tests in `tests/testcases*.yml` and was using a different mechanism than the `tests/Makefile`. This PR is an attempt to bring Vagrant CI inline with the rest of the CI.