### PR TITLE
Update containerd to 1.3.7 - add fedora32/centos8 containerd packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [kubernetes](https://github.com/kubernetes/kubernetes) v1.19.2
   - [etcd](https://github.com/coreos/etcd) v3.4.3
   - [docker](https://www.docker.com/) v19.03 (see note)
-  - [containerd](https://containerd.io/) v1.2.13
+  - [containerd](https://containerd.io/) v1.3.7
   - [cri-o](http://cri-o.io/) v1.17 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)
 - Network Plugin
   - [cni-plugins](https://github.com/containernetworking/plugins) v0.8.6

--- a/roles/container-engine/containerd-common/defaults/main.yml
+++ b/roles/container-engine/containerd-common/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-containerd_version: '1.2.13'
+containerd_version: '1.3.7'
 containerd_package: 'containerd.io'

--- a/roles/container-engine/containerd-common/vars/debian.yml
+++ b/roles/container-engine/containerd-common/vars/debian.yml
@@ -7,5 +7,6 @@ containerd_versioned_pkg:
   '1.2.10': "{{ containerd_package }}=1.2.10-3"
   '1.2.12': "{{ containerd_package }}=1.2.12-1"
   '1.2.13': "{{ containerd_package }}=1.2.13-2"
-  'stable': "{{ containerd_package }}=1.2.13-2"
-  'edge': "{{ containerd_package }}=1.2.13-2"
+  '1.3.7': "{{ containerd_package }}=1.3.7-1"
+  'stable': "{{ containerd_package }}=1.3.7-1"
+  'edge': "{{ containerd_package }}=1.3.7-1"

--- a/roles/container-engine/containerd-common/vars/fedora.yml
+++ b/roles/container-engine/containerd-common/vars/fedora.yml
@@ -1,11 +1,9 @@
 ---
-# TODO Remove the line below as soon as containerd rpm are available for f32
-fedora_distribution_package: "{{ '31' if (ansible_distribution_major_version | int) > 31 else ansible_distribution_major_version }}"
-
 containerd_versioned_pkg:
   'latest': "{{ containerd_package }}"
-  '1.2.10': "{{ containerd_package }}-1.2.10-3.2.fc{{ fedora_distribution_package }}"
-  '1.2.12': "{{ containerd_package }}-1.2.12-3.1.fc{{ fedora_distribution_package }}"
-  '1.2.13': "{{ containerd_package }}-1.2.13-3.2.fc{{ fedora_distribution_package }}"
-  'stable': "{{ containerd_package }}-1.2.13-3.2.fc{{ fedora_distribution_package }}"
-  'edge': "{{ containerd_package }}-1.2.13-3.2.fc{{ fedora_distribution_package }}"
+  '1.2.10': "{{ containerd_package }}-1.2.10-3.2.fc{{ ansible_distribution_major_version }}"
+  '1.2.12': "{{ containerd_package }}-1.2.12-3.1.fc{{ ansible_distribution_major_version }}"
+  '1.2.13': "{{ containerd_package }}-1.2.13-3.2.fc{{ ansible_distribution_major_version }}"
+  '1.3.7': "{{ containerd_package }}-1.3.7-3.1.fc{{ ansible_distribution_major_version }}"
+  'stable': "{{ containerd_package }}-1.3.7-3.1.fc{{ ansible_distribution_major_version }}"
+  'edge': "{{ containerd_package }}-1.3.7-3.1.fc{{ ansible_distribution_major_version }}"

--- a/roles/container-engine/containerd-common/vars/redhat.yml
+++ b/roles/container-engine/containerd-common/vars/redhat.yml
@@ -7,5 +7,6 @@ containerd_versioned_pkg:
   '1.2.10': "{{ containerd_package }}-1.2.10-3.2.el7"
   '1.2.12': "{{ containerd_package }}-1.2.12-3.1.el7"
   '1.2.13': "{{ containerd_package }}-1.2.13-3.2.el7"
-  'stable': "{{ containerd_package }}-1.2.13-3.2.el7"
-  'edge': "{{ containerd_package }}-1.2.13-3.2.el7"
+  '1.3.7': "{{ containerd_package }}-1.3.7-3.1.el{{ ansible_distribution_major_version }}"
+  'stable': "{{ containerd_package }}-1.3.7-3.1.el{{ ansible_distribution_major_version }}"
+  'edge': "{{ containerd_package }}-1.3.7-3.1.el{{ ansible_distribution_major_version }}"

--- a/roles/container-engine/containerd-common/vars/ubuntu-amd64.yml
+++ b/roles/container-engine/containerd-common/vars/ubuntu-amd64.yml
@@ -7,5 +7,6 @@ containerd_versioned_pkg:
   '1.2.10': "{{ containerd_package }}=1.2.10-3"
   '1.2.12': "{{ containerd_package }}=1.2.12-1"
   '1.2.13': "{{ containerd_package }}=1.2.13-2"
-  'stable': "{{ containerd_package }}=1.2.13-2"
-  'edge': "{{ containerd_package }}=1.2.13-2"
+  '1.3.7': "{{ containerd_package }}=1.3.7-1"
+  'stable': "{{ containerd_package }}=1.3.7-1"
+  'edge': "{{ containerd_package }}=1.3.7-1"

--- a/roles/container-engine/containerd-common/vars/ubuntu-arm64.yml
+++ b/roles/container-engine/containerd-common/vars/ubuntu-arm64.yml
@@ -4,5 +4,6 @@ containerd_versioned_pkg:
   '1.2.10': "{{ containerd_package }}=1.2.10-3"
   '1.2.12': "{{ containerd_package }}=1.2.12-1"
   '1.2.13': "{{ containerd_package }}=1.2.13-2"
-  'stable': "{{ containerd_package }}=1.2.13-2"
-  'edge': "{{ containerd_package }}=1.2.13-2"
+  '1.3.7': "{{ containerd_package }}=1.3.7-1"
+  'stable': "{{ containerd_package }}=1.3.7-1"
+  'edge': "{{ containerd_package }}=1.3.7-1"

--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -47,9 +47,7 @@ containerd_debian_repo_repokey: '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
 containerd_debian_repo_component: 'stable'
 
 # Fedora docker-ce repo
-# TODO Remove the line below as soon as containerd rpm are available for f32
-containerd_fedora_release: "{{ '31' if (ansible_distribution_major_version | int) > 31 else ansible_distribution_major_version }}"
-containerd_fedora_repo_base_url: 'https://download.docker.com/linux/fedora/{{ containerd_fedora_release }}/$basearch/stable'
+containerd_fedora_repo_base_url: 'https://download.docker.com/linux/fedora/{{ ansible_distribution_major_version }}/$basearch/stable'
 containerd_fedora_repo_gpgkey: 'https://download.docker.com/linux/fedora/gpg'
 containerd_fedora_repo_repokey: '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
 containerd_fedora_repo_component: 'stable'


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Update containerd to 1.3.7 
Add fedora32 and centos8 containerd specific packages

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Containerd 1.2.X is end of life on 26/09 (https://containerd.io/releases/)

**Does this PR introduce a user-facing change?**:
```release-note
Update containerd to 1.3.7
```
