### PR TITLE
Bump Openstack cloud controller image verison to 1.18.2

### DIFF
--- a/roles/kubernetes-apps/external_cloud_controller/openstack/defaults/main.yml
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/defaults/main.yml
@@ -12,4 +12,4 @@ external_openstack_domain_name: "{{ lookup('env','OS_USER_DOMAIN_NAME') }}"
 external_openstack_domain_id: "{{ lookup('env','OS_USER_DOMAIN_ID') }}"
 external_openstack_cacert: "{{ lookup('env','OS_CACERT') }}"
 
-external_openstack_cloud_controller_image_tag: "v1.18.1"
+external_openstack_cloud_controller_image_tag: "v1.18.2"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Upgrade Openstack cloud controller image from v1.18.1 to v1.18.2

**Which issue(s) this PR fixes**:
Fixes #6561

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
