### PR TITLE
Add timeout to Get current version of calico cluster version, again

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -161,6 +161,8 @@
 - name: "Get current version of calico cluster version"  # noqa 306
   shell: "{{ bin_dir }}/calicoctl.sh version  | grep 'Cluster Version:' | awk '{ print $3}'"
   register: calico_version_on_server
+  async: 10
+  poll: 3
   run_once: yes
   changed_when: false
   failed_when: false

--- a/roles/network_plugin/calico/tasks/check.yml
+++ b/roles/network_plugin/calico/tasks/check.yml
@@ -40,6 +40,8 @@
 - name: "Get current version of calico cluster version"  # noqa 306
   shell: "{{ bin_dir }}/calicoctl.sh version  | grep 'Cluster Version:' | awk '{ print $3}'"
   register: calico_version_on_server
+  async: 10
+  poll: 3
   run_once: yes
   changed_when: false
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
#4149 added a timeout to calicoctl version which was removed by #4524; but it seems that a lot of users are still experiencing the same root issue

**Which issue(s) this PR fixes**:
Fixes #6055

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
