### PR TITLE
instead of  "/etc/ssl/etcd" for etcd_config_dir param

### DIFF
--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -57,6 +57,8 @@ spec:
               name: host-local-net-dir
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir
+          securityContext:
+            privileged: true
 {% endif %}
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
@@ -88,6 +90,8 @@ spec:
               name: cni-net-dir
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir
+          securityContext:
+            privileged: true
 {% endif %}
       containers:
 {% if calico_version is version('v3.3.0', '>=') and calico_version is version('v3.4.0', '<') %}

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -199,7 +199,7 @@
     - "{{ ansible_env.HOME | default('/root') }}/.helm"
     - "{{ etcd_data_dir }}"
     - /var/lib/etcd-events
-    - /etc/ssl/etcd
+    - "{{ etcd_config_dir }}"
     - /var/log/calico
     - /etc/cni
     - "{{ nginx_config_dir }}"


### PR DESCRIPTION

What type of PR is this?

/kind cleanup

What this PR does / why we need it:

I want use etcd_config_dir param instead of /etc/ssl/etcd. this can uniform variable syntax

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:
@floryut @EppO 

Does this PR introduce a user-facing change?
NONE