### PR TITLE
Update third party librairies and tools

### DIFF
--- a/.gitlab-ci/lint.yml
+++ b/.gitlab-ci/lint.yml
@@ -14,7 +14,7 @@ vagrant-validate:
   stage: unit-tests
   tags: [light]
   variables:
-    VAGRANT_VERSION: 2.2.4
+    VAGRANT_VERSION: 2.2.10
   script:
     - ./tests/scripts/vagrant-validate.sh
   except: ['triggers', 'master']

--- a/.gitlab-ci/shellcheck.yml
+++ b/.gitlab-ci/shellcheck.yml
@@ -4,7 +4,7 @@ shellcheck:
   stage: unit-tests
   tags: [light]
   variables:
-    SHELLCHECK_VERSION: v0.6.0
+    SHELLCHECK_VERSION: v0.7.1
   before_script:
     - ./tests/scripts/rebase.sh
     - curl --silent --location "https://github.com/koalaman/shellcheck/releases/download/"${SHELLCHECK_VERSION}"/shellcheck-"${SHELLCHECK_VERSION}".linux.x86_64.tar.xz" | tar -xJv

--- a/.gitlab-ci/terraform.yml
+++ b/.gitlab-ci/terraform.yml
@@ -56,28 +56,28 @@
 tf-validate-openstack:
   extends: .terraform_validate
   variables:
-    TF_VERSION: 0.12.24
+    TF_VERSION: 0.12.29
     PROVIDER: openstack
     CLUSTER: $CI_COMMIT_REF_NAME
 
 tf-validate-packet:
   extends: .terraform_validate
   variables:
-    TF_VERSION: 0.12.24
+    TF_VERSION: 0.12.29
     PROVIDER: packet
     CLUSTER: $CI_COMMIT_REF_NAME
 
 tf-validate-aws:
   extends: .terraform_validate
   variables:
-    TF_VERSION: 0.12.24
+    TF_VERSION: 0.12.29
     PROVIDER: aws
     CLUSTER: $CI_COMMIT_REF_NAME
 
 # tf-packet-ubuntu16-default:
 #   extends: .terraform_apply
 #   variables:
-#     TF_VERSION: 0.12.24
+#     TF_VERSION: 0.12.29
 #     PROVIDER: packet
 #     CLUSTER: $CI_COMMIT_REF_NAME
 #     TF_VAR_number_of_k8s_masters: "1"
@@ -91,7 +91,7 @@ tf-validate-aws:
 # tf-packet-ubuntu18-default:
 #   extends: .terraform_apply
 #   variables:
-#     TF_VERSION: 0.12.24
+#     TF_VERSION: 0.12.29
 #     PROVIDER: packet
 #     CLUSTER: $CI_COMMIT_REF_NAME
 #     TF_VAR_number_of_k8s_masters: "1"
@@ -148,7 +148,7 @@ tf-elastx_ubuntu18-calico:
   when: on_success
   variables:
     <<: *elastx_variables
-    TF_VERSION: 0.12.24
+    TF_VERSION: 0.12.29
     PROVIDER: openstack
     CLUSTER: $CI_COMMIT_REF_NAME
     ANSIBLE_TIMEOUT: "60"
@@ -193,7 +193,7 @@ tf-ovh_ubuntu18-calico:
   environment: ovh
   variables:
     <<: *ovh_variables
-    TF_VERSION: 0.12.24
+    TF_VERSION: 0.12.29
     PROVIDER: openstack
     CLUSTER: $CI_COMMIT_REF_NAME
     ANSIBLE_TIMEOUT: "60"

--- a/docs/packet.md
+++ b/docs/packet.md
@@ -40,7 +40,7 @@ Grab the latest version of Terraform and install it.
 ```bash
 echo "https://releases.hashicorp.com/terraform/$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r -M '.current_version')/terraform_$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r -M '.current_version')_linux_amd64.zip"
 sudo yum install unzip
-sudo unzip terraform_0.12.24_linux_amd64.zip -d /usr/local/bin/
+sudo unzip terraform_0.12.29_linux_amd64.zip -d /usr/local/bin/
 ```
 
 ## Download Kubespray

--- a/tests/files/packet_debian10-containerd.yml
+++ b/tests/files/packet_debian10-containerd.yml
@@ -10,7 +10,6 @@ deploy_netchecker: true
 dns_min_replicas: 1
 
 helm_enabled: true
-helm_version: v3.1.0
 
 # https://gitlab.com/miouge/kubespray-ci/-/blob/a4fd5ed6857807f1c353cb60848aedebaf7d2c94/manifests/http-proxy.yml#L42
 http_proxy: http://172.30.30.30:8888

--- a/tests/scripts/vagrant-validate.sh
+++ b/tests/scripts/vagrant-validate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -euxo pipefail
 
-curl -sL "https://releases.hashicorp.com/vagrant/2.2.4/vagrant_${VAGRANT_VERSION}_x86_64.deb" -o "/tmp/vagrant_${VAGRANT_VERSION}_x86_64.deb"
+curl -sL "https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_x86_64.deb" -o "/tmp/vagrant_${VAGRANT_VERSION}_x86_64.deb"
 dpkg -i "/tmp/vagrant_${VAGRANT_VERSION}_x86_64.deb"
 vagrant validate --ignore-provider

--- a/tests/testcases/100_check-k8s-conformance.yml
+++ b/tests/testcases/100_check-k8s-conformance.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: kube-master[0]
   vars:
-    sonobuoy_version: 0.18.4
+    sonobuoy_version: 0.19.0
     sonobuoy_arch: amd64
     sonobuoy_parallel: 30
     sonobuoy_path: /usr/local/bin/sonobuoy


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Update tools and libs
- Vagrant from 2.2.4 to 2.2.10
- Shellcheck from 0.6.0 to 0.7.1
- Terraform from 0.12.24 to 0.12.29
- Sonobuoy from 0.18.4 to 0.19.0

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
