### PR TITLE
Update Cinder CSI manifests to K/1.18

### DIFF
--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin-rbac.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin-rbac.yml.j2
@@ -8,7 +8,7 @@ metadata:
   namespace: kube-system
 
 ---
-# external attacher
+# external attacher 
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -16,19 +16,16 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "patch"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "patch"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["csinodes"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments/status"]
-    verbs: ["patch"]
 
 
 ---

--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin.yml.j2
@@ -23,8 +23,8 @@ spec:
           image: {{ csi_attacher_image_repo }}:{{ csi_attacher_image_tag }}
           imagePullPolicy: {{ k8s_image_pull_policy }}
           args:
-            - "--v=5"
             - "--csi-address=$(ADDRESS)"
+            - "--timeout=3m"
 {% if cinder_csi_controller_replicas is defined and cinder_csi_controller_replicas > 1 %}
             - --leader-election
             - --leader-election-namespace=kube-system
@@ -40,6 +40,7 @@ spec:
           imagePullPolicy: {{ k8s_image_pull_policy }}
           args:
             - "--csi-address=$(ADDRESS)"
+            - "--timeout=3m"
 {% if cinder_topology is defined and cinder_topology %}
             - --feature-gates=Topology=true
 {% endif %}

--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-driver.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-driver.yml.j2
@@ -5,3 +5,6 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: true
+  volumeLifecycleModes:
+  - Persistent
+  - Ephemeral


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
This PR updates manifests used by Cinder CSI driver to be compatible with K/1.18 (https://github.com/kubernetes/cloud-provider-openstack/tree/master/manifests/cinder-csi-plugin)

This also adds support for inline volume definition and increases the mount timeout from 15 seconds to 3 minutes (https://github.com/kubernetes/cloud-provider-openstack/pull/862).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
