### PR TITLE
Update bunch of dependencies with minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [cri-o](http://cri-o.io/) v1.17 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)
 - Network Plugin
   - [cni-plugins](https://github.com/containernetworking/plugins) v0.8.6
-  - [calico](https://github.com/projectcalico/calico) v3.15.1
+  - [calico](https://github.com/projectcalico/calico) v3.15.2
   - [canal](https://github.com/projectcalico/canal) (given calico/flannel versions)
   - [cilium](https://github.com/cilium/cilium) v1.8.2
   - [contiv](https://github.com/contiv/install) v1.2.1

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -65,7 +65,7 @@ quay_image_repo: "quay.io"
 
 # TODO(mattymo): Move calico versions to roles/network_plugins/calico/defaults
 # after migration to container download
-calico_version: "v3.15.1"
+calico_version: "v3.15.2"
 calico_ctl_version: "{{ calico_version }}"
 calico_cni_version: "{{ calico_version }}"
 calico_policy_version: "{{ calico_version }}"
@@ -440,20 +440,17 @@ cni_binary_checksums:
   amd64: 994fbfcdbb2eedcfa87e48d8edb9bb365f4e2747a7e47658482556c12fd9b2f5
 calicoctl_binary_checksums:
   arm:
-    v3.15.1: 0
+    v3.15.2: 0
     v3.14.1: 0
     v3.13.3: 0
-    v3.11.1: 0
   amd64:
-    v3.15.1: 0aa333986e221e6fadb74fb3dbed327fe016790a8c09e0092c8b75d5f77a843a
+    v3.15.2: 219ae954501cbe15daeda0ad52e13ec65f99c77548c7d3cbfc4ced5c7149fdf1
     v3.14.1: 5fe8a7b00a45cf48879eff42b08dcdb85cf0121f3720ac8cbd06566aaa385667
     v3.13.3: 570539d436df51bb349bb1a8c6b200a3a6f20803a9d391aa2c5cf19a70a083d4
-    v3.11.1: 045fdbfdb30789194c499ba17c8eac6d1704fe20d05e3c10027eb570767386db
   arm64:
-    v3.15.1: 275dc0fa6ce924cd1ff6c2011bb59a62a618350ef0d0549e65f7aa53058d2c57
+    v3.15.2: 49165f9e4ad55402248b578310fcf68a57363f54e66be04ac24be9714899b4d5
     v3.14.1: 326da28cb726988029f70fbf3d4de424a4edd9949fd435fad81f2203c93e4c36
     v3.13.3: 0c47acd6d200ba1f8348b389cd7a54771542158fef657afc633a30ddad97e272
-    v3.11.1: 770e0fce9acf1927726d64a885f8350d44a3fcbf248017d0aceec58bd41fa1b8
 
 etcd_binary_checksum: "{{ etcd_binary_checksums[image_arch] }}"
 cni_binary_checksum: "{{ cni_binary_checksums[image_arch] }}"
@@ -545,8 +542,8 @@ dnsautoscaler_image_tag: "{{ dnsautoscaler_version }}"
 test_image_repo: "{{ docker_image_repo }}/library/busybox"
 test_image_tag: latest
 busybox_image_repo: "{{ docker_image_repo }}/library/busybox"
-busybox_image_tag: 1.31.1
-helm_version: "v3.2.3"
+busybox_image_tag: 1.32.0
+helm_version: "v3.2.4"
 helm_image_repo: "{{ docker_image_repo }}/lachlanevenson/k8s-helm"
 helm_image_tag: "{{ helm_version }}"
 tiller_image_repo: "{{ gcr_image_repo }}/kubernetes-helm/tiller"
@@ -556,8 +553,8 @@ registry_image_repo: "{{ docker_image_repo }}/library/registry"
 registry_image_tag: "2.7.1"
 registry_proxy_image_repo: "{{ kube_image_repo }}/kube-registry-proxy"
 registry_proxy_image_tag: "0.4"
-metrics_server_version: "v0.3.6"
-metrics_server_image_repo: "{{ kube_image_repo }}/metrics-server-{{ image_arch }}"
+metrics_server_version: "v0.3.7"
+metrics_server_image_repo: "{{ kube_image_repo }}/metrics-server/metrics-server"
 metrics_server_image_tag: "{{ metrics_server_version }}"
 local_volume_provisioner_image_repo: "{{ quay_image_repo }}/external_storage/local-volume-provisioner"
 local_volume_provisioner_image_tag: "v2.3.4"
@@ -580,7 +577,7 @@ cert_manager_cainjector_image_repo: "{{ quay_image_repo }}/jetstack/cert-manager
 cert_manager_cainjector_image_tag: "{{ cert_manager_version }}"
 cert_manager_webhook_image_repo: "{{ quay_image_repo }}/jetstack/cert-manager-webhook"
 cert_manager_webhook_image_tag: "{{ cert_manager_version }}"
-addon_resizer_version: "1.8.9"
+addon_resizer_version: "1.8.11"
 addon_resizer_image_repo: "{{ kube_image_repo }}/addon-resizer"
 addon_resizer_image_tag: "{{ addon_resizer_version }}"
 
@@ -622,7 +619,7 @@ gcp_pd_csi_resizer_image_tag: "v0.4.0-gke.0"
 gcp_pd_csi_registrar_image_tag: "v1.2.0-gke.0"
 
 dashboard_image_repo: "{{ docker_image_repo }}/kubernetesui/dashboard-{{ image_arch }}"
-dashboard_image_tag: "v2.0.2"
+dashboard_image_tag: "v2.0.3"
 dashboard_metrics_scraper_repo: "{{ docker_image_repo }}/kubernetesui/metrics-scraper"
 dashboard_metrics_scraper_tag: "v1.0.5"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Bunch of dependencies with minor features, CVE fixes or bug fixes
- Busybox from 1.31.1 to 1.32
- helm from 3.2.3 to 3.2.4
- metrics_server from 0.3.6 to 0.3.7
- addon_resize from 1.8.9 to 1.8.11
- kubernetes_dashboard from 2.0.2 to 2.0.3
- calico from 3.15.1 to 3.15.2

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
Dashboard version to change at least 
```
