### PR TITLE
Add option to expose metrics on separate port

### DIFF
--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -36,6 +36,9 @@ etcd_election_timeout: "5000"
 
 etcd_metrics: "basic"
 
+# Uncomment to set a separate port for etcd to expose metrics on
+# etcd_metrics_port: 2381
+
 ## A dictionary of extra environment variables to add to etcd.env, formatted like:
 ##  etcd_extra_vars:
 ##    ETCD_VAR1: "value1"

--- a/roles/etcd/templates/etcd.env.j2
+++ b/roles/etcd/templates/etcd.env.j2
@@ -5,6 +5,9 @@ ETCD_INITIAL_ADVERTISE_PEER_URLS={{ etcd_peer_url }}
 ETCD_INITIAL_CLUSTER_STATE={% if etcd_cluster_is_healthy.rc != 0 | bool %}new{% else %}existing{% endif %}
 
 ETCD_METRICS={{ etcd_metrics }}
+{% if etcd_metrics_port is defined %}
+ETCD_LISTEN_METRICS_URLS=http://{{ etcd_address }}:{{ etcd_metrics_port }},http://127.0.0.1:{{ etcd_metrics_port }}
+{% endif %}
 ETCD_LISTEN_CLIENT_URLS=https://{{ etcd_address }}:2379,https://127.0.0.1:2379
 ETCD_ELECTION_TIMEOUT={{ etcd_election_timeout }}
 ETCD_HEARTBEAT_INTERVAL={{ etcd_heartbeat_interval }}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds the ability to configure `--listen-metrics-urls` for etcd. This is eases pulling metrics into prometheus.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added `etcd_metrics_port` to setup a separate port for metrics to listen on
```
