### PR TITLE
Fix E306 in scripts/

### DIFF
--- a/scripts/collect-info.yaml
+++ b/scripts/collect-info.yaml
@@ -112,8 +112,8 @@
           {%- endfor %}
       when: "'etcd' in groups"
 
-    - name: Storing commands output  # noqa 306
-      shell: "{{ item.cmd }} 2>&1 | tee {{ item.name }}"
+    - name: Storing commands output
+      shell: "{{ item.cmd }} &> {{ item.name }}"
       failed_when: false
       with_items: "{{ commands }}"
       when: item.when | default(True)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fix ansible-lint E306 in scripts/

**Special notes for your reviewer**:
I think that `2>&1 | tee filename` should be equivalent to `&> filename`