### PR TITLE
[2.13] Backport CRI-O bugfixes

### DIFF
--- a/roles/container-engine/cri-o/defaults/main.yml
+++ b/roles/container-engine/cri-o/defaults/main.yml
@@ -9,7 +9,7 @@ crio_conmon: "/usr/bin/conmon"
 crio_required_version: "{{ kube_version | regex_replace('^v(?P<major>\\d+).(?P<minor>\\d+).(?P<patch>\\d+)$', '\\g<major>.\\g<minor>') }}"
 
 crio_kubernetes_version_matrix:
-  "1.18": "1.17"
+  "1.18": "1.18"
   "1.17": "1.17"
   "1.16": "1.16"
 

--- a/roles/container-engine/cri-o/molecule/default/molecule.yml
+++ b/roles/container-engine/cri-o/molecule/default/molecule.yml
@@ -8,12 +8,12 @@ lint:
   options:
     config-file: ../../../.yamllint
 platforms:
-  # - name: ubuntu1804
-  #   box: generic/ubuntu1804
-  #   cpus: 2
-  #   memory: 1024
-  #   groups:
-  #     - kube-master
+  - name: ubuntu1804
+    box: generic/ubuntu1804
+    cpus: 2
+    memory: 1024
+    groups:
+      - kube-master
   - name: centos7
     box: centos/7
     cpus: 2

--- a/roles/container-engine/cri-o/tasks/crio_repo.yml
+++ b/roles/container-engine/cri-o/tasks/crio_repo.yml
@@ -22,7 +22,7 @@
   yum_repository:
     name: devel_kubic_libcontainers_stable
     description: Stable Releases of Upstream github.com/containers packages (CentOS_$releasever)
-    baseurl: http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_$releasever/
+    baseurl: http://widehat.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_$releasever/
     gpgcheck: yes
     gpgkey: http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_$releasever/repodata/repomd.xml.key
   when: ansible_distribution in ["CentOS"]
@@ -30,10 +30,10 @@
 - name: Add CRI-O kubic repo
   yum_repository:
     name: "devel_kubic_libcontainers_stable_cri-o_{{ crio_version }}"
-    description: 1.17 (CentOS_$releasever)
-    baseurl: "http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/{{ crio_version }}/CentOS_$releasever/"
+    description: "CRI-O {{ crio_version }} (CentOS_$releasever)"
+    baseurl: "http://widehat.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/{{ crio_version }}/CentOS_$releasever/"
     gpgcheck: yes
-    gpgkey: "http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/{{ crio_version }}/CentOS_$releasever/repodata/repomd.xml.key"
+    gpgkey: "http://widehat.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/{{ crio_version }}/CentOS_$releasever/repodata/repomd.xml.key"
   when: ansible_distribution in ["CentOS"]
 
 - name: Enable modular repos for CRI-O

--- a/roles/container-engine/cri-o/templates/crio.conf.j2
+++ b/roles/container-engine/cri-o/templates/crio.conf.j2
@@ -106,7 +106,7 @@ seccomp_profile = "{{crio_seccomp_profile}}"
 
 # Used to change the name of the default AppArmor profile of CRI-O. The default
 # profile name is "crio-default-" followed by the version string of CRI-O.
-apparmor_profile = "crio-default"
+# apparmor_profile = "crio-default"
 
 # Cgroup management implementation used for the runtime.
 cgroup_manager = "{{crio_cgroup_manager}}"

--- a/roles/container-engine/cri-o/vars/ubuntu.yml
+++ b/roles/container-engine/cri-o/vars/ubuntu.yml
@@ -4,3 +4,8 @@ crio_packages:
   - "cri-o-{{ crio_version }}"
 
 crio_runc_path: /usr/sbin/runc
+
+crio_kubernetes_version_matrix:
+  "1.18": "1.17"
+  "1.17": "1.17"
+  "1.16": "1.16"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Backport CRI-O bugfixes
- CentOS repositories redirect issue
- Enable CRI-O 1.18
- Ubuntu: AppArmor fix

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Backport #6224 
Backport #6197 
Backport #6125 
```
