### PR TITLE
Disable OVH CI

### DIFF
--- a/.gitlab-ci/terraform.yml
+++ b/.gitlab-ci/terraform.yml
@@ -98,80 +98,80 @@ tf-validate-aws:
 #     TF_VAR_public_key_path: ""
 #     TF_VAR_operating_system: ubuntu_18_04
 
-.ovh_variables: &ovh_variables
-  OS_AUTH_URL: https://auth.cloud.ovh.net/v3
-  OS_PROJECT_ID: 8d3cd5d737d74227ace462dee0b903fe
-  OS_PROJECT_NAME: "9361447987648822"
-  OS_USER_DOMAIN_NAME: Default
-  OS_PROJECT_DOMAIN_ID: default
-  OS_USERNAME: 8XuhBMfkKVrk
-  OS_REGION_NAME: UK1
-  OS_INTERFACE: public
-  OS_IDENTITY_API_VERSION: "3"
+# .ovh_variables: &ovh_variables
+#   OS_AUTH_URL: https://auth.cloud.ovh.net/v3
+#   OS_PROJECT_ID: 8d3cd5d737d74227ace462dee0b903fe
+#   OS_PROJECT_NAME: "9361447987648822"
+#   OS_USER_DOMAIN_NAME: Default
+#   OS_PROJECT_DOMAIN_ID: default
+#   OS_USERNAME: 8XuhBMfkKVrk
+#   OS_REGION_NAME: UK1
+#   OS_INTERFACE: public
+#   OS_IDENTITY_API_VERSION: "3"
 
-tf-ovh_cleanup:
-  stage: unit-tests
-  tags: [light]
-  image: python
-  variables:
-    <<: *ovh_variables
-  before_script:
-    - pip install -r scripts/openstack-cleanup/requirements.txt
-  script:
-    - ./scripts/openstack-cleanup/main.py
+# tf-ovh_cleanup:
+#   stage: unit-tests
+#   tags: [light]
+#   image: python
+#   variables:
+#     <<: *ovh_variables
+#   before_script:
+#     - pip install -r scripts/openstack-cleanup/requirements.txt
+#   script:
+#     - ./scripts/openstack-cleanup/main.py
 
-tf-ovh_ubuntu18-calico:
-  extends: .terraform_apply
-  when: on_success
-  variables:
-    <<: *ovh_variables
-    TF_VERSION: 0.12.24
-    PROVIDER: openstack
-    CLUSTER: $CI_COMMIT_REF_NAME
-    ANSIBLE_TIMEOUT: "60"
-    SSH_USER: ubuntu
-    TF_VAR_number_of_k8s_masters: "0"
-    TF_VAR_number_of_k8s_masters_no_floating_ip: "1"
-    TF_VAR_number_of_k8s_masters_no_floating_ip_no_etcd: "0"
-    TF_VAR_number_of_etcd: "0"
-    TF_VAR_number_of_k8s_nodes: "0"
-    TF_VAR_number_of_k8s_nodes_no_floating_ip: "1"
-    TF_VAR_number_of_gfs_nodes_no_floating_ip: "0"
-    TF_VAR_number_of_bastions: "0"
-    TF_VAR_number_of_k8s_masters_no_etcd: "0"
-    TF_VAR_use_neutron: "0"
-    TF_VAR_floatingip_pool: "Ext-Net"
-    TF_VAR_external_net: "6011fbc9-4cbf-46a4-8452-6890a340b60b"
-    TF_VAR_network_name: "Ext-Net"
-    TF_VAR_flavor_k8s_master: "defa64c3-bd46-43b4-858a-d93bbae0a229"    # s1-8
-    TF_VAR_flavor_k8s_node: "defa64c3-bd46-43b4-858a-d93bbae0a229"      # s1-8
-    TF_VAR_image: "Ubuntu 18.04"
-    TF_VAR_k8s_allowed_remote_ips: '["0.0.0.0/0"]'
+# tf-ovh_ubuntu18-calico:
+#   extends: .terraform_apply
+#   when: on_success
+#   variables:
+#     <<: *ovh_variables
+#     TF_VERSION: 0.12.24
+#     PROVIDER: openstack
+#     CLUSTER: $CI_COMMIT_REF_NAME
+#     ANSIBLE_TIMEOUT: "60"
+#     SSH_USER: ubuntu
+#     TF_VAR_number_of_k8s_masters: "0"
+#     TF_VAR_number_of_k8s_masters_no_floating_ip: "1"
+#     TF_VAR_number_of_k8s_masters_no_floating_ip_no_etcd: "0"
+#     TF_VAR_number_of_etcd: "0"
+#     TF_VAR_number_of_k8s_nodes: "0"
+#     TF_VAR_number_of_k8s_nodes_no_floating_ip: "1"
+#     TF_VAR_number_of_gfs_nodes_no_floating_ip: "0"
+#     TF_VAR_number_of_bastions: "0"
+#     TF_VAR_number_of_k8s_masters_no_etcd: "0"
+#     TF_VAR_use_neutron: "0"
+#     TF_VAR_floatingip_pool: "Ext-Net"
+#     TF_VAR_external_net: "6011fbc9-4cbf-46a4-8452-6890a340b60b"
+#     TF_VAR_network_name: "Ext-Net"
+#     TF_VAR_flavor_k8s_master: "defa64c3-bd46-43b4-858a-d93bbae0a229"    # s1-8
+#     TF_VAR_flavor_k8s_node: "defa64c3-bd46-43b4-858a-d93bbae0a229"      # s1-8
+#     TF_VAR_image: "Ubuntu 18.04"
+#     TF_VAR_k8s_allowed_remote_ips: '["0.0.0.0/0"]'
 
