### PR TITLE
Update docker packages to 19.03.13 + add docker f32

### DIFF
--- a/roles/container-engine/docker/defaults/main.yml
+++ b/roles/container-engine/docker/defaults/main.yml
@@ -30,9 +30,7 @@ yum_repo_dir: /etc/yum.repos.d
 docker_yum_conf: /etc/yum_docker.conf
 
 # Fedora docker-ce repo
-# TODO Remove the line below as soon as docker rpm are available for f32
-docker_fedora_release: "{{ '31' if (ansible_distribution_major_version | int) > 31 else ansible_distribution_major_version }}"
-docker_fedora_repo_base_url: 'https://download.docker.com/linux/fedora/{{ docker_fedora_release }}/$basearch/stable'
+docker_fedora_repo_base_url: 'https://download.docker.com/linux/fedora/{{ ansible_distribution_major_version }}/$basearch/stable'
 docker_fedora_repo_gpgkey: 'https://download.docker.com/linux/fedora/gpg'
 # CentOS/RedHat docker-ce repo
 docker_rh_repo_base_url: 'https://download.docker.com/linux/centos/7/$basearch/stable'

--- a/roles/container-engine/docker/vars/debian.yml
+++ b/roles/container-engine/docker/vars/debian.yml
@@ -12,14 +12,14 @@ docker_versioned_pkg:
   '18.03': docker-ce=18.03.1~ce-0~debian
   '18.06': docker-ce=18.06.2~ce~3-0~debian
   '18.09': docker-ce=5:18.09.9~3-0~debian-{{ ansible_distribution_release|lower }}
