### PR TITLE
Fix #6118: Use OS packaging default for apparmor_profile in crio.conf

### DIFF
--- a/roles/container-engine/cri-o/templates/crio.conf.j2
+++ b/roles/container-engine/cri-o/templates/crio.conf.j2
@@ -106,7 +106,7 @@ seccomp_profile = "{{crio_seccomp_profile}}"
 
 # Used to change the name of the default AppArmor profile of CRI-O. The default
 # profile name is "crio-default-" followed by the version string of CRI-O.
-apparmor_profile = "crio-default"
+# apparmor_profile = "crio-default"
 
 # Cgroup management implementation used for the runtime.
 cgroup_manager = "{{crio_cgroup_manager}}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
While vanilla cri-o makes cri-o is using a `cri-default` apparmor profile (see <https://github.com/cri-o/cri-o/blob/master/docs/crio.conf.5.md>), Opensuze Kubic OS packages (the ones used by Kubespray to install cri-o, at least for CentOS, Debian and Ubuntu) install and use a default apparmor profile named 'cri-default-<crio-version>'.

Having the `crio.conf` file statically configured with `apparmor_profile="cri-default"` makes cri-o crashes at start since this profile is not installed.

Best option is to not define `apparmor_profile` in `crio.conf` and lets cri-o defaults to `'cri-default-<crio-version>'`


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6118

**Special notes for your reviewer**:`
No clue on how cri-o default apparmor profile is handled on others distributions

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
