### PR TITLE
Update deprecated api

### DIFF
--- a/roles/kubernetes-apps/csi_driver/aws_ebs/templates/aws-ebs-csi-driver.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/aws_ebs/templates/aws-ebs-csi-driver.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: ebs.csi.aws.com

--- a/roles/kubernetes-apps/csi_driver/azuredisk/templates/azure-csi-azuredisk-driver.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/azuredisk/templates/azure-csi-azuredisk-driver.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: disk.csi.azure.com

--- a/roles/kubernetes-apps/csi_driver/azuredisk/templates/azure-csi-node-info-crd.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/azuredisk/templates/azure-csi-node-info-crd.yml.j2
@@ -1,35 +1,39 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   name: csinodeinfos.csi.storage.k8s.io
 spec:
   group: csi.storage.k8s.io
+  scope: Cluster
   names:
     kind: CSINodeInfo
     plural: csinodeinfos
-  scope: Cluster
-  validation:
-    openAPIV3Schema:
-      properties:
-        csiDrivers:
-          description: List of CSI drivers running on the node and their properties.
-          items:
-            properties:
-              driver:
-                description: The CSI driver that this object refers to.
-                type: string
-              nodeID:
-                description: The node from the driver point of view.
-                type: string
-              topologyKeys:
-                description: List of keys supported by the driver.
-                items:
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          csiDrivers:
+            description: List of CSI drivers running on the node and their properties.
+            items:
+              properties:
+                driver:
+                  description: The CSI driver that this object refers to.
                   type: string
-                type: array
-          type: array
-  version: v1alpha1
+                nodeID:
+                  description: The node from the driver point of view.
+                  type: string
+                topologyKeys:
+                  description: List of keys supported by the driver.
+                  items:
+                    type: string
+                  type: array
+            type: array
 status:
   acceptedNames:
     kind: ""

--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-driver.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-driver.yml.j2
@@ -1,4 +1,4 @@
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: cinder.csi.openstack.org

--- a/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-controller-ss.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-controller-ss.yml.j2
@@ -119,7 +119,7 @@ spec:
             path: /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com
             type: DirectoryOrCreate
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: csi.vsphere.vmware.com

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/crd-certificate.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/crd-certificate.yml.j2
@@ -1,10 +1,11 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: certificates.certmanager.k8s.io
   annotations:
     "helm.sh/hook": crd-install
+    "api-approved.kubernetes.io": "unapproved-will-be-remove-with-cert-manager-update"
   labels:
     app: cert-manager
     chart: cert-manager-v0.5.2
@@ -12,8 +13,704 @@ metadata:
     heritage: Tiller
 spec:
   group: certmanager.k8s.io
