### PR TITLE
crio: configure CNI plugin dir properly

### DIFF
--- a/roles/container-engine/cri-o/defaults/main.yml
+++ b/roles/container-engine/cri-o/defaults/main.yml
@@ -14,3 +14,6 @@ crio_kubernetes_version_matrix:
   "1.16": "1.16"
 
 crio_version: "{{ crio_kubernetes_version_matrix[crio_required_version] | default('1.17') }}"
+
+crio_cni_plugin_dirs:
+  - /opt/cni/bin

--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -95,6 +95,7 @@
   template:
     src: crio.conf.j2
     dest: /etc/crio/crio.conf
+  notify: restart crio
 
 - name: Copy mounts.conf
   copy:

--- a/roles/container-engine/cri-o/templates/crio.conf.j2
+++ b/roles/container-engine/cri-o/templates/crio.conf.j2
@@ -280,6 +280,7 @@ network_dir = "/etc/cni/net.d/"
 
 # Paths to directories where CNI plugin binaries are located.
 plugin_dirs = [
-	"/usr/libexec/cni",
-	"/opt/cni/bin/",
+{% for dir in crio_cni_plugin_dirs %}
+	"{{ dir }}",
+{% endfor %}
 ]


### PR DESCRIPTION
POD networking does not work when crio is used as container engine.
"Network plugin returns error: No CNI configuration file in /etc/cni/net.d/"
can be found in journal

This is due to the configuration of crio that triggers a bug where crio
looks for cni plugin in the wrong directory.

Fixed by only configuring the existing installation directory for cni (and
removing the faulty first entry). Also making it configurable if needed.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6271 #6247 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
