### PR TITLE
Add a way to deploy cilium alongside another CNI

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -677,7 +677,7 @@ downloads:
     - k8s-cluster
 
   cilium:
-    enabled: "{{ kube_network_plugin == 'cilium' }}"
+    enabled: "{{ kube_network_plugin == 'cilium' or cilium_deploy_additionally | default(false) | bool }}"
     container: true
     repo: "{{ cilium_image_repo }}"
     tag: "{{ cilium_image_tag }}"
@@ -686,7 +686,7 @@ downloads:
     - k8s-cluster
 
   cilium_init:
-    enabled: "{{ kube_network_plugin == 'cilium' }}"
+    enabled: "{{ kube_network_plugin == 'cilium' or cilium_deploy_additionally | default(false) | bool }}"
     container: true
     repo: "{{ cilium_init_image_repo }}"
     tag: "{{ cilium_init_image_tag }}"
@@ -695,7 +695,7 @@ downloads:
     - k8s-cluster
 
   cilium_operator:
-    enabled: "{{ kube_network_plugin == 'cilium' }}"
+    enabled: "{{ kube_network_plugin == 'cilium' or cilium_deploy_additionally | default(false) | bool }}"
     container: true
     repo: "{{ cilium_operator_image_repo }}"
     tag: "{{ cilium_operator_image_tag }}"

--- a/roles/kubernetes-apps/network_plugin/meta/main.yml
+++ b/roles/kubernetes-apps/network_plugin/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 dependencies:
   - role: kubernetes-apps/network_plugin/cilium
-    when: kube_network_plugin == 'cilium'
+    when: kube_network_plugin == 'cilium' or cilium_deploy_additionally | default(false) | bool
     tags:
       - cilium
 

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -130,7 +130,7 @@
   assert:
     that: ansible_kernel.split('-')[0] is version('4.8', '>=')
   when:
-    - kube_network_plugin == 'cilium'
+    - kube_network_plugin == 'cilium' or cilium_deploy_additionally | default(false) | bool
     - not ignore_assert_errors
 
 - name: Stop if bad hostname

--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -33,3 +33,7 @@ cilium_monitor_aggregation: medium
 cilium_preallocate_bpf_maps: false
 cilium_tofqdns_enable_poller: false
 cilium_enable_legacy_services: false
+
+# Deploy cilium even if kube_network_plugin is not cilium.
+# This enables to deploy cilium alongside another CNI to replace kube-proxy.
+cilium_deploy_additionally: false

--- a/roles/network_plugin/meta/main.yml
+++ b/roles/network_plugin/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 dependencies:
   - role: network_plugin/cilium
-    when: kube_network_plugin == 'cilium'
+    when: kube_network_plugin == 'cilium' or cilium_deploy_additionally | default(false) | bool
     tags:
       - cilium
 


### PR DESCRIPTION
Signed-off-by: Arthur Outhenin-Chalandre <arthur@cri.epita.fr>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This add a simple way to deploy Cilium alongside another CNI.
With this (and my others PR #5554 and #6334) kubespray could deploy cilium as a replacement for kube-proxy alongside other CNI to benefit from all the features of cilium (observability, high performance with eBPF/XDP/...).

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
I added a simple exception for cilium because I believe It is the only CNI that can replace kube-proxy while running with another CNI (or at least I didn't see any documentation for It in others CNI).

**Does this PR introduce a user-facing change?**:

```release-note
Add cilium_deploy_additionally to deploy cilium alongside another CNI
```
