### PR TITLE
add master_volume_type TF variable to support volume type on Openstack

### DIFF
--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -51,6 +51,7 @@ module "compute" {
   node_root_volume_size_in_gb                  = var.node_root_volume_size_in_gb
   gfs_root_volume_size_in_gb                   = var.gfs_root_volume_size_in_gb
   gfs_volume_size_in_gb                        = var.gfs_volume_size_in_gb
+  master_volume_type                           = var.master_volume_type
   public_key_path                              = var.public_key_path
   image                                        = var.image
   image_gfs                                    = var.image_gfs

--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -167,6 +167,7 @@ resource "openstack_compute_instance_v2" "k8s_master" {
       uuid                  = data.openstack_images_image_v2.vm_image.id
       source_type           = "image"
       volume_size           = var.master_root_volume_size_in_gb
+      volume_type           = var.master_volume_type
       boot_index            = 0
       destination_type      = "volume"
       delete_on_termination = true
@@ -215,6 +216,7 @@ resource "openstack_compute_instance_v2" "k8s_master_no_etcd" {
       uuid                  = data.openstack_images_image_v2.vm_image.id
       source_type           = "image"
       volume_size           = var.master_root_volume_size_in_gb
+      volume_type           = var.master_volume_type
       boot_index            = 0
       destination_type      = "volume"
       delete_on_termination = true
@@ -303,6 +305,7 @@ resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip" {
       uuid                  = data.openstack_images_image_v2.vm_image.id
       source_type           = "image"
       volume_size           = var.master_root_volume_size_in_gb
+      volume_type           = var.master_volume_type
       boot_index            = 0
       destination_type      = "volume"
       delete_on_termination = true
@@ -346,6 +349,7 @@ resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip_no_etcd" {
       uuid                  = data.openstack_images_image_v2.vm_image.id
       source_type           = "image"
       volume_size           = var.master_root_volume_size_in_gb
+      volume_type           = var.master_volume_type
       boot_index            = 0
       destination_type      = "volume"
       delete_on_termination = true

--- a/contrib/terraform/openstack/modules/compute/variables.tf
+++ b/contrib/terraform/openstack/modules/compute/variables.tf
@@ -38,6 +38,8 @@ variable "gfs_root_volume_size_in_gb" {}
 
 variable "gfs_volume_size_in_gb" {}
 
+variable "master_volume_type" {}
+
 variable "public_key_path" {}
 
 variable "image" {}

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -74,6 +74,10 @@ variable "gfs_volume_size_in_gb" {
   default = 75
 }
 
+variable "master_volume_type" {
+  default = "Default"
+}
+
 variable "public_key_path" {
   description = "The path of the ssh pub key"
   default     = "~/.ssh/id_rsa.pub"


### PR DESCRIPTION

**What type of PR is this?**
 /kind feature

**What this PR does / why we need it**:
Implement support for  volume types when instantiating master nodes on Openstack, see #6523 .

**Which issue(s) this PR fixes**:
Fixes #6523

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No, the default Openstack volume type is "Default" so no change will occur.