### PR TITLE
Edited pre-upgrade task to uncordon a node failing to drain

### DIFF
--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -30,40 +30,46 @@
       false
       {%- endif %}
 
-- name: Cordon node
-  command: "{{ bin_dir }}/kubectl cordon {{ kube_override_hostname|default(inventory_hostname) }}"
-  delegate_to: "{{ groups['kube-master'][0] }}"
-  when: needs_cordoning
+- name: Node draining
+  block:
+    - name: Cordon node
+      command: "{{ bin_dir }}/kubectl cordon {{ kube_override_hostname|default(inventory_hostname) }}"
+      delegate_to: "{{ groups['kube-master'][0] }}"
 
-- name: Check kubectl version
-  command: "{{ bin_dir }}/kubectl version --client --short"
-  register: kubectl_version
-  delegate_to: "{{ groups['kube-master'][0] }}"
-  run_once: yes
-  changed_when: false
-  when:
-    - drain_nodes
-    - needs_cordoning
-    - drain_pod_selector
+    - name: Check kubectl version
+      command: "{{ bin_dir }}/kubectl version --client --short"
+      register: kubectl_version
+      delegate_to: "{{ groups['kube-master'][0] }}"
+      run_once: yes
+      changed_when: false
+      when:
+        - drain_nodes
+        - drain_pod_selector
 
-- name: Ensure minimum version for drain label selector if necessary
-  assert:
-    that: "kubectl_version.stdout.split(' ')[-1] is version('v1.10.0', '>=')"
-  when:
-    - drain_nodes
-    - needs_cordoning
-    - drain_pod_selector
+    - name: Ensure minimum version for drain label selector if necessary
+      assert:
+        that: "kubectl_version.stdout.split(' ')[-1] is version('v1.10.0', '>=')"
+      when:
+        - drain_nodes
+        - drain_pod_selector
 
-- name: Drain node
-  command: >-
-    {{ bin_dir }}/kubectl drain
-    --force
-    --ignore-daemonsets
-    --grace-period {{ drain_grace_period }}
-    --timeout {{ drain_timeout }}
-    --delete-local-data {{ kube_override_hostname|default(inventory_hostname) }}
-    {% if drain_pod_selector %}--pod-selector '{{ drain_pod_selector }}'{% endif %}
+    - name: Drain node
+      command: >-
+        {{ bin_dir }}/kubectl drain
+        --force
+        --ignore-daemonsets
+        --grace-period {{ drain_grace_period }}
+        --timeout {{ drain_timeout }}
+        --delete-local-data {{ kube_override_hostname|default(inventory_hostname) }}
+        {% if drain_pod_selector %}--pod-selector '{{ drain_pod_selector }}'{% endif %}
+      when:
+        - drain_nodes
+  rescue:
+    - name: Set node back to schedulable
+      command: "{{ bin_dir }}/kubectl --kubeconfig /etc/kubernetes/admin.conf uncordon {{ inventory_hostname }}"
+    - name: Fail after rescue
+      fail:
+        msg: "Failed to drain node {{ inventory_hostname }}"
   delegate_to: "{{ groups['kube-master'][0] }}"
   when:
-    - drain_nodes
     - needs_cordoning


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds a rescue block to uncordon nodes that failed draining during upgrade.
The goal is to avoid cordoning nodes and leaving them in that state if possible.

**Which issue(s) this PR fixes**:
Fixes issue described [there](https://github.com/kubernetes-sigs/kubespray/issues/6545).

**Automatically closes linked issue when PR is merged.**:
`Fixes #6545`

**Special notes for your reviewer**:
None.

**Does this PR introduce a user-facing change?**:
```release-note
None
```
