### PR TITLE
Allow configuration of nodelabels in local_volume_provisioner

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s-cluster/addons.yml
@@ -33,6 +33,10 @@ local_path_provisioner_enabled: false
 # Local volume provisioner deployment
 local_volume_provisioner_enabled: false
 # local_volume_provisioner_namespace: kube-system
+# local_volume_provisioner_nodelabels:
+#   - kubernetes.io/hostname
+#   - topology.kubernetes.io/region
+#   - topology.kubernetes.io/zone
 # local_volume_provisioner_storage_classes:
 #   local-storage:
 #     host_dir: /mnt/disks

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/defaults/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/defaults/main.yml
@@ -1,5 +1,10 @@
 ---
 local_volume_provisioner_namespace: "kube-system"
+# List of node labels to be copied to the PVs created by the provisioner
+local_volume_provisioner_nodelabels: []
+#   - kubernetes.io/hostname
+#   - topology.kubernetes.io/region
+#   - topology.kubernetes.io/zone
 # Levarages Ansibles string to Python datatype casting. Otherwise the dict_key isn't substituted
 # see https://github.com/ansible/ansible/issues/17324
 local_volume_provisioner_storage_classes: |

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-cm.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-cm.yml.j2
@@ -16,6 +16,12 @@ metadata:
   name: local-volume-provisioner
   namespace: {{ local_volume_provisioner_namespace }}
 data:
+{% if local_volume_provisioner_nodelabels | length > 0 %}
+  nodeLabelsForPV: |
+{% for nodelabel in local_volume_provisioner_nodelabels %}
+    - {{ nodelabel }}
+{% endfor %}
+{% endif %}
   storageClassMap: |
 {% for class_name, storage_class in local_volume_provisioner_storage_classes.items() %}
     {{ class_name }}:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR makes it possible to configure node labels that the local-static-provisioner should copy from the node the storage has been provisioned on to the PV.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
n/a

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Using the variable `local_volume_provisioner_nodelabels` it is now possible to configure node labels that the local-static-provisioner should copy from the node the storage has been provisioned on to the PV.
```
