### PR TITLE
Update containerd to 1.2.13-2

### DIFF
--- a/roles/container-engine/containerd/vars/debian.yml
+++ b/roles/container-engine/containerd/vars/debian.yml
@@ -7,9 +7,9 @@ containerd_versioned_pkg:
   '1.2.6': "{{ containerd_package }}=1.2.6-3"
   '1.2.10': "{{ containerd_package }}=1.2.10-3"
   '1.2.12': "{{ containerd_package }}=1.2.12-1"
-  '1.2.13': "{{ containerd_package }}=1.2.13-1"
-  'stable': "{{ containerd_package }}=1.2.13-1"
-  'edge': "{{ containerd_package }}=1.2.13-1"
+  '1.2.13': "{{ containerd_package }}=1.2.13-2"
+  'stable': "{{ containerd_package }}=1.2.13-2"
+  'edge': "{{ containerd_package }}=1.2.13-2"
 
 containerd_package_info:
   pkg_mgr: apt

--- a/roles/container-engine/containerd/vars/ubuntu-amd64.yml
+++ b/roles/container-engine/containerd/vars/ubuntu-amd64.yml
@@ -7,9 +7,9 @@ containerd_versioned_pkg:
   '1.2.6': "{{ containerd_package }}=1.2.6-3"
   '1.2.10': "{{ containerd_package }}=1.2.10-3"
   '1.2.12': "{{ containerd_package }}=1.2.12-1"
-  '1.2.13': "{{ containerd_package }}=1.2.13-1"
-  'stable': "{{ containerd_package }}=1.2.13-1"
-  'edge': "{{ containerd_package }}=1.2.13-1"
+  '1.2.13': "{{ containerd_package }}=1.2.13-2"
+  'stable': "{{ containerd_package }}=1.2.13-2"
+  'edge': "{{ containerd_package }}=1.2.13-2"
 
 containerd_package_info:
   pkg_mgr: apt


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Latest containerd package on Ubuntu/Debian is `1.2.13-2`