-tf-ovh_coreos-calico:
-  extends: .terraform_apply
-  when: on_success
-  variables:
-    <<: *ovh_variables
-    TF_VERSION: 0.12.24
-    PROVIDER: openstack
-    CLUSTER: $CI_COMMIT_REF_NAME
-    ANSIBLE_TIMEOUT: "60"
-    SSH_USER: core
-    TF_VAR_number_of_k8s_masters: "0"
-    TF_VAR_number_of_k8s_masters_no_floating_ip: "1"
-    TF_VAR_number_of_k8s_masters_no_floating_ip_no_etcd: "0"
-    TF_VAR_number_of_etcd: "0"
-    TF_VAR_number_of_k8s_nodes: "0"
-    TF_VAR_number_of_k8s_nodes_no_floating_ip: "1"
-    TF_VAR_number_of_gfs_nodes_no_floating_ip: "0"
-    TF_VAR_number_of_bastions: "0"
-    TF_VAR_number_of_k8s_masters_no_etcd: "0"
-    TF_VAR_use_neutron: "0"
-    TF_VAR_floatingip_pool: "Ext-Net"
-    TF_VAR_external_net: "6011fbc9-4cbf-46a4-8452-6890a340b60b"
-    TF_VAR_network_name: "Ext-Net"
-    TF_VAR_flavor_k8s_master: "4d4fd037-9493-4f2b-9afe-b542b5248eac"    # b2-7
-    TF_VAR_flavor_k8s_node: "4d4fd037-9493-4f2b-9afe-b542b5248eac"      # b2-7
-    TF_VAR_image: "CoreOS Stable"
-    TF_VAR_k8s_allowed_remote_ips: '["0.0.0.0/0"]'
+# tf-ovh_coreos-calico:
+#   extends: .terraform_apply
+#   when: on_success
+#   variables:
+#     <<: *ovh_variables
+#     TF_VERSION: 0.12.24
+#     PROVIDER: openstack
+#     CLUSTER: $CI_COMMIT_REF_NAME
+#     ANSIBLE_TIMEOUT: "60"
+#     SSH_USER: core
+#     TF_VAR_number_of_k8s_masters: "0"
+#     TF_VAR_number_of_k8s_masters_no_floating_ip: "1"
+#     TF_VAR_number_of_k8s_masters_no_floating_ip_no_etcd: "0"
+#     TF_VAR_number_of_etcd: "0"
+#     TF_VAR_number_of_k8s_nodes: "0"
+#     TF_VAR_number_of_k8s_nodes_no_floating_ip: "1"
+#     TF_VAR_number_of_gfs_nodes_no_floating_ip: "0"
+#     TF_VAR_number_of_bastions: "0"
+#     TF_VAR_number_of_k8s_masters_no_etcd: "0"
+#     TF_VAR_use_neutron: "0"
+#     TF_VAR_floatingip_pool: "Ext-Net"
+#     TF_VAR_external_net: "6011fbc9-4cbf-46a4-8452-6890a340b60b"
+#     TF_VAR_network_name: "Ext-Net"
+#     TF_VAR_flavor_k8s_master: "4d4fd037-9493-4f2b-9afe-b542b5248eac"    # b2-7
+#     TF_VAR_flavor_k8s_node: "4d4fd037-9493-4f2b-9afe-b542b5248eac"      # b2-7
+#     TF_VAR_image: "CoreOS Stable"
+#     TF_VAR_k8s_allowed_remote_ips: '["0.0.0.0/0"]'

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -9,7 +9,6 @@ To generate this Matrix run `./tests/scripts/md-table/main.py`
 amazon |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 centos7 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :white_check_mark: |
 centos8 |  :white_check_mark: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x: | :x: |
-coreos |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian10 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian9 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: |
 fedora30 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: |
@@ -27,7 +26,6 @@ ubuntu20 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 amazon |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 centos7 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 centos8 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
-coreos |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian10 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian9 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 fedora30 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
@@ -45,7 +43,6 @@ ubuntu20 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 amazon |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 centos7 |  :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: |
 centos8 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
-coreos |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian10 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian9 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 fedora30 |  :x: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |

--- a/tests/files/tf-ovh_coreos-calico.yml
+++ b/tests/files/tf-ovh_coreos-calico.yml
@@ -1,5 +1,0 @@
----
-dns_min_replicas: 1
-deploy_netchecker: true
-
-# resolvconf_mode: host_resolvconf  # this is required as long as the coreos stable channel uses docker < 1.12

--- a/tests/files/tf-ovh_ubuntu18-calico.yml
+++ b/tests/files/tf-ovh_ubuntu18-calico.yml
@@ -1,4 +1,0 @@
----
-dns_min_replicas: 1
-deploy_netchecker: true
-sonobuoy_enabled: true


### PR DESCRIPTION
**What this PR does / why we need it**:
OVH Public Cloud voucher expires 10th of May so we should disable OVH CI before that.