### PR TITLE
Update cert manager to 0.16.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [ambassador](https://github.com/datawire/ambassador): v1.5
   - [cephfs-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.0-k8s1.11
   - [rbd-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.1-k8s1.11
-  - [cert-manager](https://github.com/jetstack/cert-manager) v0.15.2
+  - [cert-manager](https://github.com/jetstack/cert-manager) v0.16.1
   - [coredns](https://github.com/coredns/coredns) v1.6.7
   - [ingress-nginx](https://github.com/kubernetes/ingress-nginx) v0.35.0
 

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -583,7 +583,7 @@ ingress_ambassador_image_repo: "{{ quay_image_repo }}/datawire/ambassador-operat
 ingress_ambassador_image_tag: "v1.2.8"
 alb_ingress_image_repo: "{{ docker_image_repo }}/amazon/aws-alb-ingress-controller"
 alb_ingress_image_tag: "v1.1.8"
-cert_manager_version: "v0.15.2"
+cert_manager_version: "v0.16.1"
 cert_manager_controller_image_repo: "{{ quay_image_repo }}/jetstack/cert-manager-controller"
 cert_manager_controller_image_tag: "{{ cert_manager_version }}"
 cert_manager_cainjector_image_repo: "{{ quay_image_repo }}/jetstack/cert-manager-cainjector"

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/clusterrole-cert-manager.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/clusterrole-cert-manager.yml.j2
@@ -50,6 +50,90 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
+  name: cert-manager-controller-issuers
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+    helm.sh/chart: cert-manager-{{ cert_manager_version }}
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["issuers", "issuers/status"]
+    verbs: ["update"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["issuers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-clusterissuers
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+    helm.sh/chart: cert-manager-{{ cert_manager_version }}
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["clusterissuers", "clusterissuers/status"]
+    verbs: ["update"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["clusterissuers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-certificates
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+    helm.sh/chart: cert-manager-{{ cert_manager_version }}
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
+    verbs: ["update"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificaterequests", "clusterissuers", "issuers"]
+    verbs: ["get", "list", "watch"]
+  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
+  # admission controller enabled:
+  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates/finalizers", "certificaterequests/finalizers"]
+    verbs: ["update"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders"]
+    verbs: ["create", "delete", "get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
   name: cert-manager-controller-orders
   labels:
     app: cert-manager
@@ -83,56 +167,6 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-  name: cert-manager-controller-ingress-shim
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: controller
-    helm.sh/chart: cert-manager-{{ cert_manager_version }}
-rules:
-  - apiGroups: ["cert-manager.io"]
-    resources: ["certificates", "certificaterequests"]
-    verbs: ["create", "update", "delete"]
-  - apiGroups: ["cert-manager.io"]
-    resources: ["certificates", "certificaterequests", "issuers", "clusterissuers"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["extensions"]
-    resources: ["ingresses"]
-    verbs: ["get", "list", "watch"]
-  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
-  # admission controller enabled:
-  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
-  - apiGroups: ["extensions"]
-    resources: ["ingresses/finalizers"]
-    verbs: ["update"]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["create", "patch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: cert-manager-view
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: controller
-    helm.sh/chart: cert-manager-{{ cert_manager_version }}
-    rbac.authorization.k8s.io/aggregate-to-view: "true"
-    rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    rbac.authorization.k8s.io/aggregate-to-admin: "true"
-rules:
-  - apiGroups: ["cert-manager.io"]
-    resources: ["certificates", "certificaterequests", "issuers"]
-    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -193,7 +227,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: cert-manager-controller-issuers
+  name: cert-manager-controller-ingress-shim
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
@@ -203,22 +237,28 @@ metadata:
     helm.sh/chart: cert-manager-{{ cert_manager_version }}
 rules:
   - apiGroups: ["cert-manager.io"]
-    resources: ["issuers", "issuers/status"]
-    verbs: ["update"]
+    resources: ["certificates", "certificaterequests"]
+    verbs: ["create", "update", "delete"]
   - apiGroups: ["cert-manager.io"]
-    resources: ["issuers"]
+    resources: ["certificates", "certificaterequests", "issuers", "clusterissuers"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: ["extensions"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]
+  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
+  # admission controller enabled:
+  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+  - apiGroups: ["extensions"]
+    resources: ["ingresses/finalizers"]
+    verbs: ["update"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cert-manager-controller-clusterissuers
+  name: cert-manager-view
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
@@ -226,19 +266,13 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
     helm.sh/chart: cert-manager-{{ cert_manager_version }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
   - apiGroups: ["cert-manager.io"]
-    resources: ["clusterissuers", "clusterissuers/status"]
-    verbs: ["update"]
-  - apiGroups: ["cert-manager.io"]
-    resources: ["clusterissuers"]
+    resources: ["certificates", "certificaterequests", "issuers"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list", "watch", "create", "update", "delete"]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["create", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -257,37 +291,3 @@ rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests", "issuers"]
     verbs: ["create", "delete", "deletecollection", "patch", "update"]
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-  name: cert-manager-controller-certificates
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: controller
-    helm.sh/chart: cert-manager-{{ cert_manager_version }}
-rules:
-  - apiGroups: ["cert-manager.io"]
-    resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
-    verbs: ["update"]
-  - apiGroups: ["cert-manager.io"]
-    resources: ["certificates", "certificaterequests", "clusterissuers", "issuers"]
-    verbs: ["get", "list", "watch"]
-  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
-  # admission controller enabled:
-  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
-  - apiGroups: ["cert-manager.io"]
-    resources: ["certificates/finalizers", "certificaterequests/finalizers"]
-    verbs: ["update"]
-  - apiGroups: ["acme.cert-manager.io"]
-    resources: ["orders"]
-    verbs: ["create", "delete", "get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list", "watch", "create", "update", "delete"]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["create", "patch"]

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/clusterrolebinding-cert-manager.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/clusterrolebinding-cert-manager.yml.j2
@@ -36,7 +36,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: cert-manager-controller-certificates
+  name: cert-manager-controller-issuers
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
@@ -47,7 +47,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cert-manager-controller-certificates
+  name: cert-manager-controller-issuers
 subjects:
   - name: cert-manager
     namespace: {{ cert_manager_namespace }}
@@ -68,6 +68,46 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cert-manager-controller-clusterissuers
+subjects:
+  - name: cert-manager
+    namespace: {{ cert_manager_namespace }}
+    kind: ServiceAccount
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-certificates
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+    helm.sh/chart: cert-manager-{{ cert_manager_version }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-certificates
+subjects:
+  - name: cert-manager
+    namespace: {{ cert_manager_namespace }}
+    kind: ServiceAccount
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-orders
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+    helm.sh/chart: cert-manager-{{ cert_manager_version }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-orders
 subjects:
   - name: cert-manager
     namespace: {{ cert_manager_namespace }}
@@ -108,46 +148,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cert-manager-controller-ingress-shim
-subjects:
-  - name: cert-manager
-    namespace: {{ cert_manager_namespace }}
-    kind: ServiceAccount
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: cert-manager-controller-orders
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: controller
-    helm.sh/chart: cert-manager-{{ cert_manager_version }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cert-manager-controller-orders
-subjects:
-  - name: cert-manager
-    namespace: {{ cert_manager_namespace }}
-    kind: ServiceAccount
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: cert-manager-controller-issuers
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: controller
-    helm.sh/chart: cert-manager-{{ cert_manager_version }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cert-manager-controller-issuers
 subjects:
   - name: cert-manager
     namespace: {{ cert_manager_namespace }}

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/crd-certificate.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/crd-certificate.yml.j2
@@ -71,157 +71,512 @@ spec:
   - name: v1alpha2
     served: true
     storage: true
+    "schema":
+      "openAPIV3Schema":
+        description: "A CertificateRequest is used to request a signed certificate
+          from one of the configured issuers. \n All fields within the CertificateRequest's
+          `spec` are immutable after creation. A CertificateRequest will either succeed
+          or fail, as denoted by its `status.state` field. \n A CertificateRequest
+          is a 'one-shot' resource, meaning it represents a single point in time request
+          for a certificate and cannot be re-used."
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Desired state of the CertificateRequest resource.
+            type: object
+            required:
+            - csr
+            - issuerRef
+            properties:
+              csr:
+                description: The PEM-encoded x509 certificate signing request to be
+                  submitted to the CA for signing.
+                type: string
+                format: byte
+              duration:
+                description: The requested 'duration' (i.e. lifetime) of the Certificate.
+                  This option may be ignored/overridden by some issuer types.
+                type: string
+              isCA:
+                description: IsCA will request to mark the certificate as valid for
+                  certificate signing when submitting to the issuer. This will automatically
+                  add the `cert sign` usage to the list of `usages`.
+                type: boolean
+              issuerRef:
+                description: IssuerRef is a reference to the issuer for this CertificateRequest.  If
+                  the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                  with the given name in the same namespace as the CertificateRequest
+                  will be used.  If the 'kind' field is set to 'ClusterIssuer', a
+                  ClusterIssuer with the provided name will be used. The 'name' field
+                  in this stanza is required at all times. The group field refers
+                  to the API group of the issuer which defaults to 'cert-manager.io'
+                  if empty.
+                type: object
+                required:
+                - name
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+              usages:
+                description: Usages is the set of x509 usages that are requested for
+                  the certificate. Defaults to `digital signature` and `key encipherment`
+                  if not specified.
+                type: array
+                items:
+                  description: 'KeyUsage specifies valid usage contexts for keys.
+                    See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+                    Valid KeyUsage values are as follows: "signing", "digital signature",
+                    "content commitment", "key encipherment", "key agreement", "data
+                    encipherment", "cert sign", "crl sign", "encipher only", "decipher
+                    only", "any", "server auth", "client auth", "code signing", "email
+                    protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec
+                    user", "timestamping", "ocsp signing", "microsoft sgc", "netscape
+                    sgc"'
+                  type: string
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+          status:
+            description: Status of the CertificateRequest. This is set and managed
+              automatically.
+            type: object
+            properties:
+              ca:
+                description: The PEM encoded x509 certificate of the signer, also
+                  known as the CA (Certificate Authority). This is set on a best-effort
+                  basis by different issuers. If not set, the CA is assumed to be
+                  unknown/not available.
+                type: string
+                format: byte
+              certificate:
+                description: The PEM encoded x509 certificate resulting from the certificate
+                  signing request. If not set, the CertificateRequest has either not
+                  been completed or has failed. More information on failure can be
+                  found by checking the `conditions` field.
+                type: string
+                format: byte
+              conditions:
+                description: List of status conditions to indicate the status of a
+                  CertificateRequest. Known condition types are `Ready` and `InvalidRequest`.
+                type: array
+                items:
+                  description: CertificateRequestCondition contains condition information
+                    for a CertificateRequest.
+                  type: object
+                  required:
+                  - status
+                  - type
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the timestamp corresponding
+                        to the last status change of this condition.
+                      type: string
+                      format: date-time
+                    message:
+                      description: Message is a human readable description of the
+                        details of the last transition, complementing reason.
+                      type: string
+                    reason:
+                      description: Reason is a brief machine readable explanation
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of ('True', 'False',
+                        'Unknown').
+                      type: string
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                    type:
+                      description: Type of the condition, known values are ('Ready',
+                        'InvalidRequest').
+                      type: string
+              failureTime:
+                description: FailureTime stores the time that this CertificateRequest
+                  failed. This is used to influence garbage collection and back-off.
+                type: string
+                format: date-time
   - name: v1alpha3
     served: true
     storage: false
-  "validation":
-    "openAPIV3Schema":
-      description: CertificateRequest is a type to represent a Certificate Signing
-        Request
-      type: object
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CertificateRequestSpec defines the desired state of CertificateRequest
-          type: object
-          required:
-          - csr
-          - issuerRef
-          properties:
-            csr:
-              description: Byte slice containing the PEM encoded CertificateSigningRequest
-              type: string
-              format: byte
-            duration:
-              description: Requested certificate default Duration
-              type: string
-            isCA:
-              description: IsCA will mark the resulting certificate as valid for signing.
-                This implies that the 'cert sign' usage is set
-              type: boolean
-            issuerRef:
-              description: IssuerRef is a reference to the issuer for this CertificateRequest.  If
-                the 'kind' field is not set, or set to 'Issuer', an Issuer resource
-                with the given name in the same namespace as the CertificateRequest
-                will be used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
-                with the provided name will be used. The 'name' field in this stanza
-                is required at all times. The group field refers to the API group
-                of the issuer which defaults to 'cert-manager.io' if empty.
-              type: object
-              required:
-              - name
-              properties:
-                group:
-                  type: string
-                kind:
-                  type: string
-                name:
-                  type: string
-            usages:
-              description: Usages is the set of x509 actions that are enabled for
-                a given key. Defaults are ('digital signature', 'key encipherment')
-                if empty
-              type: array
-              items:
-                description: 'KeyUsage specifies valid usage contexts for keys. See:
-                  https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
-                  Valid KeyUsage values are as follows: "signing", "digital signature",
-                  "content commitment", "key encipherment", "key agreement", "data
-                  encipherment", "cert sign", "crl sign", "encipher only", "decipher
-                  only", "any", "server auth", "client auth", "code signing", "email
-                  protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec
-                  user", "timestamping", "ocsp signing", "microsoft sgc", "netscape
-                  sgc"'
+    "schema":
+      "openAPIV3Schema":
+        description: "A CertificateRequest is used to request a signed certificate
+          from one of the configured issuers. \n All fields within the CertificateRequest's
+          `spec` are immutable after creation. A CertificateRequest will either succeed
+          or fail, as denoted by its `status.state` field. \n A CertificateRequest
+          is a 'one-shot' resource, meaning it represents a single point in time request
+          for a certificate and cannot be re-used."
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Desired state of the CertificateRequest resource.
+            type: object
+            required:
+            - csr
+            - issuerRef
+            properties:
+              csr:
+                description: The PEM-encoded x509 certificate signing request to be
+                  submitted to the CA for signing.
                 type: string
-                enum:
-                - signing
-                - digital signature
-                - content commitment
-                - key encipherment
-                - key agreement
-                - data encipherment
-                - cert sign
-                - crl sign
-                - encipher only
-                - decipher only
-                - any
-                - server auth
-                - client auth
-                - code signing
-                - email protection
-                - s/mime
-                - ipsec end system
-                - ipsec tunnel
-                - ipsec user
-                - timestamping
-                - ocsp signing
-                - microsoft sgc
-                - netscape sgc
-        status:
-          description: CertificateStatus defines the observed state of CertificateRequest
-            and resulting signed certificate.
-          type: object
-          properties:
-            ca:
-              description: Byte slice containing the PEM encoded certificate authority
-                of the signed certificate.
-              type: string
-              format: byte
-            certificate:
-              description: Byte slice containing a PEM encoded signed certificate
-                resulting from the given certificate signing request.
-              type: string
-              format: byte
-            conditions:
-              type: array
-              items:
-                description: CertificateRequestCondition contains condition information
-                  for a CertificateRequest.
+                format: byte
+              duration:
+                description: The requested 'duration' (i.e. lifetime) of the Certificate.
+                  This option may be ignored/overridden by some issuer types.
+                type: string
+              isCA:
+                description: IsCA will request to mark the certificate as valid for
+                  certificate signing when submitting to the issuer. This will automatically
+                  add the `cert sign` usage to the list of `usages`.
+                type: boolean
+              issuerRef:
+                description: IssuerRef is a reference to the issuer for this CertificateRequest.  If
+                  the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                  with the given name in the same namespace as the CertificateRequest
+                  will be used.  If the 'kind' field is set to 'ClusterIssuer', a
+                  ClusterIssuer with the provided name will be used. The 'name' field
+                  in this stanza is required at all times. The group field refers
+                  to the API group of the issuer which defaults to 'cert-manager.io'
+                  if empty.
                 type: object
                 required:
-                - status
-                - type
+                - name
                 properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the timestamp corresponding
-                      to the last status change of this condition.
+                  group:
+                    description: Group of the resource being referred to.
                     type: string
-                    format: date-time
-                  message:
-                    description: Message is a human readable description of the details
-                      of the last transition, complementing reason.
+                  kind:
+                    description: Kind of the resource being referred to.
                     type: string
-                  reason:
-                    description: Reason is a brief machine readable explanation for
-                      the condition's last transition.
+                  name:
+                    description: Name of the resource being referred to.
                     type: string
-                  status:
-                    description: Status of the condition, one of ('True', 'False',
-                      'Unknown').
+              usages:
+                description: Usages is the set of x509 usages that are requested for
+                  the certificate. Defaults to `digital signature` and `key encipherment`
+                  if not specified.
+                type: array
+                items:
+                  description: 'KeyUsage specifies valid usage contexts for keys.
+                    See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+                    Valid KeyUsage values are as follows: "signing", "digital signature",
+                    "content commitment", "key encipherment", "key agreement", "data
+                    encipherment", "cert sign", "crl sign", "encipher only", "decipher
+                    only", "any", "server auth", "client auth", "code signing", "email
+                    protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec
+                    user", "timestamping", "ocsp signing", "microsoft sgc", "netscape
+                    sgc"'
+                  type: string
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+          status:
+            description: Status of the CertificateRequest. This is set and managed
+              automatically.
+            type: object
+            properties:
+              ca:
+                description: The PEM encoded x509 certificate of the signer, also
+                  known as the CA (Certificate Authority). This is set on a best-effort
+                  basis by different issuers. If not set, the CA is assumed to be
+                  unknown/not available.
+                type: string
+                format: byte
+              certificate:
+                description: The PEM encoded x509 certificate resulting from the certificate
+                  signing request. If not set, the CertificateRequest has either not
+                  been completed or has failed. More information on failure can be
+                  found by checking the `conditions` field.
+                type: string
+                format: byte
+              conditions:
+                description: List of status conditions to indicate the status of a
+                  CertificateRequest. Known condition types are `Ready` and `InvalidRequest`.
+                type: array
+                items:
+                  description: CertificateRequestCondition contains condition information
+                    for a CertificateRequest.
+                  type: object
+                  required:
+                  - status
+                  - type
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the timestamp corresponding
+                        to the last status change of this condition.
+                      type: string
+                      format: date-time
+                    message:
+                      description: Message is a human readable description of the
+                        details of the last transition, complementing reason.
+                      type: string
+                    reason:
+                      description: Reason is a brief machine readable explanation
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of ('True', 'False',
+                        'Unknown').
+                      type: string
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                    type:
+                      description: Type of the condition, known values are ('Ready',
+                        'InvalidRequest').
+                      type: string
+              failureTime:
+                description: FailureTime stores the time that this CertificateRequest
+                  failed. This is used to influence garbage collection and back-off.
+                type: string
+                format: date-time
+  - name: v1beta1
+    served: true
+    storage: false
+    "schema":
+      "openAPIV3Schema":
+        description: "A CertificateRequest is used to request a signed certificate
+          from one of the configured issuers. \n All fields within the CertificateRequest's
+          `spec` are immutable after creation. A CertificateRequest will either succeed
+          or fail, as denoted by its `status.state` field. \n A CertificateRequest
+          is a 'one-shot' resource, meaning it represents a single point in time request
+          for a certificate and cannot be re-used."
+        type: object
+        required:
+        - spec
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Desired state of the CertificateRequest resource.
+            type: object
+            required:
+            - issuerRef
+            - request
+            properties:
+              duration:
+                description: The requested 'duration' (i.e. lifetime) of the Certificate.
+                  This option may be ignored/overridden by some issuer types.
+                type: string
+              isCA:
+                description: IsCA will request to mark the certificate as valid for
+                  certificate signing when submitting to the issuer. This will automatically
+                  add the `cert sign` usage to the list of `usages`.
+                type: boolean
+              issuerRef:
+                description: IssuerRef is a reference to the issuer for this CertificateRequest.  If
+                  the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                  with the given name in the same namespace as the CertificateRequest
+                  will be used.  If the 'kind' field is set to 'ClusterIssuer', a
+                  ClusterIssuer with the provided name will be used. The 'name' field
+                  in this stanza is required at all times. The group field refers
+                  to the API group of the issuer which defaults to 'cert-manager.io'
+                  if empty.
+                type: object
+                required:
+                - name
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
                     type: string
-                    enum:
-                    - "True"
-                    - "False"
-                    - Unknown
-                  type:
-                    description: Type of the condition, currently ('Ready', 'InvalidRequest').
+                  kind:
+                    description: Kind of the resource being referred to.
                     type: string
-            failureTime:
-              description: FailureTime stores the time that this CertificateRequest
-                failed. This is used to influence garbage collection and back-off.
-              type: string
-              format: date-time
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+              request:
+                description: The PEM-encoded x509 certificate signing request to be
+                  submitted to the CA for signing.
+                type: string
+                format: byte
+              usages:
+                description: Usages is the set of x509 usages that are requested for
+                  the certificate. Defaults to `digital signature` and `key encipherment`
+                  if not specified.
+                type: array
+                items:
+                  description: 'KeyUsage specifies valid usage contexts for keys.
+                    See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+                    Valid KeyUsage values are as follows: "signing", "digital signature",
+                    "content commitment", "key encipherment", "key agreement", "data
+                    encipherment", "cert sign", "crl sign", "encipher only", "decipher
+                    only", "any", "server auth", "client auth", "code signing", "email
+                    protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec
+                    user", "timestamping", "ocsp signing", "microsoft sgc", "netscape
+                    sgc"'
+                  type: string
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+          status:
+            description: Status of the CertificateRequest. This is set and managed
+              automatically.
+            type: object
+            properties:
+              ca:
+                description: The PEM encoded x509 certificate of the signer, also
+                  known as the CA (Certificate Authority). This is set on a best-effort
+                  basis by different issuers. If not set, the CA is assumed to be
+                  unknown/not available.
+                type: string
+                format: byte
+              certificate:
+                description: The PEM encoded x509 certificate resulting from the certificate
+                  signing request. If not set, the CertificateRequest has either not
+                  been completed or has failed. More information on failure can be
+                  found by checking the `conditions` field.
+                type: string
+                format: byte
+              conditions:
+                description: List of status conditions to indicate the status of a
+                  CertificateRequest. Known condition types are `Ready` and `InvalidRequest`.
+                type: array
+                items:
+                  description: CertificateRequestCondition contains condition information
+                    for a CertificateRequest.
+                  type: object
+                  required:
+                  - status
+                  - type
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the timestamp corresponding
+                        to the last status change of this condition.
+                      type: string
+                      format: date-time
+                    message:
+                      description: Message is a human readable description of the
+                        details of the last transition, complementing reason.
+                      type: string
+                    reason:
+                      description: Reason is a brief machine readable explanation
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of ('True', 'False',
+                        'Unknown').
+                      type: string
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                    type:
+                      description: Type of the condition, known values are ('Ready',
+                        'InvalidRequest').
+                      type: string
+              failureTime:
+                description: FailureTime stores the time that this CertificateRequest
+                  failed. This is used to influence garbage collection and back-off.
+                type: string
+                format: date-time
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -286,7 +641,10 @@ spec:
     storage: true
     "schema":
       "openAPIV3Schema":
-        description: Certificate is a type to represent a Certificate from ACME
+        description: "A Certificate resource should be created to ensure an up to
+          date and signed x509 certificate is stored in the Kubernetes Secret resource
+          named in `spec.secretName`. \n The stored certificate will be renewed before
+          it expires (as configured by `spec.renewBefore`)."
         type: object
         properties:
           apiVersion:
@@ -302,9 +660,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: CertificateSpec defines the desired state of Certificate.
-              A valid Certificate requires at least one of a CommonName, DNSName,
-              or URISAN to be valid.
+            description: Desired state of the Certificate resource.
             type: object
             required:
             - issuerRef
@@ -317,29 +673,34 @@ spec:
                   when any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4'
                 type: string
               dnsNames:
-                description: DNSNames is a list of subject alt names to be used on
+                description: DNSNames is a list of DNS subjectAltNames to be set on
                   the Certificate.
                 type: array
                 items:
                   type: string
               duration:
-                description: Certificate default Duration
+                description: The requested 'duration' (i.e. lifetime) of the Certificate.
+                  This option may be ignored/overridden by some issuer types. If overridden
+                  and `renewBefore` is greater than the actual certificate duration,
+                  the certificate will be automatically renewed 2/3rds of the way
+                  through the certificate's duration.
                 type: string
               emailSANs:
-                description: EmailSANs is a list of Email Subject Alternative Names
-                  to be set on this Certificate.
+                description: EmailSANs is a list of email subjectAltNames to be set
+                  on the Certificate.
                 type: array
                 items:
                   type: string
               ipAddresses:
-                description: IPAddresses is a list of IP addresses to be used on the
-                  Certificate
+                description: IPAddresses is a list of IP address subjectAltNames to
+                  be set on the Certificate.
                 type: array
                 items:
                   type: string
               isCA:
-                description: IsCA will mark this Certificate as valid for signing.
-                  This implies that the 'cert sign' usage is set
+                description: IsCA will mark this Certificate as valid for certificate
+                  signing. This will automatically add the `cert sign` usage to the
+                  list of `usages`.
                 type: boolean
               issuerRef:
                 description: IssuerRef is a reference to the issuer for this certificate.
@@ -353,15 +714,18 @@ spec:
                 - name
                 properties:
                   group:
+                    description: Group of the resource being referred to.
                     type: string
                   kind:
+                    description: Kind of the resource being referred to.
                     type: string
                   name:
+                    description: Name of the resource being referred to.
                     type: string
               keyAlgorithm:
                 description: KeyAlgorithm is the private key algorithm of the corresponding
                   private key for this certificate. If provided, allowed values are
-                  either "rsa" or "ecdsa" If KeyAlgorithm is specified and KeySize
+                  either "rsa" or "ecdsa" If `keyAlgorithm` is specified and `keySize`
                   is not provided, key size of 256 will be used for "ecdsa" key algorithm
                   and key size of 2048 will be used for "rsa" key algorithm.
                 type: string
@@ -380,10 +744,11 @@ spec:
                 - pkcs8
               keySize:
                 description: KeySize is the key bit size of the corresponding private
-                  key for this certificate. If provided, value must be between 2048
-                  and 8192 inclusive when KeyAlgorithm is empty or is set to "rsa",
-                  and value must be one of (256, 384, 521) when KeyAlgorithm is set
-                  to "ecdsa".
+                  key for this certificate. If `keyAlgorithm` is set to `RSA`, valid
+                  values are `2048`, `4096` or `8192`, and will default to `2048`
+                  if not specified. If `keyAlgorithm` is set to `ECDSA`, valid values
+                  are `256`, `384` or `521`, and will default to `256` if not specified.
+                  No other values are allowed.
                 type: integer
                 maximum: 8192
                 minimum: 0
@@ -416,12 +781,13 @@ spec:
                         - name
                         properties:
                           key:
-                            description: The key of the secret to select from. Must
-                              be a valid secret key.
+                            description: The key of the entry in the Secret resource's
+                              `data` field to be used. Some instances of this field
+                              may be defaulted, in others it may be required.
                             type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                             type: string
                   pkcs12:
                     description: PKCS12 configures options for storing a PKCS12 keystore
@@ -447,15 +813,17 @@ spec:
                         - name
                         properties:
                           key:
-                            description: The key of the secret to select from. Must
-                              be a valid secret key.
+                            description: The key of the entry in the Secret resource's
+                              `data` field to be used. Some instances of this field
+                              may be defaulted, in others it may be required.
                             type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                             type: string
               organization:
-                description: Organization is the organization to be used on the Certificate
+                description: Organization is a list of organizations to be used on
+                  the Certificate.
                 type: array
                 items:
                   type: string
@@ -475,11 +843,17 @@ spec:
                       compatibility.
                     type: string
               renewBefore:
-                description: Certificate renew before expiration duration
+                description: The amount of time before the currently issued certificate's
+                  `notAfter` time that cert-manager will begin to attempt to renew
+                  the certificate. If this value is greater than the total duration
+                  of the certificate (i.e. notAfter - notBefore), it will be automatically
+                  renewed 2/3rds of the way through the certificate's duration.
                 type: string
               secretName:
-                description: SecretName is the name of the secret resource to store
-                  this secret in
+                description: SecretName is the name of the secret resource that will
+                  be automatically created and managed by this Certificate resource.
+                  It will be populated with a private key and certificate, signed
+                  by the denoted issuer.
                 type: string
               subject:
                 description: Full X509 name specification (https://golang.org/pkg/crypto/x509/pkix/#Name).
@@ -519,15 +893,15 @@ spec:
                     items:
                       type: string
               uriSANs:
-                description: URISANs is a list of URI Subject Alternative Names to
-                  be set on this Certificate.
+                description: URISANs is a list of URI subjectAltNames to be set on
+                  the Certificate.
                 type: array
                 items:
                   type: string
               usages:
-                description: Usages is the set of x509 actions that are enabled for
-                  a given key. Defaults are ('digital signature', 'key encipherment')
-                  if empty
+                description: Usages is the set of x509 usages that are requested for
+                  the certificate. Defaults to `digital signature` and `key encipherment`
+                  if not specified.
                 type: array
                 items:
                   description: 'KeyUsage specifies valid usage contexts for keys.
@@ -565,10 +939,12 @@ spec:
                   - microsoft sgc
                   - netscape sgc
           status:
-            description: CertificateStatus defines the observed state of Certificate
+            description: Status of the Certificate. This is set and managed automatically.
             type: object
             properties:
               conditions:
+                description: List of status conditions to indicate the status of certificates.
+                  Known condition types are `Ready` and `Issuing`.
                 type: array
                 items:
                   description: CertificateCondition contains condition information
@@ -600,9 +976,14 @@ spec:
                       - "False"
                       - Unknown
                     type:
-                      description: Type of the condition, currently ('Ready').
+                      description: Type of the condition, known values are ('Ready',
+                        `Issuing`).
                       type: string
               lastFailureTime:
+                description: LastFailureTime is the time as recorded by the Certificate
+                  controller of the most recent failure to complete a CertificateRequest
+                  for this Certificate resource. If set, cert-manager will not re-request
+                  another Certificate until 1 hour has elapsed from this time.
                 type: string
                 format: date-time
               nextPrivateKeySecretName:
@@ -614,7 +995,17 @@ spec:
                 type: string
               notAfter:
                 description: The expiration time of the certificate stored in the
-                  secret named by this resource in spec.secretName.
+                  secret named by this resource in `spec.secretName`.
+                type: string
+                format: date-time
+              notBefore:
+                description: The time after which the certificate stored in the secret
+                  named by this resource in spec.secretName is valid.
+                type: string
+                format: date-time
+              renewalTime:
+                description: RenewalTime is the time at which the certificate will
+                  be next renewed. If not set, no upcoming renewal is scheduled.
                 type: string
                 format: date-time
               revision:
@@ -634,7 +1025,10 @@ spec:
     storage: false
     "schema":
       "openAPIV3Schema":
-        description: Certificate is a type to represent a Certificate from ACME
+        description: "A Certificate resource should be created to ensure an up to
+          date and signed x509 certificate is stored in the Kubernetes Secret resource
+          named in `spec.secretName`. \n The stored certificate will be renewed before
+          it expires (as configured by `spec.renewBefore`)."
         type: object
         properties:
           apiVersion:
@@ -650,9 +1044,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: CertificateSpec defines the desired state of Certificate.
-              A valid Certificate requires at least one of a CommonName, DNSName,
-              or URISAN to be valid.
+            description: Desired state of the Certificate resource.
             type: object
             required:
             - issuerRef
@@ -665,29 +1057,34 @@ spec:
                   when any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4'
                 type: string
               dnsNames:
-                description: DNSNames is a list of subject alt names to be used on
+                description: DNSNames is a list of DNS subjectAltNames to be set on
                   the Certificate.
                 type: array
                 items:
                   type: string
               duration:
-                description: Certificate default Duration
+                description: The requested 'duration' (i.e. lifetime) of the Certificate.
+                  This option may be ignored/overridden by some issuer types. If overridden
+                  and `renewBefore` is greater than the actual certificate duration,
+                  the certificate will be automatically renewed 2/3rds of the way
+                  through the certificate's duration.
                 type: string
               emailSANs:
-                description: EmailSANs is a list of Email Subject Alternative Names
-                  to be set on this Certificate.
+                description: EmailSANs is a list of email subjectAltNames to be set
+                  on the Certificate.
                 type: array
                 items:
                   type: string
               ipAddresses:
-                description: IPAddresses is a list of IP addresses to be used on the
-                  Certificate
+                description: IPAddresses is a list of IP address subjectAltNames to
+                  be set on the Certificate.
                 type: array
                 items:
                   type: string
               isCA:
-                description: IsCA will mark this Certificate as valid for signing.
-                  This implies that the 'cert sign' usage is set
+                description: IsCA will mark this Certificate as valid for certificate
+                  signing. This will automatically add the `cert sign` usage to the
+                  list of `usages`.
                 type: boolean
               issuerRef:
                 description: IssuerRef is a reference to the issuer for this certificate.
@@ -701,15 +1098,18 @@ spec:
                 - name
                 properties:
                   group:
+                    description: Group of the resource being referred to.
                     type: string
                   kind:
+                    description: Kind of the resource being referred to.
                     type: string
                   name:
+                    description: Name of the resource being referred to.
                     type: string
               keyAlgorithm:
                 description: KeyAlgorithm is the private key algorithm of the corresponding
                   private key for this certificate. If provided, allowed values are
-                  either "rsa" or "ecdsa" If KeyAlgorithm is specified and KeySize
+                  either "rsa" or "ecdsa" If `keyAlgorithm` is specified and `keySize`
                   is not provided, key size of 256 will be used for "ecdsa" key algorithm
                   and key size of 2048 will be used for "rsa" key algorithm.
                 type: string
@@ -728,10 +1128,11 @@ spec:
                 - pkcs8
               keySize:
                 description: KeySize is the key bit size of the corresponding private
-                  key for this certificate. If provided, value must be between 2048
-                  and 8192 inclusive when KeyAlgorithm is empty or is set to "rsa",
-                  and value must be one of (256, 384, 521) when KeyAlgorithm is set
-                  to "ecdsa".
+                  key for this certificate. If `keyAlgorithm` is set to `RSA`, valid
+                  values are `2048`, `4096` or `8192`, and will default to `2048`
+                  if not specified. If `keyAlgorithm` is set to `ECDSA`, valid values
+                  are `256`, `384` or `521`, and will default to `256` if not specified.
+                  No other values are allowed.
                 type: integer
                 maximum: 8192
                 minimum: 0
@@ -764,12 +1165,13 @@ spec:
                         - name
                         properties:
                           key:
-                            description: The key of the secret to select from. Must
-                              be a valid secret key.
+                            description: The key of the entry in the Secret resource's
+                              `data` field to be used. Some instances of this field
+                              may be defaulted, in others it may be required.
                             type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                             type: string
                   pkcs12:
                     description: PKCS12 configures options for storing a PKCS12 keystore
@@ -795,12 +1197,13 @@ spec:
                         - name
                         properties:
                           key:
-                            description: The key of the secret to select from. Must
-                              be a valid secret key.
+                            description: The key of the entry in the Secret resource's
+                              `data` field to be used. Some instances of this field
+                              may be defaulted, in others it may be required.
                             type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                             type: string
               privateKey:
                 description: Options to control private keys used for the Certificate.
@@ -818,11 +1221,17 @@ spec:
                       compatibility.
                     type: string
               renewBefore:
-                description: Certificate renew before expiration duration
+                description: The amount of time before the currently issued certificate's
+                  `notAfter` time that cert-manager will begin to attempt to renew
+                  the certificate. If this value is greater than the total duration
+                  of the certificate (i.e. notAfter - notBefore), it will be automatically
+                  renewed 2/3rds of the way through the certificate's duration.
                 type: string
               secretName:
-                description: SecretName is the name of the secret resource to store
-                  this secret in
+                description: SecretName is the name of the secret resource that will
+                  be automatically created and managed by this Certificate resource.
+                  It will be populated with a private key and certificate, signed
+                  by the denoted issuer.
                 type: string
               subject:
                 description: Full X509 name specification (https://golang.org/pkg/crypto/x509/pkix/#Name).
@@ -867,15 +1276,15 @@ spec:
                     items:
                       type: string
               uriSANs:
-                description: URISANs is a list of URI Subject Alternative Names to
-                  be set on this Certificate.
+                description: URISANs is a list of URI subjectAltNames to be set on
+                  the Certificate.
                 type: array
                 items:
                   type: string
               usages:
-                description: Usages is the set of x509 actions that are enabled for
-                  a given key. Defaults are ('digital signature', 'key encipherment')
-                  if empty
+                description: Usages is the set of x509 usages that are requested for
+                  the certificate. Defaults to `digital signature` and `key encipherment`
+                  if not specified.
                 type: array
                 items:
                   description: 'KeyUsage specifies valid usage contexts for keys.
@@ -913,10 +1322,12 @@ spec:
                   - microsoft sgc
                   - netscape sgc
           status:
-            description: CertificateStatus defines the observed state of Certificate
+            description: Status of the Certificate. This is set and managed automatically.
             type: object
             properties:
               conditions:
+                description: List of status conditions to indicate the status of certificates.
+                  Known condition types are `Ready` and `Issuing`.
                 type: array
                 items:
                   description: CertificateCondition contains condition information
@@ -948,9 +1359,14 @@ spec:
                       - "False"
                       - Unknown
                     type:
-                      description: Type of the condition, currently ('Ready').
+                      description: Type of the condition, known values are ('Ready',
+                        `Issuing`).
                       type: string
               lastFailureTime:
+                description: LastFailureTime is the time as recorded by the Certificate
+                  controller of the most recent failure to complete a CertificateRequest
+                  for this Certificate resource. If set, cert-manager will not re-request
+                  another Certificate until 1 hour has elapsed from this time.
                 type: string
                 format: date-time
               nextPrivateKeySecretName:
@@ -962,7 +1378,402 @@ spec:
                 type: string
               notAfter:
                 description: The expiration time of the certificate stored in the
-                  secret named by this resource in spec.secretName.
+                  secret named by this resource in `spec.secretName`.
+                type: string
+                format: date-time
+              notBefore:
+                description: The time after which the certificate stored in the secret
+                  named by this resource in spec.secretName is valid.
+                type: string
+                format: date-time
+              renewalTime:
+                description: RenewalTime is the time at which the certificate will
+                  be next renewed. If not set, no upcoming renewal is scheduled.
+                type: string
+                format: date-time
+              revision:
+                description: "The current 'revision' of the certificate as issued.
+                  \n When a CertificateRequest resource is created, it will have the
+                  `cert-manager.io/certificate-revision` set to one greater than the
+                  current value of this field. \n Upon issuance, this field will be
+                  set to the value of the annotation on the CertificateRequest resource
+                  used to issue the certificate. \n Persisting the value on the CertificateRequest
+                  resource allows the certificates controller to know whether a request
+                  is part of an old issuance or if it is part of the ongoing revision's
+                  issuance by checking if the revision value in the annotation is
+                  greater than this field."
+                type: integer
+  - name: v1beta1
+    served: true
+    storage: false
+    "schema":
+      "openAPIV3Schema":
+        description: "A Certificate resource should be created to ensure an up to
+          date and signed x509 certificate is stored in the Kubernetes Secret resource
+          named in `spec.secretName`. \n The stored certificate will be renewed before
+          it expires (as configured by `spec.renewBefore`)."
+        type: object
+        required:
+        - spec
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Desired state of the Certificate resource.
+            type: object
+            required:
+            - issuerRef
+            - secretName
+            properties:
+              commonName:
+                description: 'CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to
+                  avoid generating invalid CSRs. This value is ignored by TLS clients
+                  when any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4'
+                type: string
+              dnsNames:
+                description: DNSNames is a list of DNS subjectAltNames to be set on
+                  the Certificate.
+                type: array
+                items:
+                  type: string
+              duration:
+                description: The requested 'duration' (i.e. lifetime) of the Certificate.
+                  This option may be ignored/overridden by some issuer types. If overridden
+                  and `renewBefore` is greater than the actual certificate duration,
+                  the certificate will be automatically renewed 2/3rds of the way
+                  through the certificate's duration.
+                type: string
+              emailSANs:
+                description: EmailSANs is a list of email subjectAltNames to be set
+                  on the Certificate.
+                type: array
+                items:
+                  type: string
+              ipAddresses:
+                description: IPAddresses is a list of IP address subjectAltNames to
+                  be set on the Certificate.
+                type: array
+                items:
+                  type: string
+              isCA:
+                description: IsCA will mark this Certificate as valid for certificate
+                  signing. This will automatically add the `cert sign` usage to the
+                  list of `usages`.
+                type: boolean
+              issuerRef:
+                description: IssuerRef is a reference to the issuer for this certificate.
+                  If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                  with the given name in the same namespace as the Certificate will
+                  be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                  with the provided name will be used. The 'name' field in this stanza
+                  is required at all times.
+                type: object
+                required:
+                - name
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+              keystores:
+                description: Keystores configures additional keystore output formats
+                  stored in the `secretName` Secret resource.
+                type: object
+                properties:
+                  jks:
+                    description: JKS configures options for storing a JKS keystore
+                      in the `spec.secretName` Secret resource.
+                    type: object
+                    required:
+                    - create
+                    - passwordSecretRef
+                    properties:
+                      create:
+                        description: Create enables JKS keystore creation for the
+                          Certificate. If true, a file named `keystore.jks` will be
+                          created in the target Secret resource, encrypted using the
+                          password stored in `passwordSecretRef`. The keystore file
+                          will only be updated upon re-issuance.
+                        type: boolean
+                      passwordSecretRef:
+                        description: PasswordSecretRef is a reference to a key in
+                          a Secret resource containing the password used to encrypt
+                          the JKS keystore.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the entry in the Secret resource's
+                              `data` field to be used. Some instances of this field
+                              may be defaulted, in others it may be required.
+                            type: string
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                  pkcs12:
+                    description: PKCS12 configures options for storing a PKCS12 keystore
+                      in the `spec.secretName` Secret resource.
+                    type: object
+                    required:
+                    - create
+                    - passwordSecretRef
+                    properties:
+                      create:
+                        description: Create enables PKCS12 keystore creation for the
+                          Certificate. If true, a file named `keystore.p12` will be
+                          created in the target Secret resource, encrypted using the
+                          password stored in `passwordSecretRef`. The keystore file
+                          will only be updated upon re-issuance.
+                        type: boolean
+                      passwordSecretRef:
+                        description: PasswordSecretRef is a reference to a key in
+                          a Secret resource containing the password used to encrypt
+                          the PKCS12 keystore.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the entry in the Secret resource's
+                              `data` field to be used. Some instances of this field
+                              may be defaulted, in others it may be required.
+                            type: string
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                type: object
+                properties:
+                  algorithm:
+                    description: Algorithm is the private key algorithm of the corresponding
+                      private key for this certificate. If provided, allowed values
+                      are either "rsa" or "ecdsa" If `algorithm` is specified and
+                      `size` is not provided, key size of 256 will be used for "ecdsa"
+                      key algorithm and key size of 2048 will be used for "rsa" key
+                      algorithm.
+                    type: string
+                    enum:
+                    - RSA
+                    - ECDSA
+                  encoding:
+                    description: The private key cryptography standards (PKCS) encoding
+                      for this certificate's private key to be encoded in. If provided,
+                      allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and
+                      PKCS#8, respectively. Defaults to PKCS#1 if not specified.
+                    type: string
+                    enum:
+                    - PKCS1
+                    - PKCS8
+                  rotationPolicy:
+                    description: RotationPolicy controls how private keys should be
+                      regenerated when a re-issuance is being processed. If set to
+                      Never, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exists
+                      but it does not have the correct algorithm or size, a warning
+                      will be raised to await user intervention. If set to Always,
+                      a private key matching the specified requirements will be generated
+                      whenever a re-issuance occurs. Default is 'Never' for backward
+                      compatibility.
+                    type: string
+                  size:
+                    description: Size is the key bit size of the corresponding private
+                      key for this certificate. If `algorithm` is set to `RSA`, valid
+                      values are `2048`, `4096` or `8192`, and will default to `2048`
+                      if not specified. If `algorithm` is set to `ECDSA`, valid values
+                      are `256`, `384` or `521`, and will default to `256` if not
+                      specified. No other values are allowed.
+                    type: integer
+                    maximum: 8192
+                    minimum: 0
+              renewBefore:
+                description: The amount of time before the currently issued certificate's
+                  `notAfter` time that cert-manager will begin to attempt to renew
+                  the certificate. If this value is greater than the total duration
+                  of the certificate (i.e. notAfter - notBefore), it will be automatically
+                  renewed 2/3rds of the way through the certificate's duration.
+                type: string
+              secretName:
+                description: SecretName is the name of the secret resource that will
+                  be automatically created and managed by this Certificate resource.
+                  It will be populated with a private key and certificate, signed
+                  by the denoted issuer.
+                type: string
+              subject:
+                description: Full X509 name specification (https://golang.org/pkg/crypto/x509/pkix/#Name).
+                type: object
+                properties:
+                  countries:
+                    description: Countries to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  localities:
+                    description: Cities to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  organizationalUnits:
+                    description: Organizational Units to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  organizations:
+                    description: Organizations to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  postalCodes:
+                    description: Postal codes to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  provinces:
+                    description: State/Provinces to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+                  serialNumber:
+                    description: Serial number to be used on the Certificate.
+                    type: string
+                  streetAddresses:
+                    description: Street addresses to be used on the Certificate.
+                    type: array
+                    items:
+                      type: string
+              uriSANs:
+                description: URISANs is a list of URI subjectAltNames to be set on
+                  the Certificate.
+                type: array
+                items:
+                  type: string
+              usages:
+                description: Usages is the set of x509 usages that are requested for
+                  the certificate. Defaults to `digital signature` and `key encipherment`
+                  if not specified.
+                type: array
+                items:
+                  description: 'KeyUsage specifies valid usage contexts for keys.
+                    See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+                    Valid KeyUsage values are as follows: "signing", "digital signature",
+                    "content commitment", "key encipherment", "key agreement", "data
+                    encipherment", "cert sign", "crl sign", "encipher only", "decipher
+                    only", "any", "server auth", "client auth", "code signing", "email
+                    protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec
+                    user", "timestamping", "ocsp signing", "microsoft sgc", "netscape
+                    sgc"'
+                  type: string
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+          status:
+            description: Status of the Certificate. This is set and managed automatically.
+            type: object
+            properties:
+              conditions:
+                description: List of status conditions to indicate the status of certificates.
+                  Known condition types are `Ready` and `Issuing`.
+                type: array
+                items:
+                  description: CertificateCondition contains condition information
+                    for an Certificate.
+                  type: object
+                  required:
+                  - status
+                  - type
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the timestamp corresponding
+                        to the last status change of this condition.
+                      type: string
+                      format: date-time
+                    message:
+                      description: Message is a human readable description of the
+                        details of the last transition, complementing reason.
+                      type: string
+                    reason:
+                      description: Reason is a brief machine readable explanation
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of ('True', 'False',
+                        'Unknown').
+                      type: string
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                    type:
+                      description: Type of the condition, known values are ('Ready',
+                        `Issuing`).
+                      type: string
+              lastFailureTime:
+                description: LastFailureTime is the time as recorded by the Certificate
+                  controller of the most recent failure to complete a CertificateRequest
+                  for this Certificate resource. If set, cert-manager will not re-request
+                  another Certificate until 1 hour has elapsed from this time.
+                type: string
+                format: date-time
+              nextPrivateKeySecretName:
+                description: The name of the Secret resource containing the private
+                  key to be used for the next certificate iteration. The keymanager
+                  controller will automatically set this field if the `Issuing` condition
+                  is set to `True`. It will automatically unset this field when the
+                  Issuing condition is not set or False.
+                type: string
+              notAfter:
+                description: The expiration time of the certificate stored in the
+                  secret named by this resource in `spec.secretName`.
+                type: string
+                format: date-time
+              notBefore:
+                description: The time after which the certificate stored in the secret
+                  named by this resource in spec.secretName is valid.
+                type: string
+                format: date-time
+              renewalTime:
+                description: RenewalTime is the time at which the certificate will
+                  be next renewed. If not set, no upcoming renewal is scheduled.
                 type: string
                 format: date-time
               revision:

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/crd-challenge.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/crd-challenge.yml.j2
@@ -67,1400 +67,4410 @@ spec:
   - name: v1alpha2
     served: true
     storage: true
+    "schema":
+      "openAPIV3Schema":
+        description: Challenge is a type to represent a Challenge request with an
+          ACME server
+        type: object
+        required:
+        - metadata
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            required:
+            - authzURL
+            - dnsName
+            - issuerRef
+            - key
+            - solver
+            - token
+            - type
+            - url
+            properties:
+              authzURL:
+                description: AuthzURL is the URL to the ACME Authorization resource
+                  that this challenge is a part of.
+                type: string
+              dnsName:
+                description: DNSName is the identifier that this challenge is for,
+                  e.g. example.com. If the requested DNSName is a 'wildcard', this
+                  field MUST be set to the non-wildcard domain, e.g. for `*.example.com`,
+                  it must be `example.com`.
+                type: string
+              issuerRef:
+                description: IssuerRef references a properly configured ACME-type
+                  Issuer which should be used to create this Challenge. If the Issuer
+                  does not exist, processing will be retried. If the Issuer is not
+                  an 'ACME' Issuer, an error will be returned and the Challenge will
+                  be marked as failed.
+                type: object
+                required:
+                - name
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+              key:
+                description: 'Key is the ACME challenge key for this challenge For
+                  HTTP01 challenges, this is the value that must be responded with
+                  to complete the HTTP01 challenge in the format: `<private key JWK
+                  thumbprint>.<key from acme server for challenge>`. For DNS01 challenges,
+                  this is the base64 encoded SHA256 sum of the `<private key JWK thumbprint>.<key
+                  from acme server for challenge>` text that must be set as the TXT
+                  record content.'
+                type: string
+              solver:
+                description: Solver contains the domain solving configuration that
+                  should be used to solve this challenge resource.
+                type: object
+                properties:
+                  dns01:
+                    description: Configures cert-manager to attempt to complete authorizations
+                      by performing the DNS01 challenge flow.
+                    type: object
+                    properties:
+                      acmedns:
+                        description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns)
+                          API to manage DNS01 challenge records.
+                        type: object
+                        required:
+                        - accountSecretRef
+                        - host
+                        properties:
+                          accountSecretRef:
+                            description: A reference to a specific 'key' within a
+                              Secret resource. In some instances, `key` is a required
+                              field.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                          host:
+                            type: string
+                      akamai:
+                        description: Use the Akamai DNS zone management API to manage
+                          DNS01 challenge records.
+                        type: object
+                        required:
+                        - accessTokenSecretRef
+                        - clientSecretSecretRef
+                        - clientTokenSecretRef
+                        - serviceConsumerDomain
+                        properties:
+                          accessTokenSecretRef:
+                            description: A reference to a specific 'key' within a
+                              Secret resource. In some instances, `key` is a required
+                              field.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                          clientSecretSecretRef:
+                            description: A reference to a specific 'key' within a
+                              Secret resource. In some instances, `key` is a required
+                              field.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                          clientTokenSecretRef:
+                            description: A reference to a specific 'key' within a
+                              Secret resource. In some instances, `key` is a required
+                              field.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                          serviceConsumerDomain:
+                            type: string
+                      azuredns:
+                        description: Use the Microsoft Azure DNS API to manage DNS01
+                          challenge records.
+                        type: object
+                        required:
+                        - resourceGroupName
+                        - subscriptionID
+                        properties:
+                          clientID:
+                            description: if both this and ClientSecret are left unset
+                              MSI will be used
+                            type: string
+                          clientSecretSecretRef:
+                            description: if both this and ClientID are left unset
+                              MSI will be used
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                          environment:
+                            type: string
+                            enum:
+                            - AzurePublicCloud
+                            - AzureChinaCloud
+                            - AzureGermanCloud
+                            - AzureUSGovernmentCloud
+                          hostedZoneName:
+                            type: string
+                          resourceGroupName:
+                            type: string
+                          subscriptionID:
+                            type: string
+                          tenantID:
+                            description: when specifying ClientID and ClientSecret
+                              then this field is also needed
+                            type: string
+                      clouddns:
+                        description: Use the Google Cloud DNS API to manage DNS01
+                          challenge records.
+                        type: object
+                        required:
+                        - project
+                        properties:
+                          hostedZoneName:
+                            description: HostedZoneName is an optional field that
+                              tells cert-manager in which Cloud DNS zone the challenge
+                              record has to be created. If left empty cert-manager
+                              will automatically choose a zone.
+                            type: string
+                          project:
+                            type: string
+                          serviceAccountSecretRef:
+                            description: A reference to a specific 'key' within a
+                              Secret resource. In some instances, `key` is a required
+                              field.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                      cloudflare:
+                        description: Use the Cloudflare API to manage DNS01 challenge
+                          records.
+                        type: object
+                        properties:
+                          apiKeySecretRef:
+                            description: 'API key to use to authenticate with Cloudflare.
+                              Note: using an API token to authenticate is now the
+                              recommended method as it allows greater control of permissions.'
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                          apiTokenSecretRef:
+                            description: API token used to authenticate with Cloudflare.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                          email:
+                            description: Email of the account, only required when
+                              using API key based authentication.
+                            type: string
+                      cnameStrategy:
+                        description: CNAMEStrategy configures how the DNS01 provider
+                          should handle CNAME records when found in DNS zones.
+                        type: string
+                        enum:
+                        - None
+                        - Follow
+                      digitalocean:
+                        description: Use the DigitalOcean DNS API to manage DNS01
+                          challenge records.
+                        type: object
+                        required:
+                        - tokenSecretRef
+                        properties:
+                          tokenSecretRef:
+                            description: A reference to a specific 'key' within a
+                              Secret resource. In some instances, `key` is a required
+                              field.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                      rfc2136:
+                        description: Use RFC2136 ("Dynamic Updates in the Domain Name
+                          System") (https://datatracker.ietf.org/doc/rfc2136/) to
+                          manage DNS01 challenge records.
+                        type: object
+                        required:
+                        - nameserver
+                        properties:
+                          nameserver:
+                            description: The IP address or hostname of an authoritative
+                              DNS server supporting RFC2136 in the form host:port.
+                              If the host is an IPv6 address it must be enclosed in
+                              square brackets (e.g [2001:db8::1]) ; port is optional.
+                              This field is required.
+                            type: string
+                          tsigAlgorithm:
+                            description: 'The TSIG Algorithm configured in the DNS
+                              supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                              and ``tsigKeyName`` are defined. Supported values are
+                              (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
+                              ``HMACSHA256`` or ``HMACSHA512``.'
+                            type: string
+                          tsigKeyName:
+                            description: The TSIG Key name configured in the DNS.
+                              If ``tsigSecretSecretRef`` is defined, this field is
+                              required.
+                            type: string
+                          tsigSecretSecretRef:
+                            description: The name of the secret containing the TSIG
+                              value. If ``tsigKeyName`` is defined, this field is
+                              required.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                      route53:
+                        description: Use the AWS Route53 API to manage DNS01 challenge
+                          records.
+                        type: object
+                        required:
+                        - region
+                        properties:
+                          accessKeyID:
+                            description: 'The AccessKeyID is used for authentication.
+                              If not set we fall-back to using env vars, shared credentials
+                              file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                            type: string
+                          hostedZoneID:
+                            description: If set, the provider will manage only this
+                              zone in Route53 and will not do an lookup using the
+                              route53:ListHostedZonesByName api call.
+                            type: string
+                          region:
+                            description: Always set the region when using AccessKeyID
+                              and SecretAccessKey
+                            type: string
+                          role:
+                            description: Role is a Role ARN which the Route53 provider
+                              will assume using either the explicit credentials AccessKeyID/SecretAccessKey
+                              or the inferred credentials from environment variables,
+                              shared credentials file or AWS Instance metadata
+                            type: string
+                          secretAccessKeySecretRef:
+                            description: The SecretAccessKey is used for authentication.
+                              If not set we fall-back to using env vars, shared credentials
+                              file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                      webhook:
+                        description: Configure an external webhook based DNS01 challenge
+                          solver to manage DNS01 challenge records.
+                        type: object
+                        required:
+                        - groupName
+                        - solverName
+                        properties:
+                          config:
+                            description: Additional configuration that should be passed
+                              to the webhook apiserver when challenges are processed.
+                              This can contain arbitrary JSON data. Secret values
+                              should not be specified in this stanza. If secret values
+                              are needed (e.g. credentials for a DNS service), you
+                              should use a SecretKeySelector to reference a Secret
+                              resource. For details on the schema of this field, consult
+                              the webhook provider implementation's documentation.
+                            x-kubernetes-preserve-unknown-fields: true
+                          groupName:
+                            description: The API group name that should be used when
+                              POSTing ChallengePayload resources to the webhook apiserver.
+                              This should be the same as the GroupName specified in
+                              the webhook provider implementation.
+                            type: string
+                          solverName:
+                            description: The name of the solver to use, as defined
+                              in the webhook provider implementation. This will typically
+                              be the name of the provider, e.g. 'cloudflare'.
+                            type: string
+                  http01:
+                    description: Configures cert-manager to attempt to complete authorizations
+                      by performing the HTTP01 challenge flow. It is not possible
+                      to obtain certificates for wildcard domain names (e.g. `*.example.com`)
+                      using the HTTP01 challenge mechanism.
+                    type: object
+                    properties:
+                      ingress:
+                        description: The ingress based HTTP01 challenge solver will
+                          solve challenges by creating or modifying Ingress resources
+                          in order to route requests for '/.well-known/acme-challenge/XYZ'
+                          to 'challenge solver' pods that are provisioned by cert-manager
+                          for each Challenge to be completed.
+                        type: object
+                        properties:
+                          class:
+                            description: The ingress class to use when creating Ingress
+                              resources to solve ACME challenges that use this challenge
+                              solver. Only one of 'class' or 'name' may be specified.
+                            type: string
+                          ingressTemplate:
+                            description: Optional ingress template used to configure
+                              the ACME challenge solver ingress used for HTTP01 challenges
+                            type: object
+                            properties:
+                              metadata:
+                                description: ObjectMeta overrides for the ingress
+                                  used to solve HTTP01 challenges. Only the 'labels'
+                                  and 'annotations' fields may be set. If labels or
+                                  annotations overlap with in-built values, the values
+                                  here will override the in-built values.
+                                type: object
+                                properties:
+                                  annotations:
+                                    description: Annotations that should be added
+                                      to the created ACME HTTP01 solver ingress.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  labels:
+                                    description: Labels that should be added to the
+                                      created ACME HTTP01 solver ingress.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                          name:
+                            description: The name of the ingress resource that should
+                              have ACME challenge solving routes inserted into it
+                              in order to solve HTTP01 challenges. This is typically
+                              used in conjunction with ingress controllers like ingress-gce,
+                              which maintains a 1:1 mapping between external IPs and
+                              ingress resources.
+                            type: string
+                          podTemplate:
+                            description: Optional pod template used to configure the
+                              ACME challenge solver pods used for HTTP01 challenges
+                            type: object
+                            properties:
+                              metadata:
+                                description: ObjectMeta overrides for the pod used
+                                  to solve HTTP01 challenges. Only the 'labels' and
+                                  'annotations' fields may be set. If labels or annotations
+                                  overlap with in-built values, the values here will
+                                  override the in-built values.
+                                type: object
+                                properties:
+                                  annotations:
+                                    description: Annotations that should be added
+                                      to the create ACME HTTP01 solver pods.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  labels:
+                                    description: Labels that should be added to the
+                                      created ACME HTTP01 solver pods.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                              spec:
+                                description: PodSpec defines overrides for the HTTP01
+                                  challenge solver pod. Only the 'nodeSelector', 'affinity'
+                                  and 'tolerations' fields are supported currently.
+                                  All other fields will be ignored.
+                                type: object
+                                properties:
+                                  affinity:
+                                    description: If specified, the pod's scheduling
+                                      constraints
+                                    type: object
+                                    properties:
+                                      nodeAffinity:
+                                        description: Describes node affinity scheduling
+                                          rules for the pod.
+                                        type: object
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            description: The scheduler will prefer
+                                              to schedule pods to nodes that satisfy
+                                              the affinity expressions specified by
+                                              this field, but it may choose a node
+                                              that violates one or more of the expressions.
+                                              The node that is most preferred is the
+                                              one with the greatest sum of weights,
+                                              i.e. for each node that meets all of
+                                              the scheduling requirements (resource
+                                              request, requiredDuringScheduling affinity
+                                              expressions, etc.), compute a sum by
+                                              iterating through the elements of this
+                                              field and adding "weight" to the sum
+                                              if the node matches the corresponding
+                                              matchExpressions; the node(s) with the
+                                              highest sum are the most preferred.
+                                            type: array
+                                            items:
+                                              description: An empty preferred scheduling
+                                                term matches all objects with implicit
+                                                weight 0 (i.e. it's a no-op). A null
+                                                preferred scheduling term matches
+                                                no objects (i.e. is also a no-op).
+                                              type: object
+                                              required:
+                                              - preference
+                                              - weight
+                                              properties:
+                                                preference:
+                                                  description: A node selector term,
+                                                    associated with the corresponding
+                                                    weight.
+                                                  type: object
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        labels.
+                                                      type: array
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                    matchFields:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        fields.
+                                                      type: array
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                weight:
+                                                  description: Weight associated with
+                                                    matching the corresponding nodeSelectorTerm,
+                                                    in the range 1-100.
+                                                  type: integer
+                                                  format: int32
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            description: If the affinity requirements
+                                              specified by this field are not met
+                                              at scheduling time, the pod will not
+                                              be scheduled onto the node. If the affinity
+                                              requirements specified by this field
+                                              cease to be met at some point during
+                                              pod execution (e.g. due to an update),
+                                              the system may or may not try to eventually
+                                              evict the pod from its node.
+                                            type: object
+                                            required:
+                                            - nodeSelectorTerms
+                                            properties:
+                                              nodeSelectorTerms:
+                                                description: Required. A list of node
+                                                  selector terms. The terms are ORed.
+                                                type: array
+                                                items:
+                                                  description: A null or empty node
+                                                    selector term matches no objects.
+                                                    The requirements of them are ANDed.
+                                                    The TopologySelectorTerm type
+                                                    implements a subset of the NodeSelectorTerm.
+                                                  type: object
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        labels.
+                                                      type: array
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                    matchFields:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        fields.
+                                                      type: array
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                      podAffinity:
+                                        description: Describes pod affinity scheduling
+                                          rules (e.g. co-locate this pod in the same
+                                          node, zone, etc. as some other pod(s)).
+                                        type: object
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            description: The scheduler will prefer
+                                              to schedule pods to nodes that satisfy
+                                              the affinity expressions specified by
+                                              this field, but it may choose a node
+                                              that violates one or more of the expressions.
+                                              The node that is most preferred is the
+                                              one with the greatest sum of weights,
+                                              i.e. for each node that meets all of
+                                              the scheduling requirements (resource
+                                              request, requiredDuringScheduling affinity
+                                              expressions, etc.), compute a sum by
+                                              iterating through the elements of this
+                                              field and adding "weight" to the sum
+                                              if the node has pods which matches the
+                                              corresponding podAffinityTerm; the node(s)
+                                              with the highest sum are the most preferred.
+                                            type: array
+                                            items:
+                                              description: The weights of all of the
+                                                matched WeightedPodAffinityTerm fields
+                                                are added per-node to find the most
+                                                preferred node(s)
+                                              type: object
+                                              required:
+                                              - podAffinityTerm
+                                              - weight
+                                              properties:
+                                                podAffinityTerm:
+                                                  description: Required. A pod affinity
+                                                    term, associated with the corresponding
+                                                    weight.
+                                                  type: object
+                                                  required:
+                                                  - topologyKey
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      type: object
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          type: array
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                        matchLabels:
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                          additionalProperties:
+                                                            type: string
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        which namespaces the labelSelector
+                                                        applies to (matches against);
+                                                        null or empty list means "this
+                                                        pod's namespace"
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                weight:
+                                                  description: weight associated with
+                                                    matching the corresponding podAffinityTerm,
+                                                    in the range 1-100.
+                                                  type: integer
+                                                  format: int32
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            description: If the affinity requirements
+                                              specified by this field are not met
+                                              at scheduling time, the pod will not
+                                              be scheduled onto the node. If the affinity
+                                              requirements specified by this field
+                                              cease to be met at some point during
+                                              pod execution (e.g. due to a pod label
+                                              update), the system may or may not try
+                                              to eventually evict the pod from its
+                                              node. When there are multiple elements,
+                                              the lists of nodes corresponding to
+                                              each podAffinityTerm are intersected,
+                                              i.e. all terms must be satisfied.
+                                            type: array
+                                            items:
+                                              description: Defines a set of pods (namely
+                                                those matching the labelSelector relative
+                                                to the given namespace(s)) that this
+                                                pod should be co-located (affinity)
+                                                or not co-located (anti-affinity)
+                                                with, where co-located is defined
+                                                as running on a node whose value of
+                                                the label with key <topologyKey> matches
+                                                that of any node on which a pod of
+                                                the set of pods is running
+                                              type: object
+                                              required:
+                                              - topologyKey
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  type: object
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      type: array
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                    matchLabels:
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                      additionalProperties:
+                                                        type: string
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    which namespaces the labelSelector
+                                                    applies to (matches against);
+                                                    null or empty list means "this
+                                                    pod's namespace"
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                      podAntiAffinity:
+                                        description: Describes pod anti-affinity scheduling
+                                          rules (e.g. avoid putting this pod in the
+                                          same node, zone, etc. as some other pod(s)).
+                                        type: object
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            description: The scheduler will prefer
+                                              to schedule pods to nodes that satisfy
+                                              the anti-affinity expressions specified
+                                              by this field, but it may choose a node
+                                              that violates one or more of the expressions.
+                                              The node that is most preferred is the
+                                              one with the greatest sum of weights,
+                                              i.e. for each node that meets all of
+                                              the scheduling requirements (resource
+                                              request, requiredDuringScheduling anti-affinity
+                                              expressions, etc.), compute a sum by
+                                              iterating through the elements of this
+                                              field and adding "weight" to the sum
+                                              if the node has pods which matches the
+                                              corresponding podAffinityTerm; the node(s)
+                                              with the highest sum are the most preferred.
+                                            type: array
+                                            items:
+                                              description: The weights of all of the
+                                                matched WeightedPodAffinityTerm fields
+                                                are added per-node to find the most
+                                                preferred node(s)
+                                              type: object
+                                              required:
+                                              - podAffinityTerm
+                                              - weight
+                                              properties:
+                                                podAffinityTerm:
+                                                  description: Required. A pod affinity
+                                                    term, associated with the corresponding
+                                                    weight.
+                                                  type: object
+                                                  required:
+                                                  - topologyKey
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      type: object
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          type: array
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                        matchLabels:
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                          additionalProperties:
+                                                            type: string
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        which namespaces the labelSelector
+                                                        applies to (matches against);
+                                                        null or empty list means "this
+                                                        pod's namespace"
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                weight:
+                                                  description: weight associated with
+                                                    matching the corresponding podAffinityTerm,
+                                                    in the range 1-100.
+                                                  type: integer
+                                                  format: int32
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            description: If the anti-affinity requirements
+                                              specified by this field are not met
+                                              at scheduling time, the pod will not
+                                              be scheduled onto the node. If the anti-affinity
+                                              requirements specified by this field
+                                              cease to be met at some point during
+                                              pod execution (e.g. due to a pod label
+                                              update), the system may or may not try
+                                              to eventually evict the pod from its
+                                              node. When there are multiple elements,
+                                              the lists of nodes corresponding to
+                                              each podAffinityTerm are intersected,
+                                              i.e. all terms must be satisfied.
+                                            type: array
+                                            items:
+                                              description: Defines a set of pods (namely
+                                                those matching the labelSelector relative
+                                                to the given namespace(s)) that this
+                                                pod should be co-located (affinity)
+                                                or not co-located (anti-affinity)
+                                                with, where co-located is defined
+                                                as running on a node whose value of
+                                                the label with key <topologyKey> matches
+                                                that of any node on which a pod of
+                                                the set of pods is running
+                                              type: object
+                                              required:
+                                              - topologyKey
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  type: object
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      type: array
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                    matchLabels:
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                      additionalProperties:
+                                                        type: string
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    which namespaces the labelSelector
+                                                    applies to (matches against);
+                                                    null or empty list means "this
+                                                    pod's namespace"
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                  nodeSelector:
+                                    description: 'NodeSelector is a selector which
+                                      must be true for the pod to fit on a node. Selector
+                                      which must match a node''s labels for the pod
+                                      to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  tolerations:
+                                    description: If specified, the pod's tolerations.
+                                    type: array
+                                    items:
+                                      description: The pod this Toleration is attached
+                                        to tolerates any taint that matches the triple
+                                        <key,value,effect> using the matching operator
+                                        <operator>.
+                                      type: object
+                                      properties:
+                                        effect:
+                                          description: Effect indicates the taint
+                                            effect to match. Empty means match all
+                                            taint effects. When specified, allowed
+                                            values are NoSchedule, PreferNoSchedule
+                                            and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Key is the taint key that the
+                                            toleration applies to. Empty means match
+                                            all taint keys. If the key is empty, operator
+                                            must be Exists; this combination means
+                                            to match all values and all keys.
+                                          type: string
+                                        operator:
+                                          description: Operator represents a key's
+                                            relationship to the value. Valid operators
+                                            are Exists and Equal. Defaults to Equal.
+                                            Exists is equivalent to wildcard for value,
+                                            so that a pod can tolerate all taints
+                                            of a particular category.
+                                          type: string
+                                        tolerationSeconds:
+                                          description: TolerationSeconds represents
+                                            the period of time the toleration (which
+                                            must be of effect NoExecute, otherwise
+                                            this field is ignored) tolerates the taint.
+                                            By default, it is not set, which means
+                                            tolerate the taint forever (do not evict).
+                                            Zero and negative values will be treated
+                                            as 0 (evict immediately) by the system.
+                                          type: integer
+                                          format: int64
+                                        value:
+                                          description: Value is the taint value the
+                                            toleration matches to. If the operator
+                                            is Exists, the value should be empty,
+                                            otherwise just a regular string.
+                                          type: string
+                          serviceType:
+                            description: Optional service type for Kubernetes solver
+                              service
+                            type: string
+                  selector:
+                    description: Selector selects a set of DNSNames on the Certificate
+                      resource that should be solved using this challenge solver.
+                      If not specified, the solver will be treated as the 'default'
+                      solver with the lowest priority, i.e. if any other solver has
+                      a more specific match, it will be used instead.
+                    type: object
+                    properties:
+                      dnsNames:
+                        description: List of DNSNames that this solver will be used
+                          to solve. If specified and a match is found, a dnsNames
+                          selector will take precedence over a dnsZones selector.
+                          If multiple solvers match with the same dnsNames value,
+                          the solver with the most matching labels in matchLabels
+                          will be selected. If neither has more matches, the solver
+                          defined earlier in the list will be selected.
+                        type: array
+                        items:
+                          type: string
+                      dnsZones:
+                        description: List of DNSZones that this solver will be used
+                          to solve. The most specific DNS zone match specified here
+                          will take precedence over other DNS zone matches, so a solver
+                          specifying sys.example.com will be selected over one specifying
+                          example.com for the domain www.sys.example.com. If multiple
+                          solvers match with the same dnsZones value, the solver with
+                          the most matching labels in matchLabels will be selected.
+                          If neither has more matches, the solver defined earlier
+                          in the list will be selected.
+                        type: array
+                        items:
+                          type: string
+                      matchLabels:
+                        description: A label selector that is used to refine the set
+                          of certificate's that this challenge solver will apply to.
+                        type: object
+                        additionalProperties:
+                          type: string
+              token:
+                description: Token is the ACME challenge token for this challenge.
+                  This is the raw value returned from the ACME server.
+                type: string
+              type:
+                description: Type is the type of ACME challenge this resource represents.
+                  One of "http-01" or "dns-01".
+                type: string
+                enum:
+                - http-01
+                - dns-01
+              url:
+                description: URL is the URL of the ACME Challenge resource for this
+                  challenge. This can be used to lookup details about the status of
+                  this challenge.
+                type: string
+              wildcard:
+                description: Wildcard will be true if this challenge is for a wildcard
+                  identifier, for example '*.example.com'.
+                type: boolean
+          status:
+            type: object
+            properties:
+              presented:
+                description: Presented will be set to true if the challenge values
+                  for this challenge are currently 'presented'. This *does not* imply
+                  the self check is passing. Only that the values have been 'submitted'
+                  for the appropriate challenge mechanism (i.e. the DNS01 TXT record
+                  has been presented, or the HTTP01 configuration has been configured).
+                type: boolean
+              processing:
+                description: Processing is used to denote whether this challenge should
+                  be processed or not. This field will only be set to true by the
+                  'scheduling' component. It will only be set to false by the 'challenges'
+                  controller, after the challenge has reached a final state or timed
+                  out. If this field is set to false, the challenge controller will
+                  not take any more action.
+                type: boolean
+              reason:
+                description: Reason contains human readable information on why the
+                  Challenge is in the current state.
+                type: string
+              state:
+                description: State contains the current 'state' of the challenge.
+                  If not set, the state of the challenge is unknown.
+                type: string
+                enum:
+                - valid
+                - ready
+                - pending
+                - processing
+                - invalid
+                - expired
+                - errored
   - name: v1alpha3
     served: true
     storage: false
-  "validation":
-    "openAPIV3Schema":
-      description: Challenge is a type to represent a Challenge request with an ACME
-        server
-      type: object
-      required:
-      - metadata
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          type: object
-          required:
-          - authzURL
-          - dnsName
-          - issuerRef
-          - key
-          - solver
-          - token
-          - type
-          - url
-          properties:
-            authzURL:
-              description: AuthzURL is the URL to the ACME Authorization resource
-                that this challenge is a part of.
-              type: string
-            dnsName:
-              description: DNSName is the identifier that this challenge is for, e.g.
-                example.com. If the requested DNSName is a 'wildcard', this field
-                MUST be set to the non-wildcard domain, e.g. for `*.example.com`,
-                it must be `example.com`.
-              type: string
-            issuerRef:
-              description: IssuerRef references a properly configured ACME-type Issuer
-                which should be used to create this Challenge. If the Issuer does
-                not exist, processing will be retried. If the Issuer is not an 'ACME'
-                Issuer, an error will be returned and the Challenge will be marked
-                as failed.
-              type: object
-              required:
-              - name
-              properties:
-                group:
-                  type: string
-                kind:
-                  type: string
-                name:
-                  type: string
-            key:
-              description: 'Key is the ACME challenge key for this challenge For HTTP01
-                challenges, this is the value that must be responded with to complete
-                the HTTP01 challenge in the format: `<private key JWK thumbprint>.<key
-                from acme server for challenge>`. For DNS01 challenges, this is the
-                base64 encoded SHA256 sum of the `<private key JWK thumbprint>.<key
-                from acme server for challenge>` text that must be set as the TXT
-                record content.'
-              type: string
-            solver:
-              description: Solver contains the domain solving configuration that should
-                be used to solve this challenge resource.
-              type: object
-              properties:
-                dns01:
-                  type: object
-                  properties:
-                    acmedns:
-                      description: ACMEIssuerDNS01ProviderAcmeDNS is a structure containing
-                        the configuration for ACME-DNS servers
-                      type: object
-                      required:
-                      - accountSecretRef
-                      - host
-                      properties:
-                        accountSecretRef:
-                          type: object
-                          required:
-                          - name
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                        host:
-                          type: string
-                    akamai:
-                      description: ACMEIssuerDNS01ProviderAkamai is a structure containing
-                        the DNS configuration for Akamai DNS—Zone Record Management
-                        API
-                      type: object
-                      required:
-                      - accessTokenSecretRef
-                      - clientSecretSecretRef
-                      - clientTokenSecretRef
-                      - serviceConsumerDomain
-                      properties:
-                        accessTokenSecretRef:
-                          type: object
-                          required:
-                          - name
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                        clientSecretSecretRef:
-                          type: object
-                          required:
-                          - name
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                        clientTokenSecretRef:
-                          type: object
-                          required:
-                          - name
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                        serviceConsumerDomain:
-                          type: string
-                    azuredns:
-                      description: ACMEIssuerDNS01ProviderAzureDNS is a structure
-                        containing the configuration for Azure DNS
-                      type: object
-                      required:
-                      - resourceGroupName
-                      - subscriptionID
-                      properties:
-                        clientID:
-                          description: if both this and ClientSecret are left unset
-                            MSI will be used
-                          type: string
-                        clientSecretSecretRef:
-                          description: if both this and ClientID are left unset MSI
-                            will be used
-                          type: object
-                          required:
-                          - name
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                        environment:
-                          type: string
-                          enum:
-                          - AzurePublicCloud
-                          - AzureChinaCloud
-                          - AzureGermanCloud
-                          - AzureUSGovernmentCloud
-                        hostedZoneName:
-                          type: string
-                        resourceGroupName:
-                          type: string
-                        subscriptionID:
-                          type: string
-                        tenantID:
-                          description: when specifying ClientID and ClientSecret then
-                            this field is also needed
-                          type: string
-                    clouddns:
-                      description: ACMEIssuerDNS01ProviderCloudDNS is a structure
-                        containing the DNS configuration for Google Cloud DNS
-                      type: object
-                      required:
-                      - project
-                      properties:
-                        project:
-                          type: string
-                        serviceAccountSecretRef:
-                          type: object
-                          required:
-                          - name
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                    cloudflare:
-                      description: ACMEIssuerDNS01ProviderCloudflare is a structure
-                        containing the DNS configuration for Cloudflare
-                      type: object
-                      required:
-                      - email
-                      properties:
-                        apiKeySecretRef:
-                          type: object
-                          required:
-                          - name
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                        apiTokenSecretRef:
-                          type: object
-                          required:
-                          - name
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                        email:
-                          type: string
-                    cnameStrategy:
-                      description: CNAMEStrategy configures how the DNS01 provider
-                        should handle CNAME records when found in DNS zones.
-                      type: string
-                      enum:
-                      - None
-                      - Follow
-                    digitalocean:
-                      description: ACMEIssuerDNS01ProviderDigitalOcean is a structure
-                        containing the DNS configuration for DigitalOcean Domains
-                      type: object
-                      required:
-                      - tokenSecretRef
-                      properties:
-                        tokenSecretRef:
-                          type: object
-                          required:
-                          - name
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                    rfc2136:
-                      description: ACMEIssuerDNS01ProviderRFC2136 is a structure containing
-                        the configuration for RFC2136 DNS
-                      type: object
-                      required:
-                      - nameserver
-                      properties:
-                        nameserver:
-                          description: The IP address or hostname of an authoritative
-                            DNS server supporting RFC2136 in the form host:port. If
-                            the host is an IPv6 address it must be enclosed in square
-                            brackets (e.g [2001:db8::1]) ; port is optional. This
-                            field is required.
-                          type: string
-                        tsigAlgorithm:
-                          description: 'The TSIG Algorithm configured in the DNS supporting
-                            RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName``
-                            are defined. Supported values are (case-insensitive):
-                            ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or
-                            ``HMACSHA512``.'
-                          type: string
-                        tsigKeyName:
-                          description: The TSIG Key name configured in the DNS. If
-                            ``tsigSecretSecretRef`` is defined, this field is required.
-                          type: string
-                        tsigSecretSecretRef:
-                          description: The name of the secret containing the TSIG
-                            value. If ``tsigKeyName`` is defined, this field is required.
-                          type: object
-                          required:
-                          - name
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                    route53:
-                      description: ACMEIssuerDNS01ProviderRoute53 is a structure containing
-                        the Route 53 configuration for AWS
-                      type: object
-                      required:
-                      - region
-                      properties:
-                        accessKeyID:
-                          description: 'The AccessKeyID is used for authentication.
-                            If not set we fall-back to using env vars, shared credentials
-                            file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
-                          type: string
-                        hostedZoneID:
-                          description: If set, the provider will manage only this
-                            zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName
-                            api call.
-                          type: string
-                        region:
-                          description: Always set the region when using AccessKeyID
-                            and SecretAccessKey
-                          type: string
-                        role:
-                          description: Role is a Role ARN which the Route53 provider
-                            will assume using either the explicit credentials AccessKeyID/SecretAccessKey
-                            or the inferred credentials from environment variables,
-                            shared credentials file or AWS Instance metadata
-                          type: string
-                        secretAccessKeySecretRef:
-                          description: The SecretAccessKey is used for authentication.
-                            If not set we fall-back to using env vars, shared credentials
-                            file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
-                          type: object
-                          required:
-                          - name
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                    webhook:
-                      description: ACMEIssuerDNS01ProviderWebhook specifies configuration
-                        for a webhook DNS01 provider, including where to POST ChallengePayload
-                        resources.
-                      type: object
-                      required:
-                      - groupName
-                      - solverName
-                      properties:
-                        config:
-                          description: Additional configuration that should be passed
-                            to the webhook apiserver when challenges are processed.
-                            This can contain arbitrary JSON data. Secret values should
-                            not be specified in this stanza. If secret values are
-                            needed (e.g. credentials for a DNS service), you should
-                            use a SecretKeySelector to reference a Secret resource.
-                            For details on the schema of this field, consult the webhook
-                            provider implementation's documentation.
-                          x-kubernetes-preserve-unknown-fields: true
-                        groupName:
-                          description: The API group name that should be used when
-                            POSTing ChallengePayload resources to the webhook apiserver.
-                            This should be the same as the GroupName specified in
-                            the webhook provider implementation.
-                          type: string
-                        solverName:
-                          description: The name of the solver to use, as defined in
-                            the webhook provider implementation. This will typically
-                            be the name of the provider, e.g. 'cloudflare'.
-                          type: string
-                http01:
-                  description: ACMEChallengeSolverHTTP01 contains configuration detailing
-                    how to solve HTTP01 challenges within a Kubernetes cluster. Typically
-                    this is accomplished through creating 'routes' of some description
-                    that configure ingress controllers to direct traffic to 'solver
-                    pods', which are responsible for responding to the ACME server's
-                    HTTP requests.
-                  type: object
-                  properties:
-                    ingress:
-                      description: The ingress based HTTP01 challenge solver will
-                        solve challenges by creating or modifying Ingress resources
-                        in order to route requests for '/.well-known/acme-challenge/XYZ'
-                        to 'challenge solver' pods that are provisioned by cert-manager
-                        for each Challenge to be completed.
-                      type: object
-                      properties:
-                        class:
-                          description: The ingress class to use when creating Ingress
-                            resources to solve ACME challenges that use this challenge
-                            solver. Only one of 'class' or 'name' may be specified.
-                          type: string
-                        ingressTemplate:
-                          description: Optional ingress template used to configure
-                            the ACME challenge solver ingress used for HTTP01 challenges
-                          type: object
-                          properties:
-                            metadata:
-                              description: ObjectMeta overrides for the ingress used
-                                to solve HTTP01 challenges. Only the 'labels' and
-                                'annotations' fields may be set. If labels or annotations
-                                overlap with in-built values, the values here will
-                                override the in-built values.
-                              type: object
-                              properties:
-                                annotations:
-                                  description: Annotations that should be added to
-                                    the created ACME HTTP01 solver ingress.
-                                  type: object
-                                  additionalProperties:
-                                    type: string
-                                labels:
-                                  description: Labels that should be added to the
-                                    created ACME HTTP01 solver ingress.
-                                  type: object
-                                  additionalProperties:
-                                    type: string
-                        name:
-                          description: The name of the ingress resource that should
-                            have ACME challenge solving routes inserted into it in
-                            order to solve HTTP01 challenges. This is typically used
-                            in conjunction with ingress controllers like ingress-gce,
-                            which maintains a 1:1 mapping between external IPs and
-                            ingress resources.
-                          type: string
-                        podTemplate:
-                          description: Optional pod template used to configure the
-                            ACME challenge solver pods used for HTTP01 challenges
-                          type: object
-                          properties:
-                            metadata:
-                              description: ObjectMeta overrides for the pod used to
-                                solve HTTP01 challenges. Only the 'labels' and 'annotations'
-                                fields may be set. If labels or annotations overlap
-                                with in-built values, the values here will override
-                                the in-built values.
-                              type: object
-                              properties:
-                                annotations:
-                                  description: Annotations that should be added to
-                                    the create ACME HTTP01 solver pods.
-                                  type: object
-                                  additionalProperties:
-                                    type: string
-                                labels:
-                                  description: Labels that should be added to the
-                                    created ACME HTTP01 solver pods.
-                                  type: object
-                                  additionalProperties:
-                                    type: string
-                            spec:
-                              description: PodSpec defines overrides for the HTTP01
-                                challenge solver pod. Only the 'nodeSelector', 'affinity'
-                                and 'tolerations' fields are supported currently.
-                                All other fields will be ignored.
-                              type: object
-                              properties:
-                                affinity:
-                                  description: If specified, the pod's scheduling
-                                    constraints
-                                  type: object
-                                  properties:
-                                    nodeAffinity:
-                                      description: Describes node affinity scheduling
-                                        rules for the pod.
-                                      type: object
-                                      properties:
-                                        preferredDuringSchedulingIgnoredDuringExecution:
-                                          description: The scheduler will prefer to
-                                            schedule pods to nodes that satisfy the
-                                            affinity expressions specified by this
-                                            field, but it may choose a node that violates
-                                            one or more of the expressions. The node
-                                            that is most preferred is the one with
-                                            the greatest sum of weights, i.e. for
-                                            each node that meets all of the scheduling
-                                            requirements (resource request, requiredDuringScheduling
-                                            affinity expressions, etc.), compute a
-                                            sum by iterating through the elements
-                                            of this field and adding "weight" to the
-                                            sum if the node matches the corresponding
-                                            matchExpressions; the node(s) with the
-                                            highest sum are the most preferred.
-                                          type: array
-                                          items:
-                                            description: An empty preferred scheduling
-                                              term matches all objects with implicit
-                                              weight 0 (i.e. it's a no-op). A null
-                                              preferred scheduling term matches no
-                                              objects (i.e. is also a no-op).
-                                            type: object
-                                            required:
-                                            - preference
-                                            - weight
-                                            properties:
-                                              preference:
-                                                description: A node selector term,
-                                                  associated with the corresponding
-                                                  weight.
-                                                type: object
-                                                properties:
-                                                  matchExpressions:
-                                                    description: A list of node selector
-                                                      requirements by node's labels.
-                                                    type: array
-                                                    items:
-                                                      description: A node selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
-                                                      type: object
-                                                      required:
-                                                      - key
-                                                      - operator
-                                                      properties:
-                                                        key:
-                                                          description: The label key
-                                                            that the selector applies
-                                                            to.
-                                                          type: string
-                                                        operator:
-                                                          description: Represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists, DoesNotExist.
-                                                            Gt, and Lt.
-                                                          type: string
-                                                        values:
-                                                          description: An array of
-                                                            string values. If the
-                                                            operator is In or NotIn,
-                                                            the values array must
-                                                            be non-empty. If the operator
-                                                            is Exists or DoesNotExist,
-                                                            the values array must
-                                                            be empty. If the operator
-                                                            is Gt or Lt, the values
-                                                            array must have a single
-                                                            element, which will be
-                                                            interpreted as an integer.
-                                                            This array is replaced
-                                                            during a strategic merge
-                                                            patch.
-                                                          type: array
-                                                          items:
-                                                            type: string
-                                                  matchFields:
-                                                    description: A list of node selector
-                                                      requirements by node's fields.
-                                                    type: array
-                                                    items:
-                                                      description: A node selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
-                                                      type: object
-                                                      required:
-                                                      - key
-                                                      - operator
-                                                      properties:
-                                                        key:
-                                                          description: The label key
-                                                            that the selector applies
-                                                            to.
-                                                          type: string
-                                                        operator:
-                                                          description: Represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists, DoesNotExist.
-                                                            Gt, and Lt.
-                                                          type: string
-                                                        values:
-                                                          description: An array of
-                                                            string values. If the
-                                                            operator is In or NotIn,
-                                                            the values array must
-                                                            be non-empty. If the operator
-                                                            is Exists or DoesNotExist,
-                                                            the values array must
-                                                            be empty. If the operator
-                                                            is Gt or Lt, the values
-                                                            array must have a single
-                                                            element, which will be
-                                                            interpreted as an integer.
-                                                            This array is replaced
-                                                            during a strategic merge
-                                                            patch.
-                                                          type: array
-                                                          items:
-                                                            type: string
-                                              weight:
-                                                description: Weight associated with
-                                                  matching the corresponding nodeSelectorTerm,
-                                                  in the range 1-100.
-                                                type: integer
-                                                format: int32
-                                        requiredDuringSchedulingIgnoredDuringExecution:
-                                          description: If the affinity requirements
-                                            specified by this field are not met at
-                                            scheduling time, the pod will not be scheduled
-                                            onto the node. If the affinity requirements
-                                            specified by this field cease to be met
-                                            at some point during pod execution (e.g.
-                                            due to an update), the system may or may
-                                            not try to eventually evict the pod from
-                                            its node.
-                                          type: object
-                                          required:
-                                          - nodeSelectorTerms
-                                          properties:
-                                            nodeSelectorTerms:
-                                              description: Required. A list of node
-                                                selector terms. The terms are ORed.
-                                              type: array
-                                              items:
-                                                description: A null or empty node
-                                                  selector term matches no objects.
-                                                  The requirements of them are ANDed.
-                                                  The TopologySelectorTerm type implements
-                                                  a subset of the NodeSelectorTerm.
-                                                type: object
-                                                properties:
-                                                  matchExpressions:
-                                                    description: A list of node selector
-                                                      requirements by node's labels.
-                                                    type: array
-                                                    items:
-                                                      description: A node selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
-                                                      type: object
-                                                      required:
-                                                      - key
-                                                      - operator
-                                                      properties:
-                                                        key:
-                                                          description: The label key
-                                                            that the selector applies
-                                                            to.
-                                                          type: string
-                                                        operator:
-                                                          description: Represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists, DoesNotExist.
-                                                            Gt, and Lt.
-                                                          type: string
-                                                        values:
-                                                          description: An array of
-                                                            string values. If the
-                                                            operator is In or NotIn,
-                                                            the values array must
-                                                            be non-empty. If the operator
-                                                            is Exists or DoesNotExist,
-                                                            the values array must
-                                                            be empty. If the operator
-                                                            is Gt or Lt, the values
-                                                            array must have a single
-                                                            element, which will be
-                                                            interpreted as an integer.
-                                                            This array is replaced
-                                                            during a strategic merge
-                                                            patch.
-                                                          type: array
-                                                          items:
-                                                            type: string
-                                                  matchFields:
-                                                    description: A list of node selector
-                                                      requirements by node's fields.
-                                                    type: array
-                                                    items:
-                                                      description: A node selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
-                                                      type: object
-                                                      required:
-                                                      - key
-                                                      - operator
-                                                      properties:
-                                                        key:
-                                                          description: The label key
-                                                            that the selector applies
-                                                            to.
-                                                          type: string
-                                                        operator:
-                                                          description: Represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists, DoesNotExist.
-                                                            Gt, and Lt.
-                                                          type: string
-                                                        values:
-                                                          description: An array of
-                                                            string values. If the
-                                                            operator is In or NotIn,
-                                                            the values array must
-                                                            be non-empty. If the operator
-                                                            is Exists or DoesNotExist,
-                                                            the values array must
-                                                            be empty. If the operator
-                                                            is Gt or Lt, the values
-                                                            array must have a single
-                                                            element, which will be
-                                                            interpreted as an integer.
-                                                            This array is replaced
-                                                            during a strategic merge
-                                                            patch.
-                                                          type: array
-                                                          items:
-                                                            type: string
-                                    podAffinity:
-                                      description: Describes pod affinity scheduling
-                                        rules (e.g. co-locate this pod in the same
-                                        node, zone, etc. as some other pod(s)).
-                                      type: object
-                                      properties:
-                                        preferredDuringSchedulingIgnoredDuringExecution:
-                                          description: The scheduler will prefer to
-                                            schedule pods to nodes that satisfy the
-                                            affinity expressions specified by this
-                                            field, but it may choose a node that violates
-                                            one or more of the expressions. The node
-                                            that is most preferred is the one with
-                                            the greatest sum of weights, i.e. for
-                                            each node that meets all of the scheduling
-                                            requirements (resource request, requiredDuringScheduling
-                                            affinity expressions, etc.), compute a
-                                            sum by iterating through the elements
-                                            of this field and adding "weight" to the
-                                            sum if the node has pods which matches
-                                            the corresponding podAffinityTerm; the
-                                            node(s) with the highest sum are the most
-                                            preferred.
-                                          type: array
-                                          items:
-                                            description: The weights of all of the
-                                              matched WeightedPodAffinityTerm fields
-                                              are added per-node to find the most
-                                              preferred node(s)
-                                            type: object
-                                            required:
-                                            - podAffinityTerm
-                                            - weight
-                                            properties:
-                                              podAffinityTerm:
-                                                description: Required. A pod affinity
-                                                  term, associated with the corresponding
-                                                  weight.
-                                                type: object
-                                                required:
-                                                - topologyKey
-                                                properties:
-                                                  labelSelector:
-                                                    description: A label query over
-                                                      a set of resources, in this
-                                                      case pods.
-                                                    type: object
-                                                    properties:
-                                                      matchExpressions:
-                                                        description: matchExpressions
-                                                          is a list of label selector
-                                                          requirements. The requirements
-                                                          are ANDed.
-                                                        type: array
-                                                        items:
-                                                          description: A label selector
-                                                            requirement is a selector
-                                                            that contains values,
-                                                            a key, and an operator
-                                                            that relates the key and
-                                                            values.
-                                                          type: object
-                                                          required:
-                                                          - key
-                                                          - operator
-                                                          properties:
-                                                            key:
-                                                              description: key is
-                                                                the label key that
-                                                                the selector applies
-                                                                to.
-                                                              type: string
-                                                            operator:
-                                                              description: operator
-                                                                represents a key's
-                                                                relationship to a
-                                                                set of values. Valid
-                                                                operators are In,
-                                                                NotIn, Exists and
-                                                                DoesNotExist.
-                                                              type: string
-                                                            values:
-                                                              description: values
-                                                                is an array of string
-                                                                values. If the operator
-                                                                is In or NotIn, the
-                                                                values array must
-                                                                be non-empty. If the
-                                                                operator is Exists
-                                                                or DoesNotExist, the
-                                                                values array must
-                                                                be empty. This array
-                                                                is replaced during
-                                                                a strategic merge
-                                                                patch.
-                                                              type: array
-                                                              items:
-                                                                type: string
-                                                      matchLabels:
-                                                        description: matchLabels is
-                                                          a map of {key,value} pairs.
-                                                          A single {key,value} in
-                                                          the matchLabels map is equivalent
-                                                          to an element of matchExpressions,
-                                                          whose key field is "key",
-                                                          the operator is "In", and
-                                                          the values array contains
-                                                          only "value". The requirements
-                                                          are ANDed.
-                                                        type: object
-                                                        additionalProperties:
-                                                          type: string
-                                                  namespaces:
-                                                    description: namespaces specifies
-                                                      which namespaces the labelSelector
-                                                      applies to (matches against);
-                                                      null or empty list means "this
-                                                      pod's namespace"
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                                  topologyKey:
-                                                    description: This pod should be
-                                                      co-located (affinity) or not
-                                                      co-located (anti-affinity) with
-                                                      the pods matching the labelSelector
-                                                      in the specified namespaces,
-                                                      where co-located is defined
-                                                      as running on a node whose value
-                                                      of the label with key topologyKey
-                                                      matches that of any node on
-                                                      which any of the selected pods
-                                                      is running. Empty topologyKey
-                                                      is not allowed.
-                                                    type: string
-                                              weight:
-                                                description: weight associated with
-                                                  matching the corresponding podAffinityTerm,
-                                                  in the range 1-100.
-                                                type: integer
-                                                format: int32
-                                        requiredDuringSchedulingIgnoredDuringExecution:
-                                          description: If the affinity requirements
-                                            specified by this field are not met at
-                                            scheduling time, the pod will not be scheduled
-                                            onto the node. If the affinity requirements
-                                            specified by this field cease to be met
-                                            at some point during pod execution (e.g.
-                                            due to a pod label update), the system
-                                            may or may not try to eventually evict
-                                            the pod from its node. When there are
-                                            multiple elements, the lists of nodes
-                                            corresponding to each podAffinityTerm
-                                            are intersected, i.e. all terms must be
-                                            satisfied.
-                                          type: array
-                                          items:
-                                            description: Defines a set of pods (namely
-                                              those matching the labelSelector relative
-                                              to the given namespace(s)) that this
-                                              pod should be co-located (affinity)
-                                              or not co-located (anti-affinity) with,
-                                              where co-located is defined as running
-                                              on a node whose value of the label with
-                                              key <topologyKey> matches that of any
-                                              node on which a pod of the set of pods
-                                              is running
-                                            type: object
-                                            required:
-                                            - topologyKey
-                                            properties:
-                                              labelSelector:
-                                                description: A label query over a
-                                                  set of resources, in this case pods.
-                                                type: object
-                                                properties:
-                                                  matchExpressions:
-                                                    description: matchExpressions
-                                                      is a list of label selector
-                                                      requirements. The requirements
-                                                      are ANDed.
-                                                    type: array
-                                                    items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
-                                                      type: object
-                                                      required:
-                                                      - key
-                                                      - operator
-                                                      properties:
-                                                        key:
-                                                          description: key is the
-                                                            label key that the selector
-                                                            applies to.
-                                                          type: string
-                                                        operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
-                                                          type: string
-                                                        values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
-                                                          type: array
-                                                          items:
-                                                            type: string
-                                                  matchLabels:
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
-                                                    type: object
-                                                    additionalProperties:
-                                                      type: string
-                                              namespaces:
-                                                description: namespaces specifies
-                                                  which namespaces the labelSelector
-                                                  applies to (matches against); null
-                                                  or empty list means "this pod's
-                                                  namespace"
-                                                type: array
-                                                items:
-                                                  type: string
-                                              topologyKey:
-                                                description: This pod should be co-located
-                                                  (affinity) or not co-located (anti-affinity)
-                                                  with the pods matching the labelSelector
-                                                  in the specified namespaces, where
-                                                  co-located is defined as running
-                                                  on a node whose value of the label
-                                                  with key topologyKey matches that
-                                                  of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
-                                                type: string
-                                    podAntiAffinity:
-                                      description: Describes pod anti-affinity scheduling
-                                        rules (e.g. avoid putting this pod in the
-                                        same node, zone, etc. as some other pod(s)).
-                                      type: object
-                                      properties:
-                                        preferredDuringSchedulingIgnoredDuringExecution:
-                                          description: The scheduler will prefer to
-                                            schedule pods to nodes that satisfy the
-                                            anti-affinity expressions specified by
-                                            this field, but it may choose a node that
-                                            violates one or more of the expressions.
-                                            The node that is most preferred is the
-                                            one with the greatest sum of weights,
-                                            i.e. for each node that meets all of the
-                                            scheduling requirements (resource request,
-                                            requiredDuringScheduling anti-affinity
-                                            expressions, etc.), compute a sum by iterating
-                                            through the elements of this field and
-                                            adding "weight" to the sum if the node
-                                            has pods which matches the corresponding
-                                            podAffinityTerm; the node(s) with the
-                                            highest sum are the most preferred.
-                                          type: array
-                                          items:
-                                            description: The weights of all of the
-                                              matched WeightedPodAffinityTerm fields
-                                              are added per-node to find the most
-                                              preferred node(s)
-                                            type: object
-                                            required:
-                                            - podAffinityTerm
-                                            - weight
-                                            properties:
-                                              podAffinityTerm:
-                                                description: Required. A pod affinity
-                                                  term, associated with the corresponding
-                                                  weight.
-                                                type: object
-                                                required:
-                                                - topologyKey
-                                                properties:
-                                                  labelSelector:
-                                                    description: A label query over
-                                                      a set of resources, in this
-                                                      case pods.
-                                                    type: object
-                                                    properties:
-                                                      matchExpressions:
-                                                        description: matchExpressions
-                                                          is a list of label selector
-                                                          requirements. The requirements
-                                                          are ANDed.
-                                                        type: array
-                                                        items:
-                                                          description: A label selector
-                                                            requirement is a selector
-                                                            that contains values,
-                                                            a key, and an operator
-                                                            that relates the key and
-                                                            values.
-                                                          type: object
-                                                          required:
-                                                          - key
-                                                          - operator
-                                                          properties:
-                                                            key:
-                                                              description: key is
-                                                                the label key that
-                                                                the selector applies
-                                                                to.
-                                                              type: string
-                                                            operator:
-                                                              description: operator
-                                                                represents a key's
-                                                                relationship to a
-                                                                set of values. Valid
-                                                                operators are In,
-                                                                NotIn, Exists and
-                                                                DoesNotExist.
-                                                              type: string
-                                                            values:
-                                                              description: values
-                                                                is an array of string
-                                                                values. If the operator
-                                                                is In or NotIn, the
-                                                                values array must
-                                                                be non-empty. If the
-                                                                operator is Exists
-                                                                or DoesNotExist, the
-                                                                values array must
-                                                                be empty. This array
-                                                                is replaced during
-                                                                a strategic merge
-                                                                patch.
-                                                              type: array
-                                                              items:
-                                                                type: string
-                                                      matchLabels:
-                                                        description: matchLabels is
-                                                          a map of {key,value} pairs.
-                                                          A single {key,value} in
-                                                          the matchLabels map is equivalent
-                                                          to an element of matchExpressions,
-                                                          whose key field is "key",
-                                                          the operator is "In", and
-                                                          the values array contains
-                                                          only "value". The requirements
-                                                          are ANDed.
-                                                        type: object
-                                                        additionalProperties:
-                                                          type: string
-                                                  namespaces:
-                                                    description: namespaces specifies
-                                                      which namespaces the labelSelector
-                                                      applies to (matches against);
-                                                      null or empty list means "this
-                                                      pod's namespace"
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                                  topologyKey:
-                                                    description: This pod should be
-                                                      co-located (affinity) or not
-                                                      co-located (anti-affinity) with
-                                                      the pods matching the labelSelector
-                                                      in the specified namespaces,
-                                                      where co-located is defined
-                                                      as running on a node whose value
-                                                      of the label with key topologyKey
-                                                      matches that of any node on
-                                                      which any of the selected pods
-                                                      is running. Empty topologyKey
-                                                      is not allowed.
-                                                    type: string
-                                              weight:
-                                                description: weight associated with
-                                                  matching the corresponding podAffinityTerm,
-                                                  in the range 1-100.
-                                                type: integer
-                                                format: int32
-                                        requiredDuringSchedulingIgnoredDuringExecution:
-                                          description: If the anti-affinity requirements
-                                            specified by this field are not met at
-                                            scheduling time, the pod will not be scheduled
-                                            onto the node. If the anti-affinity requirements
-                                            specified by this field cease to be met
-                                            at some point during pod execution (e.g.
-                                            due to a pod label update), the system
-                                            may or may not try to eventually evict
-                                            the pod from its node. When there are
-                                            multiple elements, the lists of nodes
-                                            corresponding to each podAffinityTerm
-                                            are intersected, i.e. all terms must be
-                                            satisfied.
-                                          type: array
-                                          items:
-                                            description: Defines a set of pods (namely
-                                              those matching the labelSelector relative
-                                              to the given namespace(s)) that this
-                                              pod should be co-located (affinity)
-                                              or not co-located (anti-affinity) with,
-                                              where co-located is defined as running
-                                              on a node whose value of the label with
-                                              key <topologyKey> matches that of any
-                                              node on which a pod of the set of pods
-                                              is running
-                                            type: object
-                                            required:
-                                            - topologyKey
-                                            properties:
-                                              labelSelector:
-                                                description: A label query over a
-                                                  set of resources, in this case pods.
-                                                type: object
-                                                properties:
-                                                  matchExpressions:
-                                                    description: matchExpressions
-                                                      is a list of label selector
-                                                      requirements. The requirements
-                                                      are ANDed.
-                                                    type: array
-                                                    items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
-                                                      type: object
-                                                      required:
-                                                      - key
-                                                      - operator
-                                                      properties:
-                                                        key:
-                                                          description: key is the
-                                                            label key that the selector
-                                                            applies to.
-                                                          type: string
-                                                        operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
-                                                          type: string
-                                                        values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
-                                                          type: array
-                                                          items:
-                                                            type: string
-                                                  matchLabels:
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
-                                                    type: object
-                                                    additionalProperties:
-                                                      type: string
-                                              namespaces:
-                                                description: namespaces specifies
-                                                  which namespaces the labelSelector
-                                                  applies to (matches against); null
-                                                  or empty list means "this pod's
-                                                  namespace"
-                                                type: array
-                                                items:
-                                                  type: string
-                                              topologyKey:
-                                                description: This pod should be co-located
-                                                  (affinity) or not co-located (anti-affinity)
-                                                  with the pods matching the labelSelector
-                                                  in the specified namespaces, where
-                                                  co-located is defined as running
-                                                  on a node whose value of the label
-                                                  with key topologyKey matches that
-                                                  of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
-                                                type: string
-                                nodeSelector:
-                                  description: 'NodeSelector is a selector which must
-                                    be true for the pod to fit on a node. Selector
-                                    which must match a node''s labels for the pod
-                                    to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
-                                  type: object
-                                  additionalProperties:
-                                    type: string
-                                tolerations:
-                                  description: If specified, the pod's tolerations.
-                                  type: array
-                                  items:
-                                    description: The pod this Toleration is attached
-                                      to tolerates any taint that matches the triple
-                                      <key,value,effect> using the matching operator
-                                      <operator>.
+    "schema":
+      "openAPIV3Schema":
+        description: Challenge is a type to represent a Challenge request with an
+          ACME server
+        type: object
+        required:
+        - metadata
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            required:
+            - authzURL
+            - dnsName
+            - issuerRef
+            - key
+            - solver
+            - token
+            - type
+            - url
+            properties:
+              authzURL:
+                description: AuthzURL is the URL to the ACME Authorization resource
+                  that this challenge is a part of.
+                type: string
+              dnsName:
+                description: DNSName is the identifier that this challenge is for,
+                  e.g. example.com. If the requested DNSName is a 'wildcard', this
+                  field MUST be set to the non-wildcard domain, e.g. for `*.example.com`,
+                  it must be `example.com`.
+                type: string
+              issuerRef:
+                description: IssuerRef references a properly configured ACME-type
+                  Issuer which should be used to create this Challenge. If the Issuer
+                  does not exist, processing will be retried. If the Issuer is not
+                  an 'ACME' Issuer, an error will be returned and the Challenge will
+                  be marked as failed.
+                type: object
+                required:
+                - name
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+              key:
+                description: 'Key is the ACME challenge key for this challenge For
+                  HTTP01 challenges, this is the value that must be responded with
+                  to complete the HTTP01 challenge in the format: `<private key JWK
+                  thumbprint>.<key from acme server for challenge>`. For DNS01 challenges,
+                  this is the base64 encoded SHA256 sum of the `<private key JWK thumbprint>.<key
+                  from acme server for challenge>` text that must be set as the TXT
+                  record content.'
+                type: string
+              solver:
+                description: Solver contains the domain solving configuration that
+                  should be used to solve this challenge resource.
+                type: object
+                properties:
+                  dns01:
+                    description: Configures cert-manager to attempt to complete authorizations
+                      by performing the DNS01 challenge flow.
+                    type: object
+                    properties:
+                      acmedns:
+                        description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns)
+                          API to manage DNS01 challenge records.
+                        type: object
+                        required:
+                        - accountSecretRef
+                        - host
+                        properties:
+                          accountSecretRef:
+                            description: A reference to a specific 'key' within a
+                              Secret resource. In some instances, `key` is a required
+                              field.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                          host:
+                            type: string
+                      akamai:
+                        description: Use the Akamai DNS zone management API to manage
+                          DNS01 challenge records.
+                        type: object
+                        required:
+                        - accessTokenSecretRef
+                        - clientSecretSecretRef
+                        - clientTokenSecretRef
+                        - serviceConsumerDomain
+                        properties:
+                          accessTokenSecretRef:
+                            description: A reference to a specific 'key' within a
+                              Secret resource. In some instances, `key` is a required
+                              field.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                          clientSecretSecretRef:
+                            description: A reference to a specific 'key' within a
+                              Secret resource. In some instances, `key` is a required
+                              field.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                          clientTokenSecretRef:
+                            description: A reference to a specific 'key' within a
+                              Secret resource. In some instances, `key` is a required
+                              field.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                          serviceConsumerDomain:
+                            type: string
+                      azuredns:
+                        description: Use the Microsoft Azure DNS API to manage DNS01
+                          challenge records.
+                        type: object
+                        required:
+                        - resourceGroupName
+                        - subscriptionID
+                        properties:
+                          clientID:
+                            description: if both this and ClientSecret are left unset
+                              MSI will be used
+                            type: string
+                          clientSecretSecretRef:
+                            description: if both this and ClientID are left unset
+                              MSI will be used
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                          environment:
+                            type: string
+                            enum:
+                            - AzurePublicCloud
+                            - AzureChinaCloud
+                            - AzureGermanCloud
+                            - AzureUSGovernmentCloud
+                          hostedZoneName:
+                            type: string
+                          resourceGroupName:
+                            type: string
+                          subscriptionID:
+                            type: string
+                          tenantID:
+                            description: when specifying ClientID and ClientSecret
+                              then this field is also needed
+                            type: string
+                      clouddns:
+                        description: Use the Google Cloud DNS API to manage DNS01
+                          challenge records.
+                        type: object
+                        required:
+                        - project
+                        properties:
+                          hostedZoneName:
+                            description: HostedZoneName is an optional field that
+                              tells cert-manager in which Cloud DNS zone the challenge
+                              record has to be created. If left empty cert-manager
+                              will automatically choose a zone.
+                            type: string
+                          project:
+                            type: string
+                          serviceAccountSecretRef:
+                            description: A reference to a specific 'key' within a
+                              Secret resource. In some instances, `key` is a required
+                              field.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                      cloudflare:
+                        description: Use the Cloudflare API to manage DNS01 challenge
+                          records.
+                        type: object
+                        properties:
+                          apiKeySecretRef:
+                            description: 'API key to use to authenticate with Cloudflare.
+                              Note: using an API token to authenticate is now the
+                              recommended method as it allows greater control of permissions.'
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                          apiTokenSecretRef:
+                            description: API token used to authenticate with Cloudflare.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                          email:
+                            description: Email of the account, only required when
+                              using API key based authentication.
+                            type: string
+                      cnameStrategy:
+                        description: CNAMEStrategy configures how the DNS01 provider
+                          should handle CNAME records when found in DNS zones.
+                        type: string
+                        enum:
+                        - None
+                        - Follow
+                      digitalocean:
+                        description: Use the DigitalOcean DNS API to manage DNS01
+                          challenge records.
+                        type: object
+                        required:
+                        - tokenSecretRef
+                        properties:
+                          tokenSecretRef:
+                            description: A reference to a specific 'key' within a
+                              Secret resource. In some instances, `key` is a required
+                              field.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                      rfc2136:
+                        description: Use RFC2136 ("Dynamic Updates in the Domain Name
+                          System") (https://datatracker.ietf.org/doc/rfc2136/) to
+                          manage DNS01 challenge records.
+                        type: object
+                        required:
+                        - nameserver
+                        properties:
+                          nameserver:
+                            description: The IP address or hostname of an authoritative
+                              DNS server supporting RFC2136 in the form host:port.
+                              If the host is an IPv6 address it must be enclosed in
+                              square brackets (e.g [2001:db8::1]) ; port is optional.
+                              This field is required.
+                            type: string
+                          tsigAlgorithm:
+                            description: 'The TSIG Algorithm configured in the DNS
+                              supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                              and ``tsigKeyName`` are defined. Supported values are
+                              (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
+                              ``HMACSHA256`` or ``HMACSHA512``.'
+                            type: string
+                          tsigKeyName:
+                            description: The TSIG Key name configured in the DNS.
+                              If ``tsigSecretSecretRef`` is defined, this field is
+                              required.
+                            type: string
+                          tsigSecretSecretRef:
+                            description: The name of the secret containing the TSIG
+                              value. If ``tsigKeyName`` is defined, this field is
+                              required.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                      route53:
+                        description: Use the AWS Route53 API to manage DNS01 challenge
+                          records.
+                        type: object
+                        required:
+                        - region
+                        properties:
+                          accessKeyID:
+                            description: 'The AccessKeyID is used for authentication.
+                              If not set we fall-back to using env vars, shared credentials
+                              file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                            type: string
+                          hostedZoneID:
+                            description: If set, the provider will manage only this
+                              zone in Route53 and will not do an lookup using the
+                              route53:ListHostedZonesByName api call.
+                            type: string
+                          region:
+                            description: Always set the region when using AccessKeyID
+                              and SecretAccessKey
+                            type: string
+                          role:
+                            description: Role is a Role ARN which the Route53 provider
+                              will assume using either the explicit credentials AccessKeyID/SecretAccessKey
+                              or the inferred credentials from environment variables,
+                              shared credentials file or AWS Instance metadata
+                            type: string
+                          secretAccessKeySecretRef:
+                            description: The SecretAccessKey is used for authentication.
+                              If not set we fall-back to using env vars, shared credentials
+                              file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                      webhook:
+                        description: Configure an external webhook based DNS01 challenge
+                          solver to manage DNS01 challenge records.
+                        type: object
+                        required:
+                        - groupName
+                        - solverName
+                        properties:
+                          config:
+                            description: Additional configuration that should be passed
+                              to the webhook apiserver when challenges are processed.
+                              This can contain arbitrary JSON data. Secret values
+                              should not be specified in this stanza. If secret values
+                              are needed (e.g. credentials for a DNS service), you
+                              should use a SecretKeySelector to reference a Secret
+                              resource. For details on the schema of this field, consult
+                              the webhook provider implementation's documentation.
+                            x-kubernetes-preserve-unknown-fields: true
+                          groupName:
+                            description: The API group name that should be used when
+                              POSTing ChallengePayload resources to the webhook apiserver.
+                              This should be the same as the GroupName specified in
+                              the webhook provider implementation.
+                            type: string
+                          solverName:
+                            description: The name of the solver to use, as defined
+                              in the webhook provider implementation. This will typically
+                              be the name of the provider, e.g. 'cloudflare'.
+                            type: string
+                  http01:
+                    description: Configures cert-manager to attempt to complete authorizations
+                      by performing the HTTP01 challenge flow. It is not possible
+                      to obtain certificates for wildcard domain names (e.g. `*.example.com`)
+                      using the HTTP01 challenge mechanism.
+                    type: object
+                    properties:
+                      ingress:
+                        description: The ingress based HTTP01 challenge solver will
+                          solve challenges by creating or modifying Ingress resources
+                          in order to route requests for '/.well-known/acme-challenge/XYZ'
+                          to 'challenge solver' pods that are provisioned by cert-manager
+                          for each Challenge to be completed.
+                        type: object
+                        properties:
+                          class:
+                            description: The ingress class to use when creating Ingress
+                              resources to solve ACME challenges that use this challenge
+                              solver. Only one of 'class' or 'name' may be specified.
+                            type: string
+                          ingressTemplate:
+                            description: Optional ingress template used to configure
+                              the ACME challenge solver ingress used for HTTP01 challenges
+                            type: object
+                            properties:
+                              metadata:
+                                description: ObjectMeta overrides for the ingress
+                                  used to solve HTTP01 challenges. Only the 'labels'
+                                  and 'annotations' fields may be set. If labels or
+                                  annotations overlap with in-built values, the values
+                                  here will override the in-built values.
+                                type: object
+                                properties:
+                                  annotations:
+                                    description: Annotations that should be added
+                                      to the created ACME HTTP01 solver ingress.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  labels:
+                                    description: Labels that should be added to the
+                                      created ACME HTTP01 solver ingress.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                          name:
+                            description: The name of the ingress resource that should
+                              have ACME challenge solving routes inserted into it
+                              in order to solve HTTP01 challenges. This is typically
+                              used in conjunction with ingress controllers like ingress-gce,
+                              which maintains a 1:1 mapping between external IPs and
+                              ingress resources.
+                            type: string
+                          podTemplate:
+                            description: Optional pod template used to configure the
+                              ACME challenge solver pods used for HTTP01 challenges
+                            type: object
+                            properties:
+                              metadata:
+                                description: ObjectMeta overrides for the pod used
+                                  to solve HTTP01 challenges. Only the 'labels' and
+                                  'annotations' fields may be set. If labels or annotations
+                                  overlap with in-built values, the values here will
+                                  override the in-built values.
+                                type: object
+                                properties:
+                                  annotations:
+                                    description: Annotations that should be added
+                                      to the create ACME HTTP01 solver pods.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  labels:
+                                    description: Labels that should be added to the
+                                      created ACME HTTP01 solver pods.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                              spec:
+                                description: PodSpec defines overrides for the HTTP01
+                                  challenge solver pod. Only the 'nodeSelector', 'affinity'
+                                  and 'tolerations' fields are supported currently.
+                                  All other fields will be ignored.
+                                type: object
+                                properties:
+                                  affinity:
+                                    description: If specified, the pod's scheduling
+                                      constraints
                                     type: object
                                     properties:
-                                      effect:
-                                        description: Effect indicates the taint effect
-                                          to match. Empty means match all taint effects.
-                                          When specified, allowed values are NoSchedule,
-                                          PreferNoSchedule and NoExecute.
-                                        type: string
-                                      key:
-                                        description: Key is the taint key that the
-                                          toleration applies to. Empty means match
-                                          all taint keys. If the key is empty, operator
-                                          must be Exists; this combination means to
-                                          match all values and all keys.
-                                        type: string
-                                      operator:
-                                        description: Operator represents a key's relationship
-                                          to the value. Valid operators are Exists
-                                          and Equal. Defaults to Equal. Exists is
-                                          equivalent to wildcard for value, so that
-                                          a pod can tolerate all taints of a particular
-                                          category.
-                                        type: string
-                                      tolerationSeconds:
-                                        description: TolerationSeconds represents
-                                          the period of time the toleration (which
-                                          must be of effect NoExecute, otherwise this
-                                          field is ignored) tolerates the taint. By
-                                          default, it is not set, which means tolerate
-                                          the taint forever (do not evict). Zero and
-                                          negative values will be treated as 0 (evict
-                                          immediately) by the system.
-                                        type: integer
-                                        format: int64
-                                      value:
-                                        description: Value is the taint value the
-                                          toleration matches to. If the operator is
-                                          Exists, the value should be empty, otherwise
-                                          just a regular string.
-                                        type: string
-                        serviceType:
-                          description: Optional service type for Kubernetes solver
-                            service
+                                      nodeAffinity:
+                                        description: Describes node affinity scheduling
+                                          rules for the pod.
+                                        type: object
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            description: The scheduler will prefer
+                                              to schedule pods to nodes that satisfy
+                                              the affinity expressions specified by
+                                              this field, but it may choose a node
+                                              that violates one or more of the expressions.
+                                              The node that is most preferred is the
+                                              one with the greatest sum of weights,
+                                              i.e. for each node that meets all of
+                                              the scheduling requirements (resource
+                                              request, requiredDuringScheduling affinity
+                                              expressions, etc.), compute a sum by
+                                              iterating through the elements of this
+                                              field and adding "weight" to the sum
+                                              if the node matches the corresponding
+                                              matchExpressions; the node(s) with the
+                                              highest sum are the most preferred.
+                                            type: array
+                                            items:
+                                              description: An empty preferred scheduling
+                                                term matches all objects with implicit
+                                                weight 0 (i.e. it's a no-op). A null
+                                                preferred scheduling term matches
+                                                no objects (i.e. is also a no-op).
+                                              type: object
+                                              required:
+                                              - preference
+                                              - weight
+                                              properties:
+                                                preference:
+                                                  description: A node selector term,
+                                                    associated with the corresponding
+                                                    weight.
+                                                  type: object
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        labels.
+                                                      type: array
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                    matchFields:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        fields.
+                                                      type: array
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                weight:
+                                                  description: Weight associated with
+                                                    matching the corresponding nodeSelectorTerm,
+                                                    in the range 1-100.
+                                                  type: integer
+                                                  format: int32
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            description: If the affinity requirements
+                                              specified by this field are not met
+                                              at scheduling time, the pod will not
+                                              be scheduled onto the node. If the affinity
+                                              requirements specified by this field
+                                              cease to be met at some point during
+                                              pod execution (e.g. due to an update),
+                                              the system may or may not try to eventually
+                                              evict the pod from its node.
+                                            type: object
+                                            required:
+                                            - nodeSelectorTerms
+                                            properties:
+                                              nodeSelectorTerms:
+                                                description: Required. A list of node
+                                                  selector terms. The terms are ORed.
+                                                type: array
+                                                items:
+                                                  description: A null or empty node
+                                                    selector term matches no objects.
+                                                    The requirements of them are ANDed.
+                                                    The TopologySelectorTerm type
+                                                    implements a subset of the NodeSelectorTerm.
+                                                  type: object
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        labels.
+                                                      type: array
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                    matchFields:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        fields.
+                                                      type: array
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                      podAffinity:
+                                        description: Describes pod affinity scheduling
+                                          rules (e.g. co-locate this pod in the same
+                                          node, zone, etc. as some other pod(s)).
+                                        type: object
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            description: The scheduler will prefer
+                                              to schedule pods to nodes that satisfy
+                                              the affinity expressions specified by
+                                              this field, but it may choose a node
+                                              that violates one or more of the expressions.
+                                              The node that is most preferred is the
+                                              one with the greatest sum of weights,
+                                              i.e. for each node that meets all of
+                                              the scheduling requirements (resource
+                                              request, requiredDuringScheduling affinity
+                                              expressions, etc.), compute a sum by
+                                              iterating through the elements of this
+                                              field and adding "weight" to the sum
+                                              if the node has pods which matches the
+                                              corresponding podAffinityTerm; the node(s)
+                                              with the highest sum are the most preferred.
+                                            type: array
+                                            items:
+                                              description: The weights of all of the
+                                                matched WeightedPodAffinityTerm fields
+                                                are added per-node to find the most
+                                                preferred node(s)
+                                              type: object
+                                              required:
+                                              - podAffinityTerm
+                                              - weight
+                                              properties:
+                                                podAffinityTerm:
+                                                  description: Required. A pod affinity
+                                                    term, associated with the corresponding
+                                                    weight.
+                                                  type: object
+                                                  required:
+                                                  - topologyKey
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      type: object
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          type: array
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                        matchLabels:
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                          additionalProperties:
+                                                            type: string
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        which namespaces the labelSelector
+                                                        applies to (matches against);
+                                                        null or empty list means "this
+                                                        pod's namespace"
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                weight:
+                                                  description: weight associated with
+                                                    matching the corresponding podAffinityTerm,
+                                                    in the range 1-100.
+                                                  type: integer
+                                                  format: int32
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            description: If the affinity requirements
+                                              specified by this field are not met
+                                              at scheduling time, the pod will not
+                                              be scheduled onto the node. If the affinity
+                                              requirements specified by this field
+                                              cease to be met at some point during
+                                              pod execution (e.g. due to a pod label
+                                              update), the system may or may not try
+                                              to eventually evict the pod from its
+                                              node. When there are multiple elements,
+                                              the lists of nodes corresponding to
+                                              each podAffinityTerm are intersected,
+                                              i.e. all terms must be satisfied.
+                                            type: array
+                                            items:
+                                              description: Defines a set of pods (namely
+                                                those matching the labelSelector relative
+                                                to the given namespace(s)) that this
+                                                pod should be co-located (affinity)
+                                                or not co-located (anti-affinity)
+                                                with, where co-located is defined
+                                                as running on a node whose value of
+                                                the label with key <topologyKey> matches
+                                                that of any node on which a pod of
+                                                the set of pods is running
+                                              type: object
+                                              required:
+                                              - topologyKey
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  type: object
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      type: array
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                    matchLabels:
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                      additionalProperties:
+                                                        type: string
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    which namespaces the labelSelector
+                                                    applies to (matches against);
+                                                    null or empty list means "this
+                                                    pod's namespace"
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                      podAntiAffinity:
+                                        description: Describes pod anti-affinity scheduling
+                                          rules (e.g. avoid putting this pod in the
+                                          same node, zone, etc. as some other pod(s)).
+                                        type: object
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            description: The scheduler will prefer
+                                              to schedule pods to nodes that satisfy
+                                              the anti-affinity expressions specified
+                                              by this field, but it may choose a node
+                                              that violates one or more of the expressions.
+                                              The node that is most preferred is the
+                                              one with the greatest sum of weights,
+                                              i.e. for each node that meets all of
+                                              the scheduling requirements (resource
+                                              request, requiredDuringScheduling anti-affinity
+                                              expressions, etc.), compute a sum by
+                                              iterating through the elements of this
+                                              field and adding "weight" to the sum
+                                              if the node has pods which matches the
+                                              corresponding podAffinityTerm; the node(s)
+                                              with the highest sum are the most preferred.
+                                            type: array
+                                            items:
+                                              description: The weights of all of the
+                                                matched WeightedPodAffinityTerm fields
+                                                are added per-node to find the most
+                                                preferred node(s)
+                                              type: object
+                                              required:
+                                              - podAffinityTerm
+                                              - weight
+                                              properties:
+                                                podAffinityTerm:
+                                                  description: Required. A pod affinity
+                                                    term, associated with the corresponding
+                                                    weight.
+                                                  type: object
+                                                  required:
+                                                  - topologyKey
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      type: object
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          type: array
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                        matchLabels:
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                          additionalProperties:
+                                                            type: string
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        which namespaces the labelSelector
+                                                        applies to (matches against);
+                                                        null or empty list means "this
+                                                        pod's namespace"
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                weight:
+                                                  description: weight associated with
+                                                    matching the corresponding podAffinityTerm,
+                                                    in the range 1-100.
+                                                  type: integer
+                                                  format: int32
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            description: If the anti-affinity requirements
+                                              specified by this field are not met
+                                              at scheduling time, the pod will not
+                                              be scheduled onto the node. If the anti-affinity
+                                              requirements specified by this field
+                                              cease to be met at some point during
+                                              pod execution (e.g. due to a pod label
+                                              update), the system may or may not try
+                                              to eventually evict the pod from its
+                                              node. When there are multiple elements,
+                                              the lists of nodes corresponding to
+                                              each podAffinityTerm are intersected,
+                                              i.e. all terms must be satisfied.
+                                            type: array
+                                            items:
+                                              description: Defines a set of pods (namely
+                                                those matching the labelSelector relative
+                                                to the given namespace(s)) that this
+                                                pod should be co-located (affinity)
+                                                or not co-located (anti-affinity)
+                                                with, where co-located is defined
+                                                as running on a node whose value of
+                                                the label with key <topologyKey> matches
+                                                that of any node on which a pod of
+                                                the set of pods is running
+                                              type: object
+                                              required:
+                                              - topologyKey
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  type: object
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      type: array
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                    matchLabels:
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                      additionalProperties:
+                                                        type: string
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    which namespaces the labelSelector
+                                                    applies to (matches against);
+                                                    null or empty list means "this
+                                                    pod's namespace"
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                  nodeSelector:
+                                    description: 'NodeSelector is a selector which
+                                      must be true for the pod to fit on a node. Selector
+                                      which must match a node''s labels for the pod
+                                      to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  tolerations:
+                                    description: If specified, the pod's tolerations.
+                                    type: array
+                                    items:
+                                      description: The pod this Toleration is attached
+                                        to tolerates any taint that matches the triple
+                                        <key,value,effect> using the matching operator
+                                        <operator>.
+                                      type: object
+                                      properties:
+                                        effect:
+                                          description: Effect indicates the taint
+                                            effect to match. Empty means match all
+                                            taint effects. When specified, allowed
+                                            values are NoSchedule, PreferNoSchedule
+                                            and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Key is the taint key that the
+                                            toleration applies to. Empty means match
+                                            all taint keys. If the key is empty, operator
+                                            must be Exists; this combination means
+                                            to match all values and all keys.
+                                          type: string
+                                        operator:
+                                          description: Operator represents a key's
+                                            relationship to the value. Valid operators
+                                            are Exists and Equal. Defaults to Equal.
+                                            Exists is equivalent to wildcard for value,
+                                            so that a pod can tolerate all taints
+                                            of a particular category.
+                                          type: string
+                                        tolerationSeconds:
+                                          description: TolerationSeconds represents
+                                            the period of time the toleration (which
+                                            must be of effect NoExecute, otherwise
+                                            this field is ignored) tolerates the taint.
+                                            By default, it is not set, which means
+                                            tolerate the taint forever (do not evict).
+                                            Zero and negative values will be treated
+                                            as 0 (evict immediately) by the system.
+                                          type: integer
+                                          format: int64
+                                        value:
+                                          description: Value is the taint value the
+                                            toleration matches to. If the operator
+                                            is Exists, the value should be empty,
+                                            otherwise just a regular string.
+                                          type: string
+                          serviceType:
+                            description: Optional service type for Kubernetes solver
+                              service
+                            type: string
+                  selector:
+                    description: Selector selects a set of DNSNames on the Certificate
+                      resource that should be solved using this challenge solver.
+                      If not specified, the solver will be treated as the 'default'
+                      solver with the lowest priority, i.e. if any other solver has
+                      a more specific match, it will be used instead.
+                    type: object
+                    properties:
+                      dnsNames:
+                        description: List of DNSNames that this solver will be used
+                          to solve. If specified and a match is found, a dnsNames
+                          selector will take precedence over a dnsZones selector.
+                          If multiple solvers match with the same dnsNames value,
+                          the solver with the most matching labels in matchLabels
+                          will be selected. If neither has more matches, the solver
+                          defined earlier in the list will be selected.
+                        type: array
+                        items:
                           type: string
-                selector:
-                  description: Selector selects a set of DNSNames on the Certificate
-                    resource that should be solved using this challenge solver.
-                  type: object
-                  properties:
-                    dnsNames:
-                      description: List of DNSNames that this solver will be used
-                        to solve. If specified and a match is found, a dnsNames selector
-                        will take precedence over a dnsZones selector. If multiple
-                        solvers match with the same dnsNames value, the solver with
-                        the most matching labels in matchLabels will be selected.
-                        If neither has more matches, the solver defined earlier in
-                        the list will be selected.
-                      type: array
-                      items:
+                      dnsZones:
+                        description: List of DNSZones that this solver will be used
+                          to solve. The most specific DNS zone match specified here
+                          will take precedence over other DNS zone matches, so a solver
+                          specifying sys.example.com will be selected over one specifying
+                          example.com for the domain www.sys.example.com. If multiple
+                          solvers match with the same dnsZones value, the solver with
+                          the most matching labels in matchLabels will be selected.
+                          If neither has more matches, the solver defined earlier
+                          in the list will be selected.
+                        type: array
+                        items:
+                          type: string
+                      matchLabels:
+                        description: A label selector that is used to refine the set
+                          of certificate's that this challenge solver will apply to.
+                        type: object
+                        additionalProperties:
+                          type: string
+              token:
+                description: Token is the ACME challenge token for this challenge.
+                  This is the raw value returned from the ACME server.
+                type: string
+              type:
+                description: Type is the type of ACME challenge this resource represents.
+                  One of "http-01" or "dns-01".
+                type: string
+                enum:
+                - http-01
+                - dns-01
+              url:
+                description: URL is the URL of the ACME Challenge resource for this
+                  challenge. This can be used to lookup details about the status of
+                  this challenge.
+                type: string
+              wildcard:
+                description: Wildcard will be true if this challenge is for a wildcard
+                  identifier, for example '*.example.com'.
+                type: boolean
+          status:
+            type: object
+            properties:
+              presented:
+                description: Presented will be set to true if the challenge values
+                  for this challenge are currently 'presented'. This *does not* imply
+                  the self check is passing. Only that the values have been 'submitted'
+                  for the appropriate challenge mechanism (i.e. the DNS01 TXT record
+                  has been presented, or the HTTP01 configuration has been configured).
+                type: boolean
+              processing:
+                description: Processing is used to denote whether this challenge should
+                  be processed or not. This field will only be set to true by the
+                  'scheduling' component. It will only be set to false by the 'challenges'
+                  controller, after the challenge has reached a final state or timed
+                  out. If this field is set to false, the challenge controller will
+                  not take any more action.
+                type: boolean
+              reason:
+                description: Reason contains human readable information on why the
+                  Challenge is in the current state.
+                type: string
+              state:
+                description: State contains the current 'state' of the challenge.
+                  If not set, the state of the challenge is unknown.
+                type: string
+                enum:
+                - valid
+                - ready
+                - pending
+                - processing
+                - invalid
+                - expired
+                - errored
+  - name: v1beta1
+    served: true
+    storage: false
+    "schema":
+      "openAPIV3Schema":
+        description: Challenge is a type to represent a Challenge request with an
+          ACME server
+        type: object
+        required:
+        - metadata
+        - spec
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            required:
+            - authorizationURL
+            - dnsName
+            - issuerRef
+            - key
+            - solver
+            - token
+            - type
+            - url
+            properties:
+              authorizationURL:
+                description: The URL to the ACME Authorization resource that this
+                  challenge is a part of.
+                type: string
+              dnsName:
+                description: dnsName is the identifier that this challenge is for,
+                  e.g. example.com. If the requested DNSName is a 'wildcard', this
+                  field MUST be set to the non-wildcard domain, e.g. for `*.example.com`,
+                  it must be `example.com`.
+                type: string
+              issuerRef:
+                description: References a properly configured ACME-type Issuer which
+                  should be used to create this Challenge. If the Issuer does not
+                  exist, processing will be retried. If the Issuer is not an 'ACME'
+                  Issuer, an error will be returned and the Challenge will be marked
+                  as failed.
+                type: object
+                required:
+                - name
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+              key:
+                description: 'The ACME challenge key for this challenge For HTTP01
+                  challenges, this is the value that must be responded with to complete
+                  the HTTP01 challenge in the format: `<private key JWK thumbprint>.<key
+                  from acme server for challenge>`. For DNS01 challenges, this is
+                  the base64 encoded SHA256 sum of the `<private key JWK thumbprint>.<key
+                  from acme server for challenge>` text that must be set as the TXT
+                  record content.'
+                type: string
+              solver:
+                description: Contains the domain solving configuration that should
+                  be used to solve this challenge resource.
+                type: object
+                properties:
+                  dns01:
+                    description: Configures cert-manager to attempt to complete authorizations
+                      by performing the DNS01 challenge flow.
+                    type: object
+                    properties:
+                      acmeDNS:
+                        description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns)
+                          API to manage DNS01 challenge records.
+                        type: object
+                        required:
+                        - accountSecretRef
+                        - host
+                        properties:
+                          accountSecretRef:
+                            description: A reference to a specific 'key' within a
+                              Secret resource. In some instances, `key` is a required
+                              field.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                          host:
+                            type: string
+                      akamai:
+                        description: Use the Akamai DNS zone management API to manage
+                          DNS01 challenge records.
+                        type: object
+                        required:
+                        - accessTokenSecretRef
+                        - clientSecretSecretRef
+                        - clientTokenSecretRef
+                        - serviceConsumerDomain
+                        properties:
+                          accessTokenSecretRef:
+                            description: A reference to a specific 'key' within a
+                              Secret resource. In some instances, `key` is a required
+                              field.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                          clientSecretSecretRef:
+                            description: A reference to a specific 'key' within a
+                              Secret resource. In some instances, `key` is a required
+                              field.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                          clientTokenSecretRef:
+                            description: A reference to a specific 'key' within a
+                              Secret resource. In some instances, `key` is a required
+                              field.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                          serviceConsumerDomain:
+                            type: string
+                      azureDNS:
+                        description: Use the Microsoft Azure DNS API to manage DNS01
+                          challenge records.
+                        type: object
+                        required:
+                        - resourceGroupName
+                        - subscriptionID
+                        properties:
+                          clientID:
+                            description: if both this and ClientSecret are left unset
+                              MSI will be used
+                            type: string
+                          clientSecretSecretRef:
+                            description: if both this and ClientID are left unset
+                              MSI will be used
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                          environment:
+                            type: string
+                            enum:
+                            - AzurePublicCloud
+                            - AzureChinaCloud
+                            - AzureGermanCloud
+                            - AzureUSGovernmentCloud
+                          hostedZoneName:
+                            type: string
+                          resourceGroupName:
+                            type: string
+                          subscriptionID:
+                            type: string
+                          tenantID:
+                            description: when specifying ClientID and ClientSecret
+                              then this field is also needed
+                            type: string
+                      cloudDNS:
+                        description: Use the Google Cloud DNS API to manage DNS01
+                          challenge records.
+                        type: object
+                        required:
+                        - project
+                        properties:
+                          hostedZoneName:
+                            description: HostedZoneName is an optional field that
+                              tells cert-manager in which Cloud DNS zone the challenge
+                              record has to be created. If left empty cert-manager
+                              will automatically choose a zone.
+                            type: string
+                          project:
+                            type: string
+                          serviceAccountSecretRef:
+                            description: A reference to a specific 'key' within a
+                              Secret resource. In some instances, `key` is a required
+                              field.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                      cloudflare:
+                        description: Use the Cloudflare API to manage DNS01 challenge
+                          records.
+                        type: object
+                        properties:
+                          apiKeySecretRef:
+                            description: 'API key to use to authenticate with Cloudflare.
+                              Note: using an API token to authenticate is now the
+                              recommended method as it allows greater control of permissions.'
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                          apiTokenSecretRef:
+                            description: API token used to authenticate with Cloudflare.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                          email:
+                            description: Email of the account, only required when
+                              using API key based authentication.
+                            type: string
+                      cnameStrategy:
+                        description: CNAMEStrategy configures how the DNS01 provider
+                          should handle CNAME records when found in DNS zones.
                         type: string
-                    dnsZones:
-                      description: List of DNSZones that this solver will be used
-                        to solve. The most specific DNS zone match specified here
-                        will take precedence over other DNS zone matches, so a solver
-                        specifying sys.example.com will be selected over one specifying
-                        example.com for the domain www.sys.example.com. If multiple
-                        solvers match with the same dnsZones value, the solver with
-                        the most matching labels in matchLabels will be selected.
-                        If neither has more matches, the solver defined earlier in
-                        the list will be selected.
-                      type: array
-                      items:
-                        type: string
-                    matchLabels:
-                      description: A label selector that is used to refine the set
-                        of certificate's that this challenge solver will apply to.
-                      type: object
-                      additionalProperties:
-                        type: string
-            token:
-              description: Token is the ACME challenge token for this challenge. This
-                is the raw value returned from the ACME server.
-              type: string
-            type:
-              description: Type is the type of ACME challenge this resource represents,
-                e.g. "dns01" or "http01".
-              type: string
-            url:
-              description: URL is the URL of the ACME Challenge resource for this
-                challenge. This can be used to lookup details about the status of
-                this challenge.
-              type: string
-            wildcard:
-              description: Wildcard will be true if this challenge is for a wildcard
-                identifier, for example '*.example.com'.
-              type: boolean
-        status:
-          type: object
-          properties:
-            presented:
-              description: Presented will be set to true if the challenge values for
-                this challenge are currently 'presented'. This *does not* imply the
-                self check is passing. Only that the values have been 'submitted'
-                for the appropriate challenge mechanism (i.e. the DNS01 TXT record
-                has been presented, or the HTTP01 configuration has been configured).
-              type: boolean
-            processing:
-              description: Processing is used to denote whether this challenge should
-                be processed or not. This field will only be set to true by the 'scheduling'
-                component. It will only be set to false by the 'challenges' controller,
-                after the challenge has reached a final state or timed out. If this
-                field is set to false, the challenge controller will not take any
-                more action.
-              type: boolean
-            reason:
-              description: Reason contains human readable information on why the Challenge
-                is in the current state.
-              type: string
-            state:
-              description: State contains the current 'state' of the challenge. If
-                not set, the state of the challenge is unknown.
-              type: string
-              enum:
-              - valid
-              - ready
-              - pending
-              - processing
-              - invalid
-              - expired
-              - errored
+                        enum:
+                        - None
+                        - Follow
+                      digitalocean:
+                        description: Use the DigitalOcean DNS API to manage DNS01
+                          challenge records.
+                        type: object
+                        required:
+                        - tokenSecretRef
+                        properties:
+                          tokenSecretRef:
+                            description: A reference to a specific 'key' within a
+                              Secret resource. In some instances, `key` is a required
+                              field.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                      rfc2136:
+                        description: Use RFC2136 ("Dynamic Updates in the Domain Name
+                          System") (https://datatracker.ietf.org/doc/rfc2136/) to
+                          manage DNS01 challenge records.
+                        type: object
+                        required:
+                        - nameserver
+                        properties:
+                          nameserver:
+                            description: The IP address or hostname of an authoritative
+                              DNS server supporting RFC2136 in the form host:port.
+                              If the host is an IPv6 address it must be enclosed in
+                              square brackets (e.g [2001:db8::1]) ; port is optional.
+                              This field is required.
+                            type: string
+                          tsigAlgorithm:
+                            description: 'The TSIG Algorithm configured in the DNS
+                              supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                              and ``tsigKeyName`` are defined. Supported values are
+                              (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
+                              ``HMACSHA256`` or ``HMACSHA512``.'
+                            type: string
+                          tsigKeyName:
+                            description: The TSIG Key name configured in the DNS.
+                              If ``tsigSecretSecretRef`` is defined, this field is
+                              required.
+                            type: string
+                          tsigSecretSecretRef:
+                            description: The name of the secret containing the TSIG
+                              value. If ``tsigKeyName`` is defined, this field is
+                              required.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                      route53:
+                        description: Use the AWS Route53 API to manage DNS01 challenge
+                          records.
+                        type: object
+                        required:
+                        - region
+                        properties:
+                          accessKeyID:
+                            description: 'The AccessKeyID is used for authentication.
+                              If not set we fall-back to using env vars, shared credentials
+                              file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                            type: string
+                          hostedZoneID:
+                            description: If set, the provider will manage only this
+                              zone in Route53 and will not do an lookup using the
+                              route53:ListHostedZonesByName api call.
+                            type: string
+                          region:
+                            description: Always set the region when using AccessKeyID
+                              and SecretAccessKey
+                            type: string
+                          role:
+                            description: Role is a Role ARN which the Route53 provider
+                              will assume using either the explicit credentials AccessKeyID/SecretAccessKey
+                              or the inferred credentials from environment variables,
+                              shared credentials file or AWS Instance metadata
+                            type: string
+                          secretAccessKeySecretRef:
+                            description: The SecretAccessKey is used for authentication.
+                              If not set we fall-back to using env vars, shared credentials
+                              file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                      webhook:
+                        description: Configure an external webhook based DNS01 challenge
+                          solver to manage DNS01 challenge records.
+                        type: object
+                        required:
+                        - groupName
+                        - solverName
+                        properties:
+                          config:
+                            description: Additional configuration that should be passed
+                              to the webhook apiserver when challenges are processed.
+                              This can contain arbitrary JSON data. Secret values
+                              should not be specified in this stanza. If secret values
+                              are needed (e.g. credentials for a DNS service), you
+                              should use a SecretKeySelector to reference a Secret
+                              resource. For details on the schema of this field, consult
+                              the webhook provider implementation's documentation.
+                            x-kubernetes-preserve-unknown-fields: true
+                          groupName:
+                            description: The API group name that should be used when
+                              POSTing ChallengePayload resources to the webhook apiserver.
+                              This should be the same as the GroupName specified in
+                              the webhook provider implementation.
+                            type: string
+                          solverName:
+                            description: The name of the solver to use, as defined
+                              in the webhook provider implementation. This will typically
+                              be the name of the provider, e.g. 'cloudflare'.
+                            type: string
+                  http01:
+                    description: Configures cert-manager to attempt to complete authorizations
+                      by performing the HTTP01 challenge flow. It is not possible
+                      to obtain certificates for wildcard domain names (e.g. `*.example.com`)
+                      using the HTTP01 challenge mechanism.
+                    type: object
+                    properties:
+                      ingress:
+                        description: The ingress based HTTP01 challenge solver will
+                          solve challenges by creating or modifying Ingress resources
+                          in order to route requests for '/.well-known/acme-challenge/XYZ'
+                          to 'challenge solver' pods that are provisioned by cert-manager
+                          for each Challenge to be completed.
+                        type: object
+                        properties:
+                          class:
+                            description: The ingress class to use when creating Ingress
+                              resources to solve ACME challenges that use this challenge
+                              solver. Only one of 'class' or 'name' may be specified.
+                            type: string
+                          ingressTemplate:
+                            description: Optional ingress template used to configure
+                              the ACME challenge solver ingress used for HTTP01 challenges
+                            type: object
+                            properties:
+                              metadata:
+                                description: ObjectMeta overrides for the ingress
+                                  used to solve HTTP01 challenges. Only the 'labels'
+                                  and 'annotations' fields may be set. If labels or
+                                  annotations overlap with in-built values, the values
+                                  here will override the in-built values.
+                                type: object
+                                properties:
+                                  annotations:
+                                    description: Annotations that should be added
+                                      to the created ACME HTTP01 solver ingress.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  labels:
+                                    description: Labels that should be added to the
+                                      created ACME HTTP01 solver ingress.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                          name:
+                            description: The name of the ingress resource that should
+                              have ACME challenge solving routes inserted into it
+                              in order to solve HTTP01 challenges. This is typically
+                              used in conjunction with ingress controllers like ingress-gce,
+                              which maintains a 1:1 mapping between external IPs and
+                              ingress resources.
+                            type: string
+                          podTemplate:
+                            description: Optional pod template used to configure the
+                              ACME challenge solver pods used for HTTP01 challenges
+                            type: object
+                            properties:
+                              metadata:
+                                description: ObjectMeta overrides for the pod used
+                                  to solve HTTP01 challenges. Only the 'labels' and
+                                  'annotations' fields may be set. If labels or annotations
+                                  overlap with in-built values, the values here will
+                                  override the in-built values.
+                                type: object
+                                properties:
+                                  annotations:
+                                    description: Annotations that should be added
+                                      to the create ACME HTTP01 solver pods.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  labels:
+                                    description: Labels that should be added to the
+                                      created ACME HTTP01 solver pods.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                              spec:
+                                description: PodSpec defines overrides for the HTTP01
+                                  challenge solver pod. Only the 'nodeSelector', 'affinity'
+                                  and 'tolerations' fields are supported currently.
+                                  All other fields will be ignored.
+                                type: object
+                                properties:
+                                  affinity:
+                                    description: If specified, the pod's scheduling
+                                      constraints
+                                    type: object
+                                    properties:
+                                      nodeAffinity:
+                                        description: Describes node affinity scheduling
+                                          rules for the pod.
+                                        type: object
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            description: The scheduler will prefer
+                                              to schedule pods to nodes that satisfy
+                                              the affinity expressions specified by
+                                              this field, but it may choose a node
+                                              that violates one or more of the expressions.
+                                              The node that is most preferred is the
+                                              one with the greatest sum of weights,
+                                              i.e. for each node that meets all of
+                                              the scheduling requirements (resource
+                                              request, requiredDuringScheduling affinity
+                                              expressions, etc.), compute a sum by
+                                              iterating through the elements of this
+                                              field and adding "weight" to the sum
+                                              if the node matches the corresponding
+                                              matchExpressions; the node(s) with the
+                                              highest sum are the most preferred.
+                                            type: array
+                                            items:
+                                              description: An empty preferred scheduling
+                                                term matches all objects with implicit
+                                                weight 0 (i.e. it's a no-op). A null
+                                                preferred scheduling term matches
+                                                no objects (i.e. is also a no-op).
+                                              type: object
+                                              required:
+                                              - preference
+                                              - weight
+                                              properties:
+                                                preference:
+                                                  description: A node selector term,
+                                                    associated with the corresponding
+                                                    weight.
+                                                  type: object
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        labels.
+                                                      type: array
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                    matchFields:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        fields.
+                                                      type: array
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                weight:
+                                                  description: Weight associated with
+                                                    matching the corresponding nodeSelectorTerm,
+                                                    in the range 1-100.
+                                                  type: integer
+                                                  format: int32
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            description: If the affinity requirements
+                                              specified by this field are not met
+                                              at scheduling time, the pod will not
+                                              be scheduled onto the node. If the affinity
+                                              requirements specified by this field
+                                              cease to be met at some point during
+                                              pod execution (e.g. due to an update),
+                                              the system may or may not try to eventually
+                                              evict the pod from its node.
+                                            type: object
+                                            required:
+                                            - nodeSelectorTerms
+                                            properties:
+                                              nodeSelectorTerms:
+                                                description: Required. A list of node
+                                                  selector terms. The terms are ORed.
+                                                type: array
+                                                items:
+                                                  description: A null or empty node
+                                                    selector term matches no objects.
+                                                    The requirements of them are ANDed.
+                                                    The TopologySelectorTerm type
+                                                    implements a subset of the NodeSelectorTerm.
+                                                  type: object
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        labels.
+                                                      type: array
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                    matchFields:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        fields.
+                                                      type: array
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                      podAffinity:
+                                        description: Describes pod affinity scheduling
+                                          rules (e.g. co-locate this pod in the same
+                                          node, zone, etc. as some other pod(s)).
+                                        type: object
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            description: The scheduler will prefer
+                                              to schedule pods to nodes that satisfy
+                                              the affinity expressions specified by
+                                              this field, but it may choose a node
+                                              that violates one or more of the expressions.
+                                              The node that is most preferred is the
+                                              one with the greatest sum of weights,
+                                              i.e. for each node that meets all of
+                                              the scheduling requirements (resource
+                                              request, requiredDuringScheduling affinity
+                                              expressions, etc.), compute a sum by
+                                              iterating through the elements of this
+                                              field and adding "weight" to the sum
+                                              if the node has pods which matches the
+                                              corresponding podAffinityTerm; the node(s)
+                                              with the highest sum are the most preferred.
+                                            type: array
+                                            items:
+                                              description: The weights of all of the
+                                                matched WeightedPodAffinityTerm fields
+                                                are added per-node to find the most
+                                                preferred node(s)
+                                              type: object
+                                              required:
+                                              - podAffinityTerm
+                                              - weight
+                                              properties:
+                                                podAffinityTerm:
+                                                  description: Required. A pod affinity
+                                                    term, associated with the corresponding
+                                                    weight.
+                                                  type: object
+                                                  required:
+                                                  - topologyKey
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      type: object
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          type: array
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                        matchLabels:
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                          additionalProperties:
+                                                            type: string
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        which namespaces the labelSelector
+                                                        applies to (matches against);
+                                                        null or empty list means "this
+                                                        pod's namespace"
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                weight:
+                                                  description: weight associated with
+                                                    matching the corresponding podAffinityTerm,
+                                                    in the range 1-100.
+                                                  type: integer
+                                                  format: int32
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            description: If the affinity requirements
+                                              specified by this field are not met
+                                              at scheduling time, the pod will not
+                                              be scheduled onto the node. If the affinity
+                                              requirements specified by this field
+                                              cease to be met at some point during
+                                              pod execution (e.g. due to a pod label
+                                              update), the system may or may not try
+                                              to eventually evict the pod from its
+                                              node. When there are multiple elements,
+                                              the lists of nodes corresponding to
+                                              each podAffinityTerm are intersected,
+                                              i.e. all terms must be satisfied.
+                                            type: array
+                                            items:
+                                              description: Defines a set of pods (namely
+                                                those matching the labelSelector relative
+                                                to the given namespace(s)) that this
+                                                pod should be co-located (affinity)
+                                                or not co-located (anti-affinity)
+                                                with, where co-located is defined
+                                                as running on a node whose value of
+                                                the label with key <topologyKey> matches
+                                                that of any node on which a pod of
+                                                the set of pods is running
+                                              type: object
+                                              required:
+                                              - topologyKey
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  type: object
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      type: array
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                    matchLabels:
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                      additionalProperties:
+                                                        type: string
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    which namespaces the labelSelector
+                                                    applies to (matches against);
+                                                    null or empty list means "this
+                                                    pod's namespace"
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                      podAntiAffinity:
+                                        description: Describes pod anti-affinity scheduling
+                                          rules (e.g. avoid putting this pod in the
+                                          same node, zone, etc. as some other pod(s)).
+                                        type: object
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            description: The scheduler will prefer
+                                              to schedule pods to nodes that satisfy
+                                              the anti-affinity expressions specified
+                                              by this field, but it may choose a node
+                                              that violates one or more of the expressions.
+                                              The node that is most preferred is the
+                                              one with the greatest sum of weights,
+                                              i.e. for each node that meets all of
+                                              the scheduling requirements (resource
+                                              request, requiredDuringScheduling anti-affinity
+                                              expressions, etc.), compute a sum by
+                                              iterating through the elements of this
+                                              field and adding "weight" to the sum
+                                              if the node has pods which matches the
+                                              corresponding podAffinityTerm; the node(s)
+                                              with the highest sum are the most preferred.
+                                            type: array
+                                            items:
+                                              description: The weights of all of the
+                                                matched WeightedPodAffinityTerm fields
+                                                are added per-node to find the most
+                                                preferred node(s)
+                                              type: object
+                                              required:
+                                              - podAffinityTerm
+                                              - weight
+                                              properties:
+                                                podAffinityTerm:
+                                                  description: Required. A pod affinity
+                                                    term, associated with the corresponding
+                                                    weight.
+                                                  type: object
+                                                  required:
+                                                  - topologyKey
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      type: object
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          type: array
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                        matchLabels:
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                          additionalProperties:
+                                                            type: string
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        which namespaces the labelSelector
+                                                        applies to (matches against);
+                                                        null or empty list means "this
+                                                        pod's namespace"
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                weight:
+                                                  description: weight associated with
+                                                    matching the corresponding podAffinityTerm,
+                                                    in the range 1-100.
+                                                  type: integer
+                                                  format: int32
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            description: If the anti-affinity requirements
+                                              specified by this field are not met
+                                              at scheduling time, the pod will not
+                                              be scheduled onto the node. If the anti-affinity
+                                              requirements specified by this field
+                                              cease to be met at some point during
+                                              pod execution (e.g. due to a pod label
+                                              update), the system may or may not try
+                                              to eventually evict the pod from its
+                                              node. When there are multiple elements,
+                                              the lists of nodes corresponding to
+                                              each podAffinityTerm are intersected,
+                                              i.e. all terms must be satisfied.
+                                            type: array
+                                            items:
+                                              description: Defines a set of pods (namely
+                                                those matching the labelSelector relative
+                                                to the given namespace(s)) that this
+                                                pod should be co-located (affinity)
+                                                or not co-located (anti-affinity)
+                                                with, where co-located is defined
+                                                as running on a node whose value of
+                                                the label with key <topologyKey> matches
+                                                that of any node on which a pod of
+                                                the set of pods is running
+                                              type: object
+                                              required:
+                                              - topologyKey
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  type: object
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      type: array
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                    matchLabels:
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                      additionalProperties:
+                                                        type: string
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    which namespaces the labelSelector
+                                                    applies to (matches against);
+                                                    null or empty list means "this
+                                                    pod's namespace"
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                  nodeSelector:
+                                    description: 'NodeSelector is a selector which
+                                      must be true for the pod to fit on a node. Selector
+                                      which must match a node''s labels for the pod
+                                      to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  tolerations:
+                                    description: If specified, the pod's tolerations.
+                                    type: array
+                                    items:
+                                      description: The pod this Toleration is attached
+                                        to tolerates any taint that matches the triple
+                                        <key,value,effect> using the matching operator
+                                        <operator>.
+                                      type: object
+                                      properties:
+                                        effect:
+                                          description: Effect indicates the taint
+                                            effect to match. Empty means match all
+                                            taint effects. When specified, allowed
+                                            values are NoSchedule, PreferNoSchedule
+                                            and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Key is the taint key that the
+                                            toleration applies to. Empty means match
+                                            all taint keys. If the key is empty, operator
+                                            must be Exists; this combination means
+                                            to match all values and all keys.
+                                          type: string
+                                        operator:
+                                          description: Operator represents a key's
+                                            relationship to the value. Valid operators
+                                            are Exists and Equal. Defaults to Equal.
+                                            Exists is equivalent to wildcard for value,
+                                            so that a pod can tolerate all taints
+                                            of a particular category.
+                                          type: string
+                                        tolerationSeconds:
+                                          description: TolerationSeconds represents
+                                            the period of time the toleration (which
+                                            must be of effect NoExecute, otherwise
+                                            this field is ignored) tolerates the taint.
+                                            By default, it is not set, which means
+                                            tolerate the taint forever (do not evict).
+                                            Zero and negative values will be treated
+                                            as 0 (evict immediately) by the system.
+                                          type: integer
+                                          format: int64
+                                        value:
+                                          description: Value is the taint value the
+                                            toleration matches to. If the operator
+                                            is Exists, the value should be empty,
+                                            otherwise just a regular string.
+                                          type: string
+                          serviceType:
+                            description: Optional service type for Kubernetes solver
+                              service
+                            type: string
+                  selector:
+                    description: Selector selects a set of DNSNames on the Certificate
+                      resource that should be solved using this challenge solver.
+                      If not specified, the solver will be treated as the 'default'
+                      solver with the lowest priority, i.e. if any other solver has
+                      a more specific match, it will be used instead.
+                    type: object
+                    properties:
+                      dnsNames:
+                        description: List of DNSNames that this solver will be used
+                          to solve. If specified and a match is found, a dnsNames
+                          selector will take precedence over a dnsZones selector.
+                          If multiple solvers match with the same dnsNames value,
+                          the solver with the most matching labels in matchLabels
+                          will be selected. If neither has more matches, the solver
+                          defined earlier in the list will be selected.
+                        type: array
+                        items:
+                          type: string
+                      dnsZones:
+                        description: List of DNSZones that this solver will be used
+                          to solve. The most specific DNS zone match specified here
+                          will take precedence over other DNS zone matches, so a solver
+                          specifying sys.example.com will be selected over one specifying
+                          example.com for the domain www.sys.example.com. If multiple
+                          solvers match with the same dnsZones value, the solver with
+                          the most matching labels in matchLabels will be selected.
+                          If neither has more matches, the solver defined earlier
+                          in the list will be selected.
+                        type: array
+                        items:
+                          type: string
+                      matchLabels:
+                        description: A label selector that is used to refine the set
+                          of certificate's that this challenge solver will apply to.
+                        type: object
+                        additionalProperties:
+                          type: string
+              token:
+                description: The ACME challenge token for this challenge. This is
+                  the raw value returned from the ACME server.
+                type: string
+              type:
+                description: The type of ACME challenge this resource represents.
+                  One of "HTTP-01" or "DNS-01".
+                type: string
+                enum:
+                - HTTP-01
+                - DNS-01
+              url:
+                description: The URL of the ACME Challenge resource for this challenge.
+                  This can be used to lookup details about the status of this challenge.
+                type: string
+              wildcard:
+                description: wildcard will be true if this challenge is for a wildcard
+                  identifier, for example '*.example.com'.
+                type: boolean
+          status:
+            type: object
+            properties:
+              presented:
+                description: presented will be set to true if the challenge values
+                  for this challenge are currently 'presented'. This *does not* imply
+                  the self check is passing. Only that the values have been 'submitted'
+                  for the appropriate challenge mechanism (i.e. the DNS01 TXT record
+                  has been presented, or the HTTP01 configuration has been configured).
+                type: boolean
+              processing:
+                description: Used to denote whether this challenge should be processed
+                  or not. This field will only be set to true by the 'scheduling'
+                  component. It will only be set to false by the 'challenges' controller,
+                  after the challenge has reached a final state or timed out. If this
+                  field is set to false, the challenge controller will not take any
+                  more action.
+                type: boolean
+              reason:
+                description: Contains human readable information on why the Challenge
+                  is in the current state.
+                type: string
+              state:
+                description: Contains the current 'state' of the challenge. If not
+                  set, the state of the challenge is unknown.
+                type: string
+                enum:
+                - valid
+                - ready
+                - pending
+                - processing
+                - invalid
+                - expired
+                - errored

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/crd-clusterissuer.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/crd-clusterissuer.yml.j2
@@ -64,1757 +64,5774 @@ spec:
   - name: v1alpha2
     served: true
     storage: true
+    "schema":
+      "openAPIV3Schema":
+        description: A ClusterIssuer represents a certificate issuing authority which
+          can be referenced as part of `issuerRef` fields. It is similar to an Issuer,
+          however it is cluster-scoped and therefore can be referenced by resources
+          that exist in *any* namespace, not just the same namespace as the referent.
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Desired state of the ClusterIssuer resource.
+            type: object
+            properties:
+              acme:
+                description: ACME configures this issuer to communicate with a RFC8555
+                  (ACME) server to obtain signed x509 certificates.
+                type: object
+                required:
+                - privateKeySecretRef
+                - server
+                properties:
+                  email:
+                    description: Email is the email address to be associated with
+                      the ACME account. This field is optional, but it is strongly
+                      recommended to be set. It will be used to contact you in case
+                      of issues with your account or certificates, including expiry
+                      notification emails. This field may be updated after the account
+                      is initially registered.
+                    type: string
+                  externalAccountBinding:
+                    description: ExternalAccountBinding is a reference to a CA external
+                      account of the ACME server. If set, upon registration cert-manager
+                      will attempt to associate the given external account credentials
+                      with the registered ACME account.
+                    type: object
+                    required:
+                    - keyAlgorithm
+                    - keyID
+                    - keySecretRef
+                    properties:
+                      keyAlgorithm:
+                        description: keyAlgorithm is the MAC key algorithm that the
+                          key is used for. Valid values are "HS256", "HS384" and "HS512".
+                        type: string
+                        enum:
+                        - HS256
+                        - HS384
+                        - HS512
+                      keyID:
+                        description: keyID is the ID of the CA key that the External
+                          Account is bound to.
+                        type: string
+                      keySecretRef:
+                        description: keySecretRef is a Secret Key Selector referencing
+                          a data item in a Kubernetes Secret which holds the symmetric
+                          MAC key of the External Account Binding. The `key` is the
+                          index string that is paired with the key data in the Secret
+                          and should not be confused with the key data itself, or
+                          indeed with the External Account Binding keyID above. The
+                          secret key stored in the Secret **must** be un-padded, base64
+                          URL encoded data.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the entry in the Secret resource's
+                              `data` field to be used. Some instances of this field
+                              may be defaulted, in others it may be required.
+                            type: string
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                  privateKeySecretRef:
+                    description: PrivateKey is the name of a Kubernetes Secret resource
+                      that will be used to store the automatically generated ACME
+                      account private key. Optionally, a `key` may be specified to
+                      select a specific entry within the named Secret resource. If
+                      `key` is not specified, a default of `tls.key` will be used.
+                    type: object
+                    required:
+                    - name
+                    properties:
+                      key:
+                        description: The key of the entry in the Secret resource's
+                          `data` field to be used. Some instances of this field may
+                          be defaulted, in others it may be required.
+                        type: string
+                      name:
+                        description: 'Name of the resource being referred to. More
+                          info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                  server:
+                    description: 'Server is the URL used to access the ACME server''s
+                      ''directory'' endpoint. For example, for Let''s Encrypt''s staging
+                      endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory".
+                      Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
+                    type: string
+                  skipTLSVerify:
+                    description: Enables or disables validation of the ACME server
+                      TLS certificate. If true, requests to the ACME server will not
+                      have their TLS certificate validated (i.e. insecure connections
+                      will be allowed). Only enable this option in development environments.
+                      The cert-manager system installed roots will be used to verify
+                      connections to the ACME server if this is false. Defaults to
+                      false.
+                    type: boolean
+                  solvers:
+                    description: 'Solvers is a list of challenge solvers that will
+                      be used to solve ACME challenges for the matching domains. Solver
+                      configurations must be provided in order to obtain certificates
+                      from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/'
+                    type: array
+                    items:
+                      description: Configures an issuer to solve challenges using
+                        the specified options. Only one of HTTP01 or DNS01 may be
+                        provided.
+                      type: object
+                      properties:
+                        dns01:
+                          description: Configures cert-manager to attempt to complete
+                            authorizations by performing the DNS01 challenge flow.
+                          type: object
+                          properties:
+                            acmedns:
+                              description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns)
+                                API to manage DNS01 challenge records.
+                              type: object
+                              required:
+                              - accountSecretRef
+                              - host
+                              properties:
+                                accountSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                host:
+                                  type: string
+                            akamai:
+                              description: Use the Akamai DNS zone management API
+                                to manage DNS01 challenge records.
+                              type: object
+                              required:
+                              - accessTokenSecretRef
+                              - clientSecretSecretRef
+                              - clientTokenSecretRef
+                              - serviceConsumerDomain
+                              properties:
+                                accessTokenSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                clientSecretSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                clientTokenSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                serviceConsumerDomain:
+                                  type: string
+                            azuredns:
+                              description: Use the Microsoft Azure DNS API to manage
+                                DNS01 challenge records.
+                              type: object
+                              required:
+                              - resourceGroupName
+                              - subscriptionID
+                              properties:
+                                clientID:
+                                  description: if both this and ClientSecret are left
+                                    unset MSI will be used
+                                  type: string
+                                clientSecretSecretRef:
+                                  description: if both this and ClientID are left
+                                    unset MSI will be used
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                environment:
+                                  type: string
+                                  enum:
+                                  - AzurePublicCloud
+                                  - AzureChinaCloud
+                                  - AzureGermanCloud
+                                  - AzureUSGovernmentCloud
+                                hostedZoneName:
+                                  type: string
+                                resourceGroupName:
+                                  type: string
+                                subscriptionID:
+                                  type: string
+                                tenantID:
+                                  description: when specifying ClientID and ClientSecret
+                                    then this field is also needed
+                                  type: string
+                            clouddns:
+                              description: Use the Google Cloud DNS API to manage
+                                DNS01 challenge records.
+                              type: object
+                              required:
+                              - project
+                              properties:
+                                hostedZoneName:
+                                  description: HostedZoneName is an optional field
+                                    that tells cert-manager in which Cloud DNS zone
+                                    the challenge record has to be created. If left
+                                    empty cert-manager will automatically choose a
+                                    zone.
+                                  type: string
+                                project:
+                                  type: string
+                                serviceAccountSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                            cloudflare:
+                              description: Use the Cloudflare API to manage DNS01
+                                challenge records.
+                              type: object
+                              properties:
+                                apiKeySecretRef:
+                                  description: 'API key to use to authenticate with
+                                    Cloudflare. Note: using an API token to authenticate
+                                    is now the recommended method as it allows greater
+                                    control of permissions.'
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                apiTokenSecretRef:
+                                  description: API token used to authenticate with
+                                    Cloudflare.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                email:
+                                  description: Email of the account, only required
+                                    when using API key based authentication.
+                                  type: string
+                            cnameStrategy:
+                              description: CNAMEStrategy configures how the DNS01
+                                provider should handle CNAME records when found in
+                                DNS zones.
+                              type: string
+                              enum:
+                              - None
+                              - Follow
+                            digitalocean:
+                              description: Use the DigitalOcean DNS API to manage
+                                DNS01 challenge records.
+                              type: object
+                              required:
+                              - tokenSecretRef
+                              properties:
+                                tokenSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                            rfc2136:
+                              description: Use RFC2136 ("Dynamic Updates in the Domain
+                                Name System") (https://datatracker.ietf.org/doc/rfc2136/)
+                                to manage DNS01 challenge records.
+                              type: object
+                              required:
+                              - nameserver
+                              properties:
+                                nameserver:
+                                  description: The IP address or hostname of an authoritative
+                                    DNS server supporting RFC2136 in the form host:port.
+                                    If the host is an IPv6 address it must be enclosed
+                                    in square brackets (e.g [2001:db8::1]) ; port
+                                    is optional. This field is required.
+                                  type: string
+                                tsigAlgorithm:
+                                  description: 'The TSIG Algorithm configured in the
+                                    DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                                    and ``tsigKeyName`` are defined. Supported values
+                                    are (case-insensitive): ``HMACMD5`` (default),
+                                    ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
+                                  type: string
+                                tsigKeyName:
+                                  description: The TSIG Key name configured in the
+                                    DNS. If ``tsigSecretSecretRef`` is defined, this
+                                    field is required.
+                                  type: string
+                                tsigSecretSecretRef:
+                                  description: The name of the secret containing the
+                                    TSIG value. If ``tsigKeyName`` is defined, this
+                                    field is required.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                            route53:
+                              description: Use the AWS Route53 API to manage DNS01
+                                challenge records.
+                              type: object
+                              required:
+                              - region
+                              properties:
+                                accessKeyID:
+                                  description: 'The AccessKeyID is used for authentication.
+                                    If not set we fall-back to using env vars, shared
+                                    credentials file or AWS Instance metadata see:
+                                    https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                  type: string
+                                hostedZoneID:
+                                  description: If set, the provider will manage only
+                                    this zone in Route53 and will not do an lookup
+                                    using the route53:ListHostedZonesByName api call.
+                                  type: string
+                                region:
+                                  description: Always set the region when using AccessKeyID
+                                    and SecretAccessKey
+                                  type: string
+                                role:
+                                  description: Role is a Role ARN which the Route53
+                                    provider will assume using either the explicit
+                                    credentials AccessKeyID/SecretAccessKey or the
+                                    inferred credentials from environment variables,
+                                    shared credentials file or AWS Instance metadata
+                                  type: string
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication.
+                                    If not set we fall-back to using env vars, shared
+                                    credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                            webhook:
+                              description: Configure an external webhook based DNS01
+                                challenge solver to manage DNS01 challenge records.
+                              type: object
+                              required:
+                              - groupName
+                              - solverName
+                              properties:
+                                config:
+                                  description: Additional configuration that should
+                                    be passed to the webhook apiserver when challenges
+                                    are processed. This can contain arbitrary JSON
+                                    data. Secret values should not be specified in
+                                    this stanza. If secret values are needed (e.g.
+                                    credentials for a DNS service), you should use
+                                    a SecretKeySelector to reference a Secret resource.
+                                    For details on the schema of this field, consult
+                                    the webhook provider implementation's documentation.
+                                  x-kubernetes-preserve-unknown-fields: true
+                                groupName:
+                                  description: The API group name that should be used
+                                    when POSTing ChallengePayload resources to the
+                                    webhook apiserver. This should be the same as
+                                    the GroupName specified in the webhook provider
+                                    implementation.
+                                  type: string
+                                solverName:
+                                  description: The name of the solver to use, as defined
+                                    in the webhook provider implementation. This will
+                                    typically be the name of the provider, e.g. 'cloudflare'.
+                                  type: string
+                        http01:
+                          description: Configures cert-manager to attempt to complete
+                            authorizations by performing the HTTP01 challenge flow.
+                            It is not possible to obtain certificates for wildcard
+                            domain names (e.g. `*.example.com`) using the HTTP01 challenge
+                            mechanism.
+                          type: object
+                          properties:
+                            ingress:
+                              description: The ingress based HTTP01 challenge solver
+                                will solve challenges by creating or modifying Ingress
+                                resources in order to route requests for '/.well-known/acme-challenge/XYZ'
+                                to 'challenge solver' pods that are provisioned by
+                                cert-manager for each Challenge to be completed.
+                              type: object
+                              properties:
+                                class:
+                                  description: The ingress class to use when creating
+                                    Ingress resources to solve ACME challenges that
+                                    use this challenge solver. Only one of 'class'
+                                    or 'name' may be specified.
+                                  type: string
+                                ingressTemplate:
+                                  description: Optional ingress template used to configure
+                                    the ACME challenge solver ingress used for HTTP01
+                                    challenges
+                                  type: object
+                                  properties:
+                                    metadata:
+                                      description: ObjectMeta overrides for the ingress
+                                        used to solve HTTP01 challenges. Only the
+                                        'labels' and 'annotations' fields may be set.
+                                        If labels or annotations overlap with in-built
+                                        values, the values here will override the
+                                        in-built values.
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          description: Annotations that should be
+                                            added to the created ACME HTTP01 solver
+                                            ingress.
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        labels:
+                                          description: Labels that should be added
+                                            to the created ACME HTTP01 solver ingress.
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                name:
+                                  description: The name of the ingress resource that
+                                    should have ACME challenge solving routes inserted
+                                    into it in order to solve HTTP01 challenges. This
+                                    is typically used in conjunction with ingress
+                                    controllers like ingress-gce, which maintains
+                                    a 1:1 mapping between external IPs and ingress
+                                    resources.
+                                  type: string
+                                podTemplate:
+                                  description: Optional pod template used to configure
+                                    the ACME challenge solver pods used for HTTP01
+                                    challenges
+                                  type: object
+                                  properties:
+                                    metadata:
+                                      description: ObjectMeta overrides for the pod
+                                        used to solve HTTP01 challenges. Only the
+                                        'labels' and 'annotations' fields may be set.
+                                        If labels or annotations overlap with in-built
+                                        values, the values here will override the
+                                        in-built values.
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          description: Annotations that should be
+                                            added to the create ACME HTTP01 solver
+                                            pods.
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        labels:
+                                          description: Labels that should be added
+                                            to the created ACME HTTP01 solver pods.
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                    spec:
+                                      description: PodSpec defines overrides for the
+                                        HTTP01 challenge solver pod. Only the 'nodeSelector',
+                                        'affinity' and 'tolerations' fields are supported
+                                        currently. All other fields will be ignored.
+                                      type: object
+                                      properties:
+                                        affinity:
+                                          description: If specified, the pod's scheduling
+                                            constraints
+                                          type: object
+                                          properties:
+                                            nodeAffinity:
+                                              description: Describes node affinity
+                                                scheduling rules for the pod.
+                                              type: object
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  description: The scheduler will
+                                                    prefer to schedule pods to nodes
+                                                    that satisfy the affinity expressions
+                                                    specified by this field, but it
+                                                    may choose a node that violates
+                                                    one or more of the expressions.
+                                                    The node that is most preferred
+                                                    is the one with the greatest sum
+                                                    of weights, i.e. for each node
+                                                    that meets all of the scheduling
+                                                    requirements (resource request,
+                                                    requiredDuringScheduling affinity
+                                                    expressions, etc.), compute a
+                                                    sum by iterating through the elements
+                                                    of this field and adding "weight"
+                                                    to the sum if the node matches
+                                                    the corresponding matchExpressions;
+                                                    the node(s) with the highest sum
+                                                    are the most preferred.
+                                                  type: array
+                                                  items:
+                                                    description: An empty preferred
+                                                      scheduling term matches all
+                                                      objects with implicit weight
+                                                      0 (i.e. it's a no-op). A null
+                                                      preferred scheduling term matches
+                                                      no objects (i.e. is also a no-op).
+                                                    type: object
+                                                    required:
+                                                    - preference
+                                                    - weight
+                                                    properties:
+                                                      preference:
+                                                        description: A node selector
+                                                          term, associated with the
+                                                          corresponding weight.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: A list of
+                                                              node selector requirements
+                                                              by node's labels.
+                                                            type: array
+                                                            items:
+                                                              description: A node
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: Represents
+                                                                    a key's relationship
+                                                                    to a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists, DoesNotExist.
+                                                                    Gt, and Lt.
+                                                                  type: string
+                                                                values:
+                                                                  description: An
+                                                                    array of string
+                                                                    values. If the
+                                                                    operator is In
+                                                                    or NotIn, the
+                                                                    values array must
+                                                                    be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    If the operator
+                                                                    is Gt or Lt, the
+                                                                    values array must
+                                                                    have a single
+                                                                    element, which
+                                                                    will be interpreted
+                                                                    as an integer.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchFields:
+                                                            description: A list of
+                                                              node selector requirements
+                                                              by node's fields.
+                                                            type: array
+                                                            items:
+                                                              description: A node
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: Represents
+                                                                    a key's relationship
+                                                                    to a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists, DoesNotExist.
+                                                                    Gt, and Lt.
+                                                                  type: string
+                                                                values:
+                                                                  description: An
+                                                                    array of string
+                                                                    values. If the
+                                                                    operator is In
+                                                                    or NotIn, the
+                                                                    values array must
+                                                                    be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    If the operator
+                                                                    is Gt or Lt, the
+                                                                    values array must
+                                                                    have a single
+                                                                    element, which
+                                                                    will be interpreted
+                                                                    as an integer.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                      weight:
+                                                        description: Weight associated
+                                                          with matching the corresponding
+                                                          nodeSelectorTerm, in the
+                                                          range 1-100.
+                                                        type: integer
+                                                        format: int32
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  description: If the affinity requirements
+                                                    specified by this field are not
+                                                    met at scheduling time, the pod
+                                                    will not be scheduled onto the
+                                                    node. If the affinity requirements
+                                                    specified by this field cease
+                                                    to be met at some point during
+                                                    pod execution (e.g. due to an
+                                                    update), the system may or may
+                                                    not try to eventually evict the
+                                                    pod from its node.
+                                                  type: object
+                                                  required:
+                                                  - nodeSelectorTerms
+                                                  properties:
+                                                    nodeSelectorTerms:
+                                                      description: Required. A list
+                                                        of node selector terms. The
+                                                        terms are ORed.
+                                                      type: array
+                                                      items:
+                                                        description: A null or empty
+                                                          node selector term matches
+                                                          no objects. The requirements
+                                                          of them are ANDed. The TopologySelectorTerm
+                                                          type implements a subset
+                                                          of the NodeSelectorTerm.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: A list of
+                                                              node selector requirements
+                                                              by node's labels.
+                                                            type: array
+                                                            items:
+                                                              description: A node
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: Represents
+                                                                    a key's relationship
+                                                                    to a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists, DoesNotExist.
+                                                                    Gt, and Lt.
+                                                                  type: string
+                                                                values:
+                                                                  description: An
+                                                                    array of string
+                                                                    values. If the
+                                                                    operator is In
+                                                                    or NotIn, the
+                                                                    values array must
+                                                                    be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    If the operator
+                                                                    is Gt or Lt, the
+                                                                    values array must
+                                                                    have a single
+                                                                    element, which
+                                                                    will be interpreted
+                                                                    as an integer.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchFields:
+                                                            description: A list of
+                                                              node selector requirements
+                                                              by node's fields.
+                                                            type: array
+                                                            items:
+                                                              description: A node
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: Represents
+                                                                    a key's relationship
+                                                                    to a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists, DoesNotExist.
+                                                                    Gt, and Lt.
+                                                                  type: string
+                                                                values:
+                                                                  description: An
+                                                                    array of string
+                                                                    values. If the
+                                                                    operator is In
+                                                                    or NotIn, the
+                                                                    values array must
+                                                                    be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    If the operator
+                                                                    is Gt or Lt, the
+                                                                    values array must
+                                                                    have a single
+                                                                    element, which
+                                                                    will be interpreted
+                                                                    as an integer.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                            podAffinity:
+                                              description: Describes pod affinity
+                                                scheduling rules (e.g. co-locate this
+                                                pod in the same node, zone, etc. as
+                                                some other pod(s)).
+                                              type: object
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  description: The scheduler will
+                                                    prefer to schedule pods to nodes
+                                                    that satisfy the affinity expressions
+                                                    specified by this field, but it
+                                                    may choose a node that violates
+                                                    one or more of the expressions.
+                                                    The node that is most preferred
+                                                    is the one with the greatest sum
+                                                    of weights, i.e. for each node
+                                                    that meets all of the scheduling
+                                                    requirements (resource request,
+                                                    requiredDuringScheduling affinity
+                                                    expressions, etc.), compute a
+                                                    sum by iterating through the elements
+                                                    of this field and adding "weight"
+                                                    to the sum if the node has pods
+                                                    which matches the corresponding
+                                                    podAffinityTerm; the node(s) with
+                                                    the highest sum are the most preferred.
+                                                  type: array
+                                                  items:
+                                                    description: The weights of all
+                                                      of the matched WeightedPodAffinityTerm
+                                                      fields are added per-node to
+                                                      find the most preferred node(s)
+                                                    type: object
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        description: Required. A pod
+                                                          affinity term, associated
+                                                          with the corresponding weight.
+                                                        type: object
+                                                        required:
+                                                        - topologyKey
+                                                        properties:
+                                                          labelSelector:
+                                                            description: A label query
+                                                              over a set of resources,
+                                                              in this case pods.
+                                                            type: object
+                                                            properties:
+                                                              matchExpressions:
+                                                                description: matchExpressions
+                                                                  is a list of label
+                                                                  selector requirements.
+                                                                  The requirements
+                                                                  are ANDed.
+                                                                type: array
+                                                                items:
+                                                                  description: A label
+                                                                    selector requirement
+                                                                    is a selector
+                                                                    that contains
+                                                                    values, a key,
+                                                                    and an operator
+                                                                    that relates the
+                                                                    key and values.
+                                                                  type: object
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  properties:
+                                                                    key:
+                                                                      description: key
+                                                                        is the label
+                                                                        key that the
+                                                                        selector applies
+                                                                        to.
+                                                                      type: string
+                                                                    operator:
+                                                                      description: operator
+                                                                        represents
+                                                                        a key's relationship
+                                                                        to a set of
+                                                                        values. Valid
+                                                                        operators
+                                                                        are In, NotIn,
+                                                                        Exists and
+                                                                        DoesNotExist.
+                                                                      type: string
+                                                                    values:
+                                                                      description: values
+                                                                        is an array
+                                                                        of string
+                                                                        values. If
+                                                                        the operator
+                                                                        is In or NotIn,
+                                                                        the values
+                                                                        array must
+                                                                        be non-empty.
+                                                                        If the operator
+                                                                        is Exists
+                                                                        or DoesNotExist,
+                                                                        the values
+                                                                        array must
+                                                                        be empty.
+                                                                        This array
+                                                                        is replaced
+                                                                        during a strategic
+                                                                        merge patch.
+                                                                      type: array
+                                                                      items:
+                                                                        type: string
+                                                              matchLabels:
+                                                                description: matchLabels
+                                                                  is a map of {key,value}
+                                                                  pairs. A single
+                                                                  {key,value} in the
+                                                                  matchLabels map
+                                                                  is equivalent to
+                                                                  an element of matchExpressions,
+                                                                  whose key field
+                                                                  is "key", the operator
+                                                                  is "In", and the
+                                                                  values array contains
+                                                                  only "value". The
+                                                                  requirements are
+                                                                  ANDed.
+                                                                type: object
+                                                                additionalProperties:
+                                                                  type: string
+                                                          namespaces:
+                                                            description: namespaces
+                                                              specifies which namespaces
+                                                              the labelSelector applies
+                                                              to (matches against);
+                                                              null or empty list means
+                                                              "this pod's namespace"
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                          topologyKey:
+                                                            description: This pod
+                                                              should be co-located
+                                                              (affinity) or not co-located
+                                                              (anti-affinity) with
+                                                              the pods matching the
+                                                              labelSelector in the
+                                                              specified namespaces,
+                                                              where co-located is
+                                                              defined as running on
+                                                              a node whose value of
+                                                              the label with key topologyKey
+                                                              matches that of any
+                                                              node on which any of
+                                                              the selected pods is
+                                                              running. Empty topologyKey
+                                                              is not allowed.
+                                                            type: string
+                                                      weight:
+                                                        description: weight associated
+                                                          with matching the corresponding
+                                                          podAffinityTerm, in the
+                                                          range 1-100.
+                                                        type: integer
+                                                        format: int32
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  description: If the affinity requirements
+                                                    specified by this field are not
+                                                    met at scheduling time, the pod
+                                                    will not be scheduled onto the
+                                                    node. If the affinity requirements
+                                                    specified by this field cease
+                                                    to be met at some point during
+                                                    pod execution (e.g. due to a pod
+                                                    label update), the system may
+                                                    or may not try to eventually evict
+                                                    the pod from its node. When there
+                                                    are multiple elements, the lists
+                                                    of nodes corresponding to each
+                                                    podAffinityTerm are intersected,
+                                                    i.e. all terms must be satisfied.
+                                                  type: array
+                                                  items:
+                                                    description: Defines a set of
+                                                      pods (namely those matching
+                                                      the labelSelector relative to
+                                                      the given namespace(s)) that
+                                                      this pod should be co-located
+                                                      (affinity) or not co-located
+                                                      (anti-affinity) with, where
+                                                      co-located is defined as running
+                                                      on a node whose value of the
+                                                      label with key <topologyKey>
+                                                      matches that of any node on
+                                                      which a pod of the set of pods
+                                                      is running
+                                                    type: object
+                                                    required:
+                                                    - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query
+                                                          over a set of resources,
+                                                          in this case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions
+                                                              is a list of label selector
+                                                              requirements. The requirements
+                                                              are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key
+                                                                    is the label key
+                                                                    that the selector
+                                                                    applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator
+                                                                    represents a key's
+                                                                    relationship to
+                                                                    a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values
+                                                                    is an array of
+                                                                    string values.
+                                                                    If the operator
+                                                                    is In or NotIn,
+                                                                    the values array
+                                                                    must be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels
+                                                              is a map of {key,value}
+                                                              pairs. A single {key,value}
+                                                              in the matchLabels map
+                                                              is equivalent to an
+                                                              element of matchExpressions,
+                                                              whose key field is "key",
+                                                              the operator is "In",
+                                                              and the values array
+                                                              contains only "value".
+                                                              The requirements are
+                                                              ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaces:
+                                                        description: namespaces specifies
+                                                          which namespaces the labelSelector
+                                                          applies to (matches against);
+                                                          null or empty list means
+                                                          "this pod's namespace"
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                      topologyKey:
+                                                        description: This pod should
+                                                          be co-located (affinity)
+                                                          or not co-located (anti-affinity)
+                                                          with the pods matching the
+                                                          labelSelector in the specified
+                                                          namespaces, where co-located
+                                                          is defined as running on
+                                                          a node whose value of the
+                                                          label with key topologyKey
+                                                          matches that of any node
+                                                          on which any of the selected
+                                                          pods is running. Empty topologyKey
+                                                          is not allowed.
+                                                        type: string
+                                            podAntiAffinity:
+                                              description: Describes pod anti-affinity
+                                                scheduling rules (e.g. avoid putting
+                                                this pod in the same node, zone, etc.
+                                                as some other pod(s)).
+                                              type: object
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  description: The scheduler will
+                                                    prefer to schedule pods to nodes
+                                                    that satisfy the anti-affinity
+                                                    expressions specified by this
+                                                    field, but it may choose a node
+                                                    that violates one or more of the
+                                                    expressions. The node that is
+                                                    most preferred is the one with
+                                                    the greatest sum of weights, i.e.
+                                                    for each node that meets all of
+                                                    the scheduling requirements (resource
+                                                    request, requiredDuringScheduling
+                                                    anti-affinity expressions, etc.),
+                                                    compute a sum by iterating through
+                                                    the elements of this field and
+                                                    adding "weight" to the sum if
+                                                    the node has pods which matches
+                                                    the corresponding podAffinityTerm;
+                                                    the node(s) with the highest sum
+                                                    are the most preferred.
+                                                  type: array
+                                                  items:
+                                                    description: The weights of all
+                                                      of the matched WeightedPodAffinityTerm
+                                                      fields are added per-node to
+                                                      find the most preferred node(s)
+                                                    type: object
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        description: Required. A pod
+                                                          affinity term, associated
+                                                          with the corresponding weight.
+                                                        type: object
+                                                        required:
+                                                        - topologyKey
+                                                        properties:
+                                                          labelSelector:
+                                                            description: A label query
+                                                              over a set of resources,
+                                                              in this case pods.
+                                                            type: object
+                                                            properties:
+                                                              matchExpressions:
+                                                                description: matchExpressions
+                                                                  is a list of label
+                                                                  selector requirements.
+                                                                  The requirements
+                                                                  are ANDed.
+                                                                type: array
+                                                                items:
+                                                                  description: A label
+                                                                    selector requirement
+                                                                    is a selector
+                                                                    that contains
+                                                                    values, a key,
+                                                                    and an operator
+                                                                    that relates the
+                                                                    key and values.
+                                                                  type: object
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  properties:
+                                                                    key:
+                                                                      description: key
+                                                                        is the label
+                                                                        key that the
+                                                                        selector applies
+                                                                        to.
+                                                                      type: string
+                                                                    operator:
+                                                                      description: operator
+                                                                        represents
+                                                                        a key's relationship
+                                                                        to a set of
+                                                                        values. Valid
+                                                                        operators
+                                                                        are In, NotIn,
+                                                                        Exists and
+                                                                        DoesNotExist.
+                                                                      type: string
+                                                                    values:
+                                                                      description: values
+                                                                        is an array
+                                                                        of string
+                                                                        values. If
+                                                                        the operator
+                                                                        is In or NotIn,
+                                                                        the values
+                                                                        array must
+                                                                        be non-empty.
+                                                                        If the operator
+                                                                        is Exists
+                                                                        or DoesNotExist,
+                                                                        the values
+                                                                        array must
+                                                                        be empty.
+                                                                        This array
+                                                                        is replaced
+                                                                        during a strategic
+                                                                        merge patch.
+                                                                      type: array
+                                                                      items:
+                                                                        type: string
+                                                              matchLabels:
+                                                                description: matchLabels
+                                                                  is a map of {key,value}
+                                                                  pairs. A single
+                                                                  {key,value} in the
+                                                                  matchLabels map
+                                                                  is equivalent to
+                                                                  an element of matchExpressions,
+                                                                  whose key field
+                                                                  is "key", the operator
+                                                                  is "In", and the
+                                                                  values array contains
+                                                                  only "value". The
+                                                                  requirements are
+                                                                  ANDed.
+                                                                type: object
+                                                                additionalProperties:
+                                                                  type: string
+                                                          namespaces:
+                                                            description: namespaces
+                                                              specifies which namespaces
+                                                              the labelSelector applies
+                                                              to (matches against);
+                                                              null or empty list means
+                                                              "this pod's namespace"
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                          topologyKey:
+                                                            description: This pod
+                                                              should be co-located
+                                                              (affinity) or not co-located
+                                                              (anti-affinity) with
+                                                              the pods matching the
+                                                              labelSelector in the
+                                                              specified namespaces,
+                                                              where co-located is
+                                                              defined as running on
+                                                              a node whose value of
+                                                              the label with key topologyKey
+                                                              matches that of any
+                                                              node on which any of
+                                                              the selected pods is
+                                                              running. Empty topologyKey
+                                                              is not allowed.
+                                                            type: string
+                                                      weight:
+                                                        description: weight associated
+                                                          with matching the corresponding
+                                                          podAffinityTerm, in the
+                                                          range 1-100.
+                                                        type: integer
+                                                        format: int32
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  description: If the anti-affinity
+                                                    requirements specified by this
+                                                    field are not met at scheduling
+                                                    time, the pod will not be scheduled
+                                                    onto the node. If the anti-affinity
+                                                    requirements specified by this
+                                                    field cease to be met at some
+                                                    point during pod execution (e.g.
+                                                    due to a pod label update), the
+                                                    system may or may not try to eventually
+                                                    evict the pod from its node. When
+                                                    there are multiple elements, the
+                                                    lists of nodes corresponding to
+                                                    each podAffinityTerm are intersected,
+                                                    i.e. all terms must be satisfied.
+                                                  type: array
+                                                  items:
+                                                    description: Defines a set of
+                                                      pods (namely those matching
+                                                      the labelSelector relative to
+                                                      the given namespace(s)) that
+                                                      this pod should be co-located
+                                                      (affinity) or not co-located
+                                                      (anti-affinity) with, where
+                                                      co-located is defined as running
+                                                      on a node whose value of the
+                                                      label with key <topologyKey>
+                                                      matches that of any node on
+                                                      which a pod of the set of pods
+                                                      is running
+                                                    type: object
+                                                    required:
+                                                    - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query
+                                                          over a set of resources,
+                                                          in this case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions
+                                                              is a list of label selector
+                                                              requirements. The requirements
+                                                              are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key
+                                                                    is the label key
+                                                                    that the selector
+                                                                    applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator
+                                                                    represents a key's
+                                                                    relationship to
+                                                                    a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values
+                                                                    is an array of
+                                                                    string values.
+                                                                    If the operator
+                                                                    is In or NotIn,
+                                                                    the values array
+                                                                    must be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels
+                                                              is a map of {key,value}
+                                                              pairs. A single {key,value}
+                                                              in the matchLabels map
+                                                              is equivalent to an
+                                                              element of matchExpressions,
+                                                              whose key field is "key",
+                                                              the operator is "In",
+                                                              and the values array
+                                                              contains only "value".
+                                                              The requirements are
+                                                              ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaces:
+                                                        description: namespaces specifies
+                                                          which namespaces the labelSelector
+                                                          applies to (matches against);
+                                                          null or empty list means
+                                                          "this pod's namespace"
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                      topologyKey:
+                                                        description: This pod should
+                                                          be co-located (affinity)
+                                                          or not co-located (anti-affinity)
+                                                          with the pods matching the
+                                                          labelSelector in the specified
+                                                          namespaces, where co-located
+                                                          is defined as running on
+                                                          a node whose value of the
+                                                          label with key topologyKey
+                                                          matches that of any node
+                                                          on which any of the selected
+                                                          pods is running. Empty topologyKey
+                                                          is not allowed.
+                                                        type: string
+                                        nodeSelector:
+                                          description: 'NodeSelector is a selector
+                                            which must be true for the pod to fit
+                                            on a node. Selector which must match a
+                                            node''s labels for the pod to be scheduled
+                                            on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        tolerations:
+                                          description: If specified, the pod's tolerations.
+                                          type: array
+                                          items:
+                                            description: The pod this Toleration is
+                                              attached to tolerates any taint that
+                                              matches the triple <key,value,effect>
+                                              using the matching operator <operator>.
+                                            type: object
+                                            properties:
+                                              effect:
+                                                description: Effect indicates the
+                                                  taint effect to match. Empty means
+                                                  match all taint effects. When specified,
+                                                  allowed values are NoSchedule, PreferNoSchedule
+                                                  and NoExecute.
+                                                type: string
+                                              key:
+                                                description: Key is the taint key
+                                                  that the toleration applies to.
+                                                  Empty means match all taint keys.
+                                                  If the key is empty, operator must
+                                                  be Exists; this combination means
+                                                  to match all values and all keys.
+                                                type: string
+                                              operator:
+                                                description: Operator represents a
+                                                  key's relationship to the value.
+                                                  Valid operators are Exists and Equal.
+                                                  Defaults to Equal. Exists is equivalent
+                                                  to wildcard for value, so that a
+                                                  pod can tolerate all taints of a
+                                                  particular category.
+                                                type: string
+                                              tolerationSeconds:
+                                                description: TolerationSeconds represents
+                                                  the period of time the toleration
+                                                  (which must be of effect NoExecute,
+                                                  otherwise this field is ignored)
+                                                  tolerates the taint. By default,
+                                                  it is not set, which means tolerate
+                                                  the taint forever (do not evict).
+                                                  Zero and negative values will be
+                                                  treated as 0 (evict immediately)
+                                                  by the system.
+                                                type: integer
+                                                format: int64
+                                              value:
+                                                description: Value is the taint value
+                                                  the toleration matches to. If the
+                                                  operator is Exists, the value should
+                                                  be empty, otherwise just a regular
+                                                  string.
+                                                type: string
+                                serviceType:
+                                  description: Optional service type for Kubernetes
+                                    solver service
+                                  type: string
+                        selector:
+                          description: Selector selects a set of DNSNames on the Certificate
+                            resource that should be solved using this challenge solver.
+                            If not specified, the solver will be treated as the 'default'
+                            solver with the lowest priority, i.e. if any other solver
+                            has a more specific match, it will be used instead.
+                          type: object
+                          properties:
+                            dnsNames:
+                              description: List of DNSNames that this solver will
+                                be used to solve. If specified and a match is found,
+                                a dnsNames selector will take precedence over a dnsZones
+                                selector. If multiple solvers match with the same
+                                dnsNames value, the solver with the most matching
+                                labels in matchLabels will be selected. If neither
+                                has more matches, the solver defined earlier in the
+                                list will be selected.
+                              type: array
+                              items:
+                                type: string
+                            dnsZones:
+                              description: List of DNSZones that this solver will
+                                be used to solve. The most specific DNS zone match
+                                specified here will take precedence over other DNS
+                                zone matches, so a solver specifying sys.example.com
+                                will be selected over one specifying example.com for
+                                the domain www.sys.example.com. If multiple solvers
+                                match with the same dnsZones value, the solver with
+                                the most matching labels in matchLabels will be selected.
+                                If neither has more matches, the solver defined earlier
+                                in the list will be selected.
+                              type: array
+                              items:
+                                type: string
+                            matchLabels:
+                              description: A label selector that is used to refine
+                                the set of certificate's that this challenge solver
+                                will apply to.
+                              type: object
+                              additionalProperties:
+                                type: string
+              ca:
+                description: CA configures this issuer to sign certificates using
+                  a signing CA keypair stored in a Secret resource. This is used to
+                  build internal PKIs that are managed by cert-manager.
+                type: object
+                required:
+                - secretName
+                properties:
+                  crlDistributionPoints:
+                    description: The CRL distribution points is an X.509 v3 certificate
+                      extension which identifies the location of the CRL from which
+                      the revocation of this certificate can be checked. If not set,
+                      certificates will be issued without distribution points set.
+                    type: array
+                    items:
+                      type: string
+                  secretName:
+                    description: SecretName is the name of the secret used to sign
+                      Certificates issued by this Issuer.
+                    type: string
+              selfSigned:
+                description: SelfSigned configures this issuer to 'self sign' certificates
+                  using the private key used to create the CertificateRequest object.
+                type: object
+                properties:
+                  crlDistributionPoints:
+                    description: The CRL distribution points is an X.509 v3 certificate
+                      extension which identifies the location of the CRL from which
+                      the revocation of this certificate can be checked. If not set
+                      certificate will be issued without CDP. Values are strings.
+                    type: array
+                    items:
+                      type: string
+              vault:
+                description: Vault configures this issuer to sign certificates using
+                  a HashiCorp Vault PKI backend.
+                type: object
+                required:
+                - auth
+                - path
+                - server
+                properties:
+                  auth:
+                    description: Auth configures how cert-manager authenticates with
+                      the Vault server.
+                    type: object
+                    properties:
+                      appRole:
+                        description: AppRole authenticates with Vault using the App
+                          Role auth mechanism, with the role and secret stored in
+                          a Kubernetes Secret resource.
+                        type: object
+                        required:
+                        - path
+                        - roleId
+                        - secretRef
+                        properties:
+                          path:
+                            description: 'Path where the App Role authentication backend
+                              is mounted in Vault, e.g: "approle"'
+                            type: string
+                          roleId:
+                            description: RoleID configured in the App Role authentication
+                              backend when setting up the authentication backend in
+                              Vault.
+                            type: string
+                          secretRef:
+                            description: Reference to a key in a Secret that contains
+                              the App Role secret used to authenticate with Vault.
+                              The `key` field must be specified and denotes which
+                              entry within the Secret resource is used as the app
+                              role secret.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                      kubernetes:
+                        description: Kubernetes authenticates with Vault by passing
+                          the ServiceAccount token stored in the named Secret resource
+                          to the Vault server.
+                        type: object
+                        required:
+                        - role
+                        - secretRef
+                        properties:
+                          mountPath:
+                            description: The Vault mountPath here is the mount path
+                              to use when authenticating with Vault. For example,
+                              setting a value to `/v1/auth/foo`, will use the path
+                              `/v1/auth/foo/login` to authenticate with Vault. If
+                              unspecified, the default value "/v1/auth/kubernetes"
+                              will be used.
+                            type: string
+                          role:
+                            description: A required field containing the Vault Role
+                              to assume. A Role binds a Kubernetes ServiceAccount
+                              with a set of Vault policies.
+                            type: string
+                          secretRef:
+                            description: The required Secret field containing a Kubernetes
+                              ServiceAccount JWT used for authenticating with Vault.
+                              Use of 'ambient credentials' is not supported.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                      tokenSecretRef:
+                        description: TokenSecretRef authenticates with Vault by presenting
+                          a token.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the entry in the Secret resource's
+                              `data` field to be used. Some instances of this field
+                              may be defaulted, in others it may be required.
+                            type: string
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                  caBundle:
+                    description: PEM encoded CA bundle used to validate Vault server
+                      certificate. Only used if the Server URL is using HTTPS protocol.
+                      This parameter is ignored for plain HTTP protocol connection.
+                      If not set the system root certificates are used to validate
+                      the TLS connection.
+                    type: string
+                    format: byte
+                  path:
+                    description: 'Path is the mount path of the Vault PKI backend''s
+                      `sign` endpoint, e.g: "my_pki_mount/sign/my-role-name".'
+                    type: string
+                  server:
+                    description: 'Server is the connection address for the Vault server,
+                      e.g: "https://vault.example.com:8200".'
+                    type: string
+              venafi:
+                description: Venafi configures this issuer to sign certificates using
+                  a Venafi TPP or Venafi Cloud policy zone.
+                type: object
+                required:
+                - zone
+                properties:
+                  cloud:
+                    description: Cloud specifies the Venafi cloud configuration settings.
+                      Only one of TPP or Cloud may be specified.
+                    type: object
+                    required:
+                    - apiTokenSecretRef
+                    properties:
+                      apiTokenSecretRef:
+                        description: APITokenSecretRef is a secret key selector for
+                          the Venafi Cloud API token.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the entry in the Secret resource's
+                              `data` field to be used. Some instances of this field
+                              may be defaulted, in others it may be required.
+                            type: string
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                      url:
+                        description: URL is the base URL for Venafi Cloud. Defaults
+                          to "https://api.venafi.cloud/v1".
+                        type: string
+                  tpp:
+                    description: TPP specifies Trust Protection Platform configuration
+                      settings. Only one of TPP or Cloud may be specified.
+                    type: object
+                    required:
+                    - credentialsRef
+                    - url
+                    properties:
+                      caBundle:
+                        description: CABundle is a PEM encoded TLS certificate to
+                          use to verify connections to the TPP instance. If specified,
+                          system roots will not be used and the issuing CA for the
+                          TPP instance must be verifiable using the provided root.
+                          If not specified, the connection will be verified using
+                          the cert-manager system root certificates.
+                        type: string
+                        format: byte
+                      credentialsRef:
+                        description: CredentialsRef is a reference to a Secret containing
+                          the username and password for the TPP server. The secret
+                          must contain two keys, 'username' and 'password'.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                      url:
+                        description: 'URL is the base URL for the vedsdk endpoint
+                          of the Venafi TPP instance, for example: "https://tpp.example.com/vedsdk".'
+                        type: string
+                  zone:
+                    description: Zone is the Venafi Policy Zone to use for this issuer.
+                      All requests made to the Venafi platform will be restricted
+                      by the named zone policy. This field is required.
+                    type: string
+          status:
+            description: Status of the ClusterIssuer. This is set and managed automatically.
+            type: object
+            properties:
+              acme:
+                description: ACME specific status options. This field should only
+                  be set if the Issuer is configured to use an ACME server to issue
+                  certificates.
+                type: object
+                properties:
+                  lastRegisteredEmail:
+                    description: LastRegisteredEmail is the email associated with
+                      the latest registered ACME account, in order to track changes
+                      made to registered account associated with the  Issuer
+                    type: string
+                  uri:
+                    description: URI is the unique account identifier, which can also
+                      be used to retrieve account details from the CA
+                    type: string
+              conditions:
+                description: List of status conditions to indicate the status of a
+                  CertificateRequest. Known condition types are `Ready`.
+                type: array
+                items:
+                  description: IssuerCondition contains condition information for
+                    an Issuer.
+                  type: object
+                  required:
+                  - status
+                  - type
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the timestamp corresponding
+                        to the last status change of this condition.
+                      type: string
+                      format: date-time
+                    message:
+                      description: Message is a human readable description of the
+                        details of the last transition, complementing reason.
+                      type: string
+                    reason:
+                      description: Reason is a brief machine readable explanation
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of ('True', 'False',
+                        'Unknown').
+                      type: string
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                    type:
+                      description: Type of the condition, known values are ('Ready').
+                      type: string
   - name: v1alpha3
     served: true
     storage: false
-  "validation":
-    "openAPIV3Schema":
-      type: object
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: IssuerSpec is the specification of an Issuer. This includes
-            any configuration required for the issuer.
-          type: object
-          properties:
-            acme:
-              description: ACMEIssuer contains the specification for an ACME issuer
-              type: object
-              required:
-              - privateKeySecretRef
-              - server
-              properties:
-                email:
-                  description: Email is the email for this account
-                  type: string
-                externalAccountBinding:
-                  description: ExternalAccountBinding is a reference to a CA external
-                    account of the ACME server.
-                  type: object
-                  required:
-                  - keyAlgorithm
-                  - keyID
-                  - keySecretRef
-                  properties:
-                    keyAlgorithm:
-                      description: keyAlgorithm is the MAC key algorithm that the
-                        key is used for. Valid values are "HS256", "HS384" and "HS512".
-                      type: string
-                      enum:
-                      - HS256
-                      - HS384
-                      - HS512
-                    keyID:
-                      description: keyID is the ID of the CA key that the External
-                        Account is bound to.
-                      type: string
-                    keySecretRef:
-                      description: keySecretRef is a Secret Key Selector referencing
-                        a data item in a Kubernetes Secret which holds the symmetric
-                        MAC key of the External Account Binding. The `key` is the
-                        index string that is paired with the key data in the Secret
-                        and should not be confused with the key data itself, or indeed
-                        with the External Account Binding keyID above. The secret
-                        key stored in the Secret **must** be un-padded, base64 URL
-                        encoded data.
-                      type: object
-                      required:
-                      - name
-                      properties:
-                        key:
-                          description: The key of the secret to select from. Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                privateKeySecretRef:
-                  description: PrivateKey is the name of a secret containing the private
-                    key for this user account.
-                  type: object
-                  required:
-                  - name
-                  properties:
-                    key:
-                      description: The key of the secret to select from. Must be a
-                        valid secret key.
-                      type: string
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                server:
-                  description: Server is the ACME server URL
-                  type: string
-                skipTLSVerify:
-                  description: If true, skip verifying the ACME server TLS certificate
-                  type: boolean
-                solvers:
-                  description: Solvers is a list of challenge solvers that will be
-                    used to solve ACME challenges for the matching domains.
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      dns01:
-                        type: object
-                        properties:
-                          acmedns:
-                            description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
-                              containing the configuration for ACME-DNS servers
-                            type: object
-                            required:
-                            - accountSecretRef
-                            - host
-                            properties:
-                              accountSecretRef:
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              host:
-                                type: string
-                          akamai:
-                            description: ACMEIssuerDNS01ProviderAkamai is a structure
-                              containing the DNS configuration for Akamai DNS—Zone
-                              Record Management API
-                            type: object
-                            required:
-                            - accessTokenSecretRef
-                            - clientSecretSecretRef
-                            - clientTokenSecretRef
-                            - serviceConsumerDomain
-                            properties:
-                              accessTokenSecretRef:
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              clientSecretSecretRef:
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              clientTokenSecretRef:
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              serviceConsumerDomain:
-                                type: string
-                          azuredns:
-                            description: ACMEIssuerDNS01ProviderAzureDNS is a structure
-                              containing the configuration for Azure DNS
-                            type: object
-                            required:
-                            - resourceGroupName
-                            - subscriptionID
-                            properties:
-                              clientID:
-                                description: if both this and ClientSecret are left
-                                  unset MSI will be used
-                                type: string
-                              clientSecretSecretRef:
-                                description: if both this and ClientID are left unset
-                                  MSI will be used
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              environment:
-                                type: string
-                                enum:
-                                - AzurePublicCloud
-                                - AzureChinaCloud
-                                - AzureGermanCloud
-                                - AzureUSGovernmentCloud
-                              hostedZoneName:
-                                type: string
-                              resourceGroupName:
-                                type: string
-                              subscriptionID:
-                                type: string
-                              tenantID:
-                                description: when specifying ClientID and ClientSecret
-                                  then this field is also needed
-                                type: string
-                          clouddns:
-                            description: ACMEIssuerDNS01ProviderCloudDNS is a structure
-                              containing the DNS configuration for Google Cloud DNS
-                            type: object
-                            required:
-                            - project
-                            properties:
-                              project:
-                                type: string
-                              serviceAccountSecretRef:
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                          cloudflare:
-                            description: ACMEIssuerDNS01ProviderCloudflare is a structure
-                              containing the DNS configuration for Cloudflare
-                            type: object
-                            required:
-                            - email
-                            properties:
-                              apiKeySecretRef:
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              apiTokenSecretRef:
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              email:
-                                type: string
-                          cnameStrategy:
-                            description: CNAMEStrategy configures how the DNS01 provider
-                              should handle CNAME records when found in DNS zones.
-                            type: string
-                            enum:
-                            - None
-                            - Follow
-                          digitalocean:
-                            description: ACMEIssuerDNS01ProviderDigitalOcean is a
-                              structure containing the DNS configuration for DigitalOcean
-                              Domains
-                            type: object
-                            required:
-                            - tokenSecretRef
-                            properties:
-                              tokenSecretRef:
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                          rfc2136:
-                            description: ACMEIssuerDNS01ProviderRFC2136 is a structure
-                              containing the configuration for RFC2136 DNS
-                            type: object
-                            required:
-                            - nameserver
-                            properties:
-                              nameserver:
-                                description: The IP address or hostname of an authoritative
-                                  DNS server supporting RFC2136 in the form host:port.
-                                  If the host is an IPv6 address it must be enclosed
-                                  in square brackets (e.g [2001:db8::1]) ; port is
-                                  optional. This field is required.
-                                type: string
-                              tsigAlgorithm:
-                                description: 'The TSIG Algorithm configured in the
-                                  DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
-                                  and ``tsigKeyName`` are defined. Supported values
-                                  are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
-                                  ``HMACSHA256`` or ``HMACSHA512``.'
-                                type: string
-                              tsigKeyName:
-                                description: The TSIG Key name configured in the DNS.
-                                  If ``tsigSecretSecretRef`` is defined, this field
-                                  is required.
-                                type: string
-                              tsigSecretSecretRef:
-                                description: The name of the secret containing the
-                                  TSIG value. If ``tsigKeyName`` is defined, this
-                                  field is required.
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                          route53:
-                            description: ACMEIssuerDNS01ProviderRoute53 is a structure
-                              containing the Route 53 configuration for AWS
-                            type: object
-                            required:
-                            - region
-                            properties:
-                              accessKeyID:
-                                description: 'The AccessKeyID is used for authentication.
-                                  If not set we fall-back to using env vars, shared
-                                  credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
-                                type: string
-                              hostedZoneID:
-                                description: If set, the provider will manage only
-                                  this zone in Route53 and will not do an lookup using
-                                  the route53:ListHostedZonesByName api call.
-                                type: string
-                              region:
-                                description: Always set the region when using AccessKeyID
-                                  and SecretAccessKey
-                                type: string
-                              role:
-                                description: Role is a Role ARN which the Route53
-                                  provider will assume using either the explicit credentials
-                                  AccessKeyID/SecretAccessKey or the inferred credentials
-                                  from environment variables, shared credentials file
-                                  or AWS Instance metadata
-                                type: string
-                              secretAccessKeySecretRef:
-                                description: The SecretAccessKey is used for authentication.
-                                  If not set we fall-back to using env vars, shared
-                                  credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                          webhook:
-                            description: ACMEIssuerDNS01ProviderWebhook specifies
-                              configuration for a webhook DNS01 provider, including
-                              where to POST ChallengePayload resources.
-                            type: object
-                            required:
-                            - groupName
-                            - solverName
-                            properties:
-                              config:
-                                description: Additional configuration that should
-                                  be passed to the webhook apiserver when challenges
-                                  are processed. This can contain arbitrary JSON data.
-                                  Secret values should not be specified in this stanza.
-                                  If secret values are needed (e.g. credentials for
-                                  a DNS service), you should use a SecretKeySelector
-                                  to reference a Secret resource. For details on the
-                                  schema of this field, consult the webhook provider
-                                  implementation's documentation.
-                                x-kubernetes-preserve-unknown-fields: true
-                              groupName:
-                                description: The API group name that should be used
-                                  when POSTing ChallengePayload resources to the webhook
-                                  apiserver. This should be the same as the GroupName
-                                  specified in the webhook provider implementation.
-                                type: string
-                              solverName:
-                                description: The name of the solver to use, as defined
-                                  in the webhook provider implementation. This will
-                                  typically be the name of the provider, e.g. 'cloudflare'.
-                                type: string
-                      http01:
-                        description: ACMEChallengeSolverHTTP01 contains configuration
-                          detailing how to solve HTTP01 challenges within a Kubernetes
-                          cluster. Typically this is accomplished through creating
-                          'routes' of some description that configure ingress controllers
-                          to direct traffic to 'solver pods', which are responsible
-                          for responding to the ACME server's HTTP requests.
-                        type: object
-                        properties:
-                          ingress:
-                            description: The ingress based HTTP01 challenge solver
-                              will solve challenges by creating or modifying Ingress
-                              resources in order to route requests for '/.well-known/acme-challenge/XYZ'
-                              to 'challenge solver' pods that are provisioned by cert-manager
-                              for each Challenge to be completed.
-                            type: object
-                            properties:
-                              class:
-                                description: The ingress class to use when creating
-                                  Ingress resources to solve ACME challenges that
-                                  use this challenge solver. Only one of 'class' or
-                                  'name' may be specified.
-                                type: string
-                              ingressTemplate:
-                                description: Optional ingress template used to configure
-                                  the ACME challenge solver ingress used for HTTP01
-                                  challenges
-                                type: object
-                                properties:
-                                  metadata:
-                                    description: ObjectMeta overrides for the ingress
-                                      used to solve HTTP01 challenges. Only the 'labels'
-                                      and 'annotations' fields may be set. If labels
-                                      or annotations overlap with in-built values,
-                                      the values here will override the in-built values.
-                                    type: object
-                                    properties:
-                                      annotations:
-                                        description: Annotations that should be added
-                                          to the created ACME HTTP01 solver ingress.
-                                        type: object
-                                        additionalProperties:
-                                          type: string
-                                      labels:
-                                        description: Labels that should be added to
-                                          the created ACME HTTP01 solver ingress.
-                                        type: object
-                                        additionalProperties:
-                                          type: string
-                              name:
-                                description: The name of the ingress resource that
-                                  should have ACME challenge solving routes inserted
-                                  into it in order to solve HTTP01 challenges. This
-                                  is typically used in conjunction with ingress controllers
-                                  like ingress-gce, which maintains a 1:1 mapping
-                                  between external IPs and ingress resources.
-                                type: string
-                              podTemplate:
-                                description: Optional pod template used to configure
-                                  the ACME challenge solver pods used for HTTP01 challenges
-                                type: object
-                                properties:
-                                  metadata:
-                                    description: ObjectMeta overrides for the pod
-                                      used to solve HTTP01 challenges. Only the 'labels'
-                                      and 'annotations' fields may be set. If labels
-                                      or annotations overlap with in-built values,
-                                      the values here will override the in-built values.
-                                    type: object
-                                    properties:
-                                      annotations:
-                                        description: Annotations that should be added
-                                          to the create ACME HTTP01 solver pods.
-                                        type: object
-                                        additionalProperties:
-                                          type: string
-                                      labels:
-                                        description: Labels that should be added to
-                                          the created ACME HTTP01 solver pods.
-                                        type: object
-                                        additionalProperties:
-                                          type: string
-                                  spec:
-                                    description: PodSpec defines overrides for the
-                                      HTTP01 challenge solver pod. Only the 'nodeSelector',
-                                      'affinity' and 'tolerations' fields are supported
-                                      currently. All other fields will be ignored.
-                                    type: object
-                                    properties:
-                                      affinity:
-                                        description: If specified, the pod's scheduling
-                                          constraints
-                                        type: object
-                                        properties:
-                                          nodeAffinity:
-                                            description: Describes node affinity scheduling
-                                              rules for the pod.
-                                            type: object
-                                            properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                description: The scheduler will prefer
-                                                  to schedule pods to nodes that satisfy
-                                                  the affinity expressions specified
-                                                  by this field, but it may choose
-                                                  a node that violates one or more
-                                                  of the expressions. The node that
-                                                  is most preferred is the one with
-                                                  the greatest sum of weights, i.e.
-                                                  for each node that meets all of
-                                                  the scheduling requirements (resource
-                                                  request, requiredDuringScheduling
-                                                  affinity expressions, etc.), compute
-                                                  a sum by iterating through the elements
-                                                  of this field and adding "weight"
-                                                  to the sum if the node matches the
-                                                  corresponding matchExpressions;
-                                                  the node(s) with the highest sum
-                                                  are the most preferred.
-                                                type: array
-                                                items:
-                                                  description: An empty preferred
-                                                    scheduling term matches all objects
-                                                    with implicit weight 0 (i.e. it's
-                                                    a no-op). A null preferred scheduling
-                                                    term matches no objects (i.e.
-                                                    is also a no-op).
-                                                  type: object
-                                                  required:
-                                                  - preference
-                                                  - weight
-                                                  properties:
-                                                    preference:
-                                                      description: A node selector
-                                                        term, associated with the
-                                                        corresponding weight.
-                                                      type: object
-                                                      properties:
-                                                        matchExpressions:
-                                                          description: A list of node
-                                                            selector requirements
-                                                            by node's labels.
-                                                          type: array
-                                                          items:
-                                                            description: A node selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            type: object
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            properties:
-                                                              key:
-                                                                description: The label
-                                                                  key that the selector
-                                                                  applies to.
-                                                                type: string
-                                                              operator:
-                                                                description: Represents
-                                                                  a key's relationship
-                                                                  to a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists,
-                                                                  DoesNotExist. Gt,
-                                                                  and Lt.
-                                                                type: string
-                                                              values:
-                                                                description: An array
-                                                                  of string values.
-                                                                  If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. If
-                                                                  the operator is
-                                                                  Gt or Lt, the values
-                                                                  array must have
-                                                                  a single element,
-                                                                  which will be interpreted
-                                                                  as an integer. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                type: array
-                                                                items:
-                                                                  type: string
-                                                        matchFields:
-                                                          description: A list of node
-                                                            selector requirements
-                                                            by node's fields.
-                                                          type: array
-                                                          items:
-                                                            description: A node selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            type: object
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            properties:
-                                                              key:
-                                                                description: The label
-                                                                  key that the selector
-                                                                  applies to.
-                                                                type: string
-                                                              operator:
-                                                                description: Represents
-                                                                  a key's relationship
-                                                                  to a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists,
-                                                                  DoesNotExist. Gt,
-                                                                  and Lt.
-                                                                type: string
-                                                              values:
-                                                                description: An array
-                                                                  of string values.
-                                                                  If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. If
-                                                                  the operator is
-                                                                  Gt or Lt, the values
-                                                                  array must have
-                                                                  a single element,
-                                                                  which will be interpreted
-                                                                  as an integer. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                type: array
-                                                                items:
-                                                                  type: string
-                                                    weight:
-                                                      description: Weight associated
-                                                        with matching the corresponding
-                                                        nodeSelectorTerm, in the range
-                                                        1-100.
-                                                      type: integer
-                                                      format: int32
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                description: If the affinity requirements
-                                                  specified by this field are not
-                                                  met at scheduling time, the pod
-                                                  will not be scheduled onto the node.
-                                                  If the affinity requirements specified
-                                                  by this field cease to be met at
-                                                  some point during pod execution
-                                                  (e.g. due to an update), the system
-                                                  may or may not try to eventually
-                                                  evict the pod from its node.
-                                                type: object
-                                                required:
-                                                - nodeSelectorTerms
-                                                properties:
-                                                  nodeSelectorTerms:
-                                                    description: Required. A list
-                                                      of node selector terms. The
-                                                      terms are ORed.
-                                                    type: array
-                                                    items:
-                                                      description: A null or empty
-                                                        node selector term matches
-                                                        no objects. The requirements
-                                                        of them are ANDed. The TopologySelectorTerm
-                                                        type implements a subset of
-                                                        the NodeSelectorTerm.
-                                                      type: object
-                                                      properties:
-                                                        matchExpressions:
-                                                          description: A list of node
-                                                            selector requirements
-                                                            by node's labels.
-                                                          type: array
-                                                          items:
-                                                            description: A node selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            type: object
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            properties:
-                                                              key:
-                                                                description: The label
-                                                                  key that the selector
-                                                                  applies to.
-                                                                type: string
-                                                              operator:
-                                                                description: Represents
-                                                                  a key's relationship
-                                                                  to a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists,
-                                                                  DoesNotExist. Gt,
-                                                                  and Lt.
-                                                                type: string
-                                                              values:
-                                                                description: An array
-                                                                  of string values.
-                                                                  If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. If
-                                                                  the operator is
-                                                                  Gt or Lt, the values
-                                                                  array must have
-                                                                  a single element,
-                                                                  which will be interpreted
-                                                                  as an integer. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                type: array
-                                                                items:
-                                                                  type: string
-                                                        matchFields:
-                                                          description: A list of node
-                                                            selector requirements
-                                                            by node's fields.
-                                                          type: array
-                                                          items:
-                                                            description: A node selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            type: object
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            properties:
-                                                              key:
-                                                                description: The label
-                                                                  key that the selector
-                                                                  applies to.
-                                                                type: string
-                                                              operator:
-                                                                description: Represents
-                                                                  a key's relationship
-                                                                  to a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists,
-                                                                  DoesNotExist. Gt,
-                                                                  and Lt.
-                                                                type: string
-                                                              values:
-                                                                description: An array
-                                                                  of string values.
-                                                                  If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. If
-                                                                  the operator is
-                                                                  Gt or Lt, the values
-                                                                  array must have
-                                                                  a single element,
-                                                                  which will be interpreted
-                                                                  as an integer. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                type: array
-                                                                items:
-                                                                  type: string
-                                          podAffinity:
-                                            description: Describes pod affinity scheduling
-                                              rules (e.g. co-locate this pod in the
-                                              same node, zone, etc. as some other
-                                              pod(s)).
-                                            type: object
-                                            properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                description: The scheduler will prefer
-                                                  to schedule pods to nodes that satisfy
-                                                  the affinity expressions specified
-                                                  by this field, but it may choose
-                                                  a node that violates one or more
-                                                  of the expressions. The node that
-                                                  is most preferred is the one with
-                                                  the greatest sum of weights, i.e.
-                                                  for each node that meets all of
-                                                  the scheduling requirements (resource
-                                                  request, requiredDuringScheduling
-                                                  affinity expressions, etc.), compute
-                                                  a sum by iterating through the elements
-                                                  of this field and adding "weight"
-                                                  to the sum if the node has pods
-                                                  which matches the corresponding
-                                                  podAffinityTerm; the node(s) with
-                                                  the highest sum are the most preferred.
-                                                type: array
-                                                items:
-                                                  description: The weights of all
-                                                    of the matched WeightedPodAffinityTerm
-                                                    fields are added per-node to find
-                                                    the most preferred node(s)
-                                                  type: object
-                                                  required:
-                                                  - podAffinityTerm
-                                                  - weight
-                                                  properties:
-                                                    podAffinityTerm:
-                                                      description: Required. A pod
-                                                        affinity term, associated
-                                                        with the corresponding weight.
-                                                      type: object
-                                                      required:
-                                                      - topologyKey
-                                                      properties:
-                                                        labelSelector:
-                                                          description: A label query
-                                                            over a set of resources,
-                                                            in this case pods.
-                                                          type: object
-                                                          properties:
-                                                            matchExpressions:
-                                                              description: matchExpressions
-                                                                is a list of label
-                                                                selector requirements.
-                                                                The requirements are
-                                                                ANDed.
-                                                              type: array
-                                                              items:
-                                                                description: A label
-                                                                  selector requirement
-                                                                  is a selector that
-                                                                  contains values,
-                                                                  a key, and an operator
-                                                                  that relates the
-                                                                  key and values.
-                                                                type: object
-                                                                required:
-                                                                - key
-                                                                - operator
-                                                                properties:
-                                                                  key:
-                                                                    description: key
-                                                                      is the label
-                                                                      key that the
-                                                                      selector applies
-                                                                      to.
-                                                                    type: string
-                                                                  operator:
-                                                                    description: operator
-                                                                      represents a
-                                                                      key's relationship
-                                                                      to a set of
-                                                                      values. Valid
-                                                                      operators are
-                                                                      In, NotIn, Exists
-                                                                      and DoesNotExist.
-                                                                    type: string
-                                                                  values:
-                                                                    description: values
-                                                                      is an array
-                                                                      of string values.
-                                                                      If the operator
-                                                                      is In or NotIn,
-                                                                      the values array
-                                                                      must be non-empty.
-                                                                      If the operator
-                                                                      is Exists or
-                                                                      DoesNotExist,
-                                                                      the values array
-                                                                      must be empty.
-                                                                      This array is
-                                                                      replaced during
-                                                                      a strategic
-                                                                      merge patch.
-                                                                    type: array
-                                                                    items:
-                                                                      type: string
-                                                            matchLabels:
-                                                              description: matchLabels
-                                                                is a map of {key,value}
-                                                                pairs. A single {key,value}
-                                                                in the matchLabels
-                                                                map is equivalent
-                                                                to an element of matchExpressions,
-                                                                whose key field is
-                                                                "key", the operator
-                                                                is "In", and the values
-                                                                array contains only
-                                                                "value". The requirements
-                                                                are ANDed.
-                                                              type: object
-                                                              additionalProperties:
-                                                                type: string
-                                                        namespaces:
-                                                          description: namespaces
-                                                            specifies which namespaces
-                                                            the labelSelector applies
-                                                            to (matches against);
-                                                            null or empty list means
-                                                            "this pod's namespace"
-                                                          type: array
-                                                          items:
-                                                            type: string
-                                                        topologyKey:
-                                                          description: This pod should
-                                                            be co-located (affinity)
-                                                            or not co-located (anti-affinity)
-                                                            with the pods matching
-                                                            the labelSelector in the
-                                                            specified namespaces,
-                                                            where co-located is defined
-                                                            as running on a node whose
-                                                            value of the label with
-                                                            key topologyKey matches
-                                                            that of any node on which
-                                                            any of the selected pods
-                                                            is running. Empty topologyKey
-                                                            is not allowed.
-                                                          type: string
-                                                    weight:
-                                                      description: weight associated
-                                                        with matching the corresponding
-                                                        podAffinityTerm, in the range
-                                                        1-100.
-                                                      type: integer
-                                                      format: int32
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                description: If the affinity requirements
-                                                  specified by this field are not
-                                                  met at scheduling time, the pod
-                                                  will not be scheduled onto the node.
-                                                  If the affinity requirements specified
-                                                  by this field cease to be met at
-                                                  some point during pod execution
-                                                  (e.g. due to a pod label update),
-                                                  the system may or may not try to
-                                                  eventually evict the pod from its
-                                                  node. When there are multiple elements,
-                                                  the lists of nodes corresponding
-                                                  to each podAffinityTerm are intersected,
-                                                  i.e. all terms must be satisfied.
-                                                type: array
-                                                items:
-                                                  description: Defines a set of pods
-                                                    (namely those matching the labelSelector
-                                                    relative to the given namespace(s))
-                                                    that this pod should be co-located
-                                                    (affinity) or not co-located (anti-affinity)
-                                                    with, where co-located is defined
-                                                    as running on a node whose value
-                                                    of the label with key <topologyKey>
-                                                    matches that of any node on which
-                                                    a pod of the set of pods is running
-                                                  type: object
-                                                  required:
-                                                  - topologyKey
-                                                  properties:
-                                                    labelSelector:
-                                                      description: A label query over
-                                                        a set of resources, in this
-                                                        case pods.
-                                                      type: object
-                                                      properties:
-                                                        matchExpressions:
-                                                          description: matchExpressions
-                                                            is a list of label selector
-                                                            requirements. The requirements
-                                                            are ANDed.
-                                                          type: array
-                                                          items:
-                                                            description: A label selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            type: object
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            properties:
-                                                              key:
-                                                                description: key is
-                                                                  the label key that
-                                                                  the selector applies
-                                                                  to.
-                                                                type: string
-                                                              operator:
-                                                                description: operator
-                                                                  represents a key's
-                                                                  relationship to
-                                                                  a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists
-                                                                  and DoesNotExist.
-                                                                type: string
-                                                              values:
-                                                                description: values
-                                                                  is an array of string
-                                                                  values. If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                type: array
-                                                                items:
-                                                                  type: string
-                                                        matchLabels:
-                                                          description: matchLabels
-                                                            is a map of {key,value}
-                                                            pairs. A single {key,value}
-                                                            in the matchLabels map
-                                                            is equivalent to an element
-                                                            of matchExpressions, whose
-                                                            key field is "key", the
-                                                            operator is "In", and
-                                                            the values array contains
-                                                            only "value". The requirements
-                                                            are ANDed.
-                                                          type: object
-                                                          additionalProperties:
-                                                            type: string
-                                                    namespaces:
-                                                      description: namespaces specifies
-                                                        which namespaces the labelSelector
-                                                        applies to (matches against);
-                                                        null or empty list means "this
-                                                        pod's namespace"
-                                                      type: array
-                                                      items:
-                                                        type: string
-                                                    topologyKey:
-                                                      description: This pod should
-                                                        be co-located (affinity) or
-                                                        not co-located (anti-affinity)
-                                                        with the pods matching the
-                                                        labelSelector in the specified
-                                                        namespaces, where co-located
-                                                        is defined as running on a
-                                                        node whose value of the label
-                                                        with key topologyKey matches
-                                                        that of any node on which
-                                                        any of the selected pods is
-                                                        running. Empty topologyKey
-                                                        is not allowed.
-                                                      type: string
-                                          podAntiAffinity:
-                                            description: Describes pod anti-affinity
-                                              scheduling rules (e.g. avoid putting
-                                              this pod in the same node, zone, etc.
-                                              as some other pod(s)).
-                                            type: object
-                                            properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                description: The scheduler will prefer
-                                                  to schedule pods to nodes that satisfy
-                                                  the anti-affinity expressions specified
-                                                  by this field, but it may choose
-                                                  a node that violates one or more
-                                                  of the expressions. The node that
-                                                  is most preferred is the one with
-                                                  the greatest sum of weights, i.e.
-                                                  for each node that meets all of
-                                                  the scheduling requirements (resource
-                                                  request, requiredDuringScheduling
-                                                  anti-affinity expressions, etc.),
-                                                  compute a sum by iterating through
-                                                  the elements of this field and adding
-                                                  "weight" to the sum if the node
-                                                  has pods which matches the corresponding
-                                                  podAffinityTerm; the node(s) with
-                                                  the highest sum are the most preferred.
-                                                type: array
-                                                items:
-                                                  description: The weights of all
-                                                    of the matched WeightedPodAffinityTerm
-                                                    fields are added per-node to find
-                                                    the most preferred node(s)
-                                                  type: object
-                                                  required:
-                                                  - podAffinityTerm
-                                                  - weight
-                                                  properties:
-                                                    podAffinityTerm:
-                                                      description: Required. A pod
-                                                        affinity term, associated
-                                                        with the corresponding weight.
-                                                      type: object
-                                                      required:
-                                                      - topologyKey
-                                                      properties:
-                                                        labelSelector:
-                                                          description: A label query
-                                                            over a set of resources,
-                                                            in this case pods.
-                                                          type: object
-                                                          properties:
-                                                            matchExpressions:
-                                                              description: matchExpressions
-                                                                is a list of label
-                                                                selector requirements.
-                                                                The requirements are
-                                                                ANDed.
-                                                              type: array
-                                                              items:
-                                                                description: A label
-                                                                  selector requirement
-                                                                  is a selector that
-                                                                  contains values,
-                                                                  a key, and an operator
-                                                                  that relates the
-                                                                  key and values.
-                                                                type: object
-                                                                required:
-                                                                - key
-                                                                - operator
-                                                                properties:
-                                                                  key:
-                                                                    description: key
-                                                                      is the label
-                                                                      key that the
-                                                                      selector applies
-                                                                      to.
-                                                                    type: string
-                                                                  operator:
-                                                                    description: operator
-                                                                      represents a
-                                                                      key's relationship
-                                                                      to a set of
-                                                                      values. Valid
-                                                                      operators are
-                                                                      In, NotIn, Exists
-                                                                      and DoesNotExist.
-                                                                    type: string
-                                                                  values:
-                                                                    description: values
-                                                                      is an array
-                                                                      of string values.
-                                                                      If the operator
-                                                                      is In or NotIn,
-                                                                      the values array
-                                                                      must be non-empty.
-                                                                      If the operator
-                                                                      is Exists or
-                                                                      DoesNotExist,
-                                                                      the values array
-                                                                      must be empty.
-                                                                      This array is
-                                                                      replaced during
-                                                                      a strategic
-                                                                      merge patch.
-                                                                    type: array
-                                                                    items:
-                                                                      type: string
-                                                            matchLabels:
-                                                              description: matchLabels
-                                                                is a map of {key,value}
-                                                                pairs. A single {key,value}
-                                                                in the matchLabels
-                                                                map is equivalent
-                                                                to an element of matchExpressions,
-                                                                whose key field is
-                                                                "key", the operator
-                                                                is "In", and the values
-                                                                array contains only
-                                                                "value". The requirements
-                                                                are ANDed.
-                                                              type: object
-                                                              additionalProperties:
-                                                                type: string
-                                                        namespaces:
-                                                          description: namespaces
-                                                            specifies which namespaces
-                                                            the labelSelector applies
-                                                            to (matches against);
-                                                            null or empty list means
-                                                            "this pod's namespace"
-                                                          type: array
-                                                          items:
-                                                            type: string
-                                                        topologyKey:
-                                                          description: This pod should
-                                                            be co-located (affinity)
-                                                            or not co-located (anti-affinity)
-                                                            with the pods matching
-                                                            the labelSelector in the
-                                                            specified namespaces,
-                                                            where co-located is defined
-                                                            as running on a node whose
-                                                            value of the label with
-                                                            key topologyKey matches
-                                                            that of any node on which
-                                                            any of the selected pods
-                                                            is running. Empty topologyKey
-                                                            is not allowed.
-                                                          type: string
-                                                    weight:
-                                                      description: weight associated
-                                                        with matching the corresponding
-                                                        podAffinityTerm, in the range
-                                                        1-100.
-                                                      type: integer
-                                                      format: int32
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                description: If the anti-affinity
-                                                  requirements specified by this field
-                                                  are not met at scheduling time,
-                                                  the pod will not be scheduled onto
-                                                  the node. If the anti-affinity requirements
-                                                  specified by this field cease to
-                                                  be met at some point during pod
-                                                  execution (e.g. due to a pod label
-                                                  update), the system may or may not
-                                                  try to eventually evict the pod
-                                                  from its node. When there are multiple
-                                                  elements, the lists of nodes corresponding
-                                                  to each podAffinityTerm are intersected,
-                                                  i.e. all terms must be satisfied.
-                                                type: array
-                                                items:
-                                                  description: Defines a set of pods
-                                                    (namely those matching the labelSelector
-                                                    relative to the given namespace(s))
-                                                    that this pod should be co-located
-                                                    (affinity) or not co-located (anti-affinity)
-                                                    with, where co-located is defined
-                                                    as running on a node whose value
-                                                    of the label with key <topologyKey>
-                                                    matches that of any node on which
-                                                    a pod of the set of pods is running
-                                                  type: object
-                                                  required:
-                                                  - topologyKey
-                                                  properties:
-                                                    labelSelector:
-                                                      description: A label query over
-                                                        a set of resources, in this
-                                                        case pods.
-                                                      type: object
-                                                      properties:
-                                                        matchExpressions:
-                                                          description: matchExpressions
-                                                            is a list of label selector
-                                                            requirements. The requirements
-                                                            are ANDed.
-                                                          type: array
-                                                          items:
-                                                            description: A label selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            type: object
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            properties:
-                                                              key:
-                                                                description: key is
-                                                                  the label key that
-                                                                  the selector applies
-                                                                  to.
-                                                                type: string
-                                                              operator:
-                                                                description: operator
-                                                                  represents a key's
-                                                                  relationship to
-                                                                  a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists
-                                                                  and DoesNotExist.
-                                                                type: string
-                                                              values:
-                                                                description: values
-                                                                  is an array of string
-                                                                  values. If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                type: array
-                                                                items:
-                                                                  type: string
-                                                        matchLabels:
-                                                          description: matchLabels
-                                                            is a map of {key,value}
-                                                            pairs. A single {key,value}
-                                                            in the matchLabels map
-                                                            is equivalent to an element
-                                                            of matchExpressions, whose
-                                                            key field is "key", the
-                                                            operator is "In", and
-                                                            the values array contains
-                                                            only "value". The requirements
-                                                            are ANDed.
-                                                          type: object
-                                                          additionalProperties:
-                                                            type: string
-                                                    namespaces:
-                                                      description: namespaces specifies
-                                                        which namespaces the labelSelector
-                                                        applies to (matches against);
-                                                        null or empty list means "this
-                                                        pod's namespace"
-                                                      type: array
-                                                      items:
-                                                        type: string
-                                                    topologyKey:
-                                                      description: This pod should
-                                                        be co-located (affinity) or
-                                                        not co-located (anti-affinity)
-                                                        with the pods matching the
-                                                        labelSelector in the specified
-                                                        namespaces, where co-located
-                                                        is defined as running on a
-                                                        node whose value of the label
-                                                        with key topologyKey matches
-                                                        that of any node on which
-                                                        any of the selected pods is
-                                                        running. Empty topologyKey
-                                                        is not allowed.
-                                                      type: string
-                                      nodeSelector:
-                                        description: 'NodeSelector is a selector which
-                                          must be true for the pod to fit on a node.
-                                          Selector which must match a node''s labels
-                                          for the pod to be scheduled on that node.
-                                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
-                                        type: object
-                                        additionalProperties:
-                                          type: string
-                                      tolerations:
-                                        description: If specified, the pod's tolerations.
-                                        type: array
-                                        items:
-                                          description: The pod this Toleration is
-                                            attached to tolerates any taint that matches
-                                            the triple <key,value,effect> using the
-                                            matching operator <operator>.
-                                          type: object
-                                          properties:
-                                            effect:
-                                              description: Effect indicates the taint
-                                                effect to match. Empty means match
-                                                all taint effects. When specified,
-                                                allowed values are NoSchedule, PreferNoSchedule
-                                                and NoExecute.
-                                              type: string
-                                            key:
-                                              description: Key is the taint key that
-                                                the toleration applies to. Empty means
-                                                match all taint keys. If the key is
-                                                empty, operator must be Exists; this
-                                                combination means to match all values
-                                                and all keys.
-                                              type: string
-                                            operator:
-                                              description: Operator represents a key's
-                                                relationship to the value. Valid operators
-                                                are Exists and Equal. Defaults to
-                                                Equal. Exists is equivalent to wildcard
-                                                for value, so that a pod can tolerate
-                                                all taints of a particular category.
-                                              type: string
-                                            tolerationSeconds:
-                                              description: TolerationSeconds represents
-                                                the period of time the toleration
-                                                (which must be of effect NoExecute,
-                                                otherwise this field is ignored) tolerates
-                                                the taint. By default, it is not set,
-                                                which means tolerate the taint forever
-                                                (do not evict). Zero and negative
-                                                values will be treated as 0 (evict
-                                                immediately) by the system.
-                                              type: integer
-                                              format: int64
-                                            value:
-                                              description: Value is the taint value
-                                                the toleration matches to. If the
-                                                operator is Exists, the value should
-                                                be empty, otherwise just a regular
-                                                string.
-                                              type: string
-                              serviceType:
-                                description: Optional service type for Kubernetes
-                                  solver service
-                                type: string
-                      selector:
-                        description: Selector selects a set of DNSNames on the Certificate
-                          resource that should be solved using this challenge solver.
-                        type: object
-                        properties:
-                          dnsNames:
-                            description: List of DNSNames that this solver will be
-                              used to solve. If specified and a match is found, a
-                              dnsNames selector will take precedence over a dnsZones
-                              selector. If multiple solvers match with the same dnsNames
-                              value, the solver with the most matching labels in matchLabels
-                              will be selected. If neither has more matches, the solver
-                              defined earlier in the list will be selected.
-                            type: array
-                            items:
-                              type: string
-                          dnsZones:
-                            description: List of DNSZones that this solver will be
-                              used to solve. The most specific DNS zone match specified
-                              here will take precedence over other DNS zone matches,
-                              so a solver specifying sys.example.com will be selected
-                              over one specifying example.com for the domain www.sys.example.com.
-                              If multiple solvers match with the same dnsZones value,
-                              the solver with the most matching labels in matchLabels
-                              will be selected. If neither has more matches, the solver
-                              defined earlier in the list will be selected.
-                            type: array
-                            items:
-                              type: string
-                          matchLabels:
-                            description: A label selector that is used to refine the
-                              set of certificate's that this challenge solver will
-                              apply to.
-                            type: object
-                            additionalProperties:
-                              type: string
-            ca:
-              type: object
-              required:
-              - secretName
-              properties:
-                crlDistributionPoints:
-                  description: The CRL distribution points is an X.509 v3 certificate
-                    extension which identifies the location of the CRL from which
-                    the revocation of this certificate can be checked. If not set
-                    certificate will be issued without CDP. Values are strings.
-                  type: array
-                  items:
-                    type: string
-                secretName:
-                  description: SecretName is the name of the secret used to sign Certificates
-                    issued by this Issuer.
-                  type: string
-            selfSigned:
-              type: object
-              properties:
-                crlDistributionPoints:
-                  description: The CRL distribution points is an X.509 v3 certificate
-                    extension which identifies the location of the CRL from which
-                    the revocation of this certificate can be checked. If not set
-                    certificate will be issued without CDP. Values are strings.
-                  type: array
-                  items:
-                    type: string
-            vault:
-              type: object
-              required:
-              - auth
-              - path
-              - server
-              properties:
-                auth:
-                  description: Vault authentication
-                  type: object
-                  properties:
-                    appRole:
-                      description: This Secret contains a AppRole and Secret
-                      type: object
-                      required:
-                      - path
-                      - roleId
-                      - secretRef
-                      properties:
-                        path:
-                          description: Where the authentication path is mounted in
-                            Vault.
-                          type: string
-                        roleId:
-                          type: string
-                        secretRef:
-                          type: object
-                          required:
-                          - name
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                    kubernetes:
-                      description: This contains a Role and Secret with a ServiceAccount
-                        token to authenticate with vault.
-                      type: object
-                      required:
-                      - role
-                      - secretRef
-                      properties:
-                        mountPath:
-                          description: The Vault mountPath here is the mount path
-                            to use when authenticating with Vault. For example, setting
-                            a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login`
-                            to authenticate with Vault. If unspecified, the default
-                            value "/v1/auth/kubernetes" will be used.
-                          type: string
-                        role:
-                          description: A required field containing the Vault Role
-                            to assume. A Role binds a Kubernetes ServiceAccount with
-                            a set of Vault policies.
-                          type: string
-                        secretRef:
-                          description: The required Secret field containing a Kubernetes
-                            ServiceAccount JWT used for authenticating with Vault.
-                            Use of 'ambient credentials' is not supported.
-                          type: object
-                          required:
-                          - name
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                    tokenSecretRef:
-                      description: This Secret contains the Vault token key
-                      type: object
-                      required:
-                      - name
-                      properties:
-                        key:
-                          description: The key of the secret to select from. Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                caBundle:
-                  description: Base64 encoded CA bundle to validate Vault server certificate.
-                    Only used if the Server URL is using HTTPS protocol. This parameter
-                    is ignored for plain HTTP protocol connection. If not set the
-                    system root certificates are used to validate the TLS connection.
-                  type: string
-                  format: byte
-                path:
-                  description: Vault URL path to the certificate role
-                  type: string
-                server:
-                  description: Server is the vault connection address
-                  type: string
-            venafi:
-              description: VenafiIssuer describes issuer configuration details for
-                Venafi Cloud.
-              type: object
-              required:
-              - zone
-              properties:
-                cloud:
-                  description: Cloud specifies the Venafi cloud configuration settings.
-                    Only one of TPP or Cloud may be specified.
-                  type: object
-                  required:
-                  - apiTokenSecretRef
-                  properties:
-                    apiTokenSecretRef:
-                      description: APITokenSecretRef is a secret key selector for
-                        the Venafi Cloud API token.
-                      type: object
-                      required:
-                      - name
-                      properties:
-                        key:
-                          description: The key of the secret to select from. Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                    url:
-                      description: URL is the base URL for Venafi Cloud
-                      type: string
-                tpp:
-                  description: TPP specifies Trust Protection Platform configuration
-                    settings. Only one of TPP or Cloud may be specified.
-                  type: object
-                  required:
-                  - credentialsRef
-                  - url
-                  properties:
-                    caBundle:
-                      description: CABundle is a PEM encoded TLS certificate to use
-                        to verify connections to the TPP instance. If specified, system
-                        roots will not be used and the issuing CA for the TPP instance
-                        must be verifiable using the provided root. If not specified,
-                        the connection will be verified using the cert-manager system
-                        root certificates.
-                      type: string
-                      format: byte
-                    credentialsRef:
-                      description: CredentialsRef is a reference to a Secret containing
-                        the username and password for the TPP server. The secret must
-                        contain two keys, 'username' and 'password'.
-                      type: object
-                      required:
-                      - name
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                    url:
-                      description: URL is the base URL for the Venafi TPP instance
-                      type: string
-                zone:
-                  description: Zone is the Venafi Policy Zone to use for this issuer.
-                    All requests made to the Venafi platform will be restricted by
-                    the named zone policy. This field is required.
-                  type: string
-        status:
-          description: IssuerStatus contains status information about an Issuer
-          type: object
-          properties:
-            acme:
-              type: object
-              properties:
-                lastRegisteredEmail:
-                  description: LastRegisteredEmail is the email associated with the
-                    latest registered ACME account, in order to track changes made
-                    to registered account associated with the  Issuer
-                  type: string
-                uri:
-                  description: URI is the unique account identifier, which can also
-                    be used to retrieve account details from the CA
-                  type: string
-            conditions:
-              type: array
-              items:
-                description: IssuerCondition contains condition information for an
-                  Issuer.
+    "schema":
+      "openAPIV3Schema":
+        description: A ClusterIssuer represents a certificate issuing authority which
+          can be referenced as part of `issuerRef` fields. It is similar to an Issuer,
+          however it is cluster-scoped and therefore can be referenced by resources
+          that exist in *any* namespace, not just the same namespace as the referent.
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Desired state of the ClusterIssuer resource.
+            type: object
+            properties:
+              acme:
+                description: ACME configures this issuer to communicate with a RFC8555
+                  (ACME) server to obtain signed x509 certificates.
                 type: object
                 required:
-                - status
-                - type
+                - privateKeySecretRef
+                - server
                 properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the timestamp corresponding
-                      to the last status change of this condition.
+                  email:
+                    description: Email is the email address to be associated with
+                      the ACME account. This field is optional, but it is strongly
+                      recommended to be set. It will be used to contact you in case
+                      of issues with your account or certificates, including expiry
+                      notification emails. This field may be updated after the account
+                      is initially registered.
                     type: string
-                    format: date-time
-                  message:
-                    description: Message is a human readable description of the details
-                      of the last transition, complementing reason.
+                  externalAccountBinding:
+                    description: ExternalAccountBinding is a reference to a CA external
+                      account of the ACME server. If set, upon registration cert-manager
+                      will attempt to associate the given external account credentials
+                      with the registered ACME account.
+                    type: object
+                    required:
+                    - keyAlgorithm
+                    - keyID
+                    - keySecretRef
+                    properties:
+                      keyAlgorithm:
+                        description: keyAlgorithm is the MAC key algorithm that the
+                          key is used for. Valid values are "HS256", "HS384" and "HS512".
+                        type: string
+                        enum:
+                        - HS256
+                        - HS384
+                        - HS512
+                      keyID:
+                        description: keyID is the ID of the CA key that the External
+                          Account is bound to.
+                        type: string
+                      keySecretRef:
+                        description: keySecretRef is a Secret Key Selector referencing
+                          a data item in a Kubernetes Secret which holds the symmetric
+                          MAC key of the External Account Binding. The `key` is the
+                          index string that is paired with the key data in the Secret
+                          and should not be confused with the key data itself, or
+                          indeed with the External Account Binding keyID above. The
+                          secret key stored in the Secret **must** be un-padded, base64
+                          URL encoded data.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the entry in the Secret resource's
+                              `data` field to be used. Some instances of this field
+                              may be defaulted, in others it may be required.
+                            type: string
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                  privateKeySecretRef:
+                    description: PrivateKey is the name of a Kubernetes Secret resource
+                      that will be used to store the automatically generated ACME
+                      account private key. Optionally, a `key` may be specified to
+                      select a specific entry within the named Secret resource. If
+                      `key` is not specified, a default of `tls.key` will be used.
+                    type: object
+                    required:
+                    - name
+                    properties:
+                      key:
+                        description: The key of the entry in the Secret resource's
+                          `data` field to be used. Some instances of this field may
+                          be defaulted, in others it may be required.
+                        type: string
+                      name:
+                        description: 'Name of the resource being referred to. More
+                          info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                  server:
+                    description: 'Server is the URL used to access the ACME server''s
+                      ''directory'' endpoint. For example, for Let''s Encrypt''s staging
+                      endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory".
+                      Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                     type: string
-                  reason:
-                    description: Reason is a brief machine readable explanation for
-                      the condition's last transition.
+                  skipTLSVerify:
+                    description: Enables or disables validation of the ACME server
+                      TLS certificate. If true, requests to the ACME server will not
+                      have their TLS certificate validated (i.e. insecure connections
+                      will be allowed). Only enable this option in development environments.
+                      The cert-manager system installed roots will be used to verify
+                      connections to the ACME server if this is false. Defaults to
+                      false.
+                    type: boolean
+                  solvers:
+                    description: 'Solvers is a list of challenge solvers that will
+                      be used to solve ACME challenges for the matching domains. Solver
+                      configurations must be provided in order to obtain certificates
+                      from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/'
+                    type: array
+                    items:
+                      description: Configures an issuer to solve challenges using
+                        the specified options. Only one of HTTP01 or DNS01 may be
+                        provided.
+                      type: object
+                      properties:
+                        dns01:
+                          description: Configures cert-manager to attempt to complete
+                            authorizations by performing the DNS01 challenge flow.
+                          type: object
+                          properties:
+                            acmedns:
+                              description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns)
+                                API to manage DNS01 challenge records.
+                              type: object
+                              required:
+                              - accountSecretRef
+                              - host
+                              properties:
+                                accountSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                host:
+                                  type: string
+                            akamai:
+                              description: Use the Akamai DNS zone management API
+                                to manage DNS01 challenge records.
+                              type: object
+                              required:
+                              - accessTokenSecretRef
+                              - clientSecretSecretRef
+                              - clientTokenSecretRef
+                              - serviceConsumerDomain
+                              properties:
+                                accessTokenSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                clientSecretSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                clientTokenSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                serviceConsumerDomain:
+                                  type: string
+                            azuredns:
+                              description: Use the Microsoft Azure DNS API to manage
+                                DNS01 challenge records.
+                              type: object
+                              required:
+                              - resourceGroupName
+                              - subscriptionID
+                              properties:
+                                clientID:
+                                  description: if both this and ClientSecret are left
+                                    unset MSI will be used
+                                  type: string
+                                clientSecretSecretRef:
+                                  description: if both this and ClientID are left
+                                    unset MSI will be used
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                environment:
+                                  type: string
+                                  enum:
+                                  - AzurePublicCloud
+                                  - AzureChinaCloud
+                                  - AzureGermanCloud
+                                  - AzureUSGovernmentCloud
+                                hostedZoneName:
+                                  type: string
+                                resourceGroupName:
+                                  type: string
+                                subscriptionID:
+                                  type: string
+                                tenantID:
+                                  description: when specifying ClientID and ClientSecret
+                                    then this field is also needed
+                                  type: string
+                            clouddns:
+                              description: Use the Google Cloud DNS API to manage
+                                DNS01 challenge records.
+                              type: object
+                              required:
+                              - project
+                              properties:
+                                hostedZoneName:
+                                  description: HostedZoneName is an optional field
+                                    that tells cert-manager in which Cloud DNS zone
+                                    the challenge record has to be created. If left
+                                    empty cert-manager will automatically choose a
+                                    zone.
+                                  type: string
+                                project:
+                                  type: string
+                                serviceAccountSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                            cloudflare:
+                              description: Use the Cloudflare API to manage DNS01
+                                challenge records.
+                              type: object
+                              properties:
+                                apiKeySecretRef:
+                                  description: 'API key to use to authenticate with
+                                    Cloudflare. Note: using an API token to authenticate
+                                    is now the recommended method as it allows greater
+                                    control of permissions.'
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                apiTokenSecretRef:
+                                  description: API token used to authenticate with
+                                    Cloudflare.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                email:
+                                  description: Email of the account, only required
+                                    when using API key based authentication.
+                                  type: string
+                            cnameStrategy:
+                              description: CNAMEStrategy configures how the DNS01
+                                provider should handle CNAME records when found in
+                                DNS zones.
+                              type: string
+                              enum:
+                              - None
+                              - Follow
+                            digitalocean:
+                              description: Use the DigitalOcean DNS API to manage
+                                DNS01 challenge records.
+                              type: object
+                              required:
+                              - tokenSecretRef
+                              properties:
+                                tokenSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                            rfc2136:
+                              description: Use RFC2136 ("Dynamic Updates in the Domain
+                                Name System") (https://datatracker.ietf.org/doc/rfc2136/)
+                                to manage DNS01 challenge records.
+                              type: object
+                              required:
+                              - nameserver
+                              properties:
+                                nameserver:
+                                  description: The IP address or hostname of an authoritative
+                                    DNS server supporting RFC2136 in the form host:port.
+                                    If the host is an IPv6 address it must be enclosed
+                                    in square brackets (e.g [2001:db8::1]) ; port
+                                    is optional. This field is required.
+                                  type: string
+                                tsigAlgorithm:
+                                  description: 'The TSIG Algorithm configured in the
+                                    DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                                    and ``tsigKeyName`` are defined. Supported values
+                                    are (case-insensitive): ``HMACMD5`` (default),
+                                    ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
+                                  type: string
+                                tsigKeyName:
+                                  description: The TSIG Key name configured in the
+                                    DNS. If ``tsigSecretSecretRef`` is defined, this
+                                    field is required.
+                                  type: string
+                                tsigSecretSecretRef:
+                                  description: The name of the secret containing the
+                                    TSIG value. If ``tsigKeyName`` is defined, this
+                                    field is required.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                            route53:
+                              description: Use the AWS Route53 API to manage DNS01
+                                challenge records.
+                              type: object
+                              required:
+                              - region
+                              properties:
+                                accessKeyID:
+                                  description: 'The AccessKeyID is used for authentication.
+                                    If not set we fall-back to using env vars, shared
+                                    credentials file or AWS Instance metadata see:
+                                    https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                  type: string
+                                hostedZoneID:
+                                  description: If set, the provider will manage only
+                                    this zone in Route53 and will not do an lookup
+                                    using the route53:ListHostedZonesByName api call.
+                                  type: string
+                                region:
+                                  description: Always set the region when using AccessKeyID
+                                    and SecretAccessKey
+                                  type: string
+                                role:
+                                  description: Role is a Role ARN which the Route53
+                                    provider will assume using either the explicit
+                                    credentials AccessKeyID/SecretAccessKey or the
+                                    inferred credentials from environment variables,
+                                    shared credentials file or AWS Instance metadata
+                                  type: string
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication.
+                                    If not set we fall-back to using env vars, shared
+                                    credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                            webhook:
+                              description: Configure an external webhook based DNS01
+                                challenge solver to manage DNS01 challenge records.
+                              type: object
+                              required:
+                              - groupName
+                              - solverName
+                              properties:
+                                config:
+                                  description: Additional configuration that should
+                                    be passed to the webhook apiserver when challenges
+                                    are processed. This can contain arbitrary JSON
+                                    data. Secret values should not be specified in
+                                    this stanza. If secret values are needed (e.g.
+                                    credentials for a DNS service), you should use
+                                    a SecretKeySelector to reference a Secret resource.
+                                    For details on the schema of this field, consult
+                                    the webhook provider implementation's documentation.
+                                  x-kubernetes-preserve-unknown-fields: true
+                                groupName:
+                                  description: The API group name that should be used
+                                    when POSTing ChallengePayload resources to the
+                                    webhook apiserver. This should be the same as
+                                    the GroupName specified in the webhook provider
+                                    implementation.
+                                  type: string
+                                solverName:
+                                  description: The name of the solver to use, as defined
+                                    in the webhook provider implementation. This will
+                                    typically be the name of the provider, e.g. 'cloudflare'.
+                                  type: string
+                        http01:
+                          description: Configures cert-manager to attempt to complete
+                            authorizations by performing the HTTP01 challenge flow.
+                            It is not possible to obtain certificates for wildcard
+                            domain names (e.g. `*.example.com`) using the HTTP01 challenge
+                            mechanism.
+                          type: object
+                          properties:
+                            ingress:
+                              description: The ingress based HTTP01 challenge solver
+                                will solve challenges by creating or modifying Ingress
+                                resources in order to route requests for '/.well-known/acme-challenge/XYZ'
+                                to 'challenge solver' pods that are provisioned by
+                                cert-manager for each Challenge to be completed.
+                              type: object
+                              properties:
+                                class:
+                                  description: The ingress class to use when creating
+                                    Ingress resources to solve ACME challenges that
+                                    use this challenge solver. Only one of 'class'
+                                    or 'name' may be specified.
+                                  type: string
+                                ingressTemplate:
+                                  description: Optional ingress template used to configure
+                                    the ACME challenge solver ingress used for HTTP01
+                                    challenges
+                                  type: object
+                                  properties:
+                                    metadata:
+                                      description: ObjectMeta overrides for the ingress
+                                        used to solve HTTP01 challenges. Only the
+                                        'labels' and 'annotations' fields may be set.
+                                        If labels or annotations overlap with in-built
+                                        values, the values here will override the
+                                        in-built values.
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          description: Annotations that should be
+                                            added to the created ACME HTTP01 solver
+                                            ingress.
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        labels:
+                                          description: Labels that should be added
+                                            to the created ACME HTTP01 solver ingress.
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                name:
+                                  description: The name of the ingress resource that
+                                    should have ACME challenge solving routes inserted
+                                    into it in order to solve HTTP01 challenges. This
+                                    is typically used in conjunction with ingress
+                                    controllers like ingress-gce, which maintains
+                                    a 1:1 mapping between external IPs and ingress
+                                    resources.
+                                  type: string
+                                podTemplate:
+                                  description: Optional pod template used to configure
+                                    the ACME challenge solver pods used for HTTP01
+                                    challenges
+                                  type: object
+                                  properties:
+                                    metadata:
+                                      description: ObjectMeta overrides for the pod
+                                        used to solve HTTP01 challenges. Only the
+                                        'labels' and 'annotations' fields may be set.
+                                        If labels or annotations overlap with in-built
+                                        values, the values here will override the
+                                        in-built values.
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          description: Annotations that should be
+                                            added to the create ACME HTTP01 solver
+                                            pods.
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        labels:
+                                          description: Labels that should be added
+                                            to the created ACME HTTP01 solver pods.
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                    spec:
+                                      description: PodSpec defines overrides for the
+                                        HTTP01 challenge solver pod. Only the 'nodeSelector',
+                                        'affinity' and 'tolerations' fields are supported
+                                        currently. All other fields will be ignored.
+                                      type: object
+                                      properties:
+                                        affinity:
+                                          description: If specified, the pod's scheduling
+                                            constraints
+                                          type: object
+                                          properties:
+                                            nodeAffinity:
+                                              description: Describes node affinity
+                                                scheduling rules for the pod.
+                                              type: object
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  description: The scheduler will
+                                                    prefer to schedule pods to nodes
+                                                    that satisfy the affinity expressions
+                                                    specified by this field, but it
+                                                    may choose a node that violates
+                                                    one or more of the expressions.
+                                                    The node that is most preferred
+                                                    is the one with the greatest sum
+                                                    of weights, i.e. for each node
+                                                    that meets all of the scheduling
+                                                    requirements (resource request,
+                                                    requiredDuringScheduling affinity
+                                                    expressions, etc.), compute a
+                                                    sum by iterating through the elements
+                                                    of this field and adding "weight"
+                                                    to the sum if the node matches
+                                                    the corresponding matchExpressions;
+                                                    the node(s) with the highest sum
+                                                    are the most preferred.
+                                                  type: array
+                                                  items:
+                                                    description: An empty preferred
+                                                      scheduling term matches all
+                                                      objects with implicit weight
+                                                      0 (i.e. it's a no-op). A null
+                                                      preferred scheduling term matches
+                                                      no objects (i.e. is also a no-op).
+                                                    type: object
+                                                    required:
+                                                    - preference
+                                                    - weight
+                                                    properties:
+                                                      preference:
+                                                        description: A node selector
+                                                          term, associated with the
+                                                          corresponding weight.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: A list of
+                                                              node selector requirements
+                                                              by node's labels.
+                                                            type: array
+                                                            items:
+                                                              description: A node
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: Represents
+                                                                    a key's relationship
+                                                                    to a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists, DoesNotExist.
+                                                                    Gt, and Lt.
+                                                                  type: string
+                                                                values:
+                                                                  description: An
+                                                                    array of string
+                                                                    values. If the
+                                                                    operator is In
+                                                                    or NotIn, the
+                                                                    values array must
+                                                                    be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    If the operator
+                                                                    is Gt or Lt, the
+                                                                    values array must
+                                                                    have a single
+                                                                    element, which
+                                                                    will be interpreted
+                                                                    as an integer.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchFields:
+                                                            description: A list of
+                                                              node selector requirements
+                                                              by node's fields.
+                                                            type: array
+                                                            items:
+                                                              description: A node
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: Represents
+                                                                    a key's relationship
+                                                                    to a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists, DoesNotExist.
+                                                                    Gt, and Lt.
+                                                                  type: string
+                                                                values:
+                                                                  description: An
+                                                                    array of string
+                                                                    values. If the
+                                                                    operator is In
+                                                                    or NotIn, the
+                                                                    values array must
+                                                                    be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    If the operator
+                                                                    is Gt or Lt, the
+                                                                    values array must
+                                                                    have a single
+                                                                    element, which
+                                                                    will be interpreted
+                                                                    as an integer.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                      weight:
+                                                        description: Weight associated
+                                                          with matching the corresponding
+                                                          nodeSelectorTerm, in the
+                                                          range 1-100.
+                                                        type: integer
+                                                        format: int32
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  description: If the affinity requirements
+                                                    specified by this field are not
+                                                    met at scheduling time, the pod
+                                                    will not be scheduled onto the
+                                                    node. If the affinity requirements
+                                                    specified by this field cease
+                                                    to be met at some point during
+                                                    pod execution (e.g. due to an
+                                                    update), the system may or may
+                                                    not try to eventually evict the
+                                                    pod from its node.
+                                                  type: object
+                                                  required:
+                                                  - nodeSelectorTerms
+                                                  properties:
+                                                    nodeSelectorTerms:
+                                                      description: Required. A list
+                                                        of node selector terms. The
+                                                        terms are ORed.
+                                                      type: array
+                                                      items:
+                                                        description: A null or empty
+                                                          node selector term matches
+                                                          no objects. The requirements
+                                                          of them are ANDed. The TopologySelectorTerm
+                                                          type implements a subset
+                                                          of the NodeSelectorTerm.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: A list of
+                                                              node selector requirements
+                                                              by node's labels.
+                                                            type: array
+                                                            items:
+                                                              description: A node
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: Represents
+                                                                    a key's relationship
+                                                                    to a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists, DoesNotExist.
+                                                                    Gt, and Lt.
+                                                                  type: string
+                                                                values:
+                                                                  description: An
+                                                                    array of string
+                                                                    values. If the
+                                                                    operator is In
+                                                                    or NotIn, the
+                                                                    values array must
+                                                                    be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    If the operator
+                                                                    is Gt or Lt, the
+                                                                    values array must
+                                                                    have a single
+                                                                    element, which
+                                                                    will be interpreted
+                                                                    as an integer.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchFields:
+                                                            description: A list of
+                                                              node selector requirements
+                                                              by node's fields.
+                                                            type: array
+                                                            items:
+                                                              description: A node
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: Represents
+                                                                    a key's relationship
+                                                                    to a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists, DoesNotExist.
+                                                                    Gt, and Lt.
+                                                                  type: string
+                                                                values:
+                                                                  description: An
+                                                                    array of string
+                                                                    values. If the
+                                                                    operator is In
+                                                                    or NotIn, the
+                                                                    values array must
+                                                                    be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    If the operator
+                                                                    is Gt or Lt, the
+                                                                    values array must
+                                                                    have a single
+                                                                    element, which
+                                                                    will be interpreted
+                                                                    as an integer.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                            podAffinity:
+                                              description: Describes pod affinity
+                                                scheduling rules (e.g. co-locate this
+                                                pod in the same node, zone, etc. as
+                                                some other pod(s)).
+                                              type: object
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  description: The scheduler will
+                                                    prefer to schedule pods to nodes
+                                                    that satisfy the affinity expressions
+                                                    specified by this field, but it
+                                                    may choose a node that violates
+                                                    one or more of the expressions.
+                                                    The node that is most preferred
+                                                    is the one with the greatest sum
+                                                    of weights, i.e. for each node
+                                                    that meets all of the scheduling
+                                                    requirements (resource request,
+                                                    requiredDuringScheduling affinity
+                                                    expressions, etc.), compute a
+                                                    sum by iterating through the elements
+                                                    of this field and adding "weight"
+                                                    to the sum if the node has pods
+                                                    which matches the corresponding
+                                                    podAffinityTerm; the node(s) with
+                                                    the highest sum are the most preferred.
+                                                  type: array
+                                                  items:
+                                                    description: The weights of all
+                                                      of the matched WeightedPodAffinityTerm
+                                                      fields are added per-node to
+                                                      find the most preferred node(s)
+                                                    type: object
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        description: Required. A pod
+                                                          affinity term, associated
+                                                          with the corresponding weight.
+                                                        type: object
+                                                        required:
+                                                        - topologyKey
+                                                        properties:
+                                                          labelSelector:
+                                                            description: A label query
+                                                              over a set of resources,
+                                                              in this case pods.
+                                                            type: object
+                                                            properties:
+                                                              matchExpressions:
+                                                                description: matchExpressions
+                                                                  is a list of label
+                                                                  selector requirements.
+                                                                  The requirements
+                                                                  are ANDed.
+                                                                type: array
+                                                                items:
+                                                                  description: A label
+                                                                    selector requirement
+                                                                    is a selector
+                                                                    that contains
+                                                                    values, a key,
+                                                                    and an operator
+                                                                    that relates the
+                                                                    key and values.
+                                                                  type: object
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  properties:
+                                                                    key:
+                                                                      description: key
+                                                                        is the label
+                                                                        key that the
+                                                                        selector applies
+                                                                        to.
+                                                                      type: string
+                                                                    operator:
+                                                                      description: operator
+                                                                        represents
+                                                                        a key's relationship
+                                                                        to a set of
+                                                                        values. Valid
+                                                                        operators
+                                                                        are In, NotIn,
+                                                                        Exists and
+                                                                        DoesNotExist.
+                                                                      type: string
+                                                                    values:
+                                                                      description: values
+                                                                        is an array
+                                                                        of string
+                                                                        values. If
+                                                                        the operator
+                                                                        is In or NotIn,
+                                                                        the values
+                                                                        array must
+                                                                        be non-empty.
+                                                                        If the operator
+                                                                        is Exists
+                                                                        or DoesNotExist,
+                                                                        the values
+                                                                        array must
+                                                                        be empty.
+                                                                        This array
+                                                                        is replaced
+                                                                        during a strategic
+                                                                        merge patch.
+                                                                      type: array
+                                                                      items:
+                                                                        type: string
+                                                              matchLabels:
+                                                                description: matchLabels
+                                                                  is a map of {key,value}
+                                                                  pairs. A single
+                                                                  {key,value} in the
+                                                                  matchLabels map
+                                                                  is equivalent to
+                                                                  an element of matchExpressions,
+                                                                  whose key field
+                                                                  is "key", the operator
+                                                                  is "In", and the
+                                                                  values array contains
+                                                                  only "value". The
+                                                                  requirements are
+                                                                  ANDed.
+                                                                type: object
+                                                                additionalProperties:
+                                                                  type: string
+                                                          namespaces:
+                                                            description: namespaces
+                                                              specifies which namespaces
+                                                              the labelSelector applies
+                                                              to (matches against);
+                                                              null or empty list means
+                                                              "this pod's namespace"
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                          topologyKey:
+                                                            description: This pod
+                                                              should be co-located
+                                                              (affinity) or not co-located
+                                                              (anti-affinity) with
+                                                              the pods matching the
+                                                              labelSelector in the
+                                                              specified namespaces,
+                                                              where co-located is
+                                                              defined as running on
+                                                              a node whose value of
+                                                              the label with key topologyKey
+                                                              matches that of any
+                                                              node on which any of
+                                                              the selected pods is
+                                                              running. Empty topologyKey
+                                                              is not allowed.
+                                                            type: string
+                                                      weight:
+                                                        description: weight associated
+                                                          with matching the corresponding
+                                                          podAffinityTerm, in the
+                                                          range 1-100.
+                                                        type: integer
+                                                        format: int32
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  description: If the affinity requirements
+                                                    specified by this field are not
+                                                    met at scheduling time, the pod
+                                                    will not be scheduled onto the
+                                                    node. If the affinity requirements
+                                                    specified by this field cease
+                                                    to be met at some point during
+                                                    pod execution (e.g. due to a pod
+                                                    label update), the system may
+                                                    or may not try to eventually evict
+                                                    the pod from its node. When there
+                                                    are multiple elements, the lists
+                                                    of nodes corresponding to each
+                                                    podAffinityTerm are intersected,
+                                                    i.e. all terms must be satisfied.
+                                                  type: array
+                                                  items:
+                                                    description: Defines a set of
+                                                      pods (namely those matching
+                                                      the labelSelector relative to
+                                                      the given namespace(s)) that
+                                                      this pod should be co-located
+                                                      (affinity) or not co-located
+                                                      (anti-affinity) with, where
+                                                      co-located is defined as running
+                                                      on a node whose value of the
+                                                      label with key <topologyKey>
+                                                      matches that of any node on
+                                                      which a pod of the set of pods
+                                                      is running
+                                                    type: object
+                                                    required:
+                                                    - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query
+                                                          over a set of resources,
+                                                          in this case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions
+                                                              is a list of label selector
+                                                              requirements. The requirements
+                                                              are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key
+                                                                    is the label key
+                                                                    that the selector
+                                                                    applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator
+                                                                    represents a key's
+                                                                    relationship to
+                                                                    a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values
+                                                                    is an array of
+                                                                    string values.
+                                                                    If the operator
+                                                                    is In or NotIn,
+                                                                    the values array
+                                                                    must be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels
+                                                              is a map of {key,value}
+                                                              pairs. A single {key,value}
+                                                              in the matchLabels map
+                                                              is equivalent to an
+                                                              element of matchExpressions,
+                                                              whose key field is "key",
+                                                              the operator is "In",
+                                                              and the values array
+                                                              contains only "value".
+                                                              The requirements are
+                                                              ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaces:
+                                                        description: namespaces specifies
+                                                          which namespaces the labelSelector
+                                                          applies to (matches against);
+                                                          null or empty list means
+                                                          "this pod's namespace"
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                      topologyKey:
+                                                        description: This pod should
+                                                          be co-located (affinity)
+                                                          or not co-located (anti-affinity)
+                                                          with the pods matching the
+                                                          labelSelector in the specified
+                                                          namespaces, where co-located
+                                                          is defined as running on
+                                                          a node whose value of the
+                                                          label with key topologyKey
+                                                          matches that of any node
+                                                          on which any of the selected
+                                                          pods is running. Empty topologyKey
+                                                          is not allowed.
+                                                        type: string
+                                            podAntiAffinity:
+                                              description: Describes pod anti-affinity
+                                                scheduling rules (e.g. avoid putting
+                                                this pod in the same node, zone, etc.
+                                                as some other pod(s)).
+                                              type: object
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  description: The scheduler will
+                                                    prefer to schedule pods to nodes
+                                                    that satisfy the anti-affinity
+                                                    expressions specified by this
+                                                    field, but it may choose a node
+                                                    that violates one or more of the
+                                                    expressions. The node that is
+                                                    most preferred is the one with
+                                                    the greatest sum of weights, i.e.
+                                                    for each node that meets all of
+                                                    the scheduling requirements (resource
+                                                    request, requiredDuringScheduling
+                                                    anti-affinity expressions, etc.),
+                                                    compute a sum by iterating through
+                                                    the elements of this field and
+                                                    adding "weight" to the sum if
+                                                    the node has pods which matches
+                                                    the corresponding podAffinityTerm;
+                                                    the node(s) with the highest sum
+                                                    are the most preferred.
+                                                  type: array
+                                                  items:
+                                                    description: The weights of all
+                                                      of the matched WeightedPodAffinityTerm
+                                                      fields are added per-node to
+                                                      find the most preferred node(s)
+                                                    type: object
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        description: Required. A pod
+                                                          affinity term, associated
+                                                          with the corresponding weight.
+                                                        type: object
+                                                        required:
+                                                        - topologyKey
+                                                        properties:
+                                                          labelSelector:
+                                                            description: A label query
+                                                              over a set of resources,
+                                                              in this case pods.
+                                                            type: object
+                                                            properties:
+                                                              matchExpressions:
+                                                                description: matchExpressions
+                                                                  is a list of label
+                                                                  selector requirements.
+                                                                  The requirements
+                                                                  are ANDed.
+                                                                type: array
+                                                                items:
+                                                                  description: A label
+                                                                    selector requirement
+                                                                    is a selector
+                                                                    that contains
+                                                                    values, a key,
+                                                                    and an operator
+                                                                    that relates the
+                                                                    key and values.
+                                                                  type: object
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  properties:
+                                                                    key:
+                                                                      description: key
+                                                                        is the label
+                                                                        key that the
+                                                                        selector applies
+                                                                        to.
+                                                                      type: string
+                                                                    operator:
+                                                                      description: operator
+                                                                        represents
+                                                                        a key's relationship
+                                                                        to a set of
+                                                                        values. Valid
+                                                                        operators
+                                                                        are In, NotIn,
+                                                                        Exists and
+                                                                        DoesNotExist.
+                                                                      type: string
+                                                                    values:
+                                                                      description: values
+                                                                        is an array
+                                                                        of string
+                                                                        values. If
+                                                                        the operator
+                                                                        is In or NotIn,
+                                                                        the values
+                                                                        array must
+                                                                        be non-empty.
+                                                                        If the operator
+                                                                        is Exists
+                                                                        or DoesNotExist,
+                                                                        the values
+                                                                        array must
+                                                                        be empty.
+                                                                        This array
+                                                                        is replaced
+                                                                        during a strategic
+                                                                        merge patch.
+                                                                      type: array
+                                                                      items:
+                                                                        type: string
+                                                              matchLabels:
+                                                                description: matchLabels
+                                                                  is a map of {key,value}
+                                                                  pairs. A single
+                                                                  {key,value} in the
+                                                                  matchLabels map
+                                                                  is equivalent to
+                                                                  an element of matchExpressions,
+                                                                  whose key field
+                                                                  is "key", the operator
+                                                                  is "In", and the
+                                                                  values array contains
+                                                                  only "value". The
+                                                                  requirements are
+                                                                  ANDed.
+                                                                type: object
+                                                                additionalProperties:
+                                                                  type: string
+                                                          namespaces:
+                                                            description: namespaces
+                                                              specifies which namespaces
+                                                              the labelSelector applies
+                                                              to (matches against);
+                                                              null or empty list means
+                                                              "this pod's namespace"
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                          topologyKey:
+                                                            description: This pod
+                                                              should be co-located
+                                                              (affinity) or not co-located
+                                                              (anti-affinity) with
+                                                              the pods matching the
+                                                              labelSelector in the
+                                                              specified namespaces,
+                                                              where co-located is
+                                                              defined as running on
+                                                              a node whose value of
+                                                              the label with key topologyKey
+                                                              matches that of any
+                                                              node on which any of
+                                                              the selected pods is
+                                                              running. Empty topologyKey
+                                                              is not allowed.
+                                                            type: string
+                                                      weight:
+                                                        description: weight associated
+                                                          with matching the corresponding
+                                                          podAffinityTerm, in the
+                                                          range 1-100.
+                                                        type: integer
+                                                        format: int32
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  description: If the anti-affinity
+                                                    requirements specified by this
+                                                    field are not met at scheduling
+                                                    time, the pod will not be scheduled
+                                                    onto the node. If the anti-affinity
+                                                    requirements specified by this
+                                                    field cease to be met at some
+                                                    point during pod execution (e.g.
+                                                    due to a pod label update), the
+                                                    system may or may not try to eventually
+                                                    evict the pod from its node. When
+                                                    there are multiple elements, the
+                                                    lists of nodes corresponding to
+                                                    each podAffinityTerm are intersected,
+                                                    i.e. all terms must be satisfied.
+                                                  type: array
+                                                  items:
+                                                    description: Defines a set of
+                                                      pods (namely those matching
+                                                      the labelSelector relative to
+                                                      the given namespace(s)) that
+                                                      this pod should be co-located
+                                                      (affinity) or not co-located
+                                                      (anti-affinity) with, where
+                                                      co-located is defined as running
+                                                      on a node whose value of the
+                                                      label with key <topologyKey>
+                                                      matches that of any node on
+                                                      which a pod of the set of pods
+                                                      is running
+                                                    type: object
+                                                    required:
+                                                    - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query
+                                                          over a set of resources,
+                                                          in this case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions
+                                                              is a list of label selector
+                                                              requirements. The requirements
+                                                              are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key
+                                                                    is the label key
+                                                                    that the selector
+                                                                    applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator
+                                                                    represents a key's
+                                                                    relationship to
+                                                                    a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values
+                                                                    is an array of
+                                                                    string values.
+                                                                    If the operator
+                                                                    is In or NotIn,
+                                                                    the values array
+                                                                    must be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels
+                                                              is a map of {key,value}
+                                                              pairs. A single {key,value}
+                                                              in the matchLabels map
+                                                              is equivalent to an
+                                                              element of matchExpressions,
+                                                              whose key field is "key",
+                                                              the operator is "In",
+                                                              and the values array
+                                                              contains only "value".
+                                                              The requirements are
+                                                              ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaces:
+                                                        description: namespaces specifies
+                                                          which namespaces the labelSelector
+                                                          applies to (matches against);
+                                                          null or empty list means
+                                                          "this pod's namespace"
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                      topologyKey:
+                                                        description: This pod should
+                                                          be co-located (affinity)
+                                                          or not co-located (anti-affinity)
+                                                          with the pods matching the
+                                                          labelSelector in the specified
+                                                          namespaces, where co-located
+                                                          is defined as running on
+                                                          a node whose value of the
+                                                          label with key topologyKey
+                                                          matches that of any node
+                                                          on which any of the selected
+                                                          pods is running. Empty topologyKey
+                                                          is not allowed.
+                                                        type: string
+                                        nodeSelector:
+                                          description: 'NodeSelector is a selector
+                                            which must be true for the pod to fit
+                                            on a node. Selector which must match a
+                                            node''s labels for the pod to be scheduled
+                                            on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        tolerations:
+                                          description: If specified, the pod's tolerations.
+                                          type: array
+                                          items:
+                                            description: The pod this Toleration is
+                                              attached to tolerates any taint that
+                                              matches the triple <key,value,effect>
+                                              using the matching operator <operator>.
+                                            type: object
+                                            properties:
+                                              effect:
+                                                description: Effect indicates the
+                                                  taint effect to match. Empty means
+                                                  match all taint effects. When specified,
+                                                  allowed values are NoSchedule, PreferNoSchedule
+                                                  and NoExecute.
+                                                type: string
+                                              key:
+                                                description: Key is the taint key
+                                                  that the toleration applies to.
+                                                  Empty means match all taint keys.
+                                                  If the key is empty, operator must
+                                                  be Exists; this combination means
+                                                  to match all values and all keys.
+                                                type: string
+                                              operator:
+                                                description: Operator represents a
+                                                  key's relationship to the value.
+                                                  Valid operators are Exists and Equal.
+                                                  Defaults to Equal. Exists is equivalent
+                                                  to wildcard for value, so that a
+                                                  pod can tolerate all taints of a
+                                                  particular category.
+                                                type: string
+                                              tolerationSeconds:
+                                                description: TolerationSeconds represents
+                                                  the period of time the toleration
+                                                  (which must be of effect NoExecute,
+                                                  otherwise this field is ignored)
+                                                  tolerates the taint. By default,
+                                                  it is not set, which means tolerate
+                                                  the taint forever (do not evict).
+                                                  Zero and negative values will be
+                                                  treated as 0 (evict immediately)
+                                                  by the system.
+                                                type: integer
+                                                format: int64
+                                              value:
+                                                description: Value is the taint value
+                                                  the toleration matches to. If the
+                                                  operator is Exists, the value should
+                                                  be empty, otherwise just a regular
+                                                  string.
+                                                type: string
+                                serviceType:
+                                  description: Optional service type for Kubernetes
+                                    solver service
+                                  type: string
+                        selector:
+                          description: Selector selects a set of DNSNames on the Certificate
+                            resource that should be solved using this challenge solver.
+                            If not specified, the solver will be treated as the 'default'
+                            solver with the lowest priority, i.e. if any other solver
+                            has a more specific match, it will be used instead.
+                          type: object
+                          properties:
+                            dnsNames:
+                              description: List of DNSNames that this solver will
+                                be used to solve. If specified and a match is found,
+                                a dnsNames selector will take precedence over a dnsZones
+                                selector. If multiple solvers match with the same
+                                dnsNames value, the solver with the most matching
+                                labels in matchLabels will be selected. If neither
+                                has more matches, the solver defined earlier in the
+                                list will be selected.
+                              type: array
+                              items:
+                                type: string
+                            dnsZones:
+                              description: List of DNSZones that this solver will
+                                be used to solve. The most specific DNS zone match
+                                specified here will take precedence over other DNS
+                                zone matches, so a solver specifying sys.example.com
+                                will be selected over one specifying example.com for
+                                the domain www.sys.example.com. If multiple solvers
+                                match with the same dnsZones value, the solver with
+                                the most matching labels in matchLabels will be selected.
+                                If neither has more matches, the solver defined earlier
+                                in the list will be selected.
+                              type: array
+                              items:
+                                type: string
+                            matchLabels:
+                              description: A label selector that is used to refine
+                                the set of certificate's that this challenge solver
+                                will apply to.
+                              type: object
+                              additionalProperties:
+                                type: string
+              ca:
+                description: CA configures this issuer to sign certificates using
+                  a signing CA keypair stored in a Secret resource. This is used to
+                  build internal PKIs that are managed by cert-manager.
+                type: object
+                required:
+                - secretName
+                properties:
+                  crlDistributionPoints:
+                    description: The CRL distribution points is an X.509 v3 certificate
+                      extension which identifies the location of the CRL from which
+                      the revocation of this certificate can be checked. If not set,
+                      certificates will be issued without distribution points set.
+                    type: array
+                    items:
+                      type: string
+                  secretName:
+                    description: SecretName is the name of the secret used to sign
+                      Certificates issued by this Issuer.
                     type: string
-                  status:
-                    description: Status of the condition, one of ('True', 'False',
-                      'Unknown').
+              selfSigned:
+                description: SelfSigned configures this issuer to 'self sign' certificates
+                  using the private key used to create the CertificateRequest object.
+                type: object
+                properties:
+                  crlDistributionPoints:
+                    description: The CRL distribution points is an X.509 v3 certificate
+                      extension which identifies the location of the CRL from which
+                      the revocation of this certificate can be checked. If not set
+                      certificate will be issued without CDP. Values are strings.
+                    type: array
+                    items:
+                      type: string
+              vault:
+                description: Vault configures this issuer to sign certificates using
+                  a HashiCorp Vault PKI backend.
+                type: object
+                required:
+                - auth
+                - path
+                - server
+                properties:
+                  auth:
+                    description: Auth configures how cert-manager authenticates with
+                      the Vault server.
+                    type: object
+                    properties:
+                      appRole:
+                        description: AppRole authenticates with Vault using the App
+                          Role auth mechanism, with the role and secret stored in
+                          a Kubernetes Secret resource.
+                        type: object
+                        required:
+                        - path
+                        - roleId
+                        - secretRef
+                        properties:
+                          path:
+                            description: 'Path where the App Role authentication backend
+                              is mounted in Vault, e.g: "approle"'
+                            type: string
+                          roleId:
+                            description: RoleID configured in the App Role authentication
+                              backend when setting up the authentication backend in
+                              Vault.
+                            type: string
+                          secretRef:
+                            description: Reference to a key in a Secret that contains
+                              the App Role secret used to authenticate with Vault.
+                              The `key` field must be specified and denotes which
+                              entry within the Secret resource is used as the app
+                              role secret.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                      kubernetes:
+                        description: Kubernetes authenticates with Vault by passing
+                          the ServiceAccount token stored in the named Secret resource
+                          to the Vault server.
+                        type: object
+                        required:
+                        - role
+                        - secretRef
+                        properties:
+                          mountPath:
+                            description: The Vault mountPath here is the mount path
+                              to use when authenticating with Vault. For example,
+                              setting a value to `/v1/auth/foo`, will use the path
+                              `/v1/auth/foo/login` to authenticate with Vault. If
+                              unspecified, the default value "/v1/auth/kubernetes"
+                              will be used.
+                            type: string
+                          role:
+                            description: A required field containing the Vault Role
+                              to assume. A Role binds a Kubernetes ServiceAccount
+                              with a set of Vault policies.
+                            type: string
+                          secretRef:
+                            description: The required Secret field containing a Kubernetes
+                              ServiceAccount JWT used for authenticating with Vault.
+                              Use of 'ambient credentials' is not supported.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                      tokenSecretRef:
+                        description: TokenSecretRef authenticates with Vault by presenting
+                          a token.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the entry in the Secret resource's
+                              `data` field to be used. Some instances of this field
+                              may be defaulted, in others it may be required.
+                            type: string
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                  caBundle:
+                    description: PEM encoded CA bundle used to validate Vault server
+                      certificate. Only used if the Server URL is using HTTPS protocol.
+                      This parameter is ignored for plain HTTP protocol connection.
+                      If not set the system root certificates are used to validate
+                      the TLS connection.
                     type: string
-                    enum:
-                    - "True"
-                    - "False"
-                    - Unknown
-                  type:
-                    description: Type of the condition, currently ('Ready').
+                    format: byte
+                  path:
+                    description: 'Path is the mount path of the Vault PKI backend''s
+                      `sign` endpoint, e.g: "my_pki_mount/sign/my-role-name".'
                     type: string
+                  server:
+                    description: 'Server is the connection address for the Vault server,
+                      e.g: "https://vault.example.com:8200".'
+                    type: string
+              venafi:
+                description: Venafi configures this issuer to sign certificates using
+                  a Venafi TPP or Venafi Cloud policy zone.
+                type: object
+                required:
+                - zone
+                properties:
+                  cloud:
+                    description: Cloud specifies the Venafi cloud configuration settings.
+                      Only one of TPP or Cloud may be specified.
+                    type: object
+                    required:
+                    - apiTokenSecretRef
+                    properties:
+                      apiTokenSecretRef:
+                        description: APITokenSecretRef is a secret key selector for
+                          the Venafi Cloud API token.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the entry in the Secret resource's
+                              `data` field to be used. Some instances of this field
+                              may be defaulted, in others it may be required.
+                            type: string
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                      url:
+                        description: URL is the base URL for Venafi Cloud. Defaults
+                          to "https://api.venafi.cloud/v1".
+                        type: string
+                  tpp:
+                    description: TPP specifies Trust Protection Platform configuration
+                      settings. Only one of TPP or Cloud may be specified.
+                    type: object
+                    required:
+                    - credentialsRef
+                    - url
+                    properties:
+                      caBundle:
+                        description: CABundle is a PEM encoded TLS certificate to
+                          use to verify connections to the TPP instance. If specified,
+                          system roots will not be used and the issuing CA for the
+                          TPP instance must be verifiable using the provided root.
+                          If not specified, the connection will be verified using
+                          the cert-manager system root certificates.
+                        type: string
+                        format: byte
+                      credentialsRef:
+                        description: CredentialsRef is a reference to a Secret containing
+                          the username and password for the TPP server. The secret
+                          must contain two keys, 'username' and 'password'.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                      url:
+                        description: 'URL is the base URL for the vedsdk endpoint
+                          of the Venafi TPP instance, for example: "https://tpp.example.com/vedsdk".'
+                        type: string
+                  zone:
+                    description: Zone is the Venafi Policy Zone to use for this issuer.
+                      All requests made to the Venafi platform will be restricted
+                      by the named zone policy. This field is required.
+                    type: string
+          status:
+            description: Status of the ClusterIssuer. This is set and managed automatically.
+            type: object
+            properties:
+              acme:
+                description: ACME specific status options. This field should only
+                  be set if the Issuer is configured to use an ACME server to issue
+                  certificates.
+                type: object
+                properties:
+                  lastRegisteredEmail:
+                    description: LastRegisteredEmail is the email associated with
+                      the latest registered ACME account, in order to track changes
+                      made to registered account associated with the  Issuer
+                    type: string
+                  uri:
+                    description: URI is the unique account identifier, which can also
+                      be used to retrieve account details from the CA
+                    type: string
+              conditions:
+                description: List of status conditions to indicate the status of a
+                  CertificateRequest. Known condition types are `Ready`.
+                type: array
+                items:
+                  description: IssuerCondition contains condition information for
+                    an Issuer.
+                  type: object
+                  required:
+                  - status
+                  - type
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the timestamp corresponding
+                        to the last status change of this condition.
+                      type: string
+                      format: date-time
+                    message:
+                      description: Message is a human readable description of the
+                        details of the last transition, complementing reason.
+                      type: string
+                    reason:
+                      description: Reason is a brief machine readable explanation
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of ('True', 'False',
+                        'Unknown').
+                      type: string
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                    type:
+                      description: Type of the condition, known values are ('Ready').
+                      type: string
+  - name: v1beta1
+    served: true
+    storage: false
+    "schema":
+      "openAPIV3Schema":
+        description: A ClusterIssuer represents a certificate issuing authority which
+          can be referenced as part of `issuerRef` fields. It is similar to an Issuer,
+          however it is cluster-scoped and therefore can be referenced by resources
+          that exist in *any* namespace, not just the same namespace as the referent.
+        type: object
+        required:
+        - spec
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Desired state of the ClusterIssuer resource.
+            type: object
+            properties:
+              acme:
+                description: ACME configures this issuer to communicate with a RFC8555
+                  (ACME) server to obtain signed x509 certificates.
+                type: object
+                required:
+                - privateKeySecretRef
+                - server
+                properties:
+                  email:
+                    description: Email is the email address to be associated with
+                      the ACME account. This field is optional, but it is strongly
+                      recommended to be set. It will be used to contact you in case
+                      of issues with your account or certificates, including expiry
+                      notification emails. This field may be updated after the account
+                      is initially registered.
+                    type: string
+                  externalAccountBinding:
+                    description: ExternalAccountBinding is a reference to a CA external
+                      account of the ACME server. If set, upon registration cert-manager
+                      will attempt to associate the given external account credentials
+                      with the registered ACME account.
+                    type: object
+                    required:
+                    - keyAlgorithm
+                    - keyID
+                    - keySecretRef
+                    properties:
+                      keyAlgorithm:
+                        description: keyAlgorithm is the MAC key algorithm that the
+                          key is used for. Valid values are "HS256", "HS384" and "HS512".
+                        type: string
+                        enum:
+                        - HS256
+                        - HS384
+                        - HS512
+                      keyID:
+                        description: keyID is the ID of the CA key that the External
+                          Account is bound to.
+                        type: string
+                      keySecretRef:
+                        description: keySecretRef is a Secret Key Selector referencing
+                          a data item in a Kubernetes Secret which holds the symmetric
+                          MAC key of the External Account Binding. The `key` is the
+                          index string that is paired with the key data in the Secret
+                          and should not be confused with the key data itself, or
+                          indeed with the External Account Binding keyID above. The
+                          secret key stored in the Secret **must** be un-padded, base64
+                          URL encoded data.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the entry in the Secret resource's
+                              `data` field to be used. Some instances of this field
+                              may be defaulted, in others it may be required.
+                            type: string
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                  privateKeySecretRef:
+                    description: PrivateKey is the name of a Kubernetes Secret resource
+                      that will be used to store the automatically generated ACME
+                      account private key. Optionally, a `key` may be specified to
+                      select a specific entry within the named Secret resource. If
+                      `key` is not specified, a default of `tls.key` will be used.
+                    type: object
+                    required:
+                    - name
+                    properties:
+                      key:
+                        description: The key of the entry in the Secret resource's
+                          `data` field to be used. Some instances of this field may
+                          be defaulted, in others it may be required.
+                        type: string
+                      name:
+                        description: 'Name of the resource being referred to. More
+                          info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                  server:
+                    description: 'Server is the URL used to access the ACME server''s
+                      ''directory'' endpoint. For example, for Let''s Encrypt''s staging
+                      endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory".
+                      Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
+                    type: string
+                  skipTLSVerify:
+                    description: Enables or disables validation of the ACME server
+                      TLS certificate. If true, requests to the ACME server will not
+                      have their TLS certificate validated (i.e. insecure connections
+                      will be allowed). Only enable this option in development environments.
+                      The cert-manager system installed roots will be used to verify
+                      connections to the ACME server if this is false. Defaults to
+                      false.
+                    type: boolean
+                  solvers:
+                    description: 'Solvers is a list of challenge solvers that will
+                      be used to solve ACME challenges for the matching domains. Solver
+                      configurations must be provided in order to obtain certificates
+                      from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/'
+                    type: array
+                    items:
+                      description: Configures an issuer to solve challenges using
+                        the specified options. Only one of HTTP01 or DNS01 may be
+                        provided.
+                      type: object
+                      properties:
+                        dns01:
+                          description: Configures cert-manager to attempt to complete
+                            authorizations by performing the DNS01 challenge flow.
+                          type: object
+                          properties:
+                            acmeDNS:
+                              description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns)
+                                API to manage DNS01 challenge records.
+                              type: object
+                              required:
+                              - accountSecretRef
+                              - host
+                              properties:
+                                accountSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                host:
+                                  type: string
+                            akamai:
+                              description: Use the Akamai DNS zone management API
+                                to manage DNS01 challenge records.
+                              type: object
+                              required:
+                              - accessTokenSecretRef
+                              - clientSecretSecretRef
+                              - clientTokenSecretRef
+                              - serviceConsumerDomain
+                              properties:
+                                accessTokenSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                clientSecretSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                clientTokenSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                serviceConsumerDomain:
+                                  type: string
+                            azureDNS:
+                              description: Use the Microsoft Azure DNS API to manage
+                                DNS01 challenge records.
+                              type: object
+                              required:
+                              - resourceGroupName
+                              - subscriptionID
+                              properties:
+                                clientID:
+                                  description: if both this and ClientSecret are left
+                                    unset MSI will be used
+                                  type: string
+                                clientSecretSecretRef:
+                                  description: if both this and ClientID are left
+                                    unset MSI will be used
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                environment:
+                                  type: string
+                                  enum:
+                                  - AzurePublicCloud
+                                  - AzureChinaCloud
+                                  - AzureGermanCloud
+                                  - AzureUSGovernmentCloud
+                                hostedZoneName:
+                                  type: string
+                                resourceGroupName:
+                                  type: string
+                                subscriptionID:
+                                  type: string
+                                tenantID:
+                                  description: when specifying ClientID and ClientSecret
+                                    then this field is also needed
+                                  type: string
+                            cloudDNS:
+                              description: Use the Google Cloud DNS API to manage
+                                DNS01 challenge records.
+                              type: object
+                              required:
+                              - project
+                              properties:
+                                hostedZoneName:
+                                  description: HostedZoneName is an optional field
+                                    that tells cert-manager in which Cloud DNS zone
+                                    the challenge record has to be created. If left
+                                    empty cert-manager will automatically choose a
+                                    zone.
+                                  type: string
+                                project:
+                                  type: string
+                                serviceAccountSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                            cloudflare:
+                              description: Use the Cloudflare API to manage DNS01
+                                challenge records.
+                              type: object
+                              properties:
+                                apiKeySecretRef:
+                                  description: 'API key to use to authenticate with
+                                    Cloudflare. Note: using an API token to authenticate
+                                    is now the recommended method as it allows greater
+                                    control of permissions.'
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                apiTokenSecretRef:
+                                  description: API token used to authenticate with
+                                    Cloudflare.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                email:
+                                  description: Email of the account, only required
+                                    when using API key based authentication.
+                                  type: string
+                            cnameStrategy:
+                              description: CNAMEStrategy configures how the DNS01
+                                provider should handle CNAME records when found in
+                                DNS zones.
+                              type: string
+                              enum:
+                              - None
+                              - Follow
+                            digitalocean:
+                              description: Use the DigitalOcean DNS API to manage
+                                DNS01 challenge records.
+                              type: object
+                              required:
+                              - tokenSecretRef
+                              properties:
+                                tokenSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                            rfc2136:
+                              description: Use RFC2136 ("Dynamic Updates in the Domain
+                                Name System") (https://datatracker.ietf.org/doc/rfc2136/)
+                                to manage DNS01 challenge records.
+                              type: object
+                              required:
+                              - nameserver
+                              properties:
+                                nameserver:
+                                  description: The IP address or hostname of an authoritative
+                                    DNS server supporting RFC2136 in the form host:port.
+                                    If the host is an IPv6 address it must be enclosed
+                                    in square brackets (e.g [2001:db8::1]) ; port
+                                    is optional. This field is required.
+                                  type: string
+                                tsigAlgorithm:
+                                  description: 'The TSIG Algorithm configured in the
+                                    DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                                    and ``tsigKeyName`` are defined. Supported values
+                                    are (case-insensitive): ``HMACMD5`` (default),
+                                    ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
+                                  type: string
+                                tsigKeyName:
+                                  description: The TSIG Key name configured in the
+                                    DNS. If ``tsigSecretSecretRef`` is defined, this
+                                    field is required.
+                                  type: string
+                                tsigSecretSecretRef:
+                                  description: The name of the secret containing the
+                                    TSIG value. If ``tsigKeyName`` is defined, this
+                                    field is required.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                            route53:
+                              description: Use the AWS Route53 API to manage DNS01
+                                challenge records.
+                              type: object
+                              required:
+                              - region
+                              properties:
+                                accessKeyID:
+                                  description: 'The AccessKeyID is used for authentication.
+                                    If not set we fall-back to using env vars, shared
+                                    credentials file or AWS Instance metadata see:
+                                    https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                  type: string
+                                hostedZoneID:
+                                  description: If set, the provider will manage only
+                                    this zone in Route53 and will not do an lookup
+                                    using the route53:ListHostedZonesByName api call.
+                                  type: string
+                                region:
+                                  description: Always set the region when using AccessKeyID
+                                    and SecretAccessKey
+                                  type: string
+                                role:
+                                  description: Role is a Role ARN which the Route53
+                                    provider will assume using either the explicit
+                                    credentials AccessKeyID/SecretAccessKey or the
+                                    inferred credentials from environment variables,
+                                    shared credentials file or AWS Instance metadata
+                                  type: string
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication.
+                                    If not set we fall-back to using env vars, shared
+                                    credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                            webhook:
+                              description: Configure an external webhook based DNS01
+                                challenge solver to manage DNS01 challenge records.
+                              type: object
+                              required:
+                              - groupName
+                              - solverName
+                              properties:
+                                config:
+                                  description: Additional configuration that should
+                                    be passed to the webhook apiserver when challenges
+                                    are processed. This can contain arbitrary JSON
+                                    data. Secret values should not be specified in
+                                    this stanza. If secret values are needed (e.g.
+                                    credentials for a DNS service), you should use
+                                    a SecretKeySelector to reference a Secret resource.
+                                    For details on the schema of this field, consult
+                                    the webhook provider implementation's documentation.
+                                  x-kubernetes-preserve-unknown-fields: true
+                                groupName:
+                                  description: The API group name that should be used
+                                    when POSTing ChallengePayload resources to the
+                                    webhook apiserver. This should be the same as
+                                    the GroupName specified in the webhook provider
+                                    implementation.
+                                  type: string
+                                solverName:
+                                  description: The name of the solver to use, as defined
+                                    in the webhook provider implementation. This will
+                                    typically be the name of the provider, e.g. 'cloudflare'.
+                                  type: string
+                        http01:
+                          description: Configures cert-manager to attempt to complete
+                            authorizations by performing the HTTP01 challenge flow.
+                            It is not possible to obtain certificates for wildcard
+                            domain names (e.g. `*.example.com`) using the HTTP01 challenge
+                            mechanism.
+                          type: object
+                          properties:
+                            ingress:
+                              description: The ingress based HTTP01 challenge solver
+                                will solve challenges by creating or modifying Ingress
+                                resources in order to route requests for '/.well-known/acme-challenge/XYZ'
+                                to 'challenge solver' pods that are provisioned by
+                                cert-manager for each Challenge to be completed.
+                              type: object
+                              properties:
+                                class:
+                                  description: The ingress class to use when creating
+                                    Ingress resources to solve ACME challenges that
+                                    use this challenge solver. Only one of 'class'
+                                    or 'name' may be specified.
+                                  type: string
+                                ingressTemplate:
+                                  description: Optional ingress template used to configure
+                                    the ACME challenge solver ingress used for HTTP01
+                                    challenges
+                                  type: object
+                                  properties:
+                                    metadata:
+                                      description: ObjectMeta overrides for the ingress
+                                        used to solve HTTP01 challenges. Only the
+                                        'labels' and 'annotations' fields may be set.
+                                        If labels or annotations overlap with in-built
+                                        values, the values here will override the
+                                        in-built values.
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          description: Annotations that should be
+                                            added to the created ACME HTTP01 solver
+                                            ingress.
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        labels:
+                                          description: Labels that should be added
+                                            to the created ACME HTTP01 solver ingress.
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                name:
+                                  description: The name of the ingress resource that
+                                    should have ACME challenge solving routes inserted
+                                    into it in order to solve HTTP01 challenges. This
+                                    is typically used in conjunction with ingress
+                                    controllers like ingress-gce, which maintains
+                                    a 1:1 mapping between external IPs and ingress
+                                    resources.
+                                  type: string
+                                podTemplate:
+                                  description: Optional pod template used to configure
+                                    the ACME challenge solver pods used for HTTP01
+                                    challenges
+                                  type: object
+                                  properties:
+                                    metadata:
+                                      description: ObjectMeta overrides for the pod
+                                        used to solve HTTP01 challenges. Only the
+                                        'labels' and 'annotations' fields may be set.
+                                        If labels or annotations overlap with in-built
+                                        values, the values here will override the
+                                        in-built values.
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          description: Annotations that should be
+                                            added to the create ACME HTTP01 solver
+                                            pods.
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        labels:
+                                          description: Labels that should be added
+                                            to the created ACME HTTP01 solver pods.
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                    spec:
+                                      description: PodSpec defines overrides for the
+                                        HTTP01 challenge solver pod. Only the 'nodeSelector',
+                                        'affinity' and 'tolerations' fields are supported
+                                        currently. All other fields will be ignored.
+                                      type: object
+                                      properties:
+                                        affinity:
+                                          description: If specified, the pod's scheduling
+                                            constraints
+                                          type: object
+                                          properties:
+                                            nodeAffinity:
+                                              description: Describes node affinity
+                                                scheduling rules for the pod.
+                                              type: object
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  description: The scheduler will
+                                                    prefer to schedule pods to nodes
+                                                    that satisfy the affinity expressions
+                                                    specified by this field, but it
+                                                    may choose a node that violates
+                                                    one or more of the expressions.
+                                                    The node that is most preferred
+                                                    is the one with the greatest sum
+                                                    of weights, i.e. for each node
+                                                    that meets all of the scheduling
+                                                    requirements (resource request,
+                                                    requiredDuringScheduling affinity
+                                                    expressions, etc.), compute a
+                                                    sum by iterating through the elements
+                                                    of this field and adding "weight"
+                                                    to the sum if the node matches
+                                                    the corresponding matchExpressions;
+                                                    the node(s) with the highest sum
+                                                    are the most preferred.
+                                                  type: array
+                                                  items:
+                                                    description: An empty preferred
+                                                      scheduling term matches all
+                                                      objects with implicit weight
+                                                      0 (i.e. it's a no-op). A null
+                                                      preferred scheduling term matches
+                                                      no objects (i.e. is also a no-op).
+                                                    type: object
+                                                    required:
+                                                    - preference
+                                                    - weight
+                                                    properties:
+                                                      preference:
+                                                        description: A node selector
+                                                          term, associated with the
+                                                          corresponding weight.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: A list of
+                                                              node selector requirements
+                                                              by node's labels.
+                                                            type: array
+                                                            items:
+                                                              description: A node
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: Represents
+                                                                    a key's relationship
+                                                                    to a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists, DoesNotExist.
+                                                                    Gt, and Lt.
+                                                                  type: string
+                                                                values:
+                                                                  description: An
+                                                                    array of string
+                                                                    values. If the
+                                                                    operator is In
+                                                                    or NotIn, the
+                                                                    values array must
+                                                                    be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    If the operator
+                                                                    is Gt or Lt, the
+                                                                    values array must
+                                                                    have a single
+                                                                    element, which
+                                                                    will be interpreted
+                                                                    as an integer.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchFields:
+                                                            description: A list of
+                                                              node selector requirements
+                                                              by node's fields.
+                                                            type: array
+                                                            items:
+                                                              description: A node
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: Represents
+                                                                    a key's relationship
+                                                                    to a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists, DoesNotExist.
+                                                                    Gt, and Lt.
+                                                                  type: string
+                                                                values:
+                                                                  description: An
+                                                                    array of string
+                                                                    values. If the
+                                                                    operator is In
+                                                                    or NotIn, the
+                                                                    values array must
+                                                                    be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    If the operator
+                                                                    is Gt or Lt, the
+                                                                    values array must
+                                                                    have a single
+                                                                    element, which
+                                                                    will be interpreted
+                                                                    as an integer.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                      weight:
+                                                        description: Weight associated
+                                                          with matching the corresponding
+                                                          nodeSelectorTerm, in the
+                                                          range 1-100.
+                                                        type: integer
+                                                        format: int32
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  description: If the affinity requirements
+                                                    specified by this field are not
+                                                    met at scheduling time, the pod
+                                                    will not be scheduled onto the
+                                                    node. If the affinity requirements
+                                                    specified by this field cease
+                                                    to be met at some point during
+                                                    pod execution (e.g. due to an
+                                                    update), the system may or may
+                                                    not try to eventually evict the
+                                                    pod from its node.
+                                                  type: object
+                                                  required:
+                                                  - nodeSelectorTerms
+                                                  properties:
+                                                    nodeSelectorTerms:
+                                                      description: Required. A list
+                                                        of node selector terms. The
+                                                        terms are ORed.
+                                                      type: array
+                                                      items:
+                                                        description: A null or empty
+                                                          node selector term matches
+                                                          no objects. The requirements
+                                                          of them are ANDed. The TopologySelectorTerm
+                                                          type implements a subset
+                                                          of the NodeSelectorTerm.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: A list of
+                                                              node selector requirements
+                                                              by node's labels.
+                                                            type: array
+                                                            items:
+                                                              description: A node
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: Represents
+                                                                    a key's relationship
+                                                                    to a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists, DoesNotExist.
+                                                                    Gt, and Lt.
+                                                                  type: string
+                                                                values:
+                                                                  description: An
+                                                                    array of string
+                                                                    values. If the
+                                                                    operator is In
+                                                                    or NotIn, the
+                                                                    values array must
+                                                                    be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    If the operator
+                                                                    is Gt or Lt, the
+                                                                    values array must
+                                                                    have a single
+                                                                    element, which
+                                                                    will be interpreted
+                                                                    as an integer.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchFields:
+                                                            description: A list of
+                                                              node selector requirements
+                                                              by node's fields.
+                                                            type: array
+                                                            items:
+                                                              description: A node
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: Represents
+                                                                    a key's relationship
+                                                                    to a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists, DoesNotExist.
+                                                                    Gt, and Lt.
+                                                                  type: string
+                                                                values:
+                                                                  description: An
+                                                                    array of string
+                                                                    values. If the
+                                                                    operator is In
+                                                                    or NotIn, the
+                                                                    values array must
+                                                                    be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    If the operator
+                                                                    is Gt or Lt, the
+                                                                    values array must
+                                                                    have a single
+                                                                    element, which
+                                                                    will be interpreted
+                                                                    as an integer.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                            podAffinity:
+                                              description: Describes pod affinity
+                                                scheduling rules (e.g. co-locate this
+                                                pod in the same node, zone, etc. as
+                                                some other pod(s)).
+                                              type: object
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  description: The scheduler will
+                                                    prefer to schedule pods to nodes
+                                                    that satisfy the affinity expressions
+                                                    specified by this field, but it
+                                                    may choose a node that violates
+                                                    one or more of the expressions.
+                                                    The node that is most preferred
+                                                    is the one with the greatest sum
+                                                    of weights, i.e. for each node
+                                                    that meets all of the scheduling
+                                                    requirements (resource request,
+                                                    requiredDuringScheduling affinity
+                                                    expressions, etc.), compute a
+                                                    sum by iterating through the elements
+                                                    of this field and adding "weight"
+                                                    to the sum if the node has pods
+                                                    which matches the corresponding
+                                                    podAffinityTerm; the node(s) with
+                                                    the highest sum are the most preferred.
+                                                  type: array
+                                                  items:
+                                                    description: The weights of all
+                                                      of the matched WeightedPodAffinityTerm
+                                                      fields are added per-node to
+                                                      find the most preferred node(s)
+                                                    type: object
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        description: Required. A pod
+                                                          affinity term, associated
+                                                          with the corresponding weight.
+                                                        type: object
+                                                        required:
+                                                        - topologyKey
+                                                        properties:
+                                                          labelSelector:
+                                                            description: A label query
+                                                              over a set of resources,
+                                                              in this case pods.
+                                                            type: object
+                                                            properties:
+                                                              matchExpressions:
+                                                                description: matchExpressions
+                                                                  is a list of label
+                                                                  selector requirements.
+                                                                  The requirements
+                                                                  are ANDed.
+                                                                type: array
+                                                                items:
+                                                                  description: A label
+                                                                    selector requirement
+                                                                    is a selector
+                                                                    that contains
+                                                                    values, a key,
+                                                                    and an operator
+                                                                    that relates the
+                                                                    key and values.
+                                                                  type: object
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  properties:
+                                                                    key:
+                                                                      description: key
+                                                                        is the label
+                                                                        key that the
+                                                                        selector applies
+                                                                        to.
+                                                                      type: string
+                                                                    operator:
+                                                                      description: operator
+                                                                        represents
+                                                                        a key's relationship
+                                                                        to a set of
+                                                                        values. Valid
+                                                                        operators
+                                                                        are In, NotIn,
+                                                                        Exists and
+                                                                        DoesNotExist.
+                                                                      type: string
+                                                                    values:
+                                                                      description: values
+                                                                        is an array
+                                                                        of string
+                                                                        values. If
+                                                                        the operator
+                                                                        is In or NotIn,
+                                                                        the values
+                                                                        array must
+                                                                        be non-empty.
+                                                                        If the operator
+                                                                        is Exists
+                                                                        or DoesNotExist,
+                                                                        the values
+                                                                        array must
+                                                                        be empty.
+                                                                        This array
+                                                                        is replaced
+                                                                        during a strategic
+                                                                        merge patch.
+                                                                      type: array
+                                                                      items:
+                                                                        type: string
+                                                              matchLabels:
+                                                                description: matchLabels
+                                                                  is a map of {key,value}
+                                                                  pairs. A single
+                                                                  {key,value} in the
+                                                                  matchLabels map
+                                                                  is equivalent to
+                                                                  an element of matchExpressions,
+                                                                  whose key field
+                                                                  is "key", the operator
+                                                                  is "In", and the
+                                                                  values array contains
+                                                                  only "value". The
+                                                                  requirements are
+                                                                  ANDed.
+                                                                type: object
+                                                                additionalProperties:
+                                                                  type: string
+                                                          namespaces:
+                                                            description: namespaces
+                                                              specifies which namespaces
+                                                              the labelSelector applies
+                                                              to (matches against);
+                                                              null or empty list means
+                                                              "this pod's namespace"
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                          topologyKey:
+                                                            description: This pod
+                                                              should be co-located
+                                                              (affinity) or not co-located
+                                                              (anti-affinity) with
+                                                              the pods matching the
+                                                              labelSelector in the
+                                                              specified namespaces,
+                                                              where co-located is
+                                                              defined as running on
+                                                              a node whose value of
+                                                              the label with key topologyKey
+                                                              matches that of any
+                                                              node on which any of
+                                                              the selected pods is
+                                                              running. Empty topologyKey
+                                                              is not allowed.
+                                                            type: string
+                                                      weight:
+                                                        description: weight associated
+                                                          with matching the corresponding
+                                                          podAffinityTerm, in the
+                                                          range 1-100.
+                                                        type: integer
+                                                        format: int32
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  description: If the affinity requirements
+                                                    specified by this field are not
+                                                    met at scheduling time, the pod
+                                                    will not be scheduled onto the
+                                                    node. If the affinity requirements
+                                                    specified by this field cease
+                                                    to be met at some point during
+                                                    pod execution (e.g. due to a pod
+                                                    label update), the system may
+                                                    or may not try to eventually evict
+                                                    the pod from its node. When there
+                                                    are multiple elements, the lists
+                                                    of nodes corresponding to each
+                                                    podAffinityTerm are intersected,
+                                                    i.e. all terms must be satisfied.
+                                                  type: array
+                                                  items:
+                                                    description: Defines a set of
+                                                      pods (namely those matching
+                                                      the labelSelector relative to
+                                                      the given namespace(s)) that
+                                                      this pod should be co-located
+                                                      (affinity) or not co-located
+                                                      (anti-affinity) with, where
+                                                      co-located is defined as running
+                                                      on a node whose value of the
+                                                      label with key <topologyKey>
+                                                      matches that of any node on
+                                                      which a pod of the set of pods
+                                                      is running
+                                                    type: object
+                                                    required:
+                                                    - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query
+                                                          over a set of resources,
+                                                          in this case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions
+                                                              is a list of label selector
+                                                              requirements. The requirements
+                                                              are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key
+                                                                    is the label key
+                                                                    that the selector
+                                                                    applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator
+                                                                    represents a key's
+                                                                    relationship to
+                                                                    a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values
+                                                                    is an array of
+                                                                    string values.
+                                                                    If the operator
+                                                                    is In or NotIn,
+                                                                    the values array
+                                                                    must be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels
+                                                              is a map of {key,value}
+                                                              pairs. A single {key,value}
+                                                              in the matchLabels map
+                                                              is equivalent to an
+                                                              element of matchExpressions,
+                                                              whose key field is "key",
+                                                              the operator is "In",
+                                                              and the values array
+                                                              contains only "value".
+                                                              The requirements are
+                                                              ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaces:
+                                                        description: namespaces specifies
+                                                          which namespaces the labelSelector
+                                                          applies to (matches against);
+                                                          null or empty list means
+                                                          "this pod's namespace"
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                      topologyKey:
+                                                        description: This pod should
+                                                          be co-located (affinity)
+                                                          or not co-located (anti-affinity)
+                                                          with the pods matching the
+                                                          labelSelector in the specified
+                                                          namespaces, where co-located
+                                                          is defined as running on
+                                                          a node whose value of the
+                                                          label with key topologyKey
+                                                          matches that of any node
+                                                          on which any of the selected
+                                                          pods is running. Empty topologyKey
+                                                          is not allowed.
+                                                        type: string
+                                            podAntiAffinity:
+                                              description: Describes pod anti-affinity
+                                                scheduling rules (e.g. avoid putting
+                                                this pod in the same node, zone, etc.
+                                                as some other pod(s)).
+                                              type: object
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  description: The scheduler will
+                                                    prefer to schedule pods to nodes
+                                                    that satisfy the anti-affinity
+                                                    expressions specified by this
+                                                    field, but it may choose a node
+                                                    that violates one or more of the
+                                                    expressions. The node that is
+                                                    most preferred is the one with
+                                                    the greatest sum of weights, i.e.
+                                                    for each node that meets all of
+                                                    the scheduling requirements (resource
+                                                    request, requiredDuringScheduling
+                                                    anti-affinity expressions, etc.),
+                                                    compute a sum by iterating through
+                                                    the elements of this field and
+                                                    adding "weight" to the sum if
+                                                    the node has pods which matches
+                                                    the corresponding podAffinityTerm;
+                                                    the node(s) with the highest sum
+                                                    are the most preferred.
+                                                  type: array
+                                                  items:
+                                                    description: The weights of all
+                                                      of the matched WeightedPodAffinityTerm
+                                                      fields are added per-node to
+                                                      find the most preferred node(s)
+                                                    type: object
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        description: Required. A pod
+                                                          affinity term, associated
+                                                          with the corresponding weight.
+                                                        type: object
+                                                        required:
+                                                        - topologyKey
+                                                        properties:
+                                                          labelSelector:
+                                                            description: A label query
+                                                              over a set of resources,
+                                                              in this case pods.
+                                                            type: object
+                                                            properties:
+                                                              matchExpressions:
+                                                                description: matchExpressions
+                                                                  is a list of label
+                                                                  selector requirements.
+                                                                  The requirements
+                                                                  are ANDed.
+                                                                type: array
+                                                                items:
+                                                                  description: A label
+                                                                    selector requirement
+                                                                    is a selector
+                                                                    that contains
+                                                                    values, a key,
+                                                                    and an operator
+                                                                    that relates the
+                                                                    key and values.
+                                                                  type: object
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  properties:
+                                                                    key:
+                                                                      description: key
+                                                                        is the label
+                                                                        key that the
+                                                                        selector applies
+                                                                        to.
+                                                                      type: string
+                                                                    operator:
+                                                                      description: operator
+                                                                        represents
+                                                                        a key's relationship
+                                                                        to a set of
+                                                                        values. Valid
+                                                                        operators
+                                                                        are In, NotIn,
+                                                                        Exists and
+                                                                        DoesNotExist.
+                                                                      type: string
+                                                                    values:
+                                                                      description: values
+                                                                        is an array
+                                                                        of string
+                                                                        values. If
+                                                                        the operator
+                                                                        is In or NotIn,
+                                                                        the values
+                                                                        array must
+                                                                        be non-empty.
+                                                                        If the operator
+                                                                        is Exists
+                                                                        or DoesNotExist,
+                                                                        the values
+                                                                        array must
+                                                                        be empty.
+                                                                        This array
+                                                                        is replaced
+                                                                        during a strategic
+                                                                        merge patch.
+                                                                      type: array
+                                                                      items:
+                                                                        type: string
+                                                              matchLabels:
+                                                                description: matchLabels
+                                                                  is a map of {key,value}
+                                                                  pairs. A single
+                                                                  {key,value} in the
+                                                                  matchLabels map
+                                                                  is equivalent to
+                                                                  an element of matchExpressions,
+                                                                  whose key field
+                                                                  is "key", the operator
+                                                                  is "In", and the
+                                                                  values array contains
+                                                                  only "value". The
+                                                                  requirements are
+                                                                  ANDed.
+                                                                type: object
+                                                                additionalProperties:
+                                                                  type: string
+                                                          namespaces:
+                                                            description: namespaces
+                                                              specifies which namespaces
+                                                              the labelSelector applies
+                                                              to (matches against);
+                                                              null or empty list means
+                                                              "this pod's namespace"
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                          topologyKey:
+                                                            description: This pod
+                                                              should be co-located
+                                                              (affinity) or not co-located
+                                                              (anti-affinity) with
+                                                              the pods matching the
+                                                              labelSelector in the
+                                                              specified namespaces,
+                                                              where co-located is
+                                                              defined as running on
+                                                              a node whose value of
+                                                              the label with key topologyKey
+                                                              matches that of any
+                                                              node on which any of
+                                                              the selected pods is
+                                                              running. Empty topologyKey
+                                                              is not allowed.
+                                                            type: string
+                                                      weight:
+                                                        description: weight associated
+                                                          with matching the corresponding
+                                                          podAffinityTerm, in the
+                                                          range 1-100.
+                                                        type: integer
+                                                        format: int32
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  description: If the anti-affinity
+                                                    requirements specified by this
+                                                    field are not met at scheduling
+                                                    time, the pod will not be scheduled
+                                                    onto the node. If the anti-affinity
+                                                    requirements specified by this
+                                                    field cease to be met at some
+                                                    point during pod execution (e.g.
+                                                    due to a pod label update), the
+                                                    system may or may not try to eventually
+                                                    evict the pod from its node. When
+                                                    there are multiple elements, the
+                                                    lists of nodes corresponding to
+                                                    each podAffinityTerm are intersected,
+                                                    i.e. all terms must be satisfied.
+                                                  type: array
+                                                  items:
+                                                    description: Defines a set of
+                                                      pods (namely those matching
+                                                      the labelSelector relative to
+                                                      the given namespace(s)) that
+                                                      this pod should be co-located
+                                                      (affinity) or not co-located
+                                                      (anti-affinity) with, where
+                                                      co-located is defined as running
+                                                      on a node whose value of the
+                                                      label with key <topologyKey>
+                                                      matches that of any node on
+                                                      which a pod of the set of pods
+                                                      is running
+                                                    type: object
+                                                    required:
+                                                    - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query
+                                                          over a set of resources,
+                                                          in this case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions
+                                                              is a list of label selector
+                                                              requirements. The requirements
+                                                              are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key
+                                                                    is the label key
+                                                                    that the selector
+                                                                    applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator
+                                                                    represents a key's
+                                                                    relationship to
+                                                                    a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values
+                                                                    is an array of
+                                                                    string values.
+                                                                    If the operator
+                                                                    is In or NotIn,
+                                                                    the values array
+                                                                    must be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels
+                                                              is a map of {key,value}
+                                                              pairs. A single {key,value}
+                                                              in the matchLabels map
+                                                              is equivalent to an
+                                                              element of matchExpressions,
+                                                              whose key field is "key",
+                                                              the operator is "In",
+                                                              and the values array
+                                                              contains only "value".
+                                                              The requirements are
+                                                              ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaces:
+                                                        description: namespaces specifies
+                                                          which namespaces the labelSelector
+                                                          applies to (matches against);
+                                                          null or empty list means
+                                                          "this pod's namespace"
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                      topologyKey:
+                                                        description: This pod should
+                                                          be co-located (affinity)
+                                                          or not co-located (anti-affinity)
+                                                          with the pods matching the
+                                                          labelSelector in the specified
+                                                          namespaces, where co-located
+                                                          is defined as running on
+                                                          a node whose value of the
+                                                          label with key topologyKey
+                                                          matches that of any node
+                                                          on which any of the selected
+                                                          pods is running. Empty topologyKey
+                                                          is not allowed.
+                                                        type: string
+                                        nodeSelector:
+                                          description: 'NodeSelector is a selector
+                                            which must be true for the pod to fit
+                                            on a node. Selector which must match a
+                                            node''s labels for the pod to be scheduled
+                                            on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        tolerations:
+                                          description: If specified, the pod's tolerations.
+                                          type: array
+                                          items:
+                                            description: The pod this Toleration is
+                                              attached to tolerates any taint that
+                                              matches the triple <key,value,effect>
+                                              using the matching operator <operator>.
+                                            type: object
+                                            properties:
+                                              effect:
+                                                description: Effect indicates the
+                                                  taint effect to match. Empty means
+                                                  match all taint effects. When specified,
+                                                  allowed values are NoSchedule, PreferNoSchedule
+                                                  and NoExecute.
+                                                type: string
+                                              key:
+                                                description: Key is the taint key
+                                                  that the toleration applies to.
+                                                  Empty means match all taint keys.
+                                                  If the key is empty, operator must
+                                                  be Exists; this combination means
+                                                  to match all values and all keys.
+                                                type: string
+                                              operator:
+                                                description: Operator represents a
+                                                  key's relationship to the value.
+                                                  Valid operators are Exists and Equal.
+                                                  Defaults to Equal. Exists is equivalent
+                                                  to wildcard for value, so that a
+                                                  pod can tolerate all taints of a
+                                                  particular category.
+                                                type: string
+                                              tolerationSeconds:
+                                                description: TolerationSeconds represents
+                                                  the period of time the toleration
+                                                  (which must be of effect NoExecute,
+                                                  otherwise this field is ignored)
+                                                  tolerates the taint. By default,
+                                                  it is not set, which means tolerate
+                                                  the taint forever (do not evict).
+                                                  Zero and negative values will be
+                                                  treated as 0 (evict immediately)
+                                                  by the system.
+                                                type: integer
+                                                format: int64
+                                              value:
+                                                description: Value is the taint value
+                                                  the toleration matches to. If the
+                                                  operator is Exists, the value should
+                                                  be empty, otherwise just a regular
+                                                  string.
+                                                type: string
+                                serviceType:
+                                  description: Optional service type for Kubernetes
+                                    solver service
+                                  type: string
+                        selector:
+                          description: Selector selects a set of DNSNames on the Certificate
+                            resource that should be solved using this challenge solver.
+                            If not specified, the solver will be treated as the 'default'
+                            solver with the lowest priority, i.e. if any other solver
+                            has a more specific match, it will be used instead.
+                          type: object
+                          properties:
+                            dnsNames:
+                              description: List of DNSNames that this solver will
+                                be used to solve. If specified and a match is found,
+                                a dnsNames selector will take precedence over a dnsZones
+                                selector. If multiple solvers match with the same
+                                dnsNames value, the solver with the most matching
+                                labels in matchLabels will be selected. If neither
+                                has more matches, the solver defined earlier in the
+                                list will be selected.
+                              type: array
+                              items:
+                                type: string
+                            dnsZones:
+                              description: List of DNSZones that this solver will
+                                be used to solve. The most specific DNS zone match
+                                specified here will take precedence over other DNS
+                                zone matches, so a solver specifying sys.example.com
+                                will be selected over one specifying example.com for
+                                the domain www.sys.example.com. If multiple solvers
+                                match with the same dnsZones value, the solver with
+                                the most matching labels in matchLabels will be selected.
+                                If neither has more matches, the solver defined earlier
+                                in the list will be selected.
+                              type: array
+                              items:
+                                type: string
+                            matchLabels:
+                              description: A label selector that is used to refine
+                                the set of certificate's that this challenge solver
+                                will apply to.
+                              type: object
+                              additionalProperties:
+                                type: string
+              ca:
+                description: CA configures this issuer to sign certificates using
+                  a signing CA keypair stored in a Secret resource. This is used to
+                  build internal PKIs that are managed by cert-manager.
+                type: object
+                required:
+                - secretName
+                properties:
+                  crlDistributionPoints:
+                    description: The CRL distribution points is an X.509 v3 certificate
+                      extension which identifies the location of the CRL from which
+                      the revocation of this certificate can be checked. If not set,
+                      certificates will be issued without distribution points set.
+                    type: array
+                    items:
+                      type: string
+                  secretName:
+                    description: SecretName is the name of the secret used to sign
+                      Certificates issued by this Issuer.
+                    type: string
+              selfSigned:
+                description: SelfSigned configures this issuer to 'self sign' certificates
+                  using the private key used to create the CertificateRequest object.
+                type: object
+                properties:
+                  crlDistributionPoints:
+                    description: The CRL distribution points is an X.509 v3 certificate
+                      extension which identifies the location of the CRL from which
+                      the revocation of this certificate can be checked. If not set
+                      certificate will be issued without CDP. Values are strings.
+                    type: array
+                    items:
+                      type: string
+              vault:
+                description: Vault configures this issuer to sign certificates using
+                  a HashiCorp Vault PKI backend.
+                type: object
+                required:
+                - auth
+                - path
+                - server
+                properties:
+                  auth:
+                    description: Auth configures how cert-manager authenticates with
+                      the Vault server.
+                    type: object
+                    properties:
+                      appRole:
+                        description: AppRole authenticates with Vault using the App
+                          Role auth mechanism, with the role and secret stored in
+                          a Kubernetes Secret resource.
+                        type: object
+                        required:
+                        - path
+                        - roleId
+                        - secretRef
+                        properties:
+                          path:
+                            description: 'Path where the App Role authentication backend
+                              is mounted in Vault, e.g: "approle"'
+                            type: string
+                          roleId:
+                            description: RoleID configured in the App Role authentication
+                              backend when setting up the authentication backend in
+                              Vault.
+                            type: string
+                          secretRef:
+                            description: Reference to a key in a Secret that contains
+                              the App Role secret used to authenticate with Vault.
+                              The `key` field must be specified and denotes which
+                              entry within the Secret resource is used as the app
+                              role secret.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                      kubernetes:
+                        description: Kubernetes authenticates with Vault by passing
+                          the ServiceAccount token stored in the named Secret resource
+                          to the Vault server.
+                        type: object
+                        required:
+                        - role
+                        - secretRef
+                        properties:
+                          mountPath:
+                            description: The Vault mountPath here is the mount path
+                              to use when authenticating with Vault. For example,
+                              setting a value to `/v1/auth/foo`, will use the path
+                              `/v1/auth/foo/login` to authenticate with Vault. If
+                              unspecified, the default value "/v1/auth/kubernetes"
+                              will be used.
+                            type: string
+                          role:
+                            description: A required field containing the Vault Role
+                              to assume. A Role binds a Kubernetes ServiceAccount
+                              with a set of Vault policies.
+                            type: string
+                          secretRef:
+                            description: The required Secret field containing a Kubernetes
+                              ServiceAccount JWT used for authenticating with Vault.
+                              Use of 'ambient credentials' is not supported.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                      tokenSecretRef:
+                        description: TokenSecretRef authenticates with Vault by presenting
+                          a token.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the entry in the Secret resource's
+                              `data` field to be used. Some instances of this field
+                              may be defaulted, in others it may be required.
+                            type: string
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                  caBundle:
+                    description: PEM encoded CA bundle used to validate Vault server
+                      certificate. Only used if the Server URL is using HTTPS protocol.
+                      This parameter is ignored for plain HTTP protocol connection.
+                      If not set the system root certificates are used to validate
+                      the TLS connection.
+                    type: string
+                    format: byte
+                  path:
+                    description: 'Path is the mount path of the Vault PKI backend''s
+                      `sign` endpoint, e.g: "my_pki_mount/sign/my-role-name".'
+                    type: string
+                  server:
+                    description: 'Server is the connection address for the Vault server,
+                      e.g: "https://vault.example.com:8200".'
+                    type: string
+              venafi:
+                description: Venafi configures this issuer to sign certificates using
+                  a Venafi TPP or Venafi Cloud policy zone.
+                type: object
+                required:
+                - zone
+                properties:
+                  cloud:
+                    description: Cloud specifies the Venafi cloud configuration settings.
+                      Only one of TPP or Cloud may be specified.
+                    type: object
+                    required:
+                    - apiTokenSecretRef
+                    properties:
+                      apiTokenSecretRef:
+                        description: APITokenSecretRef is a secret key selector for
+                          the Venafi Cloud API token.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the entry in the Secret resource's
+                              `data` field to be used. Some instances of this field
+                              may be defaulted, in others it may be required.
+                            type: string
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                      url:
+                        description: URL is the base URL for Venafi Cloud. Defaults
+                          to "https://api.venafi.cloud/v1".
+                        type: string
+                  tpp:
+                    description: TPP specifies Trust Protection Platform configuration
+                      settings. Only one of TPP or Cloud may be specified.
+                    type: object
+                    required:
+                    - credentialsRef
+                    - url
+                    properties:
+                      caBundle:
+                        description: CABundle is a PEM encoded TLS certificate to
+                          use to verify connections to the TPP instance. If specified,
+                          system roots will not be used and the issuing CA for the
+                          TPP instance must be verifiable using the provided root.
+                          If not specified, the connection will be verified using
+                          the cert-manager system root certificates.
+                        type: string
+                        format: byte
+                      credentialsRef:
+                        description: CredentialsRef is a reference to a Secret containing
+                          the username and password for the TPP server. The secret
+                          must contain two keys, 'username' and 'password'.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                      url:
+                        description: 'URL is the base URL for the vedsdk endpoint
+                          of the Venafi TPP instance, for example: "https://tpp.example.com/vedsdk".'
+                        type: string
+                  zone:
+                    description: Zone is the Venafi Policy Zone to use for this issuer.
+                      All requests made to the Venafi platform will be restricted
+                      by the named zone policy. This field is required.
+                    type: string
+          status:
+            description: Status of the ClusterIssuer. This is set and managed automatically.
+            type: object
+            properties:
+              acme:
+                description: ACME specific status options. This field should only
+                  be set if the Issuer is configured to use an ACME server to issue
+                  certificates.
+                type: object
+                properties:
+                  lastRegisteredEmail:
+                    description: LastRegisteredEmail is the email associated with
+                      the latest registered ACME account, in order to track changes
+                      made to registered account associated with the  Issuer
+                    type: string
+                  uri:
+                    description: URI is the unique account identifier, which can also
+                      be used to retrieve account details from the CA
+                    type: string
+              conditions:
+                description: List of status conditions to indicate the status of a
+                  CertificateRequest. Known condition types are `Ready`.
+                type: array
+                items:
+                  description: IssuerCondition contains condition information for
+                    an Issuer.
+                  type: object
+                  required:
+                  - status
+                  - type
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the timestamp corresponding
+                        to the last status change of this condition.
+                      type: string
+                      format: date-time
+                    message:
+                      description: Message is a human readable description of the
+                        details of the last transition, complementing reason.
+                      type: string
+                    reason:
+                      description: Reason is a brief machine readable explanation
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of ('True', 'False',
+                        'Unknown').
+                      type: string
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                    type:
+                      description: Type of the condition, known values are ('Ready').
+                      type: string

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/crd-issuer.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/crd-issuer.yml.j2
@@ -64,1757 +64,5771 @@ spec:
   - name: v1alpha2
     served: true
     storage: true
+    "schema":
+      "openAPIV3Schema":
+        description: An Issuer represents a certificate issuing authority which can
+          be referenced as part of `issuerRef` fields. It is scoped to a single namespace
+          and can therefore only be referenced by resources within the same namespace.
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Desired state of the Issuer resource.
+            type: object
+            properties:
+              acme:
+                description: ACME configures this issuer to communicate with a RFC8555
+                  (ACME) server to obtain signed x509 certificates.
+                type: object
+                required:
+                - privateKeySecretRef
+                - server
+                properties:
+                  email:
+                    description: Email is the email address to be associated with
+                      the ACME account. This field is optional, but it is strongly
+                      recommended to be set. It will be used to contact you in case
+                      of issues with your account or certificates, including expiry
+                      notification emails. This field may be updated after the account
+                      is initially registered.
+                    type: string
+                  externalAccountBinding:
+                    description: ExternalAccountBinding is a reference to a CA external
+                      account of the ACME server. If set, upon registration cert-manager
+                      will attempt to associate the given external account credentials
+                      with the registered ACME account.
+                    type: object
+                    required:
+                    - keyAlgorithm
+                    - keyID
+                    - keySecretRef
+                    properties:
+                      keyAlgorithm:
+                        description: keyAlgorithm is the MAC key algorithm that the
+                          key is used for. Valid values are "HS256", "HS384" and "HS512".
+                        type: string
+                        enum:
+                        - HS256
+                        - HS384
+                        - HS512
+                      keyID:
+                        description: keyID is the ID of the CA key that the External
+                          Account is bound to.
+                        type: string
+                      keySecretRef:
+                        description: keySecretRef is a Secret Key Selector referencing
+                          a data item in a Kubernetes Secret which holds the symmetric
+                          MAC key of the External Account Binding. The `key` is the
+                          index string that is paired with the key data in the Secret
+                          and should not be confused with the key data itself, or
+                          indeed with the External Account Binding keyID above. The
+                          secret key stored in the Secret **must** be un-padded, base64
+                          URL encoded data.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the entry in the Secret resource's
+                              `data` field to be used. Some instances of this field
+                              may be defaulted, in others it may be required.
+                            type: string
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                  privateKeySecretRef:
+                    description: PrivateKey is the name of a Kubernetes Secret resource
+                      that will be used to store the automatically generated ACME
+                      account private key. Optionally, a `key` may be specified to
+                      select a specific entry within the named Secret resource. If
+                      `key` is not specified, a default of `tls.key` will be used.
+                    type: object
+                    required:
+                    - name
+                    properties:
+                      key:
+                        description: The key of the entry in the Secret resource's
+                          `data` field to be used. Some instances of this field may
+                          be defaulted, in others it may be required.
+                        type: string
+                      name:
+                        description: 'Name of the resource being referred to. More
+                          info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                  server:
+                    description: 'Server is the URL used to access the ACME server''s
+                      ''directory'' endpoint. For example, for Let''s Encrypt''s staging
+                      endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory".
+                      Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
+                    type: string
+                  skipTLSVerify:
+                    description: Enables or disables validation of the ACME server
+                      TLS certificate. If true, requests to the ACME server will not
+                      have their TLS certificate validated (i.e. insecure connections
+                      will be allowed). Only enable this option in development environments.
+                      The cert-manager system installed roots will be used to verify
+                      connections to the ACME server if this is false. Defaults to
+                      false.
+                    type: boolean
+                  solvers:
+                    description: 'Solvers is a list of challenge solvers that will
+                      be used to solve ACME challenges for the matching domains. Solver
+                      configurations must be provided in order to obtain certificates
+                      from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/'
+                    type: array
+                    items:
+                      description: Configures an issuer to solve challenges using
+                        the specified options. Only one of HTTP01 or DNS01 may be
+                        provided.
+                      type: object
+                      properties:
+                        dns01:
+                          description: Configures cert-manager to attempt to complete
+                            authorizations by performing the DNS01 challenge flow.
+                          type: object
+                          properties:
+                            acmedns:
+                              description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns)
+                                API to manage DNS01 challenge records.
+                              type: object
+                              required:
+                              - accountSecretRef
+                              - host
+                              properties:
+                                accountSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                host:
+                                  type: string
+                            akamai:
+                              description: Use the Akamai DNS zone management API
+                                to manage DNS01 challenge records.
+                              type: object
+                              required:
+                              - accessTokenSecretRef
+                              - clientSecretSecretRef
+                              - clientTokenSecretRef
+                              - serviceConsumerDomain
+                              properties:
+                                accessTokenSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                clientSecretSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                clientTokenSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                serviceConsumerDomain:
+                                  type: string
+                            azuredns:
+                              description: Use the Microsoft Azure DNS API to manage
+                                DNS01 challenge records.
+                              type: object
+                              required:
+                              - resourceGroupName
+                              - subscriptionID
+                              properties:
+                                clientID:
+                                  description: if both this and ClientSecret are left
+                                    unset MSI will be used
+                                  type: string
+                                clientSecretSecretRef:
+                                  description: if both this and ClientID are left
+                                    unset MSI will be used
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                environment:
+                                  type: string
+                                  enum:
+                                  - AzurePublicCloud
+                                  - AzureChinaCloud
+                                  - AzureGermanCloud
+                                  - AzureUSGovernmentCloud
+                                hostedZoneName:
+                                  type: string
+                                resourceGroupName:
+                                  type: string
+                                subscriptionID:
+                                  type: string
+                                tenantID:
+                                  description: when specifying ClientID and ClientSecret
+                                    then this field is also needed
+                                  type: string
+                            clouddns:
+                              description: Use the Google Cloud DNS API to manage
+                                DNS01 challenge records.
+                              type: object
+                              required:
+                              - project
+                              properties:
+                                hostedZoneName:
+                                  description: HostedZoneName is an optional field
+                                    that tells cert-manager in which Cloud DNS zone
+                                    the challenge record has to be created. If left
+                                    empty cert-manager will automatically choose a
+                                    zone.
+                                  type: string
+                                project:
+                                  type: string
+                                serviceAccountSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                            cloudflare:
+                              description: Use the Cloudflare API to manage DNS01
+                                challenge records.
+                              type: object
+                              properties:
+                                apiKeySecretRef:
+                                  description: 'API key to use to authenticate with
+                                    Cloudflare. Note: using an API token to authenticate
+                                    is now the recommended method as it allows greater
+                                    control of permissions.'
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                apiTokenSecretRef:
+                                  description: API token used to authenticate with
+                                    Cloudflare.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                email:
+                                  description: Email of the account, only required
+                                    when using API key based authentication.
+                                  type: string
+                            cnameStrategy:
+                              description: CNAMEStrategy configures how the DNS01
+                                provider should handle CNAME records when found in
+                                DNS zones.
+                              type: string
+                              enum:
+                              - None
+                              - Follow
+                            digitalocean:
+                              description: Use the DigitalOcean DNS API to manage
+                                DNS01 challenge records.
+                              type: object
+                              required:
+                              - tokenSecretRef
+                              properties:
+                                tokenSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                            rfc2136:
+                              description: Use RFC2136 ("Dynamic Updates in the Domain
+                                Name System") (https://datatracker.ietf.org/doc/rfc2136/)
+                                to manage DNS01 challenge records.
+                              type: object
+                              required:
+                              - nameserver
+                              properties:
+                                nameserver:
+                                  description: The IP address or hostname of an authoritative
+                                    DNS server supporting RFC2136 in the form host:port.
+                                    If the host is an IPv6 address it must be enclosed
+                                    in square brackets (e.g [2001:db8::1]) ; port
+                                    is optional. This field is required.
+                                  type: string
+                                tsigAlgorithm:
+                                  description: 'The TSIG Algorithm configured in the
+                                    DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                                    and ``tsigKeyName`` are defined. Supported values
+                                    are (case-insensitive): ``HMACMD5`` (default),
+                                    ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
+                                  type: string
+                                tsigKeyName:
+                                  description: The TSIG Key name configured in the
+                                    DNS. If ``tsigSecretSecretRef`` is defined, this
+                                    field is required.
+                                  type: string
+                                tsigSecretSecretRef:
+                                  description: The name of the secret containing the
+                                    TSIG value. If ``tsigKeyName`` is defined, this
+                                    field is required.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                            route53:
+                              description: Use the AWS Route53 API to manage DNS01
+                                challenge records.
+                              type: object
+                              required:
+                              - region
+                              properties:
+                                accessKeyID:
+                                  description: 'The AccessKeyID is used for authentication.
+                                    If not set we fall-back to using env vars, shared
+                                    credentials file or AWS Instance metadata see:
+                                    https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                  type: string
+                                hostedZoneID:
+                                  description: If set, the provider will manage only
+                                    this zone in Route53 and will not do an lookup
+                                    using the route53:ListHostedZonesByName api call.
+                                  type: string
+                                region:
+                                  description: Always set the region when using AccessKeyID
+                                    and SecretAccessKey
+                                  type: string
+                                role:
+                                  description: Role is a Role ARN which the Route53
+                                    provider will assume using either the explicit
+                                    credentials AccessKeyID/SecretAccessKey or the
+                                    inferred credentials from environment variables,
+                                    shared credentials file or AWS Instance metadata
+                                  type: string
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication.
+                                    If not set we fall-back to using env vars, shared
+                                    credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                            webhook:
+                              description: Configure an external webhook based DNS01
+                                challenge solver to manage DNS01 challenge records.
+                              type: object
+                              required:
+                              - groupName
+                              - solverName
+                              properties:
+                                config:
+                                  description: Additional configuration that should
+                                    be passed to the webhook apiserver when challenges
+                                    are processed. This can contain arbitrary JSON
+                                    data. Secret values should not be specified in
+                                    this stanza. If secret values are needed (e.g.
+                                    credentials for a DNS service), you should use
+                                    a SecretKeySelector to reference a Secret resource.
+                                    For details on the schema of this field, consult
+                                    the webhook provider implementation's documentation.
+                                  x-kubernetes-preserve-unknown-fields: true
+                                groupName:
+                                  description: The API group name that should be used
+                                    when POSTing ChallengePayload resources to the
+                                    webhook apiserver. This should be the same as
+                                    the GroupName specified in the webhook provider
+                                    implementation.
+                                  type: string
+                                solverName:
+                                  description: The name of the solver to use, as defined
+                                    in the webhook provider implementation. This will
+                                    typically be the name of the provider, e.g. 'cloudflare'.
+                                  type: string
+                        http01:
+                          description: Configures cert-manager to attempt to complete
+                            authorizations by performing the HTTP01 challenge flow.
+                            It is not possible to obtain certificates for wildcard
+                            domain names (e.g. `*.example.com`) using the HTTP01 challenge
+                            mechanism.
+                          type: object
+                          properties:
+                            ingress:
+                              description: The ingress based HTTP01 challenge solver
+                                will solve challenges by creating or modifying Ingress
+                                resources in order to route requests for '/.well-known/acme-challenge/XYZ'
+                                to 'challenge solver' pods that are provisioned by
+                                cert-manager for each Challenge to be completed.
+                              type: object
+                              properties:
+                                class:
+                                  description: The ingress class to use when creating
+                                    Ingress resources to solve ACME challenges that
+                                    use this challenge solver. Only one of 'class'
+                                    or 'name' may be specified.
+                                  type: string
+                                ingressTemplate:
+                                  description: Optional ingress template used to configure
+                                    the ACME challenge solver ingress used for HTTP01
+                                    challenges
+                                  type: object
+                                  properties:
+                                    metadata:
+                                      description: ObjectMeta overrides for the ingress
+                                        used to solve HTTP01 challenges. Only the
+                                        'labels' and 'annotations' fields may be set.
+                                        If labels or annotations overlap with in-built
+                                        values, the values here will override the
+                                        in-built values.
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          description: Annotations that should be
+                                            added to the created ACME HTTP01 solver
+                                            ingress.
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        labels:
+                                          description: Labels that should be added
+                                            to the created ACME HTTP01 solver ingress.
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                name:
+                                  description: The name of the ingress resource that
+                                    should have ACME challenge solving routes inserted
+                                    into it in order to solve HTTP01 challenges. This
+                                    is typically used in conjunction with ingress
+                                    controllers like ingress-gce, which maintains
+                                    a 1:1 mapping between external IPs and ingress
+                                    resources.
+                                  type: string
+                                podTemplate:
+                                  description: Optional pod template used to configure
+                                    the ACME challenge solver pods used for HTTP01
+                                    challenges
+                                  type: object
+                                  properties:
+                                    metadata:
+                                      description: ObjectMeta overrides for the pod
+                                        used to solve HTTP01 challenges. Only the
+                                        'labels' and 'annotations' fields may be set.
+                                        If labels or annotations overlap with in-built
+                                        values, the values here will override the
+                                        in-built values.
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          description: Annotations that should be
+                                            added to the create ACME HTTP01 solver
+                                            pods.
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        labels:
+                                          description: Labels that should be added
+                                            to the created ACME HTTP01 solver pods.
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                    spec:
+                                      description: PodSpec defines overrides for the
+                                        HTTP01 challenge solver pod. Only the 'nodeSelector',
+                                        'affinity' and 'tolerations' fields are supported
+                                        currently. All other fields will be ignored.
+                                      type: object
+                                      properties:
+                                        affinity:
+                                          description: If specified, the pod's scheduling
+                                            constraints
+                                          type: object
+                                          properties:
+                                            nodeAffinity:
+                                              description: Describes node affinity
+                                                scheduling rules for the pod.
+                                              type: object
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  description: The scheduler will
+                                                    prefer to schedule pods to nodes
+                                                    that satisfy the affinity expressions
+                                                    specified by this field, but it
+                                                    may choose a node that violates
+                                                    one or more of the expressions.
+                                                    The node that is most preferred
+                                                    is the one with the greatest sum
+                                                    of weights, i.e. for each node
+                                                    that meets all of the scheduling
+                                                    requirements (resource request,
+                                                    requiredDuringScheduling affinity
+                                                    expressions, etc.), compute a
+                                                    sum by iterating through the elements
+                                                    of this field and adding "weight"
+                                                    to the sum if the node matches
+                                                    the corresponding matchExpressions;
+                                                    the node(s) with the highest sum
+                                                    are the most preferred.
+                                                  type: array
+                                                  items:
+                                                    description: An empty preferred
+                                                      scheduling term matches all
+                                                      objects with implicit weight
+                                                      0 (i.e. it's a no-op). A null
+                                                      preferred scheduling term matches
+                                                      no objects (i.e. is also a no-op).
+                                                    type: object
+                                                    required:
+                                                    - preference
+                                                    - weight
+                                                    properties:
+                                                      preference:
+                                                        description: A node selector
+                                                          term, associated with the
+                                                          corresponding weight.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: A list of
+                                                              node selector requirements
+                                                              by node's labels.
+                                                            type: array
+                                                            items:
+                                                              description: A node
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: Represents
+                                                                    a key's relationship
+                                                                    to a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists, DoesNotExist.
+                                                                    Gt, and Lt.
+                                                                  type: string
+                                                                values:
+                                                                  description: An
+                                                                    array of string
+                                                                    values. If the
+                                                                    operator is In
+                                                                    or NotIn, the
+                                                                    values array must
+                                                                    be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    If the operator
+                                                                    is Gt or Lt, the
+                                                                    values array must
+                                                                    have a single
+                                                                    element, which
+                                                                    will be interpreted
+                                                                    as an integer.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchFields:
+                                                            description: A list of
+                                                              node selector requirements
+                                                              by node's fields.
+                                                            type: array
+                                                            items:
+                                                              description: A node
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: Represents
+                                                                    a key's relationship
+                                                                    to a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists, DoesNotExist.
+                                                                    Gt, and Lt.
+                                                                  type: string
+                                                                values:
+                                                                  description: An
+                                                                    array of string
+                                                                    values. If the
+                                                                    operator is In
+                                                                    or NotIn, the
+                                                                    values array must
+                                                                    be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    If the operator
+                                                                    is Gt or Lt, the
+                                                                    values array must
+                                                                    have a single
+                                                                    element, which
+                                                                    will be interpreted
+                                                                    as an integer.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                      weight:
+                                                        description: Weight associated
+                                                          with matching the corresponding
+                                                          nodeSelectorTerm, in the
+                                                          range 1-100.
+                                                        type: integer
+                                                        format: int32
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  description: If the affinity requirements
+                                                    specified by this field are not
+                                                    met at scheduling time, the pod
+                                                    will not be scheduled onto the
+                                                    node. If the affinity requirements
+                                                    specified by this field cease
+                                                    to be met at some point during
+                                                    pod execution (e.g. due to an
+                                                    update), the system may or may
+                                                    not try to eventually evict the
+                                                    pod from its node.
+                                                  type: object
+                                                  required:
+                                                  - nodeSelectorTerms
+                                                  properties:
+                                                    nodeSelectorTerms:
+                                                      description: Required. A list
+                                                        of node selector terms. The
+                                                        terms are ORed.
+                                                      type: array
+                                                      items:
+                                                        description: A null or empty
+                                                          node selector term matches
+                                                          no objects. The requirements
+                                                          of them are ANDed. The TopologySelectorTerm
+                                                          type implements a subset
+                                                          of the NodeSelectorTerm.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: A list of
+                                                              node selector requirements
+                                                              by node's labels.
+                                                            type: array
+                                                            items:
+                                                              description: A node
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: Represents
+                                                                    a key's relationship
+                                                                    to a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists, DoesNotExist.
+                                                                    Gt, and Lt.
+                                                                  type: string
+                                                                values:
+                                                                  description: An
+                                                                    array of string
+                                                                    values. If the
+                                                                    operator is In
+                                                                    or NotIn, the
+                                                                    values array must
+                                                                    be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    If the operator
+                                                                    is Gt or Lt, the
+                                                                    values array must
+                                                                    have a single
+                                                                    element, which
+                                                                    will be interpreted
+                                                                    as an integer.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchFields:
+                                                            description: A list of
+                                                              node selector requirements
+                                                              by node's fields.
+                                                            type: array
+                                                            items:
+                                                              description: A node
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: Represents
+                                                                    a key's relationship
+                                                                    to a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists, DoesNotExist.
+                                                                    Gt, and Lt.
+                                                                  type: string
+                                                                values:
+                                                                  description: An
+                                                                    array of string
+                                                                    values. If the
+                                                                    operator is In
+                                                                    or NotIn, the
+                                                                    values array must
+                                                                    be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    If the operator
+                                                                    is Gt or Lt, the
+                                                                    values array must
+                                                                    have a single
+                                                                    element, which
+                                                                    will be interpreted
+                                                                    as an integer.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                            podAffinity:
+                                              description: Describes pod affinity
+                                                scheduling rules (e.g. co-locate this
+                                                pod in the same node, zone, etc. as
+                                                some other pod(s)).
+                                              type: object
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  description: The scheduler will
+                                                    prefer to schedule pods to nodes
+                                                    that satisfy the affinity expressions
+                                                    specified by this field, but it
+                                                    may choose a node that violates
+                                                    one or more of the expressions.
+                                                    The node that is most preferred
+                                                    is the one with the greatest sum
+                                                    of weights, i.e. for each node
+                                                    that meets all of the scheduling
+                                                    requirements (resource request,
+                                                    requiredDuringScheduling affinity
+                                                    expressions, etc.), compute a
+                                                    sum by iterating through the elements
+                                                    of this field and adding "weight"
+                                                    to the sum if the node has pods
+                                                    which matches the corresponding
+                                                    podAffinityTerm; the node(s) with
+                                                    the highest sum are the most preferred.
+                                                  type: array
+                                                  items:
+                                                    description: The weights of all
+                                                      of the matched WeightedPodAffinityTerm
+                                                      fields are added per-node to
+                                                      find the most preferred node(s)
+                                                    type: object
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        description: Required. A pod
+                                                          affinity term, associated
+                                                          with the corresponding weight.
+                                                        type: object
+                                                        required:
+                                                        - topologyKey
+                                                        properties:
+                                                          labelSelector:
+                                                            description: A label query
+                                                              over a set of resources,
+                                                              in this case pods.
+                                                            type: object
+                                                            properties:
+                                                              matchExpressions:
+                                                                description: matchExpressions
+                                                                  is a list of label
+                                                                  selector requirements.
+                                                                  The requirements
+                                                                  are ANDed.
+                                                                type: array
+                                                                items:
+                                                                  description: A label
+                                                                    selector requirement
+                                                                    is a selector
+                                                                    that contains
+                                                                    values, a key,
+                                                                    and an operator
+                                                                    that relates the
+                                                                    key and values.
+                                                                  type: object
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  properties:
+                                                                    key:
+                                                                      description: key
+                                                                        is the label
+                                                                        key that the
+                                                                        selector applies
+                                                                        to.
+                                                                      type: string
+                                                                    operator:
+                                                                      description: operator
+                                                                        represents
+                                                                        a key's relationship
+                                                                        to a set of
+                                                                        values. Valid
+                                                                        operators
+                                                                        are In, NotIn,
+                                                                        Exists and
+                                                                        DoesNotExist.
+                                                                      type: string
+                                                                    values:
+                                                                      description: values
+                                                                        is an array
+                                                                        of string
+                                                                        values. If
+                                                                        the operator
+                                                                        is In or NotIn,
+                                                                        the values
+                                                                        array must
+                                                                        be non-empty.
+                                                                        If the operator
+                                                                        is Exists
+                                                                        or DoesNotExist,
+                                                                        the values
+                                                                        array must
+                                                                        be empty.
+                                                                        This array
+                                                                        is replaced
+                                                                        during a strategic
+                                                                        merge patch.
+                                                                      type: array
+                                                                      items:
+                                                                        type: string
+                                                              matchLabels:
+                                                                description: matchLabels
+                                                                  is a map of {key,value}
+                                                                  pairs. A single
+                                                                  {key,value} in the
+                                                                  matchLabels map
+                                                                  is equivalent to
+                                                                  an element of matchExpressions,
+                                                                  whose key field
+                                                                  is "key", the operator
+                                                                  is "In", and the
+                                                                  values array contains
+                                                                  only "value". The
+                                                                  requirements are
+                                                                  ANDed.
+                                                                type: object
+                                                                additionalProperties:
+                                                                  type: string
+                                                          namespaces:
+                                                            description: namespaces
+                                                              specifies which namespaces
+                                                              the labelSelector applies
+                                                              to (matches against);
+                                                              null or empty list means
+                                                              "this pod's namespace"
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                          topologyKey:
+                                                            description: This pod
+                                                              should be co-located
+                                                              (affinity) or not co-located
+                                                              (anti-affinity) with
+                                                              the pods matching the
+                                                              labelSelector in the
+                                                              specified namespaces,
+                                                              where co-located is
+                                                              defined as running on
+                                                              a node whose value of
+                                                              the label with key topologyKey
+                                                              matches that of any
+                                                              node on which any of
+                                                              the selected pods is
+                                                              running. Empty topologyKey
+                                                              is not allowed.
+                                                            type: string
+                                                      weight:
+                                                        description: weight associated
+                                                          with matching the corresponding
+                                                          podAffinityTerm, in the
+                                                          range 1-100.
+                                                        type: integer
+                                                        format: int32
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  description: If the affinity requirements
+                                                    specified by this field are not
+                                                    met at scheduling time, the pod
+                                                    will not be scheduled onto the
+                                                    node. If the affinity requirements
+                                                    specified by this field cease
+                                                    to be met at some point during
+                                                    pod execution (e.g. due to a pod
+                                                    label update), the system may
+                                                    or may not try to eventually evict
+                                                    the pod from its node. When there
+                                                    are multiple elements, the lists
+                                                    of nodes corresponding to each
+                                                    podAffinityTerm are intersected,
+                                                    i.e. all terms must be satisfied.
+                                                  type: array
+                                                  items:
+                                                    description: Defines a set of
+                                                      pods (namely those matching
+                                                      the labelSelector relative to
+                                                      the given namespace(s)) that
+                                                      this pod should be co-located
+                                                      (affinity) or not co-located
+                                                      (anti-affinity) with, where
+                                                      co-located is defined as running
+                                                      on a node whose value of the
+                                                      label with key <topologyKey>
+                                                      matches that of any node on
+                                                      which a pod of the set of pods
+                                                      is running
+                                                    type: object
+                                                    required:
+                                                    - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query
+                                                          over a set of resources,
+                                                          in this case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions
+                                                              is a list of label selector
+                                                              requirements. The requirements
+                                                              are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key
+                                                                    is the label key
+                                                                    that the selector
+                                                                    applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator
+                                                                    represents a key's
+                                                                    relationship to
+                                                                    a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values
+                                                                    is an array of
+                                                                    string values.
+                                                                    If the operator
+                                                                    is In or NotIn,
+                                                                    the values array
+                                                                    must be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels
+                                                              is a map of {key,value}
+                                                              pairs. A single {key,value}
+                                                              in the matchLabels map
+                                                              is equivalent to an
+                                                              element of matchExpressions,
+                                                              whose key field is "key",
+                                                              the operator is "In",
+                                                              and the values array
+                                                              contains only "value".
+                                                              The requirements are
+                                                              ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaces:
+                                                        description: namespaces specifies
+                                                          which namespaces the labelSelector
+                                                          applies to (matches against);
+                                                          null or empty list means
+                                                          "this pod's namespace"
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                      topologyKey:
+                                                        description: This pod should
+                                                          be co-located (affinity)
+                                                          or not co-located (anti-affinity)
+                                                          with the pods matching the
+                                                          labelSelector in the specified
+                                                          namespaces, where co-located
+                                                          is defined as running on
+                                                          a node whose value of the
+                                                          label with key topologyKey
+                                                          matches that of any node
+                                                          on which any of the selected
+                                                          pods is running. Empty topologyKey
+                                                          is not allowed.
+                                                        type: string
+                                            podAntiAffinity:
+                                              description: Describes pod anti-affinity
+                                                scheduling rules (e.g. avoid putting
+                                                this pod in the same node, zone, etc.
+                                                as some other pod(s)).
+                                              type: object
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  description: The scheduler will
+                                                    prefer to schedule pods to nodes
+                                                    that satisfy the anti-affinity
+                                                    expressions specified by this
+                                                    field, but it may choose a node
+                                                    that violates one or more of the
+                                                    expressions. The node that is
+                                                    most preferred is the one with
+                                                    the greatest sum of weights, i.e.
+                                                    for each node that meets all of
+                                                    the scheduling requirements (resource
+                                                    request, requiredDuringScheduling
+                                                    anti-affinity expressions, etc.),
+                                                    compute a sum by iterating through
+                                                    the elements of this field and
+                                                    adding "weight" to the sum if
+                                                    the node has pods which matches
+                                                    the corresponding podAffinityTerm;
+                                                    the node(s) with the highest sum
+                                                    are the most preferred.
+                                                  type: array
+                                                  items:
+                                                    description: The weights of all
+                                                      of the matched WeightedPodAffinityTerm
+                                                      fields are added per-node to
+                                                      find the most preferred node(s)
+                                                    type: object
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        description: Required. A pod
+                                                          affinity term, associated
+                                                          with the corresponding weight.
+                                                        type: object
+                                                        required:
+                                                        - topologyKey
+                                                        properties:
+                                                          labelSelector:
+                                                            description: A label query
+                                                              over a set of resources,
+                                                              in this case pods.
+                                                            type: object
+                                                            properties:
+                                                              matchExpressions:
+                                                                description: matchExpressions
+                                                                  is a list of label
+                                                                  selector requirements.
+                                                                  The requirements
+                                                                  are ANDed.
+                                                                type: array
+                                                                items:
+                                                                  description: A label
+                                                                    selector requirement
+                                                                    is a selector
+                                                                    that contains
+                                                                    values, a key,
+                                                                    and an operator
+                                                                    that relates the
+                                                                    key and values.
+                                                                  type: object
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  properties:
+                                                                    key:
+                                                                      description: key
+                                                                        is the label
+                                                                        key that the
+                                                                        selector applies
+                                                                        to.
+                                                                      type: string
+                                                                    operator:
+                                                                      description: operator
+                                                                        represents
+                                                                        a key's relationship
+                                                                        to a set of
+                                                                        values. Valid
+                                                                        operators
+                                                                        are In, NotIn,
+                                                                        Exists and
+                                                                        DoesNotExist.
+                                                                      type: string
+                                                                    values:
+                                                                      description: values
+                                                                        is an array
+                                                                        of string
+                                                                        values. If
+                                                                        the operator
+                                                                        is In or NotIn,
+                                                                        the values
+                                                                        array must
+                                                                        be non-empty.
+                                                                        If the operator
+                                                                        is Exists
+                                                                        or DoesNotExist,
+                                                                        the values
+                                                                        array must
+                                                                        be empty.
+                                                                        This array
+                                                                        is replaced
+                                                                        during a strategic
+                                                                        merge patch.
+                                                                      type: array
+                                                                      items:
+                                                                        type: string
+                                                              matchLabels:
+                                                                description: matchLabels
+                                                                  is a map of {key,value}
+                                                                  pairs. A single
+                                                                  {key,value} in the
+                                                                  matchLabels map
+                                                                  is equivalent to
+                                                                  an element of matchExpressions,
+                                                                  whose key field
+                                                                  is "key", the operator
+                                                                  is "In", and the
+                                                                  values array contains
+                                                                  only "value". The
+                                                                  requirements are
+                                                                  ANDed.
+                                                                type: object
+                                                                additionalProperties:
+                                                                  type: string
+                                                          namespaces:
+                                                            description: namespaces
+                                                              specifies which namespaces
+                                                              the labelSelector applies
+                                                              to (matches against);
+                                                              null or empty list means
+                                                              "this pod's namespace"
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                          topologyKey:
+                                                            description: This pod
+                                                              should be co-located
+                                                              (affinity) or not co-located
+                                                              (anti-affinity) with
+                                                              the pods matching the
+                                                              labelSelector in the
+                                                              specified namespaces,
+                                                              where co-located is
+                                                              defined as running on
+                                                              a node whose value of
+                                                              the label with key topologyKey
+                                                              matches that of any
+                                                              node on which any of
+                                                              the selected pods is
+                                                              running. Empty topologyKey
+                                                              is not allowed.
+                                                            type: string
+                                                      weight:
+                                                        description: weight associated
+                                                          with matching the corresponding
+                                                          podAffinityTerm, in the
+                                                          range 1-100.
+                                                        type: integer
+                                                        format: int32
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  description: If the anti-affinity
+                                                    requirements specified by this
+                                                    field are not met at scheduling
+                                                    time, the pod will not be scheduled
+                                                    onto the node. If the anti-affinity
+                                                    requirements specified by this
+                                                    field cease to be met at some
+                                                    point during pod execution (e.g.
+                                                    due to a pod label update), the
+                                                    system may or may not try to eventually
+                                                    evict the pod from its node. When
+                                                    there are multiple elements, the
+                                                    lists of nodes corresponding to
+                                                    each podAffinityTerm are intersected,
+                                                    i.e. all terms must be satisfied.
+                                                  type: array
+                                                  items:
+                                                    description: Defines a set of
+                                                      pods (namely those matching
+                                                      the labelSelector relative to
+                                                      the given namespace(s)) that
+                                                      this pod should be co-located
+                                                      (affinity) or not co-located
+                                                      (anti-affinity) with, where
+                                                      co-located is defined as running
+                                                      on a node whose value of the
+                                                      label with key <topologyKey>
+                                                      matches that of any node on
+                                                      which a pod of the set of pods
+                                                      is running
+                                                    type: object
+                                                    required:
+                                                    - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query
+                                                          over a set of resources,
+                                                          in this case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions
+                                                              is a list of label selector
+                                                              requirements. The requirements
+                                                              are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key
+                                                                    is the label key
+                                                                    that the selector
+                                                                    applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator
+                                                                    represents a key's
+                                                                    relationship to
+                                                                    a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values
+                                                                    is an array of
+                                                                    string values.
+                                                                    If the operator
+                                                                    is In or NotIn,
+                                                                    the values array
+                                                                    must be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels
+                                                              is a map of {key,value}
+                                                              pairs. A single {key,value}
+                                                              in the matchLabels map
+                                                              is equivalent to an
+                                                              element of matchExpressions,
+                                                              whose key field is "key",
+                                                              the operator is "In",
+                                                              and the values array
+                                                              contains only "value".
+                                                              The requirements are
+                                                              ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaces:
+                                                        description: namespaces specifies
+                                                          which namespaces the labelSelector
+                                                          applies to (matches against);
+                                                          null or empty list means
+                                                          "this pod's namespace"
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                      topologyKey:
+                                                        description: This pod should
+                                                          be co-located (affinity)
+                                                          or not co-located (anti-affinity)
+                                                          with the pods matching the
+                                                          labelSelector in the specified
+                                                          namespaces, where co-located
+                                                          is defined as running on
+                                                          a node whose value of the
+                                                          label with key topologyKey
+                                                          matches that of any node
+                                                          on which any of the selected
+                                                          pods is running. Empty topologyKey
+                                                          is not allowed.
+                                                        type: string
+                                        nodeSelector:
+                                          description: 'NodeSelector is a selector
+                                            which must be true for the pod to fit
+                                            on a node. Selector which must match a
+                                            node''s labels for the pod to be scheduled
+                                            on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        tolerations:
+                                          description: If specified, the pod's tolerations.
+                                          type: array
+                                          items:
+                                            description: The pod this Toleration is
+                                              attached to tolerates any taint that
+                                              matches the triple <key,value,effect>
+                                              using the matching operator <operator>.
+                                            type: object
+                                            properties:
+                                              effect:
+                                                description: Effect indicates the
+                                                  taint effect to match. Empty means
+                                                  match all taint effects. When specified,
+                                                  allowed values are NoSchedule, PreferNoSchedule
+                                                  and NoExecute.
+                                                type: string
+                                              key:
+                                                description: Key is the taint key
+                                                  that the toleration applies to.
+                                                  Empty means match all taint keys.
+                                                  If the key is empty, operator must
+                                                  be Exists; this combination means
+                                                  to match all values and all keys.
+                                                type: string
+                                              operator:
+                                                description: Operator represents a
+                                                  key's relationship to the value.
+                                                  Valid operators are Exists and Equal.
+                                                  Defaults to Equal. Exists is equivalent
+                                                  to wildcard for value, so that a
+                                                  pod can tolerate all taints of a
+                                                  particular category.
+                                                type: string
+                                              tolerationSeconds:
+                                                description: TolerationSeconds represents
+                                                  the period of time the toleration
+                                                  (which must be of effect NoExecute,
+                                                  otherwise this field is ignored)
+                                                  tolerates the taint. By default,
+                                                  it is not set, which means tolerate
+                                                  the taint forever (do not evict).
+                                                  Zero and negative values will be
+                                                  treated as 0 (evict immediately)
+                                                  by the system.
+                                                type: integer
+                                                format: int64
+                                              value:
+                                                description: Value is the taint value
+                                                  the toleration matches to. If the
+                                                  operator is Exists, the value should
+                                                  be empty, otherwise just a regular
+                                                  string.
+                                                type: string
+                                serviceType:
+                                  description: Optional service type for Kubernetes
+                                    solver service
+                                  type: string
+                        selector:
+                          description: Selector selects a set of DNSNames on the Certificate
+                            resource that should be solved using this challenge solver.
+                            If not specified, the solver will be treated as the 'default'
+                            solver with the lowest priority, i.e. if any other solver
+                            has a more specific match, it will be used instead.
+                          type: object
+                          properties:
+                            dnsNames:
+                              description: List of DNSNames that this solver will
+                                be used to solve. If specified and a match is found,
+                                a dnsNames selector will take precedence over a dnsZones
+                                selector. If multiple solvers match with the same
+                                dnsNames value, the solver with the most matching
+                                labels in matchLabels will be selected. If neither
+                                has more matches, the solver defined earlier in the
+                                list will be selected.
+                              type: array
+                              items:
+                                type: string
+                            dnsZones:
+                              description: List of DNSZones that this solver will
+                                be used to solve. The most specific DNS zone match
+                                specified here will take precedence over other DNS
+                                zone matches, so a solver specifying sys.example.com
+                                will be selected over one specifying example.com for
+                                the domain www.sys.example.com. If multiple solvers
+                                match with the same dnsZones value, the solver with
+                                the most matching labels in matchLabels will be selected.
+                                If neither has more matches, the solver defined earlier
+                                in the list will be selected.
+                              type: array
+                              items:
+                                type: string
+                            matchLabels:
+                              description: A label selector that is used to refine
+                                the set of certificate's that this challenge solver
+                                will apply to.
+                              type: object
+                              additionalProperties:
+                                type: string
+              ca:
+                description: CA configures this issuer to sign certificates using
+                  a signing CA keypair stored in a Secret resource. This is used to
+                  build internal PKIs that are managed by cert-manager.
+                type: object
+                required:
+                - secretName
+                properties:
+                  crlDistributionPoints:
+                    description: The CRL distribution points is an X.509 v3 certificate
+                      extension which identifies the location of the CRL from which
+                      the revocation of this certificate can be checked. If not set,
+                      certificates will be issued without distribution points set.
+                    type: array
+                    items:
+                      type: string
+                  secretName:
+                    description: SecretName is the name of the secret used to sign
+                      Certificates issued by this Issuer.
+                    type: string
+              selfSigned:
+                description: SelfSigned configures this issuer to 'self sign' certificates
+                  using the private key used to create the CertificateRequest object.
+                type: object
+                properties:
+                  crlDistributionPoints:
+                    description: The CRL distribution points is an X.509 v3 certificate
+                      extension which identifies the location of the CRL from which
+                      the revocation of this certificate can be checked. If not set
+                      certificate will be issued without CDP. Values are strings.
+                    type: array
+                    items:
+                      type: string
+              vault:
+                description: Vault configures this issuer to sign certificates using
+                  a HashiCorp Vault PKI backend.
+                type: object
+                required:
+                - auth
+                - path
+                - server
+                properties:
+                  auth:
+                    description: Auth configures how cert-manager authenticates with
+                      the Vault server.
+                    type: object
+                    properties:
+                      appRole:
+                        description: AppRole authenticates with Vault using the App
+                          Role auth mechanism, with the role and secret stored in
+                          a Kubernetes Secret resource.
+                        type: object
+                        required:
+                        - path
+                        - roleId
+                        - secretRef
+                        properties:
+                          path:
+                            description: 'Path where the App Role authentication backend
+                              is mounted in Vault, e.g: "approle"'
+                            type: string
+                          roleId:
+                            description: RoleID configured in the App Role authentication
+                              backend when setting up the authentication backend in
+                              Vault.
+                            type: string
+                          secretRef:
+                            description: Reference to a key in a Secret that contains
+                              the App Role secret used to authenticate with Vault.
+                              The `key` field must be specified and denotes which
+                              entry within the Secret resource is used as the app
+                              role secret.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                      kubernetes:
+                        description: Kubernetes authenticates with Vault by passing
+                          the ServiceAccount token stored in the named Secret resource
+                          to the Vault server.
+                        type: object
+                        required:
+                        - role
+                        - secretRef
+                        properties:
+                          mountPath:
+                            description: The Vault mountPath here is the mount path
+                              to use when authenticating with Vault. For example,
+                              setting a value to `/v1/auth/foo`, will use the path
+                              `/v1/auth/foo/login` to authenticate with Vault. If
+                              unspecified, the default value "/v1/auth/kubernetes"
+                              will be used.
+                            type: string
+                          role:
+                            description: A required field containing the Vault Role
+                              to assume. A Role binds a Kubernetes ServiceAccount
+                              with a set of Vault policies.
+                            type: string
+                          secretRef:
+                            description: The required Secret field containing a Kubernetes
+                              ServiceAccount JWT used for authenticating with Vault.
+                              Use of 'ambient credentials' is not supported.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                      tokenSecretRef:
+                        description: TokenSecretRef authenticates with Vault by presenting
+                          a token.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the entry in the Secret resource's
+                              `data` field to be used. Some instances of this field
+                              may be defaulted, in others it may be required.
+                            type: string
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                  caBundle:
+                    description: PEM encoded CA bundle used to validate Vault server
+                      certificate. Only used if the Server URL is using HTTPS protocol.
+                      This parameter is ignored for plain HTTP protocol connection.
+                      If not set the system root certificates are used to validate
+                      the TLS connection.
+                    type: string
+                    format: byte
+                  path:
+                    description: 'Path is the mount path of the Vault PKI backend''s
+                      `sign` endpoint, e.g: "my_pki_mount/sign/my-role-name".'
+                    type: string
+                  server:
+                    description: 'Server is the connection address for the Vault server,
+                      e.g: "https://vault.example.com:8200".'
+                    type: string
+              venafi:
+                description: Venafi configures this issuer to sign certificates using
+                  a Venafi TPP or Venafi Cloud policy zone.
+                type: object
+                required:
+                - zone
+                properties:
+                  cloud:
+                    description: Cloud specifies the Venafi cloud configuration settings.
+                      Only one of TPP or Cloud may be specified.
+                    type: object
+                    required:
+                    - apiTokenSecretRef
+                    properties:
+                      apiTokenSecretRef:
+                        description: APITokenSecretRef is a secret key selector for
+                          the Venafi Cloud API token.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the entry in the Secret resource's
+                              `data` field to be used. Some instances of this field
+                              may be defaulted, in others it may be required.
+                            type: string
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                      url:
+                        description: URL is the base URL for Venafi Cloud. Defaults
+                          to "https://api.venafi.cloud/v1".
+                        type: string
+                  tpp:
+                    description: TPP specifies Trust Protection Platform configuration
+                      settings. Only one of TPP or Cloud may be specified.
+                    type: object
+                    required:
+                    - credentialsRef
+                    - url
+                    properties:
+                      caBundle:
+                        description: CABundle is a PEM encoded TLS certificate to
+                          use to verify connections to the TPP instance. If specified,
+                          system roots will not be used and the issuing CA for the
+                          TPP instance must be verifiable using the provided root.
+                          If not specified, the connection will be verified using
+                          the cert-manager system root certificates.
+                        type: string
+                        format: byte
+                      credentialsRef:
+                        description: CredentialsRef is a reference to a Secret containing
+                          the username and password for the TPP server. The secret
+                          must contain two keys, 'username' and 'password'.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                      url:
+                        description: 'URL is the base URL for the vedsdk endpoint
+                          of the Venafi TPP instance, for example: "https://tpp.example.com/vedsdk".'
+                        type: string
+                  zone:
+                    description: Zone is the Venafi Policy Zone to use for this issuer.
+                      All requests made to the Venafi platform will be restricted
+                      by the named zone policy. This field is required.
+                    type: string
+          status:
+            description: Status of the Issuer. This is set and managed automatically.
+            type: object
+            properties:
+              acme:
+                description: ACME specific status options. This field should only
+                  be set if the Issuer is configured to use an ACME server to issue
+                  certificates.
+                type: object
+                properties:
+                  lastRegisteredEmail:
+                    description: LastRegisteredEmail is the email associated with
+                      the latest registered ACME account, in order to track changes
+                      made to registered account associated with the  Issuer
+                    type: string
+                  uri:
+                    description: URI is the unique account identifier, which can also
+                      be used to retrieve account details from the CA
+                    type: string
+              conditions:
+                description: List of status conditions to indicate the status of a
+                  CertificateRequest. Known condition types are `Ready`.
+                type: array
+                items:
+                  description: IssuerCondition contains condition information for
+                    an Issuer.
+                  type: object
+                  required:
+                  - status
+                  - type
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the timestamp corresponding
+                        to the last status change of this condition.
+                      type: string
+                      format: date-time
+                    message:
+                      description: Message is a human readable description of the
+                        details of the last transition, complementing reason.
+                      type: string
+                    reason:
+                      description: Reason is a brief machine readable explanation
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of ('True', 'False',
+                        'Unknown').
+                      type: string
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                    type:
+                      description: Type of the condition, known values are ('Ready').
+                      type: string
   - name: v1alpha3
     served: true
     storage: false
-  "validation":
-    "openAPIV3Schema":
-      type: object
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: IssuerSpec is the specification of an Issuer. This includes
-            any configuration required for the issuer.
-          type: object
-          properties:
-            acme:
-              description: ACMEIssuer contains the specification for an ACME issuer
-              type: object
-              required:
-              - privateKeySecretRef
-              - server
-              properties:
-                email:
-                  description: Email is the email for this account
-                  type: string
-                externalAccountBinding:
-                  description: ExternalAccountBinding is a reference to a CA external
-                    account of the ACME server.
-                  type: object
-                  required:
-                  - keyAlgorithm
-                  - keyID
-                  - keySecretRef
-                  properties:
-                    keyAlgorithm:
-                      description: keyAlgorithm is the MAC key algorithm that the
-                        key is used for. Valid values are "HS256", "HS384" and "HS512".
-                      type: string
-                      enum:
-                      - HS256
-                      - HS384
-                      - HS512
-                    keyID:
-                      description: keyID is the ID of the CA key that the External
-                        Account is bound to.
-                      type: string
-                    keySecretRef:
-                      description: keySecretRef is a Secret Key Selector referencing
-                        a data item in a Kubernetes Secret which holds the symmetric
-                        MAC key of the External Account Binding. The `key` is the
-                        index string that is paired with the key data in the Secret
-                        and should not be confused with the key data itself, or indeed
-                        with the External Account Binding keyID above. The secret
-                        key stored in the Secret **must** be un-padded, base64 URL
-                        encoded data.
-                      type: object
-                      required:
-                      - name
-                      properties:
-                        key:
-                          description: The key of the secret to select from. Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                privateKeySecretRef:
-                  description: PrivateKey is the name of a secret containing the private
-                    key for this user account.
-                  type: object
-                  required:
-                  - name
-                  properties:
-                    key:
-                      description: The key of the secret to select from. Must be a
-                        valid secret key.
-                      type: string
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                server:
-                  description: Server is the ACME server URL
-                  type: string
-                skipTLSVerify:
-                  description: If true, skip verifying the ACME server TLS certificate
-                  type: boolean
-                solvers:
-                  description: Solvers is a list of challenge solvers that will be
-                    used to solve ACME challenges for the matching domains.
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      dns01:
-                        type: object
-                        properties:
-                          acmedns:
-                            description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
-                              containing the configuration for ACME-DNS servers
-                            type: object
-                            required:
-                            - accountSecretRef
-                            - host
-                            properties:
-                              accountSecretRef:
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              host:
-                                type: string
-                          akamai:
-                            description: ACMEIssuerDNS01ProviderAkamai is a structure
-                              containing the DNS configuration for Akamai DNS—Zone
-                              Record Management API
-                            type: object
-                            required:
-                            - accessTokenSecretRef
-                            - clientSecretSecretRef
-                            - clientTokenSecretRef
-                            - serviceConsumerDomain
-                            properties:
-                              accessTokenSecretRef:
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              clientSecretSecretRef:
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              clientTokenSecretRef:
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              serviceConsumerDomain:
-                                type: string
-                          azuredns:
-                            description: ACMEIssuerDNS01ProviderAzureDNS is a structure
-                              containing the configuration for Azure DNS
-                            type: object
-                            required:
-                            - resourceGroupName
-                            - subscriptionID
-                            properties:
-                              clientID:
-                                description: if both this and ClientSecret are left
-                                  unset MSI will be used
-                                type: string
-                              clientSecretSecretRef:
-                                description: if both this and ClientID are left unset
-                                  MSI will be used
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              environment:
-                                type: string
-                                enum:
-                                - AzurePublicCloud
-                                - AzureChinaCloud
-                                - AzureGermanCloud
-                                - AzureUSGovernmentCloud
-                              hostedZoneName:
-                                type: string
-                              resourceGroupName:
-                                type: string
-                              subscriptionID:
-                                type: string
-                              tenantID:
-                                description: when specifying ClientID and ClientSecret
-                                  then this field is also needed
-                                type: string
-                          clouddns:
-                            description: ACMEIssuerDNS01ProviderCloudDNS is a structure
-                              containing the DNS configuration for Google Cloud DNS
-                            type: object
-                            required:
-                            - project
-                            properties:
-                              project:
-                                type: string
-                              serviceAccountSecretRef:
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                          cloudflare:
-                            description: ACMEIssuerDNS01ProviderCloudflare is a structure
-                              containing the DNS configuration for Cloudflare
-                            type: object
-                            required:
-                            - email
-                            properties:
-                              apiKeySecretRef:
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              apiTokenSecretRef:
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              email:
-                                type: string
-                          cnameStrategy:
-                            description: CNAMEStrategy configures how the DNS01 provider
-                              should handle CNAME records when found in DNS zones.
-                            type: string
-                            enum:
-                            - None
-                            - Follow
-                          digitalocean:
-                            description: ACMEIssuerDNS01ProviderDigitalOcean is a
-                              structure containing the DNS configuration for DigitalOcean
-                              Domains
-                            type: object
-                            required:
-                            - tokenSecretRef
-                            properties:
-                              tokenSecretRef:
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                          rfc2136:
-                            description: ACMEIssuerDNS01ProviderRFC2136 is a structure
-                              containing the configuration for RFC2136 DNS
-                            type: object
-                            required:
-                            - nameserver
-                            properties:
-                              nameserver:
-                                description: The IP address or hostname of an authoritative
-                                  DNS server supporting RFC2136 in the form host:port.
-                                  If the host is an IPv6 address it must be enclosed
-                                  in square brackets (e.g [2001:db8::1]) ; port is
-                                  optional. This field is required.
-                                type: string
-                              tsigAlgorithm:
-                                description: 'The TSIG Algorithm configured in the
-                                  DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
-                                  and ``tsigKeyName`` are defined. Supported values
-                                  are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
-                                  ``HMACSHA256`` or ``HMACSHA512``.'
-                                type: string
-                              tsigKeyName:
-                                description: The TSIG Key name configured in the DNS.
-                                  If ``tsigSecretSecretRef`` is defined, this field
-                                  is required.
-                                type: string
-                              tsigSecretSecretRef:
-                                description: The name of the secret containing the
-                                  TSIG value. If ``tsigKeyName`` is defined, this
-                                  field is required.
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                          route53:
-                            description: ACMEIssuerDNS01ProviderRoute53 is a structure
-                              containing the Route 53 configuration for AWS
-                            type: object
-                            required:
-                            - region
-                            properties:
-                              accessKeyID:
-                                description: 'The AccessKeyID is used for authentication.
-                                  If not set we fall-back to using env vars, shared
-                                  credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
-                                type: string
-                              hostedZoneID:
-                                description: If set, the provider will manage only
-                                  this zone in Route53 and will not do an lookup using
-                                  the route53:ListHostedZonesByName api call.
-                                type: string
-                              region:
-                                description: Always set the region when using AccessKeyID
-                                  and SecretAccessKey
-                                type: string
-                              role:
-                                description: Role is a Role ARN which the Route53
-                                  provider will assume using either the explicit credentials
-                                  AccessKeyID/SecretAccessKey or the inferred credentials
-                                  from environment variables, shared credentials file
-                                  or AWS Instance metadata
-                                type: string
-                              secretAccessKeySecretRef:
-                                description: The SecretAccessKey is used for authentication.
-                                  If not set we fall-back to using env vars, shared
-                                  credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                          webhook:
-                            description: ACMEIssuerDNS01ProviderWebhook specifies
-                              configuration for a webhook DNS01 provider, including
-                              where to POST ChallengePayload resources.
-                            type: object
-                            required:
-                            - groupName
-                            - solverName
-                            properties:
-                              config:
-                                description: Additional configuration that should
-                                  be passed to the webhook apiserver when challenges
-                                  are processed. This can contain arbitrary JSON data.
-                                  Secret values should not be specified in this stanza.
-                                  If secret values are needed (e.g. credentials for
-                                  a DNS service), you should use a SecretKeySelector
-                                  to reference a Secret resource. For details on the
-                                  schema of this field, consult the webhook provider
-                                  implementation's documentation.
-                                x-kubernetes-preserve-unknown-fields: true
-                              groupName:
-                                description: The API group name that should be used
-                                  when POSTing ChallengePayload resources to the webhook
-                                  apiserver. This should be the same as the GroupName
-                                  specified in the webhook provider implementation.
-                                type: string
-                              solverName:
-                                description: The name of the solver to use, as defined
-                                  in the webhook provider implementation. This will
-                                  typically be the name of the provider, e.g. 'cloudflare'.
-                                type: string
-                      http01:
-                        description: ACMEChallengeSolverHTTP01 contains configuration
-                          detailing how to solve HTTP01 challenges within a Kubernetes
-                          cluster. Typically this is accomplished through creating
-                          'routes' of some description that configure ingress controllers
-                          to direct traffic to 'solver pods', which are responsible
-                          for responding to the ACME server's HTTP requests.
-                        type: object
-                        properties:
-                          ingress:
-                            description: The ingress based HTTP01 challenge solver
-                              will solve challenges by creating or modifying Ingress
-                              resources in order to route requests for '/.well-known/acme-challenge/XYZ'
-                              to 'challenge solver' pods that are provisioned by cert-manager
-                              for each Challenge to be completed.
-                            type: object
-                            properties:
-                              class:
-                                description: The ingress class to use when creating
-                                  Ingress resources to solve ACME challenges that
-                                  use this challenge solver. Only one of 'class' or
-                                  'name' may be specified.
-                                type: string
-                              ingressTemplate:
-                                description: Optional ingress template used to configure
-                                  the ACME challenge solver ingress used for HTTP01
-                                  challenges
-                                type: object
-                                properties:
-                                  metadata:
-                                    description: ObjectMeta overrides for the ingress
-                                      used to solve HTTP01 challenges. Only the 'labels'
-                                      and 'annotations' fields may be set. If labels
-                                      or annotations overlap with in-built values,
-                                      the values here will override the in-built values.
-                                    type: object
-                                    properties:
-                                      annotations:
-                                        description: Annotations that should be added
-                                          to the created ACME HTTP01 solver ingress.
-                                        type: object
-                                        additionalProperties:
-                                          type: string
-                                      labels:
-                                        description: Labels that should be added to
-                                          the created ACME HTTP01 solver ingress.
-                                        type: object
-                                        additionalProperties:
-                                          type: string
-                              name:
-                                description: The name of the ingress resource that
-                                  should have ACME challenge solving routes inserted
-                                  into it in order to solve HTTP01 challenges. This
-                                  is typically used in conjunction with ingress controllers
-                                  like ingress-gce, which maintains a 1:1 mapping
-                                  between external IPs and ingress resources.
-                                type: string
-                              podTemplate:
-                                description: Optional pod template used to configure
-                                  the ACME challenge solver pods used for HTTP01 challenges
-                                type: object
-                                properties:
-                                  metadata:
-                                    description: ObjectMeta overrides for the pod
-                                      used to solve HTTP01 challenges. Only the 'labels'
-                                      and 'annotations' fields may be set. If labels
-                                      or annotations overlap with in-built values,
-                                      the values here will override the in-built values.
-                                    type: object
-                                    properties:
-                                      annotations:
-                                        description: Annotations that should be added
-                                          to the create ACME HTTP01 solver pods.
-                                        type: object
-                                        additionalProperties:
-                                          type: string
-                                      labels:
-                                        description: Labels that should be added to
-                                          the created ACME HTTP01 solver pods.
-                                        type: object
-                                        additionalProperties:
-                                          type: string
-                                  spec:
-                                    description: PodSpec defines overrides for the
-                                      HTTP01 challenge solver pod. Only the 'nodeSelector',
-                                      'affinity' and 'tolerations' fields are supported
-                                      currently. All other fields will be ignored.
-                                    type: object
-                                    properties:
-                                      affinity:
-                                        description: If specified, the pod's scheduling
-                                          constraints
-                                        type: object
-                                        properties:
-                                          nodeAffinity:
-                                            description: Describes node affinity scheduling
-                                              rules for the pod.
-                                            type: object
-                                            properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                description: The scheduler will prefer
-                                                  to schedule pods to nodes that satisfy
-                                                  the affinity expressions specified
-                                                  by this field, but it may choose
-                                                  a node that violates one or more
-                                                  of the expressions. The node that
-                                                  is most preferred is the one with
-                                                  the greatest sum of weights, i.e.
-                                                  for each node that meets all of
-                                                  the scheduling requirements (resource
-                                                  request, requiredDuringScheduling
-                                                  affinity expressions, etc.), compute
-                                                  a sum by iterating through the elements
-                                                  of this field and adding "weight"
-                                                  to the sum if the node matches the
-                                                  corresponding matchExpressions;
-                                                  the node(s) with the highest sum
-                                                  are the most preferred.
-                                                type: array
-                                                items:
-                                                  description: An empty preferred
-                                                    scheduling term matches all objects
-                                                    with implicit weight 0 (i.e. it's
-                                                    a no-op). A null preferred scheduling
-                                                    term matches no objects (i.e.
-                                                    is also a no-op).
-                                                  type: object
-                                                  required:
-                                                  - preference
-                                                  - weight
-                                                  properties:
-                                                    preference:
-                                                      description: A node selector
-                                                        term, associated with the
-                                                        corresponding weight.
-                                                      type: object
-                                                      properties:
-                                                        matchExpressions:
-                                                          description: A list of node
-                                                            selector requirements
-                                                            by node's labels.
-                                                          type: array
-                                                          items:
-                                                            description: A node selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            type: object
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            properties:
-                                                              key:
-                                                                description: The label
-                                                                  key that the selector
-                                                                  applies to.
-                                                                type: string
-                                                              operator:
-                                                                description: Represents
-                                                                  a key's relationship
-                                                                  to a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists,
-                                                                  DoesNotExist. Gt,
-                                                                  and Lt.
-                                                                type: string
-                                                              values:
-                                                                description: An array
-                                                                  of string values.
-                                                                  If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. If
-                                                                  the operator is
-                                                                  Gt or Lt, the values
-                                                                  array must have
-                                                                  a single element,
-                                                                  which will be interpreted
-                                                                  as an integer. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                type: array
-                                                                items:
-                                                                  type: string
-                                                        matchFields:
-                                                          description: A list of node
-                                                            selector requirements
-                                                            by node's fields.
-                                                          type: array
-                                                          items:
-                                                            description: A node selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            type: object
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            properties:
-                                                              key:
-                                                                description: The label
-                                                                  key that the selector
-                                                                  applies to.
-                                                                type: string
-                                                              operator:
-                                                                description: Represents
-                                                                  a key's relationship
-                                                                  to a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists,
-                                                                  DoesNotExist. Gt,
-                                                                  and Lt.
-                                                                type: string
-                                                              values:
-                                                                description: An array
-                                                                  of string values.
-                                                                  If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. If
-                                                                  the operator is
-                                                                  Gt or Lt, the values
-                                                                  array must have
-                                                                  a single element,
-                                                                  which will be interpreted
-                                                                  as an integer. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                type: array
-                                                                items:
-                                                                  type: string
-                                                    weight:
-                                                      description: Weight associated
-                                                        with matching the corresponding
-                                                        nodeSelectorTerm, in the range
-                                                        1-100.
-                                                      type: integer
-                                                      format: int32
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                description: If the affinity requirements
-                                                  specified by this field are not
-                                                  met at scheduling time, the pod
-                                                  will not be scheduled onto the node.
-                                                  If the affinity requirements specified
-                                                  by this field cease to be met at
-                                                  some point during pod execution
-                                                  (e.g. due to an update), the system
-                                                  may or may not try to eventually
-                                                  evict the pod from its node.
-                                                type: object
-                                                required:
-                                                - nodeSelectorTerms
-                                                properties:
-                                                  nodeSelectorTerms:
-                                                    description: Required. A list
-                                                      of node selector terms. The
-                                                      terms are ORed.
-                                                    type: array
-                                                    items:
-                                                      description: A null or empty
-                                                        node selector term matches
-                                                        no objects. The requirements
-                                                        of them are ANDed. The TopologySelectorTerm
-                                                        type implements a subset of
-                                                        the NodeSelectorTerm.
-                                                      type: object
-                                                      properties:
-                                                        matchExpressions:
-                                                          description: A list of node
-                                                            selector requirements
-                                                            by node's labels.
-                                                          type: array
-                                                          items:
-                                                            description: A node selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            type: object
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            properties:
-                                                              key:
-                                                                description: The label
-                                                                  key that the selector
-                                                                  applies to.
-                                                                type: string
-                                                              operator:
-                                                                description: Represents
-                                                                  a key's relationship
-                                                                  to a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists,
-                                                                  DoesNotExist. Gt,
-                                                                  and Lt.
-                                                                type: string
-                                                              values:
-                                                                description: An array
-                                                                  of string values.
-                                                                  If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. If
-                                                                  the operator is
-                                                                  Gt or Lt, the values
-                                                                  array must have
-                                                                  a single element,
-                                                                  which will be interpreted
-                                                                  as an integer. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                type: array
-                                                                items:
-                                                                  type: string
-                                                        matchFields:
-                                                          description: A list of node
-                                                            selector requirements
-                                                            by node's fields.
-                                                          type: array
-                                                          items:
-                                                            description: A node selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            type: object
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            properties:
-                                                              key:
-                                                                description: The label
-                                                                  key that the selector
-                                                                  applies to.
-                                                                type: string
-                                                              operator:
-                                                                description: Represents
-                                                                  a key's relationship
-                                                                  to a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists,
-                                                                  DoesNotExist. Gt,
-                                                                  and Lt.
-                                                                type: string
-                                                              values:
-                                                                description: An array
-                                                                  of string values.
-                                                                  If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. If
-                                                                  the operator is
-                                                                  Gt or Lt, the values
-                                                                  array must have
-                                                                  a single element,
-                                                                  which will be interpreted
-                                                                  as an integer. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                type: array
-                                                                items:
-                                                                  type: string
-                                          podAffinity:
-                                            description: Describes pod affinity scheduling
-                                              rules (e.g. co-locate this pod in the
-                                              same node, zone, etc. as some other
-                                              pod(s)).
-                                            type: object
-                                            properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                description: The scheduler will prefer
-                                                  to schedule pods to nodes that satisfy
-                                                  the affinity expressions specified
-                                                  by this field, but it may choose
-                                                  a node that violates one or more
-                                                  of the expressions. The node that
-                                                  is most preferred is the one with
-                                                  the greatest sum of weights, i.e.
-                                                  for each node that meets all of
-                                                  the scheduling requirements (resource
-                                                  request, requiredDuringScheduling
-                                                  affinity expressions, etc.), compute
-                                                  a sum by iterating through the elements
-                                                  of this field and adding "weight"
-                                                  to the sum if the node has pods
-                                                  which matches the corresponding
-                                                  podAffinityTerm; the node(s) with
-                                                  the highest sum are the most preferred.
-                                                type: array
-                                                items:
-                                                  description: The weights of all
-                                                    of the matched WeightedPodAffinityTerm
-                                                    fields are added per-node to find
-                                                    the most preferred node(s)
-                                                  type: object
-                                                  required:
-                                                  - podAffinityTerm
-                                                  - weight
-                                                  properties:
-                                                    podAffinityTerm:
-                                                      description: Required. A pod
-                                                        affinity term, associated
-                                                        with the corresponding weight.
-                                                      type: object
-                                                      required:
-                                                      - topologyKey
-                                                      properties:
-                                                        labelSelector:
-                                                          description: A label query
-                                                            over a set of resources,
-                                                            in this case pods.
-                                                          type: object
-                                                          properties:
-                                                            matchExpressions:
-                                                              description: matchExpressions
-                                                                is a list of label
-                                                                selector requirements.
-                                                                The requirements are
-                                                                ANDed.
-                                                              type: array
-                                                              items:
-                                                                description: A label
-                                                                  selector requirement
-                                                                  is a selector that
-                                                                  contains values,
-                                                                  a key, and an operator
-                                                                  that relates the
-                                                                  key and values.
-                                                                type: object
-                                                                required:
-                                                                - key
-                                                                - operator
-                                                                properties:
-                                                                  key:
-                                                                    description: key
-                                                                      is the label
-                                                                      key that the
-                                                                      selector applies
-                                                                      to.
-                                                                    type: string
-                                                                  operator:
-                                                                    description: operator
-                                                                      represents a
-                                                                      key's relationship
-                                                                      to a set of
-                                                                      values. Valid
-                                                                      operators are
-                                                                      In, NotIn, Exists
-                                                                      and DoesNotExist.
-                                                                    type: string
-                                                                  values:
-                                                                    description: values
-                                                                      is an array
-                                                                      of string values.
-                                                                      If the operator
-                                                                      is In or NotIn,
-                                                                      the values array
-                                                                      must be non-empty.
-                                                                      If the operator
-                                                                      is Exists or
-                                                                      DoesNotExist,
-                                                                      the values array
-                                                                      must be empty.
-                                                                      This array is
-                                                                      replaced during
-                                                                      a strategic
-                                                                      merge patch.
-                                                                    type: array
-                                                                    items:
-                                                                      type: string
-                                                            matchLabels:
-                                                              description: matchLabels
-                                                                is a map of {key,value}
-                                                                pairs. A single {key,value}
-                                                                in the matchLabels
-                                                                map is equivalent
-                                                                to an element of matchExpressions,
-                                                                whose key field is
-                                                                "key", the operator
-                                                                is "In", and the values
-                                                                array contains only
-                                                                "value". The requirements
-                                                                are ANDed.
-                                                              type: object
-                                                              additionalProperties:
-                                                                type: string
-                                                        namespaces:
-                                                          description: namespaces
-                                                            specifies which namespaces
-                                                            the labelSelector applies
-                                                            to (matches against);
-                                                            null or empty list means
-                                                            "this pod's namespace"
-                                                          type: array
-                                                          items:
-                                                            type: string
-                                                        topologyKey:
-                                                          description: This pod should
-                                                            be co-located (affinity)
-                                                            or not co-located (anti-affinity)
-                                                            with the pods matching
-                                                            the labelSelector in the
-                                                            specified namespaces,
-                                                            where co-located is defined
-                                                            as running on a node whose
-                                                            value of the label with
-                                                            key topologyKey matches
-                                                            that of any node on which
-                                                            any of the selected pods
-                                                            is running. Empty topologyKey
-                                                            is not allowed.
-                                                          type: string
-                                                    weight:
-                                                      description: weight associated
-                                                        with matching the corresponding
-                                                        podAffinityTerm, in the range
-                                                        1-100.
-                                                      type: integer
-                                                      format: int32
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                description: If the affinity requirements
-                                                  specified by this field are not
-                                                  met at scheduling time, the pod
-                                                  will not be scheduled onto the node.
-                                                  If the affinity requirements specified
-                                                  by this field cease to be met at
-                                                  some point during pod execution
-                                                  (e.g. due to a pod label update),
-                                                  the system may or may not try to
-                                                  eventually evict the pod from its
-                                                  node. When there are multiple elements,
-                                                  the lists of nodes corresponding
-                                                  to each podAffinityTerm are intersected,
-                                                  i.e. all terms must be satisfied.
-                                                type: array
-                                                items:
-                                                  description: Defines a set of pods
-                                                    (namely those matching the labelSelector
-                                                    relative to the given namespace(s))
-                                                    that this pod should be co-located
-                                                    (affinity) or not co-located (anti-affinity)
-                                                    with, where co-located is defined
-                                                    as running on a node whose value
-                                                    of the label with key <topologyKey>
-                                                    matches that of any node on which
-                                                    a pod of the set of pods is running
-                                                  type: object
-                                                  required:
-                                                  - topologyKey
-                                                  properties:
-                                                    labelSelector:
-                                                      description: A label query over
-                                                        a set of resources, in this
-                                                        case pods.
-                                                      type: object
-                                                      properties:
-                                                        matchExpressions:
-                                                          description: matchExpressions
-                                                            is a list of label selector
-                                                            requirements. The requirements
-                                                            are ANDed.
-                                                          type: array
-                                                          items:
-                                                            description: A label selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            type: object
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            properties:
-                                                              key:
-                                                                description: key is
-                                                                  the label key that
-                                                                  the selector applies
-                                                                  to.
-                                                                type: string
-                                                              operator:
-                                                                description: operator
-                                                                  represents a key's
-                                                                  relationship to
-                                                                  a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists
-                                                                  and DoesNotExist.
-                                                                type: string
-                                                              values:
-                                                                description: values
-                                                                  is an array of string
-                                                                  values. If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                type: array
-                                                                items:
-                                                                  type: string
-                                                        matchLabels:
-                                                          description: matchLabels
-                                                            is a map of {key,value}
-                                                            pairs. A single {key,value}
-                                                            in the matchLabels map
-                                                            is equivalent to an element
-                                                            of matchExpressions, whose
-                                                            key field is "key", the
-                                                            operator is "In", and
-                                                            the values array contains
-                                                            only "value". The requirements
-                                                            are ANDed.
-                                                          type: object
-                                                          additionalProperties:
-                                                            type: string
-                                                    namespaces:
-                                                      description: namespaces specifies
-                                                        which namespaces the labelSelector
-                                                        applies to (matches against);
-                                                        null or empty list means "this
-                                                        pod's namespace"
-                                                      type: array
-                                                      items:
-                                                        type: string
-                                                    topologyKey:
-                                                      description: This pod should
-                                                        be co-located (affinity) or
-                                                        not co-located (anti-affinity)
-                                                        with the pods matching the
-                                                        labelSelector in the specified
-                                                        namespaces, where co-located
-                                                        is defined as running on a
-                                                        node whose value of the label
-                                                        with key topologyKey matches
-                                                        that of any node on which
-                                                        any of the selected pods is
-                                                        running. Empty topologyKey
-                                                        is not allowed.
-                                                      type: string
-                                          podAntiAffinity:
-                                            description: Describes pod anti-affinity
-                                              scheduling rules (e.g. avoid putting
-                                              this pod in the same node, zone, etc.
-                                              as some other pod(s)).
-                                            type: object
-                                            properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                description: The scheduler will prefer
-                                                  to schedule pods to nodes that satisfy
-                                                  the anti-affinity expressions specified
-                                                  by this field, but it may choose
-                                                  a node that violates one or more
-                                                  of the expressions. The node that
-                                                  is most preferred is the one with
-                                                  the greatest sum of weights, i.e.
-                                                  for each node that meets all of
-                                                  the scheduling requirements (resource
-                                                  request, requiredDuringScheduling
-                                                  anti-affinity expressions, etc.),
-                                                  compute a sum by iterating through
-                                                  the elements of this field and adding
-                                                  "weight" to the sum if the node
-                                                  has pods which matches the corresponding
-                                                  podAffinityTerm; the node(s) with
-                                                  the highest sum are the most preferred.
-                                                type: array
-                                                items:
-                                                  description: The weights of all
-                                                    of the matched WeightedPodAffinityTerm
-                                                    fields are added per-node to find
-                                                    the most preferred node(s)
-                                                  type: object
-                                                  required:
-                                                  - podAffinityTerm
-                                                  - weight
-                                                  properties:
-                                                    podAffinityTerm:
-                                                      description: Required. A pod
-                                                        affinity term, associated
-                                                        with the corresponding weight.
-                                                      type: object
-                                                      required:
-                                                      - topologyKey
-                                                      properties:
-                                                        labelSelector:
-                                                          description: A label query
-                                                            over a set of resources,
-                                                            in this case pods.
-                                                          type: object
-                                                          properties:
-                                                            matchExpressions:
-                                                              description: matchExpressions
-                                                                is a list of label
-                                                                selector requirements.
-                                                                The requirements are
-                                                                ANDed.
-                                                              type: array
-                                                              items:
-                                                                description: A label
-                                                                  selector requirement
-                                                                  is a selector that
-                                                                  contains values,
-                                                                  a key, and an operator
-                                                                  that relates the
-                                                                  key and values.
-                                                                type: object
-                                                                required:
-                                                                - key
-                                                                - operator
-                                                                properties:
-                                                                  key:
-                                                                    description: key
-                                                                      is the label
-                                                                      key that the
-                                                                      selector applies
-                                                                      to.
-                                                                    type: string
-                                                                  operator:
-                                                                    description: operator
-                                                                      represents a
-                                                                      key's relationship
-                                                                      to a set of
-                                                                      values. Valid
-                                                                      operators are
-                                                                      In, NotIn, Exists
-                                                                      and DoesNotExist.
-                                                                    type: string
-                                                                  values:
-                                                                    description: values
-                                                                      is an array
-                                                                      of string values.
-                                                                      If the operator
-                                                                      is In or NotIn,
-                                                                      the values array
-                                                                      must be non-empty.
-                                                                      If the operator
-                                                                      is Exists or
-                                                                      DoesNotExist,
-                                                                      the values array
-                                                                      must be empty.
-                                                                      This array is
-                                                                      replaced during
-                                                                      a strategic
-                                                                      merge patch.
-                                                                    type: array
-                                                                    items:
-                                                                      type: string
-                                                            matchLabels:
-                                                              description: matchLabels
-                                                                is a map of {key,value}
-                                                                pairs. A single {key,value}
-                                                                in the matchLabels
-                                                                map is equivalent
-                                                                to an element of matchExpressions,
-                                                                whose key field is
-                                                                "key", the operator
-                                                                is "In", and the values
-                                                                array contains only
-                                                                "value". The requirements
-                                                                are ANDed.
-                                                              type: object
-                                                              additionalProperties:
-                                                                type: string
-                                                        namespaces:
-                                                          description: namespaces
-                                                            specifies which namespaces
-                                                            the labelSelector applies
-                                                            to (matches against);
-                                                            null or empty list means
-                                                            "this pod's namespace"
-                                                          type: array
-                                                          items:
-                                                            type: string
-                                                        topologyKey:
-                                                          description: This pod should
-                                                            be co-located (affinity)
-                                                            or not co-located (anti-affinity)
-                                                            with the pods matching
-                                                            the labelSelector in the
-                                                            specified namespaces,
-                                                            where co-located is defined
-                                                            as running on a node whose
-                                                            value of the label with
-                                                            key topologyKey matches
-                                                            that of any node on which
-                                                            any of the selected pods
-                                                            is running. Empty topologyKey
-                                                            is not allowed.
-                                                          type: string
-                                                    weight:
-                                                      description: weight associated
-                                                        with matching the corresponding
-                                                        podAffinityTerm, in the range
-                                                        1-100.
-                                                      type: integer
-                                                      format: int32
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                description: If the anti-affinity
-                                                  requirements specified by this field
-                                                  are not met at scheduling time,
-                                                  the pod will not be scheduled onto
-                                                  the node. If the anti-affinity requirements
-                                                  specified by this field cease to
-                                                  be met at some point during pod
-                                                  execution (e.g. due to a pod label
-                                                  update), the system may or may not
-                                                  try to eventually evict the pod
-                                                  from its node. When there are multiple
-                                                  elements, the lists of nodes corresponding
-                                                  to each podAffinityTerm are intersected,
-                                                  i.e. all terms must be satisfied.
-                                                type: array
-                                                items:
-                                                  description: Defines a set of pods
-                                                    (namely those matching the labelSelector
-                                                    relative to the given namespace(s))
-                                                    that this pod should be co-located
-                                                    (affinity) or not co-located (anti-affinity)
-                                                    with, where co-located is defined
-                                                    as running on a node whose value
-                                                    of the label with key <topologyKey>
-                                                    matches that of any node on which
-                                                    a pod of the set of pods is running
-                                                  type: object
-                                                  required:
-                                                  - topologyKey
-                                                  properties:
-                                                    labelSelector:
-                                                      description: A label query over
-                                                        a set of resources, in this
-                                                        case pods.
-                                                      type: object
-                                                      properties:
-                                                        matchExpressions:
-                                                          description: matchExpressions
-                                                            is a list of label selector
-                                                            requirements. The requirements
-                                                            are ANDed.
-                                                          type: array
-                                                          items:
-                                                            description: A label selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            type: object
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            properties:
-                                                              key:
-                                                                description: key is
-                                                                  the label key that
-                                                                  the selector applies
-                                                                  to.
-                                                                type: string
-                                                              operator:
-                                                                description: operator
-                                                                  represents a key's
-                                                                  relationship to
-                                                                  a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists
-                                                                  and DoesNotExist.
-                                                                type: string
-                                                              values:
-                                                                description: values
-                                                                  is an array of string
-                                                                  values. If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                type: array
-                                                                items:
-                                                                  type: string
-                                                        matchLabels:
-                                                          description: matchLabels
-                                                            is a map of {key,value}
-                                                            pairs. A single {key,value}
-                                                            in the matchLabels map
-                                                            is equivalent to an element
-                                                            of matchExpressions, whose
-                                                            key field is "key", the
-                                                            operator is "In", and
-                                                            the values array contains
-                                                            only "value". The requirements
-                                                            are ANDed.
-                                                          type: object
-                                                          additionalProperties:
-                                                            type: string
-                                                    namespaces:
-                                                      description: namespaces specifies
-                                                        which namespaces the labelSelector
-                                                        applies to (matches against);
-                                                        null or empty list means "this
-                                                        pod's namespace"
-                                                      type: array
-                                                      items:
-                                                        type: string
-                                                    topologyKey:
-                                                      description: This pod should
-                                                        be co-located (affinity) or
-                                                        not co-located (anti-affinity)
-                                                        with the pods matching the
-                                                        labelSelector in the specified
-                                                        namespaces, where co-located
-                                                        is defined as running on a
-                                                        node whose value of the label
-                                                        with key topologyKey matches
-                                                        that of any node on which
-                                                        any of the selected pods is
-                                                        running. Empty topologyKey
-                                                        is not allowed.
-                                                      type: string
-                                      nodeSelector:
-                                        description: 'NodeSelector is a selector which
-                                          must be true for the pod to fit on a node.
-                                          Selector which must match a node''s labels
-                                          for the pod to be scheduled on that node.
-                                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
-                                        type: object
-                                        additionalProperties:
-                                          type: string
-                                      tolerations:
-                                        description: If specified, the pod's tolerations.
-                                        type: array
-                                        items:
-                                          description: The pod this Toleration is
-                                            attached to tolerates any taint that matches
-                                            the triple <key,value,effect> using the
-                                            matching operator <operator>.
-                                          type: object
-                                          properties:
-                                            effect:
-                                              description: Effect indicates the taint
-                                                effect to match. Empty means match
-                                                all taint effects. When specified,
-                                                allowed values are NoSchedule, PreferNoSchedule
-                                                and NoExecute.
-                                              type: string
-                                            key:
-                                              description: Key is the taint key that
-                                                the toleration applies to. Empty means
-                                                match all taint keys. If the key is
-                                                empty, operator must be Exists; this
-                                                combination means to match all values
-                                                and all keys.
-                                              type: string
-                                            operator:
-                                              description: Operator represents a key's
-                                                relationship to the value. Valid operators
-                                                are Exists and Equal. Defaults to
-                                                Equal. Exists is equivalent to wildcard
-                                                for value, so that a pod can tolerate
-                                                all taints of a particular category.
-                                              type: string
-                                            tolerationSeconds:
-                                              description: TolerationSeconds represents
-                                                the period of time the toleration
-                                                (which must be of effect NoExecute,
-                                                otherwise this field is ignored) tolerates
-                                                the taint. By default, it is not set,
-                                                which means tolerate the taint forever
-                                                (do not evict). Zero and negative
-                                                values will be treated as 0 (evict
-                                                immediately) by the system.
-                                              type: integer
-                                              format: int64
-                                            value:
-                                              description: Value is the taint value
-                                                the toleration matches to. If the
-                                                operator is Exists, the value should
-                                                be empty, otherwise just a regular
-                                                string.
-                                              type: string
-                              serviceType:
-                                description: Optional service type for Kubernetes
-                                  solver service
-                                type: string
-                      selector:
-                        description: Selector selects a set of DNSNames on the Certificate
-                          resource that should be solved using this challenge solver.
-                        type: object
-                        properties:
-                          dnsNames:
-                            description: List of DNSNames that this solver will be
-                              used to solve. If specified and a match is found, a
-                              dnsNames selector will take precedence over a dnsZones
-                              selector. If multiple solvers match with the same dnsNames
-                              value, the solver with the most matching labels in matchLabels
-                              will be selected. If neither has more matches, the solver
-                              defined earlier in the list will be selected.
-                            type: array
-                            items:
-                              type: string
-                          dnsZones:
-                            description: List of DNSZones that this solver will be
-                              used to solve. The most specific DNS zone match specified
-                              here will take precedence over other DNS zone matches,
-                              so a solver specifying sys.example.com will be selected
-                              over one specifying example.com for the domain www.sys.example.com.
-                              If multiple solvers match with the same dnsZones value,
-                              the solver with the most matching labels in matchLabels
-                              will be selected. If neither has more matches, the solver
-                              defined earlier in the list will be selected.
-                            type: array
-                            items:
-                              type: string
-                          matchLabels:
-                            description: A label selector that is used to refine the
-                              set of certificate's that this challenge solver will
-                              apply to.
-                            type: object
-                            additionalProperties:
-                              type: string
-            ca:
-              type: object
-              required:
-              - secretName
-              properties:
-                crlDistributionPoints:
-                  description: The CRL distribution points is an X.509 v3 certificate
-                    extension which identifies the location of the CRL from which
-                    the revocation of this certificate can be checked. If not set
-                    certificate will be issued without CDP. Values are strings.
-                  type: array
-                  items:
-                    type: string
-                secretName:
-                  description: SecretName is the name of the secret used to sign Certificates
-                    issued by this Issuer.
-                  type: string
-            selfSigned:
-              type: object
-              properties:
-                crlDistributionPoints:
-                  description: The CRL distribution points is an X.509 v3 certificate
-                    extension which identifies the location of the CRL from which
-                    the revocation of this certificate can be checked. If not set
-                    certificate will be issued without CDP. Values are strings.
-                  type: array
-                  items:
-                    type: string
-            vault:
-              type: object
-              required:
-              - auth
-              - path
-              - server
-              properties:
-                auth:
-                  description: Vault authentication
-                  type: object
-                  properties:
-                    appRole:
-                      description: This Secret contains a AppRole and Secret
-                      type: object
-                      required:
-                      - path
-                      - roleId
-                      - secretRef
-                      properties:
-                        path:
-                          description: Where the authentication path is mounted in
-                            Vault.
-                          type: string
-                        roleId:
-                          type: string
-                        secretRef:
-                          type: object
-                          required:
-                          - name
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                    kubernetes:
-                      description: This contains a Role and Secret with a ServiceAccount
-                        token to authenticate with vault.
-                      type: object
-                      required:
-                      - role
-                      - secretRef
-                      properties:
-                        mountPath:
-                          description: The Vault mountPath here is the mount path
-                            to use when authenticating with Vault. For example, setting
-                            a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login`
-                            to authenticate with Vault. If unspecified, the default
-                            value "/v1/auth/kubernetes" will be used.
-                          type: string
-                        role:
-                          description: A required field containing the Vault Role
-                            to assume. A Role binds a Kubernetes ServiceAccount with
-                            a set of Vault policies.
-                          type: string
-                        secretRef:
-                          description: The required Secret field containing a Kubernetes
-                            ServiceAccount JWT used for authenticating with Vault.
-                            Use of 'ambient credentials' is not supported.
-                          type: object
-                          required:
-                          - name
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                    tokenSecretRef:
-                      description: This Secret contains the Vault token key
-                      type: object
-                      required:
-                      - name
-                      properties:
-                        key:
-                          description: The key of the secret to select from. Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                caBundle:
-                  description: Base64 encoded CA bundle to validate Vault server certificate.
-                    Only used if the Server URL is using HTTPS protocol. This parameter
-                    is ignored for plain HTTP protocol connection. If not set the
-                    system root certificates are used to validate the TLS connection.
-                  type: string
-                  format: byte
-                path:
-                  description: Vault URL path to the certificate role
-                  type: string
-                server:
-                  description: Server is the vault connection address
-                  type: string
-            venafi:
-              description: VenafiIssuer describes issuer configuration details for
-                Venafi Cloud.
-              type: object
-              required:
-              - zone
-              properties:
-                cloud:
-                  description: Cloud specifies the Venafi cloud configuration settings.
-                    Only one of TPP or Cloud may be specified.
-                  type: object
-                  required:
-                  - apiTokenSecretRef
-                  properties:
-                    apiTokenSecretRef:
-                      description: APITokenSecretRef is a secret key selector for
-                        the Venafi Cloud API token.
-                      type: object
-                      required:
-                      - name
-                      properties:
-                        key:
-                          description: The key of the secret to select from. Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                    url:
-                      description: URL is the base URL for Venafi Cloud
-                      type: string
-                tpp:
-                  description: TPP specifies Trust Protection Platform configuration
-                    settings. Only one of TPP or Cloud may be specified.
-                  type: object
-                  required:
-                  - credentialsRef
-                  - url
-                  properties:
-                    caBundle:
-                      description: CABundle is a PEM encoded TLS certificate to use
-                        to verify connections to the TPP instance. If specified, system
-                        roots will not be used and the issuing CA for the TPP instance
-                        must be verifiable using the provided root. If not specified,
-                        the connection will be verified using the cert-manager system
-                        root certificates.
-                      type: string
-                      format: byte
-                    credentialsRef:
-                      description: CredentialsRef is a reference to a Secret containing
-                        the username and password for the TPP server. The secret must
-                        contain two keys, 'username' and 'password'.
-                      type: object
-                      required:
-                      - name
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                    url:
-                      description: URL is the base URL for the Venafi TPP instance
-                      type: string
-                zone:
-                  description: Zone is the Venafi Policy Zone to use for this issuer.
-                    All requests made to the Venafi platform will be restricted by
-                    the named zone policy. This field is required.
-                  type: string
-        status:
-          description: IssuerStatus contains status information about an Issuer
-          type: object
-          properties:
-            acme:
-              type: object
-              properties:
-                lastRegisteredEmail:
-                  description: LastRegisteredEmail is the email associated with the
-                    latest registered ACME account, in order to track changes made
-                    to registered account associated with the  Issuer
-                  type: string
-                uri:
-                  description: URI is the unique account identifier, which can also
-                    be used to retrieve account details from the CA
-                  type: string
-            conditions:
-              type: array
-              items:
-                description: IssuerCondition contains condition information for an
-                  Issuer.
+    "schema":
+      "openAPIV3Schema":
+        description: An Issuer represents a certificate issuing authority which can
+          be referenced as part of `issuerRef` fields. It is scoped to a single namespace
+          and can therefore only be referenced by resources within the same namespace.
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Desired state of the Issuer resource.
+            type: object
+            properties:
+              acme:
+                description: ACME configures this issuer to communicate with a RFC8555
+                  (ACME) server to obtain signed x509 certificates.
                 type: object
                 required:
-                - status
-                - type
+                - privateKeySecretRef
+                - server
                 properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the timestamp corresponding
-                      to the last status change of this condition.
+                  email:
+                    description: Email is the email address to be associated with
+                      the ACME account. This field is optional, but it is strongly
+                      recommended to be set. It will be used to contact you in case
+                      of issues with your account or certificates, including expiry
+                      notification emails. This field may be updated after the account
+                      is initially registered.
                     type: string
-                    format: date-time
-                  message:
-                    description: Message is a human readable description of the details
-                      of the last transition, complementing reason.
+                  externalAccountBinding:
+                    description: ExternalAccountBinding is a reference to a CA external
+                      account of the ACME server. If set, upon registration cert-manager
+                      will attempt to associate the given external account credentials
+                      with the registered ACME account.
+                    type: object
+                    required:
+                    - keyAlgorithm
+                    - keyID
+                    - keySecretRef
+                    properties:
+                      keyAlgorithm:
+                        description: keyAlgorithm is the MAC key algorithm that the
+                          key is used for. Valid values are "HS256", "HS384" and "HS512".
+                        type: string
+                        enum:
+                        - HS256
+                        - HS384
+                        - HS512
+                      keyID:
+                        description: keyID is the ID of the CA key that the External
+                          Account is bound to.
+                        type: string
+                      keySecretRef:
+                        description: keySecretRef is a Secret Key Selector referencing
+                          a data item in a Kubernetes Secret which holds the symmetric
+                          MAC key of the External Account Binding. The `key` is the
+                          index string that is paired with the key data in the Secret
+                          and should not be confused with the key data itself, or
+                          indeed with the External Account Binding keyID above. The
+                          secret key stored in the Secret **must** be un-padded, base64
+                          URL encoded data.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the entry in the Secret resource's
+                              `data` field to be used. Some instances of this field
+                              may be defaulted, in others it may be required.
+                            type: string
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                  privateKeySecretRef:
+                    description: PrivateKey is the name of a Kubernetes Secret resource
+                      that will be used to store the automatically generated ACME
+                      account private key. Optionally, a `key` may be specified to
+                      select a specific entry within the named Secret resource. If
+                      `key` is not specified, a default of `tls.key` will be used.
+                    type: object
+                    required:
+                    - name
+                    properties:
+                      key:
+                        description: The key of the entry in the Secret resource's
+                          `data` field to be used. Some instances of this field may
+                          be defaulted, in others it may be required.
+                        type: string
+                      name:
+                        description: 'Name of the resource being referred to. More
+                          info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                  server:
+                    description: 'Server is the URL used to access the ACME server''s
+                      ''directory'' endpoint. For example, for Let''s Encrypt''s staging
+                      endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory".
+                      Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                     type: string
-                  reason:
-                    description: Reason is a brief machine readable explanation for
-                      the condition's last transition.
+                  skipTLSVerify:
+                    description: Enables or disables validation of the ACME server
+                      TLS certificate. If true, requests to the ACME server will not
+                      have their TLS certificate validated (i.e. insecure connections
+                      will be allowed). Only enable this option in development environments.
+                      The cert-manager system installed roots will be used to verify
+                      connections to the ACME server if this is false. Defaults to
+                      false.
+                    type: boolean
+                  solvers:
+                    description: 'Solvers is a list of challenge solvers that will
+                      be used to solve ACME challenges for the matching domains. Solver
+                      configurations must be provided in order to obtain certificates
+                      from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/'
+                    type: array
+                    items:
+                      description: Configures an issuer to solve challenges using
+                        the specified options. Only one of HTTP01 or DNS01 may be
+                        provided.
+                      type: object
+                      properties:
+                        dns01:
+                          description: Configures cert-manager to attempt to complete
+                            authorizations by performing the DNS01 challenge flow.
+                          type: object
+                          properties:
+                            acmedns:
+                              description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns)
+                                API to manage DNS01 challenge records.
+                              type: object
+                              required:
+                              - accountSecretRef
+                              - host
+                              properties:
+                                accountSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                host:
+                                  type: string
+                            akamai:
+                              description: Use the Akamai DNS zone management API
+                                to manage DNS01 challenge records.
+                              type: object
+                              required:
+                              - accessTokenSecretRef
+                              - clientSecretSecretRef
+                              - clientTokenSecretRef
+                              - serviceConsumerDomain
+                              properties:
+                                accessTokenSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                clientSecretSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                clientTokenSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                serviceConsumerDomain:
+                                  type: string
+                            azuredns:
+                              description: Use the Microsoft Azure DNS API to manage
+                                DNS01 challenge records.
+                              type: object
+                              required:
+                              - resourceGroupName
+                              - subscriptionID
+                              properties:
+                                clientID:
+                                  description: if both this and ClientSecret are left
+                                    unset MSI will be used
+                                  type: string
+                                clientSecretSecretRef:
+                                  description: if both this and ClientID are left
+                                    unset MSI will be used
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                environment:
+                                  type: string
+                                  enum:
+                                  - AzurePublicCloud
+                                  - AzureChinaCloud
+                                  - AzureGermanCloud
+                                  - AzureUSGovernmentCloud
+                                hostedZoneName:
+                                  type: string
+                                resourceGroupName:
+                                  type: string
+                                subscriptionID:
+                                  type: string
+                                tenantID:
+                                  description: when specifying ClientID and ClientSecret
+                                    then this field is also needed
+                                  type: string
+                            clouddns:
+                              description: Use the Google Cloud DNS API to manage
+                                DNS01 challenge records.
+                              type: object
+                              required:
+                              - project
+                              properties:
+                                hostedZoneName:
+                                  description: HostedZoneName is an optional field
+                                    that tells cert-manager in which Cloud DNS zone
+                                    the challenge record has to be created. If left
+                                    empty cert-manager will automatically choose a
+                                    zone.
+                                  type: string
+                                project:
+                                  type: string
+                                serviceAccountSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                            cloudflare:
+                              description: Use the Cloudflare API to manage DNS01
+                                challenge records.
+                              type: object
+                              properties:
+                                apiKeySecretRef:
+                                  description: 'API key to use to authenticate with
+                                    Cloudflare. Note: using an API token to authenticate
+                                    is now the recommended method as it allows greater
+                                    control of permissions.'
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                apiTokenSecretRef:
+                                  description: API token used to authenticate with
+                                    Cloudflare.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                email:
+                                  description: Email of the account, only required
+                                    when using API key based authentication.
+                                  type: string
+                            cnameStrategy:
+                              description: CNAMEStrategy configures how the DNS01
+                                provider should handle CNAME records when found in
+                                DNS zones.
+                              type: string
+                              enum:
+                              - None
+                              - Follow
+                            digitalocean:
+                              description: Use the DigitalOcean DNS API to manage
+                                DNS01 challenge records.
+                              type: object
+                              required:
+                              - tokenSecretRef
+                              properties:
+                                tokenSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                            rfc2136:
+                              description: Use RFC2136 ("Dynamic Updates in the Domain
+                                Name System") (https://datatracker.ietf.org/doc/rfc2136/)
+                                to manage DNS01 challenge records.
+                              type: object
+                              required:
+                              - nameserver
+                              properties:
+                                nameserver:
+                                  description: The IP address or hostname of an authoritative
+                                    DNS server supporting RFC2136 in the form host:port.
+                                    If the host is an IPv6 address it must be enclosed
+                                    in square brackets (e.g [2001:db8::1]) ; port
+                                    is optional. This field is required.
+                                  type: string
+                                tsigAlgorithm:
+                                  description: 'The TSIG Algorithm configured in the
+                                    DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                                    and ``tsigKeyName`` are defined. Supported values
+                                    are (case-insensitive): ``HMACMD5`` (default),
+                                    ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
+                                  type: string
+                                tsigKeyName:
+                                  description: The TSIG Key name configured in the
+                                    DNS. If ``tsigSecretSecretRef`` is defined, this
+                                    field is required.
+                                  type: string
+                                tsigSecretSecretRef:
+                                  description: The name of the secret containing the
+                                    TSIG value. If ``tsigKeyName`` is defined, this
+                                    field is required.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                            route53:
+                              description: Use the AWS Route53 API to manage DNS01
+                                challenge records.
+                              type: object
+                              required:
+                              - region
+                              properties:
+                                accessKeyID:
+                                  description: 'The AccessKeyID is used for authentication.
+                                    If not set we fall-back to using env vars, shared
+                                    credentials file or AWS Instance metadata see:
+                                    https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                  type: string
+                                hostedZoneID:
+                                  description: If set, the provider will manage only
+                                    this zone in Route53 and will not do an lookup
+                                    using the route53:ListHostedZonesByName api call.
+                                  type: string
+                                region:
+                                  description: Always set the region when using AccessKeyID
+                                    and SecretAccessKey
+                                  type: string
+                                role:
+                                  description: Role is a Role ARN which the Route53
+                                    provider will assume using either the explicit
+                                    credentials AccessKeyID/SecretAccessKey or the
+                                    inferred credentials from environment variables,
+                                    shared credentials file or AWS Instance metadata
+                                  type: string
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication.
+                                    If not set we fall-back to using env vars, shared
+                                    credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                            webhook:
+                              description: Configure an external webhook based DNS01
+                                challenge solver to manage DNS01 challenge records.
+                              type: object
+                              required:
+                              - groupName
+                              - solverName
+                              properties:
+                                config:
+                                  description: Additional configuration that should
+                                    be passed to the webhook apiserver when challenges
+                                    are processed. This can contain arbitrary JSON
+                                    data. Secret values should not be specified in
+                                    this stanza. If secret values are needed (e.g.
+                                    credentials for a DNS service), you should use
+                                    a SecretKeySelector to reference a Secret resource.
+                                    For details on the schema of this field, consult
+                                    the webhook provider implementation's documentation.
+                                  x-kubernetes-preserve-unknown-fields: true
+                                groupName:
+                                  description: The API group name that should be used
+                                    when POSTing ChallengePayload resources to the
+                                    webhook apiserver. This should be the same as
+                                    the GroupName specified in the webhook provider
+                                    implementation.
+                                  type: string
+                                solverName:
+                                  description: The name of the solver to use, as defined
+                                    in the webhook provider implementation. This will
+                                    typically be the name of the provider, e.g. 'cloudflare'.
+                                  type: string
+                        http01:
+                          description: Configures cert-manager to attempt to complete
+                            authorizations by performing the HTTP01 challenge flow.
+                            It is not possible to obtain certificates for wildcard
+                            domain names (e.g. `*.example.com`) using the HTTP01 challenge
+                            mechanism.
+                          type: object
+                          properties:
+                            ingress:
+                              description: The ingress based HTTP01 challenge solver
+                                will solve challenges by creating or modifying Ingress
+                                resources in order to route requests for '/.well-known/acme-challenge/XYZ'
+                                to 'challenge solver' pods that are provisioned by
+                                cert-manager for each Challenge to be completed.
+                              type: object
+                              properties:
+                                class:
+                                  description: The ingress class to use when creating
+                                    Ingress resources to solve ACME challenges that
+                                    use this challenge solver. Only one of 'class'
+                                    or 'name' may be specified.
+                                  type: string
+                                ingressTemplate:
+                                  description: Optional ingress template used to configure
+                                    the ACME challenge solver ingress used for HTTP01
+                                    challenges
+                                  type: object
+                                  properties:
+                                    metadata:
+                                      description: ObjectMeta overrides for the ingress
+                                        used to solve HTTP01 challenges. Only the
+                                        'labels' and 'annotations' fields may be set.
+                                        If labels or annotations overlap with in-built
+                                        values, the values here will override the
+                                        in-built values.
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          description: Annotations that should be
+                                            added to the created ACME HTTP01 solver
+                                            ingress.
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        labels:
+                                          description: Labels that should be added
+                                            to the created ACME HTTP01 solver ingress.
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                name:
+                                  description: The name of the ingress resource that
+                                    should have ACME challenge solving routes inserted
+                                    into it in order to solve HTTP01 challenges. This
+                                    is typically used in conjunction with ingress
+                                    controllers like ingress-gce, which maintains
+                                    a 1:1 mapping between external IPs and ingress
+                                    resources.
+                                  type: string
+                                podTemplate:
+                                  description: Optional pod template used to configure
+                                    the ACME challenge solver pods used for HTTP01
+                                    challenges
+                                  type: object
+                                  properties:
+                                    metadata:
+                                      description: ObjectMeta overrides for the pod
+                                        used to solve HTTP01 challenges. Only the
+                                        'labels' and 'annotations' fields may be set.
+                                        If labels or annotations overlap with in-built
+                                        values, the values here will override the
+                                        in-built values.
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          description: Annotations that should be
+                                            added to the create ACME HTTP01 solver
+                                            pods.
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        labels:
+                                          description: Labels that should be added
+                                            to the created ACME HTTP01 solver pods.
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                    spec:
+                                      description: PodSpec defines overrides for the
+                                        HTTP01 challenge solver pod. Only the 'nodeSelector',
+                                        'affinity' and 'tolerations' fields are supported
+                                        currently. All other fields will be ignored.
+                                      type: object
+                                      properties:
+                                        affinity:
+                                          description: If specified, the pod's scheduling
+                                            constraints
+                                          type: object
+                                          properties:
+                                            nodeAffinity:
+                                              description: Describes node affinity
+                                                scheduling rules for the pod.
+                                              type: object
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  description: The scheduler will
+                                                    prefer to schedule pods to nodes
+                                                    that satisfy the affinity expressions
+                                                    specified by this field, but it
+                                                    may choose a node that violates
+                                                    one or more of the expressions.
+                                                    The node that is most preferred
+                                                    is the one with the greatest sum
+                                                    of weights, i.e. for each node
+                                                    that meets all of the scheduling
+                                                    requirements (resource request,
+                                                    requiredDuringScheduling affinity
+                                                    expressions, etc.), compute a
+                                                    sum by iterating through the elements
+                                                    of this field and adding "weight"
+                                                    to the sum if the node matches
+                                                    the corresponding matchExpressions;
+                                                    the node(s) with the highest sum
+                                                    are the most preferred.
+                                                  type: array
+                                                  items:
+                                                    description: An empty preferred
+                                                      scheduling term matches all
+                                                      objects with implicit weight
+                                                      0 (i.e. it's a no-op). A null
+                                                      preferred scheduling term matches
+                                                      no objects (i.e. is also a no-op).
+                                                    type: object
+                                                    required:
+                                                    - preference
+                                                    - weight
+                                                    properties:
+                                                      preference:
+                                                        description: A node selector
+                                                          term, associated with the
+                                                          corresponding weight.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: A list of
+                                                              node selector requirements
+                                                              by node's labels.
+                                                            type: array
+                                                            items:
+                                                              description: A node
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: Represents
+                                                                    a key's relationship
+                                                                    to a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists, DoesNotExist.
+                                                                    Gt, and Lt.
+                                                                  type: string
+                                                                values:
+                                                                  description: An
+                                                                    array of string
+                                                                    values. If the
+                                                                    operator is In
+                                                                    or NotIn, the
+                                                                    values array must
+                                                                    be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    If the operator
+                                                                    is Gt or Lt, the
+                                                                    values array must
+                                                                    have a single
+                                                                    element, which
+                                                                    will be interpreted
+                                                                    as an integer.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchFields:
+                                                            description: A list of
+                                                              node selector requirements
+                                                              by node's fields.
+                                                            type: array
+                                                            items:
+                                                              description: A node
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: Represents
+                                                                    a key's relationship
+                                                                    to a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists, DoesNotExist.
+                                                                    Gt, and Lt.
+                                                                  type: string
+                                                                values:
+                                                                  description: An
+                                                                    array of string
+                                                                    values. If the
+                                                                    operator is In
+                                                                    or NotIn, the
+                                                                    values array must
+                                                                    be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    If the operator
+                                                                    is Gt or Lt, the
+                                                                    values array must
+                                                                    have a single
+                                                                    element, which
+                                                                    will be interpreted
+                                                                    as an integer.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                      weight:
+                                                        description: Weight associated
+                                                          with matching the corresponding
+                                                          nodeSelectorTerm, in the
+                                                          range 1-100.
+                                                        type: integer
+                                                        format: int32
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  description: If the affinity requirements
+                                                    specified by this field are not
+                                                    met at scheduling time, the pod
+                                                    will not be scheduled onto the
+                                                    node. If the affinity requirements
+                                                    specified by this field cease
+                                                    to be met at some point during
+                                                    pod execution (e.g. due to an
+                                                    update), the system may or may
+                                                    not try to eventually evict the
+                                                    pod from its node.
+                                                  type: object
+                                                  required:
+                                                  - nodeSelectorTerms
+                                                  properties:
+                                                    nodeSelectorTerms:
+                                                      description: Required. A list
+                                                        of node selector terms. The
+                                                        terms are ORed.
+                                                      type: array
+                                                      items:
+                                                        description: A null or empty
+                                                          node selector term matches
+                                                          no objects. The requirements
+                                                          of them are ANDed. The TopologySelectorTerm
+                                                          type implements a subset
+                                                          of the NodeSelectorTerm.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: A list of
+                                                              node selector requirements
+                                                              by node's labels.
+                                                            type: array
+                                                            items:
+                                                              description: A node
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: Represents
+                                                                    a key's relationship
+                                                                    to a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists, DoesNotExist.
+                                                                    Gt, and Lt.
+                                                                  type: string
+                                                                values:
+                                                                  description: An
+                                                                    array of string
+                                                                    values. If the
+                                                                    operator is In
+                                                                    or NotIn, the
+                                                                    values array must
+                                                                    be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    If the operator
+                                                                    is Gt or Lt, the
+                                                                    values array must
+                                                                    have a single
+                                                                    element, which
+                                                                    will be interpreted
+                                                                    as an integer.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchFields:
+                                                            description: A list of
+                                                              node selector requirements
+                                                              by node's fields.
+                                                            type: array
+                                                            items:
+                                                              description: A node
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: Represents
+                                                                    a key's relationship
+                                                                    to a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists, DoesNotExist.
+                                                                    Gt, and Lt.
+                                                                  type: string
+                                                                values:
+                                                                  description: An
+                                                                    array of string
+                                                                    values. If the
+                                                                    operator is In
+                                                                    or NotIn, the
+                                                                    values array must
+                                                                    be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    If the operator
+                                                                    is Gt or Lt, the
+                                                                    values array must
+                                                                    have a single
+                                                                    element, which
+                                                                    will be interpreted
+                                                                    as an integer.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                            podAffinity:
+                                              description: Describes pod affinity
+                                                scheduling rules (e.g. co-locate this
+                                                pod in the same node, zone, etc. as
+                                                some other pod(s)).
+                                              type: object
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  description: The scheduler will
+                                                    prefer to schedule pods to nodes
+                                                    that satisfy the affinity expressions
+                                                    specified by this field, but it
+                                                    may choose a node that violates
+                                                    one or more of the expressions.
+                                                    The node that is most preferred
+                                                    is the one with the greatest sum
+                                                    of weights, i.e. for each node
+                                                    that meets all of the scheduling
+                                                    requirements (resource request,
+                                                    requiredDuringScheduling affinity
+                                                    expressions, etc.), compute a
+                                                    sum by iterating through the elements
+                                                    of this field and adding "weight"
+                                                    to the sum if the node has pods
+                                                    which matches the corresponding
+                                                    podAffinityTerm; the node(s) with
+                                                    the highest sum are the most preferred.
+                                                  type: array
+                                                  items:
+                                                    description: The weights of all
+                                                      of the matched WeightedPodAffinityTerm
+                                                      fields are added per-node to
+                                                      find the most preferred node(s)
+                                                    type: object
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        description: Required. A pod
+                                                          affinity term, associated
+                                                          with the corresponding weight.
+                                                        type: object
+                                                        required:
+                                                        - topologyKey
+                                                        properties:
+                                                          labelSelector:
+                                                            description: A label query
+                                                              over a set of resources,
+                                                              in this case pods.
+                                                            type: object
+                                                            properties:
+                                                              matchExpressions:
+                                                                description: matchExpressions
+                                                                  is a list of label
+                                                                  selector requirements.
+                                                                  The requirements
+                                                                  are ANDed.
+                                                                type: array
+                                                                items:
+                                                                  description: A label
+                                                                    selector requirement
+                                                                    is a selector
+                                                                    that contains
+                                                                    values, a key,
+                                                                    and an operator
+                                                                    that relates the
+                                                                    key and values.
+                                                                  type: object
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  properties:
+                                                                    key:
+                                                                      description: key
+                                                                        is the label
+                                                                        key that the
+                                                                        selector applies
+                                                                        to.
+                                                                      type: string
+                                                                    operator:
+                                                                      description: operator
+                                                                        represents
+                                                                        a key's relationship
+                                                                        to a set of
+                                                                        values. Valid
+                                                                        operators
+                                                                        are In, NotIn,
+                                                                        Exists and
+                                                                        DoesNotExist.
+                                                                      type: string
+                                                                    values:
+                                                                      description: values
+                                                                        is an array
+                                                                        of string
+                                                                        values. If
+                                                                        the operator
+                                                                        is In or NotIn,
+                                                                        the values
+                                                                        array must
+                                                                        be non-empty.
+                                                                        If the operator
+                                                                        is Exists
+                                                                        or DoesNotExist,
+                                                                        the values
+                                                                        array must
+                                                                        be empty.
+                                                                        This array
+                                                                        is replaced
+                                                                        during a strategic
+                                                                        merge patch.
+                                                                      type: array
+                                                                      items:
+                                                                        type: string
+                                                              matchLabels:
+                                                                description: matchLabels
+                                                                  is a map of {key,value}
+                                                                  pairs. A single
+                                                                  {key,value} in the
+                                                                  matchLabels map
+                                                                  is equivalent to
+                                                                  an element of matchExpressions,
+                                                                  whose key field
+                                                                  is "key", the operator
+                                                                  is "In", and the
+                                                                  values array contains
+                                                                  only "value". The
+                                                                  requirements are
+                                                                  ANDed.
+                                                                type: object
+                                                                additionalProperties:
+                                                                  type: string
+                                                          namespaces:
+                                                            description: namespaces
+                                                              specifies which namespaces
+                                                              the labelSelector applies
+                                                              to (matches against);
+                                                              null or empty list means
+                                                              "this pod's namespace"
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                          topologyKey:
+                                                            description: This pod
+                                                              should be co-located
+                                                              (affinity) or not co-located
+                                                              (anti-affinity) with
+                                                              the pods matching the
+                                                              labelSelector in the
+                                                              specified namespaces,
+                                                              where co-located is
+                                                              defined as running on
+                                                              a node whose value of
+                                                              the label with key topologyKey
+                                                              matches that of any
+                                                              node on which any of
+                                                              the selected pods is
+                                                              running. Empty topologyKey
+                                                              is not allowed.
+                                                            type: string
+                                                      weight:
+                                                        description: weight associated
+                                                          with matching the corresponding
+                                                          podAffinityTerm, in the
+                                                          range 1-100.
+                                                        type: integer
+                                                        format: int32
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  description: If the affinity requirements
+                                                    specified by this field are not
+                                                    met at scheduling time, the pod
+                                                    will not be scheduled onto the
+                                                    node. If the affinity requirements
+                                                    specified by this field cease
+                                                    to be met at some point during
+                                                    pod execution (e.g. due to a pod
+                                                    label update), the system may
+                                                    or may not try to eventually evict
+                                                    the pod from its node. When there
+                                                    are multiple elements, the lists
+                                                    of nodes corresponding to each
+                                                    podAffinityTerm are intersected,
+                                                    i.e. all terms must be satisfied.
+                                                  type: array
+                                                  items:
+                                                    description: Defines a set of
+                                                      pods (namely those matching
+                                                      the labelSelector relative to
+                                                      the given namespace(s)) that
+                                                      this pod should be co-located
+                                                      (affinity) or not co-located
+                                                      (anti-affinity) with, where
+                                                      co-located is defined as running
+                                                      on a node whose value of the
+                                                      label with key <topologyKey>
+                                                      matches that of any node on
+                                                      which a pod of the set of pods
+                                                      is running
+                                                    type: object
+                                                    required:
+                                                    - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query
+                                                          over a set of resources,
+                                                          in this case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions
+                                                              is a list of label selector
+                                                              requirements. The requirements
+                                                              are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key
+                                                                    is the label key
+                                                                    that the selector
+                                                                    applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator
+                                                                    represents a key's
+                                                                    relationship to
+                                                                    a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values
+                                                                    is an array of
+                                                                    string values.
+                                                                    If the operator
+                                                                    is In or NotIn,
+                                                                    the values array
+                                                                    must be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels
+                                                              is a map of {key,value}
+                                                              pairs. A single {key,value}
+                                                              in the matchLabels map
+                                                              is equivalent to an
+                                                              element of matchExpressions,
+                                                              whose key field is "key",
+                                                              the operator is "In",
+                                                              and the values array
+                                                              contains only "value".
+                                                              The requirements are
+                                                              ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaces:
+                                                        description: namespaces specifies
+                                                          which namespaces the labelSelector
+                                                          applies to (matches against);
+                                                          null or empty list means
+                                                          "this pod's namespace"
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                      topologyKey:
+                                                        description: This pod should
+                                                          be co-located (affinity)
+                                                          or not co-located (anti-affinity)
+                                                          with the pods matching the
+                                                          labelSelector in the specified
+                                                          namespaces, where co-located
+                                                          is defined as running on
+                                                          a node whose value of the
+                                                          label with key topologyKey
+                                                          matches that of any node
+                                                          on which any of the selected
+                                                          pods is running. Empty topologyKey
+                                                          is not allowed.
+                                                        type: string
+                                            podAntiAffinity:
+                                              description: Describes pod anti-affinity
+                                                scheduling rules (e.g. avoid putting
+                                                this pod in the same node, zone, etc.
+                                                as some other pod(s)).
+                                              type: object
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  description: The scheduler will
+                                                    prefer to schedule pods to nodes
+                                                    that satisfy the anti-affinity
+                                                    expressions specified by this
+                                                    field, but it may choose a node
+                                                    that violates one or more of the
+                                                    expressions. The node that is
+                                                    most preferred is the one with
+                                                    the greatest sum of weights, i.e.
+                                                    for each node that meets all of
+                                                    the scheduling requirements (resource
+                                                    request, requiredDuringScheduling
+                                                    anti-affinity expressions, etc.),
+                                                    compute a sum by iterating through
+                                                    the elements of this field and
+                                                    adding "weight" to the sum if
+                                                    the node has pods which matches
+                                                    the corresponding podAffinityTerm;
+                                                    the node(s) with the highest sum
+                                                    are the most preferred.
+                                                  type: array
+                                                  items:
+                                                    description: The weights of all
+                                                      of the matched WeightedPodAffinityTerm
+                                                      fields are added per-node to
+                                                      find the most preferred node(s)
+                                                    type: object
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        description: Required. A pod
+                                                          affinity term, associated
+                                                          with the corresponding weight.
+                                                        type: object
+                                                        required:
+                                                        - topologyKey
+                                                        properties:
+                                                          labelSelector:
+                                                            description: A label query
+                                                              over a set of resources,
+                                                              in this case pods.
+                                                            type: object
+                                                            properties:
+                                                              matchExpressions:
+                                                                description: matchExpressions
+                                                                  is a list of label
+                                                                  selector requirements.
+                                                                  The requirements
+                                                                  are ANDed.
+                                                                type: array
+                                                                items:
+                                                                  description: A label
+                                                                    selector requirement
+                                                                    is a selector
+                                                                    that contains
+                                                                    values, a key,
+                                                                    and an operator
+                                                                    that relates the
+                                                                    key and values.
+                                                                  type: object
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  properties:
+                                                                    key:
+                                                                      description: key
+                                                                        is the label
+                                                                        key that the
+                                                                        selector applies
+                                                                        to.
+                                                                      type: string
+                                                                    operator:
+                                                                      description: operator
+                                                                        represents
+                                                                        a key's relationship
+                                                                        to a set of
+                                                                        values. Valid
+                                                                        operators
+                                                                        are In, NotIn,
+                                                                        Exists and
+                                                                        DoesNotExist.
+                                                                      type: string
+                                                                    values:
+                                                                      description: values
+                                                                        is an array
+                                                                        of string
+                                                                        values. If
+                                                                        the operator
+                                                                        is In or NotIn,
+                                                                        the values
+                                                                        array must
+                                                                        be non-empty.
+                                                                        If the operator
+                                                                        is Exists
+                                                                        or DoesNotExist,
+                                                                        the values
+                                                                        array must
+                                                                        be empty.
+                                                                        This array
+                                                                        is replaced
+                                                                        during a strategic
+                                                                        merge patch.
+                                                                      type: array
+                                                                      items:
+                                                                        type: string
+                                                              matchLabels:
+                                                                description: matchLabels
+                                                                  is a map of {key,value}
+                                                                  pairs. A single
+                                                                  {key,value} in the
+                                                                  matchLabels map
+                                                                  is equivalent to
+                                                                  an element of matchExpressions,
+                                                                  whose key field
+                                                                  is "key", the operator
+                                                                  is "In", and the
+                                                                  values array contains
+                                                                  only "value". The
+                                                                  requirements are
+                                                                  ANDed.
+                                                                type: object
+                                                                additionalProperties:
+                                                                  type: string
+                                                          namespaces:
+                                                            description: namespaces
+                                                              specifies which namespaces
+                                                              the labelSelector applies
+                                                              to (matches against);
+                                                              null or empty list means
+                                                              "this pod's namespace"
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                          topologyKey:
+                                                            description: This pod
+                                                              should be co-located
+                                                              (affinity) or not co-located
+                                                              (anti-affinity) with
+                                                              the pods matching the
+                                                              labelSelector in the
+                                                              specified namespaces,
+                                                              where co-located is
+                                                              defined as running on
+                                                              a node whose value of
+                                                              the label with key topologyKey
+                                                              matches that of any
+                                                              node on which any of
+                                                              the selected pods is
+                                                              running. Empty topologyKey
+                                                              is not allowed.
+                                                            type: string
+                                                      weight:
+                                                        description: weight associated
+                                                          with matching the corresponding
+                                                          podAffinityTerm, in the
+                                                          range 1-100.
+                                                        type: integer
+                                                        format: int32
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  description: If the anti-affinity
+                                                    requirements specified by this
+                                                    field are not met at scheduling
+                                                    time, the pod will not be scheduled
+                                                    onto the node. If the anti-affinity
+                                                    requirements specified by this
+                                                    field cease to be met at some
+                                                    point during pod execution (e.g.
+                                                    due to a pod label update), the
+                                                    system may or may not try to eventually
+                                                    evict the pod from its node. When
+                                                    there are multiple elements, the
+                                                    lists of nodes corresponding to
+                                                    each podAffinityTerm are intersected,
+                                                    i.e. all terms must be satisfied.
+                                                  type: array
+                                                  items:
+                                                    description: Defines a set of
+                                                      pods (namely those matching
+                                                      the labelSelector relative to
+                                                      the given namespace(s)) that
+                                                      this pod should be co-located
+                                                      (affinity) or not co-located
+                                                      (anti-affinity) with, where
+                                                      co-located is defined as running
+                                                      on a node whose value of the
+                                                      label with key <topologyKey>
+                                                      matches that of any node on
+                                                      which a pod of the set of pods
+                                                      is running
+                                                    type: object
+                                                    required:
+                                                    - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query
+                                                          over a set of resources,
+                                                          in this case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions
+                                                              is a list of label selector
+                                                              requirements. The requirements
+                                                              are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key
+                                                                    is the label key
+                                                                    that the selector
+                                                                    applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator
+                                                                    represents a key's
+                                                                    relationship to
+                                                                    a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values
+                                                                    is an array of
+                                                                    string values.
+                                                                    If the operator
+                                                                    is In or NotIn,
+                                                                    the values array
+                                                                    must be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels
+                                                              is a map of {key,value}
+                                                              pairs. A single {key,value}
+                                                              in the matchLabels map
+                                                              is equivalent to an
+                                                              element of matchExpressions,
+                                                              whose key field is "key",
+                                                              the operator is "In",
+                                                              and the values array
+                                                              contains only "value".
+                                                              The requirements are
+                                                              ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaces:
+                                                        description: namespaces specifies
+                                                          which namespaces the labelSelector
+                                                          applies to (matches against);
+                                                          null or empty list means
+                                                          "this pod's namespace"
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                      topologyKey:
+                                                        description: This pod should
+                                                          be co-located (affinity)
+                                                          or not co-located (anti-affinity)
+                                                          with the pods matching the
+                                                          labelSelector in the specified
+                                                          namespaces, where co-located
+                                                          is defined as running on
+                                                          a node whose value of the
+                                                          label with key topologyKey
+                                                          matches that of any node
+                                                          on which any of the selected
+                                                          pods is running. Empty topologyKey
+                                                          is not allowed.
+                                                        type: string
+                                        nodeSelector:
+                                          description: 'NodeSelector is a selector
+                                            which must be true for the pod to fit
+                                            on a node. Selector which must match a
+                                            node''s labels for the pod to be scheduled
+                                            on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        tolerations:
+                                          description: If specified, the pod's tolerations.
+                                          type: array
+                                          items:
+                                            description: The pod this Toleration is
+                                              attached to tolerates any taint that
+                                              matches the triple <key,value,effect>
+                                              using the matching operator <operator>.
+                                            type: object
+                                            properties:
+                                              effect:
+                                                description: Effect indicates the
+                                                  taint effect to match. Empty means
+                                                  match all taint effects. When specified,
+                                                  allowed values are NoSchedule, PreferNoSchedule
+                                                  and NoExecute.
+                                                type: string
+                                              key:
+                                                description: Key is the taint key
+                                                  that the toleration applies to.
+                                                  Empty means match all taint keys.
+                                                  If the key is empty, operator must
+                                                  be Exists; this combination means
+                                                  to match all values and all keys.
+                                                type: string
+                                              operator:
+                                                description: Operator represents a
+                                                  key's relationship to the value.
+                                                  Valid operators are Exists and Equal.
+                                                  Defaults to Equal. Exists is equivalent
+                                                  to wildcard for value, so that a
+                                                  pod can tolerate all taints of a
+                                                  particular category.
+                                                type: string
+                                              tolerationSeconds:
+                                                description: TolerationSeconds represents
+                                                  the period of time the toleration
+                                                  (which must be of effect NoExecute,
+                                                  otherwise this field is ignored)
+                                                  tolerates the taint. By default,
+                                                  it is not set, which means tolerate
+                                                  the taint forever (do not evict).
+                                                  Zero and negative values will be
+                                                  treated as 0 (evict immediately)
+                                                  by the system.
+                                                type: integer
+                                                format: int64
+                                              value:
+                                                description: Value is the taint value
+                                                  the toleration matches to. If the
+                                                  operator is Exists, the value should
+                                                  be empty, otherwise just a regular
+                                                  string.
+                                                type: string
+                                serviceType:
+                                  description: Optional service type for Kubernetes
+                                    solver service
+                                  type: string
+                        selector:
+                          description: Selector selects a set of DNSNames on the Certificate
+                            resource that should be solved using this challenge solver.
+                            If not specified, the solver will be treated as the 'default'
+                            solver with the lowest priority, i.e. if any other solver
+                            has a more specific match, it will be used instead.
+                          type: object
+                          properties:
+                            dnsNames:
+                              description: List of DNSNames that this solver will
+                                be used to solve. If specified and a match is found,
+                                a dnsNames selector will take precedence over a dnsZones
+                                selector. If multiple solvers match with the same
+                                dnsNames value, the solver with the most matching
+                                labels in matchLabels will be selected. If neither
+                                has more matches, the solver defined earlier in the
+                                list will be selected.
+                              type: array
+                              items:
+                                type: string
+                            dnsZones:
+                              description: List of DNSZones that this solver will
+                                be used to solve. The most specific DNS zone match
+                                specified here will take precedence over other DNS
+                                zone matches, so a solver specifying sys.example.com
+                                will be selected over one specifying example.com for
+                                the domain www.sys.example.com. If multiple solvers
+                                match with the same dnsZones value, the solver with
+                                the most matching labels in matchLabels will be selected.
+                                If neither has more matches, the solver defined earlier
+                                in the list will be selected.
+                              type: array
+                              items:
+                                type: string
+                            matchLabels:
+                              description: A label selector that is used to refine
+                                the set of certificate's that this challenge solver
+                                will apply to.
+                              type: object
+                              additionalProperties:
+                                type: string
+              ca:
+                description: CA configures this issuer to sign certificates using
+                  a signing CA keypair stored in a Secret resource. This is used to
+                  build internal PKIs that are managed by cert-manager.
+                type: object
+                required:
+                - secretName
+                properties:
+                  crlDistributionPoints:
+                    description: The CRL distribution points is an X.509 v3 certificate
+                      extension which identifies the location of the CRL from which
+                      the revocation of this certificate can be checked. If not set,
+                      certificates will be issued without distribution points set.
+                    type: array
+                    items:
+                      type: string
+                  secretName:
+                    description: SecretName is the name of the secret used to sign
+                      Certificates issued by this Issuer.
                     type: string
-                  status:
-                    description: Status of the condition, one of ('True', 'False',
-                      'Unknown').
+              selfSigned:
+                description: SelfSigned configures this issuer to 'self sign' certificates
+                  using the private key used to create the CertificateRequest object.
+                type: object
+                properties:
+                  crlDistributionPoints:
+                    description: The CRL distribution points is an X.509 v3 certificate
+                      extension which identifies the location of the CRL from which
+                      the revocation of this certificate can be checked. If not set
+                      certificate will be issued without CDP. Values are strings.
+                    type: array
+                    items:
+                      type: string
+              vault:
+                description: Vault configures this issuer to sign certificates using
+                  a HashiCorp Vault PKI backend.
+                type: object
+                required:
+                - auth
+                - path
+                - server
+                properties:
+                  auth:
+                    description: Auth configures how cert-manager authenticates with
+                      the Vault server.
+                    type: object
+                    properties:
+                      appRole:
+                        description: AppRole authenticates with Vault using the App
+                          Role auth mechanism, with the role and secret stored in
+                          a Kubernetes Secret resource.
+                        type: object
+                        required:
+                        - path
+                        - roleId
+                        - secretRef
+                        properties:
+                          path:
+                            description: 'Path where the App Role authentication backend
+                              is mounted in Vault, e.g: "approle"'
+                            type: string
+                          roleId:
+                            description: RoleID configured in the App Role authentication
+                              backend when setting up the authentication backend in
+                              Vault.
+                            type: string
+                          secretRef:
+                            description: Reference to a key in a Secret that contains
+                              the App Role secret used to authenticate with Vault.
+                              The `key` field must be specified and denotes which
+                              entry within the Secret resource is used as the app
+                              role secret.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                      kubernetes:
+                        description: Kubernetes authenticates with Vault by passing
+                          the ServiceAccount token stored in the named Secret resource
+                          to the Vault server.
+                        type: object
+                        required:
+                        - role
+                        - secretRef
+                        properties:
+                          mountPath:
+                            description: The Vault mountPath here is the mount path
+                              to use when authenticating with Vault. For example,
+                              setting a value to `/v1/auth/foo`, will use the path
+                              `/v1/auth/foo/login` to authenticate with Vault. If
+                              unspecified, the default value "/v1/auth/kubernetes"
+                              will be used.
+                            type: string
+                          role:
+                            description: A required field containing the Vault Role
+                              to assume. A Role binds a Kubernetes ServiceAccount
+                              with a set of Vault policies.
+                            type: string
+                          secretRef:
+                            description: The required Secret field containing a Kubernetes
+                              ServiceAccount JWT used for authenticating with Vault.
+                              Use of 'ambient credentials' is not supported.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                      tokenSecretRef:
+                        description: TokenSecretRef authenticates with Vault by presenting
+                          a token.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the entry in the Secret resource's
+                              `data` field to be used. Some instances of this field
+                              may be defaulted, in others it may be required.
+                            type: string
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                  caBundle:
+                    description: PEM encoded CA bundle used to validate Vault server
+                      certificate. Only used if the Server URL is using HTTPS protocol.
+                      This parameter is ignored for plain HTTP protocol connection.
+                      If not set the system root certificates are used to validate
+                      the TLS connection.
                     type: string
-                    enum:
-                    - "True"
-                    - "False"
-                    - Unknown
-                  type:
-                    description: Type of the condition, currently ('Ready').
+                    format: byte
+                  path:
+                    description: 'Path is the mount path of the Vault PKI backend''s
+                      `sign` endpoint, e.g: "my_pki_mount/sign/my-role-name".'
                     type: string
+                  server:
+                    description: 'Server is the connection address for the Vault server,
+                      e.g: "https://vault.example.com:8200".'
+                    type: string
+              venafi:
+                description: Venafi configures this issuer to sign certificates using
+                  a Venafi TPP or Venafi Cloud policy zone.
+                type: object
+                required:
+                - zone
+                properties:
+                  cloud:
+                    description: Cloud specifies the Venafi cloud configuration settings.
+                      Only one of TPP or Cloud may be specified.
+                    type: object
+                    required:
+                    - apiTokenSecretRef
+                    properties:
+                      apiTokenSecretRef:
+                        description: APITokenSecretRef is a secret key selector for
+                          the Venafi Cloud API token.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the entry in the Secret resource's
+                              `data` field to be used. Some instances of this field
+                              may be defaulted, in others it may be required.
+                            type: string
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                      url:
+                        description: URL is the base URL for Venafi Cloud. Defaults
+                          to "https://api.venafi.cloud/v1".
+                        type: string
+                  tpp:
+                    description: TPP specifies Trust Protection Platform configuration
+                      settings. Only one of TPP or Cloud may be specified.
+                    type: object
+                    required:
+                    - credentialsRef
+                    - url
+                    properties:
+                      caBundle:
+                        description: CABundle is a PEM encoded TLS certificate to
+                          use to verify connections to the TPP instance. If specified,
+                          system roots will not be used and the issuing CA for the
+                          TPP instance must be verifiable using the provided root.
+                          If not specified, the connection will be verified using
+                          the cert-manager system root certificates.
+                        type: string
+                        format: byte
+                      credentialsRef:
+                        description: CredentialsRef is a reference to a Secret containing
+                          the username and password for the TPP server. The secret
+                          must contain two keys, 'username' and 'password'.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                      url:
+                        description: 'URL is the base URL for the vedsdk endpoint
+                          of the Venafi TPP instance, for example: "https://tpp.example.com/vedsdk".'
+                        type: string
+                  zone:
+                    description: Zone is the Venafi Policy Zone to use for this issuer.
+                      All requests made to the Venafi platform will be restricted
+                      by the named zone policy. This field is required.
+                    type: string
+          status:
+            description: Status of the Issuer. This is set and managed automatically.
+            type: object
+            properties:
+              acme:
+                description: ACME specific status options. This field should only
+                  be set if the Issuer is configured to use an ACME server to issue
+                  certificates.
+                type: object
+                properties:
+                  lastRegisteredEmail:
+                    description: LastRegisteredEmail is the email associated with
+                      the latest registered ACME account, in order to track changes
+                      made to registered account associated with the  Issuer
+                    type: string
+                  uri:
+                    description: URI is the unique account identifier, which can also
+                      be used to retrieve account details from the CA
+                    type: string
+              conditions:
+                description: List of status conditions to indicate the status of a
+                  CertificateRequest. Known condition types are `Ready`.
+                type: array
+                items:
+                  description: IssuerCondition contains condition information for
+                    an Issuer.
+                  type: object
+                  required:
+                  - status
+                  - type
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the timestamp corresponding
+                        to the last status change of this condition.
+                      type: string
+                      format: date-time
+                    message:
+                      description: Message is a human readable description of the
+                        details of the last transition, complementing reason.
+                      type: string
+                    reason:
+                      description: Reason is a brief machine readable explanation
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of ('True', 'False',
+                        'Unknown').
+                      type: string
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                    type:
+                      description: Type of the condition, known values are ('Ready').
+                      type: string
+  - name: v1beta1
+    served: true
+    storage: false
+    "schema":
+      "openAPIV3Schema":
+        description: An Issuer represents a certificate issuing authority which can
+          be referenced as part of `issuerRef` fields. It is scoped to a single namespace
+          and can therefore only be referenced by resources within the same namespace.
+        type: object
+        required:
+        - spec
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Desired state of the Issuer resource.
+            type: object
+            properties:
+              acme:
+                description: ACME configures this issuer to communicate with a RFC8555
+                  (ACME) server to obtain signed x509 certificates.
+                type: object
+                required:
+                - privateKeySecretRef
+                - server
+                properties:
+                  email:
+                    description: Email is the email address to be associated with
+                      the ACME account. This field is optional, but it is strongly
+                      recommended to be set. It will be used to contact you in case
+                      of issues with your account or certificates, including expiry
+                      notification emails. This field may be updated after the account
+                      is initially registered.
+                    type: string
+                  externalAccountBinding:
+                    description: ExternalAccountBinding is a reference to a CA external
+                      account of the ACME server. If set, upon registration cert-manager
+                      will attempt to associate the given external account credentials
+                      with the registered ACME account.
+                    type: object
+                    required:
+                    - keyAlgorithm
+                    - keyID
+                    - keySecretRef
+                    properties:
+                      keyAlgorithm:
+                        description: keyAlgorithm is the MAC key algorithm that the
+                          key is used for. Valid values are "HS256", "HS384" and "HS512".
+                        type: string
+                        enum:
+                        - HS256
+                        - HS384
+                        - HS512
+                      keyID:
+                        description: keyID is the ID of the CA key that the External
+                          Account is bound to.
+                        type: string
+                      keySecretRef:
+                        description: keySecretRef is a Secret Key Selector referencing
+                          a data item in a Kubernetes Secret which holds the symmetric
+                          MAC key of the External Account Binding. The `key` is the
+                          index string that is paired with the key data in the Secret
+                          and should not be confused with the key data itself, or
+                          indeed with the External Account Binding keyID above. The
+                          secret key stored in the Secret **must** be un-padded, base64
+                          URL encoded data.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the entry in the Secret resource's
+                              `data` field to be used. Some instances of this field
+                              may be defaulted, in others it may be required.
+                            type: string
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                  privateKeySecretRef:
+                    description: PrivateKey is the name of a Kubernetes Secret resource
+                      that will be used to store the automatically generated ACME
+                      account private key. Optionally, a `key` may be specified to
+                      select a specific entry within the named Secret resource. If
+                      `key` is not specified, a default of `tls.key` will be used.
+                    type: object
+                    required:
+                    - name
+                    properties:
+                      key:
+                        description: The key of the entry in the Secret resource's
+                          `data` field to be used. Some instances of this field may
+                          be defaulted, in others it may be required.
+                        type: string
+                      name:
+                        description: 'Name of the resource being referred to. More
+                          info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                  server:
+                    description: 'Server is the URL used to access the ACME server''s
+                      ''directory'' endpoint. For example, for Let''s Encrypt''s staging
+                      endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory".
+                      Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
+                    type: string
+                  skipTLSVerify:
+                    description: Enables or disables validation of the ACME server
+                      TLS certificate. If true, requests to the ACME server will not
+                      have their TLS certificate validated (i.e. insecure connections
+                      will be allowed). Only enable this option in development environments.
+                      The cert-manager system installed roots will be used to verify
+                      connections to the ACME server if this is false. Defaults to
+                      false.
+                    type: boolean
+                  solvers:
+                    description: 'Solvers is a list of challenge solvers that will
+                      be used to solve ACME challenges for the matching domains. Solver
+                      configurations must be provided in order to obtain certificates
+                      from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/'
+                    type: array
+                    items:
+                      description: Configures an issuer to solve challenges using
+                        the specified options. Only one of HTTP01 or DNS01 may be
+                        provided.
+                      type: object
+                      properties:
+                        dns01:
+                          description: Configures cert-manager to attempt to complete
+                            authorizations by performing the DNS01 challenge flow.
+                          type: object
+                          properties:
+                            acmeDNS:
+                              description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns)
+                                API to manage DNS01 challenge records.
+                              type: object
+                              required:
+                              - accountSecretRef
+                              - host
+                              properties:
+                                accountSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                host:
+                                  type: string
+                            akamai:
+                              description: Use the Akamai DNS zone management API
+                                to manage DNS01 challenge records.
+                              type: object
+                              required:
+                              - accessTokenSecretRef
+                              - clientSecretSecretRef
+                              - clientTokenSecretRef
+                              - serviceConsumerDomain
+                              properties:
+                                accessTokenSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                clientSecretSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                clientTokenSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                serviceConsumerDomain:
+                                  type: string
+                            azureDNS:
+                              description: Use the Microsoft Azure DNS API to manage
+                                DNS01 challenge records.
+                              type: object
+                              required:
+                              - resourceGroupName
+                              - subscriptionID
+                              properties:
+                                clientID:
+                                  description: if both this and ClientSecret are left
+                                    unset MSI will be used
+                                  type: string
+                                clientSecretSecretRef:
+                                  description: if both this and ClientID are left
+                                    unset MSI will be used
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                environment:
+                                  type: string
+                                  enum:
+                                  - AzurePublicCloud
+                                  - AzureChinaCloud
+                                  - AzureGermanCloud
+                                  - AzureUSGovernmentCloud
+                                hostedZoneName:
+                                  type: string
+                                resourceGroupName:
+                                  type: string
+                                subscriptionID:
+                                  type: string
+                                tenantID:
+                                  description: when specifying ClientID and ClientSecret
+                                    then this field is also needed
+                                  type: string
+                            cloudDNS:
+                              description: Use the Google Cloud DNS API to manage
+                                DNS01 challenge records.
+                              type: object
+                              required:
+                              - project
+                              properties:
+                                hostedZoneName:
+                                  description: HostedZoneName is an optional field
+                                    that tells cert-manager in which Cloud DNS zone
+                                    the challenge record has to be created. If left
+                                    empty cert-manager will automatically choose a
+                                    zone.
+                                  type: string
+                                project:
+                                  type: string
+                                serviceAccountSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                            cloudflare:
+                              description: Use the Cloudflare API to manage DNS01
+                                challenge records.
+                              type: object
+                              properties:
+                                apiKeySecretRef:
+                                  description: 'API key to use to authenticate with
+                                    Cloudflare. Note: using an API token to authenticate
+                                    is now the recommended method as it allows greater
+                                    control of permissions.'
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                apiTokenSecretRef:
+                                  description: API token used to authenticate with
+                                    Cloudflare.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                email:
+                                  description: Email of the account, only required
+                                    when using API key based authentication.
+                                  type: string
+                            cnameStrategy:
+                              description: CNAMEStrategy configures how the DNS01
+                                provider should handle CNAME records when found in
+                                DNS zones.
+                              type: string
+                              enum:
+                              - None
+                              - Follow
+                            digitalocean:
+                              description: Use the DigitalOcean DNS API to manage
+                                DNS01 challenge records.
+                              type: object
+                              required:
+                              - tokenSecretRef
+                              properties:
+                                tokenSecretRef:
+                                  description: A reference to a specific 'key' within
+                                    a Secret resource. In some instances, `key` is
+                                    a required field.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                            rfc2136:
+                              description: Use RFC2136 ("Dynamic Updates in the Domain
+                                Name System") (https://datatracker.ietf.org/doc/rfc2136/)
+                                to manage DNS01 challenge records.
+                              type: object
+                              required:
+                              - nameserver
+                              properties:
+                                nameserver:
+                                  description: The IP address or hostname of an authoritative
+                                    DNS server supporting RFC2136 in the form host:port.
+                                    If the host is an IPv6 address it must be enclosed
+                                    in square brackets (e.g [2001:db8::1]) ; port
+                                    is optional. This field is required.
+                                  type: string
+                                tsigAlgorithm:
+                                  description: 'The TSIG Algorithm configured in the
+                                    DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                                    and ``tsigKeyName`` are defined. Supported values
+                                    are (case-insensitive): ``HMACMD5`` (default),
+                                    ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
+                                  type: string
+                                tsigKeyName:
+                                  description: The TSIG Key name configured in the
+                                    DNS. If ``tsigSecretSecretRef`` is defined, this
+                                    field is required.
+                                  type: string
+                                tsigSecretSecretRef:
+                                  description: The name of the secret containing the
+                                    TSIG value. If ``tsigKeyName`` is defined, this
+                                    field is required.
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                            route53:
+                              description: Use the AWS Route53 API to manage DNS01
+                                challenge records.
+                              type: object
+                              required:
+                              - region
+                              properties:
+                                accessKeyID:
+                                  description: 'The AccessKeyID is used for authentication.
+                                    If not set we fall-back to using env vars, shared
+                                    credentials file or AWS Instance metadata see:
+                                    https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                  type: string
+                                hostedZoneID:
+                                  description: If set, the provider will manage only
+                                    this zone in Route53 and will not do an lookup
+                                    using the route53:ListHostedZonesByName api call.
+                                  type: string
+                                region:
+                                  description: Always set the region when using AccessKeyID
+                                    and SecretAccessKey
+                                  type: string
+                                role:
+                                  description: Role is a Role ARN which the Route53
+                                    provider will assume using either the explicit
+                                    credentials AccessKeyID/SecretAccessKey or the
+                                    inferred credentials from environment variables,
+                                    shared credentials file or AWS Instance metadata
+                                  type: string
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication.
+                                    If not set we fall-back to using env vars, shared
+                                    credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others
+                                        it may be required.
+                                      type: string
+                                    name:
+                                      description: 'Name of the resource being referred
+                                        to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                            webhook:
+                              description: Configure an external webhook based DNS01
+                                challenge solver to manage DNS01 challenge records.
+                              type: object
+                              required:
+                              - groupName
+                              - solverName
+                              properties:
+                                config:
+                                  description: Additional configuration that should
+                                    be passed to the webhook apiserver when challenges
+                                    are processed. This can contain arbitrary JSON
+                                    data. Secret values should not be specified in
+                                    this stanza. If secret values are needed (e.g.
+                                    credentials for a DNS service), you should use
+                                    a SecretKeySelector to reference a Secret resource.
+                                    For details on the schema of this field, consult
+                                    the webhook provider implementation's documentation.
+                                  x-kubernetes-preserve-unknown-fields: true
+                                groupName:
+                                  description: The API group name that should be used
+                                    when POSTing ChallengePayload resources to the
+                                    webhook apiserver. This should be the same as
+                                    the GroupName specified in the webhook provider
+                                    implementation.
+                                  type: string
+                                solverName:
+                                  description: The name of the solver to use, as defined
+                                    in the webhook provider implementation. This will
+                                    typically be the name of the provider, e.g. 'cloudflare'.
+                                  type: string
+                        http01:
+                          description: Configures cert-manager to attempt to complete
+                            authorizations by performing the HTTP01 challenge flow.
+                            It is not possible to obtain certificates for wildcard
+                            domain names (e.g. `*.example.com`) using the HTTP01 challenge
+                            mechanism.
+                          type: object
+                          properties:
+                            ingress:
+                              description: The ingress based HTTP01 challenge solver
+                                will solve challenges by creating or modifying Ingress
+                                resources in order to route requests for '/.well-known/acme-challenge/XYZ'
+                                to 'challenge solver' pods that are provisioned by
+                                cert-manager for each Challenge to be completed.
+                              type: object
+                              properties:
+                                class:
+                                  description: The ingress class to use when creating
+                                    Ingress resources to solve ACME challenges that
+                                    use this challenge solver. Only one of 'class'
+                                    or 'name' may be specified.
+                                  type: string
+                                ingressTemplate:
+                                  description: Optional ingress template used to configure
+                                    the ACME challenge solver ingress used for HTTP01
+                                    challenges
+                                  type: object
+                                  properties:
+                                    metadata:
+                                      description: ObjectMeta overrides for the ingress
+                                        used to solve HTTP01 challenges. Only the
+                                        'labels' and 'annotations' fields may be set.
+                                        If labels or annotations overlap with in-built
+                                        values, the values here will override the
+                                        in-built values.
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          description: Annotations that should be
+                                            added to the created ACME HTTP01 solver
+                                            ingress.
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        labels:
+                                          description: Labels that should be added
+                                            to the created ACME HTTP01 solver ingress.
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                name:
+                                  description: The name of the ingress resource that
+                                    should have ACME challenge solving routes inserted
+                                    into it in order to solve HTTP01 challenges. This
+                                    is typically used in conjunction with ingress
+                                    controllers like ingress-gce, which maintains
+                                    a 1:1 mapping between external IPs and ingress
+                                    resources.
+                                  type: string
+                                podTemplate:
+                                  description: Optional pod template used to configure
+                                    the ACME challenge solver pods used for HTTP01
+                                    challenges
+                                  type: object
+                                  properties:
+                                    metadata:
+                                      description: ObjectMeta overrides for the pod
+                                        used to solve HTTP01 challenges. Only the
+                                        'labels' and 'annotations' fields may be set.
+                                        If labels or annotations overlap with in-built
+                                        values, the values here will override the
+                                        in-built values.
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          description: Annotations that should be
+                                            added to the create ACME HTTP01 solver
+                                            pods.
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        labels:
+                                          description: Labels that should be added
+                                            to the created ACME HTTP01 solver pods.
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                    spec:
+                                      description: PodSpec defines overrides for the
+                                        HTTP01 challenge solver pod. Only the 'nodeSelector',
+                                        'affinity' and 'tolerations' fields are supported
+                                        currently. All other fields will be ignored.
+                                      type: object
+                                      properties:
+                                        affinity:
+                                          description: If specified, the pod's scheduling
+                                            constraints
+                                          type: object
+                                          properties:
+                                            nodeAffinity:
+                                              description: Describes node affinity
+                                                scheduling rules for the pod.
+                                              type: object
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  description: The scheduler will
+                                                    prefer to schedule pods to nodes
+                                                    that satisfy the affinity expressions
+                                                    specified by this field, but it
+                                                    may choose a node that violates
+                                                    one or more of the expressions.
+                                                    The node that is most preferred
+                                                    is the one with the greatest sum
+                                                    of weights, i.e. for each node
+                                                    that meets all of the scheduling
+                                                    requirements (resource request,
+                                                    requiredDuringScheduling affinity
+                                                    expressions, etc.), compute a
+                                                    sum by iterating through the elements
+                                                    of this field and adding "weight"
+                                                    to the sum if the node matches
+                                                    the corresponding matchExpressions;
+                                                    the node(s) with the highest sum
+                                                    are the most preferred.
+                                                  type: array
+                                                  items:
+                                                    description: An empty preferred
+                                                      scheduling term matches all
+                                                      objects with implicit weight
+                                                      0 (i.e. it's a no-op). A null
+                                                      preferred scheduling term matches
+                                                      no objects (i.e. is also a no-op).
+                                                    type: object
+                                                    required:
+                                                    - preference
+                                                    - weight
+                                                    properties:
+                                                      preference:
+                                                        description: A node selector
+                                                          term, associated with the
+                                                          corresponding weight.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: A list of
+                                                              node selector requirements
+                                                              by node's labels.
+                                                            type: array
+                                                            items:
+                                                              description: A node
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: Represents
+                                                                    a key's relationship
+                                                                    to a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists, DoesNotExist.
+                                                                    Gt, and Lt.
+                                                                  type: string
+                                                                values:
+                                                                  description: An
+                                                                    array of string
+                                                                    values. If the
+                                                                    operator is In
+                                                                    or NotIn, the
+                                                                    values array must
+                                                                    be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    If the operator
+                                                                    is Gt or Lt, the
+                                                                    values array must
+                                                                    have a single
+                                                                    element, which
+                                                                    will be interpreted
+                                                                    as an integer.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchFields:
+                                                            description: A list of
+                                                              node selector requirements
+                                                              by node's fields.
+                                                            type: array
+                                                            items:
+                                                              description: A node
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: Represents
+                                                                    a key's relationship
+                                                                    to a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists, DoesNotExist.
+                                                                    Gt, and Lt.
+                                                                  type: string
+                                                                values:
+                                                                  description: An
+                                                                    array of string
+                                                                    values. If the
+                                                                    operator is In
+                                                                    or NotIn, the
+                                                                    values array must
+                                                                    be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    If the operator
+                                                                    is Gt or Lt, the
+                                                                    values array must
+                                                                    have a single
+                                                                    element, which
+                                                                    will be interpreted
+                                                                    as an integer.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                      weight:
+                                                        description: Weight associated
+                                                          with matching the corresponding
+                                                          nodeSelectorTerm, in the
+                                                          range 1-100.
+                                                        type: integer
+                                                        format: int32
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  description: If the affinity requirements
+                                                    specified by this field are not
+                                                    met at scheduling time, the pod
+                                                    will not be scheduled onto the
+                                                    node. If the affinity requirements
+                                                    specified by this field cease
+                                                    to be met at some point during
+                                                    pod execution (e.g. due to an
+                                                    update), the system may or may
+                                                    not try to eventually evict the
+                                                    pod from its node.
+                                                  type: object
+                                                  required:
+                                                  - nodeSelectorTerms
+                                                  properties:
+                                                    nodeSelectorTerms:
+                                                      description: Required. A list
+                                                        of node selector terms. The
+                                                        terms are ORed.
+                                                      type: array
+                                                      items:
+                                                        description: A null or empty
+                                                          node selector term matches
+                                                          no objects. The requirements
+                                                          of them are ANDed. The TopologySelectorTerm
+                                                          type implements a subset
+                                                          of the NodeSelectorTerm.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: A list of
+                                                              node selector requirements
+                                                              by node's labels.
+                                                            type: array
+                                                            items:
+                                                              description: A node
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: Represents
+                                                                    a key's relationship
+                                                                    to a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists, DoesNotExist.
+                                                                    Gt, and Lt.
+                                                                  type: string
+                                                                values:
+                                                                  description: An
+                                                                    array of string
+                                                                    values. If the
+                                                                    operator is In
+                                                                    or NotIn, the
+                                                                    values array must
+                                                                    be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    If the operator
+                                                                    is Gt or Lt, the
+                                                                    values array must
+                                                                    have a single
+                                                                    element, which
+                                                                    will be interpreted
+                                                                    as an integer.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchFields:
+                                                            description: A list of
+                                                              node selector requirements
+                                                              by node's fields.
+                                                            type: array
+                                                            items:
+                                                              description: A node
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: Represents
+                                                                    a key's relationship
+                                                                    to a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists, DoesNotExist.
+                                                                    Gt, and Lt.
+                                                                  type: string
+                                                                values:
+                                                                  description: An
+                                                                    array of string
+                                                                    values. If the
+                                                                    operator is In
+                                                                    or NotIn, the
+                                                                    values array must
+                                                                    be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    If the operator
+                                                                    is Gt or Lt, the
+                                                                    values array must
+                                                                    have a single
+                                                                    element, which
+                                                                    will be interpreted
+                                                                    as an integer.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                            podAffinity:
+                                              description: Describes pod affinity
+                                                scheduling rules (e.g. co-locate this
+                                                pod in the same node, zone, etc. as
+                                                some other pod(s)).
+                                              type: object
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  description: The scheduler will
+                                                    prefer to schedule pods to nodes
+                                                    that satisfy the affinity expressions
+                                                    specified by this field, but it
+                                                    may choose a node that violates
+                                                    one or more of the expressions.
+                                                    The node that is most preferred
+                                                    is the one with the greatest sum
+                                                    of weights, i.e. for each node
+                                                    that meets all of the scheduling
+                                                    requirements (resource request,
+                                                    requiredDuringScheduling affinity
+                                                    expressions, etc.), compute a
+                                                    sum by iterating through the elements
+                                                    of this field and adding "weight"
+                                                    to the sum if the node has pods
+                                                    which matches the corresponding
+                                                    podAffinityTerm; the node(s) with
+                                                    the highest sum are the most preferred.
+                                                  type: array
+                                                  items:
+                                                    description: The weights of all
+                                                      of the matched WeightedPodAffinityTerm
+                                                      fields are added per-node to
+                                                      find the most preferred node(s)
+                                                    type: object
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        description: Required. A pod
+                                                          affinity term, associated
+                                                          with the corresponding weight.
+                                                        type: object
+                                                        required:
+                                                        - topologyKey
+                                                        properties:
+                                                          labelSelector:
+                                                            description: A label query
+                                                              over a set of resources,
+                                                              in this case pods.
+                                                            type: object
+                                                            properties:
+                                                              matchExpressions:
+                                                                description: matchExpressions
+                                                                  is a list of label
+                                                                  selector requirements.
+                                                                  The requirements
+                                                                  are ANDed.
+                                                                type: array
+                                                                items:
+                                                                  description: A label
+                                                                    selector requirement
+                                                                    is a selector
+                                                                    that contains
+                                                                    values, a key,
+                                                                    and an operator
+                                                                    that relates the
+                                                                    key and values.
+                                                                  type: object
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  properties:
+                                                                    key:
+                                                                      description: key
+                                                                        is the label
+                                                                        key that the
+                                                                        selector applies
+                                                                        to.
+                                                                      type: string
+                                                                    operator:
+                                                                      description: operator
+                                                                        represents
+                                                                        a key's relationship
+                                                                        to a set of
+                                                                        values. Valid
+                                                                        operators
+                                                                        are In, NotIn,
+                                                                        Exists and
+                                                                        DoesNotExist.
+                                                                      type: string
+                                                                    values:
+                                                                      description: values
+                                                                        is an array
+                                                                        of string
+                                                                        values. If
+                                                                        the operator
+                                                                        is In or NotIn,
+                                                                        the values
+                                                                        array must
+                                                                        be non-empty.
+                                                                        If the operator
+                                                                        is Exists
+                                                                        or DoesNotExist,
+                                                                        the values
+                                                                        array must
+                                                                        be empty.
+                                                                        This array
+                                                                        is replaced
+                                                                        during a strategic
+                                                                        merge patch.
+                                                                      type: array
+                                                                      items:
+                                                                        type: string
+                                                              matchLabels:
+                                                                description: matchLabels
+                                                                  is a map of {key,value}
+                                                                  pairs. A single
+                                                                  {key,value} in the
+                                                                  matchLabels map
+                                                                  is equivalent to
+                                                                  an element of matchExpressions,
+                                                                  whose key field
+                                                                  is "key", the operator
+                                                                  is "In", and the
+                                                                  values array contains
+                                                                  only "value". The
+                                                                  requirements are
+                                                                  ANDed.
+                                                                type: object
+                                                                additionalProperties:
+                                                                  type: string
+                                                          namespaces:
+                                                            description: namespaces
+                                                              specifies which namespaces
+                                                              the labelSelector applies
+                                                              to (matches against);
+                                                              null or empty list means
+                                                              "this pod's namespace"
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                          topologyKey:
+                                                            description: This pod
+                                                              should be co-located
+                                                              (affinity) or not co-located
+                                                              (anti-affinity) with
+                                                              the pods matching the
+                                                              labelSelector in the
+                                                              specified namespaces,
+                                                              where co-located is
+                                                              defined as running on
+                                                              a node whose value of
+                                                              the label with key topologyKey
+                                                              matches that of any
+                                                              node on which any of
+                                                              the selected pods is
+                                                              running. Empty topologyKey
+                                                              is not allowed.
+                                                            type: string
+                                                      weight:
+                                                        description: weight associated
+                                                          with matching the corresponding
+                                                          podAffinityTerm, in the
+                                                          range 1-100.
+                                                        type: integer
+                                                        format: int32
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  description: If the affinity requirements
+                                                    specified by this field are not
+                                                    met at scheduling time, the pod
+                                                    will not be scheduled onto the
+                                                    node. If the affinity requirements
+                                                    specified by this field cease
+                                                    to be met at some point during
+                                                    pod execution (e.g. due to a pod
+                                                    label update), the system may
+                                                    or may not try to eventually evict
+                                                    the pod from its node. When there
+                                                    are multiple elements, the lists
+                                                    of nodes corresponding to each
+                                                    podAffinityTerm are intersected,
+                                                    i.e. all terms must be satisfied.
+                                                  type: array
+                                                  items:
+                                                    description: Defines a set of
+                                                      pods (namely those matching
+                                                      the labelSelector relative to
+                                                      the given namespace(s)) that
+                                                      this pod should be co-located
+                                                      (affinity) or not co-located
+                                                      (anti-affinity) with, where
+                                                      co-located is defined as running
+                                                      on a node whose value of the
+                                                      label with key <topologyKey>
+                                                      matches that of any node on
+                                                      which a pod of the set of pods
+                                                      is running
+                                                    type: object
+                                                    required:
+                                                    - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query
+                                                          over a set of resources,
+                                                          in this case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions
+                                                              is a list of label selector
+                                                              requirements. The requirements
+                                                              are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key
+                                                                    is the label key
+                                                                    that the selector
+                                                                    applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator
+                                                                    represents a key's
+                                                                    relationship to
+                                                                    a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values
+                                                                    is an array of
+                                                                    string values.
+                                                                    If the operator
+                                                                    is In or NotIn,
+                                                                    the values array
+                                                                    must be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels
+                                                              is a map of {key,value}
+                                                              pairs. A single {key,value}
+                                                              in the matchLabels map
+                                                              is equivalent to an
+                                                              element of matchExpressions,
+                                                              whose key field is "key",
+                                                              the operator is "In",
+                                                              and the values array
+                                                              contains only "value".
+                                                              The requirements are
+                                                              ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaces:
+                                                        description: namespaces specifies
+                                                          which namespaces the labelSelector
+                                                          applies to (matches against);
+                                                          null or empty list means
+                                                          "this pod's namespace"
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                      topologyKey:
+                                                        description: This pod should
+                                                          be co-located (affinity)
+                                                          or not co-located (anti-affinity)
+                                                          with the pods matching the
+                                                          labelSelector in the specified
+                                                          namespaces, where co-located
+                                                          is defined as running on
+                                                          a node whose value of the
+                                                          label with key topologyKey
+                                                          matches that of any node
+                                                          on which any of the selected
+                                                          pods is running. Empty topologyKey
+                                                          is not allowed.
+                                                        type: string
+                                            podAntiAffinity:
+                                              description: Describes pod anti-affinity
+                                                scheduling rules (e.g. avoid putting
+                                                this pod in the same node, zone, etc.
+                                                as some other pod(s)).
+                                              type: object
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  description: The scheduler will
+                                                    prefer to schedule pods to nodes
+                                                    that satisfy the anti-affinity
+                                                    expressions specified by this
+                                                    field, but it may choose a node
+                                                    that violates one or more of the
+                                                    expressions. The node that is
+                                                    most preferred is the one with
+                                                    the greatest sum of weights, i.e.
+                                                    for each node that meets all of
+                                                    the scheduling requirements (resource
+                                                    request, requiredDuringScheduling
+                                                    anti-affinity expressions, etc.),
+                                                    compute a sum by iterating through
+                                                    the elements of this field and
+                                                    adding "weight" to the sum if
+                                                    the node has pods which matches
+                                                    the corresponding podAffinityTerm;
+                                                    the node(s) with the highest sum
+                                                    are the most preferred.
+                                                  type: array
+                                                  items:
+                                                    description: The weights of all
+                                                      of the matched WeightedPodAffinityTerm
+                                                      fields are added per-node to
+                                                      find the most preferred node(s)
+                                                    type: object
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        description: Required. A pod
+                                                          affinity term, associated
+                                                          with the corresponding weight.
+                                                        type: object
+                                                        required:
+                                                        - topologyKey
+                                                        properties:
+                                                          labelSelector:
+                                                            description: A label query
+                                                              over a set of resources,
+                                                              in this case pods.
+                                                            type: object
+                                                            properties:
+                                                              matchExpressions:
+                                                                description: matchExpressions
+                                                                  is a list of label
+                                                                  selector requirements.
+                                                                  The requirements
+                                                                  are ANDed.
+                                                                type: array
+                                                                items:
+                                                                  description: A label
+                                                                    selector requirement
+                                                                    is a selector
+                                                                    that contains
+                                                                    values, a key,
+                                                                    and an operator
+                                                                    that relates the
+                                                                    key and values.
+                                                                  type: object
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  properties:
+                                                                    key:
+                                                                      description: key
+                                                                        is the label
+                                                                        key that the
+                                                                        selector applies
+                                                                        to.
+                                                                      type: string
+                                                                    operator:
+                                                                      description: operator
+                                                                        represents
+                                                                        a key's relationship
+                                                                        to a set of
+                                                                        values. Valid
+                                                                        operators
+                                                                        are In, NotIn,
+                                                                        Exists and
+                                                                        DoesNotExist.
+                                                                      type: string
+                                                                    values:
+                                                                      description: values
+                                                                        is an array
+                                                                        of string
+                                                                        values. If
+                                                                        the operator
+                                                                        is In or NotIn,
+                                                                        the values
+                                                                        array must
+                                                                        be non-empty.
+                                                                        If the operator
+                                                                        is Exists
+                                                                        or DoesNotExist,
+                                                                        the values
+                                                                        array must
+                                                                        be empty.
+                                                                        This array
+                                                                        is replaced
+                                                                        during a strategic
+                                                                        merge patch.
+                                                                      type: array
+                                                                      items:
+                                                                        type: string
+                                                              matchLabels:
+                                                                description: matchLabels
+                                                                  is a map of {key,value}
+                                                                  pairs. A single
+                                                                  {key,value} in the
+                                                                  matchLabels map
+                                                                  is equivalent to
+                                                                  an element of matchExpressions,
+                                                                  whose key field
+                                                                  is "key", the operator
+                                                                  is "In", and the
+                                                                  values array contains
+                                                                  only "value". The
+                                                                  requirements are
+                                                                  ANDed.
+                                                                type: object
+                                                                additionalProperties:
+                                                                  type: string
+                                                          namespaces:
+                                                            description: namespaces
+                                                              specifies which namespaces
+                                                              the labelSelector applies
+                                                              to (matches against);
+                                                              null or empty list means
+                                                              "this pod's namespace"
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                          topologyKey:
+                                                            description: This pod
+                                                              should be co-located
+                                                              (affinity) or not co-located
+                                                              (anti-affinity) with
+                                                              the pods matching the
+                                                              labelSelector in the
+                                                              specified namespaces,
+                                                              where co-located is
+                                                              defined as running on
+                                                              a node whose value of
+                                                              the label with key topologyKey
+                                                              matches that of any
+                                                              node on which any of
+                                                              the selected pods is
+                                                              running. Empty topologyKey
+                                                              is not allowed.
+                                                            type: string
+                                                      weight:
+                                                        description: weight associated
+                                                          with matching the corresponding
+                                                          podAffinityTerm, in the
+                                                          range 1-100.
+                                                        type: integer
+                                                        format: int32
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  description: If the anti-affinity
+                                                    requirements specified by this
+                                                    field are not met at scheduling
+                                                    time, the pod will not be scheduled
+                                                    onto the node. If the anti-affinity
+                                                    requirements specified by this
+                                                    field cease to be met at some
+                                                    point during pod execution (e.g.
+                                                    due to a pod label update), the
+                                                    system may or may not try to eventually
+                                                    evict the pod from its node. When
+                                                    there are multiple elements, the
+                                                    lists of nodes corresponding to
+                                                    each podAffinityTerm are intersected,
+                                                    i.e. all terms must be satisfied.
+                                                  type: array
+                                                  items:
+                                                    description: Defines a set of
+                                                      pods (namely those matching
+                                                      the labelSelector relative to
+                                                      the given namespace(s)) that
+                                                      this pod should be co-located
+                                                      (affinity) or not co-located
+                                                      (anti-affinity) with, where
+                                                      co-located is defined as running
+                                                      on a node whose value of the
+                                                      label with key <topologyKey>
+                                                      matches that of any node on
+                                                      which a pod of the set of pods
+                                                      is running
+                                                    type: object
+                                                    required:
+                                                    - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query
+                                                          over a set of resources,
+                                                          in this case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions
+                                                              is a list of label selector
+                                                              requirements. The requirements
+                                                              are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label
+                                                                selector requirement
+                                                                is a selector that
+                                                                contains values, a
+                                                                key, and an operator
+                                                                that relates the key
+                                                                and values.
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key
+                                                                    is the label key
+                                                                    that the selector
+                                                                    applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator
+                                                                    represents a key's
+                                                                    relationship to
+                                                                    a set of values.
+                                                                    Valid operators
+                                                                    are In, NotIn,
+                                                                    Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values
+                                                                    is an array of
+                                                                    string values.
+                                                                    If the operator
+                                                                    is In or NotIn,
+                                                                    the values array
+                                                                    must be non-empty.
+                                                                    If the operator
+                                                                    is Exists or DoesNotExist,
+                                                                    the values array
+                                                                    must be empty.
+                                                                    This array is
+                                                                    replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels
+                                                              is a map of {key,value}
+                                                              pairs. A single {key,value}
+                                                              in the matchLabels map
+                                                              is equivalent to an
+                                                              element of matchExpressions,
+                                                              whose key field is "key",
+                                                              the operator is "In",
+                                                              and the values array
+                                                              contains only "value".
+                                                              The requirements are
+                                                              ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaces:
+                                                        description: namespaces specifies
+                                                          which namespaces the labelSelector
+                                                          applies to (matches against);
+                                                          null or empty list means
+                                                          "this pod's namespace"
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                      topologyKey:
+                                                        description: This pod should
+                                                          be co-located (affinity)
+                                                          or not co-located (anti-affinity)
+                                                          with the pods matching the
+                                                          labelSelector in the specified
+                                                          namespaces, where co-located
+                                                          is defined as running on
+                                                          a node whose value of the
+                                                          label with key topologyKey
+                                                          matches that of any node
+                                                          on which any of the selected
+                                                          pods is running. Empty topologyKey
+                                                          is not allowed.
+                                                        type: string
+                                        nodeSelector:
+                                          description: 'NodeSelector is a selector
+                                            which must be true for the pod to fit
+                                            on a node. Selector which must match a
+                                            node''s labels for the pod to be scheduled
+                                            on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        tolerations:
+                                          description: If specified, the pod's tolerations.
+                                          type: array
+                                          items:
+                                            description: The pod this Toleration is
+                                              attached to tolerates any taint that
+                                              matches the triple <key,value,effect>
+                                              using the matching operator <operator>.
+                                            type: object
+                                            properties:
+                                              effect:
+                                                description: Effect indicates the
+                                                  taint effect to match. Empty means
+                                                  match all taint effects. When specified,
+                                                  allowed values are NoSchedule, PreferNoSchedule
+                                                  and NoExecute.
+                                                type: string
+                                              key:
+                                                description: Key is the taint key
+                                                  that the toleration applies to.
+                                                  Empty means match all taint keys.
+                                                  If the key is empty, operator must
+                                                  be Exists; this combination means
+                                                  to match all values and all keys.
+                                                type: string
+                                              operator:
+                                                description: Operator represents a
+                                                  key's relationship to the value.
+                                                  Valid operators are Exists and Equal.
+                                                  Defaults to Equal. Exists is equivalent
+                                                  to wildcard for value, so that a
+                                                  pod can tolerate all taints of a
+                                                  particular category.
+                                                type: string
+                                              tolerationSeconds:
+                                                description: TolerationSeconds represents
+                                                  the period of time the toleration
+                                                  (which must be of effect NoExecute,
+                                                  otherwise this field is ignored)
+                                                  tolerates the taint. By default,
+                                                  it is not set, which means tolerate
+                                                  the taint forever (do not evict).
+                                                  Zero and negative values will be
+                                                  treated as 0 (evict immediately)
+                                                  by the system.
+                                                type: integer
+                                                format: int64
+                                              value:
+                                                description: Value is the taint value
+                                                  the toleration matches to. If the
+                                                  operator is Exists, the value should
+                                                  be empty, otherwise just a regular
+                                                  string.
+                                                type: string
+                                serviceType:
+                                  description: Optional service type for Kubernetes
+                                    solver service
+                                  type: string
+                        selector:
+                          description: Selector selects a set of DNSNames on the Certificate
+                            resource that should be solved using this challenge solver.
+                            If not specified, the solver will be treated as the 'default'
+                            solver with the lowest priority, i.e. if any other solver
+                            has a more specific match, it will be used instead.
+                          type: object
+                          properties:
+                            dnsNames:
+                              description: List of DNSNames that this solver will
+                                be used to solve. If specified and a match is found,
+                                a dnsNames selector will take precedence over a dnsZones
+                                selector. If multiple solvers match with the same
+                                dnsNames value, the solver with the most matching
+                                labels in matchLabels will be selected. If neither
+                                has more matches, the solver defined earlier in the
+                                list will be selected.
+                              type: array
+                              items:
+                                type: string
+                            dnsZones:
+                              description: List of DNSZones that this solver will
+                                be used to solve. The most specific DNS zone match
+                                specified here will take precedence over other DNS
+                                zone matches, so a solver specifying sys.example.com
+                                will be selected over one specifying example.com for
+                                the domain www.sys.example.com. If multiple solvers
+                                match with the same dnsZones value, the solver with
+                                the most matching labels in matchLabels will be selected.
+                                If neither has more matches, the solver defined earlier
+                                in the list will be selected.
+                              type: array
+                              items:
+                                type: string
+                            matchLabels:
+                              description: A label selector that is used to refine
+                                the set of certificate's that this challenge solver
+                                will apply to.
+                              type: object
+                              additionalProperties:
+                                type: string
+              ca:
+                description: CA configures this issuer to sign certificates using
+                  a signing CA keypair stored in a Secret resource. This is used to
+                  build internal PKIs that are managed by cert-manager.
+                type: object
+                required:
+                - secretName
+                properties:
+                  crlDistributionPoints:
+                    description: The CRL distribution points is an X.509 v3 certificate
+                      extension which identifies the location of the CRL from which
+                      the revocation of this certificate can be checked. If not set,
+                      certificates will be issued without distribution points set.
+                    type: array
+                    items:
+                      type: string
+                  secretName:
+                    description: SecretName is the name of the secret used to sign
+                      Certificates issued by this Issuer.
+                    type: string
+              selfSigned:
+                description: SelfSigned configures this issuer to 'self sign' certificates
+                  using the private key used to create the CertificateRequest object.
+                type: object
+                properties:
+                  crlDistributionPoints:
+                    description: The CRL distribution points is an X.509 v3 certificate
+                      extension which identifies the location of the CRL from which
+                      the revocation of this certificate can be checked. If not set
+                      certificate will be issued without CDP. Values are strings.
+                    type: array
+                    items:
+                      type: string
+              vault:
+                description: Vault configures this issuer to sign certificates using
+                  a HashiCorp Vault PKI backend.
+                type: object
+                required:
+                - auth
+                - path
+                - server
+                properties:
+                  auth:
+                    description: Auth configures how cert-manager authenticates with
+                      the Vault server.
+                    type: object
+                    properties:
+                      appRole:
+                        description: AppRole authenticates with Vault using the App
+                          Role auth mechanism, with the role and secret stored in
+                          a Kubernetes Secret resource.
+                        type: object
+                        required:
+                        - path
+                        - roleId
+                        - secretRef
+                        properties:
+                          path:
+                            description: 'Path where the App Role authentication backend
+                              is mounted in Vault, e.g: "approle"'
+                            type: string
+                          roleId:
+                            description: RoleID configured in the App Role authentication
+                              backend when setting up the authentication backend in
+                              Vault.
+                            type: string
+                          secretRef:
+                            description: Reference to a key in a Secret that contains
+                              the App Role secret used to authenticate with Vault.
+                              The `key` field must be specified and denotes which
+                              entry within the Secret resource is used as the app
+                              role secret.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                      kubernetes:
+                        description: Kubernetes authenticates with Vault by passing
+                          the ServiceAccount token stored in the named Secret resource
+                          to the Vault server.
+                        type: object
+                        required:
+                        - role
+                        - secretRef
+                        properties:
+                          mountPath:
+                            description: The Vault mountPath here is the mount path
+                              to use when authenticating with Vault. For example,
+                              setting a value to `/v1/auth/foo`, will use the path
+                              `/v1/auth/foo/login` to authenticate with Vault. If
+                              unspecified, the default value "/v1/auth/kubernetes"
+                              will be used.
+                            type: string
+                          role:
+                            description: A required field containing the Vault Role
+                              to assume. A Role binds a Kubernetes ServiceAccount
+                              with a set of Vault policies.
+                            type: string
+                          secretRef:
+                            description: The required Secret field containing a Kubernetes
+                              ServiceAccount JWT used for authenticating with Vault.
+                              Use of 'ambient credentials' is not supported.
+                            type: object
+                            required:
+                            - name
+                            properties:
+                              key:
+                                description: The key of the entry in the Secret resource's
+                                  `data` field to be used. Some instances of this
+                                  field may be defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: 'Name of the resource being referred
+                                  to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                      tokenSecretRef:
+                        description: TokenSecretRef authenticates with Vault by presenting
+                          a token.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the entry in the Secret resource's
+                              `data` field to be used. Some instances of this field
+                              may be defaulted, in others it may be required.
+                            type: string
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                  caBundle:
+                    description: PEM encoded CA bundle used to validate Vault server
+                      certificate. Only used if the Server URL is using HTTPS protocol.
+                      This parameter is ignored for plain HTTP protocol connection.
+                      If not set the system root certificates are used to validate
+                      the TLS connection.
+                    type: string
+                    format: byte
+                  path:
+                    description: 'Path is the mount path of the Vault PKI backend''s
+                      `sign` endpoint, e.g: "my_pki_mount/sign/my-role-name".'
+                    type: string
+                  server:
+                    description: 'Server is the connection address for the Vault server,
+                      e.g: "https://vault.example.com:8200".'
+                    type: string
+              venafi:
+                description: Venafi configures this issuer to sign certificates using
+                  a Venafi TPP or Venafi Cloud policy zone.
+                type: object
+                required:
+                - zone
+                properties:
+                  cloud:
+                    description: Cloud specifies the Venafi cloud configuration settings.
+                      Only one of TPP or Cloud may be specified.
+                    type: object
+                    required:
+                    - apiTokenSecretRef
+                    properties:
+                      apiTokenSecretRef:
+                        description: APITokenSecretRef is a secret key selector for
+                          the Venafi Cloud API token.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          key:
+                            description: The key of the entry in the Secret resource's
+                              `data` field to be used. Some instances of this field
+                              may be defaulted, in others it may be required.
+                            type: string
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                      url:
+                        description: URL is the base URL for Venafi Cloud. Defaults
+                          to "https://api.venafi.cloud/v1".
+                        type: string
+                  tpp:
+                    description: TPP specifies Trust Protection Platform configuration
+                      settings. Only one of TPP or Cloud may be specified.
+                    type: object
+                    required:
+                    - credentialsRef
+                    - url
+                    properties:
+                      caBundle:
+                        description: CABundle is a PEM encoded TLS certificate to
+                          use to verify connections to the TPP instance. If specified,
+                          system roots will not be used and the issuing CA for the
+                          TPP instance must be verifiable using the provided root.
+                          If not specified, the connection will be verified using
+                          the cert-manager system root certificates.
+                        type: string
+                        format: byte
+                      credentialsRef:
+                        description: CredentialsRef is a reference to a Secret containing
+                          the username and password for the TPP server. The secret
+                          must contain two keys, 'username' and 'password'.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          name:
+                            description: 'Name of the resource being referred to.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                      url:
+                        description: 'URL is the base URL for the vedsdk endpoint
+                          of the Venafi TPP instance, for example: "https://tpp.example.com/vedsdk".'
+                        type: string
+                  zone:
+                    description: Zone is the Venafi Policy Zone to use for this issuer.
+                      All requests made to the Venafi platform will be restricted
+                      by the named zone policy. This field is required.
+                    type: string
+          status:
+            description: Status of the Issuer. This is set and managed automatically.
+            type: object
+            properties:
+              acme:
+                description: ACME specific status options. This field should only
+                  be set if the Issuer is configured to use an ACME server to issue
+                  certificates.
+                type: object
+                properties:
+                  lastRegisteredEmail:
+                    description: LastRegisteredEmail is the email associated with
+                      the latest registered ACME account, in order to track changes
+                      made to registered account associated with the  Issuer
+                    type: string
+                  uri:
+                    description: URI is the unique account identifier, which can also
+                      be used to retrieve account details from the CA
+                    type: string
+              conditions:
+                description: List of status conditions to indicate the status of a
+                  CertificateRequest. Known condition types are `Ready`.
+                type: array
+                items:
+                  description: IssuerCondition contains condition information for
+                    an Issuer.
+                  type: object
+                  required:
+                  - status
+                  - type
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the timestamp corresponding
+                        to the last status change of this condition.
+                      type: string
+                      format: date-time
+                    message:
+                      description: Message is a human readable description of the
+                        details of the last transition, complementing reason.
+                      type: string
+                    reason:
+                      description: Reason is a brief machine readable explanation
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of ('True', 'False',
+                        'Unknown').
+                      type: string
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                    type:
+                      description: Type of the condition, known values are ('Ready').
+                      type: string

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/crd-order.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/crd-order.yml.j2
@@ -68,7 +68,7 @@ spec:
   - name: v1alpha2
     served: true
     storage: true
-        "schema":
+    "schema":
       "openAPIV3Schema":
         description: Order is a type to represent an Order with an ACME server
         type: object

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/crd-order.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/crd-order.yml.j2
@@ -68,186 +68,562 @@ spec:
   - name: v1alpha2
     served: true
     storage: true
+        "schema":
+      "openAPIV3Schema":
+        description: Order is a type to represent an Order with an ACME server
+        type: object
+        required:
+        - metadata
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            required:
+            - csr
+            - dnsNames
+            - issuerRef
+            properties:
+              commonName:
+                description: CommonName is the common name as specified on the DER
+                  encoded CSR. If specified, this value must also be present in `dnsNames`.
+                  This field must match the corresponding field on the DER encoded
+                  CSR.
+                type: string
+              csr:
+                description: Certificate signing request bytes in DER encoding. This
+                  will be used when finalizing the order. This field must be set on
+                  the order.
+                type: string
+                format: byte
+              dnsNames:
+                description: DNSNames is a list of DNS names that should be included
+                  as part of the Order validation process. This field must match the
+                  corresponding field on the DER encoded CSR.
+                type: array
+                items:
+                  type: string
+              issuerRef:
+                description: IssuerRef references a properly configured ACME-type
+                  Issuer which should be used to create this Order. If the Issuer
+                  does not exist, processing will be retried. If the Issuer is not
+                  an 'ACME' Issuer, an error will be returned and the Order will be
+                  marked as failed.
+                type: object
+                required:
+                - name
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+          status:
+            type: object
+            properties:
+              authorizations:
+                description: Authorizations contains data returned from the ACME server
+                  on what authorizations must be completed in order to validate the
+                  DNS names specified on the Order.
+                type: array
+                items:
+                  description: ACMEAuthorization contains data returned from the ACME
+                    server on an authorization that must be completed in order validate
+                    a DNS name on an ACME Order resource.
+                  type: object
+                  required:
+                  - url
+                  properties:
+                    challenges:
+                      description: Challenges specifies the challenge types offered
+                        by the ACME server. One of these challenge types will be selected
+                        when validating the DNS name and an appropriate Challenge
+                        resource will be created to perform the ACME challenge process.
+                      type: array
+                      items:
+                        description: Challenge specifies a challenge offered by the
+                          ACME server for an Order. An appropriate Challenge resource
+                          can be created to perform the ACME challenge process.
+                        type: object
+                        required:
+                        - token
+                        - type
+                        - url
+                        properties:
+                          token:
+                            description: Token is the token that must be presented
+                              for this challenge. This is used to compute the 'key'
+                              that must also be presented.
+                            type: string
+                          type:
+                            description: Type is the type of challenge being offered,
+                              e.g. 'http-01', 'dns-01', 'tls-sni-01', etc. This is
+                              the raw value retrieved from the ACME server. Only 'http-01'
+                              and 'dns-01' are supported by cert-manager, other values
+                              will be ignored.
+                            type: string
+                          url:
+                            description: URL is the URL of this challenge. It can
+                              be used to retrieve additional metadata about the Challenge
+                              from the ACME server.
+                            type: string
+                    identifier:
+                      description: Identifier is the DNS name to be validated as part
+                        of this authorization
+                      type: string
+                    initialState:
+                      description: InitialState is the initial state of the ACME authorization
+                        when first fetched from the ACME server. If an Authorization
+                        is already 'valid', the Order controller will not create a
+                        Challenge resource for the authorization. This will occur
+                        when working with an ACME server that enables 'authz reuse'
+                        (such as Let's Encrypt's production endpoint). If not set
+                        and 'identifier' is set, the state is assumed to be pending
+                        and a Challenge will be created.
+                      type: string
+                      enum:
+                      - valid
+                      - ready
+                      - pending
+                      - processing
+                      - invalid
+                      - expired
+                      - errored
+                    url:
+                      description: URL is the URL of the Authorization that must be
+                        completed
+                      type: string
+                    wildcard:
+                      description: Wildcard will be true if this authorization is
+                        for a wildcard DNS name. If this is true, the identifier will
+                        be the *non-wildcard* version of the DNS name. For example,
+                        if '*.example.com' is the DNS name being validated, this field
+                        will be 'true' and the 'identifier' field will be 'example.com'.
+                      type: boolean
+              certificate:
+                description: Certificate is a copy of the PEM encoded certificate
+                  for this Order. This field will be populated after the order has
+                  been successfully finalized with the ACME server, and the order
+                  has transitioned to the 'valid' state.
+                type: string
+                format: byte
+              failureTime:
+                description: FailureTime stores the time that this order failed. This
+                  is used to influence garbage collection and back-off.
+                type: string
+                format: date-time
+              finalizeURL:
+                description: FinalizeURL of the Order. This is used to obtain certificates
+                  for this order once it has been completed.
+                type: string
+              reason:
+                description: Reason optionally provides more information about a why
+                  the order is in the current state.
+                type: string
+              state:
+                description: State contains the current state of this Order resource.
+                  States 'success' and 'expired' are 'final'
+                type: string
+                enum:
+                - valid
+                - ready
+                - pending
+                - processing
+                - invalid
+                - expired
+                - errored
+              url:
+                description: URL of the Order. This will initially be empty when the
+                  resource is first created. The Order controller will populate this
+                  field when the Order is first processed. This field will be immutable
+                  after it is initially set.
+                type: string
   - name: v1alpha3
     served: true
     storage: false
-  "validation":
-    "openAPIV3Schema":
-      description: Order is a type to represent an Order with an ACME server
-      type: object
-      required:
-      - metadata
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          type: object
-          required:
-          - csr
-          - issuerRef
-          properties:
-            commonName:
-              description: CommonName is the common name as specified on the DER encoded
-                CSR. If CommonName is not specified, the first DNSName specified will
-                be used as the CommonName. At least one of CommonName or a DNSNames
-                must be set. This field must match the corresponding field on the
-                DER encoded CSR.
-              type: string
-            csr:
-              description: Certificate signing request bytes in DER encoding. This
-                will be used when finalizing the order. This field must be set on
-                the order.
-              type: string
-              format: byte
-            dnsNames:
-              description: DNSNames is a list of DNS names that should be included
-                as part of the Order validation process. If CommonName is not specified,
-                the first DNSName specified will be used as the CommonName. At least
-                one of CommonName or a DNSNames must be set. This field must match
-                the corresponding field on the DER encoded CSR.
-              type: array
-              items:
+    "schema":
+      "openAPIV3Schema":
+        description: Order is a type to represent an Order with an ACME server
+        type: object
+        required:
+        - metadata
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            required:
+            - csr
+            - dnsNames
+            - issuerRef
+            properties:
+              commonName:
+                description: CommonName is the common name as specified on the DER
+                  encoded CSR. If specified, this value must also be present in `dnsNames`.
+                  This field must match the corresponding field on the DER encoded
+                  CSR.
                 type: string
-            issuerRef:
-              description: IssuerRef references a properly configured ACME-type Issuer
-                which should be used to create this Order. If the Issuer does not
-                exist, processing will be retried. If the Issuer is not an 'ACME'
-                Issuer, an error will be returned and the Order will be marked as
-                failed.
-              type: object
-              required:
-              - name
-              properties:
-                group:
+              csr:
+                description: Certificate signing request bytes in DER encoding. This
+                  will be used when finalizing the order. This field must be set on
+                  the order.
+                type: string
+                format: byte
+              dnsNames:
+                description: DNSNames is a list of DNS names that should be included
+                  as part of the Order validation process. This field must match the
+                  corresponding field on the DER encoded CSR.
+                type: array
+                items:
                   type: string
-                kind:
-                  type: string
-                name:
-                  type: string
-        status:
-          type: object
-          properties:
-            authorizations:
-              description: Authorizations contains data returned from the ACME server
-                on what authorizations must be completed in order to validate the
-                DNS names specified on the Order.
-              type: array
-              items:
-                description: ACMEAuthorization contains data returned from the ACME
-                  server on an authorization that must be completed in order validate
-                  a DNS name on an ACME Order resource.
+              issuerRef:
+                description: IssuerRef references a properly configured ACME-type
+                  Issuer which should be used to create this Order. If the Issuer
+                  does not exist, processing will be retried. If the Issuer is not
+                  an 'ACME' Issuer, an error will be returned and the Order will be
+                  marked as failed.
                 type: object
                 required:
-                - url
+                - name
                 properties:
-                  challenges:
-                    description: Challenges specifies the challenge types offered
-                      by the ACME server. One of these challenge types will be selected
-                      when validating the DNS name and an appropriate Challenge resource
-                      will be created to perform the ACME challenge process.
-                    type: array
-                    items:
-                      description: Challenge specifies a challenge offered by the
-                        ACME server for an Order. An appropriate Challenge resource
-                        can be created to perform the ACME challenge process.
-                      type: object
-                      required:
-                      - token
-                      - type
-                      - url
-                      properties:
-                        token:
-                          description: Token is the token that must be presented for
-                            this challenge. This is used to compute the 'key' that
-                            must also be presented.
-                          type: string
-                        type:
-                          description: Type is the type of challenge being offered,
-                            e.g. http-01, dns-01
-                          type: string
-                        url:
-                          description: URL is the URL of this challenge. It can be
-                            used to retrieve additional metadata about the Challenge
-                            from the ACME server.
-                          type: string
-                  identifier:
-                    description: Identifier is the DNS name to be validated as part
-                      of this authorization
+                  group:
+                    description: Group of the resource being referred to.
                     type: string
-                  initialState:
-                    description: InitialState is the initial state of the ACME authorization
-                      when first fetched from the ACME server. If an Authorization
-                      is already 'valid', the Order controller will not create a Challenge
-                      resource for the authorization. This will occur when working
-                      with an ACME server that enables 'authz reuse' (such as Let's
-                      Encrypt's production endpoint). If not set and 'identifier'
-                      is set, the state is assumed to be pending and a Challenge will
-                      be created.
+                  kind:
+                    description: Kind of the resource being referred to.
                     type: string
-                    enum:
-                    - valid
-                    - ready
-                    - pending
-                    - processing
-                    - invalid
-                    - expired
-                    - errored
-                  url:
-                    description: URL is the URL of the Authorization that must be
-                      completed
+                  name:
+                    description: Name of the resource being referred to.
                     type: string
-                  wildcard:
-                    description: Wildcard will be true if this authorization is for
-                      a wildcard DNS name. If this is true, the identifier will be
-                      the *non-wildcard* version of the DNS name. For example, if
-                      '*.example.com' is the DNS name being validated, this field
-                      will be 'true' and the 'identifier' field will be 'example.com'.
-                    type: boolean
-            certificate:
-              description: Certificate is a copy of the PEM encoded certificate for
-                this Order. This field will be populated after the order has been
-                successfully finalized with the ACME server, and the order has transitioned
-                to the 'valid' state.
-              type: string
-              format: byte
-            failureTime:
-              description: FailureTime stores the time that this order failed. This
-                is used to influence garbage collection and back-off.
-              type: string
-              format: date-time
-            finalizeURL:
-              description: FinalizeURL of the Order. This is used to obtain certificates
-                for this order once it has been completed.
-              type: string
-            reason:
-              description: Reason optionally provides more information about a why
-                the order is in the current state.
-              type: string
-            state:
-              description: State contains the current state of this Order resource.
-                States 'success' and 'expired' are 'final'
-              type: string
-              enum:
-              - valid
-              - ready
-              - pending
-              - processing
-              - invalid
-              - expired
-              - errored
-            url:
-              description: URL of the Order. This will initially be empty when the
-                resource is first created. The Order controller will populate this
-                field when the Order is first processed. This field will be immutable
-                after it is initially set.
-              type: string
+          status:
+            type: object
+            properties:
+              authorizations:
+                description: Authorizations contains data returned from the ACME server
+                  on what authorizations must be completed in order to validate the
+                  DNS names specified on the Order.
+                type: array
+                items:
+                  description: ACMEAuthorization contains data returned from the ACME
+                    server on an authorization that must be completed in order validate
+                    a DNS name on an ACME Order resource.
+                  type: object
+                  required:
+                  - url
+                  properties:
+                    challenges:
+                      description: Challenges specifies the challenge types offered
+                        by the ACME server. One of these challenge types will be selected
+                        when validating the DNS name and an appropriate Challenge
+                        resource will be created to perform the ACME challenge process.
+                      type: array
+                      items:
+                        description: Challenge specifies a challenge offered by the
+                          ACME server for an Order. An appropriate Challenge resource
+                          can be created to perform the ACME challenge process.
+                        type: object
+                        required:
+                        - token
+                        - type
+                        - url
+                        properties:
+                          token:
+                            description: Token is the token that must be presented
+                              for this challenge. This is used to compute the 'key'
+                              that must also be presented.
+                            type: string
+                          type:
+                            description: Type is the type of challenge being offered,
+                              e.g. 'http-01', 'dns-01', 'tls-sni-01', etc. This is
+                              the raw value retrieved from the ACME server. Only 'http-01'
+                              and 'dns-01' are supported by cert-manager, other values
+                              will be ignored.
+                            type: string
+                          url:
+                            description: URL is the URL of this challenge. It can
+                              be used to retrieve additional metadata about the Challenge
+                              from the ACME server.
+                            type: string
+                    identifier:
+                      description: Identifier is the DNS name to be validated as part
+                        of this authorization
+                      type: string
+                    initialState:
+                      description: InitialState is the initial state of the ACME authorization
+                        when first fetched from the ACME server. If an Authorization
+                        is already 'valid', the Order controller will not create a
+                        Challenge resource for the authorization. This will occur
+                        when working with an ACME server that enables 'authz reuse'
+                        (such as Let's Encrypt's production endpoint). If not set
+                        and 'identifier' is set, the state is assumed to be pending
+                        and a Challenge will be created.
+                      type: string
+                      enum:
+                      - valid
+                      - ready
+                      - pending
+                      - processing
+                      - invalid
+                      - expired
+                      - errored
+                    url:
+                      description: URL is the URL of the Authorization that must be
+                        completed
+                      type: string
+                    wildcard:
+                      description: Wildcard will be true if this authorization is
+                        for a wildcard DNS name. If this is true, the identifier will
+                        be the *non-wildcard* version of the DNS name. For example,
+                        if '*.example.com' is the DNS name being validated, this field
+                        will be 'true' and the 'identifier' field will be 'example.com'.
+                      type: boolean
+              certificate:
+                description: Certificate is a copy of the PEM encoded certificate
+                  for this Order. This field will be populated after the order has
+                  been successfully finalized with the ACME server, and the order
+                  has transitioned to the 'valid' state.
+                type: string
+                format: byte
+              failureTime:
+                description: FailureTime stores the time that this order failed. This
+                  is used to influence garbage collection and back-off.
+                type: string
+                format: date-time
+              finalizeURL:
+                description: FinalizeURL of the Order. This is used to obtain certificates
+                  for this order once it has been completed.
+                type: string
+              reason:
+                description: Reason optionally provides more information about a why
+                  the order is in the current state.
+                type: string
+              state:
+                description: State contains the current state of this Order resource.
+                  States 'success' and 'expired' are 'final'
+                type: string
+                enum:
+                - valid
+                - ready
+                - pending
+                - processing
+                - invalid
+                - expired
+                - errored
+              url:
+                description: URL of the Order. This will initially be empty when the
+                  resource is first created. The Order controller will populate this
+                  field when the Order is first processed. This field will be immutable
+                  after it is initially set.
+                type: string
+  - name: v1beta1
+    served: true
+    storage: false
+    "schema":
+      "openAPIV3Schema":
+        description: Order is a type to represent an Order with an ACME server
+        type: object
+        required:
+        - metadata
+        - spec
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            required:
+            - dnsNames
+            - issuerRef
+            - request
+            properties:
+              commonName:
+                description: CommonName is the common name as specified on the DER
+                  encoded CSR. If specified, this value must also be present in `dnsNames`.
+                  This field must match the corresponding field on the DER encoded
+                  CSR.
+                type: string
+              dnsNames:
+                description: DNSNames is a list of DNS names that should be included
+                  as part of the Order validation process. This field must match the
+                  corresponding field on the DER encoded CSR.
+                type: array
+                items:
+                  type: string
+              issuerRef:
+                description: IssuerRef references a properly configured ACME-type
+                  Issuer which should be used to create this Order. If the Issuer
+                  does not exist, processing will be retried. If the Issuer is not
+                  an 'ACME' Issuer, an error will be returned and the Order will be
+                  marked as failed.
+                type: object
+                required:
+                - name
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+              request:
+                description: Certificate signing request bytes in DER encoding. This
+                  will be used when finalizing the order. This field must be set on
+                  the order.
+                type: string
+                format: byte
+          status:
+            type: object
+            properties:
+              authorizations:
+                description: Authorizations contains data returned from the ACME server
+                  on what authorizations must be completed in order to validate the
+                  DNS names specified on the Order.
+                type: array
+                items:
+                  description: ACMEAuthorization contains data returned from the ACME
+                    server on an authorization that must be completed in order validate
+                    a DNS name on an ACME Order resource.
+                  type: object
+                  required:
+                  - url
+                  properties:
+                    challenges:
+                      description: Challenges specifies the challenge types offered
+                        by the ACME server. One of these challenge types will be selected
+                        when validating the DNS name and an appropriate Challenge
+                        resource will be created to perform the ACME challenge process.
+                      type: array
+                      items:
+                        description: Challenge specifies a challenge offered by the
+                          ACME server for an Order. An appropriate Challenge resource
+                          can be created to perform the ACME challenge process.
+                        type: object
+                        required:
+                        - token
+                        - type
+                        - url
+                        properties:
+                          token:
+                            description: Token is the token that must be presented
+                              for this challenge. This is used to compute the 'key'
+                              that must also be presented.
+                            type: string
+                          type:
+                            description: Type is the type of challenge being offered,
+                              e.g. 'http-01', 'dns-01', 'tls-sni-01', etc. This is
+                              the raw value retrieved from the ACME server. Only 'http-01'
+                              and 'dns-01' are supported by cert-manager, other values
+                              will be ignored.
+                            type: string
+                          url:
+                            description: URL is the URL of this challenge. It can
+                              be used to retrieve additional metadata about the Challenge
+                              from the ACME server.
+                            type: string
+                    identifier:
+                      description: Identifier is the DNS name to be validated as part
+                        of this authorization
+                      type: string
+                    initialState:
+                      description: InitialState is the initial state of the ACME authorization
+                        when first fetched from the ACME server. If an Authorization
+                        is already 'valid', the Order controller will not create a
+                        Challenge resource for the authorization. This will occur
+                        when working with an ACME server that enables 'authz reuse'
+                        (such as Let's Encrypt's production endpoint). If not set
+                        and 'identifier' is set, the state is assumed to be pending
+                        and a Challenge will be created.
+                      type: string
+                      enum:
+                      - valid
+                      - ready
+                      - pending
+                      - processing
+                      - invalid
+                      - expired
+                      - errored
+                    url:
+                      description: URL is the URL of the Authorization that must be
+                        completed
+                      type: string
+                    wildcard:
+                      description: Wildcard will be true if this authorization is
+                        for a wildcard DNS name. If this is true, the identifier will
+                        be the *non-wildcard* version of the DNS name. For example,
+                        if '*.example.com' is the DNS name being validated, this field
+                        will be 'true' and the 'identifier' field will be 'example.com'.
+                      type: boolean
+              certificate:
+                description: Certificate is a copy of the PEM encoded certificate
+                  for this Order. This field will be populated after the order has
+                  been successfully finalized with the ACME server, and the order
+                  has transitioned to the 'valid' state.
+                type: string
+                format: byte
+              failureTime:
+                description: FailureTime stores the time that this order failed. This
+                  is used to influence garbage collection and back-off.
+                type: string
+                format: date-time
+              finalizeURL:
+                description: FinalizeURL of the Order. This is used to obtain certificates
+                  for this order once it has been completed.
+                type: string
+              reason:
+                description: Reason optionally provides more information about a why
+                  the order is in the current state.
+                type: string
+              state:
+                description: State contains the current state of this Order resource.
+                  States 'success' and 'expired' are 'final'
+                type: string
+                enum:
+                - valid
+                - ready
+                - pending
+                - processing
+                - invalid
+                - expired
+                - errored
+              url:
+                description: URL of the Order. This will initially be empty when the
+                  resource is first created. The Order controller will populate this
+                  field when the Order is first processed. This field will be immutable
+                  after it is initially set.
+                type: string

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/deploy-cert-manager.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/deploy-cert-manager.yml.j2
@@ -148,7 +148,7 @@ spec:
           args:
           - --v=2
           - --secure-port=10250
-          - --dynamic-serving-ca-secret-namespace={{ cert_manager_namespace }}
+          - --dynamic-serving-ca-secret-namespace=$(POD_NAMESPACE)
           - --dynamic-serving-ca-secret-name=cert-manager-webhook-ca
           - --dynamic-serving-dns-names=cert-manager-webhook,cert-manager-webhook.cert-manager,cert-manager-webhook.cert-manager.svc
           ports:

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/webhook-cert-manager.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/webhook-cert-manager.yml.j2
@@ -33,8 +33,7 @@ webhooks:
           - "cert-manager.io"
           - "acme.cert-manager.io"
         apiVersions:
-          - v1alpha2
-          - v1alpha3
+          - "*"
         operations:
           - CREATE
           - UPDATE
@@ -79,8 +78,7 @@ webhooks:
           - "cert-manager.io"
           - "acme.cert-manager.io"
         apiVersions:
-          - v1alpha2
-          - v1alpha3
+          - "*"
         operations:
           - CREATE
           - UPDATE


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
cert manager updated to v0.16.1
please see release note

Which issue(s) this PR fixes:
None

Special notes for your reviewer:
https://github.com/jetstack/cert-manager/releases
https://quay.io/repository/jetstack/cert-manager-controller?tab=tags

Does this PR introduce a user-facing change?:
cert manager will update to v0.16.1
please see release note