### PR TITLE
cri-o: add variable to configure unsecure pull

### DIFF
--- a/roles/container-engine/cri-o/defaults/main.yml
+++ b/roles/container-engine/cri-o/defaults/main.yml
@@ -6,6 +6,11 @@ crio_enable_metrics: false
 crio_log_level: "info"
 crio_metrics_port: "9090"
 crio_pause_image: "{{ pod_infra_image_repo }}:{{ pod_infra_version }}"
+
+# Trusted registries to pull unqualified images (e.g. alpine:latest) from
+# By default unqualified images are not allowed for security reasons
+crio_registries: []
+
 crio_runc_path: "/usr/bin/runc"
 crio_seccomp_profile: ""
 crio_selinux: "{{ (preinstall_selinux_state == 'enforcing')|lower }}"

--- a/roles/container-engine/cri-o/templates/crio.conf.j2
+++ b/roles/container-engine/cri-o/templates/crio.conf.j2
@@ -350,8 +350,11 @@ image_volumes = "mkdir"
 # compatibility reasons. Depending on your workload and usecase you may add more
 # registries (e.g., "quay.io", "registry.fedoraproject.org",
 # "registry.opensuse.org", etc.).
-#registries = [
-# ]
+registries = [
+  {% for registry in crio_registries %}
+  "{{ registry }}",
+  {% endfor %}
+]
 
 
 # The crio.network table containers settings pertaining to the management of


### PR DESCRIPTION
    By default do not allow "unqualified" (without a registry) images
    because it is considered unsecure and subject to mitm attacks.
    
    To enable insecure pull configure for example:
    
    crio_registries:
      - "docker.io"
      - "quay.io"

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Clusters using CRI-O as container runtime and where pulling of unqualified images is used, now needs to explicitly allow this.
```
