### PR TITLE
Always enable GitLab CI artifacts for cluster-dump

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,6 +42,7 @@ before_script:
     - packet
   image: quay.io/kubespray/kubespray:$KUBESPRAY_VERSION
   artifacts:
+    when: always
     paths:
       - cluster-dump/
 

--- a/.gitlab-ci/terraform.yml
+++ b/.gitlab-ci/terraform.yml
@@ -38,6 +38,7 @@
   when: manual
   only: [/^pr-.*$/]
   artifacts:
+    when: always
     paths:
       - cluster-dump/
   variables:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
By [default](https://docs.gitlab.com/ee/ci/yaml/#artifactswhen) GitLab CI uploads artifacts only for failed jobs. Therefore cluster-dump were not available for debugging failed jobs.