### PR TITLE
Set ansible_python_interpreter to python3 on debian (fix error with mitogen)

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-debian.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-debian.yml
@@ -86,6 +86,10 @@
   when:
     - need_bootstrap.rc != 0
 
+- name: Set the ansible_python_interpreter fact
+  set_fact:
+    ansible_python_interpreter: "/usr/bin/python3"
+
 # Workaround for https://github.com/ansible/ansible/issues/25543
 - name: Install dbus for the hostname module
   package:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When mitogen is enable, ubuntu CI fails

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
