### PR TITLE
Move from widehat.opensuse to download.opensuse for crio centos

### DIFF
--- a/roles/container-engine/cri-o/tasks/crio_repo.yml
+++ b/roles/container-engine/cri-o/tasks/crio_repo.yml
@@ -26,7 +26,7 @@
   yum_repository:
     name: devel_kubic_libcontainers_stable
     description: Stable Releases of Upstream github.com/containers packages (CentOS_$releasever)
-    baseurl: http://widehat.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_$releasever/
+    baseurl: http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_$releasever/
     gpgcheck: yes
     gpgkey: http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_$releasever/repodata/repomd.xml.key
   when: ansible_distribution in ["CentOS"]
@@ -35,9 +35,9 @@
   yum_repository:
     name: "devel_kubic_libcontainers_stable_cri-o_{{ crio_version }}"
     description: "CRI-O {{ crio_version }} (CentOS_$releasever)"
-    baseurl: "http://widehat.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/{{ crio_version }}/CentOS_$releasever/"
+    baseurl: "http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/{{ crio_version }}/CentOS_$releasever/"
     gpgcheck: yes
-    gpgkey: "http://widehat.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/{{ crio_version }}/CentOS_$releasever/repodata/repomd.xml.key"
+    gpgkey: "http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/{{ crio_version }}/CentOS_$releasever/repodata/repomd.xml.key"
   when: ansible_distribution in ["CentOS"]
 
 - name: Enable modular repos for CRI-O


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix cri-o issue with centos (following 1.19 release)

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Molecule error in recent builds:
```
failed: [centos7] (item=cri-o) => {"ansible_loop_var": "item", "attempts": 4, "changed": false, "item": "cri-o", "msg": "Failure talking to yum: failure: repodata/repomd.xml from devel_kubic_libcontainers_stable: [Errno 256] No more mirrors to try.\nhttp://widehat.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_7/repodata/repomd.xml: [Errno 14] HTTP Error 404 - Not Found"}
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
