### PR TITLE
Cilium: overwrite auto-detected MTU of underlying network

### DIFF
--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -2,6 +2,7 @@
 # Log-level
 cilium_debug: false
 
+cilium_mtu: ""
 cilium_enable_ipv4: true
 cilium_enable_ipv6: false
 

--- a/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
@@ -25,6 +25,9 @@ spec:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
         - --config-dir=/tmp/cilium/config-map
+{% if cilium_mtu != "" %}
+        - --mtu={{ cilium_mtu }}
+{% endif %}
         command:
         - cilium-agent
         env:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Overwrite the auto-detected MTU in Cilium agents.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
1. Set `vagrant/config.rb`:
```
$network_plugin = "cilium"
```

2. Update `inventory/sample/group_vars/k8s-cluster/k8s-net-cilium.yml`:
```yaml
cilium_mtu: 1300
```

3. Run vagrant:
```bash
vagrant up
```

4. Verify the MTU:
```bash
for pod in $(kubectl -n kube-system get pods -o name -l k8s-app=cilium); do kubectl -n kube-system exec -it $pod -- cilium debuginfo | grep mtu ; done
mtu:1300
mtu:1300
mtu:1300
```

**Does this PR introduce a user-facing change?**:
```release-note
Support the overwrite of MTU in Cilium agents
```
