### PR TITLE
Fix ansible-lint E301 for commands fetching data

### DIFF
--- a/roles/network_plugin/calico/rr/tasks/main.yml
+++ b/roles/network_plugin/calico/rr/tasks/main.yml
@@ -2,8 +2,9 @@
 - name: Calico-rr | Pre-upgrade tasks
   include_tasks: pre.yml
 
-- name: Calico-rr | Fetch current node object  # noqa 301
+- name: Calico-rr | Fetch current node object
   command: "{{ bin_dir }}/calicoctl.sh get node {{ inventory_hostname }} -ojson"
+  changed_when: false
   register: calico_rr_node
   until: calico_rr_node is succeeded
   delay: "{{ retry_stagger | random + 3 }}"

--- a/roles/network_plugin/calico/tasks/reset.yml
+++ b/roles/network_plugin/calico/tasks/reset.yml
@@ -8,8 +8,9 @@
   command: ip link del dummy0
   when: dummy0.stat.exists
 
-- name: reset | get remaining routes set by bird  # noqa 301
+- name: reset | get remaining routes set by bird
   command: ip route show proto bird
+  changed_when: false
   register: bird_routes
 
 - name: reset | remove remaining routes set by bird  # noqa 301

--- a/roles/network_plugin/macvlan/tasks/main.yml
+++ b/roles/network_plugin/macvlan/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
-- name: Macvlan | Retrieve Pod Cidr  # noqa 301
+- name: Macvlan | Retrieve Pod Cidr
   command: "{{ bin_dir }}/kubectl get nodes {{ kube_override_hostname | default(inventory_hostname) }} -o jsonpath='{.spec.podCIDR}'"
+  changed_when: false
   register: node_pod_cidr_cmd
   delegate_to: "{{ groups['kube-master'][0] }}"
 
@@ -8,9 +9,10 @@
   set_fact:
     node_pod_cidr={{ node_pod_cidr_cmd.stdout }}
 
-- name: Macvlan | Retrieve default gateway network interface  # noqa 301
+- name: Macvlan | Retrieve default gateway network interface
   become: false
   raw: ip -4 route list 0/0 | sed 's/.*dev \([[:alnum:]]*\).*/\1/'
+  changed_when: false
   register: node_default_gateway_interface_cmd
 
 - name: Macvlan | set node_default_gateway_interface

--- a/tests/cloud_playbooks/roles/packet-ci/tasks/create-vms.yml
+++ b/tests/cloud_playbooks/roles/packet-ci/tasks/create-vms.yml
@@ -29,8 +29,9 @@
   loop_control:
     index_var: vm_id
 
-- name: Wait for vms to have ipaddress assigned  # noqa 301 306
+- name: Wait for vms to have ipaddress assigned  # noqa 306
   shell: "kubectl get vmis -n {{ test_name }} instance-{{ vm_id }} -o json | jq '.status.interfaces[].ipAddress' | tr -d '\"'"
+  changed_when: false
   register: vm_ips
   loop: "{{ range(1, vm_count|int + 1, 1) | list }}"
   loop_control:

--- a/tests/cloud_playbooks/upload-logs-gcs.yml
+++ b/tests/cloud_playbooks/upload-logs-gcs.yml
@@ -7,8 +7,9 @@
     expire_days: 2
 
   tasks:
-    - name: Generate uniq bucket name prefix  # noqa 301
+    - name: Generate uniq bucket name prefix
       raw: date +%Y%m%d
+      changed_when: false
       register: out
 
     - name: replace_test_id

--- a/tests/testcases/015_check-nodes-ready.yml
+++ b/tests/testcases/015_check-nodes-ready.yml
@@ -15,16 +15,18 @@
   - import_role:
       name: cluster-dump
 
-  - name: Check kubectl output  # noqa 301 305
+  - name: Check kubectl output  # noqa 305
     shell: "{{ bin_dir }}/kubectl get nodes"
+    changed_when: false
     register: get_nodes
     no_log: true
 
   - debug:
       msg: "{{ get_nodes.stdout.split('\n') }}"
 
