### PR TITLE
Correct sample inventory to pass yamllint

### DIFF
--- a/inventory/sample/group_vars/all/all.yml
+++ b/inventory/sample/group_vars/all/all.yml
@@ -25,7 +25,7 @@ bin_dir: /usr/local/bin
 ## Internal loadbalancers for apiservers
 # loadbalancer_apiserver_localhost: true
 # valid options are "nginx" or "haproxy"
-# loadbalancer_apiserver_type: nginx # valid values "nginx" or "haproxy"
+# loadbalancer_apiserver_type: nginx  # valid values "nginx" or "haproxy"
 
 ## Local loadbalancer should use this port
 ## And must be set port 6443


### PR DESCRIPTION
Nit alert.  Sample inventory throws an error when processed
by yamllint.  The default line is currently commented out.
However, when uncommenting it our linters fail.


**What type of PR is this?**

/kind cleanup
