### PR TITLE
Check node_ip is defined when removing etcd node

### DIFF
--- a/roles/remove-node/remove-etcd-node/tasks/main.yml
+++ b/roles/remove-node/remove-etcd-node/tasks/main.yml
@@ -17,6 +17,11 @@
   when:
     - inventory_hostname in groups['etcd']
 
+- name: Make sure node_ip is set
+  assert:
+    that: node_ip is defined and node_ip | length > 0
+    msg: "Etcd node ip is not set !"
+
 - name: Lookup etcd member id
   shell: "{{ bin_dir }}/etcdctl member list | grep {{ node_ip }} | cut -d, -f1"
   register: etcd_member_id


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In some case, if access_ip/ip is not, remove-etcd will try to find IP by querying k8s cluster.
If the etcd node is not in the cluster this won't work and node_ip will stay empty.
This PR aimed to at least fail in this case and not output everything as if the play finish with success

**Which issue(s) this PR fixes**:
Fixes #6588 (partially)

**Special notes for your reviewer**:
This is a partial fix, we (or I) need to reproduce the setup and find an implementation that works best

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
