### PR TITLE
change /etc/ssl/etcd to etcd_config_dir param

### DIFF
--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -8,7 +8,7 @@ etcd_events_cluster_enabled: false
 
 etcd_backup_prefix: "/var/backups"
 etcd_data_dir: "/var/lib/etcd"
-etcd_events_data_dir: "/var/lib/etcd-events"
+
 
 etcd_config_dir: /etc/ssl/etcd
 etcd_cert_dir: "{{ etcd_config_dir }}/ssl"

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -505,6 +505,7 @@ pip_extra_args: |-
   {{ pip_extra_args_list|join(' ') }}
 
 etcd_config_dir: /etc/ssl/etcd
+etcd_events_data_dir: "/var/lib/etcd-events"
 etcd_cert_dir: "{{ etcd_config_dir }}/ssl"
 
 typha_enabled: false

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -198,7 +198,7 @@
     - "{{ ansible_env.HOME | default('/root') }}/.kube"
     - "{{ ansible_env.HOME | default('/root') }}/.helm"
     - "{{ etcd_data_dir }}"
-    - /var/lib/etcd-events
+    - "{{ etcd_events_data_dir }}"
     - "{{ etcd_config_dir }}"
     - /var/log/calico
     - /etc/cni

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -199,7 +199,7 @@
     - "{{ ansible_env.HOME | default('/root') }}/.helm"
     - "{{ etcd_data_dir }}"
     - /var/lib/etcd-events
-    - /etc/ssl/etcd
+    - "{{ etcd_config_dir }}"
     - /var/log/calico
     - /etc/cni
     - "{{ nginx_config_dir }}"


### PR DESCRIPTION
What type of PR is this?

/kind cleanup

What this PR does / why we need it:

I want use etcd_config_dir param instead of /etc/ssl/etcd. this can uniform variable syntax

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:
@EppO @floryut 

Does this PR introduce a user-facing change?
NONE