### PR TITLE
Ignore pause from kubeadm config images list

### DIFF
--- a/roles/download/tasks/prep_kubeadm_images.yml
+++ b/roles/download/tasks/prep_kubeadm_images.yml
@@ -31,7 +31,7 @@
     state: file
 
 - name: prep_kubeadm_images | Generate list of required images
-  shell: "set -o pipefail && {{ bin_dir }}/kubeadm config images list --config={{ kube_config_dir }}/kubeadm-images.yaml | grep -v coredns"
+  shell: "set -o pipefail && {{ bin_dir }}/kubeadm config images list --config={{ kube_config_dir }}/kubeadm-images.yaml | grep -Ev 'coredns|pause'"
   args:
     executable: /bin/bash
   register: kubeadm_images_raw


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As we specify (in CRI configs and kubelet parameters) and pull pause image from our configs files, we should ignore it from `kubeadm config list` (as we do with coredns)

**Which issue(s) this PR fixes**:
Fixes #6686

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
