### PR TITLE
Fix example value for etcd_quota_backend_bytes

### DIFF
--- a/inventory/sample/group_vars/etcd.yml
+++ b/inventory/sample/group_vars/etcd.yml
@@ -12,7 +12,7 @@
 ## Etcd has a default of 2G for its space quota. If you put a value in etcd_memory_limit which is less than
 ## etcd_quota_backend_bytes, you may encounter out of memory terminations of the etcd cluster. Please check
 ## etcd documentation for more information.
-# etcd_quota_backend_bytes: "2G"
+# etcd_quota_backend_bytes: "2147483648"
 
 ### ETCD: disable peer client cert authentication.
 # This affects ETCD_PEER_CLIENT_CERT_AUTH variable

--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -49,7 +49,7 @@ etcd_extra_vars: {}
 # Limit memory only if <4GB memory on host. 0=unlimited
 etcd_memory_limit: "{% if ansible_memtotal_mb < 4096 %}512M{% else %}0{% endif %}"
 
-# etcd_quota_backend_bytes: "2G"
+# etcd_quota_backend_bytes: "2147483648"
 
 # Uncomment to set CPU share for etcd
 # etcd_cpu_limit: 300m

--- a/roles/kubernetes/master/defaults/main/etcd.yml
+++ b/roles/kubernetes/master/defaults/main/etcd.yml
@@ -27,6 +27,6 @@ etcd_metrics: "basic"
 ## Note this is different from the etcd role with ETCD_ prfexi, caps, and underscores
 etcd_extra_vars: {}
 
-# etcd_quota_backend_bytes: "2G"
+# etcd_quota_backend_bytes: "2147483648"
 
 etcd_compaction_retention: "8"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
With given example etcd won't start, as the value should contains bytes and not shorthands
`etcdmain: invalid value "2G" for ETCD_QUOTA_BACKEND_BYTES: strconv.ParseInt: parsing "2G": invalid syntax`

**Which issue(s) this PR fixes**:
Fixes #4917

**Special notes for your reviewer**:
Cheery-pick of #6214
Credits to @faust64

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
