### PR TITLE
Update nginx ingress to 0.35.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [rbd-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.1-k8s1.11
   - [cert-manager](https://github.com/jetstack/cert-manager) v0.15.2
   - [coredns](https://github.com/coredns/coredns) v1.6.7
-  - [ingress-nginx](https://github.com/kubernetes/ingress-nginx) v0.34.1
+  - [ingress-nginx](https://github.com/kubernetes/ingress-nginx) v0.35.0
 
 Note: The list of validated [docker versions](https://kubernetes.io/docs/setup/production-environment/container-runtimes/#docker) is 1.13.1, 17.03, 17.06, 17.09, 18.06, 18.09 and 19.03. The recommended docker version is 19.03. The kubelet might break on docker's non-standard version numbering (it no longer uses semantic versioning). To ensure auto-updates don't break your cluster look into e.g. yum versionlock plugin or apt pin).
 

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -53,8 +53,7 @@ kube_version: v1.18.8
 kubeadm_version: "{{ kube_version }}"
 etcd_version: v3.4.3
 
-# gcr and kubernetes image repo define (gcr location might be 'asia', 'eu' or 'us')
-gcr_location_default: "eu"
+# gcr and kubernetes image repo define
 gcr_image_repo: "gcr.io"
 kube_image_repo: "k8s.gcr.io"
 
@@ -574,8 +573,8 @@ rbd_provisioner_image_repo: "{{ quay_image_repo }}/external_storage/rbd-provisio
 rbd_provisioner_image_tag: "v2.1.1-k8s1.11"
 local_path_provisioner_image_repo: "{{ docker_image_repo }}/rancher/local-path-provisioner"
 local_path_provisioner_image_tag: "v0.0.14"
-ingress_nginx_controller_image_repo: "{{ gcr_location_default }}.{{ gcr_image_repo }}/k8s-artifacts-prod/ingress-nginx/controller"
-ingress_nginx_controller_image_tag: "v0.34.1"
+ingress_nginx_controller_image_repo: "{{ kube_image_repo }}/ingress-nginx/controller"
+ingress_nginx_controller_image_tag: "v0.35.0"
 ingress_ambassador_image_repo: "{{ quay_image_repo }}/datawire/ambassador-operator"
 ingress_ambassador_image_tag: "v1.2.8"
 alb_ingress_image_repo: "{{ docker_image_repo }}/amazon/aws-alb-ingress-controller"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Well... update again nginx ingress, 0.35.0 is released, best to ship it with 2.14

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Rolling back my changes with `k8s.gcr.io` didn't understood what nginx-ingress did, but everything is on the main repo

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
