### PR TITLE
/opt/cni/bin/install does not exist not before calico 3.16

### DIFF
--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -63,7 +63,7 @@ spec:
         # and CNI network config file on each node.
         - name: install-cni
           image: {{ calico_cni_image_repo }}:{{ calico_cni_image_tag }}
-          command: ["/opt/cni/bin/install"]
+          command: ["{{ (calico_version is version('v3.16.0', '<'))|ternary('/install-cni.sh','/opt/cni/bin/install') }}"]
           env:
             # Name of the CNI config file to create.
             - name: CNI_CONF_NAME


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
/opt/cni/bin/install does not exist in calico-cni image until 3.16.
This PR checks for calico_version for command setup in initContainer and reverts sideCar command to /install-cni.sh (as it applies to calico_version >=v3.3.0 and <v3.4.0)

**Which issue(s) this PR fixes**:
None reported afaik

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
None
