### PR TITLE
Add centos8 docker repo

### DIFF
--- a/roles/container-engine/docker/defaults/main.yml
+++ b/roles/container-engine/docker/defaults/main.yml
@@ -33,7 +33,7 @@ docker_yum_conf: /etc/yum_docker.conf
 docker_fedora_repo_base_url: 'https://download.docker.com/linux/fedora/{{ ansible_distribution_major_version }}/$basearch/stable'
 docker_fedora_repo_gpgkey: 'https://download.docker.com/linux/fedora/gpg'
 # CentOS/RedHat docker-ce repo
-docker_rh_repo_base_url: 'https://download.docker.com/linux/centos/7/$basearch/stable'
+docker_rh_repo_base_url: 'https://download.docker.com/linux/centos/{{ ansible_distribution_major_version }}/$basearch/stable'
 docker_rh_repo_gpgkey: 'https://download.docker.com/linux/centos/gpg'
 # Ubuntu docker-ce repo
 docker_ubuntu_repo_base_url: "https://download.docker.com/linux/ubuntu"

--- a/roles/container-engine/docker/vars/redhat.yml
+++ b/roles/container-engine/docker/vars/redhat.yml
@@ -12,14 +12,14 @@ docker_versioned_pkg:
   '18.03': docker-ce-18.03.1.ce-1.el7.centos
   '18.06': docker-ce-18.06.3.ce-3.el7
   '18.09': docker-ce-18.09.9-3.el7
-  '19.03': docker-ce-19.03.13-3.el7
-  'stable': docker-ce-19.03.13-3.el7
-  'edge': docker-ce-19.03.13-3.el7
+  '19.03': docker-ce-19.03.13-3.el{{ ansible_distribution_major_version }}
+  'stable': docker-ce-19.03.13-3.el{{ ansible_distribution_major_version }}
+  'edge': docker-ce-19.03.13-3.el{{ ansible_distribution_major_version }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
   '18.09': docker-ce-cli-18.09.9-3.el7
-  '19.03': docker-ce-cli-19.03.13-3.el7
+  '19.03': docker-ce-cli-19.03.13-3.el{{ ansible_distribution_major_version }}
 
 docker_selinux_versioned_pkg:
   'latest': docker-ce-selinux-17.03.3.ce-1.el7


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Fedora32 and centos8 are now available through download.docker.com

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Next PR after #6712

**Does this PR introduce a user-facing change?**:
```release-note
None
```
