### PR TITLE
[2.12] Bump CNI plugins to 0.8.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [containerd](https://containerd.io/) v1.2.13
   - [cri-o](http://cri-o.io/) v1.14.0 (experimental: see [CRI-O Note](docs/cri-o.md). Only on centos based OS)
 - Network Plugin
-  - [cni-plugins](https://github.com/containernetworking/plugins) v0.8.1
+  - [cni-plugins](https://github.com/containernetworking/plugins) v0.8.6
   - [calico](https://github.com/projectcalico/calico) v3.7.3
   - [canal](https://github.com/projectcalico/canal) (given calico/flannel versions)
   - [cilium](https://github.com/cilium/cilium) v1.5.5

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -76,7 +76,7 @@ typha_enabled: false
 flannel_version: "v0.11.0"
 flannel_cni_version: "v0.3.0"
 
-cni_version: "v0.8.1"
+cni_version: "v0.8.6"
 
 weave_version: 2.5.2
 pod_infra_version: 3.1
@@ -383,9 +383,9 @@ etcd_binary_checksums:
   arm64: 170b848ac1a071fe7d495d404a868a2c0090750b2944f8a260ef1c6125b2b4f4
   amd64: dc5d82df095dae0a2970e4d870b6929590689dd707ae3d33e7b86da0f7f211b6
 cni_binary_checksums:
-  arm: ae6ddbd87c05a79aceb92e1c8c32d11e302f6fc55045f87f6a3ea7e0268b2fda
-  arm64: acde854e3def3c776c532ae521c19d8784534918cc56449ff16945a2909bff6d
-  amd64: e9bfc78acd3ae71be77eb8f3e890cc9078a33cc3797703b8ff2fc3077a232252
+  arm: 28e61b5847265135dc1ca397bf94322ecce4acab5c79cc7d360ca3f6a655bdb7
+  arm64: 43fbf750c5eccb10accffeeb092693c32b236fb25d919cf058c91a677822c999
+  amd64: 994fbfcdbb2eedcfa87e48d8edb9bb365f4e2747a7e47658482556c12fd9b2f5
 calicoctl_binary_checksums:
   arm:
     v3.6.1: 0


### PR DESCRIPTION
https://github.com/containernetworking/plugins/releases/tag/v0.8.6
https://github.com/kubernetes/kubernetes/issues/91507

Signed-off-by: Etienne Champetier <champetier.etienne@gmail.com>
(cherry picked from commit 41b44739b17329905987a4cd15c3320e1f1271de)

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Bump CNI plugins to 0.8.6 / Fix CVE-2020-10749
```