### PR TITLE
Add Vagrant CI for Ubuntu 20.04

### DIFF
--- a/.gitlab-ci/vagrant.yml
+++ b/.gitlab-ci/vagrant.yml
@@ -47,3 +47,8 @@ vagrant_ubuntu18-weave-medium:
   stage: deploy-part2
   extends: .vagrant
   when: manual
+
+vagrant_ubuntu20-flannel:
+  stage: deploy-part2
+  extends: .vagrant
+  when: on_success

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -17,7 +17,7 @@ opensuse |  :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 oracle7 |  :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 ubuntu16 |  :x: | :white_check_mark: | :x: | :white_check_mark: | :white_check_mark: | :x: | :white_check_mark: | :x: | :white_check_mark: |
 ubuntu18 |  :white_check_mark: | :x: | :white_check_mark: | :x: | :white_check_mark: | :x: | :x: | :x: | :white_check_mark: |
-ubuntu20 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
+ubuntu20 |  :white_check_mark: | :x: | :x: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: |
 
 ## crio
 

--- a/tests/files/vagrant_ubuntu20-flannel.rb
+++ b/tests/files/vagrant_ubuntu20-flannel.rb
@@ -1,0 +1,9 @@
+$os = "ubuntu2004"
+
+# For CI we are not worries about data persistence across reboot
+$libvirt_volume_cache = "unsafe"
+
+# Checking for box update can trigger API rate limiting
+# https://www.vagrantup.com/docs/vagrant-cloud/request-limits.html
+$box_check_update = false
+$vm_cpus = 2

--- a/tests/files/vagrant_ubuntu20-flannel.yml
+++ b/tests/files/vagrant_ubuntu20-flannel.yml
@@ -1,0 +1,7 @@
+---
+# Kubespray settings
+
+kube_network_plugin: flannel
+
+deploy_netchecker: true
+dns_min_replicas: 1


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
After adding support for Ubuntu 20.04 in Vagrantfile in #6157 let's add CI for it.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
