### PR TITLE
Update the calico_veth_mtu setting to affect IP-in-IP users

### DIFF
--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -231,13 +231,8 @@ spec:
               value: "{{ calico_usage_reporting }}"
             # Set MTU for tunnel device used if ipip is enabled
 {% if calico_mtu is defined %}
-{% if calico_veth_mtu is defined %}
             - name: FELIX_IPINIPMTU
-              value: "{{ calico_veth_mtu }}"
-{% else %}
-            - name: FELIX_IPINIPMTU
-              value: "{{ calico_mtu }}"
-{% endif %}
+              value: "{{ calico_veth_mtu | default(calico_mtu) }}"
 {% endif %}
             - name: FELIX_CHAININSERTMODE
               value: "{{ calico_felix_chaininsertmode }}"

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -231,8 +231,13 @@ spec:
               value: "{{ calico_usage_reporting }}"
             # Set MTU for tunnel device used if ipip is enabled
 {% if calico_mtu is defined %}
+{% if calico_veth_mtu is defined %}
+            - name: FELIX_IPINIPMTU
+              value: "{{ calico_veth_mtu }}"
+{% else %}
             - name: FELIX_IPINIPMTU
               value: "{{ calico_mtu }}"
+{% endif %}
 {% endif %}
             - name: FELIX_CHAININSERTMODE
               value: "{{ calico_felix_chaininsertmode }}"


### PR DESCRIPTION
calico_veth_mtu is specified in the configuration, but since it only works for wireguard, modify it to work for IP-in-IP users.

**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
When using IP-in-IP, the tunnel's MTU is set equal to the calico's MTU. This PR changes the calico_veth_mtu variable to affect the IP-in-IP tunnel.

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update the calico_veth_mtu setting to affect IP-in-IP users
```
