### PR TITLE
Add new variable allowing additionnal audit webhook server configuration

### DIFF
--- a/roles/kubernetes/master/defaults/main/main.yml
+++ b/roles/kubernetes/master/defaults/main/main.yml
@@ -72,6 +72,7 @@ kubernetes_audit_webhook: false
 # path to audit webhook config file
 audit_webhook_config_file: "{{ kube_config_dir }}/audit-policy/apiserver-audit-webhook-config.yaml"
 audit_webhook_server_url: "https://audit.app"
+audit_webhook_server_extra_args: {}
 audit_webhook_mode: batch
 audit_webhook_batch_max_size: 100
 audit_webhook_batch_max_wait: 1s

--- a/roles/kubernetes/master/templates/apiserver-audit-webhook-config.yaml.j2
+++ b/roles/kubernetes/master/templates/apiserver-audit-webhook-config.yaml.j2
@@ -3,6 +3,9 @@ kind: Config
 clusters:
 - cluster:
     server: {{ audit_webhook_server_url }}
+{% for key in audit_webhook_server_extra_args %}
+    {{ key }}: "{{ audit_webhook_server_extra_args[key] }}"
+{% endfor %}
   name: auditsink
 contexts:
 - context:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Allows to specify additionnal parameters in the apiserver webhook configuration file (kubeconfig-like file stored at `{{ kube_config_dir }}/audit-policy/apiserver-audit-webhook-config.yaml`)
Currently, the only configuration accessible for this file is the server url (through `audit_webhook_server_url`).
Other kubeconfig-like options can be required to configure the webhook correctly. In my case it were SSL options (`certificate-authority` or `insecure-skip-tls-verify`)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
