### PR TITLE
Fix check external_openstack_tenant_name value

### DIFF
--- a/roles/kubernetes-apps/external_cloud_controller/openstack/tasks/openstack-credential-check.yml
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/tasks/openstack-credential-check.yml
@@ -23,12 +23,5 @@
   fail:
     msg: "one of external_openstack_tenant_id or external_openstack_tenant_name must be specified"
   when:
-    - external_openstack_tenant_id is not defined or not external_openstack_tenant_id
-    - external_openstack_tenant_name is not defined
-
-- name: External OpenStack Cloud Controller | check external_openstack_tenant_name value
-  fail:
-    msg: "one of external_openstack_tenant_id or external_openstack_tenant_name must be specified"
-  when:
-    - external_openstack_tenant_name is not defined or not external_openstack_tenant_name
-    - external_openstack_tenant_id is not defined
+    - (external_openstack_tenant_id is not defined or not external_openstack_tenant_id) and
+      (external_openstack_tenant_name is not defined or not external_openstack_tenant_name)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

We need to specify either external_openstack_tenant_name or external_openstack_tenant_id. Those values were checked by seeing they are defined or they have actual values separately.
However those values are always defined because of the following code of openstack/defaults/main.yml:

```
external_openstack_tenant_id: "{{ lookup('env','OS_TENANT_ID')| default(lookup('env','OS_PROJECT_ID'),true) }}"
external_openstack_tenant_name: "{{ lookup('env','OS_TENANT_NAME')| default(lookup('env','OS_PROJECT_NAME'),true) }}"
```

So even if not specifying both values, those checks could not detect the misconfiguration. This fixes this to detect the misconfiguration.

**Special notes for your reviewer**:

I found this issue because of https://github.com/kubernetes-sigs/kubespray/pull/6262

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
