### PR TITLE
Enable /etc/hosts creation without ansible_default_ipv4

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0090-etchosts.yml
+++ b/roles/kubernetes/preinstall/tasks/0090-etchosts.yml
@@ -4,7 +4,11 @@
     etc_hosts_inventory_block: |-
       {% for item in (groups['k8s-cluster'] + groups['etcd'] + groups['calico-rr']|default([]))|unique -%}
       {% if 'access_ip' in hostvars[item] or 'ip' in hostvars[item] or 'ansible_default_ipv4' in hostvars[item] -%}
-      {{ hostvars[item]['access_ip'] | default(hostvars[item]['ip'] | default(hostvars[item]['ansible_default_ipv4']['address'])) }}
+      {% if 'access_ip' in hostvars[item] or 'ip' in hostvars[item] -%}
+      {{ hostvars[item]['access_ip'] | default(hostvars[item]['ip']) }}
+      {%- elif ansible_default_ipv4 in hostvars[item] -%}
+      {{ hostvars[item]['ansible_default_ipv4']['address'] }}
+      {% endif %}
       {%- if ('ansible_hostname' in hostvars[item] and item != hostvars[item]['ansible_hostname']) %} {{ hostvars[item]['ansible_hostname'] }}.{{ dns_domain }} {{ hostvars[item]['ansible_hostname'] }}{% endif %} {{ item }}.{{ dns_domain }} {{ item }}
       {% endif %}
       {% endfor %}


### PR DESCRIPTION
Jinja2 renders all ansible_default_ipv4 hostvars even if it doesn't need it unless it's in a separate logical construct. It should be possible to use access_ip and/or ip var to create /etc/hosts without any host facts.