### PR TITLE
Create a PodDisruptionBudget for the Cinder CSI controller plugin

### DIFF
--- a/roles/kubernetes-apps/csi_driver/cinder/tasks/main.yml
+++ b/roles/kubernetes-apps/csi_driver/cinder/tasks/main.yml
@@ -41,6 +41,7 @@
     - {name: cinder-csi-controllerplugin, file: cinder-csi-controllerplugin.yml}
     - {name: cinder-csi-nodeplugin, file: cinder-csi-nodeplugin-rbac.yml}
     - {name: cinder-csi-nodeplugin, file: cinder-csi-nodeplugin.yml}
+    - {name: cinder-csi-poddisruptionbudget, file: cinder-csi-poddisruptionbudget.yml}
   register: cinder_csi_manifests
   when: inventory_hostname == groups['kube-master'][0]
   tags: cinder-csi-driver

--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-poddisruptionbudget.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-poddisruptionbudget.yml.j2
@@ -1,0 +1,14 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: cinder-csi-pdb
+  namespace: kube-system
+spec:
+{% if cinder_csi_controller_replicas is defined and cinder_csi_controller_replicas > 1 %}
+  minAvailable: 1
+{% else %}
+  minAvailable: 0
+{% endif %}
+  selector:
+    matchLabels:
+      app: csi-cinder-controllerplugin


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR adds a PodDisruptionBudget for the Cinder CSI controller plugin. This is to ensure the following scenario doesn't happen:

- `cinder-csi-controllerplugin` is deployed with `replicas: 2`
- An administrator drains two nodes at the same time, which happen to be the nodes the `cinder-csi-controllerplugin` pods are running on
- Both `cinder-csi-controllerplugin` pods are down, and get rescheduled to be started on other nodes
- All other pods that were running on the two drained nodes are rescheduled on other nodes. In my case, a lot of these pods have Cinder volumes attached to them. However, these pods cannot be started without the `cinder-csi-controllerplugin` starting first, because the `csi-attacher` is missing.
- There is no way to tell Kubernetes which pods are to be rescheduled first upon eviction, so what you end up with is a lot of volumed pods not being able to start until the `cinder-csi-controllerplugin` is restarted on another node.
- Eventually, `cinder-csi-controllerplugin` will be rescheduled and all other pods can be started, but in my experience, with a lot of volumed pods, this could take minutes.

With a PDB this whole scenario is prevented.

**Special notes for your reviewer**:
The PDB is disabled with `minAvailable: 0` when `cinder-csi-controllerplugin` is deployed in single mode, because otherwise it would prevent you from ever draining a node or upgrading the workload.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
