### PR TITLE
Rollback coredns, should not have been updated before 1.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [cephfs-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.0-k8s1.11
   - [rbd-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.1-k8s1.11
   - [cert-manager](https://github.com/jetstack/cert-manager) v0.15.2
-  - [coredns](https://github.com/coredns/coredns) v1.7.0
+  - [coredns](https://github.com/coredns/coredns) v1.6.7
   - [ingress-nginx](https://github.com/kubernetes/ingress-nginx) v0.32.0
 
 Note: The list of validated [docker versions](https://kubernetes.io/docs/setup/production-environment/container-runtimes/#docker) is 1.13.1, 17.03, 17.06, 17.09, 18.06, 18.09 and 19.03. The recommended docker version is 19.03. The kubelet might break on docker's non-standard version numbering (it no longer uses semantic versioning). To ensure auto-updates don't break your cluster look into e.g. yum versionlock plugin or apt pin).

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -531,7 +531,7 @@ haproxy_image_tag: 2.1
 
 # Coredns version should be supported by corefile-migration (or at least work with)
 # bundle with kubeadm; if not 'basic' upgrade can sometimes fail
-coredns_version: "1.7.0"
+coredns_version: "1.6.7"
 coredns_image_repo: "{{ docker_image_repo }}/coredns/coredns"
 coredns_image_tag: "{{ coredns_version }}"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Jobs are starting to fail on upgrade, when reaching coredns, this is due to corefile-migration bundled with kubeadm not supporting coredns 1.6.7+
Rollback while still on 1.18

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
