### PR TITLE
Remove vagrant.deb from docker image

### DIFF
--- a/test-infra/vagrant-docker/Dockerfile
+++ b/test-infra/vagrant-docker/Dockerfile
@@ -9,6 +9,7 @@ ENV VAGRANT_DEFAULT_PROVIDER=libvirt
 RUN apt-get update && apt-get install -y wget libvirt-dev openssh-client rsync git
 
 # Install Vagrant
-RUN wget https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_x86_64.deb
-RUN dpkg -i vagrant_${VAGRANT_VERSION}_x86_64.deb
-RUN vagrant plugin install vagrant-libvirt
+RUN wget https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_x86_64.deb && \
+ dpkg -i vagrant_${VAGRANT_VERSION}_x86_64.deb && \
+ rm vagrant_${VAGRANT_VERSION}_x86_64.deb && \
+ vagrant plugin install vagrant-libvirt


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
There is no need to keep the `.deb` package around. Also collapsing several `RUN` into a single layer.