### PR TITLE
Added ability to set calico vxlan vni and port. defaults to calico's …

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/k8s-net-calico.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-net-calico.yml
@@ -65,6 +65,10 @@
 # set VXLAN encapsulation mode: "Always", "CrossSubnet", "Never"
 # calico_vxlan_mode: 'Never'
 
+# set VXLAN port and VNI
+# calico_vxlan_vni: 4096
+# calico_vxlan_port: 4789
+
 # If you want to use non default IP_AUTODETECTION_METHOD for calico node set this option to one of:
 # * can-reach=DESTINATION
 # * interface=INTERFACE-REGEX

--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -29,6 +29,12 @@ calico_node_memory_requests: 64M
 calico_node_cpu_requests: 150m
 calico_felix_chaininsertmode: Insert
 
+# Virtual network ID to use for VXLAN traffic. A value of 0 means “use the kernel default”.
+calico_vxlan_vni: 4096
+
+# Port to use for VXLAN traffic. A value of 0 means “use the kernel default”.
+calico_vxlan_port: 4789
+
 # Enable Prometheus Metrics endpoint for felix
 calico_felix_prometheusmetricsenabled: false
 calico_felix_prometheusmetricsport: 9091

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -175,7 +175,7 @@ spec:
               value: "true"
 {% endif %}
 {% if calico_network_backend is defined and calico_network_backend == 'vxlan' %}
-            - name: FELIX_VXLANNVI
+            - name: FELIX_VXLANVNI
               value: "{{ calico_vxlan_vni }}"
             - name: FELIX_VXLANPORT
               value: "{{ calico_vxlan_port }}"

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -176,9 +176,9 @@ spec:
 {% endif %}
 {% if calico_network_backend is defined and calico_network_backend == 'vxlan' %}
             - name: FELIX_VXLANNVI
-              value: "{{ calico_vxlan_vni | default(4096) }}"
+              value: "{{ calico_vxlan_vni }}"
             - name: FELIX_VXLANPORT
-              value: "{{ calico_vxlan_port | default(4789) }}"
+              value: "{{ calico_vxlan_port }}"
 {% endif %}
             # Choose the backend to use.
             - name: CALICO_NETWORKING_BACKEND

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -174,6 +174,12 @@ spec:
             - name: WAIT_FOR_DATASTORE
               value: "true"
 {% endif %}
+{% if calico_network_backend == 'vxlan' %}
+            - name: FELIX_VXLANNVI
+              value: "{{ calico_vxlan_vni | default(4096) }}"
+            - name: FELIX_VXLANPORT
+              value: "{{ calico_vxlan_port | default(4789) }}"
+{% endif %}
             # Choose the backend to use.
             - name: CALICO_NETWORKING_BACKEND
               valueFrom:

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -174,7 +174,7 @@ spec:
             - name: WAIT_FOR_DATASTORE
               value: "true"
 {% endif %}
-{% if calico_network_backend == 'vxlan' %}
+{% if calico_network_backend is defined and calico_network_backend == 'vxlan' %}
             - name: FELIX_VXLANNVI
               value: "{{ calico_vxlan_vni | default(4096) }}"
             - name: FELIX_VXLANPORT


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**: In order to run Calico with VXLAN enabled and on non default ports and unique VNI

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6677

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: No
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
