### PR TITLE
Update kube-ovn to 1.2.0 - also update minor version for multus and weave

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ Note: Upstart/SysV init based OS types are not supported.
   - [cilium](https://github.com/cilium/cilium) v1.7.4
   - [contiv](https://github.com/contiv/install) v1.2.1
   - [flanneld](https://github.com/coreos/flannel) v0.12.0
-  - [kube-ovn](https://github.com/alauda/kube-ovn) v1.1.1
+  - [kube-ovn](https://github.com/alauda/kube-ovn) v1.2.0
   - [kube-router](https://github.com/cloudnativelabs/kube-router) v0.4.0
-  - [multus](https://github.com/intel/multus-cni) v3.4.1
-  - [weave](https://github.com/weaveworks/weave) v2.6.3
+  - [multus](https://github.com/intel/multus-cni) v3.4.2
+  - [weave](https://github.com/weaveworks/weave) v2.6.4
 - Application
   - [cephfs-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.0-k8s1.11
   - [rbd-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.1-k8s1.11

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -63,9 +63,6 @@ docker_image_repo: "docker.io"
 # quay image repo define
 quay_image_repo: "quay.io"
 
-# alauda.cn image repo (for kube-ovn...)
-alauda_image_repo: "index.alauda.cn"
-
 # TODO(mattymo): Move calico versions to roles/network_plugins/calico/defaults
 # after migration to container download
 calico_version: "v3.14.1"
@@ -79,13 +76,13 @@ flannel_version: "v0.12.0"
 
 cni_version: "v0.8.6"
 
-weave_version: 2.6.3
+weave_version: 2.6.4
 pod_infra_version: "3.2"
 contiv_version: 1.2.1
 cilium_version: "v1.7.4"
-kube_ovn_version: "v1.1.1"
+kube_ovn_version: "v1.2.0"
 kube_router_version: "v0.4.0"
-multus_version: "v3.4.1"
+multus_version: "v3.4.2"
 
 # Get kubernetes major version (i.e. 1.17.4 => 1.17)
 kube_major_version: "{{ kube_version | regex_replace('^v([0-9])+\\.([0-9]+)\\.[0-9]+', 'v\\1.\\2') }}"
@@ -408,7 +405,7 @@ cilium_init_image_repo: "{{ docker_image_repo }}/cilium/cilium-init"
 cilium_init_image_tag: "2019-04-05"
 cilium_operator_image_repo: "{{ docker_image_repo }}/cilium/operator"
 cilium_operator_image_tag: "{{ cilium_version }}"
-kube_ovn_container_image_repo: "{{ alauda_image_repo }}/alaudak8s/kube-ovn"
+kube_ovn_container_image_repo: "{{ docker_image_repo }}/kubeovn/kube-ovn"
 kube_ovn_container_image_tag: "{{ kube_ovn_version }}"
 kube_router_image_repo: "{{ docker_image_repo }}/cloudnativelabs/kube-router"
 kube_router_image_tag: "{{ kube_router_version }}"

--- a/roles/network_plugin/kube-ovn/templates/cni-kube-ovn-crd.yml.j2
+++ b/roles/network_plugin/kube-ovn/templates/cni-kube-ovn-crd.yml.j2
@@ -65,10 +65,10 @@ spec:
       type: string
       JSONPath: .spec.gatewayType
     - name: Used
-      type: integer
+      type: number
       JSONPath: .status.usingIPs
     - name: Available
-      type: integer
+      type: number
       JSONPath: .status.availableIPs
   validation:
     openAPIV3Schema:
@@ -80,3 +80,28 @@ spec:
               type: "string"
             gateway:
               type: "string"
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: vlans.kubeovn.io
+spec:
+  group: kubeovn.io
+  version: v1
+  scope: Cluster
+  names:
+    plural: vlans
+    singular: vlan
+    kind: Vlan
+    shortNames:
+      - vlan
+  additionalPrinterColumns:
+    - name: VlanID
+      type: string
+      JSONPath: .spec.vlanId
+    - name: ProviderInterfaceName
+      type: string
+      JSONPath: .spec.providerInterfaceName
+    - name: Subnet
+      type: string
+      JSONPath: .spec.subnet

--- a/roles/network_plugin/kube-ovn/templates/cni-ovn.yml.j2
+++ b/roles/network_plugin/kube-ovn/templates/cni-ovn.yml.j2
@@ -27,7 +27,6 @@ rules:
       - subnets/status
       - ips
       - vlans
-      - networks
     verbs:
       - "*"
   - apiGroups:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Update kube-ovn to 1.2.0
Also update minor version for weave (2.6.4) and multus (3.4.2)

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Kubeovn is back on dockerhub and no longer need alauda.cn repo

**Does this PR introduce a user-facing change?**:
```release-note
Update kube-ovn to 1.2.0
```
