### PR TITLE
Add cilium hubble server in config

### DIFF
--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -23,6 +23,8 @@ cilium_tunnel_mode: vxlan
 # Optional features
 cilium_enable_prometheus: false
 cilium_enable_hubble_metrics: false
+cilium_enable_hubble: false
+cilium_hubble_metrics: ""
 # Enable if you want to make use of hostPort mappings
 cilium_enable_portmap: false
 # Monitor aggregation level (none/low/medium/maximum)

--- a/roles/network_plugin/cilium/templates/cilium-config.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-config.yml.j2
@@ -145,3 +145,13 @@ data:
 
   native-routing-cidr: "{{ cilium_native_routing_cidr }}"
   auto-direct-node-routes: "{{ cilium_auto_direct_node_routes }}"
+
+  # Hubble settings
+{% if cilium_enable_hubble %}
+  enable-hubble: "true"
+  hubble-metrics: "{{ cilium_hubble_metrics }}"
+  hubble-listen-address: ":4244"
+{% if cilium_enable_hubble_metrics %}
+  hubble-metrics-server: ":9091"
+{% endif %}
+{% endif %}


### PR DESCRIPTION
Signed-off-by: Arthur Outhenin-Chalandre <arthur@cri.epita.fr>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This add config for hubble server support in cilium.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add hubble server support in cilium
```
