### PR TITLE
Use NetworkManager to manage resolv.conf for Fedora CoreOS

### DIFF
--- a/roles/kubernetes/preinstall/handlers/main.yml
+++ b/roles/kubernetes/preinstall/handlers/main.yml
@@ -16,11 +16,22 @@
   notify:
     - Preinstall | apply resolvconf cloud-init
     - Preinstall | reload kubelet
-  when: ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"] or is_fedora_coreos
+  when: ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
 
 - name: Preinstall | apply resolvconf cloud-init
   command: /usr/bin/coreos-cloudinit --from-file {{ resolveconf_cloud_init_conf }}
-  when: ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"] or is_fedora_coreos
+  when: ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+
+- name: Preinstall | update resolvconf for Fedora CoreOS
+  command: /bin/true
+  notify:
+    - Preinstall | reload NetworkManager
+    - Preinstall | reload kubelet
+  when: is_fedora_coreos
+
+- name: Preinstall | reload NetworkManager
+  command: systemctl restart NetworkManager.service
+  when: is_fedora_coreos
 
 - name: Preinstall | reload kubelet
   service:

--- a/roles/kubernetes/preinstall/tasks/0060-resolvconf.yml
+++ b/roles/kubernetes/preinstall/tasks/0060-resolvconf.yml
@@ -1,7 +1,7 @@
 ---
 - name: create temporary resolveconf cloud init file
   command: cp -f /etc/resolv.conf "{{ resolvconffile }}"
-  when: ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"] or is_fedora_coreos
+  when: ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
 
 - name: Add domain/search/nameservers/options to resolv.conf
   blockinfile:
@@ -47,7 +47,7 @@
 - name: get temporary resolveconf cloud init file content
   command: cat {{ resolvconffile }}
   register: cloud_config
-  when: ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"] or is_fedora_coreos
+  when: ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
 
 - name: persist resolvconf cloud init file
   template:
@@ -56,4 +56,4 @@
     owner: root
     mode: 0644
   notify: Preinstall | update resolvconf for Container Linux by CoreOS and Flatcar
-  when: ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"] or is_fedora_coreos
+  when: ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]

--- a/roles/kubernetes/preinstall/tasks/0062-networkmanager.yml
+++ b/roles/kubernetes/preinstall/tasks/0062-networkmanager.yml
@@ -1,0 +1,40 @@
+---
+- name: NetworkManager | Add nameservers to NM configuration
+  ini_file:
+    path: /etc/NetworkManager/system-connections/default_connection.nmconnection
+    section: ipv4
+    option: dns
+    value: "{{ ( coredns_server + nameservers|d([]) + cloud_resolver|d([])) | unique | join(';') }}"
+    mode: '0600'
+    backup: yes
+  notify: Preinstall | update resolvconf for Fedora CoreOS
+
+- name: NetworkManager | Add DNS search to NM configuration
+  ini_file:
+    path: /etc/NetworkManager/system-connections/default_connection.nmconnection
+    section: ipv4
+    option: dns-search
+    value: "{{ ([ 'default.svc.' + dns_domain, 'svc.' + dns_domain ] + searchdomains|default([])) | join(';') }}"
+    mode: '0600'
+    backup: yes
+  notify: Preinstall | update resolvconf for Fedora CoreOS
+
+- name: NetworkManager | Add DNS options to NM configuration
+  ini_file:
+    path: /etc/NetworkManager/system-connections/default_connection.nmconnection
+    section: ipv4
+    option: dns-options
+    value: "ndots:{{ ndots }};timeout:2;attempts:2;"
+    mode: '0600'
+    backup: yes
+  notify: Preinstall | update resolvconf for Fedora CoreOS
+
+- name: NetworkManager | Ignore DNS auto configuration
+  ini_file:
+    path: /etc/NetworkManager/system-connections/default_connection.nmconnection
+    section: ipv4
+    option: ignore-auto-dns
+    value: 'true'
+    mode: '0600'
+    backup: yes
+  notify: Preinstall | update resolvconf for Fedora CoreOS

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -33,6 +33,7 @@
     - dns_mode != 'none'
     - resolvconf_mode == 'host_resolvconf'
     - systemd_resolved_enabled.rc != 0
+    - not is_fedora_coreos
   tags:
     - bootstrap-os
     - resolvconf
@@ -42,6 +43,15 @@
     - dns_mode != 'none'
     - resolvconf_mode == 'host_resolvconf'
     - systemd_resolved_enabled.rc == 0
+  tags:
+    - bootstrap-os
+    - resolvconf
+
+- import_tasks: 0062-networkmanager.yml
+  when:
+    - dns_mode != 'none'
+    - resolvconf_mode == 'host_resolvconf'
+    - is_fedora_coreos
   tags:
     - bootstrap-os
     - resolvconf


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind bug

**What this PR does / why we need it**:
`resolv.conf` is not generated on Fedora CoreOS when `resolvconf_mode == 'host_resolvconf'`.
Add DNS configuration in NetworkManager to build `resolv.conf` 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Tested with:
* Fedora CoreOS 31.20200517.3.0
* Kubespray 2.13
 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add DNS configuration in NetworkManager for Fedora CoreOS
```
