### PR TITLE
Fix issue 6294 - "All pods simultaneously restart during worker scaling"

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -14,3 +14,10 @@ If you set http and https proxy, all nodes and loadbalancer will be excluded fro
 ## Set additional addresses to default no_proxy (all cluster nodes and loadbalancer)
 
 `additional_no_proxy: "aditional_host,"`
+
+## Exclude workers from no_proxy
+
+Since workers are included in the no_proxy variable, by default, docker engine will be restarted on all nodes (all
+pods will restart) when adding or removing workers.  To override this behaviour by only including master nodes in the
+no_proxy variable, set:
+`no_proxy_exclude_workers: true`

--- a/docs/vars.md
+++ b/docs/vars.md
@@ -109,7 +109,7 @@ Stack](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/dns-stack.m
 * *docker_plugins* - This list can be used to define [Docker plugins](https://docs.docker.com/engine/extend/) to install.
 * *containerd_config* - Controls some parameters in containerd configuration file (usually /etc/containerd/config.toml).
   [Default config](https://github.com/kubernetes-sigs/kubespray/blob/master/roles/container-engine/containerd/defaults/main.yml) can be overriden in inventory vars.
-* *http_proxy/https_proxy/no_proxy* - Proxy variables for deploying behind a
+* *http_proxy/https_proxy/no_proxy/no_proxy_exclude_workers/additional_no_proxy* - Proxy variables for deploying behind a
   proxy. Note that no_proxy defaults to all internal cluster IPs and hostnames
   that correspond to each node.
 * *kubelet_deployment_type* - Controls which platform to deploy kubelet on.

--- a/inventory/sample/group_vars/all/all.yml
+++ b/inventory/sample/group_vars/all/all.yml
@@ -68,6 +68,11 @@ loadbalancer_apiserver_healthcheck_port: 8081
 ## If you need exclude all cluster nodes from proxy and other resources, add other resources here.
 # additional_no_proxy: ""
 
+## Since workers are included in the no_proxy variable by default, docker engine will be restarted on all nodes (all
+## pods will restart) when adding or removing workers.  To override this behaviour by only including master nodes in the
+## no_proxy variable, set below to true:
+no_proxy_exclude_workers: false
+
 ## Certificate Management
 ## This setting determines whether certs are generated via scripts.
 ## Chose 'none' if you provide your own certificates.

--- a/roles/kubespray-defaults/tasks/no_proxy.yml
+++ b/roles/kubespray-defaults/tasks/no_proxy.yml
@@ -6,7 +6,12 @@
       {{ apiserver_loadbalancer_domain_name| default('') }},
       {{ loadbalancer_apiserver.address | default('') }},
       {%- endif -%}
-      {%- for item in (groups['k8s-cluster'] + groups['etcd'] + groups['calico-rr']|default([]))|unique -%}
+      {%- if ( (no_proxy_exclude_workers is defined) and (no_proxy_exclude_workers) ) -%}
+      {% set cluster_or_master = 'kube-master' %}
+      {% else %}
+      {% set cluster_or_master = 'k8s-cluster' %}
+      {% endif %}
+      {%- for item in (groups[cluster_or_master] + groups['etcd'] + groups['calico-rr']|default([]))|unique -%}
       {{ hostvars[item]['access_ip'] | default(hostvars[item]['ip'] | default(fallback_ips[item])) }},
       {%-   if item != hostvars[item].get('ansible_hostname', '') -%}
       {{ hostvars[item]['ansible_hostname'] }},


### PR DESCRIPTION
If no_proxy_exclude_workers is true, workers will be excluded from the no_proxy variable.  This prevents docker engine restarting when scaling workers.

/kind bug

**What this PR does / why we need it**:
See issue #6294

**Which issue(s) this PR fixes**:
Fixes #6294

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```