### PR TITLE
Fix some doc links

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,7 +36,7 @@ ansible-playbook -i inventory/mycluster/hosts.yml cluster.yml -b -v \
   --private-key=~/.ssh/private_key
 ```
 
-See more details in the [ansible guide](docs/ansible.md).
+See more details in the [ansible guide](/docs/ansible.md).
 
 ### Adding nodes
 
@@ -81,12 +81,12 @@ kube-apiserver via port 8080. A kubeconfig file is not necessary in this case,
 because kubectl will use <http://localhost:8080> to connect. The kubeconfig files
 generated will point to localhost (on kube-masters) and kube-node hosts will
 connect either to a localhost nginx proxy or to a loadbalancer if configured.
-More details on this process are in the [HA guide](docs/ha-mode.md).
+More details on this process are in the [HA guide](/docs/ha-mode.md).
 
 Kubespray permits connecting to the cluster remotely on any IP of any
 kube-master host on port 6443 by default. However, this requires
 authentication. One can get a kubeconfig from kube-master hosts
-(see [below](#accessing-kubernetes-api)) or connect with a [username and password](vars.md#user-accounts).
+(see [below](#accessing-kubernetes-api)) or connect with a [username and password](/docs/vars.md#user-accounts).
 
 For more information on kubeconfig and accessing a Kubernetes cluster, refer to
 the Kubernetes [documentation](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/).

--- a/docs/test_cases.md
+++ b/docs/test_cases.md
@@ -20,7 +20,7 @@ Note, the canal network plugin deploys flannel as well plus calico policy contro
 
 ## Test cases
 
-The [CI Matrix](docs/ci.md) displays OS, Network Plugin and Container Manager tested.
+The [CI Matrix](/docs/ci.md) displays OS, Network Plugin and Container Manager tested.
 
 All tests are breakdown into 3 "stages" ("Stage" means a build step of the build pipeline) as follows:
 

--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -24,7 +24,7 @@ The supported operating systems for vagrant are defined in the `SUPPORTED_OS` co
 
 ## File and image caching
 
-Kubespray can take quite a while to start on a laptop. To improve provisioning speed, the variable 'download_run_once' is set. This will make kubespray download all files and containers just once and then redistributes them to the other nodes and as a bonus, also cache all downloads locally and re-use them on the next provisioning run. For more information on download settings see [download documentation](downloads.md).
+Kubespray can take quite a while to start on a laptop. To improve provisioning speed, the variable 'download_run_once' is set. This will make kubespray download all files and containers just once and then redistributes them to the other nodes and as a bonus, also cache all downloads locally and re-use them on the next provisioning run. For more information on download settings see [download documentation](/docs/downloads.md).
 
 ## Example use of Vagrant
 

--- a/docs/vars.md
+++ b/docs/vars.md
@@ -38,11 +38,11 @@ Some variables of note include:
 * *loadbalancer_apiserver* - If defined, all hosts will connect to this
   address instead of localhost for kube-masters and kube-master[0] for
   kube-nodes. See more details in the
-  [HA guide](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/ha-mode.md).
+  [HA guide](/docs/ha-mode.md).
 * *loadbalancer_apiserver_localhost* - makes all hosts to connect to
   the apiserver internally load balanced endpoint. Mutual exclusive to the
   `loadbalancer_apiserver`. See more details in the
-  [HA guide](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/ha-mode.md).
+  [HA guide](/docs/ha-mode.md).
 
 ## Cluster variables
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind documentation
**What this PR does / why we need it**:
Depending if you check the docs in GitHub or in kubespray.io links might be broken using relative paths (docs/), using (/docs/) works in both cases.

**Which issue(s) this PR fixes**:

Fixes #6168
