### PR TITLE
Scale up coredns to 1 replica before upgrade if using manual mode

### DIFF
--- a/roles/kubernetes/master/tasks/kubeadm-upgrade.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-upgrade.yml
@@ -9,6 +9,24 @@
   delay: 5
   until: _result.status == 200
 
+# FIXME: https://github.com/kubernetes/kubeadm/issues/1318
+- name: kubeadm | scale up coredns replicas to 1 if not using coredns dns_mode
+  command: >-
+    {{ bin_dir }}/kubectl
+    --kubeconfig /etc/kubernetes/admin.conf
+    -n kube-system
+    scale deployment/coredns --replicas 1
+  register: scale_up_coredns
+  retries: 4
+  delay: 1
+  until: scale_up_coredns is succeeded
+  run_once: yes
+  when:
+    - kubeadm_scale_down_coredns_enabled
+    - dns_mode not in ['coredns', 'coredns_dual']
+  changed_when: false
+  failed_when: false
+
 - name: kubeadm | Upgrade first master
   command: >-
     timeout -k 600s 600s


### PR DESCRIPTION
In k8s v1.18, kubeadm upgrade validates that coredns has at least 1 ready replica before finishing the upgrade. On the upside, this is fixed for v1.19 and we don't need to create coredns deployment at all.