### PR TITLE
remove variable 'etcd_ionice'

### DIFF
--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -29,11 +29,6 @@ etcd_election_timeout: "5000"
 
 # etcd_snapshot_count: "10000"
 
-# Parameters for ionice
-# -c takes an integer between 0 and 3 or one of the strings none, realtime, best-effort or idle.
-# -n takes an integer between 0 (highest priority) and 7 (lowest priority)
-# etcd_ionice: "-c2 -n0"
-
 etcd_metrics: "basic"
 
 # Uncomment to set a separate port for etcd to expose metrics on

--- a/roles/etcd/templates/etcd.j2
+++ b/roles/etcd/templates/etcd.j2
@@ -17,8 +17,5 @@
 {% endif %}
   --name={{ etcd_member_name | default("etcd") }} \
   {{ etcd_image_repo }}:{{ etcd_image_tag }} \
-{% if etcd_ionice is defined %}
-  /bin/ionice {{ etcd_ionice }} \
-{% endif %}
   /usr/local/bin/etcd \
   "$@"

--- a/roles/kubernetes/master/defaults/main/etcd.yml
+++ b/roles/kubernetes/master/defaults/main/etcd.yml
@@ -13,11 +13,6 @@ etcd_election_timeout: "5000"
 
 # etcd_snapshot_count: "10000"
 
-# Parameters for ionice
-# -c takes an integer between 0 and 3 or one of the strings none, realtime, best-effort or idle.
-# -n takes an integer between 0 (highest priority) and 7 (lowest priority)
-# etcd_ionice: "-c2 -n0"
-
 etcd_metrics: "basic"
 
 ## A dictionary of extra environment variables to add to etcd.env, formatted like:


### PR DESCRIPTION
 because ionice removed from container image etcd:v3.4.x

**What type of PR is this?**
/kind bug
/kind cleanup

**What this PR does / why we need it**:

etcd v3.4.3 failed to launch? when etcd_ionice variable exists
