### PR TITLE
[2.11] added azure_cloud parameter to Azure's cloud_config

### DIFF
--- a/docs/azure.md
+++ b/docs/azure.md
@@ -14,6 +14,12 @@ Before creating the instances you must first set the `azure_` variables in the `
 All of the values can be retrieved using the azure cli tool which can be downloaded here: https://docs.microsoft.com/en-gb/azure/xplat-cli-install
 After installation you have to run `azure login` to get access to your account.
 
+### azure_cloud
+
+Azure Stack has different API endpoints, depending on the Azure Stack deployment. These need to be provided to the Azure SDK.
+Possible values are: `AzureChinaCloud`, `AzureGermanCloud`, `AzurePublicCloud` and `AzureUSGovernmentCloud`.
+The full list of existing settings for the AzureChinaCloud, AzureGermanCloud, AzurePublicCloud and AzureUSGovernmentCloud
+is available in the source code [here](https://github.com/kubernetes-sigs/cloud-provider-azure/blob/master/docs/cloud-provider-config.md)
 
 #### azure\_tenant\_id + azure\_subscription\_id
 run `azure account show` to retrieve your subscription id and tenant id:

--- a/inventory/sample/group_vars/all/azure.yml
+++ b/inventory/sample/group_vars/all/azure.yml
@@ -1,6 +1,7 @@
 ## When azure is used, you need to also set the following variables.
 ## see docs/azure.md for details on how to get these values
 
+# azure_cloud:
 # azure_tenant_id:
 # azure_subscription_id:
 # azure_aad_client_id:

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -129,3 +129,5 @@ azure_exclude_master_from_standard_lb: true
 azure_disable_outbound_snat: false
 # use instance metadata service where possible
 azure_use_instance_metadata: true
+# use specific Azure API endpoints
+azure_cloud: AzurePublicCloud

--- a/roles/kubernetes/node/tasks/cloud-credentials/azure-credential-check.yml
+++ b/roles/kubernetes/node/tasks/cloud-credentials/azure-credential-check.yml
@@ -70,3 +70,8 @@
 - name: "check azure_use_instance_metadata is a bool"
   assert:
     that: azure_use_instance_metadata |type_debug == 'bool'
+
+- name: check azure_cloud value
+  fail:
+    msg: "azure_cloud has an invalid value '{{ azure_cloud }}'. Supported values are 'AzureChinaCloud', 'AzureGermanCloud', 'AzurePublicCloud', 'AzureUSGovernmentCloud'."
+  when: azure_cloud not in ["AzureChinaCloud", "AzureGermanCloud", "AzurePublicCloud", "AzureUSGovernmentCloud"]

--- a/roles/kubernetes/node/templates/cloud-configs/azure-cloud-config.j2
+++ b/roles/kubernetes/node/templates/cloud-configs/azure-cloud-config.j2
@@ -1,4 +1,5 @@
 {
+  "cloud": "{{ azure_cloud }}"
   "tenantId": "{{ azure_tenant_id }}",
   "subscriptionId": "{{ azure_subscription_id }}",
   "aadClientId": "{{ azure_aad_client_id }}",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

/sig cloud-provider

**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

There is a lack of `"cloud"` parameter in Azure's `cloud_config` which is needed in deployments on which Azure Stack we deploy.
This causes issues with csi drivers which needs to communicate with proper API endpoints.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

I think it's quite critical as it makes wrong configuration for Azure's cloud_config.

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