-  version: v1alpha1
   scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        description: Certificate is a type to represent a Certificate from ACME
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CertificateSpec defines the desired state of Certificate.
+              A valid Certificate requires at least one of a CommonName, DNSName,
+              or URISAN to be valid.
+            type: object
+            required:
+            - issuerRef
+            - secretName
+            properties:
+              commonName:
+                description: 'CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to
+                  avoid generating invalid CSRs. This value is ignored by TLS clients
+                  when any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4'
+                type: string
+              dnsNames:
+                description: DNSNames is a list of subject alt names to be used on
+                  the Certificate.
+                type: array
+                items:
+                  type: string
+              duration:
+                description: Certificate default Duration
+                type: string
+              emailSANs:
+                description: EmailSANs is a list of Email Subject Alternative Names
+                  to be set on this Certificate.
+                type: array
+                items:
+                  type: string
+              ipAddresses:
+                description: IPAddresses is a list of IP addresses to be used on the
+                  Certificate
+                type: array
+                items:
+                  type: string
+              isCA:
+                description: IsCA will mark this Certificate as valid for signing.
+                  This implies that the 'cert sign' usage is set
+                type: boolean
+              issuerRef:
+                description: IssuerRef is a reference to the issuer for this certificate.
+                  If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                  with the given name in the same namespace as the Certificate will
+                  be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                  with the provided name will be used. The 'name' field in this stanza
+                  is required at all times.
+                type: object
+                required:
+                - name
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+              keyAlgorithm:
+                description: KeyAlgorithm is the private key algorithm of the corresponding
+                  private key for this certificate. If provided, allowed values are
+                  either "rsa" or "ecdsa" If KeyAlgorithm is specified and KeySize
+                  is not provided, key size of 256 will be used for "ecdsa" key algorithm
+                  and key size of 2048 will be used for "rsa" key algorithm.
+                type: string
+                enum:
+                - rsa
+                - ecdsa
+              keyEncoding:
+                description: KeyEncoding is the private key cryptography standards
+                  (PKCS) for this certificate's private key to be encoded in. If provided,
+                  allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8,
+                  respectively. If KeyEncoding is not specified, then PKCS#1 will
+                  be used by default.
+                type: string
+                enum:
+                - pkcs1
+                - pkcs8
+              keySize:
+                description: KeySize is the key bit size of the corresponding private
+                  key for this certificate. If provided, value must be between 2048
+                  and 8192 inclusive when KeyAlgorithm is empty or is set to "rsa",
+                  and value must be one of (256, 384, 521) when KeyAlgorithm is set
+                  to "ecdsa".
+                type: integer
+                maximum: 8192
+                minimum: 0
+              keystores:
+                description: Keystores configures additional keystore output formats
+                  stored in the `secretName` Secret resource.
+                type: object
+                properties:
+                  jks:
+                    description: JKS configures options for storing a JKS keystore
+                      in the `spec.secretName` Secret resource.
+                    type: object
+                    required:
+                    - create
+                    - passwordSecretRef
+                    properties:
+                      create:
+                        description: Create enables JKS keystore creation for the
+                          Certificate. If true, a file named `keystore.jks` will be
+                          created in the target Secret resource, encrypted using the
+                          password stored in `passwordSecretRef`. The keystore file
+                          will only be updated upon re-issuance.
+                        type: boolean
+                      passwordSecretRef:
+                        description: PasswordSecretRef is a reference to a key in
+                          a Secret resource containing the password used to encrypt
+                          the JKS keystore.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the secret to select from. Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                  pkcs12:
+                    description: PKCS12 configures options for storing a PKCS12 keystore
+                      in the `spec.secretName` Secret resource.
+                    type: object
+                    required:
+                    - create
+                    - passwordSecretRef
+                    properties:
+                      create:
+                        description: Create enables PKCS12 keystore creation for the
+                          Certificate. If true, a file named `keystore.p12` will be
+                          created in the target Secret resource, encrypted using the
+                          password stored in `passwordSecretRef`. The keystore file
+                          will only be updated upon re-issuance.
+                        type: boolean
+                      passwordSecretRef:
+                        description: PasswordSecretRef is a reference to a key in
+                          a Secret resource containing the password used to encrypt
+                          the PKCS12 keystore.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the secret to select from. Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+              organization:
+                description: Organization is the organization to be used on the Certificate
+                type: array
+                items:
+                  type: string
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                type: object
+                properties:
+                  rotationPolicy:
+                    description: RotationPolicy controls how private keys should be
+                      regenerated when a re-issuance is being processed. If set to
+                      Never, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exists
+                      but it does not have the correct algorithm or size, a warning
+                      will be raised to await user intervention. If set to Always,
+                      a private key matching the specified requirements will be generated
+                      whenever a re-issuance occurs. Default is 'Never' for backward
+                      compatibility.
+                    type: string
+              renewBefore:
+                description: Certificate renew before expiration duration
+                type: string
+              secretName:
+                description: SecretName is the name of the secret resource to store
+                  this secret in
+                type: string
+              subject:
+                description: Full X509 name specification (https://golang.org/pkg/crypto/x509/pkix/#Name).
+                type: object
+                properties:
+                  countries:
+                    description: Countries to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  localities:
+                    description: Cities to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  organizationalUnits:
+                    description: Organizational Units to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  postalCodes:
+                    description: Postal codes to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  provinces:
+                    description: State/Provinces to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  serialNumber:
+                    description: Serial number to be used on the Certificate.
+                    type: string
+                  streetAddresses:
+                    description: Street addresses to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+              uriSANs:
+                description: URISANs is a list of URI Subject Alternative Names to
+                  be set on this Certificate.
+                type: array
+                items:
+                  type: string
+              usages:
+                description: Usages is the set of x509 actions that are enabled for
+                  a given key. Defaults are ('digital signature', 'key encipherment')
+                  if empty
+                type: array
+                items:
+                  description: 'KeyUsage specifies valid usage contexts for keys.
+                    See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+                    Valid KeyUsage values are as follows: "signing", "digital signature",
+                    "content commitment", "key encipherment", "key agreement", "data
+                    encipherment", "cert sign", "crl sign", "encipher only", "decipher
+                    only", "any", "server auth", "client auth", "code signing", "email
+                    protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec
+                    user", "timestamping", "ocsp signing", "microsoft sgc", "netscape
+                    sgc"'
+                  type: string
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+          status:
+            description: CertificateStatus defines the observed state of Certificate
+            type: object
+            properties:
+              conditions:
+                type: array
+                items:
+                  description: CertificateCondition contains condition information
+                    for an Certificate.
+                  type: object
+                  required:
+                  - status
+                  - type
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the timestamp corresponding
+                        to the last status change of this condition.
+                      type: string
+                      format: date-time
+                    message:
+                      description: Message is a human readable description of the
+                        details of the last transition, complementing reason.
+                      type: string
+                    reason:
+                      description: Reason is a brief machine readable explanation
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of ('True', 'False',
+                        'Unknown').
+                      type: string
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                    type:
+                      description: Type of the condition, currently ('Ready').
+                      type: string
+              lastFailureTime:
+                type: string
+                format: date-time
+              nextPrivateKeySecretName:
+                description: The name of the Secret resource containing the private
+                  key to be used for the next certificate iteration. The keymanager
+                  controller will automatically set this field if the `Issuing` condition
+                  is set to `True`. It will automatically unset this field when the
+                  Issuing condition is not set or False.
+                type: string
+              notAfter:
+                description: The expiration time of the certificate stored in the
+                  secret named by this resource in spec.secretName.
+                type: string
+                format: date-time
+              revision:
+                description: "The current 'revision' of the certificate as issued.
+                  \n When a CertificateRequest resource is created, it will have the
+                  `cert-manager.io/certificate-revision` set to one greater than the
+                  current value of this field. \n Upon issuance, this field will be
+                  set to the value of the annotation on the CertificateRequest resource
+                  used to issue the certificate. \n Persisting the value on the CertificateRequest
+                  resource allows the certificates controller to know whether a request
+                  is part of an old issuance or if it is part of the ongoing revision's
+                  issuance by checking if the revision value in the annotation is
+                  greater than this field."
+                type: integer
+  - name: v1alpha3
+    served: true
+    storage: false
+    "schema":
+      "openAPIV3Schema":
+        description: Certificate is a type to represent a Certificate from ACME
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CertificateSpec defines the desired state of Certificate.
+              A valid Certificate requires at least one of a CommonName, DNSName,
+              or URISAN to be valid.
+            type: object
+            required:
+            - issuerRef
+            - secretName
+            properties:
+              commonName:
+                description: 'CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to
+                  avoid generating invalid CSRs. This value is ignored by TLS clients
+                  when any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4'
+                type: string
+              dnsNames:
+                description: DNSNames is a list of subject alt names to be used on
+                  the Certificate.
+                type: array
+                items:
+                  type: string
+              duration:
+                description: Certificate default Duration
+                type: string
+              emailSANs:
+                description: EmailSANs is a list of Email Subject Alternative Names
+                  to be set on this Certificate.
+                type: array
+                items:
+                  type: string
+              ipAddresses:
+                description: IPAddresses is a list of IP addresses to be used on the
+                  Certificate
+                type: array
+                items:
+                  type: string
+              isCA:
+                description: IsCA will mark this Certificate as valid for signing.
+                  This implies that the 'cert sign' usage is set
+                type: boolean
+              issuerRef:
+                description: IssuerRef is a reference to the issuer for this certificate.
+                  If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                  with the given name in the same namespace as the Certificate will
+                  be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                  with the provided name will be used. The 'name' field in this stanza
+                  is required at all times.
+                type: object
+                required:
+                - name
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+              keyAlgorithm:
+                description: KeyAlgorithm is the private key algorithm of the corresponding
+                  private key for this certificate. If provided, allowed values are
+                  either "rsa" or "ecdsa" If KeyAlgorithm is specified and KeySize
+                  is not provided, key size of 256 will be used for "ecdsa" key algorithm
+                  and key size of 2048 will be used for "rsa" key algorithm.
+                type: string
+                enum:
+                - rsa
+                - ecdsa
+              keyEncoding:
+                description: KeyEncoding is the private key cryptography standards
+                  (PKCS) for this certificate's private key to be encoded in. If provided,
+                  allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8,
+                  respectively. If KeyEncoding is not specified, then PKCS#1 will
+                  be used by default.
+                type: string
+                enum:
+                - pkcs1
+                - pkcs8
+              keySize:
+                description: KeySize is the key bit size of the corresponding private
+                  key for this certificate. If provided, value must be between 2048
+                  and 8192 inclusive when KeyAlgorithm is empty or is set to "rsa",
+                  and value must be one of (256, 384, 521) when KeyAlgorithm is set
+                  to "ecdsa".
+                type: integer
+                maximum: 8192
+                minimum: 0
+              keystores:
+                description: Keystores configures additional keystore output formats
+                  stored in the `secretName` Secret resource.
+                type: object
+                properties:
+                  jks:
+                    description: JKS configures options for storing a JKS keystore
+                      in the `spec.secretName` Secret resource.
+                    type: object
+                    required:
+                    - create
+                    - passwordSecretRef
+                    properties:
+                      create:
+                        description: Create enables JKS keystore creation for the
+                          Certificate. If true, a file named `keystore.jks` will be
+                          created in the target Secret resource, encrypted using the
+                          password stored in `passwordSecretRef`. The keystore file
+                          will only be updated upon re-issuance.
+                        type: boolean
+                      passwordSecretRef:
+                        description: PasswordSecretRef is a reference to a key in
+                          a Secret resource containing the password used to encrypt
+                          the JKS keystore.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the secret to select from. Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                  pkcs12:
+                    description: PKCS12 configures options for storing a PKCS12 keystore
+                      in the `spec.secretName` Secret resource.
+                    type: object
+                    required:
+                    - create
+                    - passwordSecretRef
+                    properties:
+                      create:
+                        description: Create enables PKCS12 keystore creation for the
+                          Certificate. If true, a file named `keystore.p12` will be
+                          created in the target Secret resource, encrypted using the
+                          password stored in `passwordSecretRef`. The keystore file
+                          will only be updated upon re-issuance.
+                        type: boolean
+                      passwordSecretRef:
+                        description: PasswordSecretRef is a reference to a key in
+                          a Secret resource containing the password used to encrypt
+                          the PKCS12 keystore.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the secret to select from. Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                type: object
+                properties:
+                  rotationPolicy:
+                    description: RotationPolicy controls how private keys should be
+                      regenerated when a re-issuance is being processed. If set to
+                      Never, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exists
+                      but it does not have the correct algorithm or size, a warning
+                      will be raised to await user intervention. If set to Always,
+                      a private key matching the specified requirements will be generated
+                      whenever a re-issuance occurs. Default is 'Never' for backward
+                      compatibility.
+                    type: string
+              renewBefore:
+                description: Certificate renew before expiration duration
+                type: string
+              secretName:
+                description: SecretName is the name of the secret resource to store
+                  this secret in
+                type: string
+              subject:
+                description: Full X509 name specification (https://golang.org/pkg/crypto/x509/pkix/#Name).
+                type: object
+                properties:
+                  countries:
+                    description: Countries to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  localities:
+                    description: Cities to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  organizationalUnits:
+                    description: Organizational Units to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  organizations:
+                    description: Organizations to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  postalCodes:
+                    description: Postal codes to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  provinces:
+                    description: State/Provinces to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  serialNumber:
+                    description: Serial number to be used on the Certificate.
+                    type: string
+                  streetAddresses:
+                    description: Street addresses to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+              uriSANs:
+                description: URISANs is a list of URI Subject Alternative Names to
+                  be set on this Certificate.
+                type: array
+                items:
+                  type: string
+              usages:
+                description: Usages is the set of x509 actions that are enabled for
+                  a given key. Defaults are ('digital signature', 'key encipherment')
+                  if empty
+                type: array
+                items:
+                  description: 'KeyUsage specifies valid usage contexts for keys.
+                    See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+                    Valid KeyUsage values are as follows: "signing", "digital signature",
+                    "content commitment", "key encipherment", "key agreement", "data
+                    encipherment", "cert sign", "crl sign", "encipher only", "decipher
+                    only", "any", "server auth", "client auth", "code signing", "email
+                    protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec
+                    user", "timestamping", "ocsp signing", "microsoft sgc", "netscape
+                    sgc"'
+                  type: string
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+          status:
+            description: CertificateStatus defines the observed state of Certificate
+            type: object
+            properties:
+              conditions:
+                type: array
+                items:
+                  description: CertificateCondition contains condition information
+                    for an Certificate.
+                  type: object
+                  required:
+                  - status
+                  - type
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the timestamp corresponding
+                        to the last status change of this condition.
+                      type: string
+                      format: date-time
+                    message:
+                      description: Message is a human readable description of the
+                        details of the last transition, complementing reason.
+                      type: string
+                    reason:
+                      description: Reason is a brief machine readable explanation
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of ('True', 'False',
+                        'Unknown').
+                      type: string
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                    type:
+                      description: Type of the condition, currently ('Ready').
+                      type: string
+              lastFailureTime:
+                type: string
+                format: date-time
+              nextPrivateKeySecretName:
+                description: The name of the Secret resource containing the private
+                  key to be used for the next certificate iteration. The keymanager
+                  controller will automatically set this field if the `Issuing` condition
+                  is set to `True`. It will automatically unset this field when the
+                  Issuing condition is not set or False.
+                type: string
+              notAfter:
+                description: The expiration time of the certificate stored in the
+                  secret named by this resource in spec.secretName.
+                type: string
+                format: date-time
+              revision:
+                description: "The current 'revision' of the certificate as issued.
+                  \n When a CertificateRequest resource is created, it will have the
+                  `cert-manager.io/certificate-revision` set to one greater than the
+                  current value of this field. \n Upon issuance, this field will be
+                  set to the value of the annotation on the CertificateRequest resource
+                  used to issue the certificate. \n Persisting the value on the CertificateRequest
+                  resource allows the certificates controller to know whether a request
+                  is part of an old issuance or if it is part of the ongoing revision's
+                  issuance by checking if the revision value in the annotation is
+                  greater than this field."
+                type: integer
   names:
     kind: Certificate
     plural: certificates

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/crd-clusterissuer.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/crd-clusterissuer.yml.j2
@@ -1,10 +1,11 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterissuers.certmanager.k8s.io
   annotations:
     "helm.sh/hook": crd-install
+    "api-approved.kubernetes.io": "unapproved-will-be-remove-with-cert-manager-update"
   labels:
     app: cert-manager
     chart: cert-manager-v0.5.2
@@ -12,8 +13,1762 @@ metadata:
     heritage: Tiller
 spec:
   group: certmanager.k8s.io
-  version: v1alpha1
+  scope: Cluster
   names:
     kind: ClusterIssuer
     plural: clusterissuers
-  scope: Cluster
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: IssuerSpec is the specification of an Issuer. This includes
+                any configuration required for the issuer.
+              type: object
+              properties:
+                acme:
+                  description: ACMEIssuer contains the specification for an ACME issuer
+                  type: object
+                  required:
+                  - privateKeySecretRef
+                  - server
+                  properties:
+                    email:
+                      description: Email is the email for this account
+                      type: string
+                    externalAccountBinding:
+                      description: ExternalAccountBinding is a reference to a CA external
+                        account of the ACME server.
+                      type: object
+                      required:
+                      - keyAlgorithm
+                      - keyID
+                      - keySecretRef
+                      properties:
+                        keyAlgorithm:
+                          description: keyAlgorithm is the MAC key algorithm that the
+                            key is used for. Valid values are "HS256", "HS384" and "HS512".
+                          type: string
+                          enum:
+                          - HS256
+                          - HS384
+                          - HS512
+                        keyID:
+                          description: keyID is the ID of the CA key that the External
+                            Account is bound to.
+                          type: string
+                        keySecretRef:
+                          description: keySecretRef is a Secret Key Selector referencing
+                            a data item in a Kubernetes Secret which holds the symmetric
+                            MAC key of the External Account Binding. The `key` is the
+                            index string that is paired with the key data in the Secret
+                            and should not be confused with the key data itself, or indeed
+                            with the External Account Binding keyID above. The secret
+                            key stored in the Secret **must** be un-padded, base64 URL
+                            encoded data.
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                    privateKeySecretRef:
+                      description: PrivateKey is the name of a secret containing the private
+                        key for this user account.
+                      type: object
+                      required:
+                      - name
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must be a
+                            valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                    server:
+                      description: Server is the ACME server URL
+                      type: string
+                    skipTLSVerify:
+                      description: If true, skip verifying the ACME server TLS certificate
+                      type: boolean
+                    solvers:
+                      description: Solvers is a list of challenge solvers that will be
+                        used to solve ACME challenges for the matching domains.
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          dns01:
+                            type: object
+                            properties:
+                              acmedns:
+                                description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
+                                  containing the configuration for ACME-DNS servers
+                                type: object
+                                required:
+                                - accountSecretRef
+                                - host
+                                properties:
+                                  accountSecretRef:
+                                    type: object
+                                    required:
+                                    - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind,
+                                          uid?'
+                                        type: string
+                                  host:
+                                    type: string
+                              akamai:
+                                description: ACMEIssuerDNS01ProviderAkamai is a structure
+                                  containing the DNS configuration for Akamai DNS—Zone
+                                  Record Management API
+                                type: object
+                                required:
+                                - accessTokenSecretRef
+                                - clientSecretSecretRef
+                                - clientTokenSecretRef
+                                - serviceConsumerDomain
+                                properties:
+                                  accessTokenSecretRef:
+                                    type: object
+                                    required:
+                                    - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind,
+                                          uid?'
+                                        type: string
+                                  clientSecretSecretRef:
+                                    type: object
+                                    required:
+                                    - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind,
+                                          uid?'
+                                        type: string
+                                  clientTokenSecretRef:
+                                    type: object
+                                    required:
+                                    - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind,
+                                          uid?'
+                                        type: string
+                                  serviceConsumerDomain:
+                                    type: string
+                              azuredns:
+                                description: ACMEIssuerDNS01ProviderAzureDNS is a structure
+                                  containing the configuration for Azure DNS
+                                type: object
+                                required:
+                                - resourceGroupName
+                                - subscriptionID
+                                properties:
+                                  clientID:
+                                    description: if both this and ClientSecret are left
+                                      unset MSI will be used
+                                    type: string
+                                  clientSecretSecretRef:
+                                    description: if both this and ClientID are left unset
+                                      MSI will be used
+                                    type: object
+                                    required:
+                                    - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind,
+                                          uid?'
+                                        type: string
+                                  environment:
+                                    type: string
+                                    enum:
+                                    - AzurePublicCloud
+                                    - AzureChinaCloud
+                                    - AzureGermanCloud
+                                    - AzureUSGovernmentCloud
+                                  hostedZoneName:
+                                    type: string
+                                  resourceGroupName:
+                                    type: string
+                                  subscriptionID:
+                                    type: string
+                                  tenantID:
+                                    description: when specifying ClientID and ClientSecret
+                                      then this field is also needed
+                                    type: string
+                              clouddns:
+                                description: ACMEIssuerDNS01ProviderCloudDNS is a structure
+                                  containing the DNS configuration for Google Cloud DNS
+                                type: object
+                                required:
+                                - project
+                                properties:
+                                  project:
+                                    type: string
+                                  serviceAccountSecretRef:
+                                    type: object
+                                    required:
+                                    - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind,
+                                          uid?'
+                                        type: string
+                              cloudflare:
+                                description: ACMEIssuerDNS01ProviderCloudflare is a structure
+                                  containing the DNS configuration for Cloudflare
+                                type: object
+                                required:
+                                - email
+                                properties:
+                                  apiKeySecretRef:
+                                    type: object
+                                    required:
+                                    - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind,
+                                          uid?'
+                                        type: string
+                                  apiTokenSecretRef:
+                                    type: object
+                                    required:
+                                    - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind,
+                                          uid?'
+                                        type: string
+                                  email:
+                                    type: string
+                              cnameStrategy:
+                                description: CNAMEStrategy configures how the DNS01 provider
+                                  should handle CNAME records when found in DNS zones.
+                                type: string
+                                enum:
+                                - None
+                                - Follow
+                              digitalocean:
+                                description: ACMEIssuerDNS01ProviderDigitalOcean is a
+                                  structure containing the DNS configuration for DigitalOcean
+                                  Domains
+                                type: object
+                                required:
+                                - tokenSecretRef
+                                properties:
+                                  tokenSecretRef:
+                                    type: object
+                                    required:
+                                    - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind,
+                                          uid?'
+                                        type: string
+                              rfc2136:
+                                description: ACMEIssuerDNS01ProviderRFC2136 is a structure
+                                  containing the configuration for RFC2136 DNS
+                                type: object
+                                required:
+                                - nameserver
+                                properties:
+                                  nameserver:
+                                    description: The IP address or hostname of an authoritative
+                                      DNS server supporting RFC2136 in the form host:port.
+                                      If the host is an IPv6 address it must be enclosed
+                                      in square brackets (e.g [2001:db8::1]) ; port is
+                                      optional. This field is required.
+                                    type: string
+                                  tsigAlgorithm:
+                                    description: 'The TSIG Algorithm configured in the
+                                      DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                                      and ``tsigKeyName`` are defined. Supported values
+                                      are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
+                                      ``HMACSHA256`` or ``HMACSHA512``.'
+                                    type: string
+                                  tsigKeyName:
+                                    description: The TSIG Key name configured in the DNS.
+                                      If ``tsigSecretSecretRef`` is defined, this field
+                                      is required.
+                                    type: string
+                                  tsigSecretSecretRef:
+                                    description: The name of the secret containing the
+                                      TSIG value. If ``tsigKeyName`` is defined, this
+                                      field is required.
+                                    type: object
+                                    required:
+                                    - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind,
+                                          uid?'
+                                        type: string
+                              route53:
+                                description: ACMEIssuerDNS01ProviderRoute53 is a structure
+                                  containing the Route 53 configuration for AWS
+                                type: object
+                                required:
+                                - region
+                                properties:
+                                  accessKeyID:
+                                    description: 'The AccessKeyID is used for authentication.
+                                      If not set we fall-back to using env vars, shared
+                                      credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                    type: string
+                                  hostedZoneID:
+                                    description: If set, the provider will manage only
+                                      this zone in Route53 and will not do an lookup using
+                                      the route53:ListHostedZonesByName api call.
+                                    type: string
+                                  region:
+                                    description: Always set the region when using AccessKeyID
+                                      and SecretAccessKey
+                                    type: string
+                                  role:
+                                    description: Role is a Role ARN which the Route53
+                                      provider will assume using either the explicit credentials
+                                      AccessKeyID/SecretAccessKey or the inferred credentials
+                                      from environment variables, shared credentials file
+                                      or AWS Instance metadata
+                                    type: string
+                                  secretAccessKeySecretRef:
+                                    description: The SecretAccessKey is used for authentication.
+                                      If not set we fall-back to using env vars, shared
+                                      credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    type: object
+                                    required:
+                                    - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind,
+                                          uid?'
+                                        type: string
+                              webhook:
+                                description: ACMEIssuerDNS01ProviderWebhook specifies
+                                  configuration for a webhook DNS01 provider, including
+                                  where to POST ChallengePayload resources.
+                                type: object
+                                required:
+                                - groupName
+                                - solverName
+                                properties:
+                                  config:
+                                    description: Additional configuration that should
+                                      be passed to the webhook apiserver when challenges
+                                      are processed. This can contain arbitrary JSON data.
+                                      Secret values should not be specified in this stanza.
+                                      If secret values are needed (e.g. credentials for
+                                      a DNS service), you should use a SecretKeySelector
+                                      to reference a Secret resource. For details on the
+                                      schema of this field, consult the webhook provider
+                                      implementation's documentation.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  groupName:
+                                    description: The API group name that should be used
+                                      when POSTing ChallengePayload resources to the webhook
+                                      apiserver. This should be the same as the GroupName
+                                      specified in the webhook provider implementation.
+                                    type: string
+                                  solverName:
+                                    description: The name of the solver to use, as defined
+                                      in the webhook provider implementation. This will
+                                      typically be the name of the provider, e.g. 'cloudflare'.
+                                    type: string
+                          http01:
+                            description: ACMEChallengeSolverHTTP01 contains configuration
+                              detailing how to solve HTTP01 challenges within a Kubernetes
+                              cluster. Typically this is accomplished through creating
+                              'routes' of some description that configure ingress controllers
+                              to direct traffic to 'solver pods', which are responsible
+                              for responding to the ACME server's HTTP requests.
+                            type: object
+                            properties:
+                              ingress:
+                                description: The ingress based HTTP01 challenge solver
+                                  will solve challenges by creating or modifying Ingress
+                                  resources in order to route requests for '/.well-known/acme-challenge/XYZ'
+                                  to 'challenge solver' pods that are provisioned by cert-manager
+                                  for each Challenge to be completed.
+                                type: object
+                                properties:
+                                  class:
+                                    description: The ingress class to use when creating
+                                      Ingress resources to solve ACME challenges that
+                                      use this challenge solver. Only one of 'class' or
+                                      'name' may be specified.
+                                    type: string
+                                  ingressTemplate:
+                                    description: Optional ingress template used to configure
+                                      the ACME challenge solver ingress used for HTTP01
+                                      challenges
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the ingress
+                                          used to solve HTTP01 challenges. Only the 'labels'
+                                          and 'annotations' fields may be set. If labels
+                                          or annotations overlap with in-built values,
+                                          the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added
+                                              to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to
+                                              the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                  name:
+                                    description: The name of the ingress resource that
+                                      should have ACME challenge solving routes inserted
+                                      into it in order to solve HTTP01 challenges. This
+                                      is typically used in conjunction with ingress controllers
+                                      like ingress-gce, which maintains a 1:1 mapping
+                                      between external IPs and ingress resources.
+                                    type: string
+                                  podTemplate:
+                                    description: Optional pod template used to configure
+                                      the ACME challenge solver pods used for HTTP01 challenges
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the pod
+                                          used to solve HTTP01 challenges. Only the 'labels'
+                                          and 'annotations' fields may be set. If labels
+                                          or annotations overlap with in-built values,
+                                          the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added
+                                              to the create ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to
+                                              the created ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                      spec:
+                                        description: PodSpec defines overrides for the
+                                          HTTP01 challenge solver pod. Only the 'nodeSelector',
+                                          'affinity' and 'tolerations' fields are supported
+                                          currently. All other fields will be ignored.
+                                        type: object
+                                        properties:
+                                          affinity:
+                                            description: If specified, the pod's scheduling
+                                              constraints
+                                            type: object
+                                            properties:
+                                              nodeAffinity:
+                                                description: Describes node affinity scheduling
+                                                  rules for the pod.
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer
+                                                      to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified
+                                                      by this field, but it may choose
+                                                      a node that violates one or more
+                                                      of the expressions. The node that
+                                                      is most preferred is the one with
+                                                      the greatest sum of weights, i.e.
+                                                      for each node that meets all of
+                                                      the scheduling requirements (resource
+                                                      request, requiredDuringScheduling
+                                                      affinity expressions, etc.), compute
+                                                      a sum by iterating through the elements
+                                                      of this field and adding "weight"
+                                                      to the sum if the node matches the
+                                                      corresponding matchExpressions;
+                                                      the node(s) with the highest sum
+                                                      are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: An empty preferred
+                                                        scheduling term matches all objects
+                                                        with implicit weight 0 (i.e. it's
+                                                        a no-op). A null preferred scheduling
+                                                        term matches no objects (i.e.
+                                                        is also a no-op).
+                                                      type: object
+                                                      required:
+                                                      - preference
+                                                      - weight
+                                                      properties:
+                                                        preference:
+                                                          description: A node selector
+                                                            term, associated with the
+                                                            corresponding weight.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node
+                                                                selector requirements
+                                                                by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label
+                                                                      key that the selector
+                                                                      applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents
+                                                                      a key's relationship
+                                                                      to a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists,
+                                                                      DoesNotExist. Gt,
+                                                                      and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. If
+                                                                      the operator is
+                                                                      Gt or Lt, the values
+                                                                      array must have
+                                                                      a single element,
+                                                                      which will be interpreted
+                                                                      as an integer. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node
+                                                                selector requirements
+                                                                by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label
+                                                                      key that the selector
+                                                                      applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents
+                                                                      a key's relationship
+                                                                      to a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists,
+                                                                      DoesNotExist. Gt,
+                                                                      and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. If
+                                                                      the operator is
+                                                                      Gt or Lt, the values
+                                                                      array must have
+                                                                      a single element,
+                                                                      which will be interpreted
+                                                                      as an integer. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                        weight:
+                                                          description: Weight associated
+                                                            with matching the corresponding
+                                                            nodeSelectorTerm, in the range
+                                                            1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements
+                                                      specified by this field are not
+                                                      met at scheduling time, the pod
+                                                      will not be scheduled onto the node.
+                                                      If the affinity requirements specified
+                                                      by this field cease to be met at
+                                                      some point during pod execution
+                                                      (e.g. due to an update), the system
+                                                      may or may not try to eventually
+                                                      evict the pod from its node.
+                                                    type: object
+                                                    required:
+                                                    - nodeSelectorTerms
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        description: Required. A list
+                                                          of node selector terms. The
+                                                          terms are ORed.
+                                                        type: array
+                                                        items:
+                                                          description: A null or empty
+                                                            node selector term matches
+                                                            no objects. The requirements
+                                                            of them are ANDed. The TopologySelectorTerm
+                                                            type implements a subset of
+                                                            the NodeSelectorTerm.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node
+                                                                selector requirements
+                                                                by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label
+                                                                      key that the selector
+                                                                      applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents
+                                                                      a key's relationship
+                                                                      to a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists,
+                                                                      DoesNotExist. Gt,
+                                                                      and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. If
+                                                                      the operator is
+                                                                      Gt or Lt, the values
+                                                                      array must have
+                                                                      a single element,
+                                                                      which will be interpreted
+                                                                      as an integer. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node
+                                                                selector requirements
+                                                                by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label
+                                                                      key that the selector
+                                                                      applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents
+                                                                      a key's relationship
+                                                                      to a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists,
+                                                                      DoesNotExist. Gt,
+                                                                      and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. If
+                                                                      the operator is
+                                                                      Gt or Lt, the values
+                                                                      array must have
+                                                                      a single element,
+                                                                      which will be interpreted
+                                                                      as an integer. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                              podAffinity:
+                                                description: Describes pod affinity scheduling
+                                                  rules (e.g. co-locate this pod in the
+                                                  same node, zone, etc. as some other
+                                                  pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer
+                                                      to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified
+                                                      by this field, but it may choose
+                                                      a node that violates one or more
+                                                      of the expressions. The node that
+                                                      is most preferred is the one with
+                                                      the greatest sum of weights, i.e.
+                                                      for each node that meets all of
+                                                      the scheduling requirements (resource
+                                                      request, requiredDuringScheduling
+                                                      affinity expressions, etc.), compute
+                                                      a sum by iterating through the elements
+                                                      of this field and adding "weight"
+                                                      to the sum if the node has pods
+                                                      which matches the corresponding
+                                                      podAffinityTerm; the node(s) with
+                                                      the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all
+                                                        of the matched WeightedPodAffinityTerm
+                                                        fields are added per-node to find
+                                                        the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                      - podAffinityTerm
+                                                      - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod
+                                                            affinity term, associated
+                                                            with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                          - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query
+                                                                over a set of resources,
+                                                                in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions
+                                                                    is a list of label
+                                                                    selector requirements.
+                                                                    The requirements are
+                                                                    ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label
+                                                                      selector requirement
+                                                                      is a selector that
+                                                                      contains values,
+                                                                      a key, and an operator
+                                                                      that relates the
+                                                                      key and values.
+                                                                    type: object
+                                                                    required:
+                                                                    - key
+                                                                    - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key
+                                                                          is the label
+                                                                          key that the
+                                                                          selector applies
+                                                                          to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator
+                                                                          represents a
+                                                                          key's relationship
+                                                                          to a set of
+                                                                          values. Valid
+                                                                          operators are
+                                                                          In, NotIn, Exists
+                                                                          and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values
+                                                                          is an array
+                                                                          of string values.
+                                                                          If the operator
+                                                                          is In or NotIn,
+                                                                          the values array
+                                                                          must be non-empty.
+                                                                          If the operator
+                                                                          is Exists or
+                                                                          DoesNotExist,
+                                                                          the values array
+                                                                          must be empty.
+                                                                          This array is
+                                                                          replaced during
+                                                                          a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels
+                                                                    is a map of {key,value}
+                                                                    pairs. A single {key,value}
+                                                                    in the matchLabels
+                                                                    map is equivalent
+                                                                    to an element of matchExpressions,
+                                                                    whose key field is
+                                                                    "key", the operator
+                                                                    is "In", and the values
+                                                                    array contains only
+                                                                    "value". The requirements
+                                                                    are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces
+                                                                specifies which namespaces
+                                                                the labelSelector applies
+                                                                to (matches against);
+                                                                null or empty list means
+                                                                "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should
+                                                                be co-located (affinity)
+                                                                or not co-located (anti-affinity)
+                                                                with the pods matching
+                                                                the labelSelector in the
+                                                                specified namespaces,
+                                                                where co-located is defined
+                                                                as running on a node whose
+                                                                value of the label with
+                                                                key topologyKey matches
+                                                                that of any node on which
+                                                                any of the selected pods
+                                                                is running. Empty topologyKey
+                                                                is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated
+                                                            with matching the corresponding
+                                                            podAffinityTerm, in the range
+                                                            1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements
+                                                      specified by this field are not
+                                                      met at scheduling time, the pod
+                                                      will not be scheduled onto the node.
+                                                      If the affinity requirements specified
+                                                      by this field cease to be met at
+                                                      some point during pod execution
+                                                      (e.g. due to a pod label update),
+                                                      the system may or may not try to
+                                                      eventually evict the pod from its
+                                                      node. When there are multiple elements,
+                                                      the lists of nodes corresponding
+                                                      to each podAffinityTerm are intersected,
+                                                      i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods
+                                                        (namely those matching the labelSelector
+                                                        relative to the given namespace(s))
+                                                        that this pod should be co-located
+                                                        (affinity) or not co-located (anti-affinity)
+                                                        with, where co-located is defined
+                                                        as running on a node whose value
+                                                        of the label with key <topologyKey>
+                                                        matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                      - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over
+                                                            a set of resources, in this
+                                                            case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label selector
+                                                                requirements. The requirements
+                                                                are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is
+                                                                      the label key that
+                                                                      the selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a key's
+                                                                      relationship to
+                                                                      a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array of string
+                                                                      values. If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels map
+                                                                is equivalent to an element
+                                                                of matchExpressions, whose
+                                                                key field is "key", the
+                                                                operator is "In", and
+                                                                the values array contains
+                                                                only "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies
+                                                            which namespaces the labelSelector
+                                                            applies to (matches against);
+                                                            null or empty list means "this
+                                                            pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity) or
+                                                            not co-located (anti-affinity)
+                                                            with the pods matching the
+                                                            labelSelector in the specified
+                                                            namespaces, where co-located
+                                                            is defined as running on a
+                                                            node whose value of the label
+                                                            with key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods is
+                                                            running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                              podAntiAffinity:
+                                                description: Describes pod anti-affinity
+                                                  scheduling rules (e.g. avoid putting
+                                                  this pod in the same node, zone, etc.
+                                                  as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer
+                                                      to schedule pods to nodes that satisfy
+                                                      the anti-affinity expressions specified
+                                                      by this field, but it may choose
+                                                      a node that violates one or more
+                                                      of the expressions. The node that
+                                                      is most preferred is the one with
+                                                      the greatest sum of weights, i.e.
+                                                      for each node that meets all of
+                                                      the scheduling requirements (resource
+                                                      request, requiredDuringScheduling
+                                                      anti-affinity expressions, etc.),
+                                                      compute a sum by iterating through
+                                                      the elements of this field and adding
+                                                      "weight" to the sum if the node
+                                                      has pods which matches the corresponding
+                                                      podAffinityTerm; the node(s) with
+                                                      the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all
+                                                        of the matched WeightedPodAffinityTerm
+                                                        fields are added per-node to find
+                                                        the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                      - podAffinityTerm
+                                                      - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod
+                                                            affinity term, associated
+                                                            with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                          - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query
+                                                                over a set of resources,
+                                                                in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions
+                                                                    is a list of label
+                                                                    selector requirements.
+                                                                    The requirements are
+                                                                    ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label
+                                                                      selector requirement
+                                                                      is a selector that
+                                                                      contains values,
+                                                                      a key, and an operator
+                                                                      that relates the
+                                                                      key and values.
+                                                                    type: object
+                                                                    required:
+                                                                    - key
+                                                                    - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key
+                                                                          is the label
+                                                                          key that the
+                                                                          selector applies
+                                                                          to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator
+                                                                          represents a
+                                                                          key's relationship
+                                                                          to a set of
+                                                                          values. Valid
+                                                                          operators are
+                                                                          In, NotIn, Exists
+                                                                          and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values
+                                                                          is an array
+                                                                          of string values.
+                                                                          If the operator
+                                                                          is In or NotIn,
+                                                                          the values array
+                                                                          must be non-empty.
+                                                                          If the operator
+                                                                          is Exists or
+                                                                          DoesNotExist,
+                                                                          the values array
+                                                                          must be empty.
+                                                                          This array is
+                                                                          replaced during
+                                                                          a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels
+                                                                    is a map of {key,value}
+                                                                    pairs. A single {key,value}
+                                                                    in the matchLabels
+                                                                    map is equivalent
+                                                                    to an element of matchExpressions,
+                                                                    whose key field is
+                                                                    "key", the operator
+                                                                    is "In", and the values
+                                                                    array contains only
+                                                                    "value". The requirements
+                                                                    are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces
+                                                                specifies which namespaces
+                                                                the labelSelector applies
+                                                                to (matches against);
+                                                                null or empty list means
+                                                                "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should
+                                                                be co-located (affinity)
+                                                                or not co-located (anti-affinity)
+                                                                with the pods matching
+                                                                the labelSelector in the
+                                                                specified namespaces,
+                                                                where co-located is defined
+                                                                as running on a node whose
+                                                                value of the label with
+                                                                key topologyKey matches
+                                                                that of any node on which
+                                                                any of the selected pods
+                                                                is running. Empty topologyKey
+                                                                is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated
+                                                            with matching the corresponding
+                                                            podAffinityTerm, in the range
+                                                            1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the anti-affinity
+                                                      requirements specified by this field
+                                                      are not met at scheduling time,
+                                                      the pod will not be scheduled onto
+                                                      the node. If the anti-affinity requirements
+                                                      specified by this field cease to
+                                                      be met at some point during pod
+                                                      execution (e.g. due to a pod label
+                                                      update), the system may or may not
+                                                      try to eventually evict the pod
+                                                      from its node. When there are multiple
+                                                      elements, the lists of nodes corresponding
+                                                      to each podAffinityTerm are intersected,
+                                                      i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods
+                                                        (namely those matching the labelSelector
+                                                        relative to the given namespace(s))
+                                                        that this pod should be co-located
+                                                        (affinity) or not co-located (anti-affinity)
+                                                        with, where co-located is defined
+                                                        as running on a node whose value
+                                                        of the label with key <topologyKey>
+                                                        matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                      - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over
+                                                            a set of resources, in this
+                                                            case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label selector
+                                                                requirements. The requirements
+                                                                are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is
+                                                                      the label key that
+                                                                      the selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a key's
+                                                                      relationship to
+                                                                      a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array of string
+                                                                      values. If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels map
+                                                                is equivalent to an element
+                                                                of matchExpressions, whose
+                                                                key field is "key", the
+                                                                operator is "In", and
+                                                                the values array contains
+                                                                only "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies
+                                                            which namespaces the labelSelector
+                                                            applies to (matches against);
+                                                            null or empty list means "this
+                                                            pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity) or
+                                                            not co-located (anti-affinity)
+                                                            with the pods matching the
+                                                            labelSelector in the specified
+                                                            namespaces, where co-located
+                                                            is defined as running on a
+                                                            node whose value of the label
+                                                            with key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods is
+                                                            running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                          nodeSelector:
+                                            description: 'NodeSelector is a selector which
+                                              must be true for the pod to fit on a node.
+                                              Selector which must match a node''s labels
+                                              for the pod to be scheduled on that node.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          tolerations:
+                                            description: If specified, the pod's tolerations.
+                                            type: array
+                                            items:
+                                              description: The pod this Toleration is
+                                                attached to tolerates any taint that matches
+                                                the triple <key,value,effect> using the
+                                                matching operator <operator>.
+                                              type: object
+                                              properties:
+                                                effect:
+                                                  description: Effect indicates the taint
+                                                    effect to match. Empty means match
+                                                    all taint effects. When specified,
+                                                    allowed values are NoSchedule, PreferNoSchedule
+                                                    and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: Key is the taint key that
+                                                    the toleration applies to. Empty means
+                                                    match all taint keys. If the key is
+                                                    empty, operator must be Exists; this
+                                                    combination means to match all values
+                                                    and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: Operator represents a key's
+                                                    relationship to the value. Valid operators
+                                                    are Exists and Equal. Defaults to
+                                                    Equal. Exists is equivalent to wildcard
+                                                    for value, so that a pod can tolerate
+                                                    all taints of a particular category.
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: TolerationSeconds represents
+                                                    the period of time the toleration
+                                                    (which must be of effect NoExecute,
+                                                    otherwise this field is ignored) tolerates
+                                                    the taint. By default, it is not set,
+                                                    which means tolerate the taint forever
+                                                    (do not evict). Zero and negative
+                                                    values will be treated as 0 (evict
+                                                    immediately) by the system.
+                                                  type: integer
+                                                  format: int64
+                                                value:
+                                                  description: Value is the taint value
+                                                    the toleration matches to. If the
+                                                    operator is Exists, the value should
+                                                    be empty, otherwise just a regular
+                                                    string.
+                                                  type: string
+                                  serviceType:
+                                    description: Optional service type for Kubernetes
+                                      solver service
+                                    type: string
+                          selector:
+                            description: Selector selects a set of DNSNames on the Certificate
+                              resource that should be solved using this challenge solver.
+                            type: object
+                            properties:
+                              dnsNames:
+                                description: List of DNSNames that this solver will be
+                                  used to solve. If specified and a match is found, a
+                                  dnsNames selector will take precedence over a dnsZones
+                                  selector. If multiple solvers match with the same dnsNames
+                                  value, the solver with the most matching labels in matchLabels
+                                  will be selected. If neither has more matches, the solver
+                                  defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              dnsZones:
+                                description: List of DNSZones that this solver will be
+                                  used to solve. The most specific DNS zone match specified
+                                  here will take precedence over other DNS zone matches,
+                                  so a solver specifying sys.example.com will be selected
+                                  over one specifying example.com for the domain www.sys.example.com.
+                                  If multiple solvers match with the same dnsZones value,
+                                  the solver with the most matching labels in matchLabels
+                                  will be selected. If neither has more matches, the solver
+                                  defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              matchLabels:
+                                description: A label selector that is used to refine the
+                                  set of certificate's that this challenge solver will
+                                  apply to.
+                                type: object
+                                additionalProperties:
+                                  type: string
+                ca:
+                  type: object
+                  required:
+                  - secretName
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate
+                        extension which identifies the location of the CRL from which
+                        the revocation of this certificate can be checked. If not set
+                        certificate will be issued without CDP. Values are strings.
+                      type: array
+                      items:
+                        type: string
+                    secretName:
+                      description: SecretName is the name of the secret used to sign Certificates
+                        issued by this Issuer.
+                      type: string
+                selfSigned:
+                  type: object
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate
+                        extension which identifies the location of the CRL from which
+                        the revocation of this certificate can be checked. If not set
+                        certificate will be issued without CDP. Values are strings.
+                      type: array
+                      items:
+                        type: string
+                vault:
+                  type: object
+                  required:
+                  - auth
+                  - path
+                  - server
+                  properties:
+                    auth:
+                      description: Vault authentication
+                      type: object
+                      properties:
+                        appRole:
+                          description: This Secret contains a AppRole and Secret
+                          type: object
+                          required:
+                          - path
+                          - roleId
+                          - secretRef
+                          properties:
+                            path:
+                              description: Where the authentication path is mounted in
+                                Vault.
+                              type: string
+                            roleId:
+                              type: string
+                            secretRef:
+                              type: object
+                              required:
+                              - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                        kubernetes:
+                          description: This contains a Role and Secret with a ServiceAccount
+                            token to authenticate with vault.
+                          type: object
+                          required:
+                          - role
+                          - secretRef
+                          properties:
+                            mountPath:
+                              description: The Vault mountPath here is the mount path
+                                to use when authenticating with Vault. For example, setting
+                                a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login`
+                                to authenticate with Vault. If unspecified, the default
+                                value "/v1/auth/kubernetes" will be used.
+                              type: string
+                            role:
+                              description: A required field containing the Vault Role
+                                to assume. A Role binds a Kubernetes ServiceAccount with
+                                a set of Vault policies.
+                              type: string
+                            secretRef:
+                              description: The required Secret field containing a Kubernetes
+                                ServiceAccount JWT used for authenticating with Vault.
+                                Use of 'ambient credentials' is not supported.
+                              type: object
+                              required:
+                              - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                        tokenSecretRef:
+                          description: This Secret contains the Vault token key
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                    caBundle:
+                      description: Base64 encoded CA bundle to validate Vault server certificate.
+                        Only used if the Server URL is using HTTPS protocol. This parameter
+                        is ignored for plain HTTP protocol connection. If not set the
+                        system root certificates are used to validate the TLS connection.
+                      type: string
+                      format: byte
+                    path:
+                      description: Vault URL path to the certificate role
+                      type: string
+                    server:
+                      description: Server is the vault connection address
+                      type: string
+                venafi:
+                  description: VenafiIssuer describes issuer configuration details for
+                    Venafi Cloud.
+                  type: object
+                  required:
+                  - zone
+                  properties:
+                    cloud:
+                      description: Cloud specifies the Venafi cloud configuration settings.
+                        Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                      - apiTokenSecretRef
+                      properties:
+                        apiTokenSecretRef:
+                          description: APITokenSecretRef is a secret key selector for
+                            the Venafi Cloud API token.
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                        url:
+                          description: URL is the base URL for Venafi Cloud
+                          type: string
+                    tpp:
+                      description: TPP specifies Trust Protection Platform configuration
+                        settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                      - credentialsRef
+                      - url
+                      properties:
+                        caBundle:
+                          description: CABundle is a PEM encoded TLS certificate to use
+                            to verify connections to the TPP instance. If specified, system
+                            roots will not be used and the issuing CA for the TPP instance
+                            must be verifiable using the provided root. If not specified,
+                            the connection will be verified using the cert-manager system
+                            root certificates.
+                          type: string
+                          format: byte
+                        credentialsRef:
+                          description: CredentialsRef is a reference to a Secret containing
+                            the username and password for the TPP server. The secret must
+                            contain two keys, 'username' and 'password'.
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                        url:
+                          description: URL is the base URL for the Venafi TPP instance
+                          type: string
+                    zone:
+                      description: Zone is the Venafi Policy Zone to use for this issuer.
+                        All requests made to the Venafi platform will be restricted by
+                        the named zone policy. This field is required.
+                      type: string
+            status:
+              description: IssuerStatus contains status information about an Issuer
+              type: object
+              properties:
+                acme:
+                  type: object
+                  properties:
+                    lastRegisteredEmail:
+                      description: LastRegisteredEmail is the email associated with the
+                        latest registered ACME account, in order to track changes made
+                        to registered account associated with the  Issuer
+                      type: string
+                    uri:
+                      description: URI is the unique account identifier, which can also
+                        be used to retrieve account details from the CA
+                      type: string
+                conditions:
+                  type: array
+                  items:
+                    description: IssuerCondition contains condition information for an
+                      Issuer.
+                    type: object
+                    required:
+                    - status
+                    - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the timestamp corresponding
+                          to the last status change of this condition.
+                        type: string
+                        format: date-time
+                      message:
+                        description: Message is a human readable description of the details
+                          of the last transition, complementing reason.
+                        type: string
+                      reason:
+                        description: Reason is a brief machine readable explanation for
+                          the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of ('True', 'False',
+                          'Unknown').
+                        type: string
+                        enum:
+                        - "True"
+                        - "False"
+                        - Unknown
+                      type:
+                        description: Type of the condition, currently ('Ready').
+                        type: string

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/crd-issuer.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/crd-issuer.yml.j2
@@ -1,10 +1,11 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: issuers.certmanager.k8s.io
   annotations:
     "helm.sh/hook": crd-install
+    "api-approved.kubernetes.io": "unapproved-will-be-remove-with-cert-manager-update"
   labels:
     app: cert-manager
     chart: cert-manager-v0.5.2
@@ -12,8 +13,1762 @@ metadata:
     heritage: Tiller
 spec:
   group: certmanager.k8s.io
-  version: v1alpha1
+  scope: Namespaced
   names:
     kind: Issuer
     plural: issuers
-  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: IssuerSpec is the specification of an Issuer. This includes
+                any configuration required for the issuer.
+              type: object
+              properties:
+                acme:
+                  description: ACMEIssuer contains the specification for an ACME issuer
+                  type: object
+                  required:
+                  - privateKeySecretRef
+                  - server
+                  properties:
+                    email:
+                      description: Email is the email for this account
+                      type: string
+                    externalAccountBinding:
+                      description: ExternalAccountBinding is a reference to a CA external
+                        account of the ACME server.
+                      type: object
+                      required:
+                      - keyAlgorithm
+                      - keyID
+                      - keySecretRef
+                      properties:
+                        keyAlgorithm:
+                          description: keyAlgorithm is the MAC key algorithm that the
+                            key is used for. Valid values are "HS256", "HS384" and "HS512".
+                          type: string
+                          enum:
+                          - HS256
+                          - HS384
+                          - HS512
+                        keyID:
+                          description: keyID is the ID of the CA key that the External
+                            Account is bound to.
+                          type: string
+                        keySecretRef:
+                          description: keySecretRef is a Secret Key Selector referencing
+                            a data item in a Kubernetes Secret which holds the symmetric
+                            MAC key of the External Account Binding. The `key` is the
+                            index string that is paired with the key data in the Secret
+                            and should not be confused with the key data itself, or indeed
+                            with the External Account Binding keyID above. The secret
+                            key stored in the Secret **must** be un-padded, base64 URL
+                            encoded data.
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                    privateKeySecretRef:
+                      description: PrivateKey is the name of a secret containing the private
+                        key for this user account.
+                      type: object
+                      required:
+                      - name
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must be a
+                            valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                    server:
+                      description: Server is the ACME server URL
+                      type: string
+                    skipTLSVerify:
+                      description: If true, skip verifying the ACME server TLS certificate
+                      type: boolean
+                    solvers:
+                      description: Solvers is a list of challenge solvers that will be
+                        used to solve ACME challenges for the matching domains.
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          dns01:
+                            type: object
+                            properties:
+                              acmedns:
+                                description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
+                                  containing the configuration for ACME-DNS servers
+                                type: object
+                                required:
+                                - accountSecretRef
+                                - host
+                                properties:
+                                  accountSecretRef:
+                                    type: object
+                                    required:
+                                    - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind,
+                                          uid?'
+                                        type: string
+                                  host:
+                                    type: string
+                              akamai:
+                                description: ACMEIssuerDNS01ProviderAkamai is a structure
+                                  containing the DNS configuration for Akamai DNS—Zone
+                                  Record Management API
+                                type: object
+                                required:
+                                - accessTokenSecretRef
+                                - clientSecretSecretRef
+                                - clientTokenSecretRef
+                                - serviceConsumerDomain
+                                properties:
+                                  accessTokenSecretRef:
+                                    type: object
+                                    required:
+                                    - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind,
+                                          uid?'
+                                        type: string
+                                  clientSecretSecretRef:
+                                    type: object
+                                    required:
+                                    - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind,
+                                          uid?'
+                                        type: string
+                                  clientTokenSecretRef:
+                                    type: object
+                                    required:
+                                    - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind,
+                                          uid?'
+                                        type: string
+                                  serviceConsumerDomain:
+                                    type: string
+                              azuredns:
+                                description: ACMEIssuerDNS01ProviderAzureDNS is a structure
+                                  containing the configuration for Azure DNS
+                                type: object
+                                required:
+                                - resourceGroupName
+                                - subscriptionID
+                                properties:
+                                  clientID:
+                                    description: if both this and ClientSecret are left
+                                      unset MSI will be used
+                                    type: string
+                                  clientSecretSecretRef:
+                                    description: if both this and ClientID are left unset
+                                      MSI will be used
+                                    type: object
+                                    required:
+                                    - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind,
+                                          uid?'
+                                        type: string
+                                  environment:
+                                    type: string
+                                    enum:
+                                    - AzurePublicCloud
+                                    - AzureChinaCloud
+                                    - AzureGermanCloud
+                                    - AzureUSGovernmentCloud
+                                  hostedZoneName:
+                                    type: string
+                                  resourceGroupName:
+                                    type: string
+                                  subscriptionID:
+                                    type: string
+                                  tenantID:
+                                    description: when specifying ClientID and ClientSecret
+                                      then this field is also needed
+                                    type: string
+                              clouddns:
+                                description: ACMEIssuerDNS01ProviderCloudDNS is a structure
+                                  containing the DNS configuration for Google Cloud DNS
+                                type: object
+                                required:
+                                - project
+                                properties:
+                                  project:
+                                    type: string
+                                  serviceAccountSecretRef:
+                                    type: object
+                                    required:
+                                    - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind,
+                                          uid?'
+                                        type: string
+                              cloudflare:
+                                description: ACMEIssuerDNS01ProviderCloudflare is a structure
+                                  containing the DNS configuration for Cloudflare
+                                type: object
+                                required:
+                                - email
+                                properties:
+                                  apiKeySecretRef:
+                                    type: object
+                                    required:
+                                    - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind,
+                                          uid?'
+                                        type: string
+                                  apiTokenSecretRef:
+                                    type: object
+                                    required:
+                                    - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind,
+                                          uid?'
+                                        type: string
+                                  email:
+                                    type: string
+                              cnameStrategy:
+                                description: CNAMEStrategy configures how the DNS01 provider
+                                  should handle CNAME records when found in DNS zones.
+                                type: string
+                                enum:
+                                - None
+                                - Follow
+                              digitalocean:
+                                description: ACMEIssuerDNS01ProviderDigitalOcean is a
+                                  structure containing the DNS configuration for DigitalOcean
+                                  Domains
+                                type: object
+                                required:
+                                - tokenSecretRef
+                                properties:
+                                  tokenSecretRef:
+                                    type: object
+                                    required:
+                                    - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind,
+                                          uid?'
+                                        type: string
+                              rfc2136:
+                                description: ACMEIssuerDNS01ProviderRFC2136 is a structure
+                                  containing the configuration for RFC2136 DNS
+                                type: object
+                                required:
+                                - nameserver
+                                properties:
+                                  nameserver:
+                                    description: The IP address or hostname of an authoritative
+                                      DNS server supporting RFC2136 in the form host:port.
+                                      If the host is an IPv6 address it must be enclosed
+                                      in square brackets (e.g [2001:db8::1]) ; port is
+                                      optional. This field is required.
+                                    type: string
+                                  tsigAlgorithm:
+                                    description: 'The TSIG Algorithm configured in the
+                                      DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                                      and ``tsigKeyName`` are defined. Supported values
+                                      are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
+                                      ``HMACSHA256`` or ``HMACSHA512``.'
+                                    type: string
+                                  tsigKeyName:
+                                    description: The TSIG Key name configured in the DNS.
+                                      If ``tsigSecretSecretRef`` is defined, this field
+                                      is required.
+                                    type: string
+                                  tsigSecretSecretRef:
+                                    description: The name of the secret containing the
+                                      TSIG value. If ``tsigKeyName`` is defined, this
+                                      field is required.
+                                    type: object
+                                    required:
+                                    - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind,
+                                          uid?'
+                                        type: string
+                              route53:
+                                description: ACMEIssuerDNS01ProviderRoute53 is a structure
+                                  containing the Route 53 configuration for AWS
+                                type: object
+                                required:
+                                - region
+                                properties:
+                                  accessKeyID:
+                                    description: 'The AccessKeyID is used for authentication.
+                                      If not set we fall-back to using env vars, shared
+                                      credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                    type: string
+                                  hostedZoneID:
+                                    description: If set, the provider will manage only
+                                      this zone in Route53 and will not do an lookup using
+                                      the route53:ListHostedZonesByName api call.
+                                    type: string
+                                  region:
+                                    description: Always set the region when using AccessKeyID
+                                      and SecretAccessKey
+                                    type: string
+                                  role:
+                                    description: Role is a Role ARN which the Route53
+                                      provider will assume using either the explicit credentials
+                                      AccessKeyID/SecretAccessKey or the inferred credentials
+                                      from environment variables, shared credentials file
+                                      or AWS Instance metadata
+                                    type: string
+                                  secretAccessKeySecretRef:
+                                    description: The SecretAccessKey is used for authentication.
+                                      If not set we fall-back to using env vars, shared
+                                      credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    type: object
+                                    required:
+                                    - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind,
+                                          uid?'
+                                        type: string
+                              webhook:
+                                description: ACMEIssuerDNS01ProviderWebhook specifies
+                                  configuration for a webhook DNS01 provider, including
+                                  where to POST ChallengePayload resources.
+                                type: object
+                                required:
+                                - groupName
+                                - solverName
+                                properties:
+                                  config:
+                                    description: Additional configuration that should
+                                      be passed to the webhook apiserver when challenges
+                                      are processed. This can contain arbitrary JSON data.
+                                      Secret values should not be specified in this stanza.
+                                      If secret values are needed (e.g. credentials for
+                                      a DNS service), you should use a SecretKeySelector
+                                      to reference a Secret resource. For details on the
+                                      schema of this field, consult the webhook provider
+                                      implementation's documentation.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  groupName:
+                                    description: The API group name that should be used
+                                      when POSTing ChallengePayload resources to the webhook
+                                      apiserver. This should be the same as the GroupName
+                                      specified in the webhook provider implementation.
+                                    type: string
+                                  solverName:
+                                    description: The name of the solver to use, as defined
+                                      in the webhook provider implementation. This will
+                                      typically be the name of the provider, e.g. 'cloudflare'.
+                                    type: string
+                          http01:
+                            description: ACMEChallengeSolverHTTP01 contains configuration
+                              detailing how to solve HTTP01 challenges within a Kubernetes
+                              cluster. Typically this is accomplished through creating
+                              'routes' of some description that configure ingress controllers
+                              to direct traffic to 'solver pods', which are responsible
+                              for responding to the ACME server's HTTP requests.
+                            type: object
+                            properties:
+                              ingress:
+                                description: The ingress based HTTP01 challenge solver
+                                  will solve challenges by creating or modifying Ingress
+                                  resources in order to route requests for '/.well-known/acme-challenge/XYZ'
+                                  to 'challenge solver' pods that are provisioned by cert-manager
+                                  for each Challenge to be completed.
+                                type: object
+                                properties:
+                                  class:
+                                    description: The ingress class to use when creating
+                                      Ingress resources to solve ACME challenges that
+                                      use this challenge solver. Only one of 'class' or
+                                      'name' may be specified.
+                                    type: string
+                                  ingressTemplate:
+                                    description: Optional ingress template used to configure
+                                      the ACME challenge solver ingress used for HTTP01
+                                      challenges
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the ingress
+                                          used to solve HTTP01 challenges. Only the 'labels'
+                                          and 'annotations' fields may be set. If labels
+                                          or annotations overlap with in-built values,
+                                          the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added
+                                              to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to
+                                              the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                  name:
+                                    description: The name of the ingress resource that
+                                      should have ACME challenge solving routes inserted
+                                      into it in order to solve HTTP01 challenges. This
+                                      is typically used in conjunction with ingress controllers
+                                      like ingress-gce, which maintains a 1:1 mapping
+                                      between external IPs and ingress resources.
+                                    type: string
+                                  podTemplate:
+                                    description: Optional pod template used to configure
+                                      the ACME challenge solver pods used for HTTP01 challenges
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the pod
+                                          used to solve HTTP01 challenges. Only the 'labels'
+                                          and 'annotations' fields may be set. If labels
+                                          or annotations overlap with in-built values,
+                                          the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added
+                                              to the create ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to
+                                              the created ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                      spec:
+                                        description: PodSpec defines overrides for the
+                                          HTTP01 challenge solver pod. Only the 'nodeSelector',
+                                          'affinity' and 'tolerations' fields are supported
+                                          currently. All other fields will be ignored.
+                                        type: object
+                                        properties:
+                                          affinity:
+                                            description: If specified, the pod's scheduling
+                                              constraints
+                                            type: object
+                                            properties:
+                                              nodeAffinity:
+                                                description: Describes node affinity scheduling
+                                                  rules for the pod.
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer
+                                                      to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified
+                                                      by this field, but it may choose
+                                                      a node that violates one or more
+                                                      of the expressions. The node that
+                                                      is most preferred is the one with
+                                                      the greatest sum of weights, i.e.
+                                                      for each node that meets all of
+                                                      the scheduling requirements (resource
+                                                      request, requiredDuringScheduling
+                                                      affinity expressions, etc.), compute
+                                                      a sum by iterating through the elements
+                                                      of this field and adding "weight"
+                                                      to the sum if the node matches the
+                                                      corresponding matchExpressions;
+                                                      the node(s) with the highest sum
+                                                      are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: An empty preferred
+                                                        scheduling term matches all objects
+                                                        with implicit weight 0 (i.e. it's
+                                                        a no-op). A null preferred scheduling
+                                                        term matches no objects (i.e.
+                                                        is also a no-op).
+                                                      type: object
+                                                      required:
+                                                      - preference
+                                                      - weight
+                                                      properties:
+                                                        preference:
+                                                          description: A node selector
+                                                            term, associated with the
+                                                            corresponding weight.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node
+                                                                selector requirements
+                                                                by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label
+                                                                      key that the selector
+                                                                      applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents
+                                                                      a key's relationship
+                                                                      to a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists,
+                                                                      DoesNotExist. Gt,
+                                                                      and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. If
+                                                                      the operator is
+                                                                      Gt or Lt, the values
+                                                                      array must have
+                                                                      a single element,
+                                                                      which will be interpreted
+                                                                      as an integer. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node
+                                                                selector requirements
+                                                                by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label
+                                                                      key that the selector
+                                                                      applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents
+                                                                      a key's relationship
+                                                                      to a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists,
+                                                                      DoesNotExist. Gt,
+                                                                      and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. If
+                                                                      the operator is
+                                                                      Gt or Lt, the values
+                                                                      array must have
+                                                                      a single element,
+                                                                      which will be interpreted
+                                                                      as an integer. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                        weight:
+                                                          description: Weight associated
+                                                            with matching the corresponding
+                                                            nodeSelectorTerm, in the range
+                                                            1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements
+                                                      specified by this field are not
+                                                      met at scheduling time, the pod
+                                                      will not be scheduled onto the node.
+                                                      If the affinity requirements specified
+                                                      by this field cease to be met at
+                                                      some point during pod execution
+                                                      (e.g. due to an update), the system
+                                                      may or may not try to eventually
+                                                      evict the pod from its node.
+                                                    type: object
+                                                    required:
+                                                    - nodeSelectorTerms
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        description: Required. A list
+                                                          of node selector terms. The
+                                                          terms are ORed.
+                                                        type: array
+                                                        items:
+                                                          description: A null or empty
+                                                            node selector term matches
+                                                            no objects. The requirements
+                                                            of them are ANDed. The TopologySelectorTerm
+                                                            type implements a subset of
+                                                            the NodeSelectorTerm.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node
+                                                                selector requirements
+                                                                by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label
+                                                                      key that the selector
+                                                                      applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents
+                                                                      a key's relationship
+                                                                      to a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists,
+                                                                      DoesNotExist. Gt,
+                                                                      and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. If
+                                                                      the operator is
+                                                                      Gt or Lt, the values
+                                                                      array must have
+                                                                      a single element,
+                                                                      which will be interpreted
+                                                                      as an integer. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node
+                                                                selector requirements
+                                                                by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label
+                                                                      key that the selector
+                                                                      applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents
+                                                                      a key's relationship
+                                                                      to a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists,
+                                                                      DoesNotExist. Gt,
+                                                                      and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. If
+                                                                      the operator is
+                                                                      Gt or Lt, the values
+                                                                      array must have
+                                                                      a single element,
+                                                                      which will be interpreted
+                                                                      as an integer. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                              podAffinity:
+                                                description: Describes pod affinity scheduling
+                                                  rules (e.g. co-locate this pod in the
+                                                  same node, zone, etc. as some other
+                                                  pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer
+                                                      to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified
+                                                      by this field, but it may choose
+                                                      a node that violates one or more
+                                                      of the expressions. The node that
+                                                      is most preferred is the one with
+                                                      the greatest sum of weights, i.e.
+                                                      for each node that meets all of
+                                                      the scheduling requirements (resource
+                                                      request, requiredDuringScheduling
+                                                      affinity expressions, etc.), compute
+                                                      a sum by iterating through the elements
+                                                      of this field and adding "weight"
+                                                      to the sum if the node has pods
+                                                      which matches the corresponding
+                                                      podAffinityTerm; the node(s) with
+                                                      the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all
+                                                        of the matched WeightedPodAffinityTerm
+                                                        fields are added per-node to find
+                                                        the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                      - podAffinityTerm
+                                                      - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod
+                                                            affinity term, associated
+                                                            with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                          - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query
+                                                                over a set of resources,
+                                                                in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions
+                                                                    is a list of label
+                                                                    selector requirements.
+                                                                    The requirements are
+                                                                    ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label
+                                                                      selector requirement
+                                                                      is a selector that
+                                                                      contains values,
+                                                                      a key, and an operator
+                                                                      that relates the
+                                                                      key and values.
+                                                                    type: object
+                                                                    required:
+                                                                    - key
+                                                                    - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key
+                                                                          is the label
+                                                                          key that the
+                                                                          selector applies
+                                                                          to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator
+                                                                          represents a
+                                                                          key's relationship
+                                                                          to a set of
+                                                                          values. Valid
+                                                                          operators are
+                                                                          In, NotIn, Exists
+                                                                          and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values
+                                                                          is an array
+                                                                          of string values.
+                                                                          If the operator
+                                                                          is In or NotIn,
+                                                                          the values array
+                                                                          must be non-empty.
+                                                                          If the operator
+                                                                          is Exists or
+                                                                          DoesNotExist,
+                                                                          the values array
+                                                                          must be empty.
+                                                                          This array is
+                                                                          replaced during
+                                                                          a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels
+                                                                    is a map of {key,value}
+                                                                    pairs. A single {key,value}
+                                                                    in the matchLabels
+                                                                    map is equivalent
+                                                                    to an element of matchExpressions,
+                                                                    whose key field is
+                                                                    "key", the operator
+                                                                    is "In", and the values
+                                                                    array contains only
+                                                                    "value". The requirements
+                                                                    are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces
+                                                                specifies which namespaces
+                                                                the labelSelector applies
+                                                                to (matches against);
+                                                                null or empty list means
+                                                                "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should
+                                                                be co-located (affinity)
+                                                                or not co-located (anti-affinity)
+                                                                with the pods matching
+                                                                the labelSelector in the
+                                                                specified namespaces,
+                                                                where co-located is defined
+                                                                as running on a node whose
+                                                                value of the label with
+                                                                key topologyKey matches
+                                                                that of any node on which
+                                                                any of the selected pods
+                                                                is running. Empty topologyKey
+                                                                is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated
+                                                            with matching the corresponding
+                                                            podAffinityTerm, in the range
+                                                            1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements
+                                                      specified by this field are not
+                                                      met at scheduling time, the pod
+                                                      will not be scheduled onto the node.
+                                                      If the affinity requirements specified
+                                                      by this field cease to be met at
+                                                      some point during pod execution
+                                                      (e.g. due to a pod label update),
+                                                      the system may or may not try to
+                                                      eventually evict the pod from its
+                                                      node. When there are multiple elements,
+                                                      the lists of nodes corresponding
+                                                      to each podAffinityTerm are intersected,
+                                                      i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods
+                                                        (namely those matching the labelSelector
+                                                        relative to the given namespace(s))
+                                                        that this pod should be co-located
+                                                        (affinity) or not co-located (anti-affinity)
+                                                        with, where co-located is defined
+                                                        as running on a node whose value
+                                                        of the label with key <topologyKey>
+                                                        matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                      - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over
+                                                            a set of resources, in this
+                                                            case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label selector
+                                                                requirements. The requirements
+                                                                are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is
+                                                                      the label key that
+                                                                      the selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a key's
+                                                                      relationship to
+                                                                      a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array of string
+                                                                      values. If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels map
+                                                                is equivalent to an element
+                                                                of matchExpressions, whose
+                                                                key field is "key", the
+                                                                operator is "In", and
+                                                                the values array contains
+                                                                only "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies
+                                                            which namespaces the labelSelector
+                                                            applies to (matches against);
+                                                            null or empty list means "this
+                                                            pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity) or
+                                                            not co-located (anti-affinity)
+                                                            with the pods matching the
+                                                            labelSelector in the specified
+                                                            namespaces, where co-located
+                                                            is defined as running on a
+                                                            node whose value of the label
+                                                            with key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods is
+                                                            running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                              podAntiAffinity:
+                                                description: Describes pod anti-affinity
+                                                  scheduling rules (e.g. avoid putting
+                                                  this pod in the same node, zone, etc.
+                                                  as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer
+                                                      to schedule pods to nodes that satisfy
+                                                      the anti-affinity expressions specified
+                                                      by this field, but it may choose
+                                                      a node that violates one or more
+                                                      of the expressions. The node that
+                                                      is most preferred is the one with
+                                                      the greatest sum of weights, i.e.
+                                                      for each node that meets all of
+                                                      the scheduling requirements (resource
+                                                      request, requiredDuringScheduling
+                                                      anti-affinity expressions, etc.),
+                                                      compute a sum by iterating through
+                                                      the elements of this field and adding
+                                                      "weight" to the sum if the node
+                                                      has pods which matches the corresponding
+                                                      podAffinityTerm; the node(s) with
+                                                      the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all
+                                                        of the matched WeightedPodAffinityTerm
+                                                        fields are added per-node to find
+                                                        the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                      - podAffinityTerm
+                                                      - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod
+                                                            affinity term, associated
+                                                            with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                          - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query
+                                                                over a set of resources,
+                                                                in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions
+                                                                    is a list of label
+                                                                    selector requirements.
+                                                                    The requirements are
+                                                                    ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label
+                                                                      selector requirement
+                                                                      is a selector that
+                                                                      contains values,
+                                                                      a key, and an operator
+                                                                      that relates the
+                                                                      key and values.
+                                                                    type: object
+                                                                    required:
+                                                                    - key
+                                                                    - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key
+                                                                          is the label
+                                                                          key that the
+                                                                          selector applies
+                                                                          to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator
+                                                                          represents a
+                                                                          key's relationship
+                                                                          to a set of
+                                                                          values. Valid
+                                                                          operators are
+                                                                          In, NotIn, Exists
+                                                                          and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values
+                                                                          is an array
+                                                                          of string values.
+                                                                          If the operator
+                                                                          is In or NotIn,
+                                                                          the values array
+                                                                          must be non-empty.
+                                                                          If the operator
+                                                                          is Exists or
+                                                                          DoesNotExist,
+                                                                          the values array
+                                                                          must be empty.
+                                                                          This array is
+                                                                          replaced during
+                                                                          a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels
+                                                                    is a map of {key,value}
+                                                                    pairs. A single {key,value}
+                                                                    in the matchLabels
+                                                                    map is equivalent
+                                                                    to an element of matchExpressions,
+                                                                    whose key field is
+                                                                    "key", the operator
+                                                                    is "In", and the values
+                                                                    array contains only
+                                                                    "value". The requirements
+                                                                    are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces
+                                                                specifies which namespaces
+                                                                the labelSelector applies
+                                                                to (matches against);
+                                                                null or empty list means
+                                                                "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should
+                                                                be co-located (affinity)
+                                                                or not co-located (anti-affinity)
+                                                                with the pods matching
+                                                                the labelSelector in the
+                                                                specified namespaces,
+                                                                where co-located is defined
+                                                                as running on a node whose
+                                                                value of the label with
+                                                                key topologyKey matches
+                                                                that of any node on which
+                                                                any of the selected pods
+                                                                is running. Empty topologyKey
+                                                                is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated
+                                                            with matching the corresponding
+                                                            podAffinityTerm, in the range
+                                                            1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the anti-affinity
+                                                      requirements specified by this field
+                                                      are not met at scheduling time,
+                                                      the pod will not be scheduled onto
+                                                      the node. If the anti-affinity requirements
+                                                      specified by this field cease to
+                                                      be met at some point during pod
+                                                      execution (e.g. due to a pod label
+                                                      update), the system may or may not
+                                                      try to eventually evict the pod
+                                                      from its node. When there are multiple
+                                                      elements, the lists of nodes corresponding
+                                                      to each podAffinityTerm are intersected,
+                                                      i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods
+                                                        (namely those matching the labelSelector
+                                                        relative to the given namespace(s))
+                                                        that this pod should be co-located
+                                                        (affinity) or not co-located (anti-affinity)
+                                                        with, where co-located is defined
+                                                        as running on a node whose value
+                                                        of the label with key <topologyKey>
+                                                        matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                      - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over
+                                                            a set of resources, in this
+                                                            case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label selector
+                                                                requirements. The requirements
+                                                                are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is
+                                                                      the label key that
+                                                                      the selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a key's
+                                                                      relationship to
+                                                                      a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array of string
+                                                                      values. If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels map
+                                                                is equivalent to an element
+                                                                of matchExpressions, whose
+                                                                key field is "key", the
+                                                                operator is "In", and
+                                                                the values array contains
+                                                                only "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies
+                                                            which namespaces the labelSelector
+                                                            applies to (matches against);
+                                                            null or empty list means "this
+                                                            pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity) or
+                                                            not co-located (anti-affinity)
+                                                            with the pods matching the
+                                                            labelSelector in the specified
+                                                            namespaces, where co-located
+                                                            is defined as running on a
+                                                            node whose value of the label
+                                                            with key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods is
+                                                            running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                          nodeSelector:
+                                            description: 'NodeSelector is a selector which
+                                              must be true for the pod to fit on a node.
+                                              Selector which must match a node''s labels
+                                              for the pod to be scheduled on that node.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          tolerations:
+                                            description: If specified, the pod's tolerations.
+                                            type: array
+                                            items:
+                                              description: The pod this Toleration is
+                                                attached to tolerates any taint that matches
+                                                the triple <key,value,effect> using the
+                                                matching operator <operator>.
+                                              type: object
+                                              properties:
+                                                effect:
+                                                  description: Effect indicates the taint
+                                                    effect to match. Empty means match
+                                                    all taint effects. When specified,
+                                                    allowed values are NoSchedule, PreferNoSchedule
+                                                    and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: Key is the taint key that
+                                                    the toleration applies to. Empty means
+                                                    match all taint keys. If the key is
+                                                    empty, operator must be Exists; this
+                                                    combination means to match all values
+                                                    and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: Operator represents a key's
+                                                    relationship to the value. Valid operators
+                                                    are Exists and Equal. Defaults to
+                                                    Equal. Exists is equivalent to wildcard
+                                                    for value, so that a pod can tolerate
+                                                    all taints of a particular category.
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: TolerationSeconds represents
+                                                    the period of time the toleration
+                                                    (which must be of effect NoExecute,
+                                                    otherwise this field is ignored) tolerates
+                                                    the taint. By default, it is not set,
+                                                    which means tolerate the taint forever
+                                                    (do not evict). Zero and negative
+                                                    values will be treated as 0 (evict
+                                                    immediately) by the system.
+                                                  type: integer
+                                                  format: int64
+                                                value:
+                                                  description: Value is the taint value
+                                                    the toleration matches to. If the
+                                                    operator is Exists, the value should
+                                                    be empty, otherwise just a regular
+                                                    string.
+                                                  type: string
+                                  serviceType:
+                                    description: Optional service type for Kubernetes
+                                      solver service
+                                    type: string
+                          selector:
+                            description: Selector selects a set of DNSNames on the Certificate
+                              resource that should be solved using this challenge solver.
+                            type: object
+                            properties:
+                              dnsNames:
+                                description: List of DNSNames that this solver will be
+                                  used to solve. If specified and a match is found, a
+                                  dnsNames selector will take precedence over a dnsZones
+                                  selector. If multiple solvers match with the same dnsNames
+                                  value, the solver with the most matching labels in matchLabels
+                                  will be selected. If neither has more matches, the solver
+                                  defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              dnsZones:
+                                description: List of DNSZones that this solver will be
+                                  used to solve. The most specific DNS zone match specified
+                                  here will take precedence over other DNS zone matches,
+                                  so a solver specifying sys.example.com will be selected
+                                  over one specifying example.com for the domain www.sys.example.com.
+                                  If multiple solvers match with the same dnsZones value,
+                                  the solver with the most matching labels in matchLabels
+                                  will be selected. If neither has more matches, the solver
+                                  defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              matchLabels:
+                                description: A label selector that is used to refine the
+                                  set of certificate's that this challenge solver will
+                                  apply to.
+                                type: object
+                                additionalProperties:
+                                  type: string
+                ca:
+                  type: object
+                  required:
+                  - secretName
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate
+                        extension which identifies the location of the CRL from which
+                        the revocation of this certificate can be checked. If not set
+                        certificate will be issued without CDP. Values are strings.
+                      type: array
+                      items:
+                        type: string
+                    secretName:
+                      description: SecretName is the name of the secret used to sign Certificates
+                        issued by this Issuer.
+                      type: string
+                selfSigned:
+                  type: object
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate
+                        extension which identifies the location of the CRL from which
+                        the revocation of this certificate can be checked. If not set
+                        certificate will be issued without CDP. Values are strings.
+                      type: array
+                      items:
+                        type: string
+                vault:
+                  type: object
+                  required:
+                  - auth
+                  - path
+                  - server
+                  properties:
+                    auth:
+                      description: Vault authentication
+                      type: object
+                      properties:
+                        appRole:
+                          description: This Secret contains a AppRole and Secret
+                          type: object
+                          required:
+                          - path
+                          - roleId
+                          - secretRef
+                          properties:
+                            path:
+                              description: Where the authentication path is mounted in
+                                Vault.
+                              type: string
+                            roleId:
+                              type: string
+                            secretRef:
+                              type: object
+                              required:
+                              - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                        kubernetes:
+                          description: This contains a Role and Secret with a ServiceAccount
+                            token to authenticate with vault.
+                          type: object
+                          required:
+                          - role
+                          - secretRef
+                          properties:
+                            mountPath:
+                              description: The Vault mountPath here is the mount path
+                                to use when authenticating with Vault. For example, setting
+                                a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login`
+                                to authenticate with Vault. If unspecified, the default
+                                value "/v1/auth/kubernetes" will be used.
+                              type: string
+                            role:
+                              description: A required field containing the Vault Role
+                                to assume. A Role binds a Kubernetes ServiceAccount with
+                                a set of Vault policies.
+                              type: string
+                            secretRef:
+                              description: The required Secret field containing a Kubernetes
+                                ServiceAccount JWT used for authenticating with Vault.
+                                Use of 'ambient credentials' is not supported.
+                              type: object
+                              required:
+                              - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                        tokenSecretRef:
+                          description: This Secret contains the Vault token key
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                    caBundle:
+                      description: Base64 encoded CA bundle to validate Vault server certificate.
+                        Only used if the Server URL is using HTTPS protocol. This parameter
+                        is ignored for plain HTTP protocol connection. If not set the
+                        system root certificates are used to validate the TLS connection.
+                      type: string
+                      format: byte
+                    path:
+                      description: Vault URL path to the certificate role
+                      type: string
+                    server:
+                      description: Server is the vault connection address
+                      type: string
+                venafi:
+                  description: VenafiIssuer describes issuer configuration details for
+                    Venafi Cloud.
+                  type: object
+                  required:
+                  - zone
+                  properties:
+                    cloud:
+                      description: Cloud specifies the Venafi cloud configuration settings.
+                        Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                      - apiTokenSecretRef
+                      properties:
+                        apiTokenSecretRef:
+                          description: APITokenSecretRef is a secret key selector for
+                            the Venafi Cloud API token.
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                        url:
+                          description: URL is the base URL for Venafi Cloud
+                          type: string
+                    tpp:
+                      description: TPP specifies Trust Protection Platform configuration
+                        settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                      - credentialsRef
+                      - url
+                      properties:
+                        caBundle:
+                          description: CABundle is a PEM encoded TLS certificate to use
+                            to verify connections to the TPP instance. If specified, system
+                            roots will not be used and the issuing CA for the TPP instance
+                            must be verifiable using the provided root. If not specified,
+                            the connection will be verified using the cert-manager system
+                            root certificates.
+                          type: string
+                          format: byte
+                        credentialsRef:
+                          description: CredentialsRef is a reference to a Secret containing
+                            the username and password for the TPP server. The secret must
+                            contain two keys, 'username' and 'password'.
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                        url:
+                          description: URL is the base URL for the Venafi TPP instance
+                          type: string
+                    zone:
+                      description: Zone is the Venafi Policy Zone to use for this issuer.
+                        All requests made to the Venafi platform will be restricted by
+                        the named zone policy. This field is required.
+                      type: string
+            status:
+              description: IssuerStatus contains status information about an Issuer
+              type: object
+              properties:
+                acme:
+                  type: object
+                  properties:
+                    lastRegisteredEmail:
+                      description: LastRegisteredEmail is the email associated with the
+                        latest registered ACME account, in order to track changes made
+                        to registered account associated with the  Issuer
+                      type: string
+                    uri:
+                      description: URI is the unique account identifier, which can also
+                        be used to retrieve account details from the CA
+                      type: string
+                conditions:
+                  type: array
+                  items:
+                    description: IssuerCondition contains condition information for an
+                      Issuer.
+                    type: object
+                    required:
+                    - status
+                    - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the timestamp corresponding
+                          to the last status change of this condition.
+                        type: string
+                        format: date-time
+                      message:
+                        description: Message is a human readable description of the details
+                          of the last transition, complementing reason.
+                        type: string
+                      reason:
+                        description: Reason is a brief machine readable explanation for
+                          the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of ('True', 'False',
+                          'Unknown').
+                        type: string
+                        enum:
+                        - "True"
+                        - "False"
+                        - Unknown
+                      type:
+                        description: Type of the condition, currently ('Ready').
+                        type: string

--- a/roles/kubernetes-apps/metrics_server/templates/metrics-apiservice.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/metrics-apiservice.yaml.j2
@@ -1,4 +1,4 @@
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1beta1.metrics.k8s.io

--- a/roles/network_plugin/calico/templates/kdd-crds.yml.j2
+++ b/roles/network_plugin/calico/templates/kdd-crds.yml.j2
@@ -1,212 +1,2742 @@
 # Create all the CustomResourceDefinitions needed for
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: felixconfigurations.crd.projectcalico.org
 spec:
-  scope: Cluster
   group: crd.projectcalico.org
-  version: v1
   names:
     kind: FelixConfiguration
+    listKind: FelixConfigurationList
     plural: felixconfigurations
     singular: felixconfiguration
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Felix Configuration contains the configuration for Felix.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FelixConfigurationSpec contains the values of the Felix configuration.
+            properties:
+              awsSrcDstCheck:
+                description: 'Set source-destination-check on AWS EC2 instances. Accepted
+                  value must be one of "DoNothing", "Enabled" or "Disabled". [Default:
+                  DoNothing]'
+                enum:
+                - DoNothing
+                - Enable
+                - Disable
+                type: string
+              bpfConnectTimeLoadBalancingEnabled:
+                description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
+                  controls whether Felix installs the connection-time load balancer.  The
+                  connect-time load balancer is required for the host to be able to
+                  reach Kubernetes services and it improves the performance of pod-to-service
+                  connections.  The only reason to disable it is for debugging purposes.  [Default:
+                  true]'
+                type: boolean
+              bpfDataIfacePattern:
+                description: 'BPFDataIfacePattern is a regular expression that controls
+                  which interfaces Felix should attach BPF programs to in order to
+                  catch traffic to/from the network.  This needs to match the interfaces
+                  that Calico workload traffic flows over as well as any interfaces
+                  that handle incoming traffic to nodeports and services from outside
+                  the cluster.  It should not match the workload interfaces (usually
+                  named cali...). [Default: ^(en.*|eth.*|tunl0$)]'
+                type: string
+              bpfDisableUnprivileged:
+                description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
+                  sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
+                  users cannot access Calico''s BPF maps and cannot insert their own
+                  BPF programs to interfere with Calico''s. [Default: true]'
+                type: boolean
+              bpfEnabled:
+                description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
+                  [Default: false]'
+                type: boolean
+              bpfExternalServiceMode:
+                description: 'BPFExternalServiceMode in BPF mode, controls how connections
+                  from outside the cluster to services (node ports and cluster IPs)
+                  are forwarded to remote workloads.  If set to "Tunnel" then both
+                  request and response traffic is tunneled to the remote node.  If
+                  set to "DSR", the request traffic is tunneled but the response traffic
+                  is sent directly from the remote node.  In "DSR" mode, the remote
+                  node appears to use the IP of the ingress node; this requires a
+                  permissive L2 network.  [Default: Tunnel]'
+                type: string
+              bpfKubeProxyEndpointSlicesEnabled:
+                description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
+                  whether Felix's embedded kube-proxy accepts EndpointSlices or not.
+                type: boolean
+              bpfKubeProxyIptablesCleanupEnabled:
+                description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF
+                  mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s
+                  iptables chains.  Should only be enabled if kube-proxy is not running.  [Default:
+                  true]'
+                type: boolean
+              bpfKubeProxyMinSyncPeriod:
+                description: 'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the
+                  minimum time between updates to the dataplane for Felix''s embedded
+                  kube-proxy.  Lower values give reduced set-up latency.  Higher values
+                  reduce Felix CPU usage by batching up more work.  [Default: 1s]'
+                type: string
+              bpfLogLevel:
+                description: 'BPFLogLevel controls the log level of the BPF programs
+                  when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
+                  logs are emitted to the BPF trace pipe, accessible with the command
+                  `tc exec bpf debug`. [Default: Off].'
+                type: string
+              chainInsertMode:
+                description: 'ChainInsertMode controls whether Felix hooks the kernel’s
+                  top-level iptables chains by inserting a rule at the top of the
+                  chain or by appending a rule at the bottom. insert is the safe default
+                  since it prevents Calico’s rules from being bypassed. If you switch
+                  to append mode, be sure that the other rules in the chains signal
+                  acceptance by falling through to the Calico rules, otherwise the
+                  Calico policy will be bypassed. [Default: insert]'
+                type: string
+              dataplaneDriver:
+                type: string
+              debugDisableLogDropping:
+                type: boolean
+              debugMemoryProfilePath:
+                type: string
+              debugSimulateCalcGraphHangAfter:
+                type: string
+              debugSimulateDataplaneHangAfter:
+                type: string
+              defaultEndpointToHostAction:
+                description: 'DefaultEndpointToHostAction controls what happens to
+                  traffic that goes from a workload endpoint to the host itself (after
+                  the traffic hits the endpoint egress policy). By default Calico
+                  blocks traffic from workload endpoints to the host itself with an
+                  iptables “DROP” action. If you want to allow some or all traffic
+                  from endpoint to host, set this parameter to RETURN or ACCEPT. Use
+                  RETURN if you have your own rules in the iptables “INPUT” chain;
+                  Calico will insert its rules at the top of that chain, then “RETURN”
+                  packets to the “INPUT” chain once it has completed processing workload
+                  endpoint egress policy. Use ACCEPT to unconditionally accept packets
+                  from workloads after processing workload endpoint egress policy.
+                  [Default: Drop]'
+                type: string
+              deviceRouteProtocol:
+                description: This defines the route protocol added to programmed device
+                  routes, by default this will be RTPROT_BOOT when left blank.
+                type: integer
+              deviceRouteSourceAddress:
+                description: This is the source address to use on programmed device
+                  routes. By default the source address is left blank, leaving the
+                  kernel to choose the source address used.
+                type: string
+              disableConntrackInvalidCheck:
+                type: boolean
+              endpointReportingDelay:
+                type: string
+              endpointReportingEnabled:
+                type: boolean
+              externalNodesList:
+                description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
+                  which may source tunnel traffic and have the tunneled traffic be
+                  accepted at calico nodes.
+                items:
+                  type: string
+                type: array
+              failsafeInboundHostPorts:
+                description: 'FailsafeInboundHostPorts is a comma-delimited list of
+                  UDP/TCP ports that Felix will allow incoming traffic to host endpoints
+                  on irrespective of the security policy. This is useful to avoid
+                  accidentally cutting off a host with incorrect configuration. Each
+                  port should be specified as tcp:<port-number> or udp:<port-number>.
+                  For back-compatibility, if the protocol is not specified, it defaults
+                  to “tcp”. To disable all inbound host ports, use the value none.
+                  The default value allows ssh access and DHCP. [Default: tcp:22,
+                  udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
+                items:
+                  description: ProtoPort is combination of protocol and port, both
+                    must be specified.
+                  properties:
+                    port:
+                      type: integer
+                    protocol:
+                      type: string
+                  required:
+                  - port
+                  - protocol
+                  type: object
+                type: array
+              failsafeOutboundHostPorts:
+                description: 'FailsafeOutboundHostPorts is a comma-delimited list
+                  of UDP/TCP ports that Felix will allow outgoing traffic from host
+                  endpoints to irrespective of the security policy. This is useful
+                  to avoid accidentally cutting off a host with incorrect configuration.
+                  Each port should be specified as tcp:<port-number> or udp:<port-number>.
+                  For back-compatibility, if the protocol is not specified, it defaults
+                  to “tcp”. To disable all outbound host ports, use the value none.
+                  The default value opens etcd’s standard ports to ensure that Felix
+                  does not get cut off from etcd as well as allowing DHCP and DNS.
+                  [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667,
+                  udp:53, udp:67]'
+                items:
+                  description: ProtoPort is combination of protocol and port, both
+                    must be specified.
+                  properties:
+                    port:
+                      type: integer
+                    protocol:
+                      type: string
+                  required:
+                  - port
+                  - protocol
+                  type: object
+                type: array
+              genericXDPEnabled:
+                description: 'GenericXDPEnabled enables Generic XDP so network cards
+                  that don''t support XDP offload or driver modes can use XDP. This
+                  is not recommended since it doesn''t provide better performance
+                  than iptables. [Default: false]'
+                type: boolean
+              healthEnabled:
+                type: boolean
+              healthHost:
+                type: string
+              healthPort:
+                type: integer
+              interfaceExclude:
+                description: 'InterfaceExclude is a comma-separated list of interfaces
+                  that Felix should exclude when monitoring for host endpoints. The
+                  default value ensures that Felix ignores Kubernetes'' IPVS dummy
+                  interface, which is used internally by kube-proxy. If you want to
+                  exclude multiple interface names using a single value, the list
+                  supports regular expressions. For regular expressions you must wrap
+                  the value with ''/''. For example having values ''/^kube/,veth1''
+                  will exclude all interfaces that begin with ''kube'' and also the
+                  interface ''veth1''. [Default: kube-ipvs0]'
+                type: string
+              interfacePrefix:
+                description: 'InterfacePrefix is the interface name prefix that identifies
+                  workload endpoints and so distinguishes them from host endpoint
+                  interfaces. Note: in environments other than bare metal, the orchestrators
+                  configure this appropriately. For example our Kubernetes and Docker
+                  integrations set the ‘cali’ value, and our OpenStack integration
+                  sets the ‘tap’ value. [Default: cali]'
+                type: string
+              ipipEnabled:
+                type: boolean
+              ipipMTU:
+                description: 'IPIPMTU is the MTU to set on the tunnel device. See
+                  Configuring MTU [Default: 1440]'
+                type: integer
+              ipsetsRefreshInterval:
+                description: 'IpsetsRefreshInterval is the period at which Felix re-checks
+                  all iptables state to ensure that no other process has accidentally
+                  broken Calico’s rules. Set to 0 to disable iptables refresh. [Default:
+                  90s]'
+                type: string
+              iptablesBackend:
+                description: IptablesBackend specifies which backend of iptables will
+                  be used. The default is legacy.
+                type: string
+              iptablesFilterAllowAction:
+                type: string
+              iptablesLockFilePath:
+                description: 'IptablesLockFilePath is the location of the iptables
+                  lock file. You may need to change this if the lock file is not in
+                  its standard location (for example if you have mapped it into Felix’s
+                  container at a different path). [Default: /run/xtables.lock]'
+                type: string
+              iptablesLockProbeInterval:
+                description: 'IptablesLockProbeInterval is the time that Felix will
+                  wait between attempts to acquire the iptables lock if it is not
+                  available. Lower values make Felix more responsive when the lock
+                  is contended, but use more CPU. [Default: 50ms]'
+                type: string
+              iptablesLockTimeout:
+                description: 'IptablesLockTimeout is the time that Felix will wait
+                  for the iptables lock, or 0, to disable. To use this feature, Felix
+                  must share the iptables lock file with all other processes that
+                  also take the lock. When running Felix inside a container, this
+                  requires the /run directory of the host to be mounted into the calico/node
+                  or calico/felix container. [Default: 0s disabled]'
+                type: string
+              iptablesMangleAllowAction:
+                type: string
+              iptablesMarkMask:
+                description: 'IptablesMarkMask is the mask that Felix selects its
+                  IPTables Mark bits from. Should be a 32 bit hexadecimal number with
+                  at least 8 bits set, none of which clash with any other mark bits
+                  in use on the system. [Default: 0xff000000]'
+                format: int32
+                type: integer
+              iptablesNATOutgoingInterfaceFilter:
+                type: string
+              iptablesPostWriteCheckInterval:
+                description: 'IptablesPostWriteCheckInterval is the period after Felix
+                  has done a write to the dataplane that it schedules an extra read
+                  back in order to check the write was not clobbered by another process.
+                  This should only occur if another application on the system doesn’t
+                  respect the iptables lock. [Default: 1s]'
+                type: string
+              iptablesRefreshInterval:
+                description: 'IptablesRefreshInterval is the period at which Felix
+                  re-checks the IP sets in the dataplane to ensure that no other process
+                  has accidentally broken Calico’s rules. Set to 0 to disable IP sets
+                  refresh. Note: the default for this value is lower than the other
+                  refresh intervals as a workaround for a Linux kernel bug that was
+                  fixed in kernel version 4.11. If you are using v4.11 or greater
+                  you may want to set this to, a higher value to reduce Felix CPU
+                  usage. [Default: 10s]'
+                type: string
+              ipv6Support:
+                type: boolean
+              kubeNodePortRanges:
+                description: 'KubeNodePortRanges holds list of port ranges used for
+                  service node ports. Only used if felix detects kube-proxy running
+                  in ipvs mode. Felix uses these ranges to separate host and workload
+                  traffic. [Default: 30000:32767].'
+                items:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^.*
+                  x-kubernetes-int-or-string: true
+                type: array
+              logFilePath:
+                description: 'LogFilePath is the full path to the Felix log. Set to
+                  none to disable file logging. [Default: /var/log/calico/felix.log]'
+                type: string
+              logPrefix:
+                description: 'LogPrefix is the log prefix that Felix uses when rendering
+                  LOG rules. [Default: calico-packet]'
+                type: string
+              logSeverityFile:
+                description: 'LogSeverityFile is the log severity above which logs
+                  are sent to the log file. [Default: Info]'
+                type: string
+              logSeverityScreen:
+                description: 'LogSeverityScreen is the log severity above which logs
+                  are sent to the stdout. [Default: Info]'
+                type: string
+              logSeveritySys:
+                description: 'LogSeveritySys is the log severity above which logs
+                  are sent to the syslog. Set to None for no logging to syslog. [Default:
+                  Info]'
+                type: string
+              maxIpsetSize:
+                type: integer
+              metadataAddr:
+                description: 'MetadataAddr is the IP address or domain name of the
+                  server that can answer VM queries for cloud-init metadata. In OpenStack,
+                  this corresponds to the machine running nova-api (or in Ubuntu,
+                  nova-api-metadata). A value of none (case insensitive) means that
+                  Felix should not set up any NAT rule for the metadata path. [Default:
+                  127.0.0.1]'
+                type: string
+              metadataPort:
+                description: 'MetadataPort is the port of the metadata server. This,
+                  combined with global.MetadataAddr (if not ‘None’), is used to set
+                  up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+                  In most cases this should not need to be changed [Default: 8775].'
+                type: integer
+              natOutgoingAddress:
+                description: NATOutgoingAddress specifies an address to use when performing
+                  source NAT for traffic in a natOutgoing pool that is leaving the
+                  network. By default the address used is an address on the interface
+                  the traffic is leaving on (ie it uses the iptables MASQUERADE target)
+                type: string
+              natPortRange:
+                anyOf:
+                - type: integer
+                - type: string
+                description: NATPortRange specifies the range of ports that is used
+                  for port mapping when doing outgoing NAT. When unset the default
+                  behavior of the network stack is used.
+                pattern: ^.*
+                x-kubernetes-int-or-string: true
+              netlinkTimeout:
+                type: string
+              openstackRegion:
+                description: 'OpenstackRegion is the name of the region that a particular
+                  Felix belongs to. In a multi-region Calico/OpenStack deployment,
+                  this must be configured somehow for each Felix (here in the datamodel,
+                  or in felix.cfg or the environment on each compute node), and must
+                  match the [calico] openstack_region value configured in neutron.conf
+                  on each node. [Default: Empty]'
+                type: string
+              policySyncPathPrefix:
+                description: 'PolicySyncPathPrefix is used to by Felix to communicate
+                  policy changes to external services, like Application layer policy.
+                  [Default: Empty]'
+                type: string
+              prometheusGoMetricsEnabled:
+                description: 'PrometheusGoMetricsEnabled disables Go runtime metrics
+                  collection, which the Prometheus client does by default, when set
+                  to false. This reduces the number of metrics reported, reducing
+                  Prometheus load. [Default: true]'
+                type: boolean
+              prometheusMetricsEnabled:
+                description: 'PrometheusMetricsEnabled enables the Prometheus metrics
+                  server in Felix if set to true. [Default: false]'
+                type: boolean
+              prometheusMetricsHost:
+                description: 'PrometheusMetricsHost is the host that the Prometheus
+                  metrics server should bind to. [Default: empty]'
+                type: string
+              prometheusMetricsPort:
+                description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                  metrics server should bind to. [Default: 9091]'
+                type: integer
+              prometheusProcessMetricsEnabled:
+                description: 'PrometheusProcessMetricsEnabled disables process metrics
+                  collection, which the Prometheus client does by default, when set
+                  to false. This reduces the number of metrics reported, reducing
+                  Prometheus load. [Default: true]'
+                type: boolean
+              removeExternalRoutes:
+                description: Whether or not to remove device routes that have not
+                  been programmed by Felix. Disabling this will allow external applications
+                  to also add device routes. This is enabled by default which means
+                  we will remove externally added routes.
+                type: boolean
+              reportingInterval:
+                description: 'ReportingInterval is the interval at which Felix reports
+                  its status into the datastore or 0 to disable. Must be non-zero
+                  in OpenStack deployments. [Default: 30s]'
+                type: string
+              reportingTTL:
+                description: 'ReportingTTL is the time-to-live setting for process-wide
+                  status reports. [Default: 90s]'
+                type: string
+              routeRefreshInterval:
+                description: 'RouterefreshInterval is the period at which Felix re-checks
+                  the routes in the dataplane to ensure that no other process has
+                  accidentally broken Calico’s rules. Set to 0 to disable route refresh.
+                  [Default: 90s]'
+                type: string
+              routeSource:
+                description: 'RouteSource configures where Felix gets its routing
+                  information. - WorkloadIPs: use workload endpoints to construct
+                  routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
+                type: string
+              routeTableRange:
+                description: Calico programs additional Linux route tables for various
+                  purposes.  RouteTableRange specifies the indices of the route tables
+                  that Calico should use.
+                properties:
+                  max:
+                    type: integer
+                  min:
+                    type: integer
+                required:
+                - max
+                - min
+                type: object
+              sidecarAccelerationEnabled:
+                description: 'SidecarAccelerationEnabled enables experimental sidecar
+                  acceleration [Default: false]'
+                type: boolean
+              usageReportingEnabled:
+                description: 'UsageReportingEnabled reports anonymous Calico version
+                  number and cluster size to projectcalico.org. Logs warnings returned
+                  by the usage server. For example, if a significant security vulnerability
+                  has been discovered in the version of Calico being used. [Default:
+                  true]'
+                type: boolean
+              usageReportingInitialDelay:
+                description: 'UsageReportingInitialDelay controls the minimum delay
+                  before Felix makes a report. [Default: 300s]'
+                type: string
+              usageReportingInterval:
+                description: 'UsageReportingInterval controls the interval at which
+                  Felix makes reports. [Default: 86400s]'
+                type: string
+              useInternalDataplaneDriver:
+                type: boolean
+              vxlanEnabled:
+                type: boolean
+              vxlanMTU:
+                description: 'VXLANMTU is the MTU to set on the tunnel device. See
+                  Configuring MTU [Default: 1440]'
+                type: integer
+              vxlanPort:
+                type: integer
+              vxlanVNI:
+                type: integer
+              wireguardEnabled:
+                description: 'WireguardEnabled controls whether Wireguard is enabled.
+                  [Default: false]'
+                type: boolean
+              wireguardInterfaceName:
+                description: 'WireguardInterfaceName specifies the name to use for
+                  the Wireguard interface. [Default: wg.calico]'
+                type: string
+              wireguardListeningPort:
+                description: 'WireguardListeningPort controls the listening port used
+                  by Wireguard. [Default: 51820]'
+                type: integer
+              wireguardMTU:
+                description: 'WireguardMTU controls the MTU on the Wireguard interface.
+                  See Configuring MTU [Default: 1420]'
+                type: integer
+              wireguardRoutingRulePriority:
+                description: 'WireguardRoutingRulePriority controls the priority value
+                  to use for the Wireguard routing rule. [Default: 99]'
+                type: integer
+              xdpEnabled:
+                description: 'XDPEnabled enables XDP acceleration for suitable untracked
+                  incoming deny rules. [Default: true]'
+                type: boolean
+              xdpRefreshInterval:
+                description: 'XDPRefreshInterval is the period at which Felix re-checks
+                  all XDP state to ensure that no other process has accidentally broken
+                  Calico''s BPF maps or attached programs. Set to 0 to disable XDP
+                  refresh. [Default: 90s]'
+                type: string
+            required:
+            - bpfLogLevel
+            type: object
+        type: object
+    served: true
+    storage: true
 ---
 
 {% if calico_version is version('v3.6.0', '>=') %}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ipamblocks.crd.projectcalico.org
 spec:
-  scope: Cluster
   group: crd.projectcalico.org
-  version: v1
   names:
     kind: IPAMBlock
+    listKind: IPAMBlockList
     plural: ipamblocks
     singular: ipamblock
-
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAMBlockSpec contains the specification for an IPAMBlock
+              resource.
+            properties:
+              affinity:
+                type: string
+              allocations:
+                items:
+                  type: integer
+                  # TODO: This nullable is manually added in. We should update controller-gen
+                  # to handle []*int properly itself.
+                  nullable: true
+                type: array
+              attributes:
+                items:
+                  properties:
+                    handle_id:
+                      type: string
+                    secondary:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                type: array
+              cidr:
+                type: string
+              deleted:
+                type: boolean
+              strictAffinity:
+                type: boolean
+              unallocated:
+                items:
+                  type: integer
+                type: array
+            required:
+            - allocations
+            - attributes
+            - cidr
+            - deleted
+            - strictAffinity
+            - unallocated
+            type: object
+        type: object
+    served: true
+    storage: true
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: blockaffinities.crd.projectcalico.org
 spec:
-  scope: Cluster
   group: crd.projectcalico.org
-  version: v1
   names:
     kind: BlockAffinity
+    listKind: BlockAffinityList
     plural: blockaffinities
     singular: blockaffinity
-
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BlockAffinitySpec contains the specification for a BlockAffinity
+              resource.
+            properties:
+              cidr:
+                type: string
+              deleted:
+                description: Deleted indicates that this block affinity is being deleted.
+                  This field is a string for compatibility with older releases that
+                  mistakenly treat this field as a string.
+                type: string
+              node:
+                type: string
+              state:
+                type: string
+            required:
+            - cidr
+            - deleted
+            - node
+            - state
+            type: object
+        type: object
+    served: true
+    storage: true
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ipamhandles.crd.projectcalico.org
 spec:
-  scope: Cluster
   group: crd.projectcalico.org
-  version: v1
   names:
     kind: IPAMHandle
+    listKind: IPAMHandleList
     plural: ipamhandles
     singular: ipamhandle
-
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAMHandleSpec contains the specification for an IPAMHandle
+              resource.
+            properties:
+              block:
+                additionalProperties:
+                  type: integer
+                type: object
+              handleID:
+                type: string
+            required:
+            - block
+            - handleID
+            type: object
+        type: object
+    served: true
+    storage: true
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ipamconfigs.crd.projectcalico.org
 spec:
-  scope: Cluster
   group: crd.projectcalico.org
-  version: v1
   names:
     kind: IPAMConfig
+    listKind: IPAMConfigList
     plural: ipamconfigs
     singular: ipamconfig
-
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAMConfigSpec contains the specification for an IPAMConfig
+              resource.
+            properties:
+              autoAllocateBlocks:
+                type: boolean
+              strictAffinity:
+                type: boolean
+            required:
+            - autoAllocateBlocks
+            - strictAffinity
+            type: object
+        type: object
+    served: true
+    storage: true
 ---
 
 {% endif %}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: bgppeers.crd.projectcalico.org
 spec:
-  scope: Cluster
   group: crd.projectcalico.org
-  version: v1
   names:
     kind: BGPPeer
+    listKind: BGPPeerList
     plural: bgppeers
     singular: bgppeer
-
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BGPPeerSpec contains the specification for a BGPPeer resource.
+            properties:
+              asNumber:
+                description: The AS Number of the peer.
+                format: int32
+                type: integer
+              node:
+                description: The node name identifying the Calico node instance that
+                  is peering with this peer. If this is not set, this represents a
+                  global peer, i.e. a peer that peers with every node in the deployment.
+                type: string
+              nodeSelector:
+                description: Selector for the nodes that should have this peering.  When
+                  this is set, the Node field must be empty.
+                type: string
+              peerIP:
+                description: The IP address of the peer.
+                type: string
+              peerSelector:
+                description: Selector for the remote nodes to peer with.  When this
+                  is set, the PeerIP and ASNumber fields must be empty.  For each
+                  peering between the local node and selected remote nodes, we configure
+                  an IPv4 peering if both ends have NodeBGPSpec.IPv4Address specified,
+                  and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address specified.  The
+                  remote AS number comes from the remote node’s NodeBGPSpec.ASNumber,
+                  or the global default if that is not set.
+                type: string
+            required:
+            - asNumber
+            - peerIP
+            type: object
+        type: object
+    served: true
+    storage: true
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org
 spec:
-  scope: Cluster
   group: crd.projectcalico.org
-  version: v1
   names:
     kind: BGPConfiguration
+    listKind: BGPConfigurationList
     plural: bgpconfigurations
     singular: bgpconfiguration
-
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: BGPConfiguration contains the configuration for any BGP routing.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BGPConfigurationSpec contains the values of the BGP configuration.
+            properties:
+              asNumber:
+                description: 'ASNumber is the default AS number used by a node. [Default:
+                  64512]'
+                format: int32
+                type: integer
+              logSeverityScreen:
+                description: 'LogSeverityScreen is the log severity above which logs
+                  are sent to the stdout. [Default: INFO]'
+                type: string
+              nodeToNodeMeshEnabled:
+                description: 'NodeToNodeMeshEnabled sets whether full node to node
+                  BGP mesh is enabled. [Default: true]'
+                type: boolean
+              serviceClusterIPs:
+                description: ServiceClusterIPs are the CIDR blocks from which service
+                  cluster IPs are allocated. If specified, Calico will advertise these
+                  blocks, as well as any cluster IPs within them.
+                items:
+                  description: ServiceClusterIPBlock represents a single whitelisted
+                    CIDR block for ClusterIPs.
+                  properties:
+                    cidr:
+                      type: string
+                  type: object
+                type: array
+              serviceExternalIPs:
+                description: ServiceExternalIPs are the CIDR blocks for Kubernetes
+                  Service External IPs. Kubernetes Service ExternalIPs will only be
+                  advertised if they are within one of these blocks.
+                items:
+                  description: ServiceExternalIPBlock represents a single whitelisted
+                    CIDR External IP block.
+                  properties:
+                    cidr:
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org
 spec:
-  scope: Cluster
   group: crd.projectcalico.org
-  version: v1
   names:
     kind: IPPool
+    listKind: IPPoolList
     plural: ippools
     singular: ippool
-
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPPoolSpec contains the specification for an IPPool resource.
+            properties:
+              blockSize:
+                description: The block size to use for IP address assignments from
+                  this pool. Defaults to 26 for IPv4 and 112 for IPv6.
+                type: integer
+              cidr:
+                description: The pool CIDR.
+                type: string
+              disabled:
+                description: When disabled is true, Calico IPAM will not assign addresses
+                  from this pool.
+                type: boolean
+              ipip:
+                description: 'Deprecated: this field is only used for APIv1 backwards
+                  compatibility. Setting this field is not allowed, this field is
+                  for internal use only.'
+                properties:
+                  enabled:
+                    description: When enabled is true, ipip tunneling will be used
+                      to deliver packets to destinations within this pool.
+                    type: boolean
+                  mode:
+                    description: The IPIP mode.  This can be one of "always" or "cross-subnet".  A
+                      mode of "always" will also use IPIP tunneling for routing to
+                      destination IP addresses within this pool.  A mode of "cross-subnet"
+                      will only use IPIP tunneling when the destination node is on
+                      a different subnet to the originating node.  The default value
+                      (if not specified) is "always".
+                    type: string
+                type: object
+              ipipMode:
+                description: Contains configuration for IPIP tunneling for this pool.
+                  If not specified, then this is defaulted to "Never" (i.e. IPIP tunelling
+                  is disabled).
+                type: string
+              nat-outgoing:
+                description: 'Deprecated: this field is only used for APIv1 backwards
+                  compatibility. Setting this field is not allowed, this field is
+                  for internal use only.'
+                type: boolean
+              natOutgoing:
+                description: When nat-outgoing is true, packets sent from Calico networked
+                  containers in this pool to destinations outside of this pool will
+                  be masqueraded.
+                type: boolean
+              nodeSelector:
+                description: Allows IPPool to allocate for a specific node by label
+                  selector.
+                type: string
+              vxlanMode:
+                description: Contains configuration for VXLAN tunneling for this pool.
+                  If not specified, then this is defaulted to "Never" (i.e. VXLAN
+                  tunelling is disabled).
+                type: string
+            required:
+            - cidr
+            type: object
+        type: object
+    served: true
+    storage: true
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: hostendpoints.crd.projectcalico.org
 spec:
-  scope: Cluster
   group: crd.projectcalico.org
-  version: v1
   names:
     kind: HostEndpoint
+    listKind: HostEndpointList
     plural: hostendpoints
     singular: hostendpoint
-
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HostEndpointSpec contains the specification for a HostEndpoint
+              resource.
+            properties:
+              expectedIPs:
+                description: "The expected IP addresses (IPv4 and IPv6) of the endpoint.
+                  If \"InterfaceName\" is not present, Calico will look for an interface
+                  matching any of the IPs in the list and apply policy to that. Note:
+                  \tWhen using the selector match criteria in an ingress or egress
+                  security Policy \tor Profile, Calico converts the selector into
+                  a set of IP addresses. For host \tendpoints, the ExpectedIPs field
+                  is used for that purpose. (If only the interface \tname is specified,
+                  Calico does not learn the IPs of the interface for use in match
+                  \tcriteria.)"
+                items:
+                  type: string
+                type: array
+              interfaceName:
+                description: "Either \"*\", or the name of a specific Linux interface
+                  to apply policy to; or empty.  \"*\" indicates that this HostEndpoint
+                  governs all traffic to, from or through the default network namespace
+                  of the host named by the \"Node\" field; entering and leaving that
+                  namespace via any interface, including those from/to non-host-networked
+                  local workloads. \n If InterfaceName is not \"*\", this HostEndpoint
+                  only governs traffic that enters or leaves the host through the
+                  specific interface named by InterfaceName, or - when InterfaceName
+                  is empty - through the specific interface that has one of the IPs
+                  in ExpectedIPs. Therefore, when InterfaceName is empty, at least
+                  one expected IP must be specified.  Only external interfaces (such
+                  as “eth0”) are supported here; it isn't possible for a HostEndpoint
+                  to protect traffic through a specific local workload interface.
+                  \n Note: Only some kinds of policy are implemented for \"*\" HostEndpoints;
+                  initially just pre-DNAT policy.  Please check Calico documentation
+                  for the latest position."
+                type: string
+              node:
+                description: The node name identifying the Calico node instance.
+                type: string
+              ports:
+                description: Ports contains the endpoint's named ports, which may
+                  be referenced in security policy rules.
+                items:
+                  properties:
+                    name:
+                      type: string
+                    port:
+                      type: integer
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                  required:
+                  - name
+                  - port
+                  - protocol
+                  type: object
+                type: array
+              profiles:
+                description: A list of identifiers of security Profile objects that
+                  apply to this endpoint. Each profile is applied in the order that
+                  they appear in this list.  Profile rules are applied after the selector-based
+                  security policy.
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterinformations.crd.projectcalico.org
 spec:
-  scope: Cluster
   group: crd.projectcalico.org
-  version: v1
   names:
     kind: ClusterInformation
+    listKind: ClusterInformationList
     plural: clusterinformations
     singular: clusterinformation
-
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ClusterInformation contains the cluster specific information.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterInformationSpec contains the values of describing
+              the cluster.
+            properties:
+              calicoVersion:
+                description: CalicoVersion is the version of Calico that the cluster
+                  is running
+                type: string
+              clusterGUID:
+                description: ClusterGUID is the GUID of the cluster
+                type: string
+              clusterType:
+                description: ClusterType describes the type of the cluster
+                type: string
+              datastoreReady:
+                description: DatastoreReady is used during significant datastore migrations
+                  to signal to components such as Felix that it should wait before
+                  accessing the datastore.
+                type: boolean
+              variant:
+                description: Variant declares which variant of Calico should be active.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org
 spec:
-  scope: Cluster
   group: crd.projectcalico.org
-  version: v1
   names:
     kind: GlobalNetworkPolicy
+    listKind: GlobalNetworkPolicyList
     plural: globalnetworkpolicies
     singular: globalnetworkpolicy
-
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              applyOnForward:
+                description: ApplyOnForward indicates to apply the rules in this policy
+                  on forward traffic.
+                type: boolean
+              doNotTrack:
+                description: DoNotTrack indicates whether packets matched by the rules
+                  in this policy should go through the data plane's connection tracking,
+                  such as Linux conntrack.  If True, the rules in this policy are
+                  applied before any data plane connection tracking, and packets allowed
+                  by this policy are marked as not to be tracked.
+                type: boolean
+              egress:
+                description: The ordered set of egress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with ”Not”. All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and Selector are defined on the same rule, then only workload
+                            endpoints that are matched by both selectors will be selected
+                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                            implies that the Selector is limited to selecting only
+                            workload endpoints in the same namespace as the NetworkPolicy.
+                            \n For NetworkPolicy, `global()` NamespaceSelector implies
+                            that the Selector is limited to selecting only GlobalNetworkSet
+                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                            NamespaceSelector implies the Selector applies to workload
+                            endpoints across all namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label “my_label”. \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label “my_label”.
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel’s iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel’s iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and Selector are defined on the same rule, then only workload
+                            endpoints that are matched by both selectors will be selected
+                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                            implies that the Selector is limited to selecting only
+                            workload endpoints in the same namespace as the NetworkPolicy.
+                            \n For NetworkPolicy, `global()` NamespaceSelector implies
+                            that the Selector is limited to selecting only GlobalNetworkSet
+                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                            NamespaceSelector implies the Selector applies to workload
+                            endpoints across all namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label “my_label”. \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label “my_label”.
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                description: The ordered set of ingress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with ”Not”. All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and Selector are defined on the same rule, then only workload
+                            endpoints that are matched by both selectors will be selected
+                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                            implies that the Selector is limited to selecting only
+                            workload endpoints in the same namespace as the NetworkPolicy.
+                            \n For NetworkPolicy, `global()` NamespaceSelector implies
+                            that the Selector is limited to selecting only GlobalNetworkSet
+                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                            NamespaceSelector implies the Selector applies to workload
+                            endpoints across all namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label “my_label”. \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label “my_label”.
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel’s iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel’s iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and Selector are defined on the same rule, then only workload
+                            endpoints that are matched by both selectors will be selected
+                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                            implies that the Selector is limited to selecting only
+                            workload endpoints in the same namespace as the NetworkPolicy.
+                            \n For NetworkPolicy, `global()` NamespaceSelector implies
+                            that the Selector is limited to selecting only GlobalNetworkSet
+                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                            NamespaceSelector implies the Selector applies to workload
+                            endpoints across all namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label “my_label”. \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label “my_label”.
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              namespaceSelector:
+                description: NamespaceSelector is an optional field for an expression
+                  used to select a pod based on namespaces.
+                type: string
+              order:
+                description: Order is an optional field that specifies the order in
+                  which the policy is applied. Policies with higher "order" are applied
+                  after those with lower order.  If the order is omitted, it may be
+                  considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                  with identical order will be applied in alphanumerical order based
+                  on the Policy "Name".
+                type: number
+              preDNAT:
+                description: PreDNAT indicates to apply the rules in this policy before
+                  any DNAT.
+                type: boolean
+              selector:
+                description: "The selector is an expression used to pick pick out
+                  the endpoints that the policy should be applied to. \n Selector
+                  expressions follow this syntax: \n \tlabel == \"string_literal\"
+                  \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                  \  ->  not equal; also matches if label is not present \tlabel in
+                  { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                  one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                  ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                  \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                  -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                  || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                  or the empty selector -> matches all endpoints. \n Label names are
+                  allowed to contain alphanumerics, -, _ and /. String literals are
+                  more permissive but they do not support escape characters. \n Examples
+                  (with made-up labels): \n \ttype == \"webserver\" && deployment
+                  == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                  \"dev\" \t! has(label_name)"
+                type: string
+              serviceAccountSelector:
+                description: ServiceAccountSelector is an optional field for an expression
+                  used to select a pod based on service accounts.
+                type: string
+              types:
+                description: "Types indicates whether this policy applies to ingress,
+                  or to egress, or to both.  When not explicitly specified (and so
+                  the value on creation is empty or nil), Calico defaults Types according
+                  to what Ingress and Egress rules are present in the policy.  The
+                  default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
+                  (including the case where there are   also no Ingress rules) \n
+                  - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
+                  rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
+                  both Ingress and Egress rules. \n When the policy is read back again,
+                  Types will always be one of these values, never empty or nil."
+                items:
+                  description: PolicyType enumerates the possible values of the PolicySpec
+                    Types field.
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworksets.crd.projectcalico.org
 spec:
-  scope: Cluster
   group: crd.projectcalico.org
-  version: v1
   names:
     kind: GlobalNetworkSet
+    listKind: GlobalNetworkSetList
     plural: globalnetworksets
     singular: globalnetworkset
-
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs
+          that share labels to allow rules to refer to them via selectors.  The labels
+          of GlobalNetworkSet are not namespaced.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GlobalNetworkSetSpec contains the specification for a NetworkSet
+              resource.
+            properties:
+              nets:
+                description: The list of IP networks that belong to this set.
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.crd.projectcalico.org
 spec:
-  scope: Namespaced
   group: crd.projectcalico.org
-  version: v1
   names:
     kind: NetworkPolicy
+    listKind: NetworkPolicyList
     plural: networkpolicies
     singular: networkpolicy
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              egress:
+                description: The ordered set of egress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with ”Not”. All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and Selector are defined on the same rule, then only workload
+                            endpoints that are matched by both selectors will be selected
+                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                            implies that the Selector is limited to selecting only
+                            workload endpoints in the same namespace as the NetworkPolicy.
+                            \n For NetworkPolicy, `global()` NamespaceSelector implies
+                            that the Selector is limited to selecting only GlobalNetworkSet
+                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                            NamespaceSelector implies the Selector applies to workload
+                            endpoints across all namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label “my_label”. \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label “my_label”.
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel’s iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel’s iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and Selector are defined on the same rule, then only workload
+                            endpoints that are matched by both selectors will be selected
+                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                            implies that the Selector is limited to selecting only
+                            workload endpoints in the same namespace as the NetworkPolicy.
+                            \n For NetworkPolicy, `global()` NamespaceSelector implies
+                            that the Selector is limited to selecting only GlobalNetworkSet
+                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                            NamespaceSelector implies the Selector applies to workload
+                            endpoints across all namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label “my_label”. \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label “my_label”.
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                description: The ordered set of ingress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with ”Not”. All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and Selector are defined on the same rule, then only workload
+                            endpoints that are matched by both selectors will be selected
+                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                            implies that the Selector is limited to selecting only
+                            workload endpoints in the same namespace as the NetworkPolicy.
+                            \n For NetworkPolicy, `global()` NamespaceSelector implies
+                            that the Selector is limited to selecting only GlobalNetworkSet
+                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                            NamespaceSelector implies the Selector applies to workload
+                            endpoints across all namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label “my_label”. \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label “my_label”.
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel’s iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel’s iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and Selector are defined on the same rule, then only workload
+                            endpoints that are matched by both selectors will be selected
+                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                            implies that the Selector is limited to selecting only
+                            workload endpoints in the same namespace as the NetworkPolicy.
+                            \n For NetworkPolicy, `global()` NamespaceSelector implies
+                            that the Selector is limited to selecting only GlobalNetworkSet
+                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                            NamespaceSelector implies the Selector applies to workload
+                            endpoints across all namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label “my_label”. \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label “my_label”.
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              order:
+                description: Order is an optional field that specifies the order in
+                  which the policy is applied. Policies with higher "order" are applied
+                  after those with lower order.  If the order is omitted, it may be
+                  considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                  with identical order will be applied in alphanumerical order based
+                  on the Policy "Name".
+                type: number
+              selector:
+                description: "The selector is an expression used to pick pick out
+                  the endpoints that the policy should be applied to. \n Selector
+                  expressions follow this syntax: \n \tlabel == \"string_literal\"
+                  \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                  \  ->  not equal; also matches if label is not present \tlabel in
+                  { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                  one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                  ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                  \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                  -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                  || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                  or the empty selector -> matches all endpoints. \n Label names are
+                  allowed to contain alphanumerics, -, _ and /. String literals are
+                  more permissive but they do not support escape characters. \n Examples
+                  (with made-up labels): \n \ttype == \"webserver\" && deployment
+                  == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                  \"dev\" \t! has(label_name)"
+                type: string
+              serviceAccountSelector:
+                description: ServiceAccountSelector is an optional field for an expression
+                  used to select a pod based on service accounts.
+                type: string
+              types:
+                description: "Types indicates whether this policy applies to ingress,
+                  or to egress, or to both.  When not explicitly specified (and so
+                  the value on creation is empty or nil), Calico defaults Types according
+                  to what Ingress and Egress are present in the policy.  The default
+                  is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
+                  the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
+                  ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
+                  PolicyTypeEgress ], if there are both Ingress and Egress rules.
+                  \n When the policy is read back again, Types will always be one
+                  of these values, never empty or nil."
+                items:
+                  description: PolicyType enumerates the possible values of the PolicySpec
+                    Types field.
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
 
 {% if calico_version is version('v3.7.0', '>=') %}
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: networksets.crd.projectcalico.org
 spec:
-  scope: Namespaced
   group: crd.projectcalico.org
-  version: v1
   names:
     kind: NetworkSet
+    listKind: NetworkSetList
     plural: networksets
     singular: networkset
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: NetworkSet is the Namespaced-equivalent of the GlobalNetworkSet.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NetworkSetSpec contains the specification for a NetworkSet
+              resource.
+            properties:
+              nets:
+                description: The list of IP networks that belong to this set.
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
 {% endif %}

--- a/roles/network_plugin/kube-ovn/templates/cni-kube-ovn-crd.yml.j2
+++ b/roles/network_plugin/kube-ovn/templates/cni-kube-ovn-crd.yml.j2
@@ -1,10 +1,62 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ips.kubeovn.io
 spec:
   group: kubeovn.io
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+      - name: Provider
+        type: string
+        jsonPath: .spec.provider
+      - name: IP
+        type: string
+        jsonPath: .spec.ipAddress
+      - name: Mac
+        type: string
+        jsonPath: .spec.macAddress
+      - name: Node
+        type: string
+        jsonPath: .spec.nodeName
+      - name: Subnet
+        type: string
+        jsonPath: .spec.subnet
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                podName:
+                  type: string
+                namespace:
+                  type: string
+                subnet:
+                  type: string
+                attachSubnets:
+                  type: array
+                  items:
+                    type: string
+                nodeName:
+                  type: string
+                ipAddress:
+                  type: string
+                attachIps:
+                  type: array
+                  items:
+                    type: string
+                macAddress:
+                  type: string
+                attachMacs:
+                  type: array
+                  items:
+                    type: string
+                containerID:
+                  type: string
   scope: Cluster
   names:
     plural: ips
@@ -12,27 +64,111 @@ spec:
     kind: IP
     shortNames:
       - ip
-  additionalPrinterColumns:
-    - name: IP
-      type: string
-      JSONPath: .spec.ipAddress
-    - name: Mac
-      type: string
-      JSONPath: .spec.macAddress
-    - name: Node
-      type: string
-      JSONPath: .spec.nodeName
-    - name: Subnet
-      type: string
-      JSONPath: .spec.subnet
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: subnets.kubeovn.io
 spec:
   group: kubeovn.io
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+      - name: Protocol
+        type: string
+        jsonPath: .spec.protocol
+      - name: CIDR
+        type: string
+        jsonPath: .spec.cidrBlock
+      - name: Private
+        type: boolean
+        jsonPath: .spec.private
+      - name: NAT
+        type: boolean
+        jsonPath: .spec.natOutgoing
+      - name: Default
+        type: boolean
+        jsonPath: .spec.default
+      - name: GatewayType
+        type: string
+        jsonPath: .spec.gatewayType
+      - name: Used
+        type: number
+        jsonPath: .status.usingIPs
+      - name: Available
+        type: number
+        jsonPath: .status.availableIPs
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            status:
+              type: object
+              properties:
+                availableIPs:
+                  type: number
+                usingIPs:
+                  type: number
+                activateGateway:
+                  type: string
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastUpdateTime:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+            spec:
+              type: object
+              properties:
+                default:
+                  type: boolean
+                protocol:
+                  type: string
+                cidrBlock:
+                  type: string
+                namespaces:
+                  type: array
+                  items:
+                    type: string
+                gateway:
+                  type: string
+                provider:
+                  type: string
+                excludeIps:
+                  type: array
+                  items:
+                    type: string
+                gatewayType:
+                  type: string
+                allowSubnets:
+                  type: array
+                  items:
+                    type: string
+                gatewayNode:
+                  type: string
+                natOutgoing:
+                  type: boolean
+                private:
+                  type: boolean
+                vlan:
+                  type: string
+                underlayGateway:
+                  type: boolean
   scope: Cluster
   names:
     plural: subnets
@@ -40,54 +176,42 @@ spec:
     kind: Subnet
     shortNames:
       - subnet
-  subresources:
-    status: {}
-  additionalPrinterColumns:
-    - name: Provider
-      type: string
-      JSONPath: .spec.provider
-    - name: Protocol
-      type: string
-      JSONPath: .spec.protocol
-    - name: CIDR
-      type: string
-      JSONPath: .spec.cidrBlock
-    - name: Private
-      type: boolean
-      JSONPath: .spec.private
-    - name: NAT
-      type: boolean
-      JSONPath: .spec.natOutgoing
-    - name: Default
-      type: boolean
-      JSONPath: .spec.default
-    - name: GatewayType
-      type: string
-      JSONPath: .spec.gatewayType
-    - name: Used
-      type: number
-      JSONPath: .status.usingIPs
-    - name: Available
-      type: number
-      JSONPath: .status.availableIPs
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          required: ["cidrBlock"]
-          properties:
-            cidrBlock:
-              type: "string"
-            gateway:
-              type: "string"
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: vlans.kubeovn.io
 spec:
   group: kubeovn.io
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                vlanId:
+                  type: integer
+                providerInterfaceName:
+                  type: string
+                logicalInterfaceName:
+                  type: string
+                subnet:
+                  type: string
+      additionalPrinterColumns:
+      - name: VlanID
+        type: string
+        jsonPath: .spec.vlanId
+      - name: ProviderInterfaceName
+        type: string
+        jsonPath: .spec.providerInterfaceName
+      - name: Subnet
+        type: string
+        jsonPath: .spec.subnet
   scope: Cluster
   names:
     plural: vlans
@@ -95,13 +219,3 @@ spec:
     kind: Vlan
     shortNames:
       - vlan
-  additionalPrinterColumns:
-    - name: VlanID
-      type: string
-      JSONPath: .spec.vlanId
-    - name: ProviderInterfaceName
-      type: string
-      JSONPath: .spec.providerInterfaceName
-    - name: Subnet
-      type: string
-      JSONPath: .spec.subnet


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Bunch of deprecated API in [1.19](https://github.com/kubernetes/kubernetes/blob/v1.19.0-beta.1/CHANGELOG/CHANGELOG-1.19.md#changes-by-kind-1)

About CRD changes
```
The `CustomResourceDefinition` API type is promoted to `apiextensions.k8s.io/v1` with the following changes:
* Use of the new `default` feature in validation schemas is limited to v1
* `spec.scope` is no longer defaulted to `Namespaced` and must be explicitly specified
* `spec.version` is removed; use `spec.versions` instead
* `spec.validation` is removed; use `spec.versions[*].schema` instead
* `spec.subresources` is removed; use `spec.versions[*].subresources` instead
* `spec.additionalPrinterColumns` is removed; use `spec.versions[*].additionalPrinterColumns` instead
* `spec.conversion.webhookClientConfig` is moved to `spec.conversion.webhook.clientConfig`
* `spec.conversion.conversionReviewVersions` is moved to `spec.conversion.webhook.conversionReviewVersions`
* `spec.versions[*].schema.openAPIV3Schema` is now required when creating v1 CustomResourceDefinitions
* `spec.preserveUnknownFields: true` is disallowed when creating v1 CustomResourceDefinitions; it must be specified within schema definitions as `x-kubernetes-preserve-unknown-fields: true`
* In `additionalPrinterColumns` items, the `JSONPath` field was renamed to `jsonPath` (fixes https://github.com/kubernetes/kubernetes/issues/66531)
The `apiextensions.k8s.io/v1beta1` version of `CustomResourceDefinition` is deprecated and will no longer be served in v1.19.
```

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Make kubespray 1.19 ready.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
