### PR TITLE
Adding kube-proxy-replacement support in cilium

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -68,6 +68,11 @@ packet_ubuntu16-kube-router-svc-proxy:
   extends: .packet
   when: manual
 
+packet_debian10-cilium-svc-proxy:
+  stage: deploy-part2
+  extends: .packet
+  when: manual
+
 packet_debian10-containerd:
   stage: deploy-part2
   extends: .packet

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -9,7 +9,7 @@ To generate this Matrix run `./tests/scripts/md-table/main.py`
 amazon |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 centos7 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :white_check_mark: |
 centos8 |  :white_check_mark: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x: | :x: |
-debian10 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
+debian10 |  :x: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian9 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: |
 fedora30 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: |
 fedora31 |  :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: |

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -27,7 +27,14 @@ kubeadm_use_hyperkube_image: False
 kube_proxy_mode: ipvs
 
 ## Delete kube-proxy daemonset if kube_proxy_remove set, e.g. kube_network_plugin providing proxy services
-kube_proxy_remove: "{{ (kube_network_plugin == 'kube-router') and (kube_router_run_service_proxy is defined and kube_router_run_service_proxy)| bool }}"
+kube_proxy_remove: >-
+  {%- if kube_network_plugin == 'kube-router' -%}
+  {{ (kube_router_run_service_proxy is defined and kube_router_run_service_proxy)| bool }}
+  {%- elif kube_network_plugin == 'cilium' -%}
+  {{ (cilium_kube_proxy_replacement is defined and cilium_kube_proxy_replacement == 'strict')| bool }}
+  {%- else -%}
+  false
+  {%- endif -%}
 
 # A string slice of values which specify the addresses to use for NodePorts.
 # Values may be valid IP blocks (e.g. 1.2.3.0/24, 1.2.3.4/32).

--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -26,6 +26,8 @@ cilium_enable_prometheus: false
 cilium_enable_portmap: false
 # Monitor aggregation level (none/low/medium/maximum)
 cilium_monitor_aggregation: medium
+# Kube Proxy Replacement mode (strict/probe/partial)
+cilium_kube_proxy_replacement: probe
 
 # If upgrading from Cilium < 1.5, you may want to override some of these options
 # to prevent service disruptions. See also:

--- a/roles/network_plugin/cilium/templates/cilium-config.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-config.yml.j2
@@ -140,3 +140,5 @@ data:
   # Enable legacy services (prior v1.5) to prevent from terminating existing
   # connections with services when upgrading Cilium from < v1.5 to v1.5.
   enable-legacy-services: "{{cilium_enable_legacy_services}}"
+
+  kube-proxy-replacement: "{{ cilium_kube_proxy_replacement }}"

--- a/tests/files/packet_debian10-cilium-svc-proxy.yml
+++ b/tests/files/packet_debian10-cilium-svc-proxy.yml
@@ -1,0 +1,12 @@
+---
+# Instance settings
+cloud_image: debian-10
+mode: separate
+
+# Kubespray settings
+kube_network_plugin: cilium
+deploy_netchecker: true
+enable_network_policy: true
+dns_min_replicas: 1
+
+cilium_kube_proxy_replacement: strict


### PR DESCRIPTION
Signed-off-by: Arthur Outhenin-Chalandre <arthur@cri.epita.fr>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add kube-proxy-replacement support for a kube proxy free deployment with cilium https://docs.cilium.io/en/v1.8/gettingstarted/kubeproxy-free/

It still needs #5554 to fix various kube_proxy_remove bugs...

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add new variable cilium_kube_proxy_replacement
```
