### PR TITLE
Use 19.03.9 in localhost CI

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -73,10 +73,12 @@ packet_debian10-containerd:
 packet_centos7-calico-ha-once-localhost:
   stage: deploy-part2
   extends: .packet
-  # Problem with docker-cli client
-  when: manual
+  when: on_success
+  variables:
+    # This will instruct Docker not to start over TLS.
+    DOCKER_TLS_CERTDIR: ""
   services:
-    - docker:18.09.9-dind
+    - docker:19.03.9-dind
 
 packet_centos8-kube-ovn:
   stage: deploy-part2


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
As of 19.03.8 the dind image starts in TLS mode