### PR TITLE
Add installation of requirements for Azure

### DIFF
--- a/contrib/azurerm/README.md
+++ b/contrib/azurerm/README.md
@@ -60,6 +60,7 @@ It will create the file ./inventory which can then be used with kubespray, e.g.:
 
 ```shell
 $ cd kubespray-root-dir
+$ sudo pip3 install -r requirements.txt
 $ ansible-playbook -i contrib/azurerm/inventory -u devops --become -e "@inventory/sample/group_vars/all/all.yml" cluster.yml
 ```
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Due to lack of requirements installation on Azure README, the error could happen:

`The ipaddr filter requires python's netaddr be installed on the ansible controller`

It is nice to add the installation for Azure users.

**Special notes for your reviewer**:

I confirmed Azure README way works fine on my Azure account by applying this step.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
