### PR TITLE
Replace Openstack with OpenStack in docs

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -1,11 +1,11 @@
-# Kubernetes on Openstack with Terraform
+# Kubernetes on OpenStack with Terraform
 
 Provision a Kubernetes cluster with [Terraform](https://www.terraform.io) on
-Openstack.
+OpenStack.
 
 ## Status
 
-This will install a Kubernetes cluster on an Openstack Cloud. It should work on
+This will install a Kubernetes cluster on an OpenStack Cloud. It should work on
 most modern installs of OpenStack that support the basic services.
 
 ### Known compatible public clouds

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,7 +13,7 @@
 - [ ] Terraform to provision instances on:
   - [ ] GCE
   - [x] AWS (contrib/terraform/aws)
-  - [x] Openstack (contrib/terraform/openstack)
+  - [x] OpenStack (contrib/terraform/openstack)
   - [x] Packet
   - [ ] Digital Ocean
   - [ ] Azure


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind documentation

**What this PR does / why we need it**:

The official word is OpenStack, not Openstack as [1].
This replaces it with OpenStack in the docs.

[1]: https://www.openstack.org/

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