-  '19.03': docker-ce=5:19.03.12~3-0~debian-{{ ansible_distribution_release|lower }}
-  'stable': docker-ce=5:19.03.12~3-0~debian-{{ ansible_distribution_release|lower }}
-  'edge': docker-ce=5:19.03.12~3-0~debian-{{ ansible_distribution_release|lower }}
+  '19.03': docker-ce=5:19.03.13~3-0~debian-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce=5:19.03.13~3-0~debian-{{ ansible_distribution_release|lower }}
+  'edge': docker-ce=5:19.03.13~3-0~debian-{{ ansible_distribution_release|lower }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
   '18.09': docker-ce-cli=5:18.09.9~3-0~debian-{{ ansible_distribution_release|lower }}
-  '19.03': docker-ce-cli=5:19.03.12~3-0~debian-{{ ansible_distribution_release|lower }}
+  '19.03': docker-ce-cli=5:19.03.13~3-0~debian-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkg_mgr: apt

--- a/roles/container-engine/docker/vars/fedora.yml
+++ b/roles/container-engine/docker/vars/fedora.yml
@@ -1,24 +1,21 @@
 ---
 docker_kernel_min_version: '0'
 
-# TODO Remove the line below as soon as docker rpm are available for f32
-fedora_distribution_package: "{{ '31' if (ansible_distribution_major_version | int) > 31 else ansible_distribution_major_version }}"
-
 # https://docs.docker.com/install/linux/docker-ce/fedora/
 # https://download.docker.com/linux/fedora/<fedora-version>/x86_64/stable/Packages/
 docker_versioned_pkg:
   'latest': docker-ce
-  '18.03': docker-ce-18.03.1.ce-3.fc{{ fedora_distribution_package }}
-  '18.06': docker-ce-18.06.2.ce-3.fc{{ fedora_distribution_package }}
-  '18.09': docker-ce-18.09.7-3.fc{{ fedora_distribution_package }}
-  '19.03': docker-ce-19.03.12-3.fc{{ fedora_distribution_package }}
-  'stable': docker-ce-19.03.12-3.fc{{ fedora_distribution_package }}
-  'edge': docker-ce-19.03.12-3.fc{{ fedora_distribution_package }}
+  '18.03': docker-ce-18.03.1.ce-3.fc{{ ansible_distribution_major_version }}
+  '18.06': docker-ce-18.06.2.ce-3.fc{{ ansible_distribution_major_version }}
+  '18.09': docker-ce-18.09.7-3.fc{{ ansible_distribution_major_version }}
+  '19.03': docker-ce-19.03.13-3.fc{{ ansible_distribution_major_version }}
+  'stable': docker-ce-19.03.13-3.fc{{ ansible_distribution_major_version }}
+  'edge': docker-ce-19.03.13-3.fc{{ ansible_distribution_major_version }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
-  '18.09': docker-ce-cli-19.03.12-3.fc{{ fedora_distribution_package }}
-  '19.03': docker-ce-cli-19.03.12-3.fc{{ fedora_distribution_package }}
+  '18.09': docker-ce-cli-19.03.13-3.fc{{ ansible_distribution_major_version }}
+  '19.03': docker-ce-cli-19.03.13-3.fc{{ ansible_distribution_major_version }}
 
 docker_package_info:
   pkg_mgr: dnf

--- a/roles/container-engine/docker/vars/redhat.yml
+++ b/roles/container-engine/docker/vars/redhat.yml
@@ -2,7 +2,7 @@
 docker_kernel_min_version: '0'
 
 # https://docs.docker.com/engine/installation/linux/centos/#install-from-a-package
-# https://download.docker.com/linux/centos/7/x86_64/stable/Packages/
+# https://download.docker.com/linux/centos/<centos_version>>/x86_64/stable/Packages/
 # or do 'yum --showduplicates list docker-engine'
 docker_versioned_pkg:
   'latest': docker-ce
@@ -12,14 +12,14 @@ docker_versioned_pkg:
   '18.03': docker-ce-18.03.1.ce-1.el7.centos
   '18.06': docker-ce-18.06.3.ce-3.el7
   '18.09': docker-ce-18.09.9-3.el7
-  '19.03': docker-ce-19.03.12-3.el7
-  'stable': docker-ce-19.03.12-3.el7
-  'edge': docker-ce-19.03.12-3.el7
+  '19.03': docker-ce-19.03.13-3.el7
+  'stable': docker-ce-19.03.13-3.el7
+  'edge': docker-ce-19.03.13-3.el7
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
   '18.09': docker-ce-cli-18.09.9-3.el7
-  '19.03': docker-ce-cli-19.03.12-3.el7
+  '19.03': docker-ce-cli-19.03.13-3.el7
 
 docker_selinux_versioned_pkg:
   'latest': docker-ce-selinux-17.03.3.ce-1.el7

--- a/roles/container-engine/docker/vars/ubuntu-amd64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-amd64.yml
@@ -12,14 +12,14 @@ docker_versioned_pkg:
   '17.12': docker-ce=17.12.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
   '18.06': docker-ce=18.06.2~ce~3-0~ubuntu
   '18.09': docker-ce=5:18.09.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  '19.03': docker-ce=5:19.03.12~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'stable': docker-ce=5:19.03.12~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'edge': docker-ce=5:19.03.12~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '19.03': docker-ce=5:19.03.13~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce=5:19.03.13~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'edge': docker-ce=5:19.03.13~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
   '18.09': docker-ce-cli=5:18.09.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  '19.03': docker-ce-cli=5:19.03.12~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '19.03': docker-ce-cli=5:19.03.13~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkg_mgr: apt

--- a/roles/container-engine/docker/vars/ubuntu-arm64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-arm64.yml
@@ -8,14 +8,14 @@ docker_versioned_pkg:
   '17.12': docker-ce=17.12.1~ce-0~ubuntu-{{ ansible_distribution_release|lower }}
   '18.06': docker-ce=18.06.2~ce~3-0~ubuntu
   '18.09': docker-ce=5:18.09.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  '19.03': docker-ce=5:19.03.12~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'stable': docker-ce=5:19.03.12~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'edge': docker-ce=5:19.03.12~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '19.03': docker-ce=5:19.03.13~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce=5:19.03.13~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'edge': docker-ce=5:19.03.13~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
   '18.09': docker-ce-cli=5:18.09.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  '19.03': docker-ce-cli=5:19.03.12~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '19.03': docker-ce-cli=5:19.03.13~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkg_mgr: apt


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add new docker 19.03.13 version, and add Fedora 32 docker packages now available with this tag!

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Following [Docker 19.03.13 release](https://github.com/docker/docker-ce/releases/tag/v19.03.13)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
