### PR TITLE
Enable OVH CI

### DIFF
--- a/.gitlab-ci/terraform.yml
+++ b/.gitlab-ci/terraform.yml
@@ -101,16 +101,16 @@ tf-validate-aws:
 #     TF_VAR_public_key_path: ""
 #     TF_VAR_operating_system: ubuntu_18_04
 
-# .ovh_variables: &ovh_variables
-#   OS_AUTH_URL: https://auth.cloud.ovh.net/v3
-#   OS_PROJECT_ID: 8d3cd5d737d74227ace462dee0b903fe
-#   OS_PROJECT_NAME: "9361447987648822"
-#   OS_USER_DOMAIN_NAME: Default
-#   OS_PROJECT_DOMAIN_ID: default
-#   OS_USERNAME: 8XuhBMfkKVrk
-#   OS_REGION_NAME: UK1
-#   OS_INTERFACE: public
-#   OS_IDENTITY_API_VERSION: "3"
+.ovh_variables: &ovh_variables
+  OS_AUTH_URL: https://auth.cloud.ovh.net/v3
+  OS_PROJECT_ID: 8d3cd5d737d74227ace462dee0b903fe
+  OS_PROJECT_NAME: "9361447987648822"
+  OS_USER_DOMAIN_NAME: Default
+  OS_PROJECT_DOMAIN_ID: default
+  OS_USERNAME: 8XuhBMfkKVrk
+  OS_REGION_NAME: UK1
+  OS_INTERFACE: public
+  OS_IDENTITY_API_VERSION: "3"
 
 # Elastx is generously donating resources for Kubespray on Openstack CI
 # Contacts: @gix @bl0m1
@@ -171,4 +171,46 @@ tf-elastx_ubuntu18-calico:
     TF_VAR_flavor_k8s_master: 3f73fc93-ec61-4808-88df-2580d94c1a9b    # v1-standard-2
     TF_VAR_flavor_k8s_node: 3f73fc93-ec61-4808-88df-2580d94c1a9b      # v1-standard-2
     TF_VAR_image: ubuntu-18.04-server-latest
+    TF_VAR_k8s_allowed_remote_ips: '["0.0.0.0/0"]'
+
+
+tf-ovh_cleanup:
+  stage: unit-tests
+  tags: [light]
+  image: python
+  environment: ovh
+  variables:
+    <<: *ovh_variables
+  before_script:
+    - pip install -r scripts/openstack-cleanup/requirements.txt
+  script:
+    - ./scripts/openstack-cleanup/main.py
+
+tf-ovh_ubuntu18-calico:
+  extends: .terraform_apply
+  when: on_success
+  environment: ovh
+  variables:
+    <<: *ovh_variables
+    TF_VERSION: 0.12.24
+    PROVIDER: openstack
+    CLUSTER: $CI_COMMIT_REF_NAME
+    ANSIBLE_TIMEOUT: "60"
+    SSH_USER: ubuntu
+    TF_VAR_number_of_k8s_masters: "0"
+    TF_VAR_number_of_k8s_masters_no_floating_ip: "1"
+    TF_VAR_number_of_k8s_masters_no_floating_ip_no_etcd: "0"
+    TF_VAR_number_of_etcd: "0"
+    TF_VAR_number_of_k8s_nodes: "0"
+    TF_VAR_number_of_k8s_nodes_no_floating_ip: "1"
+    TF_VAR_number_of_gfs_nodes_no_floating_ip: "0"
+    TF_VAR_number_of_bastions: "0"
+    TF_VAR_number_of_k8s_masters_no_etcd: "0"
+    TF_VAR_use_neutron: "0"
+    TF_VAR_floatingip_pool: "Ext-Net"
+    TF_VAR_external_net: "6011fbc9-4cbf-46a4-8452-6890a340b60b"
+    TF_VAR_network_name: "Ext-Net"
+    TF_VAR_flavor_k8s_master: "defa64c3-bd46-43b4-858a-d93bbae0a229"    # s1-8
+    TF_VAR_flavor_k8s_node: "defa64c3-bd46-43b4-858a-d93bbae0a229"      # s1-8
+    TF_VAR_image: "Ubuntu 18.04"
     TF_VAR_k8s_allowed_remote_ips: '["0.0.0.0/0"]'

--- a/tests/files/tf-ovh_ubuntu18-calico.yml
+++ b/tests/files/tf-ovh_ubuntu18-calico.yml
@@ -1,0 +1,7 @@
+---
+dns_min_replicas: 1
+deploy_netchecker: true
+sonobuoy_enabled: true
+
+# Ignore ping errors
+ignore_assert_errors: true


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:

OVH re-activated our CI voucher for another 12 months (until July 2021).

Each OpenStack deployment is a little different (and sometimes alot!), ELASTX and OVH cloud both cover different aspects of contrib/terraform/openstack, therefore I think there is value to have them both. For instance OVH has "router-less" scenario whereas ELASTX covers a "with Neutron router" scenario.