### PR TITLE
Add external_openstack_lbaas_provider setting for occm

### DIFF
--- a/inventory/sample/group_vars/all/openstack.yml
+++ b/inventory/sample/group_vars/all/openstack.yml
@@ -20,9 +20,8 @@
 # external_openstack_lbaas_subnet_id: "Neutron subnet ID to create LBaaS VIP"
 # external_openstack_lbaas_floating_network_id: "Neutron network ID to get floating IP from"
 # external_openstack_lbaas_floating_subnet_id: "Neutron subnet ID to get floating IP from"
-# external_openstack_lbaas_use_octavia: true
 # external_openstack_lbaas_method: "ROUND_ROBIN"
-# external_openstack_lbaas_provider: "amphora"
+# external_openstack_lbaas_provider: "octavia"
 # external_openstack_lbaas_create_monitor: false
 # external_openstack_lbaas_monitor_delay: "1m"
 # external_openstack_lbaas_monitor_timeout: "30s"

--- a/inventory/sample/group_vars/all/openstack.yml
+++ b/inventory/sample/group_vars/all/openstack.yml
@@ -22,6 +22,7 @@
 # external_openstack_lbaas_floating_subnet_id: "Neutron subnet ID to get floating IP from"
 # external_openstack_lbaas_use_octavia: true
 # external_openstack_lbaas_method: "ROUND_ROBIN"
+# external_openstack_lbaas_provider: "amphora"
 # external_openstack_lbaas_create_monitor: false
 # external_openstack_lbaas_monitor_delay: "1m"
 # external_openstack_lbaas_monitor_timeout: "30s"

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
@@ -27,6 +27,9 @@ monitor-max-retries={{ external_openstack_lbaas_monitor_max_retries }}
 {% if external_openstack_lbaas_method is defined %}
 lb-method={{ external_openstack_lbaas_method }}
 {% endif %}
+{% if external_openstack_lbaas_provider is defined %}
+lb-provider={{ external_openstack_lbaas_provider }}
+{% endif %}
 {% if external_openstack_lbaas_network_id is defined %}
 network-id={{ external_openstack_lbaas_network_id }}
 {% endif %}

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
@@ -19,7 +19,6 @@ ca-file="{{ kube_config_dir }}/external-openstack-cacert.pem"
 {% endif %}
 
 [LoadBalancer]
-use-octavia={{ external_openstack_lbaas_use_octavia | string | lower }}
 create-monitor={{ external_openstack_lbaas_create_monitor }}
 monitor-delay={{ external_openstack_lbaas_monitor_delay }}
 monitor-timeout={{ external_openstack_lbaas_monitor_timeout }}
@@ -45,12 +44,13 @@ manage-security-groups={{ external_openstack_lbaas_manage_security_groups }}
 {% if external_openstack_lbaas_internal_lb is defined %}
 internal-lb={{ external_openstack_lbaas_internal_lb }}
 {% endif %}
-{% if external_openstack_lbaas_use_octavia is defined and external_openstack_lbaas_use_octavia %}
-lb-provider=octavia
-{% elif external_openstack_lbaas_provider is defined %}
+{% if external_openstack_lbaas_provider is defined %}
 lb-provider={{ external_openstack_lbaas_provider }}
+use-octavia={{ external_openstack_lbaas_provider | lower == 'octavia' }}
+{% else %}
+lb-provider=octavia
+use-octavia=true
 {% endif %}
-
 
 [Networking]
 ipv6-support-disabled={{ external_openstack_network_ipv6_disabled | string | lower }}

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
@@ -27,9 +27,6 @@ monitor-max-retries={{ external_openstack_lbaas_monitor_max_retries }}
 {% if external_openstack_lbaas_method is defined %}
 lb-method={{ external_openstack_lbaas_method }}
 {% endif %}
-{% if external_openstack_lbaas_provider is defined %}
-lb-provider={{ external_openstack_lbaas_provider }}
-{% endif %}
 {% if external_openstack_lbaas_network_id is defined %}
 network-id={{ external_openstack_lbaas_network_id }}
 {% endif %}
@@ -50,7 +47,10 @@ internal-lb={{ external_openstack_lbaas_internal_lb }}
 {% endif %}
 {% if external_openstack_lbaas_use_octavia is defined and external_openstack_lbaas_use_octavia %}
 lb-provider=octavia
+{% elif external_openstack_lbaas_provider is defined %}
+lb-provider={{ external_openstack_lbaas_provider }}
 {% endif %}
+
 
 [Networking]
 ipv6-support-disabled={{ external_openstack_network_ipv6_disabled | string | lower }}


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
Add a new parameter in `openstack.yml` to be able to specify a loadbalancerv2 service provider and update config template file to include this new parameter.

**Which issue(s) this PR fixes**:
Fixes #6565

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
