### PR TITLE
Add retries to update calico-rr data in etcd through calicoctl

### DIFF
--- a/roles/network_plugin/calico/rr/tasks/main.yml
+++ b/roles/network_plugin/calico/rr/tasks/main.yml
@@ -2,24 +2,8 @@
 - name: Calico-rr | Pre-upgrade tasks
   include_tasks: pre.yml
 
-- name: Calico-rr | Fetch current node object
-  command: "{{ bin_dir }}/calicoctl.sh get node {{ inventory_hostname }} -ojson"
-  changed_when: false
-  register: calico_rr_node
-  until: calico_rr_node is succeeded
-  delay: "{{ retry_stagger | random + 3 }}"
-  retries: 10
-
-- name: Calico-rr | Set route reflector cluster ID
-  set_fact:
-    calico_rr_node_patched: >-
-      {{ calico_rr_node.stdout | from_json | combine({ 'spec': { 'bgp':
-      { 'routeReflectorClusterID': cluster_id }}}, recursive=True) }}
-
-- name: Calico-rr | Configure route reflector  # noqa 301 305
-  shell: "{{ bin_dir }}/calicoctl.sh replace -f-"
-  args:
-    stdin: "{{ calico_rr_node_patched | to_json }}"
+- name: Calico-rr | Configuring node tasks
+  include_tasks: update-node.yml
 
 - name: Calico-rr | Set label for route reflector  # noqa 301
   command: >-

--- a/roles/network_plugin/calico/rr/tasks/update-node.yml
+++ b/roles/network_plugin/calico/rr/tasks/update-node.yml
@@ -1,0 +1,37 @@
+---
+- block:
+  - name: Set the retry count
+    set_fact:
+      retry_count: "{{ 0 if retry_count is undefined else retry_count|int + 1 }}"
+
+  - name: Calico-rr | Fetch current node object
+    command: "{{ bin_dir }}/calicoctl.sh get node {{ inventory_hostname }} -ojson"
+    changed_when: false
+    register: calico_rr_node
+    until: calico_rr_node is succeeded
+    delay: "{{ retry_stagger | random + 3 }}"
+    retries: 10
+
+  - name: Calico-rr | Set route reflector cluster ID
+    set_fact:
+      calico_rr_node_patched: >-
+        {{ calico_rr_node.stdout | from_json | combine({ 'spec': { 'bgp':
+        { 'routeReflectorClusterID': cluster_id }}}, recursive=True) }}
+
+  - name: Calico-rr | Configure route reflector  # noqa 301 305
+    shell: "{{ bin_dir }}/calicoctl.sh replace -f-"
+    args:
+      stdin: "{{ calico_rr_node_patched | to_json }}"
+
+  rescue:
+    - fail:
+        msg: Ended after 10 retries
+      when: retry_count|int == 10
+
+    - debug:
+        msg: "Failed to configure route reflector - Retrying..."
+
+    - include_tasks: update-node.yml
+
+
+

--- a/roles/network_plugin/calico/rr/tasks/update-node.yml
+++ b/roles/network_plugin/calico/rr/tasks/update-node.yml
@@ -1,4 +1,6 @@
 ---
+# Workaround to retry a block of tasks, ansible doesn't have a direct way to do it, 
+# you can follow the block loop request in: https://github.com/ansible/ansible/issues/46203
 - block:
   - name: Set the retry count
     set_fact:

--- a/roles/network_plugin/calico/rr/tasks/update-node.yml
+++ b/roles/network_plugin/calico/rr/tasks/update-node.yml
@@ -1,5 +1,5 @@
 ---
-# Workaround to retry a block of tasks, ansible doesn't have a direct way to do it, 
+# Workaround to retry a block of tasks, ansible doesn't have a direct way to do it,
 # you can follow the block loop request in: https://github.com/ansible/ansible/issues/46203
 - block:
   - name: Set the retry count

--- a/roles/network_plugin/calico/rr/tasks/update-node.yml
+++ b/roles/network_plugin/calico/rr/tasks/update-node.yml
@@ -24,14 +24,14 @@
       stdin: "{{ calico_rr_node_patched | to_json }}"
 
   rescue:
-    - fail:
-        msg: Ended after 10 retries
-      when: retry_count|int == 10
+  - name: Fail if retry limit is reached
+    fail:
+      msg: Ended after 10 retries
+    when: retry_count|int == 10
 
-    - debug:
-        msg: "Failed to configure route reflector - Retrying..."
+  - name: Retrying node configuration
+    debug:
+      msg: "Failed to configure route reflector - Retrying..."
 
-    - include_tasks: update-node.yml
-
-
-
+  - name: Retry node configuration
+    include_tasks: update-node.yml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Fix a race condition configuring router reflector with calicoctl. See https://github.com/kubernetes-sigs/kubespray/issues/6504
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6504 
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE