### PR TITLE
Remove deprecated flag for Cinder CSI controllerplugin

### DIFF
--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin-rbac.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin-rbac.yml.j2
@@ -16,16 +16,19 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "patch"]
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["csinodes"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
 
 
 ---

--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin.yml.j2
@@ -27,7 +27,6 @@ spec:
             - "--csi-address=$(ADDRESS)"
 {% if cinder_csi_controller_replicas is defined and cinder_csi_controller_replicas > 1 %}
             - --leader-election
-            - --leader-election-type=leases
             - --leader-election-namespace=kube-system
 {% endif %}
           env:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
https://github.com/kubernetes-sigs/kubespray/pull/6221 broke the Cinder CSI plugin because a flag is being used that was removed

**Special notes for your reviewer**:
The `--leader-election-type` flag in the `csi-attacher` container is unsupported from the current version. It's deprecated in `csi-provisioner`, but the default there is still `Endpoints` instead of `Lease` so I guess we have to wait for the removal to change it.

See: https://github.com/kubernetes-csi/external-attacher

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
