### PR TITLE
Update minor version for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,13 +123,13 @@ Note: Upstart/SysV init based OS types are not supported.
   - [cni-plugins](https://github.com/containernetworking/plugins) v0.8.6
   - [calico](https://github.com/projectcalico/calico) v3.14.0
   - [canal](https://github.com/projectcalico/canal) (given calico/flannel versions)
-  - [cilium](https://github.com/cilium/cilium) v1.7.3
+  - [cilium](https://github.com/cilium/cilium) v1.7.4
   - [contiv](https://github.com/contiv/install) v1.2.1
   - [flanneld](https://github.com/coreos/flannel) v0.12.0
   - [kube-ovn](https://github.com/alauda/kube-ovn) v1.1.1
   - [kube-router](https://github.com/cloudnativelabs/kube-router) v0.4.0
   - [multus](https://github.com/intel/multus-cni) v3.4.1
-  - [weave](https://github.com/weaveworks/weave) v2.6.2
+  - [weave](https://github.com/weaveworks/weave) v2.6.3
 - Application
   - [cephfs-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.0-k8s1.11
   - [rbd-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.1-k8s1.11

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -79,10 +79,10 @@ flannel_version: "v0.12.0"
 
 cni_version: "v0.8.6"
 
-weave_version: 2.6.2
+weave_version: 2.6.3
 pod_infra_version: "3.2"
 contiv_version: 1.2.1
-cilium_version: "v1.7.3"
+cilium_version: "v1.7.4"
 kube_ovn_version: "v1.1.1"
 kube_router_version: "v0.4.0"
 multus_version: "v3.4.1"
@@ -423,7 +423,7 @@ coredns_version: "1.6.7"
 coredns_image_repo: "{{ docker_image_repo }}/coredns/coredns"
 coredns_image_tag: "{{ coredns_version }}"
 
-nodelocaldns_version: "1.15.12"
+nodelocaldns_version: "1.15.13"
 nodelocaldns_image_repo: "{{ kube_image_repo }}/k8s-dns-node-cache"
 nodelocaldns_image_tag: "{{ nodelocaldns_version }}"
 
@@ -434,14 +434,14 @@ test_image_repo: "{{ docker_image_repo }}/library/busybox"
 test_image_tag: latest
 busybox_image_repo: "{{ docker_image_repo }}/library/busybox"
 busybox_image_tag: 1.31.1
-helm_version: "v3.1.2"
+helm_version: "v3.1.3"
 helm_image_repo: "{{ docker_image_repo }}/lachlanevenson/k8s-helm"
 helm_image_tag: "{{ helm_version }}"
 tiller_image_repo: "{{ gcr_image_repo }}/kubernetes-helm/tiller"
 tiller_image_tag: "{{ helm_version }}"
 
 registry_image_repo: "{{ docker_image_repo }}/library/registry"
-registry_image_tag: "2.7"
+registry_image_tag: "2.7.1"
 registry_proxy_image_repo: "{{ kube_image_repo }}/kube-registry-proxy"
 registry_proxy_image_tag: "0.4"
 metrics_server_version: "v0.3.6"
@@ -458,11 +458,11 @@ local_path_provisioner_image_tag: "v0.0.12"
 ingress_nginx_controller_image_repo: "{{ quay_image_repo }}/kubernetes-ingress-controller/nginx-ingress-controller"
 ingress_nginx_controller_image_tag: "0.30.0"
 alb_ingress_image_repo: "{{ docker_image_repo }}/amazon/aws-alb-ingress-controller"
-alb_ingress_image_tag: "v1.1.6"
+alb_ingress_image_tag: "v1.1.7"
 cert_manager_version: "v0.11.1"
 cert_manager_controller_image_repo: "{{ quay_image_repo }}/jetstack/cert-manager-controller"
 cert_manager_controller_image_tag: "{{ cert_manager_version }}"
-addon_resizer_version: "1.8.8"
+addon_resizer_version: "1.8.9"
 addon_resizer_image_repo: "{{ kube_image_repo }}/addon-resizer"
 addon_resizer_image_tag: "{{ addon_resizer_version }}"
 
@@ -504,7 +504,7 @@ gcp_pd_csi_resizer_image_tag: "v0.4.0-gke.0"
 gcp_pd_csi_registrar_image_tag: "v1.2.0-gke.0"
 
 dashboard_image_repo: "{{ docker_image_repo }}/kubernetesui/dashboard-{{ image_arch }}"
-dashboard_image_tag: "v2.0.0"
+dashboard_image_tag: "v2.0.1"
 dashboard_metrics_scraper_repo: "{{ docker_image_repo }}/kubernetesui/metrics-scraper"
 dashboard_metrics_scraper_tag: "v1.0.4"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Update minor version for different components

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
- cilium: 1.7.3 -> 1.7.4
- weave: 2.6.2 -> 2.6.3
- nodelocaldns: 1.15.12 -> 1.15.13
- helm: 3.1.2 -> 3.1.3
- registry: 2.7 -> 2.7.1
- alb_ingress: 1.1.6 -> 1.1.7
- addon_resizer: 1.8.8 -> 1.8.9
- dashboard: 2.0.0 -> 2.0.1

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
