### PR TITLE
Use v2.14.0 as base image for CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ stages:
   - deploy-special
 
 variables:
-  KUBESPRAY_VERSION: v2.13.3
+  KUBESPRAY_VERSION: v2.14.0
   FAILFASTCI_NAMESPACE: 'kargo-ci'
   GITLAB_REPOSITORY: 'kargo-ci/kubernetes-sigs-kubespray'
   ANSIBLE_FORCE_COLOR: "true"


### PR DESCRIPTION
As per RELEASE.md KUBESPRA_VERSION needs to be updated to v2.14.0.


Marking this as DRAFT/WIP until v2.14.0 is released/finalized.