### PR TITLE
Allow containerd runtime with fedora os (30/31) - add CI test

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -162,6 +162,11 @@ packet_amazon-linux-2-aio:
   extends: .packet
   when: manual
 
+packet_fedora30-cilium-containerd:
+  stage: deploy-part2
+  extends: .packet
+  when: on_success
+
 # ### PR JOBS PART3
 # Long jobs (45min+)
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -48,7 +48,7 @@ centos8 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 coreos |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian10 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian9 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
-fedora30 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
+fedora30 |  :x: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
 fedora31 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 opensuse |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 oracle7 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |

--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -49,6 +49,12 @@ containerd_debian_repo_gpgkey: 'https://download.docker.com/linux/debian/gpg'
 containerd_debian_repo_repokey: '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
 containerd_debian_repo_component: 'stable'
 
+# Fedora docker-ce repo
+containerd_fedora_repo_base_url: 'https://download.docker.com/linux/fedora/$releasever/$basearch/stable'
+containerd_fedora_repo_gpgkey: 'https://download.docker.com/linux/fedora/gpg'
+containerd_fedora_repo_repokey: '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
+containerd_fedora_repo_component: 'stable'
+
 containerd_default_runtime:
   type: io.containerd.runtime.v1.linux
   engine: ''

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -13,7 +13,7 @@
   fail:
     msg: "{{ ansible_distribution }} is not supported by containerd."
   when:
-    - not ansible_distribution in ["CentOS","RedHat", "Ubuntu", "Debian"]
+    - not ansible_distribution in ["CentOS","RedHat", "Ubuntu", "Debian", "Fedora"]
 
 - name: gather os specific variables
   include_vars: "{{ item }}"
@@ -33,6 +33,21 @@
       skip: true
   tags:
     - facts
+
+- name: disable unified_cgroup_hierarchy in Fedora 31+
+  shell:
+    cmd: grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0"
+  when:
+    - ansible_distribution == "Fedora"
+    - (ansible_distribution_major_version | int) >= 31
+    - ansible_proc_cmdline['systemd.unified_cgroup_hierarchy'] is not defined or ansible_proc_cmdline['systemd.unified_cgroup_hierarchy'] != '0'
+
+- name: reboot in Fedora 31+
+  reboot:
+  when:
+    - ansible_distribution == "Fedora"
+    - (ansible_distribution_major_version | int) >= 31
+    - ansible_proc_cmdline['systemd.unified_cgroup_hierarchy'] is not defined or ansible_proc_cmdline['systemd.unified_cgroup_hierarchy'] != '0'
 
 - include_tasks: containerd_repo.yml
   when: not is_ostree

--- a/roles/container-engine/containerd/templates/fedora_containerd.repo.j2
+++ b/roles/container-engine/containerd/templates/fedora_containerd.repo.j2
@@ -1,0 +1,7 @@
+[docker-ce]
+name=Docker-CE Repository
+baseurl={{ containerd_fedora_repo_base_url }}
+enabled=1
+gpgcheck={{ '1' if containerd_fedora_repo_gpgkey else '0' }}
+gpgkey={{ containerd_fedora_repo_gpgkey }}
+{% if http_proxy is defined %}proxy={{ http_proxy }}{% endif %}

--- a/roles/container-engine/containerd/vars/fedora.yml
+++ b/roles/container-engine/containerd/vars/fedora.yml
@@ -1,0 +1,16 @@
+---
+
+containerd_versioned_pkg:
+  'latest': "{{ containerd_package }}"
+  '1.2.10': "{{ containerd_package }}-1.2.10-3.2.fc{{ ansible_distribution_major_version }}"
+  '1.2.12': "{{ containerd_package }}-1.2.12-3.2.fc{{ ansible_distribution_major_version }}"
+  '1.2.13': "{{ containerd_package }}-1.2.13-3.1.fc{{ ansible_distribution_major_version }}"
+  'stable': "{{ containerd_package }}-1.2.13-3.1.fc{{ ansible_distribution_major_version }}"
+  'edge': "{{ containerd_package }}-1.2.13-3.1.fc{{ ansible_distribution_major_version }}"
+
+containerd_package_info:
+  pkg_mgr: dnf
+  pkgs:
+    - name: "{{ containerd_versioned_pkg[containerd_version | string] }}"
+
+runc_binary: /usr/bin/runc

--- a/tests/files/packet_fedora30-cilium-containerd.yml
+++ b/tests/files/packet_fedora30-cilium-containerd.yml
@@ -1,0 +1,11 @@
+---
+# Instance settings
+cloud_image: fedora-30
+mode: default
+
+# Kubespray settings
+container_manager: containerd
+etcd_deployment_type: host
+deploy_netchecker: true
+dns_min_replicas: 1
+kube_network_plugin: cilium


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Fedora should support containerd.. fix plays for that

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Add CI test to validate.

**Does this PR introduce a user-facing change?**:
```release-note
Add support for containerd in Fedora
```
