### PR TITLE
Remove duplicate audit-policy-file argument in kubeadm configuration

### DIFF
--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
@@ -162,16 +162,17 @@ apiServer:
     runtime-config: {{ kube_api_runtime_config | join(',') }}
 {% endif %}
     allow-privileged: "true"
+{% if kubernetes_audit or kubernetes_audit_webhook %}
+    audit-policy-file: {{ audit_policy_file }}
+{% endif %}
 {% if kubernetes_audit %}
     audit-log-path: "{{ audit_log_path }}"
     audit-log-maxage: "{{ audit_log_maxage }}"
     audit-log-maxbackup: "{{ audit_log_maxbackups }}"
     audit-log-maxsize: "{{ audit_log_maxsize }}"
-    audit-policy-file: {{ audit_policy_file }}
 {% endif %}
 {% if kubernetes_audit_webhook %}
     audit-webhook-config-file: {{ audit_webhook_config_file }}
-    audit-policy-file: {{ audit_policy_file }}
     audit-webhook-mode: {{ audit_webhook_mode }}
     audit-webhook-batch-max-size: "{{ audit_webhook_batch_max_size }}"
     audit-webhook-batch-max-wait: "{{ audit_webhook_batch_max_wait }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Removes duplicate definition of `audit-policy-file` field in kubeadm configuration.

**Which issue(s) this PR fixes**:
The following error happens when both `kubernetes_audit` and `kubernetes_audit_webhook` are true:
```
error unmarshaling configuration schema.GroupVersionKind{Group:\"kubeadm.k8s.io\", Version:\"v1beta2\", Kind:\"ClusterConfiguration\"}: error converting YAML to JSON: yaml: unmarshal errors:
  line 52: key \"audit-policy-file\" already set in map
```
In my understanding, there is not reason the line deleted in this PR should be there, activating the apiserver audit webhook should not influence the configuration of audit logs. 
The deleted line (174) is a duplicate of line 170 in the same file.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
