### PR TITLE
Manage containerd.io package with docker CRI.

### DIFF
--- a/roles/container-engine/containerd-common/defaults/main.yml
+++ b/roles/container-engine/containerd-common/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+containerd_version: '1.2.13'
+containerd_package: 'containerd.io'

--- a/roles/container-engine/containerd-common/tasks/main.yml
+++ b/roles/container-engine/containerd-common/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: gather os specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - files:
+        - "{{ ansible_distribution|lower }}-{{ ansible_distribution_version|lower|replace('/', '_') }}.yml"
+        - "{{ ansible_distribution|lower }}-{{ ansible_distribution_release|lower }}-{{ host_architecture }}.yml"
+        - "{{ ansible_distribution|lower }}-{{ ansible_distribution_release|lower }}.yml"
+        - "{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version|lower|replace('/', '_') }}.yml"
+        - "{{ ansible_distribution|lower }}-{{ host_architecture }}.yml"
+        - "{{ ansible_distribution|lower }}.yml"
+        - "{{ ansible_os_family|lower }}-{{ host_architecture }}.yml"
+        - "{{ ansible_os_family|lower }}.yml"
+        - defaults.yml
+      paths:
+        - ../vars
+      skip: true
+  tags:
+    - facts

--- a/roles/container-engine/containerd-common/vars/debian.yml
+++ b/roles/container-engine/containerd-common/vars/debian.yml
@@ -1,0 +1,11 @@
+---
+containerd_versioned_pkg:
+  'latest': "{{ containerd_package }}"
+  '1.2.4': "{{ containerd_package }}=1.2.4-1"
+  '1.2.5': "{{ containerd_package }}=1.2.5-1"
+  '1.2.6': "{{ containerd_package }}=1.2.6-3"
+  '1.2.10': "{{ containerd_package }}=1.2.10-3"
+  '1.2.12': "{{ containerd_package }}=1.2.12-1"
+  '1.2.13': "{{ containerd_package }}=1.2.13-2"
+  'stable': "{{ containerd_package }}=1.2.13-2"
+  'edge': "{{ containerd_package }}=1.2.13-2"

--- a/roles/container-engine/containerd-common/vars/fedora.yml
+++ b/roles/container-engine/containerd-common/vars/fedora.yml
@@ -1,0 +1,8 @@
+---
+containerd_versioned_pkg:
+  'latest': "{{ containerd_package }}"
+  '1.2.10': "{{ containerd_package }}-1.2.10-3.2.fc{{ ansible_distribution_major_version }}"
+  '1.2.12': "{{ containerd_package }}-1.2.12-3.1.fc{{ ansible_distribution_major_version }}"
+  '1.2.13': "{{ containerd_package }}-1.2.13-3.2.fc{{ ansible_distribution_major_version }}"
+  'stable': "{{ containerd_package }}-1.2.13-3.2.fc{{ ansible_distribution_major_version }}"
+  'edge': "{{ containerd_package }}-1.2.13-3.2.fc{{ ansible_distribution_major_version }}"

--- a/roles/container-engine/containerd-common/vars/redhat.yml
+++ b/roles/container-engine/containerd-common/vars/redhat.yml
@@ -1,0 +1,11 @@
+---
+containerd_versioned_pkg:
+  'latest': "{{ containerd_package }}"
+  '1.2.4': "{{ containerd_package }}-1.2.4-3.1.el7"
+  '1.2.5': "{{ containerd_package }}-1.2.5-3.1.el7"
+  '1.2.6': "{{ containerd_package }}-1.2.6-3.3.el7"
+  '1.2.10': "{{ containerd_package }}-1.2.10-3.2.el7"
+  '1.2.12': "{{ containerd_package }}-1.2.12-3.1.el7"
+  '1.2.13': "{{ containerd_package }}-1.2.13-3.2.el7"
+  'stable': "{{ containerd_package }}-1.2.13-3.2.el7"
+  'edge': "{{ containerd_package }}-1.2.13-3.2.el7"

