### PR TITLE
Allows tls verify skip on webhook auth url

### DIFF
--- a/roles/kubernetes/master/defaults/main/main.yml
+++ b/roles/kubernetes/master/defaults/main/main.yml
@@ -119,6 +119,7 @@ kube_basic_auth: false
 kube_token_auth: false
 kube_oidc_auth: false
 kube_webhook_token_auth: false
+kube_webhook_token_auth_url_skip_tls_verify: false
 
 ## Variables for OpenID Connect Configuration https://kubernetes.io/docs/admin/authentication/
 ## To use OpenID you have to deploy additional an OpenID Provider (e.g Dex, Keycloak, ...)

--- a/roles/kubernetes/master/templates/webhook-token-auth-config.yaml.j2
+++ b/roles/kubernetes/master/templates/webhook-token-auth-config.yaml.j2
@@ -3,6 +3,7 @@ clusters:
 - name: webhook-token-auth-cluster
   cluster:
     server: {{ kube_webhook_token_auth_url }}
+    insecure-skip-tls-verify: {{ kube_webhook_token_auth_url_skip_tls_verify }}
 
 # users refers to the API server's webhook configuration.
 users:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Allows users to add tls verification skip to webhook
auth url, such that self/private signed certificates
can be used for webhook auth plugins.

**Which issue(s) this PR fixes**:
Fixes #6471

**Special notes for your reviewer:**
None

**Does this PR introduce a user-facing change?:**
```
NONE
```