### PR TITLE
Update kube_version_min_required for 2.14 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Note: The list of validated [docker versions](https://kubernetes.io/docs/setup/p
 
 ## Requirements
 
-- **Minimum required version of Kubernetes is v1.16**
+- **Minimum required version of Kubernetes is v1.17**
 - **Ansible v2.9+, Jinja 2.11+ and python-netaddr is installed on the machine that will run Ansible commands**
 - The target servers must have **access to the Internet** in order to pull docker images. Otherwise, additional configuration is required (See [Offline Environment](docs/offline-environment.md))
 - The target servers are configured to allow **IPv4 forwarding**.

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -18,7 +18,7 @@ disable_swap: true
 kube_version: v1.18.8
 
 ## The minimum version working
-kube_version_min_required: v1.16.0
+kube_version_min_required: v1.17.0
 
 # use HyperKube image to control plane containers
 kubeadm_use_hyperkube_image: False


### PR DESCRIPTION
As per RELEASE.md kube_version_min_required should be `n-1` for 2.14 release