### PR TITLE
Add RHEL support subscription registration

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,6 +36,8 @@ SUPPORTED_OS = {
   "opensuse-tumbleweed" => {box: "opensuse/Tumbleweed.x86_64", user: "vagrant"},
   "oraclelinux"         => {box: "generic/oracle7",            user: "vagrant"},
   "oraclelinux8"        => {box: "generic/oracle8",            user: "vagrant"},
+  "redhat7"             => {box: "generic/rhel7",              user: "vagrant"},
+  "redhat8"             => {box: "generic/rhel8",              user: "vagrant"},
 }
 
 if File.exist?(CONFIG)
@@ -93,10 +95,10 @@ if ! File.exist?(File.join(File.dirname($inventory), "hosts.ini"))
 end
 
 if Vagrant.has_plugin?("vagrant-proxyconf")
-    $no_proxy = ENV['NO_PROXY'] || ENV['no_proxy'] || "127.0.0.1,localhost"
-    (1..$num_instances).each do |i|
-        $no_proxy += ",#{$subnet}.#{i+100}"
-    end
+  $no_proxy = ENV['NO_PROXY'] || ENV['no_proxy'] || "127.0.0.1,localhost"
+  (1..$num_instances).each do |i|
+      $no_proxy += ",#{$subnet}.#{i+100}"
+  end
 end
 
 Vagrant.configure("2") do |config|
@@ -180,9 +182,18 @@ Vagrant.configure("2") do |config|
         node.vm.network "forwarded_port", guest: guest, host: host, auto_correct: true
       end
 
-      node.vm.synced_folder ".", "/vagrant", disabled: false, type: "rsync", rsync__args: ['--verbose', '--archive', '--delete', '-z'] , rsync__exclude: ['.git','venv']
-      $shared_folders.each do |src, dst|
-        node.vm.synced_folder src, dst, type: "rsync", rsync__args: ['--verbose', '--archive', '--delete', '-z']
+      if ["redhat7","redhat8"].include? $os
+        # Vagrant synced_folder rsync options cannot be used for RHEL boxes as Rsync package cannot
+        # be installed until the host is registered with a valid Red Hat support subscription
+        node.vm.synced_folder ".", "/vagrant", disabled: false
+        $shared_folders.each do |src, dst|
+          node.vm.synced_folder src, dst
+        end
+      else
+        node.vm.synced_folder ".", "/vagrant", disabled: false, type: "rsync", rsync__args: ['--verbose', '--archive', '--delete', '-z'] , rsync__exclude: ['.git','venv']
+        $shared_folders.each do |src, dst|
+          node.vm.synced_folder src, dst, type: "rsync", rsync__args: ['--verbose', '--archive', '--delete', '-z']
+        end
       end
 
       ip = "#{$subnet}.#{i+100}"
@@ -191,8 +202,8 @@ Vagrant.configure("2") do |config|
       # Disable swap for each vm
       node.vm.provision "shell", inline: "swapoff -a"
 
-      # Disable firewalld on oraclelinux vms
-      if ["oraclelinux","oraclelinux8"].include? $os
+      # Disable firewalld on oraclelinux/redhat vms
+      if ["oraclelinux","oraclelinux8","redhat7","redhat8"].include? $os
         node.vm.provision "shell", inline: "systemctl stop firewalld; systemctl disable firewalld"
       end
 

--- a/docs/centos8.md
+++ b/docs/centos8.md
@@ -1,6 +1,6 @@
-# RHEL / CentOS 8
+# CentOS 8
 
-RHEL / CentOS 8 ships only with iptables-nft (ie without iptables-legacy)
+CentOS 8 ships only with iptables-nft (ie without iptables-legacy)
 The only tested configuration for now is using Calico CNI
 You need to use K8S 1.17+ and to add `calico_iptables_backend: "NFT"` to your configuration
 

