### PR TITLE
FIx Cilium deploy additionally with etcd kubeadm

### DIFF
--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -178,5 +178,5 @@
     - etcd_kubeadm_enabled
     - kubeadm_control_plane
     - inventory_hostname not in groups['kube-master']
-    - kube_network_plugin in ["calico", "flannel", "canal", "cilium"]
+    - kube_network_plugin in ["calico", "flannel", "canal", "cilium"] or cilium_deploy_additionally | default(false) | bool
     - kube_network_plugin != "calico" or calico_datastore == "etcd"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Cilium deployed with `cilium_deploy_additionally` on a cluster with `etcd_kubeadm_enabled`doesn't work. This PR resolves this issue.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
