### PR TITLE
Remove ethtool workaround, issue is now fixed

### DIFF
--- a/tests/testcases/040_check-network-adv.yml
+++ b/tests/testcases/040_check-network-adv.yml
@@ -16,12 +16,6 @@
     netchecker_port: 31081
 
   tasks:
-    - name: Flannel | Disable tx and rx offloading on VXLAN interfaces (see https://github.com/coreos/flannel/pull/1282)
-      command: "ethtool --offload flannel.1 rx off tx off"
-      ignore_errors: true
-      when:
-        - kube_network_plugin|default('calico') == 'flannel'
-
     - name: Force binaries directory for Container Linux by CoreOS and Flatcar
       set_fact:
         bin_dir: "/opt/bin"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Issue is now fix with https://github.com/kubernetes/kubernetes/pull/92035 push to 1.19, cherry pick to 1.18(.5) with https://github.com/kubernetes/kubernetes/pull/92256
We can remove the workaround we got.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
`Fixes a problem with 63-second or 1-second connection delays with some VXLAN-based network plugins which was first widely noticed in 1.16 (though some users saw it earlier than that, possibly only with specific network plugins). If you were previously using ethtool to disable checksum offload on your primary network interface, you should now be able to stop doing that. (#92035, @danwinship) [SIG Network and Node]`

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
