### PR TITLE
Update MetalLB version

### DIFF
--- a/contrib/metallb/roles/provision/defaults/main.yml
+++ b/contrib/metallb/roles/provision/defaults/main.yml
@@ -13,4 +13,4 @@ metallb:
     cpu: "100m"
     memory: "100Mi"
   port: "7472"
-  version: v0.7.3
+  version: v0.9.3


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

If running MetalLB v0.7.3 on k8s v1.18.2, metallb pods output the following parsing error of v1.ServiceList:
```
  $ kubectl logs controller-dbb46cf84-fw8h8 -n metallb-system
  {
    "caller":"reflector.go:205",
    "level":"error",
    "msg":"go.universe.tf/metallb/internal/k8s/k8s.go:231:
      Failed to list *v1.Service: v1.ServiceList:
        Items: []v1.Service: v1.Service: ObjectMeta:
        v1.ObjectMeta: readObjectFieldAsBytes:
        expect : after object field, parsing 1605
```
Then an external IP address is never allocated to the Service of LoadBalancer type.
By updating MetalLB version to the latest v0.9 [1] today, this issue can be solved.

[1]: https://hub.docker.com/r/metallb/controller/tags

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
