### PR TITLE
Improve Cilium metrics support

### DIFF
--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -22,6 +22,7 @@ cilium_cpu_requests: 100m
 cilium_tunnel_mode: vxlan
 # Optional features
 cilium_enable_prometheus: false
+cilium_enable_hubble_metrics: false
 # Enable if you want to make use of hostPort mappings
 cilium_enable_portmap: false
 # Monitor aggregation level (none/low/medium/maximum)

--- a/roles/network_plugin/cilium/templates/cilium-deploy.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-deploy.yml.j2
@@ -20,6 +20,11 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+{% if cilium_enable_prometheus %}
+      annotations:
+        prometheus.io/port: "6942"
+        prometheus.io/scrape: "true"
+{% endif %}
       labels:
         io.cilium/app: operator
         name: cilium-operator
@@ -93,6 +98,13 @@ spec:
           image: "{{ cilium_operator_image_repo }}:{{ cilium_operator_image_tag }}"
           imagePullPolicy: {{ k8s_image_pull_policy }}
           name: cilium-operator
+{% if cilium_enable_prometheus %}
+          ports:
+            - containerPort: 6942
+              hostPort: 6942
+              name: prometheus
+              protocol: TCP
+{% endif %}
           livenessProbe:
             httpGet:
 {% if cilium_enable_ipv4 %}

--- a/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
@@ -85,11 +85,19 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
         name: cilium-agent
-{% if cilium_enable_prometheus %}
+{% if cilium_enable_prometheus or cilium_enable_hubble_metrics %}
         ports:
+{% endif %}
+{% if cilium_enable_prometheus %}
         - containerPort: 9090
           hostPort: 9090
           name: prometheus
+          protocol: TCP
+{% endif %}
+{% if cilium_enable_hubble_metrics %}
+        - containerPort: 9091
+          hostPort: 9091
+          name: hubble-metrics
           protocol: TCP
 {% endif %}
         readinessProbe:


### PR DESCRIPTION
Signed-off-by: Arthur Outhenin-Chalandre <arthur@cri.epita.fr>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR add missing metrics port for Cilium (including hubble metrics ports)
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add metrics in cilium operator and add hubble metrics port in agents
```
