### PR TITLE
Add option to configure IPVS timeouts in kube-proxy configration

### DIFF
--- a/roles/kubernetes/master/defaults/main/kube-proxy.yml
+++ b/roles/kubernetes/master/defaults/main/kube-proxy.yml
@@ -84,6 +84,18 @@ kube_proxy_scheduler: rr
 # must be set to true for MetalLB to work
 kube_proxy_strict_arp: false
 
+# kube_proxy_tcp_timeout is the timeout value used for idle IPVS TCP sessions.
+# The default value is 0, which preserves the current timeout value on the system.
+kube_proxy_tcp_timeout: 0s
+
+# kube_proxy_tcp_fin_timeout is the timeout value used for IPVS TCP sessions after receiving a FIN.
+# The default value is 0, which preserves the current timeout value on the system.
+kube_proxy_tcp_fin_timeout: 0s
+
+# kube_proxy_udp_timeout is the timeout value used for IPVS UDP packets.
+# The default value is 0, which preserves the current timeout value on the system.
+kube_proxy_udp_timeout: 0s
+
 # The IP address and port for the metrics server to serve on
 # (set to 0.0.0.0 for all IPv4 interfaces and `::` for all IPv6 interfaces)
 kube_proxy_metrics_bind_address: 127.0.0.1:10249

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
@@ -351,6 +351,9 @@ ipvs:
   scheduler: {{ kube_proxy_scheduler }}
   syncPeriod: {{ kube_proxy_sync_period }}
   strictARP: {{ kube_proxy_strict_arp }}
+  tcpTimeout: {{ kube_proxy_tcp_timeout }}
+  tcpFinTimeout: {{ kube_proxy_tcp_fin_timeout }}
+  udpTimeout: {{ kube_proxy_udp_timeout }}
 metricsBindAddress: {{ kube_proxy_metrics_bind_address }}
 mode: {{ kube_proxy_mode }}
 nodePortAddresses: {{ kube_proxy_nodeport_addresses }}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
- Configurable IPVS timeouts with kubespray.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes-sigs/kubespray/issues/6395

**Does this PR introduce a user-facing change?**:
```release-note
- Extend `roles/kubernetes/master/templates/kubeadm-controlplane.v1beta2.yaml.j2` with IPVS timeout options.
```
