### PR TITLE
Use proper openssl command to differentiate between host and ip in API certificate check

### DIFF
--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -104,7 +104,7 @@
     - kubeadm_already_run.stat.exists
 
 - name: kubeadm | Check if apiserver.crt contains all needed SANs
-  command: openssl x509 -noout -in "{{ kube_cert_dir }}/apiserver.crt" -checkip "{{ item }}"
+  command: openssl x509 -noout -in "{{ kube_cert_dir }}/apiserver.crt" -check{{ item|ipaddr|ternary('ip','host') }} {{ item }}
   with_items: "{{ apiserver_sans }}"
   register: apiserver_sans_check
   changed_when: "'does match certificate' not in apiserver_sans_check.stdout"


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind bug


**What this PR does / why we need it**:
Currently, adding new host (not IP) to `supplementary_addresses_in_ssl_keys` list and re-applying the playbook does *NOT* regenerate the api certificate. 

The root cause seems to be the use of `-checkip` in [openssl x509 option](https://github.com/kubernetes-sigs/kubespray/blob/master/roles/kubernetes/master/tasks/kubeadm-setup.yml#L107) which always ends with a false-positive when called with anything but an IP address:

```bash
# openssl x509 -in apiserver.crt -text -noout
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 1911228677063672228 (0x1a860c5b0ceb81a4)
        Signature Algorithm: sha256WithRSAEncryption
        Issuer: CN = kubernetes
        Validity
            Not Before: May 10 18:54:48 2020 GMT
            Not After : Jul  4 22:28:55 2021 GMT
        Subject: CN = kube-apiserver
        Subject Public Key Info:
            Public Key Algorithm: rsaEncryption
                RSA Public-Key: (2048 bit)
                Modulus:
                    00:df:c9:35:1c:a2:9d:ff:38:c6:0b:7b:8d:7a:3d:
                    7e:15:bb:04:f1:d5:91:23:92:d6:30:e0:9b:13:6b:
                    24:47:cc:f9:e7:4b:26:c7:48:6c:a2:0a:ce:ac:42:
                    c0:fc:b2:1d:25:ad:0a:8a:fc:d0:3e:72:b5:b9:49:
                    1a:01:72:8c:a1:1e:9e:69:5c:9a:33:02:95:68:95:
                    8a:8c:9c:d1:cc:0f:98:8d:69:bb:23:2f:24:6d:c0:
                    70:4d:4a:e8:5a:aa:ff:3f:64:5d:98:c3:e4:aa:fc:
                    ef:ee:43:2c:64:bb:0a:d5:d1:fe:80:01:e2:3e:3c:
                    6d:31:6d:ea:8a:7d:67:da:ab:e8:d0:c8:0f:12:65:
                    6d:16:b9:1d:8f:f8:ac:aa:f4:cd:8d:43:d6:2c:86:
                    28:f4:7a:f8:0d:dc:42:34:c5:30:a4:ba:fd:df:b2:
                    76:25:d9:e7:24:cd:0a:0c:5f:af:6a:05:7c:43:8d:
                    e7:62:70:d6:90:7e:01:dc:7e:57:f3:1c:8f:f0:ef:
                    85:92:23:a9:21:f2:bd:d8:03:23:8e:69:a6:6a:59:
                    48:69:40:43:b0:29:01:1e:fa:8f:e4:b6:77:23:d5:
                    a1:96:bd:2e:71:9e:64:d5:b4:ba:2c:37:98:36:53:
                    67:17:8a:68:d3:b7:cb:ca:02:8c:9e:e6:9f:2c:3d:
                    6a:11
                Exponent: 65537 (0x10001)
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment
            X509v3 Extended Key Usage: 
                TLS Web Server Authentication
            X509v3 Subject Alternative Name: 
                DNS:nuc8i5beh-1, DNS:kubernetes, DNS:kubernetes.default, DNS:kubernetes.default.svc, DNS:kubernetes.default.svc.home-production, DNS:kubernetes, DNS:kubernetes.default, DNS:kubernetes.default.svc, DNS:kubernetes.default.svc.home-production, DNS:localhost, DNS:nuc8i5beh-1, DNS:nuc8i5beh-2, DNS:nuc6i5syh, DNS:lb-apiserver.kubernetes.local, DNS:nuc8i5beh-1.maas, DNS:nuc8i5beh-2.maas, DNS:nuc6i5syh.maas, IP Address:10.233.0.1, IP Address:192.168.10.12, IP Address:192.168.10.12, IP Address:10.233.0.1, IP Address:127.0.0.1, IP Address:192.168.10.12, IP Address:192.168.10.3, IP Address:192.168.10.2
    Signature Algorithm: sha256WithRSAEncryption
         34:2b:5d:b0:05:dc:c1:d8:e1:69:41:a1:0d:3a:0b:49:ba:b4:
         3f:ed:ab:1f:b3:16:ec:bc:b6:5b:f9:a7:b8:05:d0:ac:da:92:
         6c:55:f7:e6:85:7e:93:6c:c4:93:0a:93:d3:1f:bd:04:11:a6:
         d9:98:9e:89:8b:e9:3f:bf:35:63:22:07:e5:ad:3a:da:c0:08:
         b9:93:82:ff:8d:4f:49:05:ca:76:36:2a:67:e1:9b:a5:3e:69:
         6d:6c:6a:1c:d9:fd:d2:bb:52:0e:be:78:b9:69:6b:6b:bd:35:
         fb:a1:1b:e1:8b:58:88:1c:dd:71:7c:2b:be:e4:cd:2d:36:db:
         19:aa:a1:07:c6:b3:1e:eb:25:c1:dc:d2:cd:7c:31:17:a6:a2:
         f2:3b:7d:ca:64:73:c0:02:7c:a7:3a:8b:35:c9:22:5d:b6:cb:
         a1:67:fa:39:57:1c:10:9d:b2:0d:3c:72:35:7e:d5:70:25:9c:
         65:c9:a5:75:dd:6c:45:ea:ee:c0:05:07:a8:cd:86:27:40:65:
         91:03:95:f2:69:bb:93:fc:b4:64:a2:92:a7:5e:a4:30:1d:fc:
         63:51:85:84:5a:b6:ee:46:43:0b:75:0b:e2:08:57:0f:fe:a7:
         35:d2:3c:29:6d:27:56:82:43:66:8d:4a:15:15:d8:7c:1e:87:
         3d:cd:b1:5a

# openssl x509 -in apiserver.crt -noout -checkip f.q.d.n
IP f.q.d.n does match certificate

# openssl x509 -in apiserver.crt -noout -checkhost f.q.d.n
Hostname f.q.d.n does NOT match certificate
```

This PR differentiates host and IP by using `-checkip` for IP addresses and `-checkhost` for anything else.

**Does this PR introduce a user-facing change?**:
NONE
