### PR TITLE
Add support for Calico CNI "host-local" IPAM plugin

### DIFF
--- a/docs/calico.md
+++ b/docs/calico.md
@@ -248,3 +248,15 @@ calico_node_extra_envs:
 neutron  security-group-rule-create  --protocol 4  --direction egress  k8s-a0tp4t
 neutron  security-group-rule-create  --protocol 4  --direction igress  k8s-a0tp4t
 ```
+
+### Optional : Use Calico CNI host-local IPAM plugin
+
+Calico currently supports two types of CNI IPAM plugins, `host-local` and `calico-ipam` (default).
+
+To allow Calico to determine the subnet to use from the Kubernetes API based on the `Node.podCIDR` field, enable the following setting.
+
+```yml
+calico_ipam_host_local: true
+```
+
+Refer to Project Calico section [Using host-local IPAM](https://docs.projectcalico.org/reference/cni-plugin/configuration#using-host-local-ipam) for further information.

--- a/inventory/sample/group_vars/k8s-cluster/k8s-net-calico.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-net-calico.yml
@@ -8,6 +8,9 @@
 # Enables Internet connectivity from containers
 # nat_outgoing: true
 
+# Enables Calico CNI "host-local" IPAM plugin
+# calico_ipam_host_local: true
+
 # add default ippool name
 # calico_pool_name: "default-pool"
 

--- a/roles/network_plugin/calico/templates/cni-calico.conflist.j2
+++ b/roles/network_plugin/calico/templates/cni-calico.conflist.j2
@@ -9,9 +9,9 @@
 {% else %}
 {% if cloud_provider is defined %}
       "nodename": "{{ calico_kubelet_name.stdout }}",
-    {% else %}
+{% else %}
       "nodename": "{{ calico_baremetal_nodename }}",
-    {% endif %}
+{% endif %}
 {% endif %}
       "type": "calico",
       "log_level": "info",
@@ -21,7 +21,7 @@
       "etcd_key_file": "{{ calico_cert_dir }}/key.pem",
       "etcd_ca_cert_file": "{{ calico_cert_dir }}/ca_cert.crt",
 {% endif %}
-{% if calico_datastore == "kdd" and calico_version is version('v3.6.0', '<') %}
+{% if calico_ipam_host_local is defined %}
       "ipam": {
         "type": "host-local",
         "subnet": "usePodCidr"
@@ -46,18 +46,18 @@
       "policy": {
         "type": "k8s"
       },
-{%- endif %}
+{% endif %}
 {% if calico_mtu is defined and calico_mtu is number %}
       "mtu": {{ calico_mtu }},
-{%- endif %}
+{% endif %}
       "kubernetes": {
         "kubeconfig": "{% if calico_version is version('v3.3.0', '>=') %}__KUBECONFIG_FILEPATH__{% else %}{{ kube_config_dir }}/node-kubeconfig.yaml{% endif %}"
       }
     },
     {
       "type":"portmap",
-      "capabilities":{
-        "portMappings":true
+      "capabilities": {
+        "portMappings": true
       }
     }
   ]


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Add support for the Calico CNI `host-local` IPAM plugin to allow pods to be created with the correct subnet IPs from the Calico CNI `podCIDR` range assigned to K8s nodes.

e.g.
**/etc/cni/net.d/10-calico.conflist**

```
...
      "ipam": {
        "type": "host-local",
        "subnet": "usePodCidr"
      },
...
```

```
$ kubectl get nodes k8s-2 -ojsonpath='{.spec.podCIDR}{"\n"}'
10.233.66.0/24

$ kubectl get nodes k8s-3 -ojsonpath='{.spec.podCIDR}{"\n"}'
10.233.65.0/24

$ kubectl get nodes k8s-4 -ojsonpath='{.spec.podCIDR}{"\n"}'
10.233.67.0/24
```

```
$ k run nginx --image=nginx --replicas=6
default       nginx-76df748b9-69zdg                         1/1     Running   0          19s     10.242.66.7    k8s-2   <none>           <none>
default       nginx-76df748b9-b94rh                         1/1     Running   0          19s     10.242.66.8    k8s-2   <none>           <none>
default       nginx-76df748b9-f9wqq                         1/1     Running   0          19s     10.242.65.9    k8s-3   <none>           <none>
default       nginx-76df748b9-qk26k                         1/1     Running   0          19s     10.242.65.10   k8s-3   <none>           <none>
default       nginx-76df748b9-86p47                         1/1     Running   0          19s     10.242.67.8    k8s-4   <none>           <none>
default       nginx-76df748b9-98r76                         1/1     Running   0          19s     10.242.67.9    k8s-4   <none>           <none>
```

**Which issue(s) this PR fixes**:
Fixes #5231 

**Special notes for your reviewer**:
There are also some minor changes to correctly format the Calico CNI configuration file.

**Does this PR introduce a user-facing change?**:
```release-note
Add support for Calico CNI `host-local` IPAM plugin
```
