### PR TITLE
Add Elastx CI (TF OpenStack)

### DIFF
--- a/.gitlab-ci/terraform.yml
+++ b/.gitlab-ci/terraform.yml
@@ -18,6 +18,7 @@
     - echo "$PACKET_PRIVATE_KEY" | base64 -d > ~/.ssh/id_rsa
     - chmod 400 ~/.ssh/id_rsa
     - echo "$PACKET_PUBLIC_KEY" | base64 -d > ~/.ssh/id_rsa.pub
+    - mkdir -p group_vars
 
 .terraform_validate:
   extends: .terraform_install
@@ -109,16 +110,63 @@ tf-validate-aws:
 #   OS_INTERFACE: public
 #   OS_IDENTITY_API_VERSION: "3"
 
-# tf-ovh_cleanup:
-#   stage: unit-tests
-#   tags: [light]
-#   image: python
-#   variables:
-#     <<: *ovh_variables
-#   before_script:
-#     - pip install -r scripts/openstack-cleanup/requirements.txt
-#   script:
-#     - ./scripts/openstack-cleanup/main.py
+# Elastx is generously donating resources for Kubespray on Openstack CI
+# Contacts: @gix @bl0m1
+.elastx_variables: &elastx_variables
+  OS_AUTH_URL: https://ops.elastx.cloud:5000
+  OS_PROJECT_ID: 564c6b461c6b44b1bb19cdb9c2d928e4
+  OS_PROJECT_NAME: kubespray_ci
+  OS_USER_DOMAIN_NAME: Default
+  OS_PROJECT_DOMAIN_ID: default
+  OS_USERNAME: kubespray@root314.com
+  OS_REGION_NAME: se-sto
+  OS_INTERFACE: public
+  OS_IDENTITY_API_VERSION: "3"
+  TF_VAR_router_id: "ab95917c-41fb-4881-b507-3a6dfe9403df"
+  # Since ELASTX is in Stockholm, Mitogen helps with latency
+  MITOGEN_ENABLE: "true"
+
+tf-elastx_cleanup:
+  stage: unit-tests
+  tags: [light]
+  image: python
+  variables:
+    <<: *elastx_variables
+  before_script:
+    - pip install -r scripts/openstack-cleanup/requirements.txt
+  script:
+    - ./scripts/openstack-cleanup/main.py
+
+tf-elastx_ubuntu18-calico:
+  extends: .terraform_apply
+  when: on_success
+  variables:
+    <<: *elastx_variables
+    TF_VERSION: 0.12.24
+    PROVIDER: openstack
+    CLUSTER: $CI_COMMIT_REF_NAME
+    ANSIBLE_TIMEOUT: "60"
+    SSH_USER: ubuntu
+    TF_VAR_number_of_k8s_masters: "1"
+    TF_VAR_number_of_k8s_masters_no_floating_ip: "0"
+    TF_VAR_number_of_k8s_masters_no_floating_ip_no_etcd: "0"
+    TF_VAR_number_of_etcd: "0"
+    TF_VAR_number_of_k8s_nodes: "1"
+    TF_VAR_number_of_k8s_nodes_no_floating_ip: "0"
+    TF_VAR_number_of_gfs_nodes_no_floating_ip: "0"
+    TF_VAR_number_of_bastions: "0"
+    TF_VAR_number_of_k8s_masters_no_etcd: "0"
+    TF_VAR_floatingip_pool: "elx-public1"
+    TF_VAR_dns_nameservers: '["1.1.1.1", "8.8.8.8", "8.8.4.4"]'
+    TF_VAR_use_access_ip: "0"
+    TF_VAR_external_net: "600b8501-78cb-4155-9c9f-23dfcba88828"
+    TF_VAR_network_name: "ci-$CI_JOB_ID"
+    TF_VAR_az_list: '["sto1"]'
+    TF_VAR_az_list_node: '["sto1"]'
+    TF_VAR_flavor_k8s_master: 3f73fc93-ec61-4808-88df-2580d94c1a9b    # v1-standard-2
+    TF_VAR_flavor_k8s_node: 3f73fc93-ec61-4808-88df-2580d94c1a9b      # v1-standard-2
+    TF_VAR_image: ubuntu-18.04-server-latest
+    TF_VAR_k8s_allowed_remote_ips: '["0.0.0.0/0"]'
 
 # tf-ovh_ubuntu18-calico:
 #   extends: .terraform_apply

--- a/tests/files/tf-elastx_ubuntu18-calico.yml
+++ b/tests/files/tf-elastx_ubuntu18-calico.yml
@@ -1,0 +1,7 @@
+---
+dns_min_replicas: 1
+deploy_netchecker: true
+sonobuoy_enabled: true
+
+# Ignore ping errors
+ignore_assert_errors: true

--- a/tests/scripts/create-tf.sh
+++ b/tests/scripts/create-tf.sh
@@ -2,4 +2,4 @@
 set -euxo pipefail
 
 cd ..
-terraform apply -auto-approve "contrib/terraform/$PROVIDER"
+terraform apply -auto-approve -parallelism=1 "contrib/terraform/$PROVIDER"

--- a/tests/testcases/040_check-network-adv.yml
+++ b/tests/testcases/040_check-network-adv.yml
@@ -188,7 +188,7 @@
           EOF
       when:
         - inventory_hostname == groups['kube-master'][0]
-        - kube_network_plugin_multus|bool|default(false)
+        - kube_network_plugin_multus|default(false)|bool
 
     - name: Annotate pod with macvlan network
       # We cannot use only shell: below because Ansible will render the text
@@ -212,7 +212,7 @@
           EOF
       when:
         - inventory_hostname == groups['kube-master'][0]
-        - kube_network_plugin_multus|bool|default(false)
+        - kube_network_plugin_multus|default(false)|bool
 
     - name: Check secondary macvlan interface
       shell: "{{ bin_dir }}/kubectl exec samplepod -- ip addr show dev net1"
@@ -222,4 +222,4 @@
       changed_when: false
       when:
         - inventory_hostname == groups['kube-master'][0]
-        - kube_network_plugin_multus|bool|default(false)
+        - kube_network_plugin_multus|default(false)|bool


### PR DESCRIPTION
**What this PR does / why we need it**:
Since the OVH voucher expired 10th of May, [ELASTX](https://elastx.se/en/) (one of the leading Swedish Public Cloud provider) donated CI resources for Kubespray on OpenStack.

This PR adds a simple `ubuntu18-calico` CI job (it used to be on OVH CI), CoreOS image is currently not available on ELASTX, but that's not a problem since CoreOS is going EOL end of May anyway.

Big thanks to [ELASTX](https://elastx.se/en/) @holmsten and @bl0m1 to make this possible! ❤️ 

**Notes:**
Changing the order of filters from `kube_network_plugin_multus|bool|default(false)` to `kube_network_plugin_multus|default(false)|bool`, to address the situation where `kube_network_plugin_multus` is undef as well as if `kube_network_plugin_multus` is a non-boolean