### PR TITLE
Fix erroneous variable name (docker_keepcache)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -197,7 +197,7 @@ Vagrant.configure("2") do |config|
         "download_force_cache": "True",
         # Keeping the cache on the nodes can improve provisioning speed while debugging kubespray
         "download_keep_remote_cache": "False",
-        "docker_keepcache": "1",
+        "docker_rpm_keepcache": "1",
         # These two settings will put kubectl and admin.config in $inventory/artifacts
         "kubeconfig_localhost": "True",
         "kubectl_localhost": "True",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
`docker_keepcache` is wrong and should be `docker_rpm_keepcache`
Can be misleading to spray user

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
