### PR TITLE
Test bootstrap-os on more platforms

### DIFF
--- a/roles/bootstrap-os/molecule/default/molecule.yml
+++ b/roles/bootstrap-os/molecule/default/molecule.yml
@@ -10,12 +10,28 @@ driver:
   provider:
     name: libvirt
 platforms:
+  - name: ubuntu16
+    box: generic/ubuntu1604
+    cpus: 1
+    memory: 512
   - name: ubuntu18
     box: generic/ubuntu1804
     cpus: 1
     memory: 512
   - name: ubuntu20
     box: generic/ubuntu2004
+    cpus: 1
+    memory: 512
+  - name: centos7
+    box: centos/7
+    cpus: 1
+    memory: 512
+  - name: debian9
+    box: generic/debian9
+    cpus: 1
+    memory: 512
+  - name: debian10
+    box: generic/debian10
     cpus: 1
     memory: 512
 provisioner:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
boostrap-os is a role that is very dependent on the OS by definition, therefore it makes sense to test it on as many platforms as reasonably possible.

**Notes**
- Fedora fails in molecule
- Flatcar uses a special box URL, so it's not very easy to use in molecule