### PR TITLE
Fix cert-manager E305 ansible-lint error

### DIFF
--- a/roles/kubernetes-apps/ingress_controller/cert_manager/tasks/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/tasks/main.yml
@@ -68,7 +68,7 @@
     - inventory_hostname == groups['kube-master'][0]
 
 - name: Cert Manager | Wait for Webhook pods become ready
-  shell: "{{ bin_dir }}/kubectl wait po --namespace={{ cert_manager_namespace }} --selector app=webhook --for=condition=Ready --timeout=600s"
+  command: "{{ bin_dir }}/kubectl wait po --namespace={{ cert_manager_namespace }} --selector app=webhook --for=condition=Ready --timeout=600s"
   register: cert_manager_webhook_pods_ready
   when: inventory_hostname == groups['kube-master'][0]
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix the following error reported by Kubespray **ansible-lint** utility.

```
roles/kubernetes-apps/ingress_controller/cert_manager/tasks/main.yml:70: [E305] Use shell only when shell functionality is required
```

**Which issue(s) this PR fixes**:
Fixes #6548 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
