### PR TITLE
Use async to download containers; as large images can cause ssh timeout

### DIFF
--- a/roles/download/tasks/download_container.yml
+++ b/roles/download/tasks/download_container.yml
@@ -57,6 +57,9 @@
       until: pull_task_result is succeeded
       delay: "{{ retry_stagger | random + 3 }}"
       retries: 4
+      # Use async/poll to avoid ssh connection timeout for very large images
+      async: 3600
+      poll: 5
       become: "{{ user_can_become_root | default(false) or not download_localhost }}"
       when:
         - pull_required or download_run_once


### PR DESCRIPTION
/kind flake

**What this PR does / why we need it**:
After applying the https://github.com/openstack/ansible-hardening, the ssh connection timeout is quite short. Occasionally, the Kubespray download of large container images caused the ssh connection to timeout and the playbook to fail.
This PR adds a 1-hour async connection and a 5-second poll while downloading container images.
The poll keeps the ssh connection alive in hardened environments.

**Which issue(s) this PR fixes**:
N/A
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE