### PR TITLE
Remove allow-release-candidate-upgrades already include in experimental-upgrades flag

### DIFF
--- a/roles/kubernetes/master/tasks/kubeadm-upgrade.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-upgrade.yml
@@ -17,9 +17,7 @@
     --config={{ kube_config_dir }}/kubeadm-config.yaml
     --ignore-preflight-errors=all
     --allow-experimental-upgrades
-    --allow-release-candidate-upgrades
     --etcd-upgrade={{ etcd_kubeadm_enabled | bool | lower }}
-    --certificate-renewal=true
     --force
   register: kubeadm_upgrade
   # Retry is because upload config sometimes fails
@@ -39,9 +37,7 @@
     --config={{ kube_config_dir }}/kubeadm-config.yaml
     --ignore-preflight-errors=all
     --allow-experimental-upgrades
-    --allow-release-candidate-upgrades
     --etcd-upgrade={{ etcd_kubeadm_enabled | bool | lower }}
-    --certificate-renewal=true
     --force
   register: kubeadm_upgrade
   when: inventory_hostname != groups['kube-master']|first


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
"experimental-upgrades" allow upgrade from alpha/beta and release candidate.
This can be check [here](https://github.com/kubernetes/kubernetes/blob/908847c01e9640ffce2ffda5acf88d92c48a5148/cmd/kubeadm/app/phases/upgrade/compute.go#L202)

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Also remove `certificate-renewal` as the default value is [already true](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-upgrade/#options).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
