### PR TITLE
Use crictl 1.19.0 for k8s 1.19.x

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -89,6 +89,7 @@ ovn4nfv_k8s_plugin_image_version: "v1.1.0"
 # Get kubernetes major version (i.e. 1.17.4 => 1.17)
 kube_major_version: "{{ kube_version | regex_replace('^v([0-9])+\\.([0-9]+)\\.[0-9]+', 'v\\1.\\2') }}"
 crictl_supported_versions:
+  v1.19: "v1.19.0"
   v1.18: "v1.18.0"
   v1.17: "v1.17.0"
   v1.16: "v1.16.1"
@@ -105,14 +106,17 @@ crictl_download_url: "https://github.com/kubernetes-sigs/cri-tools/releases/down
 
 crictl_checksums:
   arm:
+    v1.19.0: b72fd3c4b35f60f5db2cfcd8e932f6000cf9c2978b54adfcf60ee5e2d452e92f
     v1.18.0: d420925d10b47a234b7e51e9cf1039c3c09f2703945a99435549fcdd7487ae3a
     v1.17.0: 9700957218e8e7bdc02cbc8fda4c189f5b6223a93ba89d876bdfd77b6117e9b7
     v1.16.1: 367826f3eb06c4d923f3174d23141ddacef9ffcb0c902502bd922dbad86d08dd
   arm64:
+    v1.19.0: ec040d14ca03e8e4e504a85dae5353e04b5d9d8aea3df68699258992c0eb8d88
     v1.18.0: 95ba32c47ad690b1e3e24f60255273dd7d176e62b1a0b482e5b44a7c31639979
     v1.17.0: d89afd89c2852509fafeaff6534d456272360fcee732a8d0cb89476377387e12
     v1.16.1: 62b60ab7046b788df892a1b746bd602c520a59c38232febc0580692c9805f641
   amd64:
+    v1.19.0: 87d8ef70b61f2fe3d8b4a48f6f712fd798c6e293ed3723c1e4bbb5052098f0ae
     v1.18.0: 876dd2b3d0d1c2590371f940fb1bf1fbd5f15aebfbe456703ee465d959700f4a
     v1.17.0: 7b72073797f638f099ed19550d52e9b9067672523fc51b746e65d7aa0bafa414
     v1.16.1: 19fed421710fccfe58f5573383bb137c19438a9056355556f1a15da8d23b3ad1


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add crictl 1.19 hashes, and use it when k8s version is set to 1.19.x

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
