### PR TITLE
Bump CNI plugins to 0.8.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [containerd](https://containerd.io/) v1.2.13
   - [cri-o](http://cri-o.io/) v1.17 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)
 - Network Plugin
-  - [cni-plugins](https://github.com/containernetworking/plugins) v0.8.5
+  - [cni-plugins](https://github.com/containernetworking/plugins) v0.8.6
   - [calico](https://github.com/projectcalico/calico) v3.14.0
   - [canal](https://github.com/projectcalico/canal) (given calico/flannel versions)
   - [cilium](https://github.com/cilium/cilium) v1.7.3

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -77,7 +77,7 @@ typha_enabled: false
 
 flannel_version: "v0.12.0"
 
-cni_version: "v0.8.5"
+cni_version: "v0.8.6"
 
 weave_version: 2.6.2
 pod_infra_version: "3.1"
@@ -303,9 +303,9 @@ etcd_binary_checksums:
   arm64: 170b848ac1a071fe7d495d404a868a2c0090750b2944f8a260ef1c6125b2b4f4
   amd64: dc5d82df095dae0a2970e4d870b6929590689dd707ae3d33e7b86da0f7f211b6
 cni_binary_checksums:
-  arm: 86a868234045837cb3f5d58a0a4468ff42845d50b5e87bd128f050ef393d7495
-  arm64: a7881ec37e592c897bdfd2a225b4ed74caa981e3c4cdcf8f45574f8d2f111bce
-  amd64: bd682ffcf701e8f83283cdff7281aad0c83b02a56084d6e601216210732833f9
+  arm: 28e61b5847265135dc1ca397bf94322ecce4acab5c79cc7d360ca3f6a655bdb7
+  arm64: 43fbf750c5eccb10accffeeb092693c32b236fb25d919cf058c91a677822c999
+  amd64: 994fbfcdbb2eedcfa87e48d8edb9bb365f4e2747a7e47658482556c12fd9b2f5
 calicoctl_binary_checksums:
   arm:
     v3.14.0: 0


### PR DESCRIPTION
https://github.com/containernetworking/plugins/releases/tag/v0.8.6

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Bump CNI plugins to 0.8.6
```
