### PR TITLE
Remove support for CoreOS Container Linux (EOL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ vagrant up
 - [HA mode](docs/ha-mode.md)
 - [Network plugins](#network-plugins)
 - [Vagrant install](docs/vagrant.md)
-- [CoreOS bootstrap](docs/coreos.md)
+- [Flatcar Container Linux bootstrap](docs/flatcar.md)
 - [Fedora CoreOS bootstrap](docs/fcos.md)
 - [Debian Jessie setup](docs/debian.md)
 - [openSUSE setup](docs/opensuse.md)
@@ -102,7 +102,7 @@ vagrant up
 
 ## Supported Linux Distributions
 
-- **Container Linux by CoreOS**
+- **Flatcar Container Linux by Kinvolk**
 - **Debian** Buster, Jessie, Stretch, Wheezy
 - **Ubuntu** 16.04, 18.04, 20.04
 - **CentOS/RHEL** 7, 8 (experimental: see [centos 8 notes](docs/centos8.md))

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,16 +9,12 @@ Vagrant.require_version ">= 2.0.0"
 
 CONFIG = File.join(File.dirname(__FILE__), ENV['KUBESPRAY_VAGRANT_CONFIG'] || 'vagrant/config.rb')
 
-COREOS_URL_TEMPLATE = "https://storage.googleapis.com/%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json"
 FLATCAR_URL_TEMPLATE = "https://%s.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vagrant.json"
 
 # Uniq disk UUID for libvirt
 DISK_UUID = Time.now.utc.to_i
 
 SUPPORTED_OS = {
-  "coreos-stable"       => {box: "coreos-stable",              user: "core", box_url: COREOS_URL_TEMPLATE % ["stable"]},
-  "coreos-alpha"        => {box: "coreos-alpha",               user: "core", box_url: COREOS_URL_TEMPLATE % ["alpha"]},
-  "coreos-beta"         => {box: "coreos-beta",                user: "core", box_url: COREOS_URL_TEMPLATE % ["beta"]},
   "flatcar-stable"      => {box: "flatcar-stable",             user: "core", box_url: FLATCAR_URL_TEMPLATE % ["stable"]},
   "flatcar-beta"        => {box: "flatcar-beta",               user: "core", box_url: FLATCAR_URL_TEMPLATE % ["beta"]},
   "flatcar-alpha"       => {box: "flatcar-alpha",              user: "core", box_url: FLATCAR_URL_TEMPLATE % ["alpha"]},

--- a/contrib/terraform/aws/README.md
+++ b/contrib/terraform/aws/README.md
@@ -22,7 +22,7 @@ export TF_VAR_AWS_SECRET_ACCESS_KEY ="xxx"
 export TF_VAR_AWS_SSH_KEY_NAME="yyy"
 export TF_VAR_AWS_DEFAULT_REGION="zzz"
 ```
-- Update `contrib/terraform/aws/terraform.tfvars` with your data. By default, the Terraform scripts use CoreOS as base image. If you want to change this behaviour, see note "Using other distrib than CoreOs" below.
+- Update `contrib/terraform/aws/terraform.tfvars` with your data. By default, the Terraform scripts use Ubuntu 18.04 LTS (Bionic) as base image. If you want to change this behaviour, see note "Using other distrib than Ubuntu" below.
 - Create an AWS EC2 SSH Key
 - Run with `terraform apply --var-file="credentials.tfvars"` or `terraform apply` depending if you exported your AWS credentials
 
@@ -41,12 +41,12 @@ ssh -F ./ssh-bastion.conf user@$ip
 
 - Once the infrastructure is created, you can run the kubespray playbooks and supply inventory/hosts with the `-i` flag.
 
-Example (this one assumes you are using CoreOS)
+Example (this one assumes you are using Ubuntu)
 ```commandline
-ansible-playbook -i ./inventory/hosts ./cluster.yml -e ansible_user=core -b --become-user=root --flush-cache
+ansible-playbook -i ./inventory/hosts ./cluster.yml -e ansible_user=ubuntu -b --become-user=root --flush-cache
 ```
-***Using other distrib than CoreOs***
-If you want to use another distribution than CoreOS, you can modify the search filters of the 'data "aws_ami" "distro"' in variables.tf.
+***Using other distrib than Ubuntu***
+If you want to use another distribution than Ubuntu 18.04 (Bionic) LTS, you can modify the search filters of the 'data "aws_ami" "distro"' in variables.tf.
 
 For example, to use:
 - Debian Jessie, replace 'data "aws_ami" "distro"' in variables.tf with

--- a/contrib/terraform/aws/variables.tf
+++ b/contrib/terraform/aws/variables.tf
@@ -25,7 +25,7 @@ data "aws_ami" "distro" {
 
   filter {
     name   = "name"
-    values = ["CoreOS-stable-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"]
   }
 
   filter {
@@ -33,7 +33,7 @@ data "aws_ami" "distro" {
     values = ["hvm"]
   }
 
-  owners = ["595879546273"] #CoreOS
+  owners = ["099720109477"] # Canonical
 }
 
 //AWS VPC Variables

--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -72,9 +72,9 @@ specify:
 - Size of the non-ephemeral volumes to be attached to store the GlusterFS bricks
 - Other properties related to provisioning the hosts
 
-Even if you are using Container Linux by CoreOS for your cluster, you will still
+Even if you are using Flatcar Container Linux by Kinvolk for your cluster, you will still
 need the GlusterFS VMs to be based on either Debian or RedHat based images.
-Container Linux by CoreOS cannot serve GlusterFS, but can connect to it through
+Flatcar Container Linux by Kinvolk cannot serve GlusterFS, but can connect to it through
 binaries available on hyperkube v1.4.3_coreos.0 or higher.
 
 ## Requirements
@@ -482,7 +482,7 @@ So, either a bastion host, or at least master/node with a floating IP are requir
 
 #### Test access
 
-Make sure you can connect to the hosts.  Note that Container Linux by CoreOS will have a state `FAILED` due to Python not being present.  This is okay, because Python will be installed during bootstrapping, so long as the hosts are not `UNREACHABLE`.
+Make sure you can connect to the hosts.  Note that Flatcar Container Linux by Kinvolk will have a state `FAILED` due to Python not being present.  This is okay, because Python will be installed during bootstrapping, so long as the hosts are not `UNREACHABLE`.
 
 ```
 $ ansible -i inventory/$CLUSTER/hosts -m ping all
@@ -510,7 +510,7 @@ Edit `inventory/$CLUSTER/group_vars/all/all.yml`:
 # Directory where the binaries will be installed
 # Default:
 # bin_dir: /usr/local/bin
-# For Container Linux by CoreOS:
+# For Flatcar Container Linux by Kinvolk:
 bin_dir: /opt/bin
 ```
 - and **cloud_provider**:
@@ -531,7 +531,7 @@ kube_network_plugin: flannel
 # Can be docker_dns, host_resolvconf or none
 # Default:
 # resolvconf_mode: docker_dns
-# For Container Linux by CoreOS:
+# For Flatcar Container Linux by Kinvolk:
 resolvconf_mode: host_resolvconf
 ```
 - Set max amount of attached cinder volume per host (default 256)

--- a/contrib/terraform/packet/README.md
+++ b/contrib/terraform/packet/README.md
@@ -176,7 +176,7 @@ If you have deployed and destroyed a previous iteration of your cluster, you wil
 
 #### Test access
 
-Make sure you can connect to the hosts.  Note that Container Linux by CoreOS will have a state `FAILED` due to Python not being present.  This is okay, because Python will be installed during bootstrapping, so long as the hosts are not `UNREACHABLE`.
+Make sure you can connect to the hosts.  Note that Flatcar Container Linux by Kinvolk will have a state `FAILED` due to Python not being present.  This is okay, because Python will be installed during bootstrapping, so long as the hosts are not `UNREACHABLE`.
 
 ```
 $ ansible -i inventory/$CLUSTER/hosts -m ping all

--- a/contrib/terraform/terraform.py
+++ b/contrib/terraform/terraform.py
@@ -223,8 +223,8 @@ def packet_device(resource, tfvars=None):
         'provider': 'packet',
     }
 
-    if raw_attrs['operating_system'] == 'coreos_stable':
-        # For CoreOS set the ssh_user to core
+    if raw_attrs['operating_system'] == 'flatcar_stable':
+        # For Flatcar set the ssh_user to core
         attrs.update({'ansible_ssh_user': 'core'})
 
     # add groups based on attrs

--- a/contrib/vault/roles/vault/tasks/bootstrap/ca_trust.yml
+++ b/contrib/vault/roles/vault/tasks/bootstrap/ca_trust.yml
@@ -13,7 +13,7 @@
       /usr/local/share/ca-certificates/vault-ca.crt
       {%- elif ansible_os_family == "RedHat" -%}
       /etc/pki/ca-trust/source/anchors/vault-ca.crt
-      {%- elif ansible_os_family in ["Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"] -%}
+      {%- elif ansible_os_family in ["Flatcar Container Linux by Kinvolk"] -%}
       /etc/ssl/certs/vault-ca.pem
       {%- endif %}
 
@@ -23,9 +23,9 @@
     dest: "{{ ca_cert_path }}"
   register: vault_ca_cert
 
-- name: bootstrap/ca_trust | update ca-certificates (Debian/Ubuntu/CoreOS)
+- name: bootstrap/ca_trust | update ca-certificates (Debian/Ubuntu/Flatcar)
   command: update-ca-certificates
-  when: vault_ca_cert.changed and ansible_os_family in ["Debian", "CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+  when: vault_ca_cert.changed and ansible_os_family in ["Debian", "Flatcar Container Linux by Kinvolk"]
 
 - name: bootstrap/ca_trust | update ca-certificates (RedHat)
   command: update-ca-trust extract

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -27,7 +27,7 @@
   * [vSphere](/docs/vsphere.md)
 * Operating Systems
   * [Debian](docs/debian.md)
-  * [Coreos](docs/coreos.md)
+  * [Flatcar Container Linux](docs/flatcar.md)
   * [Fedora CoreOS](docs/fcos.md)
   * [OpenSUSE](docs/opensuse.md)
 * Advanced

--- a/docs/flatcar.md
+++ b/docs/flatcar.md
@@ -1,0 +1,14 @@
+Flatcar Container Linux bootstrap
+===============
+
+Example with Ansible:
+
+Before running the cluster playbook you must satisfy the following requirements:
+
+General Flatcar Pre-Installation Notes:
+
+- Ensure that the bin_dir is set to `/opt/bin`
+- ansible_python_interpreter should be `/opt/bin/python`. This will be laid down by the bootstrap task.
+- The default resolvconf_mode setting of `docker_dns` **does not** work for Flatcar. This is because we do not edit the systemd service file for docker on Flatcar nodes. Instead, just use the `host_resolvconf` mode. It should work out of the box.
+
+Then you can proceed to [cluster deployment](#run-deployment)

--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -17,7 +17,7 @@ By default, Vagrant uses Ubuntu 18.04 box to provision a local cluster. You may 
 Customize `$os` variable in `Vagrantfile` or as override, e.g.,:
 
 ```ShellSession
-echo '$os = "coreos-stable"' >> vagrant/config.rb
+echo '$os = "flatcar-stable"' >> vagrant/config.rb
 ```
 
 The supported operating systems for vagrant are defined in the `SUPPORTED_OS` constant in the `Vagrantfile`.

--- a/roles/bootstrap-os/README.md
+++ b/roles/bootstrap-os/README.md
@@ -29,7 +29,7 @@ Variables are listed with their default values, if applicable.
 
 ### Per distribution variables
 
-#### CoreOS
+#### Flatcar Container Linux
 
 * `coreos_locksmithd_disable: false`
   Whether `locksmithd` (responsible for rolling restarts) should be disabled or be left alone.

--- a/roles/bootstrap-os/defaults/main.yml
+++ b/roles/bootstrap-os/defaults/main.yml
@@ -3,7 +3,7 @@
 # Use the fastestmirror yum plugin
 centos_fastestmirror_enabled: false
 
-## CoreOS specific variables
+## Flatcar Container Linux specific variables
 # Disable locksmithd or leave it in its current state
 coreos_locksmithd_disable: false
 

--- a/roles/bootstrap-os/tasks/bootstrap-flatcar.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-flatcar.yml
@@ -1,0 +1,40 @@
+---
+# Flatcar Container Linux ships without Python installed
+
+- name: Check if bootstrap is needed
+  raw: stat /opt/bin/.bootstrapped
+  register: need_bootstrap
+  environment: {}
+  failed_when: false
+  changed_when: false
+  tags:
+    - facts
+
+- name: Force binaries directory for Flatcar Container Linux by Kinvolk
+  set_fact:
+    bin_dir: "/opt/bin"
+  tags:
+    - facts
+
+- name: Run bootstrap.sh
+  script: bootstrap.sh
+  become: true
+  environment:
+    http_proxy: "{{ http_proxy | default('') }}"
+    https_proxy: "{{ https_proxy | default('') }}"
+  when:
+    - need_bootstrap.rc != 0
+
+- name: Set the ansible_python_interpreter fact
+  set_fact:
+    ansible_python_interpreter: "{{ bin_dir }}/python"
+  tags:
+    - facts
+
+- name: Disable auto-upgrade
+  systemd:
+    name: locksmithd.service
+    masked: true
+    state: stopped
+  when:
+    - coreos_locksmithd_disable

--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -16,9 +16,9 @@
 - include_tasks: bootstrap-fedora-coreos.yml
   when: '"ID=fedora" in os_release.stdout and "VARIANT_ID=coreos" in os_release.stdout'
 
-- include_tasks: bootstrap-coreos.yml
+- include_tasks: bootstrap-flatcar.yml
   when:
-    - '"CoreOS" in os_release.stdout or "Flatcar" in os_release.stdout'
+    - '"Flatcar" in os_release.stdout'
     - '"ID=fedora" not in os_release.stdout'
 
 - include_tasks: bootstrap-debian.yml
@@ -50,17 +50,17 @@
     name: "{{ inventory_hostname }}"
   when:
     - override_system_hostname
-    - ansible_os_family not in ['Suse', 'Container Linux by CoreOS', 'Flatcar Container Linux by Kinvolk', 'ClearLinux'] and not is_fedora_coreos
+    - ansible_os_family not in ['Suse', 'Flatcar Container Linux by Kinvolk', 'ClearLinux'] and not is_fedora_coreos
 
 # (2/3)
-- name: Assign inventory name to unconfigured hostnames (CoreOS, non-Flatcar, Suse and ClearLinux only)
+- name: Assign inventory name to unconfigured hostnames (CoreOS, Flatcar, Suse and ClearLinux only)
   command: "hostnamectl set-hostname {{ inventory_hostname }}"
   register: hostname_changed
   become: true
   changed_when: false
   when:
     - override_system_hostname
-    - ansible_os_family in ['Suse', 'Container Linux by CoreOS', 'Flatcar Container Linux by Kinvolk', 'ClearLinux'] or is_fedora_coreos
+    - ansible_os_family in ['Suse', 'Flatcar Container Linux by Kinvolk', 'ClearLinux'] or is_fedora_coreos
 
 # (3/3)
 - name: Update hostname fact (CoreOS, Flatcar, Suse and ClearLinux only)
@@ -69,7 +69,7 @@
     filter: ansible_hostname
   when:
     - override_system_hostname
-    - ansible_os_family in ['Suse', 'Flatcar Container Linux by Kinvolk', 'Container Linux by CoreOS', 'ClearLinux'] or is_fedora_coreos
+    - ansible_os_family in ['Suse', 'Flatcar Container Linux by Kinvolk', 'ClearLinux'] or is_fedora_coreos
 
 - name: "Install ceph-commmon package"
   package:

--- a/roles/container-engine/docker/handlers/main.yml
+++ b/roles/container-engine/docker/handlers/main.yml
@@ -15,7 +15,7 @@
   service:
     name: docker.socket
     state: restarted
-  when: ansible_os_family in ['Coreos', 'CoreOS', 'Container Linux by CoreOS', 'Flatcar', 'Flatcar Container Linux by Kinvolk'] or is_fedora_coreos
+  when: ansible_os_family in ['Flatcar Container Linux by Kinvolk'] or is_fedora_coreos
 
 - name: Docker | reload docker
   service:

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -43,7 +43,7 @@
           docker requires a minimum kernel version of
           {{ docker_kernel_min_version }} on
           {{ ansible_distribution }}-{{ ansible_distribution_version }}
-  when: (not ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk", "ClearLinux"]) and (ansible_kernel is version(docker_kernel_min_version, "<"))
+  when: (not ansible_os_family in ["Flatcar Container Linux by Kinvolk", "ClearLinux"]) and (ansible_kernel is version(docker_kernel_min_version, "<"))
   tags:
     - facts
 
@@ -74,7 +74,7 @@
   retries: 4
   delay: "{{ retry_stagger | d(3) }}"
   with_items: "{{ docker_repo_key_info.repo_keys }}"
-  when: not (ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk", "RedHat", "Suse", "ClearLinux"] or is_ostree)
+  when: not (ansible_os_family in ["Flatcar Container Linux by Kinvolk", "RedHat", "Suse", "ClearLinux"] or is_ostree)
 
 - name: ensure docker-ce repository is enabled
   action: "{{ docker_repo_info.pkg_repo }}"
@@ -82,7 +82,7 @@
     repo: "{{ item }}"
     state: present
   with_items: "{{ docker_repo_info.repos }}"
-  when: not (ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk", "RedHat", "Suse", "ClearLinux"] or is_ostree) and (docker_repo_info.repos|length > 0)
+  when: not (ansible_os_family in ["Flatcar Container Linux by Kinvolk", "RedHat", "Suse", "ClearLinux"] or is_ostree) and (docker_repo_info.repos|length > 0)
 
 - name: ensure docker-engine repository public key is installed
   action: "{{ dockerproject_repo_key_info.pkg_key }}"
@@ -96,7 +96,7 @@
   delay: "{{ retry_stagger | d(3) }}"
   with_items: "{{ dockerproject_repo_key_info.repo_keys }}"
   when:
-    - not (ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk", "RedHat", "Suse", "ClearLinux"] or is_ostree)
+    - not (ansible_os_family in ["Flatcar Container Linux by Kinvolk", "RedHat", "Suse", "ClearLinux"] or is_ostree)
     - use_docker_engine is defined and use_docker_engine
 
 - name: ensure docker-engine repository is enabled
@@ -107,7 +107,7 @@
   with_items: "{{ dockerproject_repo_info.repos }}"
   when:
     - use_docker_engine is defined and use_docker_engine
-    - not (ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk", "RedHat", "Suse", "ClearLinux"] or is_ostree) and (dockerproject_repo_info.repos|length > 0)
+    - not (ansible_os_family in ["Flatcar Container Linux by Kinvolk", "RedHat", "Suse", "ClearLinux"] or is_ostree) and (dockerproject_repo_info.repos|length > 0)
 
 - name: Configure docker repository on Fedora
   template:
@@ -172,7 +172,7 @@
   delay: "{{ retry_stagger | d(3) }}"
   with_items: "{{ docker_package_info.pkgs }}"
   notify: restart docker
-  when: not (ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk", "ClearLinux"] or is_ostree) and (docker_package_info.pkgs|length > 0)
+  when: not (ansible_os_family in ["Flatcar Container Linux by Kinvolk", "ClearLinux"] or is_ostree) and (docker_package_info.pkgs|length > 0)
   ignore_errors: true
 
 - name: Ensure docker packages are installed

--- a/roles/container-engine/docker/tasks/systemd.yml
+++ b/roles/container-engine/docker/tasks/systemd.yml
@@ -25,7 +25,7 @@
     dest: /etc/systemd/system/docker.service
   register: docker_service_file
   notify: restart docker
-  when: not ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+  when: not ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
 
 - name: Write docker options systemd drop-in
   template:

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -19,7 +19,7 @@ skip_kubeadm_images: false
 kubeadm_images: {}
 
 # if this is set to true will only download files once. Doesn't work
-# on Container Linux by CoreOS unless the download_localhost is true and localhost
+# on Flatcar Container Linux by Kinvolk unless the download_localhost is true and localhost
 # is running another OS type. Default compress level is 1 (fastest).
 download_run_once: false
 download_compress: 1
@@ -29,7 +29,7 @@ download_container: true
 
 # if this is set to true, uses the localhost for download_run_once mode
 # (requires docker and sudo to access docker). You may want this option for
-# local caching of docker images or for Container Linux by CoreOS cluster nodes.
+# local caching of docker images or for Flatcar Container Linux by Kinvolk cluster nodes.
 # Otherwise, uses the first node in the kube-master group to store images
 # in the download_run_once mode.
 download_localhost: false
@@ -910,7 +910,7 @@ downloads:
     - k8s-cluster
 
   install_socat:
-    enabled: "{{ ansible_os_family in ['CoreOS', 'Container Linux by CoreOS', 'Flatcar', 'Flatcar Container Linux by Kinvolk'] }}"
+    enabled: "{{ ansible_os_family in ['Flatcar Container Linux by Kinvolk'] }}"
     container: true
     repo: "{{ install_socat_image_repo }}"
     tag: "{{ install_socat_image_tag }}"

--- a/roles/download/tasks/prep_download.yml
+++ b/roles/download/tasks/prep_download.yml
@@ -85,7 +85,7 @@
     mode: 0755
     owner: "{{ ansible_ssh_user | default(ansible_user_id) }}"
   when:
-    - ansible_os_family not in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+    - ansible_os_family not in ["Flatcar Container Linux by Kinvolk"]
 
 - name: prep_download | Create local cache for files and images on control node
   file:

--- a/roles/etcd/meta/main.yml
+++ b/roles/etcd/meta/main.yml
@@ -2,7 +2,7 @@
 dependencies:
   - role: adduser
     user: "{{ addusers.etcd }}"
-    when: not (ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk", "ClearLinux"] or is_fedora_coreos)
+    when: not (ansible_os_family in ["Flatcar Container Linux by Kinvolk", "ClearLinux"] or is_fedora_coreos)
   - role: adduser
     user: "{{ addusers.kube }}"
-    when: not (ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk", "ClearLinux"] or is_fedora_coreos)
+    when: not (ansible_os_family in ["Flatcar Container Linux by Kinvolk", "ClearLinux"] or is_fedora_coreos)

--- a/roles/etcd/tasks/upd_ca_trust.yml
+++ b/roles/etcd/tasks/upd_ca_trust.yml
@@ -6,7 +6,7 @@
       /usr/local/share/ca-certificates/etcd-ca.crt
       {%- elif ansible_os_family == "RedHat" -%}
       /etc/pki/ca-trust/source/anchors/etcd-ca.crt
-      {%- elif ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"] -%}
+      {%- elif ansible_os_family in ["Flatcar Container Linux by Kinvolk"] -%}
       /etc/ssl/certs/etcd-ca.pem
       {%- elif ansible_os_family == "Suse" -%}
       /etc/pki/trust/anchors/etcd-ca.pem
@@ -23,9 +23,9 @@
     remote_src: true
   register: etcd_ca_cert
 
-- name: Gen_certs | update ca-certificates (Debian/Ubuntu/SUSE/Container Linux by CoreOS)  # noqa 503
+- name: Gen_certs | update ca-certificates (Debian/Ubuntu/SUSE/Flatcar)  # noqa 503
   command: update-ca-certificates
-  when: etcd_ca_cert.changed and ansible_os_family in ["Debian", "CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk", "Suse"]
+  when: etcd_ca_cert.changed and ansible_os_family in ["Debian", "Flatcar Container Linux by Kinvolk", "Suse"]
 
 - name: Gen_certs | update ca-certificates (RedHat)  # noqa 503
   command: update-ca-trust extract

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/README.md
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/README.md
@@ -118,7 +118,7 @@ delete the daemonset pod on the relevant host after creating volumes. The pod
 will be recreated and read the size correctly.
 
 Make sure to make any mounts persist via /etc/fstab or with systemd mounts (for
-CoreOS/Container Linux and Flatcar). Pods with persistent volume claims will not be
+Flatcar Container Linux). Pods with persistent volume claims will not be
 able to start if the mounts become unavailable.
 
 Further reading

--- a/roles/kubernetes-apps/helm/tasks/install_host.yml
+++ b/roles/kubernetes-apps/helm/tasks/install_host.yml
@@ -35,8 +35,8 @@
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
 
-- name: Helm | Copy socat wrapper for Container Linux and Flatcat
+- name: Helm | Copy socat wrapper for Flatcar Container Linux by Kinvolk
   command: "{{ docker_bin_dir }}/docker run --rm -v {{ bin_dir }}:/opt/bin {{ install_socat_image_repo }}:{{ install_socat_image_tag }}"
   args:
     creates: "{{ bin_dir }}/socat"
-  when: ansible_os_family in ['CoreOS', 'Container Linux by CoreOS', 'Flatcar', 'Flatcar Container Linux by Kinvolk']
+  when: ansible_os_family in ['Flatcar Container Linux by Kinvolk']

--- a/roles/kubernetes-apps/helm/tasks/main.yml
+++ b/roles/kubernetes-apps/helm/tasks/main.yml
@@ -120,4 +120,4 @@
   shell: "umask 022 && {{ bin_dir }}/helm completion bash >/etc/bash_completion.d/helm.sh"
   when:
     - ((helm_container is defined and helm_container.changed) or (helm_task_result is defined and helm_task_result.changed))
-    - not ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+    - not ansible_os_family in ["Flatcar Container Linux by Kinvolk"]

--- a/roles/kubernetes/node/tasks/install.yml
+++ b/roles/kubernetes/node/tasks/install.yml
@@ -50,4 +50,4 @@
   command: "{{ docker_bin_dir }}/docker run --rm -v {{ bin_dir }}:/opt/bin {{ install_socat_image_repo }}:{{ install_socat_image_tag }}"
   args:
     creates: "{{ bin_dir }}/socat"
-  when: ansible_os_family in ['CoreOS', 'Container Linux by CoreOS', 'Flatcar', 'Flatcar Container Linux by Kinvolk']
+  when: ansible_os_family in ['Flatcar Container Linux by Kinvolk']

--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -26,7 +26,7 @@ kube_cert_dir: "{{ kube_config_dir }}/ssl"
 kube_cert_compat_dir: /etc/kubernetes/pki
 kubelet_flexvolumes_plugins_dir: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
 
-# Container Linux by CoreOS cloud init config file to define /etc/resolv.conf content
+# Flatcar Container Linux by Kinvolk cloud init config file to define /etc/resolv.conf content
 # for hostnet pods and infra needs
 resolveconf_cloud_init_conf: /etc/resolveconf_cloud_init.conf
 

--- a/roles/kubernetes/preinstall/handlers/main.yml
+++ b/roles/kubernetes/preinstall/handlers/main.yml
@@ -9,18 +9,18 @@
     - Preinstall | restart kube-controller-manager crio/containerd
     - Preinstall | restart kube-apiserver docker
     - Preinstall | restart kube-apiserver crio/containerd
-  when: not ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"] and not is_fedora_coreos
+  when: not ansible_os_family in ["Flatcar Container Linux by Kinvolk"] and not is_fedora_coreos
 
-- name: Preinstall | update resolvconf for Container Linux by CoreOS and Flatcar
+- name: Preinstall | update resolvconf for Flatcar Container Linux by Kinvolk
   command: /bin/true
   notify:
     - Preinstall | apply resolvconf cloud-init
     - Preinstall | reload kubelet
-  when: ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+  when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
 
 - name: Preinstall | apply resolvconf cloud-init
   command: /usr/bin/coreos-cloudinit --from-file {{ resolveconf_cloud_init_conf }}
-  when: ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+  when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
 
 - name: Preinstall | update resolvconf for Fedora CoreOS
   command: /bin/true

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -16,7 +16,7 @@
 
 - name: Stop if unknown OS
   assert:
-    that: ansible_os_family in ['RedHat', 'CentOS', 'Fedora', 'Ubuntu', 'Debian', 'CoreOS', 'Coreos', 'Container Linux by CoreOS', 'Flatcar', 'Flatcar Container Linux by Kinvolk', 'Suse', 'ClearLinux', 'OracleLinux']
+    that: ansible_os_family in ['RedHat', 'CentOS', 'Fedora', 'Ubuntu', 'Debian', 'Flatcar Container Linux by Kinvolk', 'Suse', 'ClearLinux', 'OracleLinux']
     msg: "{{ ansible_os_family }} is not a known OS"
   when: not ignore_assert_errors
 
@@ -282,8 +282,8 @@
     msg: "download_run_once support only for docker. See https://github.com/containerd/containerd/issues/4075 for details"
   when: download_run_once or download_force_cache
 
-- name: Stop if download_localhost is enabled for CoreOS or Flatcar
+- name: Stop if download_localhost is enabled for Flatcar Container Linux
   assert:
-    that: ansible_os_family not in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
-    msg: "download_run_once not support for CoreOS or Flatcar"
+    that: ansible_os_family not in ["Flatcar Container Linux by Kinvolk"]
+    msg: "download_run_once not supported for Flatcar Container Linux"
   when: download_run_once or download_force_cache

--- a/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
@@ -1,8 +1,8 @@
 ---
-- name: Force binaries directory for Container Linux by CoreOS and Flatcar
+- name: Force binaries directory for Flatcar Container Linux by Kinvolk
   set_fact:
     bin_dir: "/opt/bin"
-  when: ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+  when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
   tags:
     - facts
 
@@ -73,12 +73,12 @@
       {%- if resolvconf|bool -%}/etc/resolvconf/resolv.conf.d/base{%- endif -%}
     head: >-
       {%- if resolvconf|bool -%}/etc/resolvconf/resolv.conf.d/head{%- endif -%}
-  when: not ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"] and not is_fedora_coreos
+  when: not ansible_os_family in ["Flatcar Container Linux by Kinvolk"] and not is_fedora_coreos
 
-- name: target temporary resolvconf cloud init file (Container Linux by CoreOS)
+- name: target temporary resolvconf cloud init file (Flatcar Container Linux by Kinvolk / Fedora CoreOS)
   set_fact:
     resolvconffile: /tmp/resolveconf_cloud_init_conf
-  when: ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"] or is_fedora_coreos
+  when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"] or is_fedora_coreos
 
 - name: check if /etc/dhclient.conf exists
   stat:

--- a/roles/kubernetes/preinstall/tasks/0060-resolvconf.yml
+++ b/roles/kubernetes/preinstall/tasks/0060-resolvconf.yml
@@ -1,7 +1,7 @@
 ---
 - name: create temporary resolveconf cloud init file
   command: cp -f /etc/resolv.conf "{{ resolvconffile }}"
-  when: ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+  when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
 
 - name: Add domain/search/nameservers/options to resolv.conf
   blockinfile:
@@ -47,7 +47,7 @@
 - name: get temporary resolveconf cloud init file content
   command: cat {{ resolvconffile }}
   register: cloud_config
-  when: ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+  when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
 
 - name: persist resolvconf cloud init file
   template:
@@ -55,5 +55,5 @@
     src: resolvconf.j2
     owner: root
     mode: 0644
-  notify: Preinstall | update resolvconf for Container Linux by CoreOS and Flatcar
-  when: ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+  notify: Preinstall | update resolvconf for Flatcar Container Linux by Kinvolk
+  when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"]

--- a/roles/kubernetes/preinstall/tasks/0070-system-packages.yml
+++ b/roles/kubernetes/preinstall/tasks/0070-system-packages.yml
@@ -79,7 +79,7 @@
   until: pkgs_task_result is succeeded
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
-  when: not (ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk", "ClearLinux"] or is_fedora_coreos)
+  when: not (ansible_os_family in ["Flatcar Container Linux by Kinvolk", "ClearLinux"] or is_fedora_coreos)
   tags:
     - bootstrap-os
 

--- a/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
+++ b/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
@@ -29,7 +29,7 @@
     backup: yes
   when:
     - disable_ipv6_dns
-    - not ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+    - not ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
   tags:
     - bootstrap-os
 

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -79,7 +79,7 @@
   when:
     - dns_mode != 'none'
     - resolvconf_mode == 'host_resolvconf'
-    - not ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+    - not ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
   tags:
     - bootstrap-os
     - resolvconf
@@ -88,7 +88,7 @@
   when:
     - dns_mode != 'none'
     - resolvconf_mode != 'host_resolvconf'
-    - not ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+    - not ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
   tags:
     - bootstrap-os
     - resolvconf

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -428,7 +428,7 @@ contiv_global_neighbor_as: "500"
 
 ssl_ca_dirs: >-
   [
-  {% if ansible_os_family in ['CoreOS', 'Container Linux by CoreOS', 'Flatcar', 'Flatcar Container Linux by Kinvolk'] -%}
+  {% if ansible_os_family in ['Flatcar Container Linux by Kinvolk'] -%}
   '/usr/share/ca-certificates',
   {% elif ansible_os_family == 'RedHat' -%}
   '/etc/pki/tls',

--- a/roles/network_plugin/macvlan/handlers/main.yml
+++ b/roles/network_plugin/macvlan/handlers/main.yml
@@ -3,7 +3,7 @@
   command: /bin/true
   notify:
     - Macvlan | reload network
-  when: not ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+  when: not ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
 
 - name: Macvlan | reload network
   service:
@@ -16,4 +16,4 @@
       networking
       {%- endif %}
     state: restarted
-  when: not ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"] and kube_network_plugin not in ['canal', 'calico']
+  when: not ansible_os_family in ["Flatcar Container Linux by Kinvolk"] and kube_network_plugin not in ['canal', 'calico']

--- a/roles/network_plugin/macvlan/tasks/main.yml
+++ b/roles/network_plugin/macvlan/tasks/main.yml
@@ -57,20 +57,20 @@
   notify: Macvlan | restart network
   when: ansible_os_family in ["CentOS","RedHat"]
 
-- name: Macvlan | Install service nat via gateway on coreos
+- name: Macvlan | Install service nat via gateway on Flatcar Container Linux
   template:
     src: coreos-service-nat_ouside.j2
     dest: /etc/systemd/system/enable_nat_ouside.service
-  when: ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"] and enable_nat_default_gateway
+  when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"] and enable_nat_default_gateway
 
-- name: Macvlan | Enable service nat via gateway on coreos
+- name: Macvlan | Enable service nat via gateway on Flatcar Container Linux
   command: "{{ item }}"
   with_items:
     - systemctl daemon-reload
     - systemctl enable enable_nat_ouside.service
-  when: ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"] and enable_nat_default_gateway
+  when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"] and enable_nat_default_gateway
 
-- name: Macvlan | Install network gateway interface on coreos
+- name: Macvlan | Install network gateway interface on Flatcar Container Linux
   template:
     src: "{{ item.src }}.j2"
     dest: "/etc/systemd/network/{{ item.dst }}"
@@ -79,7 +79,7 @@
     - {src: coreos-interface-macvlan.cfg, dst: output.network }
     - {src: coreos-network-macvlan.cfg, dst: macvlan.network }
   notify: Macvlan | restart network
-  when: ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+  when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
 
 - name: Macvlan | Install cni definition for Macvlan
   template:

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -302,7 +302,7 @@
       {%- endif %}
     state: restarted
   when:
-    - ansible_os_family not in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+    - ansible_os_family not in ["Flatcar Container Linux by Kinvolk"]
     - reset_restart_network
   tags:
     - services

--- a/tests/cloud_playbooks/create-do.yml
+++ b/tests/cloud_playbooks/create-do.yml
@@ -20,7 +20,6 @@
       - sfo2
       - blr1
     cloud_images:
-      - coreos-beta
       - fedora-24-x64
       - centos-5-x64
       - centos-5-x32
@@ -31,12 +30,10 @@
       - debian-8-x32
       - centos-6-x32
       - centos-6-x64
-      - coreos-stable
       - ubuntu-16-10-x32
       - ubuntu-16-10-x64
       - freebsd-11-0-x64-zfs
       - freebsd-10-3-x64-zfs
-      - coreos-alpha
       - ubuntu-12-04-x32
       - ubuntu-12-04-x64
       - ubuntu-16-04-x64

--- a/tests/scripts/testcases_run.sh
+++ b/tests/scripts/testcases_run.sh
@@ -23,7 +23,7 @@ export ANSIBLE_BECOME_USER=root
 cd tests && make create-${CI_PLATFORM} -s ; cd -
 ansible-playbook tests/cloud_playbooks/wait-for-ssh.yml
 
-# CoreOS needs auto update disabled
+# Flatcar Container Linux needs auto update disabled
 if [[ "$CI_JOB_NAME" =~ "coreos" ]]; then
   ansible all -m raw -a 'systemctl disable locksmithd'
   ansible all -m raw -a 'systemctl stop locksmithd'

--- a/tests/testcases/015_check-nodes-ready.yml
+++ b/tests/testcases/015_check-nodes-ready.yml
@@ -2,15 +2,15 @@
 - hosts: kube-master[0]
   tasks:
 
-  - name: Force binaries directory for Container Linux by CoreOS and Flatcar
+  - name: Force binaries directory for Flatcar Container Linux by Kinvolk
     set_fact:
       bin_dir: "/opt/bin"
-    when: ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+    when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
 
   - name: Force binaries directory for other hosts
     set_fact:
       bin_dir: "/usr/local/bin"
-    when: not ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+    when: not ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
 
   - import_role:
       name: cluster-dump

--- a/tests/testcases/020_check-pods-running.yml
+++ b/tests/testcases/020_check-pods-running.yml
@@ -2,15 +2,15 @@
 - hosts: kube-master[0]
   tasks:
 
-  - name: Force binaries directory for Container Linux by CoreOS and Flatcar
+  - name: Force binaries directory for Flatcar Container Linux by Kinvolk
     set_fact:
       bin_dir: "/opt/bin"
-    when: ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+    when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
 
   - name: Force binaries directory for other hosts
     set_fact:
       bin_dir: "/usr/local/bin"
-    when: not ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+    when: not ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
 
   - import_role:
       name: cluster-dump

--- a/tests/testcases/030_check-network.yml
+++ b/tests/testcases/030_check-network.yml
@@ -5,15 +5,15 @@
     test_image_tag: latest
 
   tasks:
-  - name: Force binaries directory for Container Linux by CoreOS and Flatcar
+  - name: Force binaries directory for Flatcar Container Linux by Kinvolk
     set_fact:
       bin_dir: "/opt/bin"
-    when: ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+    when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
 
   - name: Force binaries directory for other hosts
     set_fact:
       bin_dir: "/usr/local/bin"
-    when: not ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+    when: not ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
 
   - name: Create test namespace  # noqa 301 305
     shell: "{{ bin_dir }}/kubectl create namespace test"

--- a/tests/testcases/040_check-network-adv.yml
+++ b/tests/testcases/040_check-network-adv.yml
@@ -19,12 +19,12 @@
     - name: Force binaries directory for Container Linux by CoreOS and Flatcar
       set_fact:
         bin_dir: "/opt/bin"
-      when: ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+      when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
 
     - name: Force binaries directory on other hosts
       set_fact:
         bin_dir: "/usr/local/bin"
-      when: not ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
+      when: not ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
 
     - import_role:
         name: cluster-dump


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
As of May 26, 2020, CoreOS Container Linux reached its end of life and will no longer receive updates.

https://coreos.com/os/eol/

https://cloud.google.com/compute/docs/eol/coreOS

Fedora CoreOS is the official successor to CoreOS Container Linux.

Fedora CoreOS is a new Fedora Edition built specifically for running containerized workloads securely and at scale.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
PR changes tested using the following `Flatcar Container Linux by Kinvolk` stable, beta, alpha and edge versions.

- 2512.3.0
- 2513.3.0
- 2605.0.0
- 2466.99.0

**Does this PR introduce a user-facing change?**:
```release-note
Remove support for CoreOS Container Linux (EOL)
```
