### PR TITLE
Add new cilium options for native routing

### DIFF
--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -39,3 +39,12 @@ cilium_enable_legacy_services: false
 # Deploy cilium even if kube_network_plugin is not cilium.
 # This enables to deploy cilium alongside another CNI to replace kube-proxy.
 cilium_deploy_additionally: false
+
+# Auto direct nodes routes can be used to advertise pods routes in your cluster
+# without any tunelling (with `cilium_tunnel_mode` sets to `disabled`).
+# This works only if you have a L2 connectivity between all your nodes.
+# You wil also have to specify the variable `cilium_native_routing_cidr` to
+# make this work. Please refer to the cilium documentation for more
+# information about this kind of setups.
+cilium_auto_direct_node_routes: false
+cilium_native_routing_cidr: ""

--- a/roles/network_plugin/cilium/templates/cilium-config.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-config.yml.j2
@@ -142,3 +142,6 @@ data:
   enable-legacy-services: "{{cilium_enable_legacy_services}}"
 
   kube-proxy-replacement: "{{ cilium_kube_proxy_replacement }}"
+
+  native-routing-cidr: "{{ cilium_native_routing_cidr }}"
+  auto-direct-node-routes: "{{ cilium_auto_direct_node_routes }}"


### PR DESCRIPTION
Signed-off-by: Arthur Outhenin-Chalandre <arthur@cri.epita.fr>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR add cilium options to add native routing. With It you can set the tunnel to disable with the auto direct nodes route feature or use kube-router to achieve the same kind of setup
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add new cilium options for native routing
```
