### PR TITLE
allow pre-existing floating IPs to be specified with k8s_master_fips

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -239,6 +239,7 @@ For your cluster, edit `inventory/$CLUSTER/cluster.tfvars`.
 |`network_dns_domain` | (Optional) The dns_domain for the internal network that will be generated |
 |`dns_nameservers`| An array of DNS name server names to be used by hosts in the internal subnet. |
 |`floatingip_pool` | Name of the pool from which floating IPs will be allocated |
+|`k8s_master_fips` | A list of floating IPs that you have already pre-allocated; they will be attached to master nodes instead of creating new random floating IPs. |
 |`external_net` | UUID of the external network that will be routed to |
 |`flavor_k8s_master`,`flavor_k8s_node`,`flavor_etcd`, `flavor_bastion`,`flavor_gfs_node` | Flavor depends on your openstack installation, you can get available flavor IDs through `openstack flavor list` |
 |`image`,`image_gfs` | Name of the image to use in provisioning the compute resources. Should already be loaded into glance. |

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -27,6 +27,7 @@ module "ips" {
   network_name                  = var.network_name
   router_id                     = module.network.router_id
   k8s_nodes                     = var.k8s_nodes
+  k8s_master_fips               = var.k8s_master_fips
 }
 
 module "compute" {

--- a/contrib/terraform/openstack/modules/ips/main.tf
+++ b/contrib/terraform/openstack/modules/ips/main.tf
@@ -4,14 +4,16 @@ resource "null_resource" "dummy_dependency" {
   }
 }
 
+# If user specifies pre-existing IPs to use in k8s_master_fips, do not create new ones.
 resource "openstack_networking_floatingip_v2" "k8s_master" {
-  count      = var.number_of_k8s_masters
+  count      = length(var.k8s_master_fips) > 0 ? 0 : var.number_of_k8s_masters
   pool       = var.floatingip_pool
   depends_on = [null_resource.dummy_dependency]
 }
 
+# If user specifies pre-existing IPs to use in k8s_master_fips, do not create new ones.
 resource "openstack_networking_floatingip_v2" "k8s_master_no_etcd" {
-  count      = var.number_of_k8s_masters_no_etcd
+  count      = length(var.k8s_master_fips) > 0 ? 0 : var.number_of_k8s_masters_no_etcd
   pool       = var.floatingip_pool
   depends_on = [null_resource.dummy_dependency]
 }

--- a/contrib/terraform/openstack/modules/ips/outputs.tf
+++ b/contrib/terraform/openstack/modules/ips/outputs.tf
@@ -1,9 +1,11 @@
+# If k8s_master_fips is already defined as input, keep the same value since new FIPs have not been created.
 output "k8s_master_fips" {
-  value = openstack_networking_floatingip_v2.k8s_master[*].address
+  value = length(var.k8s_master_fips) > 0 ? var.k8s_master_fips : openstack_networking_floatingip_v2.k8s_master[*].address
 }
 
+# If k8s_master_fips is already defined as input, keep the same value since new FIPs have not been created.
 output "k8s_master_no_etcd_fips" {
-  value = openstack_networking_floatingip_v2.k8s_master_no_etcd[*].address
+  value = length(var.k8s_master_fips) > 0 ? var.k8s_master_fips : openstack_networking_floatingip_v2.k8s_master_no_etcd[*].address
 }
 
 output "k8s_node_fips" {

--- a/contrib/terraform/openstack/modules/ips/variables.tf
+++ b/contrib/terraform/openstack/modules/ips/variables.tf
@@ -17,3 +17,5 @@ variable "router_id" {
 }
 
 variable "k8s_nodes" {}
+
+variable "k8s_master_fips" {}

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -156,6 +156,12 @@ variable "dns_nameservers" {
   default     = []
 }
 
+variable "k8s_master_fips" {
+  description = "specific pre-existing floating IPs to use for master nodes"
+  type        = list(string)
+  default     = []
+}
+
 variable "floatingip_pool" {
   description = "name of the floating ip pool to use"
   default     = "external"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind feature


**What this PR does / why we need it**:

See https://github.com/kubernetes-sigs/kubespray/issues/6754

The logic works as follows.

If k8s_master_fips is defined as an input variable, then when the IP module runs, new floating IPs are not created, since the specified pre-existing ones will be used instead.

Then the IP module sets k8s_master_fips (or k8s_master_no_etcd_fips) as an output variable.
If new floating IPs were created it uses those values. Otherwise it retains the value that was set in the k8s_master_fips input variable.

Then when the compute module runs, the desired floating IPs are attached.

I have tested this on openstack with k8s_master node types and it works as expected. If I set 
`k8s_master_fips = ["1.2.92.165", "1.2.92.166", "1.2.92.167"]`
then I get those floating IPs (which I already had allocated) on the masters.

If k8s_master_fips is not set I get new random FIPs.

**Which issue(s) this PR fixes**:

Fixes #6754 

**Special notes for your reviewer**:

Requires TF >= 0.12  due to lazy operator evaluation
 https://www.hashicorp.com/blog/terraform-0-12-conditional-operator-improvements

**Does this PR introduce a user-facing change?**:
No, if k8s_master_fips remains unspecified, the same behaviour occurs.
If k8s_master_fips is defined, then those floating IPs will be re-used. The documentation already claims this is the case.

```release-note
The documented behaviour of k8s_master_fips is now honoured.
```
