### PR TITLE
Add disable_ipv6_dns: true in E2E tests

### DIFF
--- a/tests/files/packet_centos7-calico-ha-once-localhost.yml
+++ b/tests/files/packet_centos7-calico-ha-once-localhost.yml
@@ -12,3 +12,4 @@ dns_min_replicas: 1
 typha_enabled: true
 calico_backend: kdd
 typha_secure: true
+disable_ipv6_dns: true


### PR DESCRIPTION
**What type of PR is this?**
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:

Adding test to ensure `disable_ipv6_dns` as `true` works as expected.

**Special notes for your reviewer**:

I have included the `disable_ipv6_dns` in  a `packet_centos7` based test after checking that in this VM `/etc/gai.conf` is not present. This will ensure [this PR](https://github.com/kubernetes-sigs/kubespray/pull/6258) fix continues to work.