--- a/roles/container-engine/containerd-common/vars/ubuntu-amd64.yml
+++ b/roles/container-engine/containerd-common/vars/ubuntu-amd64.yml
@@ -1,0 +1,11 @@
+---
+containerd_versioned_pkg:
+  'latest': "{{ containerd_package }}"
+  '1.2.4': "{{ containerd_package }}=1.2.4-1"
+  '1.2.5': "{{ containerd_package }}=1.2.5-1"
+  '1.2.6': "{{ containerd_package }}=1.2.6-3"
+  '1.2.10': "{{ containerd_package }}=1.2.10-3"
+  '1.2.12': "{{ containerd_package }}=1.2.12-1"
+  '1.2.13': "{{ containerd_package }}=1.2.13-2"
+  'stable': "{{ containerd_package }}=1.2.13-2"
+  'edge': "{{ containerd_package }}=1.2.13-2"

--- a/roles/container-engine/containerd-common/vars/ubuntu-arm64.yml
+++ b/roles/container-engine/containerd-common/vars/ubuntu-arm64.yml
@@ -1,0 +1,8 @@
+---
+containerd_versioned_pkg:
+  'latest': "{{ containerd_package }}"
+  '1.2.10': "{{ containerd_package }}=1.2.10-3"
+  '1.2.12': "{{ containerd_package }}=1.2.12-1"
+  '1.2.13': "{{ containerd_package }}=1.2.13-2"
+  'stable': "{{ containerd_package }}=1.2.13-2"
+  'edge': "{{ containerd_package }}=1.2.13-2"

--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -11,9 +11,6 @@ containerd_config:
   # containerd:
   #   snapshotter: native
 
-containerd_version: '1.2.13'
-containerd_package: 'containerd.io'
-
 containerd_cfg_dir: /etc/containerd
 
 # Path to runc binary

--- a/roles/container-engine/containerd/meta/main.yml
+++ b/roles/container-engine/containerd/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: container-engine/containerd-common

--- a/roles/container-engine/containerd/tasks/crictl.yml
+++ b/roles/container-engine/containerd/tasks/crictl.yml
@@ -22,9 +22,10 @@
   delegate_to: "{{ inventory_hostname }}"
 
 - name: Get crictl completion
-  shell: "{{ bin_dir }}/crictl completion"
+  command: "{{ bin_dir }}/crictl completion"
   changed_when: False
   register: cri_completion
+  check_mode: False
 
 - name: Install crictl completion
   copy:

--- a/roles/container-engine/containerd/vars/debian.yml
+++ b/roles/container-engine/containerd/vars/debian.yml
@@ -1,16 +1,4 @@
 ---
-
-containerd_versioned_pkg:
-  'latest': "{{ containerd_package }}"
-  '1.2.4': "{{ containerd_package }}=1.2.4-1"
-  '1.2.5': "{{ containerd_package }}=1.2.5-1"
-  '1.2.6': "{{ containerd_package }}=1.2.6-3"
-  '1.2.10': "{{ containerd_package }}=1.2.10-3"
-  '1.2.12': "{{ containerd_package }}=1.2.12-1"
-  '1.2.13': "{{ containerd_package }}=1.2.13-2"
-  'stable': "{{ containerd_package }}=1.2.13-2"
-  'edge': "{{ containerd_package }}=1.2.13-2"
-
 containerd_package_info:
   pkg_mgr: apt
   pkgs:

--- a/roles/container-engine/containerd/vars/fedora.yml
+++ b/roles/container-engine/containerd/vars/fedora.yml
@@ -1,13 +1,4 @@
 ---
-
-containerd_versioned_pkg:
-  'latest': "{{ containerd_package }}"
-  '1.2.10': "{{ containerd_package }}-1.2.10-3.2.fc{{ ansible_distribution_major_version }}"
-  '1.2.12': "{{ containerd_package }}-1.2.12-3.2.fc{{ ansible_distribution_major_version }}"
-  '1.2.13': "{{ containerd_package }}-1.2.13-3.2.fc{{ ansible_distribution_major_version }}"
-  'stable': "{{ containerd_package }}-1.2.13-3.2.fc{{ ansible_distribution_major_version }}"
-  'edge': "{{ containerd_package }}-1.2.13-3.2.fc{{ ansible_distribution_major_version }}"
-
 containerd_package_info:
   pkg_mgr: dnf
   pkgs:

