### PR TITLE
[2.13] Update base image to v2.12.8

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ stages:
   - deploy-special
 
 variables:
-  KUBESPRAY_VERSION: v2.12.7
+  KUBESPRAY_VERSION: v2.12.8
   FAILFASTCI_NAMESPACE: 'kargo-ci'
   GITLAB_REPOSITORY: 'kargo-ci/kubernetes-sigs-kubespray'
   ANSIBLE_FORCE_COLOR: "true"


### PR DESCRIPTION
**What this PR does / why we need it**:
Update base image to [v2.12.8](https://github.com/kubernetes-sigs/kubespray/releases/tag/v2.12.8)