### PR TITLE
kube_encryption_resources must be output as yaml

### DIFF
--- a/roles/kubernetes/master/templates/secrets_encryption.yaml.j2
+++ b/roles/kubernetes/master/templates/secrets_encryption.yaml.j2
@@ -1,7 +1,8 @@
 kind: EncryptionConfig
 apiVersion: v1
 resources:
-  - resources: {{ kube_encryption_resources }}
+  - resources:
+{{ kube_encryption_resources|to_nice_yaml|indent(4, True) }}
     providers:
     - {{ kube_encryption_algorithm }}:
         keys:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`kube_encryption_resources` variable (list) is rendered as plain text from secrets_encryption.yaml.j2 template, elements of this list (strings) are prefixed with unicode "u" prefix in the rendered manifest.
As a consequence, encryption at REST is simply ignored for these resources.

This variable must be serialized as yaml, that's what this PR does.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
Once the encryption-at-rest is in place, resources must be updated.
As mentioned in https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/, for example with secrets only (as the default value of `kube_encryption_resources` variable is), the following command should be applied:
kubectl get secrets --all-namespaces -o json | kubectl replace -f -
```