--- a/roles/container-engine/containerd/vars/redhat.yml
+++ b/roles/container-engine/containerd/vars/redhat.yml
@@ -1,16 +1,4 @@
 ---
-
-containerd_versioned_pkg:
-  'latest': "{{ containerd_package }}"
-  '1.2.4': "{{ containerd_package }}-1.2.4-3.1.el7"
-  '1.2.5': "{{ containerd_package }}-1.2.5-3.1.el7"
-  '1.2.6': "{{ containerd_package }}-1.2.6-3.3.el7"
-  '1.2.10': "{{ containerd_package }}-1.2.10-3.2.el7"
-  '1.2.12': "{{ containerd_package }}-1.2.12-3.1.el7"
-  '1.2.13': "{{ containerd_package }}-1.2.13-3.2.el7"
-  'stable': "{{ containerd_package }}-1.2.13-3.2.el7"
-  'edge': "{{ containerd_package }}-1.2.13-3.2.el7"
-
 containerd_package_info:
   pkg_mgr: yum
   pkgs:

--- a/roles/container-engine/containerd/vars/ubuntu-amd64.yml
+++ b/roles/container-engine/containerd/vars/ubuntu-amd64.yml
@@ -1,16 +1,4 @@
 ---
-
-containerd_versioned_pkg:
-  'latest': "{{ containerd_package }}"
-  '1.2.4': "{{ containerd_package }}=1.2.4-1"
-  '1.2.5': "{{ containerd_package }}=1.2.5-1"
-  '1.2.6': "{{ containerd_package }}=1.2.6-3"
-  '1.2.10': "{{ containerd_package }}=1.2.10-3"
-  '1.2.12': "{{ containerd_package }}=1.2.12-1"
-  '1.2.13': "{{ containerd_package }}=1.2.13-2"
-  'stable': "{{ containerd_package }}=1.2.13-2"
-  'edge': "{{ containerd_package }}=1.2.13-2"
-
 containerd_package_info:
   pkg_mgr: apt
   pkgs:

--- a/roles/container-engine/docker/defaults/main.yml
+++ b/roles/container-engine/docker/defaults/main.yml
@@ -22,6 +22,9 @@ docker_dns_servers_strict: true
 
 docker_container_storage_setup: false
 
+containerd_version: '1.2.13'
+containerd_package: 'containerd.io'
+
 # Used to override obsoletes=0
 yum_conf: /etc/yum.conf
 yum_repo_dir: /etc/yum.repos.d

--- a/roles/container-engine/docker/defaults/main.yml
+++ b/roles/container-engine/docker/defaults/main.yml
@@ -22,9 +22,6 @@ docker_dns_servers_strict: true
 
 docker_container_storage_setup: false
 
-containerd_version: '1.2.13'
-containerd_package: 'containerd.io'
-
 # Used to override obsoletes=0
 yum_conf: /etc/yum.conf
 yum_repo_dir: /etc/yum.repos.d

--- a/roles/container-engine/docker/meta/main.yml
+++ b/roles/container-engine/docker/meta/main.yml
@@ -1,4 +1,5 @@
 ---
 dependencies:
+  - role: container-engine/containerd-common
   - role: container-engine/docker-storage
     when: docker_container_storage_setup and ansible_os_family == "RedHat"

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -196,6 +196,7 @@
     - docker_task_result is failed
     - ansible_distribution == 'Ubuntu'
   register: available_packages
+  check_mode: false
 
 - name: show available packages on ubuntu
   fail:
@@ -239,6 +240,7 @@
   command: "docker version -f '{{ '{{' }}.Client.Version{{ '}}' }}'"
   register: installed_docker_version
   changed_when: false
