### PR TITLE
Allow period ci jobs to fail

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -19,6 +19,7 @@
   only:
     variables:
       - $PERIODIC_CI_ENABLED
+  allow_failure: true
   extends: .packet
 
 packet_ubuntu18-calico-aio:


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
With the new period CI at night, some jobs might fail and other CI stage aren't executed (even if the error is random, like ssh connection or anything else)

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Example, last night : https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/754400202

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
