### PR TITLE
Use a random subnet for elastx CI

### DIFF
--- a/.gitlab-ci/terraform.yml
+++ b/.gitlab-ci/terraform.yml
@@ -19,6 +19,8 @@
     - chmod 400 ~/.ssh/id_rsa
     - echo "$PACKET_PUBLIC_KEY" | base64 -d > ~/.ssh/id_rsa.pub
     - mkdir -p group_vars
+    # Random subnet to avoid routing conflicts
+    - export TF_VAR_subnet_cidr="10.$(( $RANDOM % 256 )).$(( $RANDOM % 256 )).0/24"
 
 .terraform_validate:
   extends: .terraform_install
@@ -167,59 +169,3 @@ tf-elastx_ubuntu18-calico:
     TF_VAR_flavor_k8s_node: 3f73fc93-ec61-4808-88df-2580d94c1a9b      # v1-standard-2
     TF_VAR_image: ubuntu-18.04-server-latest
     TF_VAR_k8s_allowed_remote_ips: '["0.0.0.0/0"]'
-
-# tf-ovh_ubuntu18-calico:
-#   extends: .terraform_apply
-#   when: on_success
-#   variables:
-#     <<: *ovh_variables
-#     TF_VERSION: 0.12.24
-#     PROVIDER: openstack
-#     CLUSTER: $CI_COMMIT_REF_NAME
-#     ANSIBLE_TIMEOUT: "60"
-#     SSH_USER: ubuntu
-#     TF_VAR_number_of_k8s_masters: "0"
-#     TF_VAR_number_of_k8s_masters_no_floating_ip: "1"
-#     TF_VAR_number_of_k8s_masters_no_floating_ip_no_etcd: "0"
-#     TF_VAR_number_of_etcd: "0"
-#     TF_VAR_number_of_k8s_nodes: "0"
-#     TF_VAR_number_of_k8s_nodes_no_floating_ip: "1"
-#     TF_VAR_number_of_gfs_nodes_no_floating_ip: "0"
-#     TF_VAR_number_of_bastions: "0"
-#     TF_VAR_number_of_k8s_masters_no_etcd: "0"
-#     TF_VAR_use_neutron: "0"
-#     TF_VAR_floatingip_pool: "Ext-Net"
-#     TF_VAR_external_net: "6011fbc9-4cbf-46a4-8452-6890a340b60b"
-#     TF_VAR_network_name: "Ext-Net"
-#     TF_VAR_flavor_k8s_master: "defa64c3-bd46-43b4-858a-d93bbae0a229"    # s1-8
-#     TF_VAR_flavor_k8s_node: "defa64c3-bd46-43b4-858a-d93bbae0a229"      # s1-8
-#     TF_VAR_image: "Ubuntu 18.04"
-#     TF_VAR_k8s_allowed_remote_ips: '["0.0.0.0/0"]'
-
-# tf-ovh_coreos-calico:
-#   extends: .terraform_apply
-#   when: on_success
-#   variables:
-#     <<: *ovh_variables
-#     TF_VERSION: 0.12.24
-#     PROVIDER: openstack
-#     CLUSTER: $CI_COMMIT_REF_NAME
-#     ANSIBLE_TIMEOUT: "60"
-#     SSH_USER: core
-#     TF_VAR_number_of_k8s_masters: "0"
-#     TF_VAR_number_of_k8s_masters_no_floating_ip: "1"
-#     TF_VAR_number_of_k8s_masters_no_floating_ip_no_etcd: "0"
-#     TF_VAR_number_of_etcd: "0"
-#     TF_VAR_number_of_k8s_nodes: "0"
-#     TF_VAR_number_of_k8s_nodes_no_floating_ip: "1"
-#     TF_VAR_number_of_gfs_nodes_no_floating_ip: "0"
-#     TF_VAR_number_of_bastions: "0"
-#     TF_VAR_number_of_k8s_masters_no_etcd: "0"
-#     TF_VAR_use_neutron: "0"
-#     TF_VAR_floatingip_pool: "Ext-Net"
-#     TF_VAR_external_net: "6011fbc9-4cbf-46a4-8452-6890a340b60b"
-#     TF_VAR_network_name: "Ext-Net"
-#     TF_VAR_flavor_k8s_master: "4d4fd037-9493-4f2b-9afe-b542b5248eac"    # b2-7
-#     TF_VAR_flavor_k8s_node: "4d4fd037-9493-4f2b-9afe-b542b5248eac"      # b2-7
-#     TF_VAR_image: "CoreOS Stable"
-#     TF_VAR_k8s_allowed_remote_ips: '["0.0.0.0/0"]'


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
`tf-elastx*` CI would fail if 2 jobs run in parallel ([example](https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/581161807)).

Also cleaning up the OVH comments, we can always use git history if needed.