### PR TITLE
Update vsphere.md to fix broken URL

### DIFF
--- a/docs/vsphere.md
+++ b/docs/vsphere.md
@@ -71,7 +71,7 @@ You'll find some useful examples [here](https://github.com/kubernetes/cloud-prov
 
 ### Prerequisites (deprecated)
 
-You need at first to configure your vSphere environment by following the [official documentation](https://kubernetes.io/docs/getting-started-guides/vsphere/#vsphere-cloud-provider).
+You need at first to configure your vSphere environment by following the [documentation](https://github.com/kubernetes/cloud-provider-vsphere/blob/master/docs/book/tutorials/kubernetes-on-vsphere-with-kubeadm.md).
 
 After this step you should have:
 


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> 
/kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: Link in "docs/vsphere.md" file and "In-tree vSphere cloud provider (deprecated)" part was broken. I think it is removed, best I could was [kubeadm documentation for vSphere requirements doc](https://github.com/kubernetes/cloud-provider-vsphere/blob/master/docs/book/tutorials/kubernetes-on-vsphere-with-kubeadm.md). I looked up previous releases of kubernetes docs but couldn't find original documentation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
