### PR TITLE
Fedora coreos networkmanager global dns and bootstrapping fix

### DIFF
--- a/roles/bootstrap-os/defaults/main.yml
+++ b/roles/bootstrap-os/defaults/main.yml
@@ -13,7 +13,7 @@ use_oracle_public_repo: true
 
 fedora_coreos_packages:
   - python
-  - libselinux-python3
+  - python3-libselinux
   - ethtool                 # required in kubeadm preflight phase for verifying the environment
   - ipset                   # required in kubeadm preflight phase for verifying the environment
   - conntrack-tools         # required by kube-proxy

--- a/roles/bootstrap-os/tasks/bootstrap-fedora-coreos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-fedora-coreos.yml
@@ -8,6 +8,12 @@
   tags:
     - facts
 
+- name: Remove podman network cni
+  raw: "podman network rm podman"
+  become: true
+  ignore_errors: yes
+  when: need_bootstrap.rc != 0
+
 - name: Clean up possible pending packages on fedora coreos
   raw: "export http_proxy={{ http_proxy | default('') }};rpm-ostree cleanup -p }}"
   become: true

--- a/roles/bootstrap-os/tasks/bootstrap-fedora-coreos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-fedora-coreos.yml
@@ -19,12 +19,27 @@
   become: true
   when: need_bootstrap.rc != 0
 
+  # Because the package "python3-libselinux" has a dependency on libselinux,
+  # which is a base package in Fedora CoreOS and cannot be upgraded.
+  # Temporary disabling update repo allows to install python3-libselinux
+  # see https://github.com/coreos/fedora-coreos-tracker/issues/592
+- name: Temporary disable fedora updates repo because of base packages conflicts
+  raw: "sed -i 's|^enabled=1|enabled=0|g' /etc/yum.repos.d/fedora-updates.repo"
+  become: true
+  when: need_bootstrap.rc != 0
+
 - name: Install required packages on fedora coreos
   raw: "export http_proxy={{ http_proxy | default('') }};rpm-ostree install {{ fedora_coreos_packages|join(' ') }}"
   become: true
   when: need_bootstrap.rc != 0
 
-# playbook fails because connection lost
+  # see https://github.com/coreos/fedora-coreos-tracker/issues/592
+- name: Enable fedora updates repo
+  raw: "sed -i 's|^enabled=0|enabled=1|g' /etc/yum.repos.d/fedora-updates.repo"
+  become: true
+  when: need_bootstrap.rc != 0
+
+  # playbook fails because connection lost
 - name: Reboot immediately for updated ostree, please run playbook again if failed first time.
   raw: "nohup bash -c 'sleep 5s && shutdown -r now'"
   become: true

--- a/roles/kubernetes/preinstall/tasks/0062-networkmanager.yml
+++ b/roles/kubernetes/preinstall/tasks/0062-networkmanager.yml
@@ -1,9 +1,9 @@
 ---
 - name: NetworkManager | Add nameservers to NM configuration
   ini_file:
-    path: /etc/NetworkManager/system-connections/default_connection.nmconnection
-    section: ipv4
-    option: dns
+    path: /etc/NetworkManager/conf.d/dns.conf
+    section: global-dns-domain-*
+    option: servers
     value: "{{ ( coredns_server + nameservers|d([]) + cloud_resolver|d([])) | unique | join(';') }}"
     mode: '0600'
     backup: yes
@@ -11,9 +11,9 @@
 
 - name: NetworkManager | Add DNS search to NM configuration
   ini_file:
-    path: /etc/NetworkManager/system-connections/default_connection.nmconnection
-    section: ipv4
-    option: dns-search
+    path: /etc/NetworkManager/conf.d/dns.conf
+    section: global-dns
+    option: searches
     value: "{{ ([ 'default.svc.' + dns_domain, 'svc.' + dns_domain ] + searchdomains|default([])) | join(';') }}"
     mode: '0600'
     backup: yes
@@ -21,9 +21,9 @@
 
 - name: NetworkManager | Add DNS options to NM configuration
   ini_file:
-    path: /etc/NetworkManager/system-connections/default_connection.nmconnection
-    section: ipv4
-    option: dns-options
+    path: /etc/NetworkManager/conf.d/dns.conf
+    section: global-dns
+    option: options
     value: "ndots:{{ ndots }};timeout:2;attempts:2;"
     mode: '0600'
     backup: yes
@@ -31,7 +31,7 @@
 
 - name: NetworkManager | Ignore DNS auto configuration
   ini_file:
-    path: /etc/NetworkManager/system-connections/default_connection.nmconnection
+    path: /etc/NetworkManager/conf.d/dns.conf
     section: ipv4
     option: ignore-auto-dns
     value: 'true'

--- a/roles/kubernetes/preinstall/tasks/0062-networkmanager.yml
+++ b/roles/kubernetes/preinstall/tasks/0062-networkmanager.yml
@@ -28,13 +28,3 @@
     mode: '0600'
     backup: yes
   notify: Preinstall | update resolvconf for Fedora CoreOS
-
-- name: NetworkManager | Ignore DNS auto configuration
-  ini_file:
-    path: /etc/NetworkManager/conf.d/dns.conf
-    section: ipv4
-    option: ignore-auto-dns
-    value: 'true'
-    mode: '0600'
-    backup: yes
-  notify: Preinstall | update resolvconf for Fedora CoreOS


### PR DESCRIPTION


**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
- Use global `NetworkManager` dns configuration
  Allows to have other connections than `default_connection.nmconnection`  (for example a `bond` configuration)
- Fixes bootstrapping of fedora coreos by
-- removing podman network cni plugin
-- disabling fedora-updates.repo before installing `python3-libselinux` package

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #591

**Special notes for your reviewer**:
I can split the commits in two different `PRs` if required, because it solves different issues.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
