### PR TITLE
Fix snapshot.storage apiVersion

### DIFF
--- a/roles/kubernetes-apps/snapshots/cinder-csi/templates/cinder-csi-snapshot-class.yml.j2
+++ b/roles/kubernetes-apps/snapshots/cinder-csi/templates/cinder-csi-snapshot-class.yml.j2
@@ -1,7 +1,7 @@
 {% for class in snapshot_classes %}
 ---
 kind: VolumeSnapshotClass
-apiVersion: snapshot.storage.k8s.io/v1
+apiVersion: snapshot.storage.k8s.io/v1beta1
 metadata:
   name: "{{ class.name }}"
   annotations:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`storage.k8s.io/v1beta1` was updated to v1, but `snapshot.storage.k8s.io` should not have been

**Which issue(s) this PR fixes**:
Fixes #6656

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
