### PR TITLE
Add setting timezone task, fixes issues - etcd cluster is unavailable or misconfigured

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ As a consequence, `ansible-playbook` command will fail with:
 ERROR! no action detected in task. This often indicates a misspelled module name, or incorrect module path.
 ```
 
-probably pointing on a task depending on a module present in requirements.txt (i.e. "unseal vault").
+Probably pointing on a task depending on a module present in requirements.txt (i.e. "unseal vault").
 
 One way of solving this would be to uninstall the Ansible package and then, to install it via pip but it is not always possible.
 A workaround consists of setting `ANSIBLE_LIBRARY` and `ANSIBLE_MODULE_UTILS` environment variables respectively to the `ansible/modules` and `ansible/module_utils` subdirectories of pip packages installation location, which can be found in the Location field of the output of `pip show [package]` before executing `ansible-playbook`.

--- a/facts.yml
+++ b/facts.yml
@@ -3,6 +3,12 @@
   hosts: k8s-cluster:etcd:calico-rr
   gather_facts: False
   tasks:
+    - name: Ensure datetime, timezone on cluster hosts
+      timezone:
+        name: "{{ timezone }}"
+        hwclock: UTC
+      failed_when: false
+
     - name: Gather minimal facts
       setup:
         gather_subset: '!all'

--- a/facts.yml
+++ b/facts.yml
@@ -3,12 +3,6 @@
   hosts: k8s-cluster:etcd:calico-rr
   gather_facts: False
   tasks:
-    - name: Ensure datetime, timezone on cluster hosts
-      timezone:
-        name: "{{ timezone }}"
-        hwclock: UTC
-      failed_when: false
-
     - name: Gather minimal facts
       setup:
         gather_subset: '!all'

--- a/inventory/sample/group_vars/all/all.yml
+++ b/inventory/sample/group_vars/all/all.yml
@@ -1,4 +1,7 @@
 ---
+# Set timezone for hosts, change to your timezone
+timezone: "UTC"
+
 ## Directory where etcd data stored
 etcd_data_dir: /var/lib/etcd
 

--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -7,6 +7,15 @@
   check_mode: false
   environment: {}
 
+# Ensure timezone on etcd_hosts
+- name: Ensure datetime, timezone on etcd hosts
+  timezone:
+    name: "{{ timezone }}"
+    hwclock: UTC
+  failed_when: false
+  tags:
+    - facts
+
 - include_tasks: bootstrap-centos.yml
   when: '"CentOS" in os_release.stdout or "Red Hat Enterprise Linux" in os_release.stdout or "Oracle" in os_release.stdout'
 

--- a/roles/etcd/tasks/configure.yml
+++ b/roles/etcd/tasks/configure.yml
@@ -1,4 +1,14 @@
 ---
+# Ensure timezone on etcd_hosts
+- name: Ensure datetime, timezone on etcd hosts
+  timezone:
+    name: "{{ timezone }}"
+    hwclock: UTC
+  failed_when: false
+  when: is_etcd_master and etcd_cluster_setup
+  tags:
+    - facts
+
 - name: Configure | Check if etcd cluster is healthy  # noqa 306
   shell: "{{ bin_dir }}/etcdctl endpoint --cluster status && {{ bin_dir }}/etcdctl endpoint --cluster health  2>&1 | grep -q -v 'Error: unhealthy cluster'"
   register: etcd_cluster_is_healthy


### PR DESCRIPTION
When run task:

```bash
TASK [etcd : Configure | Check if etcd cluster is healthy] 
```

If the etcd cluster hosts isn't have the same time with each other, the stdout result when joining etcd cluster will be:
```bash
...Error:  client: etcd cluster is unavailable or misconfigured; error #0: dial tcp xx.xx.xx.xx:2379: connect: connection refused...
```

It's obscured, make work around the problem, very difficult to spot that the datetime is the root caused.

**What type of PR is this?**
 
/kind bug

**What this PR does / why we need it**:

This PR is about to set the timezone for hosts, when bootstrap and when **etcd** role is being call.
I added setting timezone task in the roles when etcd cluster configuration before task **Configure | Check if etcd cluster is healthy** and when **bootstrap**.
I also fixed some typo in the README, btw!

**Which issue(s) this PR fixes**:

Fixes #2767, #6488

**Special notes for your reviewer**:

The imgbot is automacially merged the PR to optimize picture when I make a fork, if reviewer who don't like it, please let me know to remove those imgbot's commits.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
