### PR TITLE
add selinux for calico-node

### DIFF
--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -57,6 +57,8 @@ spec:
               name: host-local-net-dir
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir
+          securityContext:
+            privileged: true
 {% endif %}
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
@@ -113,6 +115,8 @@ spec:
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir
 {% endif %}
+          securityContext:
+            privileged: true
         # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and routes on each
         # host.


### PR DESCRIPTION
When I use calico network to test selinux for kubernetes， I find that when selinux enable , calico-node fail。
This is due to calico-node.yaml not have securityContext param.
What type of PR is this?
/kind bug
What this PR does / why we need it:
When slinux enable calico-node can not run, we need add securityContext param

Which issue(s) this PR fixes:
projectcalico/calico#2704


Does this PR introduce a user-facing change?:
None
