### PR TITLE
Allow metallb:speaker to create events

### DIFF
--- a/contrib/metallb/roles/provision/templates/metallb.yml.j2
+++ b/contrib/metallb/roles/provision/templates/metallb.yml.j2
@@ -50,6 +50,9 @@ rules:
 - apiGroups: [""]
   resources: ["services", "endpoints", "nodes"]
   verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
 {% if podsecuritypolicy_enabled %}
 - apiGroups: ["policy"]
   resourceNames: ["metallb"]


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Since MetalLB v0.8[1], metallb:speaker has started publishing an event nodeAssigned on k8s resource.
To support MetalLB v0.8+, this allows metallb:speaker to create events.

[1]: https://github.com/metallb/metallb/commit/5cc6e237766d742fccde1a8a325baba2608024df#diff-60053ad6fecb5a3cfabb6f3d9e720899R246

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6146 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
