### PR TITLE
Fix kubectl.sh parameter quoting

### DIFF
--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -106,7 +106,7 @@
   copy:
     content: |
       #!/bin/bash
-      ${BASH_SOURCE%/*}/kubectl --kubeconfig=${BASH_SOURCE%/*}/admin.conf $@
+      ${BASH_SOURCE%/*}/kubectl --kubeconfig=${BASH_SOURCE%/*}/admin.conf "$@"
     dest: "{{ artifacts_dir }}/kubectl.sh"
     mode: 0755
   become: no


### PR DESCRIPTION
**What type of PR is this?**

 /kind bug

**What this PR does / why we need it**:

This PR fixes kubectl.sh parameter quoting.

If the special parameter "$@" is not quoted, the following command will not work:

```
./kubectl.sh patch storageclass my-storage-class -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
```

For example:

```
$ ./kubectl.sh patch storageclass my-storage-class -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
error: there is no need to specify a resource type as a separate argument when passing arguments in resource/name form (e.g. 'kubectl get resource/<resource_name>' instead of 'kubectl get resource resource/<resource_name>'
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
kubectl.sh: fix parameter quoting
```
