### PR TITLE
disable bird-check flag when calico_network_backend is not 'bird'

### DIFF
--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -284,7 +284,9 @@ spec:
               command:
               - /bin/calico-node
               - -felix-live
+{% if calico_network_backend|default("bird") == "bird" %}
               - -bird-live
+{% endif %}
 {% endif %}
             initialDelaySeconds: 5
             failureThreshold: 6
@@ -299,7 +301,9 @@ spec:
             exec:
               command:
               - /bin/calico-node
+{% if calico_network_backend|default("bird") == "bird" %}
               - -bird-ready
+{% endif %}
               - -felix-ready
 {% endif %}
           volumeMounts:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

calico-node pod failed probes when no-bird mode used 
`calico_network_backend: vxlan`
or none

