### PR TITLE
Ignore error in check mode when disabling swap

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0010-swapoff.yml
+++ b/roles/kubernetes/preinstall/tasks/0010-swapoff.yml
@@ -16,3 +16,4 @@
 - name: Disable swap
   command: /sbin/swapoff -a
   when: swapon.stdout
+  ignore_errors: "{{ ansible_check_mode }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Swap role fail in check mode, ignoring error when it's the case

**Which issue(s) this PR fixes**:
Fixes #6642

**Special notes for your reviewer**:
Other solution might be to always run the task `check swap` in check mode, but I think this change is "cleaner"

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
