### PR TITLE
Skip molecule tests for Ubuntu 18.04

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -29,10 +29,17 @@ packet_centos7-flannel-containerd-addons-ha:
   variables:
     MITOGEN_ENABLE: "true"
 
-packet_ubuntu18-crio:
+packet_centos7-crio:
   extends: .packet
   stage: deploy-part2
   when: on_success
+  variables:
+    MITOGEN_ENABLE: "true"
+
+packet_ubuntu18-crio:
+  extends: .packet
+  stage: deploy-part2
+  when: manual
   variables:
     MITOGEN_ENABLE: "true"
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -25,7 +25,7 @@ ubuntu20 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 | OS / CNI | calico | canal | cilium | contiv | flannel | kube-ovn | kube-router | macvlan | weave |
 |---| --- | --- | --- | --- | --- | --- | --- | --- | --- |
 amazon |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
-centos7 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
+centos7 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 centos8 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 coreos |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian10 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -7,7 +7,7 @@
 
 2. Add **forked repo** as submodule to desired folder in your existent ansible repo(for example 3d/kubespray):
   ```git submodule add https://github.com/YOUR_GITHUB/kubespray.git kubespray```
-  Git will create _.gitmodules_ file in your existent ansible repo:
+  Git will create `.gitmodules` file in your existent ansible repo:
 
    ```ini
    [submodule "3d/kubespray"]

--- a/roles/container-engine/cri-o/molecule/default/molecule.yml
+++ b/roles/container-engine/cri-o/molecule/default/molecule.yml
@@ -8,12 +8,12 @@ lint:
   options:
     config-file: ../../../.yamllint
 platforms:
-  - name: ubuntu1804
-    box: generic/ubuntu1804
-    cpus: 2
-    memory: 1024
-    groups:
-      - kube-master
+  # - name: ubuntu1804
+  #   box: generic/ubuntu1804
+  #   cpus: 2
+  #   memory: 1024
+  #   groups:
+  #     - kube-master
   - name: centos7
     box: centos/7
     cpus: 2

--- a/tests/files/packet_centos7-crio.yml
+++ b/tests/files/packet_centos7-crio.yml
@@ -1,0 +1,14 @@
+---
+# Instance settings
+cloud_image: centos-7
+mode: default
+
+# Kubespray settings
+deploy_netchecker: true
+dns_min_replicas: 1
+container_manager: crio
+
+# CRI-O requirements
+download_container: false
+etcd_deployment_type: host
+kubelet_deployment_type: host


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Latest CRI-O package is broken on Ubuntu 18.04. Let's skip it in CI for now.

The package went from 1.9GB to 144MB, so probably something missing?

https://build.opensuse.org/package/revisions/devel:kubic:libcontainers:stable/cri-o-1.17