+  check_mode: false
 
 - name: check minimum docker version for docker_dns mode. You need at least docker version >= 1.12 for resolvconf_mode=docker_dns
   fail:

--- a/roles/container-engine/docker/tasks/systemd.yml
+++ b/roles/container-engine/docker/tasks/systemd.yml
@@ -17,6 +17,7 @@
   register: systemd_version
   when: not is_ostree
   changed_when: false
+  check_mode: false
 
 - name: Write docker.service systemd file
   template:

--- a/roles/container-engine/docker/vars/debian.yml
+++ b/roles/container-engine/docker/vars/debian.yml
@@ -21,14 +21,6 @@ docker_cli_versioned_pkg:
   '18.09': docker-ce-cli=5:18.09.9~3-0~debian-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce-cli=5:19.03.9~3-0~debian-{{ ansible_distribution_release|lower }}
 
-containerd_versioned_pkg:
-  'latest': "{{ containerd_package }}"
-  '1.2.10': "{{ containerd_package }}=1.2.10-3"
-  '1.2.12': "{{ containerd_package }}=1.2.12-1"
-  '1.2.13': "{{ containerd_package }}=1.2.13-2"
-  'stable': "{{ containerd_package }}=1.2.13-2"
-  'edge': "{{ containerd_package }}=1.2.13-2"
-
 docker_package_info:
   pkg_mgr: apt
   pkgs:

--- a/roles/container-engine/docker/vars/debian.yml
+++ b/roles/container-engine/docker/vars/debian.yml
@@ -21,9 +21,19 @@ docker_cli_versioned_pkg:
   '18.09': docker-ce-cli=5:18.09.9~3-0~debian-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce-cli=5:19.03.9~3-0~debian-{{ ansible_distribution_release|lower }}
 
+containerd_versioned_pkg:
+  'latest': "{{ containerd_package }}"
+  '1.2.10': "{{ containerd_package }}=1.2.10-3"
+  '1.2.12': "{{ containerd_package }}=1.2.12-1"
+  '1.2.13': "{{ containerd_package }}=1.2.13-2"
+  'stable': "{{ containerd_package }}=1.2.13-2"
+  'edge': "{{ containerd_package }}=1.2.13-2"
+
 docker_package_info:
   pkg_mgr: apt
   pkgs:
+    - name: "{{ containerd_versioned_pkg[containerd_version | string] }}"
+      force: yes
     - name: "{{ docker_cli_versioned_pkg[docker_cli_version | string] }}"
       force: yes
     - name: "{{ docker_versioned_pkg[docker_version | string] }}"

--- a/roles/container-engine/docker/vars/fedora.yml
+++ b/roles/container-engine/docker/vars/fedora.yml
@@ -18,14 +18,6 @@ docker_cli_versioned_pkg:
   '18.09': docker-ce-cli-19.03.8-3.fc{{ ansible_distribution_major_version }}
   '19.03': docker-ce-cli-19.03.9-3.fc{{ ansible_distribution_major_version }}
 
-containerd_versioned_pkg:
-  'latest': "{{ containerd_package }}"
-  '1.2.10': "{{ containerd_package }}-1.2.10-3.2.fc{{ ansible_distribution_major_version }}"
-  '1.2.12': "{{ containerd_package }}-1.2.12-3.1.fc{{ ansible_distribution_major_version }}"
-  '1.2.13': "{{ containerd_package }}-1.2.13-3.2.fc{{ ansible_distribution_major_version }}"
-  'stable': "{{ containerd_package }}-1.2.13-3.2.fc{{ ansible_distribution_major_version }}"
-  'edge': "{{ containerd_package }}-1.2.13-3.2.fc{{ ansible_distribution_major_version }}"
-
 docker_package_info:
   pkg_mgr: dnf
   pkgs:

