### PR TITLE
Add iptables_backend to weave options

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/k8s-net-weave.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-net-weave.yml
@@ -53,6 +53,9 @@
 # only with Weave IPAM (default).
 # weave_no_masq_local: true
 
+# set to nft to use nftables backend for iptables (default is iptables)
+# weave_iptables_backend: iptables
+
 # Extra variables that passing to launch.sh, useful for enabling seed mode, see
 # https://www.weave.works/docs/net/latest/tasks/ipam/ipam/
 # weave_extra_args: ~

--- a/roles/network_plugin/weave/defaults/main.yml
+++ b/roles/network_plugin/weave/defaults/main.yml
@@ -53,6 +53,9 @@ weave_mtu: 1376
 # only with Weave IPAM (default).
 weave_no_masq_local: true
 
+# set to nft to use nftables backend for iptables (default is iptables)
+weave_iptables_backend: ~
+
 # Extra variables that passing to launch.sh, useful for enabling seed mode, see
 # https://www.weave.works/docs/net/latest/tasks/ipam/ipam/
 weave_extra_args: ~

--- a/roles/network_plugin/weave/templates/weave-net.yml.j2
+++ b/roles/network_plugin/weave/templates/weave-net.yml.j2
@@ -164,6 +164,10 @@ items:
                 - name: WEAVE_STATUS_ADDR
                   value: "{{ weave_status_addr }}"
 {% endif %}
+{% if weave_iptables_backend %}
+                - name: IPTABLES_BACKEND
+                  value: "{{ weave_iptables_backend }}"
+{% endif %}
                 - name: WEAVE_MTU
                   value: "{{ weave_mtu | int }}"
                 - name: NO_MASQ_LOCAL


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add weave options IPTABLES_BACKEND (from [weave documentation](https://www.weave.works/docs/net/latest/kubernetes/kube-addon/)) as a configurable options

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
[Weave] Add configurable option IPTABLES_BACKEND 
```
