### PR TITLE
Move healthz check to secure ports

### DIFF
--- a/roles/kubernetes/master/handlers/main.yml
+++ b/roles/kubernetes/master/handlers/main.yml
@@ -93,7 +93,8 @@
 
 - name: Master | wait for kube-scheduler
   uri:
-    url: http://localhost:10251/healthz
+    url: https://localhost:10259/healthz
+    validate_certs: no
   register: scheduler_result
   until: scheduler_result.status == 200
   retries: 60
@@ -101,7 +102,8 @@
 
 - name: Master | wait for kube-controller-manager
   uri:
-    url: http://localhost:10252/healthz
+    url: https://localhost:10257/healthz
+    validate_certs: no
   register: controller_manager_result
   until: controller_manager_result.status == 200
   retries: 60
@@ -111,8 +113,6 @@
   uri:
     url: "{{ kube_apiserver_endpoint }}/healthz"
     validate_certs: no
-    client_cert: "{{ kube_apiserver_client_cert }}"
-    client_key: "{{ kube_apiserver_client_key }}"
   register: result
   until: result.status == 200
   retries: 60


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Insecure port were deprecated and are now removed by default (since 1.17.9, 1.18.6 etc..)

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
