### PR TITLE
Update CoreDNS to 1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [cephfs-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.0-k8s1.11
   - [rbd-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.1-k8s1.11
   - [cert-manager](https://github.com/jetstack/cert-manager) v0.16.1
-  - [coredns](https://github.com/coredns/coredns) v1.6.7
+  - [coredns](https://github.com/coredns/coredns) v1.7.0
   - [ingress-nginx](https://github.com/kubernetes/ingress-nginx) v0.35.0
 
 Note: The list of validated [docker versions](https://kubernetes.io/docs/setup/production-environment/container-runtimes/#docker) is 1.13.1, 17.03, 17.06, 17.09, 18.06, 18.09 and 19.03. The recommended docker version is 19.03. The kubelet might break on docker's non-standard version numbering (it no longer uses semantic versioning). To ensure auto-updates don't break your cluster look into e.g. yum versionlock plugin or apt pin).

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -423,7 +423,7 @@ haproxy_image_tag: 2.1
 
 # Coredns version should be supported by corefile-migration (or at least work with)
 # bundle with kubeadm; if not 'basic' upgrade can sometimes fail
-coredns_version: "1.6.7"
+coredns_version: "1.7.0"
 coredns_image_repo: "{{ docker_image_repo }}/coredns/coredns"
 coredns_image_tag: "{{ coredns_version }}"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
As per 1.19 [dependencies](https://github.com/kubernetes/kubernetes/blob/88e3c95d7c46431e0842e0fdc2cb99279c038515/build/dependencies.yaml#L51) CoreDNS should now be updated to 1.7.0

**Which issue(s) this PR fixes**:
Link to #6654

**Special notes for your reviewer**:
This PR should not be merged until #6654 is in master

**Does this PR introduce a user-facing change?**:
```release-note
Update CoreDNS to 1.7.0
```
