### PR TITLE
[2.13] add missing 'Set up proxy environment' tasks

### DIFF
--- a/remove-node.yml
+++ b/remove-node.yml
@@ -2,6 +2,21 @@
 - name: Check ansible version
   import_playbook: ansible_version.yml
 
+- hosts: all
+  gather_facts: false
+  tags: always
+  tasks:
+    - name: "Set up proxy environment"
+      set_fact:
+        proxy_env:
+          http_proxy: "{{ http_proxy | default ('') }}"
+          HTTP_PROXY: "{{ http_proxy | default ('') }}"
+          https_proxy: "{{ https_proxy | default ('') }}"
+          HTTPS_PROXY: "{{ https_proxy | default ('') }}"
+          no_proxy: "{{ no_proxy | default ('') }}"
+          NO_PROXY: "{{ no_proxy | default ('') }}"
+      no_log: true
+
 - hosts: "{{ node | default('etcd:k8s-cluster:calico-rr') }}"
   gather_facts: no
   vars_prompt:

--- a/reset.yml
+++ b/reset.yml
@@ -2,6 +2,21 @@
 - name: Check ansible version
   import_playbook: ansible_version.yml
 
+- hosts: all
+  gather_facts: false
+  tags: always
+  tasks:
+    - name: "Set up proxy environment"
+      set_fact:
+        proxy_env:
+          http_proxy: "{{ http_proxy | default ('') }}"
+          HTTP_PROXY: "{{ http_proxy | default ('') }}"
+          https_proxy: "{{ https_proxy | default ('') }}"
+          HTTPS_PROXY: "{{ https_proxy | default ('') }}"
+          no_proxy: "{{ no_proxy | default ('') }}"
+          NO_PROXY: "{{ no_proxy | default ('') }}"
+      no_log: true
+
 - hosts: bastion[0]
   gather_facts: False
   roles:


### PR DESCRIPTION
this is the backport of the fixes of #6430 and #6527 to `2.13` release