### PR TITLE
Create /etc/gai.conf if not exists when disable_ipv6_dns is 'true'

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
+++ b/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
@@ -25,6 +25,7 @@
     dest: /etc/gai.conf
     line: "precedence ::ffff:0:0/96  100"
     state: present
+    create: yes
     backup: yes
   when:
     - disable_ipv6_dns


### PR DESCRIPTION
**What type of PR is this?**
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

When disabling IPV6 dns by setting `disable_ipv6_dns` as `true`, installation fails as `/etc/gai.conf` is not present.

**Which issue(s) this PR fixes**:
Fixes #6257
