### PR TITLE
Added option to force apiserver and respective client certificate to …

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -312,3 +312,5 @@ persistent_volumes_enabled: false
 
 ## Amount of time to retain events. (default 1h0m0s)
 event_ttl_duration: "1h0m0s"
+##  Force regeneration of kubernetes control plane certificates without the need of bumping the cluster version
+force_certificate_regeneration: false

--- a/roles/kubernetes/master/defaults/main/main.yml
+++ b/roles/kubernetes/master/defaults/main/main.yml
@@ -199,4 +199,3 @@ secrets_encryption_query: "resources[*].providers[0].{{kube_encryption_algorithm
 event_ttl_duration: "1h0m0s"
 ##  Force regeneration of kubernetes control plane certificates without the need of bumping the cluster version
 force_certificate_regeneration: false
-

--- a/roles/kubernetes/master/defaults/main/main.yml
+++ b/roles/kubernetes/master/defaults/main/main.yml
@@ -197,3 +197,6 @@ secrets_encryption_query: "resources[*].providers[0].{{kube_encryption_algorithm
 
 ## Amount of time to retain events. (default 1h0m0s)
 event_ttl_duration: "1h0m0s"
+##  Force regeneration of kubernetes control plane certificates without the need of bumping the cluster version
+force_certificate_regeneration: false
+

--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -122,7 +122,7 @@
   when:
     - inventory_hostname == groups['kube-master']|first
     - kubeadm_already_run.stat.exists
-    - apiserver_sans_check.changed
+    - apiserver_sans_check.changed or force_certificate_regeneration
 
 - name: kubeadm | regenerate apiserver cert 2/2
   command: >-
@@ -132,7 +132,7 @@
   when:
     - inventory_hostname == groups['kube-master']|first
     - kubeadm_already_run.stat.exists
-    - apiserver_sans_check.changed
+    - apiserver_sans_check.changed or force_certificate_regeneration
 
 - name: kubeadm | Initialize first master
   command: >-


### PR DESCRIPTION
<b>What type of PR is this?</b>
/kind feature

<b>What this PR does / why we need it:</b>
This gives users a way to force regeneration of kube-apiserver certificate (and by the code that's already there , all the relevant client certificates) without the need to upgrade the cluster.
Since certificates are valid for 1 year, some deployments that may not want to upgrade their k8s cluster version  might end up broken.

<b>Which issue(s) this PR fixes:</b>

Fixes #

<b>Special notes for your reviewer:</b>
I added a simple variable named force_certificate_regeneration (default to false) that the users may set to True during a subsequent run of cluster.yml in order to force apiserver certificate regeneration flow.

<b>Does this PR introduce a user-facing change?:</b>

Add force_certificate_regeneration variable