### PR TITLE
Update docker default to 19.03 - cleanup docker docs & refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Note: Upstart/SysV init based OS types are not supported.
 - Core
   - [kubernetes](https://github.com/kubernetes/kubernetes) v1.18.2
   - [etcd](https://github.com/coreos/etcd) v3.3.12
-  - [docker](https://www.docker.com/) v18.06 (see note)
+  - [docker](https://www.docker.com/) v19.03 (see note)
   - [containerd](https://containerd.io/) v1.2.13
   - [cri-o](http://cri-o.io/) v1.17 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)
 - Network Plugin
@@ -137,7 +137,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [coredns](https://github.com/coredns/coredns) v1.6.7
   - [ingress-nginx](https://github.com/kubernetes/ingress-nginx) v0.30.0
 
-Note: The list of validated [docker versions](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md) was updated to 1.13.1, 17.03, 17.06, 17.09, 18.06, 18.09. kubeadm now properly recognizes Docker 18.09.0 and newer, but still treats 18.06 as the default supported version. The kubelet might break on docker's non-standard version numbering (it no longer uses semantic versioning). To ensure auto-updates don't break your cluster look into e.g. yum versionlock plugin or apt pin).
+Note: The list of validated [docker versions](https://kubernetes.io/docs/setup/production-environment/container-runtimes/#docker) is 1.13.1, 17.03, 17.06, 17.09, 18.06, 18.09 and 19.03. The recommended docker version is 19.03. The kubelet might break on docker's non-standard version numbering (it no longer uses semantic versioning). To ensure auto-updates don't break your cluster look into e.g. yum versionlock plugin or apt pin).
 
 ## Requirements
 

--- a/roles/container-engine/docker/defaults/main.yml
+++ b/roles/container-engine/docker/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-docker_version: '18.09'
+docker_version: '19.03'
 docker_cli_version: "{{ 'latest' if docker_version != 'latest' and docker_version is version('18.09', '<') else docker_version }}"
 docker_selinux_version: '17.03'
 

--- a/roles/container-engine/docker/vars/debian.yml
+++ b/roles/container-engine/docker/vars/debian.yml
@@ -11,10 +11,10 @@ docker_versioned_pkg:
   '17.12': docker-ce=17.12.1~ce-0~debian
   '18.03': docker-ce=18.03.1~ce-0~debian
   '18.06': docker-ce=18.06.2~ce~3-0~debian
-  '18.09': docker-ce=5:18.09.7~3-0~debian-{{ ansible_distribution_release|lower }}
-  '19.03': docker-ce=5:19.03.7~3-0~debian-{{ ansible_distribution_release|lower }}
-  'stable': docker-ce=5:18.09.7~3-0~debian-{{ ansible_distribution_release|lower }}
-  'edge': docker-ce=5:19.03.7~3-0~debian-{{ ansible_distribution_release|lower }}
+  '18.09': docker-ce=5:18.09.9~3-0~debian-{{ ansible_distribution_release|lower }}
+  '19.03': docker-ce=5:19.03.9~3-0~debian-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce=5:19.03.9~3-0~debian-{{ ansible_distribution_release|lower }}
+  'edge': docker-ce=5:19.03.9~3-0~debian-{{ ansible_distribution_release|lower }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli

--- a/roles/container-engine/docker/vars/fedora.yml
+++ b/roles/container-engine/docker/vars/fedora.yml
@@ -9,16 +9,14 @@ docker_versioned_pkg:
   '18.03': docker-ce-18.03.1.ce-3.fc{{ ansible_distribution_major_version }}
   '18.06': docker-ce-18.06.2.ce-3.fc{{ ansible_distribution_major_version }}
   '18.09': docker-ce-18.09.7-3.fc{{ ansible_distribution_major_version }}
-  '19.03': docker-ce-19.03.8-3.fc{{ ansible_distribution_major_version }}
+  '19.03': docker-ce-19.03.9-3.fc{{ ansible_distribution_major_version }}
+  'stable': docker-ce-19.03.9-3.fc{{ ansible_distribution_major_version }}
+  'edge': docker-ce-19.03.9-3.fc{{ ansible_distribution_major_version }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
   '18.09': docker-ce-cli-19.03.8-3.fc{{ ansible_distribution_major_version }}
   '19.03': docker-ce-cli-19.03.9-3.fc{{ ansible_distribution_major_version }}
-
-# Fedora 30/31 don't provide packages for docker 18.0x ...
-docker_version: "19.03"
-docker_cli_version: "19.03"
 
 docker_package_info:
   pkg_mgr: dnf

--- a/roles/container-engine/docker/vars/redhat.yml
+++ b/roles/container-engine/docker/vars/redhat.yml
@@ -12,9 +12,9 @@ docker_versioned_pkg:
   '18.03': docker-ce-18.03.1.ce-1.el7.centos
   '18.06': docker-ce-18.06.3.ce-3.el7
   '18.09': docker-ce-18.09.9-3.el7
-  '19.03': docker-ce-19.03.8-3.el7
-  'stable': docker-ce-18.09.9-3.el7
-  'edge': docker-ce-19.03.8-3.el7
+  '19.03': docker-ce-19.03.9-3.el7
+  'stable': docker-ce-19.03.9-3.el7
+  'edge': docker-ce-19.03.9-3.el7
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli

--- a/roles/container-engine/docker/vars/ubuntu-amd64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-amd64.yml
@@ -11,10 +11,10 @@ docker_versioned_pkg:
   '17.09': docker-ce=17.09.0~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
   '17.12': docker-ce=17.12.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
   '18.06': docker-ce=18.06.2~ce~3-0~ubuntu
-  '18.09': docker-ce=5:18.09.7~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  '19.03': docker-ce=5:19.03.7~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'stable': docker-ce=5:18.09.7~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'edge': docker-ce=5:19.03.7~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '18.09': docker-ce=5:18.09.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '19.03': docker-ce=5:19.03.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce=5:19.03.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'edge': docker-ce=5:19.03.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli

--- a/roles/container-engine/docker/vars/ubuntu-arm64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-arm64.yml
@@ -7,10 +7,10 @@ docker_versioned_pkg:
   '17.09': docker-ce=17.09.1~ce-0~ubuntu
   '17.12': docker-ce=17.12.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
   '18.06': docker-ce=18.06.2~ce~3-0~ubuntu
-  '18.09': docker-ce=5:18.09.7~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  '19.03': docker-ce=5:19.03.7~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'stable': docker-ce=5:18.09.7~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'edge': docker-ce=5:19.03.7~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '18.09': docker-ce=5:18.09.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '19.03': docker-ce=5:19.03.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce=5:19.03.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'edge': docker-ce=5:19.03.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/README.md
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/README.md
@@ -45,9 +45,9 @@ There are cloud provider specific yaml files.
 
 Kubernetes is available in Docker for Mac (from [version 18.06.0-ce](https://docs.docker.com/docker-for-mac/release-notes/#stable-releases-of-2018))
 
-[enable]: https://docs.docker.com/docker-for-mac/#kubernetes
+First you need to [enable kubernetes](https://docs.docker.com/docker-for-mac/#kubernetes).
 
-Create a service
+Then you have to create a service:
 
 ```console
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/cloud-generic.yaml
@@ -60,7 +60,6 @@ For standard usage:
 ```console
 minikube addons enable ingress
 ```
-
 For development:
 
 1. Disable the ingress addon:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Upgrade docker to 19.03
Also fix a some message with wrong intent (outdated)

**Which issue(s) this PR fixes**:
None (and hopefully it won't generate lots of new one)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Update docker version, kubeadm now default and recommend 19.03(.8)
```
