### PR TITLE
Fix order of OS CI cleanup

### DIFF
--- a/scripts/openstack-cleanup/main.py
+++ b/scripts/openstack-cleanup/main.py
@@ -34,13 +34,13 @@ def main():
 
     conn = openstack.connect()
 
-    print('Security groups...')
-    map_if_old(conn.network.delete_security_group,
-               conn.network.security_groups())
-
     print('Servers...')
     map_if_old(conn.compute.delete_server,
                conn.compute.servers())
+
+    print('Security groups...')
+    map_if_old(conn.network.delete_security_group,
+               conn.network.security_groups())
 
     print('Subnets...')
     map_if_old(conn.network.delete_subnet,


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
It is not possible to delete an OpenStack security group is a Server/VM still uses it. Therefore we should delete servers before Servers/VMs