### PR TITLE
Allow hosts with hyphen in name

### DIFF
--- a/contrib/inventory_builder/inventory.py
+++ b/contrib/inventory_builder/inventory.py
@@ -238,7 +238,7 @@ class KubesprayInventory(object):
             return [ip_address(ip).exploded for ip in range(start, end + 1)]
 
         for host in hosts:
-            if '-' in host and not host.startswith('-'):
+            if '-' in host and not (host.startswith('-') or host[0].isalpha()):
                 start, end = host.strip().split('-')
                 try:
                     reworked_hosts.extend(ips(start, end))


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Hostname with hyphen should be allowed 

**Which issue(s) this PR fixes**:
Fixes #6509

**Special notes for your reviewer**:
Tests ok
```
[floryut@lkubedev inventory_builder ] $ pytest
============================= test session starts =============================
platform linux -- Python 3.6.8, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /home/floryut/inventory_builder
collected 29 items

tests/test_inventory.py .............................[100%]

============================= 29 passed in 0.15s ==============================
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
