### PR TITLE
Gather ansible_default_ipv4 for specific groups

### DIFF
--- a/roles/kubespray-defaults/tasks/fallback_ips.yml
+++ b/roles/kubespray-defaults/tasks/fallback_ips.yml
@@ -6,7 +6,7 @@
 - name: Gather ansible_default_ipv4 from all hosts
   include_tasks: fallback_ips_gather.yml
   when: hostvars[delegate_host_to_gather_facts].ansible_default_ipv4 is not defined
-  loop: "{{ groups['all'] }}"
+  loop: "{{ groups['k8s-cluster']|default([]) + groups['etcd']|default([]) + groups['calico-rr']|default([]) }}"
   loop_control:
     loop_var: delegate_host_to_gather_facts
   run_once: yes


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
`/kind bug`

**What this PR does / why we need it**:
Currently we try to gather `ansible_default_ipv4` for `all` hosts. Which works well if you use kubespray as standalone project but since we use it as a submodule we have inventory with much more hosts and[ gather fact](https://github.com/kubernetes-sigs/kubespray/blob/master/roles/kubespray-defaults/tasks/fallback_ips.yml#L9) play takes much time or becomes fragile. The idea here is to limit it to specific groups so it works well for projects consuming it as submodule.

**Special notes for your reviewer**:
If we must gather facts for `all`. May be we can mark the tasks as `ignore_errors: true` ? 
