### PR TITLE
Declare port 10254 in nginx ingress pod template

### DIFF
--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
@@ -7,6 +7,7 @@ ingress_nginx_nodeselector:
 ingress_nginx_tolerations: []
 ingress_nginx_insecure_port: 80
 ingress_nginx_secure_port: 443
+ingress_nginx_metrics_port: 10254
 ingress_nginx_configmap: {}
 ingress_nginx_configmap_tcp_services: {}
 ingress_nginx_configmap_udp_services: {}

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
@@ -84,6 +84,11 @@ spec:
             - name: https
               containerPort: 443
               hostPort: {{ ingress_nginx_secure_port }}
+            - name: metrics
+              containerPort: 10254
+{% if not ingress_nginx_host_network %}
+              hostPort: {{ ingress_nginx_metrics_port }}
+{% endif %}
           livenessProbe:
             failureThreshold: 3
             httpGet:


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:

This PR exposes port 10254 in the ingress-nginx-controller pod explicitly (it was previously exposed implicitly by the prometheus.io/scrape annotations).

It is required so that prometheus metrics on port 10254 can be scraped by prometheus instances managed by the prometheus-operator (as long as a `PodMonitor` object is also provided).

**Which issue(s) this PR fixes**:

Fixes #6608

**Special notes for your reviewer**:

The PR does not supply a `PodMonitor` object (that would be far-reaching since prometheus-operator is not deployed by kubespray), it only declares the port properly so that the metrics can be found in a prometheus-operator environment.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
