### PR TITLE
Remove outdated CriticalAddonsOnly toleration and critical-pod annotation

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
@@ -31,8 +31,6 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-        - key: "CriticalAddonsOnly"
-          operator: "Exists"
 {% if dns_extra_tolerations | default(None) %}
         {{ dns_extra_tolerations | list | to_nice_yaml(indent=2) | indent(8) }}
 {% endif %}

--- a/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
@@ -30,7 +30,6 @@ spec:
       labels:
         k8s-app: dns-autoscaler{{ coredns_ordinal_suffix }}
       annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
         seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
     spec:
       priorityClassName: system-cluster-critical
@@ -43,8 +42,6 @@ spec:
         - effect: NoSchedule
           operator: Equal
           key: node-role.kubernetes.io/master
-        - key: "CriticalAddonsOnly"
-          operator: "Exists"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-daemonset.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-daemonset.yml.j2
@@ -27,8 +27,6 @@ spec:
         operator: "Exists"
       - effect: NoExecute
         operator: "Exists"
-      - key: "CriticalAddonsOnly"
-        operator: "Exists"
       containers:
       - name: node-cache
         image: "{{ nodelocaldns_image_repo }}:{{ nodelocaldns_image_tag }}"

--- a/roles/kubernetes-apps/csi_driver/aws_ebs/templates/aws-ebs-csi-controllerservice.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/aws_ebs/templates/aws-ebs-csi-controllerservice.yml.j2
@@ -20,9 +20,6 @@ spec:
         kubernetes.io/os: linux
       serviceAccount: ebs-csi-controller-sa
       priorityClassName: system-cluster-critical
-      tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
       containers:
         - name: ebs-plugin
           image: {{ aws_ebs_csi_plugin_image_repo }}:{{ aws_ebs_csi_plugin_image_tag }}

--- a/roles/kubernetes-apps/csi_driver/aws_ebs/templates/aws-ebs-csi-nodeservice.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/aws_ebs/templates/aws-ebs-csi-nodeservice.yml.j2
@@ -20,9 +20,6 @@ spec:
         kubernetes.io/os: linux
       hostNetwork: true
       priorityClassName: system-node-critical
-      tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
       containers:
         - name: ebs-plugin
           securityContext:

--- a/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
@@ -120,8 +120,6 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-        - key: "CriticalAddonsOnly"
-          operator: "Exists"
 {% endif %}
       affinity:
         nodeAffinity:

--- a/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-controllers.yml.j2
+++ b/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-controllers.yml.j2
@@ -24,8 +24,6 @@ spec:
       hostNetwork: true
       serviceAccountName: calico-kube-controllers
       tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
       priorityClassName: system-cluster-critical

--- a/roles/network_plugin/canal/templates/canal-node.yaml.j2
+++ b/roles/network_plugin/canal/templates/canal-node.yaml.j2
@@ -21,9 +21,6 @@ spec:
       serviceAccountName: canal
       tolerations:
         - operator: Exists
-        # Mark pod as critical for rescheduling (Will have no effect starting with kubernetes 1.12)
-        - key: CriticalAddonsOnly
-          operator: "Exists"
       volumes:
         # Used by calico/node.
         - name: lib-modules

--- a/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
@@ -16,11 +16,6 @@ spec:
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
 {% endif %}
-        # This annotation plus the CriticalAddonsOnly toleration makes
-        # cilium to be a critical pod in the cluster, which ensures cilium
-        # gets priority scheduling.
-        # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ""
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]'
       labels:
         k8s-app: cilium

--- a/roles/network_plugin/contiv/templates/contiv-api-proxy.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-api-proxy.yml.j2
@@ -29,9 +29,6 @@ spec:
         node-role.kubernetes.io/master: ""
       tolerations:
         - operator: Exists
-        # Mark pod as critical for rescheduling (Will have no effect starting with kubernetes 1.12)
-        - key: CriticalAddonsOnly
-          operator: "Exists"
       serviceAccountName: contiv-netmaster
       containers:
         - name: contiv-api-proxy

--- a/roles/network_plugin/contiv/templates/contiv-cleanup.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-cleanup.yml.j2
@@ -21,9 +21,6 @@ spec:
       hostPID: true
       tolerations:
         - operator: Exists
-        # Mark pod as critical for rescheduling (Will have no effect starting with kubernetes 1.12)
-        - key: CriticalAddonsOnly
-          operator: "Exists"
       serviceAccountName: contiv-netplugin
       containers:
       - name: contiv-ovs-cleanup

--- a/roles/network_plugin/contiv/templates/contiv-etcd.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-etcd.yml.j2
@@ -23,9 +23,6 @@ spec:
         node-role.kubernetes.io/master: ""
       tolerations:
         - operator: Exists
-        # Mark pod as critical for rescheduling (Will have no effect starting with kubernetes 1.12)
-        - key: CriticalAddonsOnly
-          operator: "Exists"
       initContainers:
         - name: contiv-etcd-init
           image: {{ contiv_etcd_init_image_repo }}:{{ contiv_etcd_init_image_tag }}

--- a/roles/network_plugin/contiv/templates/contiv-netmaster.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-netmaster.yml.j2
@@ -29,9 +29,6 @@ spec:
         node-role.kubernetes.io/master: ""
       tolerations:
         - operator: Exists
-        # Mark pod as critical for rescheduling (Will have no effect starting with kubernetes 1.12)
-        - key: CriticalAddonsOnly
-          operator: "Exists"
       serviceAccountName: contiv-netmaster
       containers:
         - name: contiv-netmaster

--- a/roles/network_plugin/contiv/templates/contiv-netplugin.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-netplugin.yml.j2
@@ -26,9 +26,6 @@ spec:
       hostPID: true
       tolerations:
         - operator: Exists
-        # Mark pod as critical for rescheduling (Will have no effect starting with kubernetes 1.12)
-        - key: CriticalAddonsOnly
-          operator: "Exists"
       serviceAccountName: contiv-netplugin
       initContainers:
         - name: contiv-netplugin-init

--- a/roles/network_plugin/contiv/templates/contiv-ovs.yml.j2
+++ b/roles/network_plugin/contiv/templates/contiv-ovs.yml.j2
@@ -23,9 +23,6 @@ spec:
       hostPID: true
       tolerations:
         - operator: Exists
-        # Mark pod as critical for rescheduling (Will have no effect starting with kubernetes 1.12)
-        - key: CriticalAddonsOnly
-          operator: "Exists"
       containers:
       # Runs ovs containers on each Kubernetes node.
       - name: contiv-ovsdb-server

--- a/roles/network_plugin/kube-router/templates/kube-router.yml.j2
+++ b/roles/network_plugin/kube-router/templates/kube-router.yml.j2
@@ -112,9 +112,6 @@ spec:
 {% endif %}
       tolerations:
       - operator: Exists
-      # Mark pod as critical for rescheduling (Will have no effect starting with kubernetes 1.12)
-      - key: CriticalAddonsOnly
-        operator: "Exists"
       volumes:
 {% if kube_router_enable_dsr %}
       - name: docker-socket


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Cleanup outdated toleration and annotation

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
>Alternatively, ensure both PodPriority and ExperimentalCriticalPodAnnotation feature gates are enabled, you could add an annotation scheduler.alpha.kubernetes.io/critical-pod as key and empty string as value to your pod, but this annotation is deprecated as of version 1.13 and will be removed in a future release.


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
