### PR TITLE
Fix Ansible-lint E303

### DIFF
--- a/roles/kubernetes/preinstall/handlers/main.yml
+++ b/roles/kubernetes/preinstall/handlers/main.yml
@@ -29,8 +29,10 @@
     - Preinstall | reload kubelet
   when: is_fedora_coreos
 
-- name: Preinstall | reload NetworkManager  # noqa 303
-  command: systemctl restart NetworkManager.service
+- name: Preinstall | reload NetworkManager
+  service:
+    name: NetworkManager.service
+    state: restarted
   when: is_fedora_coreos
 
 - name: Preinstall | reload kubelet

--- a/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
@@ -31,7 +31,8 @@
   changed_when: false
   check_mode: no
 
-- name: check systemd-resolved  # noqa 303
+- name: check systemd-resolved
+  # noqa 303 Should we use service_facts for this?
   command: systemctl is-active systemd-resolved
   register: systemd_resolved_enabled
   failed_when: false

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -6,7 +6,8 @@
     mode: 0755
     remote_src: yes
 
-- name: Calico | Check if host has NetworkManager  # noqa 303
+- name: Calico | Check if host has NetworkManager
+  # noqa 303 Should we use service_facts for this?
   command: systemctl show NetworkManager
   register: nm_check
   failed_when: false


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
ansible-lint E303 was fixed in #3961 then got re-introduced.

I suggest to re-remove the global exception for E303, and add local exceptions to avoid more unintentional E303s.

Regarding the 2x noqa, I don't know if we should use service_facts or what, but another PR is welcome to address it.