### PR TITLE
echo in dash (/bin/sh) does not support -e, /bin/echo does regardless

### DIFF
--- a/roles/network_plugin/calico/rr/tasks/main.yml
+++ b/roles/network_plugin/calico/rr/tasks/main.yml
@@ -9,14 +9,14 @@
 # FIXME(mattymo): Use jsonpatch when ansible/ansible#52931 is merged
 - name: Calico-rr | Set route reflector cluster ID
   shell: >-
-    echo -e '{{ calico_rr_node.stdout }}' |
+    /bin/echo -e '{{ calico_rr_node.stdout }}' |
     sed '/bgp:/a \ \ \ \ routeReflectorClusterID: {{ cluster_id }}'
   register: calico_rr_node
   when: '("routeReflectorClusterID: " + cluster_id|string) not in calico_rr_node.stdout_lines'
 
 - name: Calico-rr | Configure route reflector
   shell: |-
-    echo -e '{{ calico_rr_node.stdout }}' |
+    /bin/echo -e '{{ calico_rr_node.stdout }}' |
     {{ bin_dir }}/calicoctl.sh replace -f-
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

I'm running kubespray against Debian Buster which is using dash as /bin/sh.
The built in echo in dash does not support -e (it actually does the expansion by default), instead it includes the -e in the output.
Because there is a -e in the output there is a -e at the beginning of the json making it invalid and therefore refused by `calicoctl.sh replace` during an upgrade from v2.10.4 to v2.11.2

**Special notes for your reviewer**:

This is a patch against branch release-2.11, master and release-2.12 don't attempt to mung the output of calicoctl.sh to add `routeReflectorClusterID`

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