-  - name: Check that all nodes are running and ready  # noqa 301 305
+  - name: Check that all nodes are running and ready  # noqa 305
     shell: "{{ bin_dir }}/kubectl get nodes --no-headers -o yaml"
+    changed_when: false
     register: get_nodes_yaml
     until:
     # Check that all nodes are Status=Ready

--- a/tests/testcases/020_check-pods-running.yml
+++ b/tests/testcases/020_check-pods-running.yml
@@ -15,16 +15,18 @@
   - import_role:
       name: cluster-dump
 
-  - name: Check kubectl output  # noqa 301 305
+  - name: Check kubectl output  # noqa 305
     shell: "{{ bin_dir }}/kubectl get pods --all-namespaces -owide"
+    changed_when: false
     register: get_pods
     no_log: true
 
   - debug:
       msg: "{{ get_pods.stdout.split('\n') }}"
 
-  - name: Check that all pods are running and ready  # noqa 301 305
+  - name: Check that all pods are running and ready  # noqa 305
     shell: "{{ bin_dir }}/kubectl get pods --all-namespaces --no-headers -o yaml"
+    changed_when: false
     register: run_pods_log
     until:
     # Check that all pods are running
@@ -36,8 +38,9 @@
     failed_when: false
     no_log: true
 
-  - name: Check kubectl output  # noqa 301 305
+  - name: Check kubectl output  # noqa 305
     shell: "{{ bin_dir }}/kubectl get pods --all-namespaces -owide"
+    changed_when: false
     register: get_pods
     no_log: true
 

--- a/tests/testcases/030_check-network.yml
+++ b/tests/testcases/030_check-network.yml
@@ -18,8 +18,9 @@
   - name: Create test namespace  # noqa 301 305
     shell: "{{ bin_dir }}/kubectl create namespace test"
 
-  - name: Run 2 busybox pods in test ns  # noqa 301 305
+  - name: Run 2 busybox pods in test ns  # noqa 305
     shell: "{{ bin_dir }}/kubectl run {{ item }} --image={{ test_image_repo }}:{{ test_image_tag }} --namespace test --command -- tail -f /dev/null"
+    changed_when: false
     loop:
     - busybox1
     - busybox2
@@ -27,8 +28,9 @@
   - import_role:
       name: cluster-dump
 
-  - name: Check that all pods are running and ready  # noqa 301 305
+  - name: Check that all pods are running and ready  # noqa 305
     shell: "{{ bin_dir }}/kubectl get pods --namespace test --no-headers -o yaml"
+    changed_when: false
     register: run_pods_log
     until:
     # Check that all pods are running
@@ -40,8 +42,9 @@
     failed_when: false
     no_log: true
 
-  - name: Get pod names  # noqa 301 305
+  - name: Get pod names  # noqa 305
     shell: "{{ bin_dir }}/kubectl get pods -n test -o json"
+    changed_when: false
     register: pods
     no_log: true
 
@@ -49,20 +52,23 @@
       msg: "{{ pods.stdout.split('\n') }}"
     failed_when: not run_pods_log is success
 
-  - name: Get hostnet pods  # noqa 301
+  - name: Get hostnet pods
     command: "{{ bin_dir }}/kubectl get pods -n test -o
             jsonpath='{range .items[?(.spec.hostNetwork)]}{.metadata.name} {.status.podIP} {.status.containerStatuses} {end}'"
+    changed_when: false
     register: hostnet_pods
     no_log: true
 
-  - name: Get running pods  # noqa 301
+  - name: Get running pods
     command: "{{ bin_dir }}/kubectl get pods -n test -o
             jsonpath='{range .items[?(.status.phase==\"Running\")]}{.metadata.name} {.status.podIP} {.status.containerStatuses} {end}'"
+    changed_when: False
     register: running_pods
     no_log: true
 
-  - name: Check kubectl output  # noqa 301 305
+  - name: Check kubectl output  # noqa 305
     shell: "{{ bin_dir }}/kubectl get pods --all-namespaces -owide"
+    changed_when: False
     register: get_pods
     no_log: true
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
When using a command to get information, `changed_when: false` should be used since it should never change the state.

See [ansible-lint rule E301](https://docs.ansible.com/ansible-lint/rules/default_rules.html)