### PR TITLE
Add additional network configuration options to external Openstack CCM (#6083)

### DIFF
--- a/docs/openstack.md
+++ b/docs/openstack.md
@@ -95,6 +95,16 @@ The new cloud provider is configured to have Octavia by default in Kubespray.
   - ExpandCSIVolumes=true
   ```
 
+- If you are in a case of a multi-nic OpenStack VMs (see [kubernetes/cloud-provider-openstack#407](https://github.com/kubernetes/cloud-provider-openstack/issues/407) and [#6083](https://github.com/kubernetes-sigs/kubespray/issues/6083) for explanation), you should override the default OpenStack networking configuration:
+
+  ```yaml
+  external_openstack_network_ipv6_disabled: false
+  external_openstack_network_internal_networks:
+  - ""
+  external_openstack_network_public_networks:
+  - ""
+  ```
+
 - Run the `upgrade-cluster.yml` playbook
 - Run the cleanup playbook located under extra_playbooks `extra_playbooks/migrate_openstack_provider.yml` (this will clean up all resources used by the old cloud provider)
 - You can remove the feature gates for Volume migration. If you want to enable the possibility to expand CSI volumes you could leave the `ExpandCSIVolumes=true` feature gate

--- a/inventory/sample/group_vars/all/openstack.yml
+++ b/inventory/sample/group_vars/all/openstack.yml
@@ -28,6 +28,11 @@
 # external_openstack_lbaas_monitor_max_retries: "3"
 # external_openstack_lbaas_manage_security_groups: false
 # external_openstack_lbaas_internal_lb: false
+# external_openstack_network_ipv6_disabled: false
+# external_openstack_network_internal_networks:
+#   - ""
+# external_openstack_network_public_networks:
+#   - ""
 
 ## The tag of the external OpenStack Cloud Controller image
 # external_openstack_cloud_controller_image_tag: "latest"

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/defaults/main.yml
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/defaults/main.yml
@@ -12,4 +12,4 @@ external_openstack_domain_name: "{{ lookup('env','OS_USER_DOMAIN_NAME') }}"
 external_openstack_domain_id: "{{ lookup('env','OS_USER_DOMAIN_ID') }}"
 external_openstack_cacert: "{{ lookup('env','OS_CACERT') }}"
 
-external_openstack_cloud_controller_image_tag: "v1.18.0"
+external_openstack_cloud_controller_image_tag: "v1.18.1"

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
@@ -49,7 +49,7 @@ internal-lb={{ external_openstack_lbaas_internal_lb }}
 lb-provider=octavia
 {% endif %}
 
-[Network]
+[Networking]
 ipv6-support-disabled={{ external_openstack_network_ipv6_disabled | string | lower }}
 {% for network_name in external_openstack_network_internal_networks %}
 internal-network-name="{{ network_name }}"

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
@@ -48,3 +48,12 @@ internal-lb={{ external_openstack_lbaas_internal_lb }}
 {% if external_openstack_lbaas_use_octavia is defined and external_openstack_lbaas_use_octavia %}
 lb-provider=octavia
 {% endif %}
+
+[Network]
+ipv6-support-disabled={{ external_openstack_network_ipv6_disabled | string | lower }}
+{% for network_name in external_openstack_network_internal_networks %}
+internal-network-name="{{ network_name }}"
+{% endfor %}
+{% for network_name in external_openstack_network_public_networks %}
+public-network-name="{{ network_name }}"
+{% endfor %}

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -351,6 +351,11 @@ external_openstack_lbaas_create_monitor: false
 external_openstack_lbaas_monitor_delay: "1m"
 external_openstack_lbaas_monitor_timeout: "30s"
 external_openstack_lbaas_monitor_max_retries: "3"
+external_openstack_network_ipv6_disabled: false
+external_openstack_network_internal_networks:
+  - ""
+external_openstack_network_public_networks:
+  - ""
 
 ## List of authorization modes that must be configured for
 ## the k8s cluster. Only 'AlwaysAllow', 'AlwaysDeny', 'Node' and


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Additional configuration options for external OpenStack CCM:

* Added Network configuration in cloud.conf which can be overriden:
    * Added parameter to disable IPv6 support
    * Added parameter to define public networks names
    * Added parameter to define internal networks names

**Which issue(s) this PR fixes**:

Fixes #6083

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

NONE