### PR TITLE
Docker: Set Cgroup driver by default to systemd

### DIFF
--- a/inventory/sample/group_vars/all/docker.yml
+++ b/inventory/sample/group_vars/all/docker.yml
@@ -10,6 +10,10 @@ docker_container_storage_setup: false
 ## Otherwise docker-storage-setup will be executed incorrectly.
 # docker_container_storage_setup_devs: /dev/vdb
 
+## Uncomment this if you want to change the Docker Cgroup driver (native.cgroupdriver)
+## Valid options are systemd or cgroupfs, default is systemd
+# docker_cgroup_driver: systemd
+
 ## Uncomment this if you have more than 3 nameservers, then we'll only use the first 3.
 docker_dns_servers_strict: false
 

--- a/roles/container-engine/docker/defaults/main.yml
+++ b/roles/container-engine/docker/defaults/main.yml
@@ -18,6 +18,8 @@ dockerproject_repo_key_info:
 dockerproject_repo_info:
   repos:
 
+docker_cgroup_driver: systemd
+
 docker_dns_servers_strict: true
 
 docker_container_storage_setup: false

--- a/roles/container-engine/docker/templates/docker-options.conf.j2
+++ b/roles/container-engine/docker/templates/docker-options.conf.j2
@@ -1,6 +1,6 @@
 [Service]
 Environment="DOCKER_OPTS={{ docker_options|default('') }} --iptables={{ docker_iptables_enabled | default('false') }} \
---exec-opt native.cgroupdriver={{ docker_cgroup_driver | default('systemd') }} \
+--exec-opt native.cgroupdriver={{ docker_cgroup_driver }} \
 {% for i in docker_insecure_registries %}--insecure-registry={{ i }} {% endfor %} \
 {% for i in docker_registry_mirrors %}--registry-mirror={{ i }} {% endfor %} \
 {% if docker_version != "latest" and docker_version is version('17.05', '<') %}--graph={% else %}--data-root={% endif %}{{ docker_daemon_graph }} \

--- a/roles/container-engine/docker/templates/docker-options.conf.j2
+++ b/roles/container-engine/docker/templates/docker-options.conf.j2
@@ -1,12 +1,12 @@
 [Service]
 Environment="DOCKER_OPTS={{ docker_options|default('') }} --iptables={{ docker_iptables_enabled | default('false') }} \
+--exec-opt native.cgroupdriver={{ docker_cgroup_driver | default('systemd') }} \
 {% for i in docker_insecure_registries %}--insecure-registry={{ i }} {% endfor %} \
 {% for i in docker_registry_mirrors %}--registry-mirror={{ i }} {% endfor %} \
 {% if docker_version != "latest" and docker_version is version('17.05', '<') %}--graph={% else %}--data-root={% endif %}{{ docker_daemon_graph }} \
 {% if ansible_os_family not in ["openSUSE Leap", "openSUSE Tumbleweed", "Suse"] %}{{ docker_log_opts }}{% endif %} \
 {% if ansible_architecture == "aarch64" and ansible_os_family == "RedHat" %} \
---add-runtime docker-runc=/usr/libexec/docker/docker-runc-current \
---default-runtime=docker-runc --exec-opt native.cgroupdriver=systemd \
+--add-runtime docker-runc=/usr/libexec/docker/docker-runc-current --default-runtime=docker-runc \
 --userland-proxy-path=/usr/libexec/docker/docker-proxy-current --signature-verification=false \
 {% endif %}"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This change is required to align with the official Kubernetes recommendation to use `systemd` as the Docker Cgroup driver for both the container runtime and kubelet to stabilize the allocation of resources to processes.

https://kubernetes.io/docs/setup/production-environment/container-runtimes/#cgroup-drivers

**Which issue(s) this PR fixes**:
Fixes #5134 

**Special notes for your reviewer**:
Before working on the user documentation, I'm seeking initial feedback on the implementation.

I also believe that we should just document and advise user's of https://github.com/lnykryn/systemd-rhel/issues/266 and ensure responsibility of addressing Linux OS issues, such as dbus, systemd, etc continues to be with the DevOps / Platform Engineers and the cloud providers via prebuilt images, AMIs, etc.

Whilst it's important to ensure the relevant OS packages are installed prior to deploying Kubespray, by trying to mitigate every possible Linux OS issue would result in over-engineering the solution, which may introduce unknown consequences and constraints for our users.

**Does this PR introduce a user-facing change?**:
```release-note
Docker: Set cgroup driver by default to systemd
```
