### PR TITLE
remove_node node_ip check only if in etcd hostgroup

### DIFF
--- a/roles/remove-node/remove-etcd-node/tasks/main.yml
+++ b/roles/remove-node/remove-etcd-node/tasks/main.yml
@@ -21,6 +21,8 @@
   assert:
     that: node_ip is defined and node_ip | length > 0
     msg: "Etcd node ip is not set !"
+  when:
+    - inventory_hostname in groups['etcd']
 
 - name: Lookup etcd member id
   shell: "{{ bin_dir }}/etcdctl member list | grep {{ node_ip }} | cut -d, -f1"


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind bug

**What this PR does / why we need it**:
Removal of non-etcd nodes is not possible in 2.14.0 and master at this point.

**Which issue(s) this PR fixes**:
Fixes #6690

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```