### PR TITLE
etcd should not fail when adding an already existing member

### DIFF
--- a/roles/etcd/tasks/join_etcd_member.yml
+++ b/roles/etcd/tasks/join_etcd_member.yml
@@ -2,7 +2,8 @@
 - name: Join Member | Add member to etcd cluster  # noqa 301 305
   shell: "{{ bin_dir }}/etcdctl member add {{ etcd_member_name }} --peer-urls={{ etcd_peer_url }}"
   register: member_add_result
-  until: member_add_result.rc == 0
+  until: member_add_result.rc == 0 or 'Peer URLs already exists' in member_add_result.stderr
+  failed_when: member_add_result.rc != 0 and 'Peer URLs already exists' not in member_add_result.stderr
   retries: "{{ etcd_retries }}"
   delay: "{{ retry_stagger | random + 3 }}"
   environment:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The job `packet_ubuntu18-calico-ha-recover-noquorum` is failing a lot since etcd3.
issue seems to be that sometimes when adding an etcd member to the cluster the return code is not 0 but the member is still added to the cluster, thus failing next retries with error `Error: etcdserver: Peer URLs already exists`

ex: https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/703686879

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
The root cause is a bit weird/unclear I agree, but anyway, adding a member peer when the peer url is already there should not be a failing workflow 🤷 

**Does this PR introduce a user-facing change?**:
```release-note
None
```
