### PR TITLE
make pre-remove node draining a failable task

### DIFF
--- a/roles/remove-node/pre-remove/defaults/main.yml
+++ b/roles/remove-node/pre-remove/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
+allow_ungraceful_removal: false
 drain_grace_period: 300
 drain_timeout: 360s

--- a/roles/remove-node/pre-remove/tasks/main.yml
+++ b/roles/remove-node/pre-remove/tasks/main.yml
@@ -4,7 +4,7 @@
     {{ bin_dir }}/kubectl cordon {{ hostvars[item]['kube_override_hostname']|default(item) }}
   with_items:
     - "{{ node.split(',') | default(groups['kube-node']) }}"
-  failed_when: false
+  failed_when: result.rc == 0 and not allow_ungraceful_removal
   delegate_to: "{{ groups['kube-master']|first }}"
   run_once: true
   ignore_errors: yes
@@ -19,7 +19,7 @@
       --delete-local-data {{ hostvars[item]['kube_override_hostname']|default(item) }}
   with_items:
     - "{{ node.split(',') | default(groups['kube-node']) }}"
-  failed_when: false
+  failed_when: result.rc == 0 and not allow_ungraceful_removal
   delegate_to: "{{ groups['kube-master']|first }}"
   run_once: true
   ignore_errors: yes


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Having unfailable tasks for draining and cordoning exposes the risk of
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6441

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
remove-node play will fail if node can not be drained
```
