### PR TITLE
Fix remove etcd broken with etcdctl_api 3

### DIFF
--- a/roles/remove-node/remove-etcd-node/tasks/main.yml
+++ b/roles/remove-node/remove-etcd-node/tasks/main.yml
@@ -18,7 +18,7 @@
     - inventory_hostname in groups['etcd']
 
 - name: Lookup etcd member id
-  shell: "{{ bin_dir }}/etcdctl member list | grep {{ node_ip }} | cut -d: -f1"
+  shell: "{{ bin_dir }}/etcdctl member list | grep {{ node_ip }} | cut -d, -f1"
   register: etcd_member_id
   ignore_errors: true
   changed_when: false


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Remove etcd member doesn't work since etcd 3.4 update (etcdctl api 3)

**Which issue(s) this PR fixes**:
Fixes #6445

**Special notes for your reviewer**:
The `etcdcl member list` now output
```
35ee157a644a984s, started, etcd3, https://172.30.72.65.2380, https://172.30.72.65:2379, false
ae329sdx899sda580, started, etcd1, https://172.30.72.64.2380, https://172.30.72.64:2379, false
48679550c06ad4xw16, started, etcd2, https://172.30.72.63.2380, https://172.30.72.63:2379, false
```
The `cut` now needs to be on `,` (to get the member ID)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
