### PR TITLE
Oracle Linux 8 support and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ vagrant up
 - **Container Linux by CoreOS**
 - **Debian** Buster, Jessie, Stretch, Wheezy
 - **Ubuntu** 16.04, 18.04
-- **CentOS/RHEL** 7, 8 (experimental: see [centos 8 notes](docs/centos8.md)
+- **CentOS/RHEL** 7, 8 (experimental: see [centos 8 notes](docs/centos8.md))
 - **Fedora** 30, 31
 - **Fedora CoreOS** (experimental: see [fcos Note](docs/fcos.md))
 - **openSUSE** Leap 42.3/Tumbleweed
-- **Oracle Linux** 7
+- **Oracle Linux** 7, 8 (experimental: [centos 8 notes](docs/centos8.md) apply)
 
 Note: Upstart/SysV init based OS types are not supported.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,6 +35,7 @@ SUPPORTED_OS = {
   "opensuse"            => {box: "bento/opensuse-leap-15.1",   user: "vagrant"},
   "opensuse-tumbleweed" => {box: "opensuse/Tumbleweed.x86_64", user: "vagrant"},
   "oraclelinux"         => {box: "generic/oracle7",            user: "vagrant"},
+  "oraclelinux8"        => {box: "generic/oracle8",            user: "vagrant"},
 }
 
 if File.exist?(CONFIG)
@@ -185,6 +186,11 @@ Vagrant.configure("2") do |config|
       # Disable swap for each vm
       node.vm.provision "shell", inline: "swapoff -a"
 
+      # Disable firewalld on oraclelinux vms
+      if ["oraclelinux","oraclelinux8"].include? $os
+        node.vm.provision "shell", inline: "systemctl stop firewalld; systemctl disable firewalld"
+      end
+      
       host_vars[vm_name] = {
         "ip": ip,
         "flannel_interface": "eth1",

--- a/roles/bootstrap-os/tasks/bootstrap-centos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-centos.yml
@@ -1,5 +1,5 @@
 ---
-- name: Gather host facts to get ansible_distribution_major_version
+- name: Gather host facts to get ansible_distribution_version ansible_distribution_major_version
   setup:
     gather_subset: '!all'
     filter: ansible_distribution_*version
@@ -12,7 +12,7 @@
   when:
     - use_oracle_public_repo|default(true)
     - '"Oracle" in os_release.stdout'
-    - (ansible_distribution_major_version | float) < 7.6
+    - (ansible_distribution_version | float) < 7.6
 
 - name: Enable Oracle Linux repo
   ini_file:
@@ -27,7 +27,7 @@
   when:
     - use_oracle_public_repo|default(true)
     - '"Oracle" in os_release.stdout'
-    - (ansible_distribution_major_version | float) < 7.6
+    - (ansible_distribution_version | float) < 7.6
 
 - name: Enable Oracle Linux repo
   ini_file:

--- a/roles/bootstrap-os/tasks/bootstrap-centos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-centos.yml
@@ -1,4 +1,9 @@
 ---
+- name: Gather host facts to get ansible_distribution_major_version
+  setup:
+    gather_subset: '!all'
+    filter: ansible_distribution_*version
+
 # For Oracle Linux install public repo
 - name: Download Oracle Linux public yum repo
   get_url:
@@ -7,6 +12,7 @@
   when:
     - use_oracle_public_repo|default(true)
     - '"Oracle" in os_release.stdout'
+    - (ansible_distribution_major_version | float) < 7.6
 
 - name: Enable Oracle Linux repo
   ini_file:
@@ -21,6 +27,27 @@
   when:
     - use_oracle_public_repo|default(true)
     - '"Oracle" in os_release.stdout'
+    - (ansible_distribution_major_version | float) < 7.6
+
+- name: Enable Oracle Linux repo
+  ini_file:
+    dest: "/etc/yum.repos.d/oracle-linux-ol{{ ansible_distribution_major_version }}.repo"
+    section: "{{ item }}"
+    option: enabled
+    value: "1"
+  with_items:
+    - "ol{{ ansible_distribution_major_version }}_addons"
+  when:
+    - '"Oracle" in os_release.stdout'
+    - (ansible_distribution_version | float) >= 7.6
+
+- name: Install EPEL for Oracle Linux repo package
+  package:
+    name: "oracle-epel-release-el{{ ansible_distribution_major_version }}"
+    state: present
+  when:
+    - '"Oracle" in os_release.stdout'
+    - (ansible_distribution_version | float) >= 7.6
 
 # CentOS ships with python installed
 
@@ -50,11 +77,6 @@
     state: "{{ http_proxy | default(False) | ternary('present', 'absent') }}"
     no_extra_spaces: true
   become: true
-
-- name: Gather host facts to get ansible_distribution_major_version
-  setup:
-    gather_subset: '!all'
-    filter: ansible_distribution_major_version
 
 # libselinux-python is required on SELinux enabled hosts
 # See https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#managed-node-requirements


### PR DESCRIPTION
As documented in [1], public-yum-ol7.repo was deprecated on release 7.6. Some repos were integrated into oracle-linux-ol7.repo (i.e.: ol7_latest, ol7_addons) and other are available as packages (epel). This also adds support for oraclelinux8

[1] http://yum.oracle.com/getting-started.html#installing-software-from-oracle-linux-yum-server