### PR TITLE
Update various dependencies following 1.19 release

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -77,7 +77,7 @@ flannel_version: "v0.12.0"
 cni_version: "v0.8.7"
 
 weave_version: 2.7.0
-pod_infra_version: "3.2"
+pod_infra_version: "3.3"
 contiv_version: 1.2.1
 cilium_version: "v1.8.3"
 kube_ovn_version: "v1.3.0"
@@ -419,8 +419,8 @@ nodelocaldns_version: "1.15.13"
 nodelocaldns_image_repo: "{{ kube_image_repo }}/k8s-dns-node-cache"
 nodelocaldns_image_tag: "{{ nodelocaldns_version }}"
 
-dnsautoscaler_version: 1.8.1
-dnsautoscaler_image_repo: "{{ kube_image_repo }}/cluster-proportional-autoscaler-{{ image_arch }}"
+dnsautoscaler_version: 1.8.3
+dnsautoscaler_image_repo: "{{ kube_image_repo }}/cpa/cluster-proportional-autoscaler-{{ image_arch }}"
 dnsautoscaler_image_tag: "{{ dnsautoscaler_version }}"
 test_image_repo: "{{ docker_image_repo }}/library/busybox"
 test_image_tag: latest
@@ -446,13 +446,13 @@ cephfs_provisioner_image_tag: "v2.1.0-k8s1.11"
 rbd_provisioner_image_repo: "{{ quay_image_repo }}/external_storage/rbd-provisioner"
 rbd_provisioner_image_tag: "v2.1.1-k8s1.11"
 local_path_provisioner_image_repo: "{{ docker_image_repo }}/rancher/local-path-provisioner"
-local_path_provisioner_image_tag: "v0.0.14"
+local_path_provisioner_image_tag: "v0.0.17"
 ingress_nginx_controller_image_repo: "{{ kube_image_repo }}/ingress-nginx/controller"
 ingress_nginx_controller_image_tag: "v0.35.0"
 ingress_ambassador_image_repo: "{{ quay_image_repo }}/datawire/ambassador-operator"
-ingress_ambassador_image_tag: "v1.2.8"
+ingress_ambassador_image_tag: "v1.2.9"
 alb_ingress_image_repo: "{{ docker_image_repo }}/amazon/aws-alb-ingress-controller"
-alb_ingress_image_tag: "v1.1.8"
+alb_ingress_image_tag: "v1.1.9"
 cert_manager_version: "v0.16.1"
 cert_manager_controller_image_repo: "{{ quay_image_repo }}/jetstack/cert-manager-controller"
 cert_manager_controller_image_tag: "{{ cert_manager_version }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Update bunch of dependencies
- Pause from 3.2 to 3.3
- dnsautoscaler from 1.8.1 to 1.8.3
- local-path-provisioner from 0.0.15 to 0.0.17
- ingress_ambassador from 1.2.8 to 1.2.9
- alb_ingress from 1.1.8 to 1.1.9

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Mainly to update pause for 1.19

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
