### PR TITLE
Replace seccomp profile docker/default with runtime/default

### DIFF
--- a/contrib/metallb/roles/provision/templates/metallb.yml.j2
+++ b/contrib/metallb/roles/provision/templates/metallb.yml.j2
@@ -61,8 +61,8 @@ kind: PodSecurityPolicy
 metadata:
   name: metallb
   annotations:
-    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
 {% if apparmor_enabled %}
     apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'

--- a/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
@@ -22,7 +22,7 @@ spec:
       labels:
         k8s-app: kube-dns{{ coredns_ordinal_suffix }}
       annotations:
-        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+        seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
     spec:
       priorityClassName: system-cluster-critical
       nodeSelector:

--- a/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
@@ -31,7 +31,7 @@ spec:
         k8s-app: dns-autoscaler{{ coredns_ordinal_suffix }}
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
-        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+        seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
     spec:
       priorityClassName: system-cluster-critical
       securityContext:

--- a/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-psp.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-psp.yml.j2
@@ -4,8 +4,8 @@ kind: PodSecurityPolicy
 metadata:
   name: netchecker-agent-hostnet
   annotations:
-    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
 {% if apparmor_enabled %}
     apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'

--- a/roles/kubernetes-apps/cluster_roles/templates/psp.yml.j2
+++ b/roles/kubernetes-apps/cluster_roles/templates/psp.yml.j2
@@ -4,8 +4,8 @@ kind: PodSecurityPolicy
 metadata:
   name: restricted
   annotations:
-    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
 {% if apparmor_enabled %}
     apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'

--- a/roles/kubernetes-apps/external_provisioner/cephfs_provisioner/templates/psp-cephfs-provisioner.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/cephfs_provisioner/templates/psp-cephfs-provisioner.yml.j2
@@ -4,8 +4,8 @@ kind: PodSecurityPolicy
 metadata:
   name: cephfs-provisioner
   annotations:
-    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
 {% if apparmor_enabled %}
     apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'

--- a/roles/kubernetes-apps/external_provisioner/local_path_provisioner/templates/local-path-storage-psp.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_path_provisioner/templates/local-path-storage-psp.yml.j2
@@ -4,8 +4,8 @@ kind: PodSecurityPolicy
 metadata:
   name: local-path-provisioner
   annotations:
-    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
 {% if apparmor_enabled %}
     apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-psp.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-psp.yml.j2
@@ -4,8 +4,8 @@ kind: PodSecurityPolicy
 metadata:
   name: local-volume-provisioner
   annotations:
-    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
 {% if apparmor_enabled %}
     apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'

--- a/roles/kubernetes-apps/external_provisioner/rbd_provisioner/templates/psp-rbd-provisioner.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/rbd_provisioner/templates/psp-rbd-provisioner.yml.j2
@@ -4,8 +4,8 @@ kind: PodSecurityPolicy
 metadata:
   name: rbd-provisioner
   annotations:
-    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
 {% if apparmor_enabled %}
     apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/psp-ingress-nginx.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/psp-ingress-nginx.yml.j2
@@ -4,8 +4,8 @@ kind: PodSecurityPolicy
 metadata:
   name: ingress-nginx
   annotations:
-    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
 {% if apparmor_enabled %}
     apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'

--- a/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: metrics-server
         version: {{ metrics_server_version }}
       annotations:
-        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+        seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: metrics-server

--- a/roles/kubernetes-apps/registry/templates/registry-proxy-psp.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-proxy-psp.yml.j2
@@ -4,8 +4,8 @@ kind: PodSecurityPolicy
 metadata:
   name: registry-proxy
   annotations:
-    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
 {% if apparmor_enabled %}
     apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'

--- a/roles/kubernetes-apps/registry/templates/registry-psp.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-psp.yml.j2
@@ -4,8 +4,8 @@ kind: PodSecurityPolicy
 metadata:
   name: registry
   annotations:
-    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
 {% if apparmor_enabled %}
     apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'

--- a/roles/network_plugin/flannel/templates/cni-flannel-rbac.yml.j2
+++ b/roles/network_plugin/flannel/templates/cni-flannel-rbac.yml.j2
@@ -10,8 +10,8 @@ kind: PodSecurityPolicy
 metadata:
   name: psp.flannel.unprivileged
   annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: docker/default
-    seccomp.security.alpha.kubernetes.io/defaultProfileName: docker/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
 {% if podsecuritypolicy_enabled and apparmor_enabled %}
     apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
     apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

`docker/default` is deprecated as of Kubernetes 1.11.  See https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp

Also set `seccomp.security.alpha.kubernetes.io/allowedProfileNames` of psp `restricted` to `docker/default,runtime/default` to avoid breaking existing usage of `docker/default`.



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6169

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
