### PR TITLE
Add comment clarifying network allocation and sizes

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -95,16 +95,20 @@ kube_service_addresses: 10.233.0.0/18
 kube_pods_subnet: 10.233.64.0/18
 
 # internal network node size allocation (optional). This is the size allocated
-# to each node on your network.  With these defaults you should have
-# room for 64 nodes with 254 pods per node.
-# Example: Up to 256 nodes, 100 pods per node (/16 network):
-#  - kube_service_addresses: 10.233.0.0/17
-#  - kube_pods_subnet: 10.233.128.0/17
+# to each node for pod IP address allocation. Note that the number of pods per node is
+# also limited by the kubelet_max_pods variable which defaults to 110.
+#
+# Example:
+# Up to 64 nodes and up to 254 or kubelet_max_pods (the lowest of the two) pods per node:
+#  - kube_pods_subnet: 10.233.64.0/18
+#  - kube_network_node_prefix: 24
+#  - kubelet_max_pods: 110
+#
+# Example:
+# Up to 128 nodes and up to 126 or kubelet_max_pods (the lowest of the two) pods per node:
+#  - kube_pods_subnet: 10.233.64.0/18
 #  - kube_network_node_prefix: 25
-# Example: Up to 4096 nodes, 100 pods per node (/12 network):
-#  - kube_service_addresses: 10.192.0.0/13
-#  - kube_pods_subnet: 10.200.0.0/13
-#  - kube_network_node_prefix: 25
+#  - kubelet_max_pods: 110
 kube_network_node_prefix: 24
 
 # The port the API Server will be listening on.

--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -96,7 +96,15 @@ kube_pods_subnet: 10.233.64.0/18
 
 # internal network node size allocation (optional). This is the size allocated
 # to each node on your network.  With these defaults you should have
-# room for 4096 nodes with 254 pods per node.
+# room for 64 nodes with 254 pods per node.
+# Example: Up to 256 nodes, 100 pods per node (/16 network):
+#  - kube_service_addresses: 10.233.0.0/17
+#  - kube_pods_subnet: 10.233.128.0/17
+#  - kube_network_node_prefix: 25
+# Example: Up to 4096 nodes, 100 pods per node (/12 network):
+#  - kube_service_addresses: 10.192.0.0/13
+#  - kube_pods_subnet: 10.200.0.0/13
+#  - kube_network_node_prefix: 25
 kube_network_node_prefix: 24
 
 # The port the API Server will be listening on.

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -174,16 +174,20 @@ kube_service_addresses: 10.233.0.0/18
 kube_pods_subnet: 10.233.64.0/18
 
 # internal network node size allocation (optional). This is the size allocated
-# to each node on your network.  With these defaults you should have
-# room for 64 nodes with 254 pods per node.
-# Example: Up to 256 nodes, 100 pods per node (/16 network):
-#  - kube_service_addresses: 10.233.0.0/17
-#  - kube_pods_subnet: 10.233.128.0/17
+# to each node for pod IP address allocation. Note that the number of pods per node is
+# also limited by the kubelet_max_pods variable which defaults to 110.
+#
+# Example:
+# Up to 64 nodes and up to 254 or kubelet_max_pods (the lowest of the two) pods per node:
+#  - kube_pods_subnet: 10.233.64.0/18
+#  - kube_network_node_prefix: 24
+#  - kubelet_max_pods: 110
+#
+# Example:
+# Up to 128 nodes and up to 126 or kubelet_max_pods (the lowest of the two) pods per node:
+#  - kube_pods_subnet: 10.233.64.0/18
 #  - kube_network_node_prefix: 25
-# Example: Up to 4096 nodes, 100 pods per node (/12 network):
-#  - kube_service_addresses: 10.192.0.0/13
-#  - kube_pods_subnet: 10.200.0.0/13
-#  - kube_network_node_prefix: 25
+#  - kubelet_max_pods: 110
 kube_network_node_prefix: 24
 
 # The virtual cluster IP, real host IPs and ports the API Server will be


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
/kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
In the `inventory/sample/groups_vars/k8s-cluster/k8s-cluster.yml` there's a typo that may lead to confusion regarding the `kube_network_node_prefix` and how it relates to the `kube_pods_subnet`. This was fixed as seen here:

https://github.com/kubernetes-sigs/kubespray/blob/240d4193ae0474ae2a24e8938dcf96a73b4333f4/roles/kubespray-defaults/defaults/main.yaml#L100-L110

This PR adds the comment from `defaults/main.yml` to the sample `k8s-cluster.yml` file.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
