### PR TITLE
[2.14] Set ansible_python_interpreter to python3 on debian

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-debian.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-debian.yml
@@ -86,6 +86,10 @@
   when:
     - need_bootstrap.rc != 0
 
+- name: Set the ansible_python_interpreter fact
+  set_fact:
+    ansible_python_interpreter: "/usr/bin/python3"
+
 # Workaround for https://github.com/ansible/ansible/issues/25543
 - name: Install dbus for the hostname module
   package:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When mitogen is enable, ubuntu CI fails
This is a backport PR of https://github.com/kubernetes-sigs/kubespray/pull/6633 for v2.14.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
