### PR TITLE
Fixes #6740: Allow disabling reverse DNS lookups in coredns

### DIFF
--- a/docs/dns-stack.md
+++ b/docs/dns-stack.md
@@ -82,7 +82,7 @@ dns_etchosts: |
   192.168.0.200 ingress.example.com
 ```
 
-### enable_coredns_reverse_dns_lookups 
+### enable_coredns_reverse_dns_lookups
 
 Whether reverse DNS lookups are enabled in the coredns config. Defaults to `true`.
 

--- a/docs/dns-stack.md
+++ b/docs/dns-stack.md
@@ -82,6 +82,10 @@ dns_etchosts: |
   192.168.0.200 ingress.example.com
 ```
 
+### enable_coredns_reverse_dns_lookups 
+
+Whether reverse DNS lookups are enabled in the coredns config. Defaults to `true`.
+
 ## DNS modes supported by Kubespray
 
 You can modify how Kubespray sets up DNS for your cluster with the variables ``dns_mode`` and ``resolvconf_mode``.

--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -7,6 +7,7 @@ dns_min_replicas: 2
 dns_nodes_per_replica: 16
 dns_cores_per_replica: 256
 dns_prevent_single_point_failure: "{{ 'true' if dns_min_replicas|int > 1 else 'false' }}"
+enable_coredns_reverse_dns_lookups: true
 coredns_ordinal_suffix: ""
 # dns_extra_tolerations: [{effect: NoSchedule, operator: "Exists"}]
 

--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -31,12 +31,14 @@ data:
             lameduck 5s
         }
         ready
-        kubernetes {{ dns_domain }} in-addr.arpa ip6.arpa {
+        kubernetes {{ dns_domain }} {% if enable_coredns_reverse_dns_lookups %}in-addr.arpa ip6.arpa {% endif %}{
           pods insecure
 {% if enable_coredns_k8s_endpoint_pod_names %}
           endpoint_pod_names
 {% endif %}
+{% if enable_coredns_reverse_dns_lookups %}
           fallthrough in-addr.arpa ip6.arpa
+{% endif %}
         }
         prometheus :9153
 {% if resolvconf_mode == 'host_resolvconf' and upstream_dns_servers is defined and upstream_dns_servers|length > 0 %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

Fixes #6740 : Disabling this can make a cluster more secure if the reverse dns lookup feature is not required. The default remains that the feature is enabled, such that there will be no immediate impact for current kubespray users.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6740 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added the option to disable reverse DNS lookups in coredns
```
