### PR TITLE
Auto detect target branch in rebase script

### DIFF
--- a/tests/scripts/rebase.sh
+++ b/tests/scripts/rebase.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 set -euxo pipefail
 
-# Rebase PRs on master to get latest changes
+KUBESPRAY_NEXT_VERSION=2.$(( ${KUBESPRAY_VERSION:3:2} + 1 ))
+
+# Rebase PRs on master (or release branch) to get latest changes
 if [[ $CI_COMMIT_REF_NAME == pr-* ]]; then
   git config user.email "ci@kubespray.io"
   git config user.name "CI"
-  git pull --rebase origin master
+  if [[ -z "`git branch -a --list origin/release-$KUBESPRAY_NEXT_VERSION`" ]]; then
+    git pull --rebase origin master
+  else
+    git pull --rebase origin release-$KUBESPRAY_NEXT_VERSION
+  fi
 fi


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
"Auto-detect" branch to rebase change before executing CI jobs

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
A bit hackish but as the benefits of not adding any variable.
Using the KUBESPRAY_VARIABLE (set to latest release, used for upgrade) I increment it by 1 and check if a branch exist, if not then we are targeting master, otherwise we should target the branch. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