--- a/roles/container-engine/docker/vars/fedora.yml
+++ b/roles/container-engine/docker/vars/fedora.yml
@@ -18,8 +18,17 @@ docker_cli_versioned_pkg:
   '18.09': docker-ce-cli-19.03.8-3.fc{{ ansible_distribution_major_version }}
   '19.03': docker-ce-cli-19.03.9-3.fc{{ ansible_distribution_major_version }}
 
+containerd_versioned_pkg:
+  'latest': "{{ containerd_package }}"
+  '1.2.10': "{{ containerd_package }}-1.2.10-3.2.fc{{ ansible_distribution_major_version }}"
+  '1.2.12': "{{ containerd_package }}-1.2.12-3.1.fc{{ ansible_distribution_major_version }}"
+  '1.2.13': "{{ containerd_package }}-1.2.13-3.2.fc{{ ansible_distribution_major_version }}"
+  'stable': "{{ containerd_package }}-1.2.13-3.2.fc{{ ansible_distribution_major_version }}"
+  'edge': "{{ containerd_package }}-1.2.13-3.2.fc{{ ansible_distribution_major_version }}"
+
 docker_package_info:
   pkg_mgr: dnf
   pkgs:
+    - name: "{{ containerd_versioned_pkg[containerd_version | string] }}"
     - name: "{{ docker_cli_versioned_pkg[docker_cli_version | string] }}"
     - name: "{{ docker_versioned_pkg[docker_version | string] }}"

--- a/roles/container-engine/docker/vars/redhat.yml
+++ b/roles/container-engine/docker/vars/redhat.yml
@@ -27,6 +27,13 @@ docker_selinux_versioned_pkg:
   'stable': docker-ce-selinux-17.03.3.ce-1.el7
   'edge': docker-ce-selinux-17.03.3.ce-1.el7
 
+containerd_versioned_pkg:
+  'latest': "{{ containerd_package }}"
+  '1.2.10': "{{ containerd_package }}-1.2.10-3.2.el7"
+  '1.2.12': "{{ containerd_package }}-1.2.12-3.1.el7"
+  '1.2.13': "{{ containerd_package }}-1.2.13-3.2.el7"
+  'stable': "{{ containerd_package }}-1.2.13-3.2.el7"
+  'edge': "{{ containerd_package }}-1.2.13-3.2.el7"
 
 docker_pkgs_use_docker_ce:
   - name: "{{ docker_selinux_versioned_pkg[docker_selinux_version | string] }}"
@@ -35,6 +42,8 @@ docker_pkgs_use_docker_ce:
     yum_conf: "{{ docker_yum_conf }}"
 
 docker_pkgs:
+  - name: "{{ containerd_versioned_pkg[containerd_version | string] }}"
+    yum_conf: "{{ docker_yum_conf }}"
   - name: "{{ docker_cli_versioned_pkg[docker_cli_version | string] }}"
     yum_conf: "{{ docker_yum_conf }}"
   - name: "{{ docker_versioned_pkg[docker_version | string] }}"

--- a/roles/container-engine/docker/vars/redhat.yml
+++ b/roles/container-engine/docker/vars/redhat.yml
@@ -27,13 +27,6 @@ docker_selinux_versioned_pkg:
   'stable': docker-ce-selinux-17.03.3.ce-1.el7
   'edge': docker-ce-selinux-17.03.3.ce-1.el7
 
-containerd_versioned_pkg:
-  'latest': "{{ containerd_package }}"
-  '1.2.10': "{{ containerd_package }}-1.2.10-3.2.el7"
-  '1.2.12': "{{ containerd_package }}-1.2.12-3.1.el7"
-  '1.2.13': "{{ containerd_package }}-1.2.13-3.2.el7"
-  'stable': "{{ containerd_package }}-1.2.13-3.2.el7"
-  'edge': "{{ containerd_package }}-1.2.13-3.2.el7"
 
 docker_pkgs_use_docker_ce:
   - name: "{{ docker_selinux_versioned_pkg[docker_selinux_version | string] }}"

--- a/roles/container-engine/docker/vars/ubuntu-amd64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-amd64.yml
@@ -21,9 +21,19 @@ docker_cli_versioned_pkg:
   '18.09': docker-ce-cli=5:18.09.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce-cli=5:19.03.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
