### PR TITLE
Fix state value for glusterfs role (Debian)

### DIFF
--- a/contrib/network-storage/glusterfs/roles/glusterfs/client/tasks/setup-Debian.yml
+++ b/contrib/network-storage/glusterfs/roles/glusterfs/client/tasks/setup-Debian.yml
@@ -18,7 +18,7 @@
 - name: Ensure GlusterFS client is installed.
   apt:
     name: "{{ item }}"
-    state: installed
+    state: present
     default_release: "{{ glusterfs_default_release }}"
   with_items:
     - glusterfs-client

--- a/contrib/network-storage/glusterfs/roles/glusterfs/server/tasks/setup-Debian.yml
+++ b/contrib/network-storage/glusterfs/roles/glusterfs/server/tasks/setup-Debian.yml
@@ -19,7 +19,7 @@
 - name: Ensure GlusterFS is installed.
   apt:
     name: "{{ item }}"
-    state: installed
+    state: present
     default_release: "{{ glusterfs_default_release }}"
   with_items:
     - glusterfs-server


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Changed state value to present instead of installed in glusterfs role for Debian 

**Which issue(s) this PR fixes**:

Fixes #6093

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:

```NONE

```
