### PR TITLE
WIP: Fix hostnames if not override_system_hostname

### DIFF
--- a/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1beta2.j2
+++ b/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1beta2.j2
@@ -19,7 +19,9 @@ discovery:
   tlsBootstrapToken: {{ kubeadm_token }}
 caCertPath: {{ kube_cert_dir }}/ca.crt
 nodeRegistration:
+{% if override_system_hostname %}
   name: {{ kube_override_hostname }}
+{% endif %}
   criSocket: {{ cri_socket }}
 {% if 'calico-rr' in group_names and 'kube-node' not in group_names %}
   taints:

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
@@ -13,7 +13,7 @@ localAPIEndpoint:
 certificateKey: {{ kubeadm_certificate_key }}
 {% endif %}
 nodeRegistration:
-{% if kube_override_hostname|default('') %}
+{% if override_system_hostname %}
   name: {{ kube_override_hostname }}
 {% endif %}
 {% if inventory_hostname in groups['kube-master'] and inventory_hostname not in groups['kube-node'] %}
@@ -336,7 +336,9 @@ conntrack:
  tcpEstablishedTimeout: {{ kube_proxy_conntrack_tcp_established_timeout }}
 enableProfiling: {{ kube_proxy_enable_profiling }}
 healthzBindAddress: {{ kube_proxy_healthz_bind_address }}
+{% if override_system_hostname %}
 hostnameOverride: {{ kube_override_hostname }}
+{% endif %}
 iptables:
  masqueradeAll: {{ kube_proxy_masquerade_all }}
  masqueradeBit: {{ kube_proxy_masquerade_bit }}

--- a/roles/kubernetes/master/templates/kubeadm-controlplane.v1beta2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-controlplane.v1beta2.yaml.j2
@@ -17,5 +17,7 @@ controlPlane:
     bindPort: {{ kube_apiserver_port }}
   certificateKey: {{ kubeadm_certificate_key }}
 nodeRegistration:
+{% if override_system_hostname %}
   name: {{ kube_override_hostname|default(inventory_hostname) }}
+{% endif %}
   criSocket: {{ cri_socket }}

--- a/roles/kubernetes/node/templates/kubelet.env.v1beta1.j2
+++ b/roles/kubernetes/node/templates/kubelet.env.v1beta1.j2
@@ -1,7 +1,7 @@
 KUBE_LOGTOSTDERR="--logtostderr=true"
 KUBE_LOG_LEVEL="--v={{ kube_log_level }}"
 KUBELET_ADDRESS="--node-ip={{ kubelet_address }}"
-{% if kube_override_hostname|default('') %}
+{% if override_system_hostname %}
 KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {% endif %}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When override_system_hostname is false hostnames should not be overrided
with ansible inventory hostnames, and the original hostnames should be
kept on each node. This feature itself works fine.
However, the result of "kubectl get nodes" shows the inventory hostnames
instead.
This fixes the issue.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
