### PR TITLE
Update multus version & crio conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [flanneld](https://github.com/coreos/flannel) v0.12.0
   - [kube-ovn](https://github.com/alauda/kube-ovn) v1.2.1
   - [kube-router](https://github.com/cloudnativelabs/kube-router) v1.0.0
-  - [multus](https://github.com/intel/multus-cni) v3.4.2
+  - [multus](https://github.com/intel/multus-cni) v3.6.0
   - [weave](https://github.com/weaveworks/weave) v2.6.5
 - Application
   - [cephfs-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.0-k8s1.11

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -82,7 +82,7 @@ contiv_version: 1.2.1
 cilium_version: "v1.8.0"
 kube_ovn_version: "v1.2.1"
 kube_router_version: "v1.0.0"
-multus_version: "v3.4.2"
+multus_version: "v3.6"
 
 # Get kubernetes major version (i.e. 1.17.4 => 1.17)
 kube_major_version: "{{ kube_version | regex_replace('^v([0-9])+\\.([0-9]+)\\.[0-9]+', 'v\\1.\\2') }}"

--- a/roles/network_plugin/multus/defaults/main.yml
+++ b/roles/network_plugin/multus/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 multus_conf_file: "auto"
 multus_cni_conf_dir_host: "/etc/cni/net.d"
-multus_cni_bin_dir_host: "{{ '/usr/libexec/cni' if container_manager == 'crio' else '/opt/cni/bin' }}"
+multus_cni_bin_dir_host: "/opt/cni/bin"
 multus_cni_run_dir_host: "/run"
 multus_cni_conf_dir: "{{ ('/host',  multus_cni_conf_dir_host) | join }}"
 multus_cni_bin_dir: "{{ ('/host', multus_cni_bin_dir_host) | join }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Update multus cni to latest version

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
I've update cni path for crio as I think it's outdated ? every references fond for crio now default to `/opt/cni/bin`

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