--- a/docs/rhel.md
+++ b/docs/rhel.md
@@ -1,0 +1,38 @@
+# Red Hat Enterprise Linux (RHEL)
+
+## RHEL Support Subscription Registration
+
+In order to install packages via yum or dnf, RHEL 7/8 hosts are required to be registered for a valid Red Hat support subscription.
+
+You can apply for a 1-year Development support subscription by creating a [Red Hat Developers](https://developers.redhat.com/) account. Be aware though that as the Red Hat Developers subscription is limited to only 1 year, it should not be used to register RHEL 7/8 hosts provisioned in Production environments.
+
+Once you have a Red Hat support account, simply add the credentials to the Ansible inventory parameters `rh_subscription_username` and `rh_subscription_password` prior to deploying Kubespray. If your company has a Corporate Red Hat support account, then obtain an **Organization ID** and **Activation Key**, and add these to the Ansible inventory parameters `rh_subscription_org_id` and `rh_subscription_activation_key` instead of using your Red Hat support account credentials.
+
+```ini
+rh_subscription_username: ""
+rh_subscription_password: ""
+# rh_subscription_org_id: ""
+# rh_subscription_activation_key: ""
+```
+
+Either the Red Hat support account username/password, or Organization ID/Activation Key combination must be specified in the Ansible inventory in order for the Red Hat subscription registration to complete successfully during the deployment of Kubespray.
+
+Update the Ansible inventory parameters `rh_subscription_usage`, `rh_subscription_role` and `rh_subscription_sla` if necessary to suit your specific requirements.
+
+```ini
+rh_subscription_usage: "Development"
+rh_subscription_role: "Red Hat Enterprise Server"
+rh_subscription_sla: "Self-Support"
+```
+
+If the RHEL 7/8 hosts are already registered to a valid Red Hat support subscription via an alternative configuration management approach prior to the deployment of Kubespray, the successful RHEL `subscription-manager` status check will simply result in the RHEL subscription registration tasks being skipped.
+
+## RHEL 8
+
+RHEL 8 ships only with iptables-nft (ie without iptables-legacy)
+The only tested configuration for now is using Calico CNI
+You need to use K8S 1.17+ and to add `calico_iptables_backend: "NFT"` to your configuration
+
+If you have containers that are using iptables in the host network namespace (`hostNetwork=true`),
+you need to ensure they are using iptables-nft.
+An example how k8s do the autodetection can be found [in this PR](https://github.com/kubernetes/kubernetes/pull/82966)

--- a/inventory/sample/group_vars/all/all.yml
+++ b/inventory/sample/group_vars/all/all.yml
@@ -96,3 +96,14 @@ loadbalancer_apiserver_healthcheck_port: 8081
 ## Set Pypi repo and cert accordingly
 # pyrepo_index: https://pypi.example.com/simple
 # pyrepo_cert: /etc/ssl/certs/ca-certificates.crt
+
+## Red Hat Enterprise Linux subscription registration
+## Add either RHEL subscription Username/Password or Organization ID/Activation Key combination
+## Update RHEL subscription purpose usage, role and SLA if necessary
+# rh_subscription_username: ""
+# rh_subscription_password: ""
+# rh_subscription_org_id: ""
+# rh_subscription_activation_key: ""
+# rh_subscription_usage: "Development"
+# rh_subscription_role: "Red Hat Enterprise Server"
+# rh_subscription_sla: "Self-Support"

--- a/roles/bootstrap-os/tasks/bootstrap-redhat.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-redhat.yml
@@ -1,0 +1,87 @@
+---
+- name: Gather host facts to get ansible_distribution_version ansible_distribution_major_version
+  setup:
+    gather_subset: '!all'
+    filter: ansible_distribution_*version
+
+- name: Check RHEL subscription-manager status
+  command: /sbin/subscription-manager status
+  register: rh_subscription_status
+  ignore_errors: true
+  become: true
+
+- name: RHEL subscription Organization ID/Activation Key registration
+  redhat_subscription:
+    state: present
+    org_id: "{{ rh_subscription_org_id }}"
+    activationkey: "{{ rh_subscription_activation_key }}"
+    auto_attach: true
+    force_register: true
+    syspurpose:
+      usage: "{{ rh_subscription_usage }}"
+      role: "{{ rh_subscription_role }}"
+      service_level_agreement: "{{ rh_subscription_sla }}"
+      sync: true
+  ignore_errors: true
+  become: true
+  when:
+    - rh_subscription_org_id is defined
+    - rh_subscription_status.rc != 0
+
+- name: RHEL subscription Username/Password registration
+  redhat_subscription:
+    state: present
+    username: "{{ rh_subscription_username }}"
+    password: "{{ rh_subscription_password }}"
+    auto_attach: true
+    force_register: true
+    syspurpose:
+      usage: "{{ rh_subscription_usage }}"
+      role: "{{ rh_subscription_role }}"
+      service_level_agreement: "{{ rh_subscription_sla }}"
+      sync: true
+  ignore_errors: true
+  become: true
+  when:
+    - rh_subscription_username is defined
+    - rh_subscription_status.rc != 0
+
+- name: RHEL auto-attach subscription
+  command: /sbin/subscription-manager attach --auto
+  become: true
+  when: rh_subscription_status.rc != 0
+
+- name: Check presence of fastestmirror.conf
+  stat:
+    path: /etc/yum/pluginconf.d/fastestmirror.conf
+  register: fastestmirror
+
+# the fastestmirror plugin can actually slow down Ansible deployments
+- name: Disable fastestmirror plugin if requested
+  lineinfile:
+    dest: /etc/yum/pluginconf.d/fastestmirror.conf
+    regexp: "^enabled=.*"
+    line: "enabled=0"
+    state: present
+  become: true
+  when:
+    - fastestmirror.stat.exists
+    - not centos_fastestmirror_enabled
+
+- name: Add proxy to /etc/yum.conf if http_proxy is defined
+  ini_file:
+    path: "/etc/yum.conf"
+    section: main
+    option: proxy
+    value: "{{ http_proxy | default(omit) }}"
+    state: "{{ http_proxy | default(False) | ternary('present', 'absent') }}"
+    no_extra_spaces: true
+  become: true
+
+# libselinux-python is required on SELinux enabled hosts
+# See https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#managed-node-requirements
+- name: Install libselinux python package
+  package:
+    name: "{{ ( (ansible_distribution_major_version | int) < 8) | ternary('libselinux-python','python3-libselinux') }}"
+    state: present
+  become: true

--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -8,7 +8,10 @@
   environment: {}
 
 - include_tasks: bootstrap-centos.yml
-  when: '"CentOS" in os_release.stdout or "Red Hat Enterprise Linux" in os_release.stdout or "Oracle" in os_release.stdout'
+  when: '"CentOS" in os_release.stdout or "Oracle" in os_release.stdout'
+
+- include_tasks: bootstrap-redhat.yml
+  when: '"Red Hat Enterprise Linux" in os_release.stdout'
 
 - include_tasks: bootstrap-clearlinux.yml
   when: '"Clear Linux OS" in os_release.stdout'

--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -31,7 +31,7 @@ containerd_repo_key_info:
 containerd_repo_info:
   repos:
 
-extras_rh_repo_base_url: "http://mirror.centos.org/centos/$releasever/extras/$basearch/"
+extras_rh_repo_base_url: "http://mirror.centos.org/centos/7/extras/$basearch/"
 extras_rh_repo_gpgkey: "http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-7"
 
 # Ubuntu docker-ce repo

--- a/roles/container-engine/docker/defaults/main.yml
+++ b/roles/container-engine/docker/defaults/main.yml
@@ -43,7 +43,7 @@ docker_debian_repo_base_url: "https://download.docker.com/linux/debian"
 docker_debian_repo_gpgkey: 'https://download.docker.com/linux/debian/gpg'
 docker_bin_dir: "/usr/bin"
 # CentOS/RedHat Extras repo
-extras_rh_repo_base_url: "http://mirror.centos.org/centos/$releasever/extras/$basearch/"
+extras_rh_repo_base_url: "http://mirror.centos.org/centos/7/extras/$basearch/"
 extras_rh_repo_gpgkey: "http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-7"
 
 # flag to enable/disable docker cleanup

--- a/roles/container-engine/docker/vars/redhat.yml
+++ b/roles/container-engine/docker/vars/redhat.yml
@@ -27,7 +27,6 @@ docker_selinux_versioned_pkg:
   'stable': docker-ce-selinux-17.03.3.ce-1.el7
   'edge': docker-ce-selinux-17.03.3.ce-1.el7
 
-
 docker_pkgs_use_docker_ce:
   - name: "{{ docker_selinux_versioned_pkg[docker_selinux_version | string] }}"
     yum_conf: "{{ docker_yum_conf }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
The new Red Hat support subscription registration feature will allow developers and administrators to deploy Kubespray across RHEL 7/8 hosts using Red Hat support account credentials, or an Organization ID/Activation Key combination.

A valid Red Hat support subscription is required to download packages from the RHEL 7/8 repositories via yum or dnf.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE