### PR TITLE
Updated KataContainers version to 1.11.3

### DIFF
--- a/roles/container-engine/kata-containers/defaults/main.yml
+++ b/roles/container-engine/kata-containers/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-kata_containers_version: 1.11.1
+kata_containers_version: 1.11.3
 kata_containers_release_url: https://github.com/kata-containers/runtime/releases/download/{{ kata_containers_version }}/kata-static-{{ kata_containers_version }}-{{ ansible_architecture }}.tar.xz
 kata_containers_dir: /opt/kata
 kata_containers_config_dir: /etc/kata-containers


### PR DESCRIPTION
**What this PR does / why we need it**:

Update KataContainer version to latest stable.

**Special notes for your reviewer**:

This PR can be tested with Vagrant using KVM nested virutalization and Libvirt.

1. As first, configure KVM nested virtualization where Vagrant will be executed, following the KVM [documentantion](https://www.linux-kvm.org/page/Nested_Guests)

2. Set the following vagrant configuration (*vagrant/config.rb*):
```
$subnet = "10.0.20"
$download_force_cache = "False"
$download_run_once = "False"
$libvirt_nested = true
```

3. Set the following configuration in the inventory (*inventory/sample*):
```
etcd_deployment_type: host
container_manager: containerd
kata_containers_enabled: true
```

4. Run Vagrant
```bash
$ vagrant up
```

5. Once the cluster is installed, verify RuntimeClass has been created (run the command from inside the first instance):
```
root@k8s-1:~# kubectl get runtimeclasses
NAME        HANDLER     AGE
kata-qemu   kata-qemu   33s
```

6. Run a Pod with *kata-qemu* as RuntimeClass. Example template:

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: validate-kata-containers
spec:
  runtimeClassName: kata-qemu
  containers:
    - name: nginx
      image: nginx

```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
