### PR TITLE
Patch Calico V3.14.0 roles, missing CR and CRD for calico_kube_controller

### DIFF
--- a/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-cr.yml.j2
+++ b/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-cr.yml.j2
@@ -57,6 +57,7 @@ rules:
       - blockaffinities
       - ipamblocks
       - ipamhandles
+      - hostendpoints
     verbs:
       - get
       - list
@@ -71,4 +72,19 @@ rules:
       - get
       - create
       - update
+{% endif %}
+{% if calico_version is version('v3.14.0', '>=') %}
+  # KubeControllersConfiguration is where it gets its config
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - kubecontrollersconfigurations
+    verbs:
+      # read its own config
+      - get
+      # create a default if none exists
+      - create
+      # update status
+      - update
+      # watch for changes
+      - watch
 {% endif %}

--- a/roles/network_plugin/calico/templates/kdd-crds.yml.j2
+++ b/roles/network_plugin/calico/templates/kdd-crds.yml.j2
@@ -210,3 +210,18 @@ spec:
     plural: networksets
     singular: networkset
 {% endif %}
+{% if calico_version is version('v3.14.0', '>=') %}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubecontrollersconfigurations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: KubeControllersConfiguration
+    plural: kubecontrollersconfigurations
+    singular: kubecontrollersconfiguration
+{% endif %}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Ensures existence of CRD "kubecontrollersconfigurations" and defines rbac for this CR

**Which issue(s) this PR fixes**:

Fixes #6275

**Special notes for your reviewer**:

We patched live didn't test kubespray deploy (issue came after a gracefull upgrade)

**Does this PR introduce a user-facing change?**:
No idea
```release-note
Add kubecontrollersconfigurations CRD in kdd-crds.yml in roles/network_plugins/calico/templates and corresponding CR in roles/kubernetes_apps/policy_controller/calico/templates/calico_kube_cr.yml
Also defined missing "hostendpoints" CR in roles/kubernetes_apps/policy_controller/calico/templates/calico_kube_cr.yml

Source https://docs.projectcalico.org/manifests/calico.yaml
```
