### PR TITLE
[2.14] properly generate extravolumes in kubeadmconfig for centos

### DIFF
--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -431,7 +431,7 @@ contiv_peer_with_uplink_leaf: false
 contiv_global_as: "65002"
 contiv_global_neighbor_as: "500"
 
-ssl_ca_dirs: >-
+ssl_ca_dirs: |-
   [
   {% if ansible_os_family in ['Flatcar Container Linux by Kinvolk'] -%}
   '/usr/share/ca-certificates',


### PR DESCRIPTION
kind bug


**What this PR does / why we need it**:
This is fix, for proper extravolumes generation for centos/rh in kubeadm config file.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->




**Does this PR introduce a user-facing change?**:
NONE
-->
```release-note

```
