### PR TITLE
[2.13] Update base image to v2.12.7

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ stages:
   - deploy-special
 
 variables:
-  KUBESPRAY_VERSION: v2.12.6
+  KUBESPRAY_VERSION: v2.12.7
   FAILFASTCI_NAMESPACE: 'kargo-ci'
   GITLAB_REPOSITORY: 'kargo-ci/kubernetes-sigs-kubespray'
   ANSIBLE_FORCE_COLOR: "true"

--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -74,8 +74,11 @@ packet_centos7-calico-ha-once-localhost:
   stage: deploy-part2
   extends: .packet
   when: on_success
+  variables:
+    # This will instruct Docker not to start over TLS.
+    DOCKER_TLS_CERTDIR: ""
   services:
-    - docker:18.09.9-dind
+    - docker:19.03.9-dind
 
 packet_centos8-kube-ovn:
   stage: deploy-part2


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
v2.12.7 has been release, we should use that as a base image.