+containerd_versioned_pkg:
+  'latest': "{{ containerd_package }}"
+  '1.2.10': "{{ containerd_package }}=1.2.10-3"
+  '1.2.12': "{{ containerd_package }}=1.2.12-1"
+  '1.2.13': "{{ containerd_package }}=1.2.13-2"
+  'stable': "{{ containerd_package }}=1.2.13-2"
+  'edge': "{{ containerd_package }}=1.2.13-2"
+
 docker_package_info:
   pkg_mgr: apt
   pkgs:
+    - name: "{{ containerd_versioned_pkg[containerd_version | string] }}"
+      force: yes
     - name: "{{ docker_cli_versioned_pkg[docker_cli_version | string] }}"
       force: yes
     - name: "{{ docker_versioned_pkg[docker_version | string] }}"

--- a/roles/container-engine/docker/vars/ubuntu-amd64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-amd64.yml
@@ -21,14 +21,6 @@ docker_cli_versioned_pkg:
   '18.09': docker-ce-cli=5:18.09.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce-cli=5:19.03.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
-containerd_versioned_pkg:
-  'latest': "{{ containerd_package }}"
-  '1.2.10': "{{ containerd_package }}=1.2.10-3"
-  '1.2.12': "{{ containerd_package }}=1.2.12-1"
-  '1.2.13': "{{ containerd_package }}=1.2.13-2"
-  'stable': "{{ containerd_package }}=1.2.13-2"
-  'edge': "{{ containerd_package }}=1.2.13-2"
-
 docker_package_info:
   pkg_mgr: apt
   pkgs:

--- a/roles/container-engine/docker/vars/ubuntu-arm64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-arm64.yml
@@ -17,9 +17,19 @@ docker_cli_versioned_pkg:
   '18.09': docker-ce-cli=5:18.09.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce-cli=5:19.03.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
+containerd_versioned_pkg:
+  'latest': "{{ containerd_package }}"
+  '1.2.10': "{{ containerd_package }}=1.2.10-3"
+  '1.2.12': "{{ containerd_package }}=1.2.12-1"
+  '1.2.13': "{{ containerd_package }}=1.2.13-2"
+  'stable': "{{ containerd_package }}=1.2.13-2"
+  'edge': "{{ containerd_package }}=1.2.13-2"
+
 docker_package_info:
   pkg_mgr: apt
   pkgs:
+    - name: "{{ containerd_versioned_pkg[containerd_version | string] }}"
+      force: yes
     - name: "{{ docker_cli_versioned_pkg[docker_cli_version | string] }}"
       force: yes
     - name: "{{ docker_versioned_pkg[docker_version | string] }}"

--- a/roles/container-engine/docker/vars/ubuntu-arm64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-arm64.yml
@@ -17,14 +17,6 @@ docker_cli_versioned_pkg:
   '18.09': docker-ce-cli=5:18.09.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce-cli=5:19.03.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
-containerd_versioned_pkg:
-  'latest': "{{ containerd_package }}"
-  '1.2.10': "{{ containerd_package }}=1.2.10-3"
-  '1.2.12': "{{ containerd_package }}=1.2.12-1"
-  '1.2.13': "{{ containerd_package }}=1.2.13-2"
-  'stable': "{{ containerd_package }}=1.2.13-2"
-  'edge': "{{ containerd_package }}=1.2.13-2"
-
 docker_package_info:
   pkg_mgr: apt
   pkgs:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Docker depends on the package `containerd.io`. However, the version of containerd.io is not managed in kubespray when container runtime is docker. The result is that it is not upgraded when necessary.

This PR adds containerd.io to managed packages for docker.

**Which issue(s) this PR fixes**:
Fixes #6192 

**Special notes for your reviewer**:
To keep things dry, variables common to both `containerd` and `docker` are moved to new role `container-engine/containerd-common` on which these two now depend. These variables include containerd version and versioned packages, so this would be the place to add new versions from now on.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
