### PR TITLE
Allowing resource management of metrics-server container.  

### DIFF
--- a/roles/kubernetes-apps/metrics_server/defaults/main.yml
+++ b/roles/kubernetes-apps/metrics_server/defaults/main.yml
@@ -6,6 +6,10 @@ metrics_server_cpu: 40m
 metrics_server_memory: 35Mi
 metrics_server_memory_per_node: 4Mi
 metrics_server_min_cluster_size: 5
+metrics_server_limits_cpu: 43m
+metrics_server_limits_memory: 55Mi
+metrics_server_requests_cpu: 43m
+metrics_server_requests_memory: 55Mi
 addon_resizer_limits_cpu: 100m
 addon_resizer_limits_memory: 300Mi
 addon_resizer_requests_cpu: 5m

--- a/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
@@ -73,6 +73,13 @@ spec:
           runAsGroup: 10001
           runAsNonRoot: true
           runAsUser: 10001
+        resources:
+          limits:
+            cpu: {{ metrics_server_limits_cpu }}
+            memory: {{ metrics_server_limits_memory }}
+          requests:
+            cpu: {{ metrics_server_requests_cpu }}
+            memory: {{ metrics_server_requests_memory }}
       - name: metrics-server-nanny
         image: {{ addon_resizer_image_repo }}:{{ addon_resizer_image_tag }}
         imagePullPolicy: {{ k8s_image_pull_policy }}


### PR DESCRIPTION
Per issue #6648
Will allow fine-tuning of resource allocation and solving throttling issues.  Setting defaults as per the current request & limit allocation: cpu: 43m, memory 55Mi for both limits & requests.

**What type of PR is this?**
> /kind feature

**Which issue(s) this PR fixes**:
#6648

**Does this PR introduce a user-facing change?**:
No

```release-note
Allow resource management of metrics-server container
```