### PR TITLE
calico: use absolute path to docker, crictl binary

### DIFF
--- a/roles/network_plugin/calico/handlers/main.yml
+++ b/roles/network_plugin/calico/handlers/main.yml
@@ -12,14 +12,14 @@
     state: absent
 
 - name: docker | delete calico-node containers
-  shell: "docker ps -af name=k8s_POD_calico-node* -q | xargs --no-run-if-empty docker rm -f"
+  shell: "{{ docker_bin_dir }}/docker ps -af name=k8s_POD_calico-node* -q | xargs --no-run-if-empty {{ docker_bin_dir }}/docker rm -f"
   register: docker_calico_node_remove
   until: docker_calico_node_remove is succeeded
   retries: 5
   when: container_manager in ["docker"]
 
 - name: containerd | delete calico-node containers
-  shell: 'crictl pods --name calico-node-* -q | xargs -I% --no-run-if-empty bash -c "crictl stopp % && crictl rmp %"'
+  shell: '{{ bin_dir }}/crictl pods --name calico-node-* -q | xargs -I% --no-run-if-empty bash -c "{{ bin_dir }}/crictl stopp % && {{ bin_dir }}/crictl rmp %"'
   register: crictl_calico_node_remove
   until: crictl_calico_node_remove is succeeded
   retries: 5


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

To avoid the following error (ignored when pipefail is off)

  RUNNING HANDLER [network_plugin/calico : containerd | delete calico-node containers] *******************************************************************************
  changed: [node1] => {"attempts": 1, "changed": true, "cmd": "crictl pods --name calico-node-* -q | xargs -I% --no-run-if-empty bash -c \"crictl stopp % && crictl rmp %\"", "delta": "0:00:00.004240", "end": "2020-06-10 03:32:41.316955", "rc": 0, "start": "2020-06-10 03:32:41.312715", "stderr": "/bin/sh: crictl: command not found", "stderr_lines": ["/bin/sh: crictl: command not found"], "stdout": "", "stdout_lines": []}


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
