### PR TITLE
Fix issue 6294 - "All pods simultaneously restart during worker scaling"

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -1,16 +1,33 @@
 # Setting up Environment Proxy
 
-If you set http and https proxy, all nodes and loadbalancer will be excluded from proxy with generating no_proxy variable in `roles/kubespray-defaults/tasks/no_proxy.yml`, if you have additional resources for exclude add them to `additional_no_proxy` variable. If you want fully override your `no_proxy` setting, then fill in just `no_proxy` and no nodes or loadbalancer addresses will be added to no_proxy.
+If you set http and https proxy, all nodes and loadbalancer will be excluded from proxy with generating no_proxy
+variable in `roles/kubespray-defaults/defaults/main.yml`, if you have additional resources for exclude add them to
+`additional_no_proxy` variable.
+
+By default, these settings will restart the docker engine on all nodes (all pods will restart) when adding\removing
+workers to the cluster.  To override this behaviour by only including master nodes in the no_proxy variable, set
+`no_proxy_exclude_workers: true`.
+
+If you want to fully override your `no_proxy` setting, then fill in just `no_proxy` and no nodes or loadbalancer
+addresses will be added to no_proxy.
+
+If your cluster is already operational, be aware that changing any of these values will cause docker engine and all
+pods to restart upon next convergence.
 
 ## Set proxy for http and https
 
  `http_proxy:"http://example.proxy.tld:port"`
  `https_proxy:"http://example.proxy.tld:port"`
 
-## Set default no_proxy (this will override default no_proxy generation)
+## Add additional addresses to default no_proxy
+
+Specified hosts\IPs will be added to cluster nodes and loadbalancer.
+`additional_no_proxy: "aditional_host, 10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12"`
+
+## Exclude workers from no_proxy
+
+`no_proxy_exclude_workers: true`
+
+## Override no_proxy completely
 
 `no_proxy: "node1,node1_ip,node2,node2_ip...additional_host"`
-
-## Set additional addresses to default no_proxy (all cluster nodes and loadbalancer)
-
-`additional_no_proxy: "aditional_host,"`

--- a/docs/vars.md
+++ b/docs/vars.md
@@ -110,7 +110,7 @@ Stack](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/dns-stack.m
 * *docker_plugins* - This list can be used to define [Docker plugins](https://docs.docker.com/engine/extend/) to install.
 * *containerd_config* - Controls some parameters in containerd configuration file (usually /etc/containerd/config.toml).
   [Default config](https://github.com/kubernetes-sigs/kubespray/blob/master/roles/container-engine/containerd/defaults/main.yml) can be overriden in inventory vars.
-* *http_proxy/https_proxy/no_proxy* - Proxy variables for deploying behind a
+* *http_proxy/https_proxy/no_proxy/no_proxy_exclude_workers/additional_no_proxy* - Proxy variables for deploying behind a
   proxy. Note that no_proxy defaults to all internal cluster IPs and hostnames
   that correspond to each node.
 * *kubelet_deployment_type* - Controls which platform to deploy kubelet on.

--- a/inventory/sample/group_vars/all/all.yml
+++ b/inventory/sample/group_vars/all/all.yml
@@ -58,20 +58,26 @@ loadbalancer_apiserver_healthcheck_port: 8081
 ## When openstack or vsphere are used make sure to source in the required fields
 # external_cloud_provider:
 
-## Set these proxy values in order to update package manager and docker daemon to use proxies
+## Set these proxy values in order to update package manager and docker daemon to use proxies.  If your cluster is
+## already operational, be aware that changing any of the below proxy values will cause docker engine and all pods to
+## restart upon next convergence.
 # http_proxy: ""
 # https_proxy: ""
 
-## Refer to roles/kubespray-defaults/defaults/main.yml before modifying no_proxy
+## Default proxy behaviour causes docker engine and all pods to restart on all nodes when adding\removing workers.  To
+## override by excluding workers from no_proxy, set below boolean to true:
+no_proxy_exclude_workers: false
+
+## This will override no_proxy completely, see roles/kubespray-defaults/defaults/main.yml before modifying no_proxy:
 # no_proxy: ""
+
+## If you need exclude all cluster nodes from proxy and other resources, add other resources here.
+# additional_no_proxy: ""
 
 ## Some problems may occur when downloading files over https proxy due to ansible bug
 ## https://github.com/ansible/ansible/issues/32750. Set this variable to False to disable
 ## SSL validation of get_url module. Note that kubespray will still be performing checksum validation.
 # download_validate_certs: False
-
-## If you need exclude all cluster nodes from proxy and other resources, add other resources here.
-# additional_no_proxy: ""
 
 ## Certificate Management
 ## This setting determines whether certs are generated via scripts.

--- a/roles/kubespray-defaults/tasks/no_proxy.yml
+++ b/roles/kubespray-defaults/tasks/no_proxy.yml
@@ -6,6 +6,16 @@
       {{ apiserver_loadbalancer_domain_name| default('') }},
       {{ loadbalancer_apiserver.address | default('') }},
       {%- endif -%}
+      {%- if ( (no_proxy_exclude_workers is defined) and (no_proxy_exclude_workers) ) -%}
+      {%- for item in (groups['kube-master'] + groups['etcd'] + groups['calico-rr']|default([]))|unique -%}
+      {{ hostvars[item]['access_ip'] | default(hostvars[item]['ip'] | default(fallback_ips[item])) }},
+      {%-   if item != hostvars[item].get('ansible_hostname', '') -%}
+      {{ hostvars[item]['ansible_hostname'] }},
+      {{ hostvars[item]['ansible_hostname'] }}.{{ dns_domain }},
+      {%- endif -%}
+      {{ item }},{{ item }}.{{ dns_domain }},
+      {%- endfor -%}
+      {%- else -%}
       {%- for item in (groups['k8s-cluster'] + groups['etcd'] + groups['calico-rr']|default([]))|unique -%}
       {{ hostvars[item]['access_ip'] | default(hostvars[item]['ip'] | default(fallback_ips[item])) }},
       {%-   if item != hostvars[item].get('ansible_hostname', '') -%}
@@ -14,6 +24,7 @@
       {%-   endif -%}
       {{ item }},{{ item }}.{{ dns_domain }},
       {%- endfor -%}
+      {%- endif -%}
       {%- if additional_no_proxy is defined -%}
       {{ additional_no_proxy }},
       {%- endif -%}


### PR DESCRIPTION
Scaling masters will still cause docker engine to restart on all nodes, but this is unavoidable.

/kind bug

**What this PR does / why we need it**:
See issue #6294

**Which issue(s) this PR fixes**:
Fixes #6294

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```