### PR TITLE
Fixed Kubespray container-engine/docker role to populate docker.service

### DIFF
--- a/roles/container-engine/docker/tasks/systemd.yml
+++ b/roles/container-engine/docker/tasks/systemd.yml
@@ -25,7 +25,7 @@
     dest: /etc/systemd/system/docker.service
   register: docker_service_file
   notify: restart docker
-  when: not (ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"] or is_ostree)
+  when: not ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
 
 - name: Write docker options systemd drop-in
   template:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
It deploys the docker.service file. Without this deployment, container options configured in Kubespray are never applied.

**Which issue(s) this PR fixes**:
Fixes #6348 

**Special notes for your reviewer**:
First PR I make to this repo. Let me know if I missed something in the process.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
