### PR TITLE
[2.13] Fix no_proxy generation tasks

### DIFF
--- a/roles/kubespray-defaults/tasks/no_proxy.yml
+++ b/roles/kubespray-defaults/tasks/no_proxy.yml
@@ -26,6 +26,7 @@
 - name: Populates no_proxy to all hosts
   set_fact:
     no_proxy: "{{ hostvars.localhost.no_proxy_prepare }}"
-    proxy_env:
-      no_proxy: "{{ hostvars.localhost.no_proxy_prepare }}"
-      NO_PROXY: "{{ hostvars.localhost.no_proxy_prepare }}"
+    proxy_env: "{{ proxy_env | combine({
+      'no_proxy': hostvars.localhost.no_proxy_prepare,
+      'NO_PROXY': hostvars.localhost.no_proxy_prepare
+    }) }}"


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Currently deploying a cluster using explicit proxy doesn't work ever since 2.13 was released.
A fix has been push on master but 2.13 is still broken
ref #6112 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6108 

**Special notes for your reviewer**:
Cherry pick b6e21a18cc6b57d62684604af4ada70b955be15b

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
