### PR TITLE
Respect kube_override_hostname during removal/upgrade

### DIFF
--- a/roles/remove-node/post-remove/tasks/main.yml
+++ b/roles/remove-node/post-remove/tasks/main.yml
@@ -12,6 +12,6 @@
   failed_when: false
 
 - name: Delete node
-  command: "{{ bin_dir }}/kubectl delete node {{ inventory_hostname }}"
+  command: "{{ bin_dir }}/kubectl delete node {{ kube_override_hostname|default(inventory_hostname) }}"
   delegate_to: "{{ groups['kube-master']|first }}"
   ignore_errors: yes

--- a/roles/remove-node/pre-remove/tasks/main.yml
+++ b/roles/remove-node/pre-remove/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: cordon-node | Mark all nodes as unschedulable before drain
   command: >-
-    {{ bin_dir }}/kubectl cordon {{ kube_override_hostname|default(item) }}
+    {{ bin_dir }}/kubectl cordon {{ hostvars[item]['kube_override_hostname']|default(item) }}
   with_items:
     - "{{ node.split(',') | default(groups['kube-node']) }}"
   failed_when: false
@@ -16,7 +16,7 @@
       --ignore-daemonsets
       --grace-period {{ drain_grace_period }}
       --timeout {{ drain_timeout }}
-      --delete-local-data {{ kube_override_hostname|default(item) }}
+      --delete-local-data {{ hostvars[item]['kube_override_hostname']|default(item) }}
   with_items:
     - "{{ node.split(',') | default(groups['kube-node']) }}"
   failed_when: false

--- a/roles/remove-node/pre-remove/tasks/main.yml
+++ b/roles/remove-node/pre-remove/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: cordon-node | Mark all nodes as unschedulable before drain
   command: >-
-    {{ bin_dir }}/kubectl cordon {{ item }}
+    {{ bin_dir }}/kubectl cordon {{ kube_override_hostname|default(item) }}
   with_items:
     - "{{ node.split(',') | default(groups['kube-node']) }}"
   failed_when: false
@@ -16,7 +16,7 @@
       --ignore-daemonsets
       --grace-period {{ drain_grace_period }}
       --timeout {{ drain_timeout }}
-      --delete-local-data {{ item }}
+      --delete-local-data {{ kube_override_hostname|default(item) }}
   with_items:
     - "{{ node.split(',') | default(groups['kube-node']) }}"
   failed_when: false

--- a/roles/upgrade/post-upgrade/tasks/main.yml
+++ b/roles/upgrade/post-upgrade/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Uncordon node
-  command: "{{ bin_dir }}/kubectl --kubeconfig /etc/kubernetes/admin.conf uncordon {{ inventory_hostname }}"
+  command: "{{ bin_dir }}/kubectl --kubeconfig /etc/kubernetes/admin.conf uncordon {{ kube_override_hostname|default(inventory_hostname) }}"
   delegate_to: "{{ groups['kube-master'][0] }}"
   when:
     - needs_cordoning|default(false)

--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -3,7 +3,7 @@
 # Node NotReady: type = ready, status = Unknown
 - name: See if node is in ready state
   shell: >-
-    {{ bin_dir }}/kubectl get node {{ inventory_hostname }}
+    {{ bin_dir }}/kubectl get node {{ kube_override_hostname|default(inventory_hostname) }}
     -o jsonpath='{ range .status.conditions[?(@.type == "Ready")].status }{ @ }{ end }'
   register: kubectl_node_ready
   delegate_to: "{{ groups['kube-master'][0] }}"
@@ -14,7 +14,7 @@
 # else unschedulable key doesn't exist
 - name: See if node is schedulable
   shell: >-
-    {{ bin_dir }}/kubectl get node {{ inventory_hostname }}
+    {{ bin_dir }}/kubectl get node {{ kube_override_hostname|default(inventory_hostname) }}
     -o jsonpath='{ .spec.unschedulable }'
   register: kubectl_node_schedulable
   delegate_to: "{{ groups['kube-master'][0] }}"
@@ -31,7 +31,7 @@
       {%- endif %}
 
 - name: Cordon node
-  command: "{{ bin_dir }}/kubectl cordon {{ inventory_hostname }}"
+  command: "{{ bin_dir }}/kubectl cordon {{ kube_override_hostname|default(inventory_hostname) }}"
   delegate_to: "{{ groups['kube-master'][0] }}"
   when: needs_cordoning
 
@@ -61,7 +61,7 @@
     --ignore-daemonsets
     --grace-period {{ drain_grace_period }}
     --timeout {{ drain_timeout }}
-    --delete-local-data {{ inventory_hostname }}
+    --delete-local-data {{ kube_override_hostname|default(inventory_hostname) }}
     {% if drain_pod_selector %}--pod-selector '{{ drain_pod_selector }}'{% endif %}
   delegate_to: "{{ groups['kube-master'][0] }}"
   when:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
**What this PR does / why we need it**:
kubespray allows using `kube_override_hostname` which is then passed to `kubelet` and other components and hence commands like `kubectl` should respect the overridden names. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2088 (kindof)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Nodes will now be properly drained during upgrade while using `kube_override_hostname`
```
