### PR TITLE
[WIP] Add NSX-T configuration to external vsphere cloud controller.

### DIFF
--- a/docs/vsphere.md
+++ b/docs/vsphere.md
@@ -30,16 +30,27 @@ external_cloud_provider: "vsphere"
 
 Then, `inventory/sample/group_vars/vsphere.yml`, you need to declare your vCenter credentials and enable the vSphere CSI following the description below.
 
-| Variable                               | Required | Type    | Choices                    | Default | Comment                                                                   |
-|----------------------------------------|----------|---------|----------------------------|---------|---------------------------------------------------------------------------|
-| external_vsphere_vcenter_ip            | TRUE     | string  |                            |                           | IP/URL of the vCenter                                   |
-| external_vsphere_vcenter_port          | TRUE     | string  |                            | "443"                     | Port of the vCenter API                                 |
-| external_vsphere_insecure              | TRUE     | string  | "true", "false"            | "true"                    | set to "true" if the host above uses a self-signed cert |
-| external_vsphere_user                  | TRUE     | string  |                            |                           | User name for vCenter with required privileges          |
-| external_vsphere_password              | TRUE     | string  |                            |                           | Password for vCenter                                    |
-| external_vsphere_datacenter            | TRUE     | string  |                            |                           | Datacenter name to use                                  |
-| external_vsphere_kubernetes_cluster_id | TRUE     | string  |                            | "kubernetes-cluster-id"   | Kubernetes cluster ID to use                            |
-| vsphere_csi_enabled                    | TRUE     | boolean |                            | false                     | Enable vSphere CSI                                      |
+| Variable                                 | Required | Type    | Choices         | Default                    | Comment                                                                                           |
+|------------------------------------------|----------|---------|-----------------|----------------------------|---------------------------------------------------------------------------------------------------|
+| external_vsphere_vcenter_ip              | TRUE     | string  |                 |                            | IP/URL of the vCenter                                                                             |
+| external_vsphere_vcenter_port            | TRUE     | string  |                 | "443"                      | Port of the vCenter API                                                                           |
+| external_vsphere_insecure                | TRUE     | string  | "true", "false" | "true"                     | set to "true" if the host above uses a self-signed cert                                           |
+| external_vsphere_user                    | TRUE     | string  |                 |                            | User name for vCenter with required privileges                                                    |
+| external_vsphere_password                | TRUE     | string  |                 |                            | Password for vCenter                                                                              |
+| external_vsphere_datacenter              | TRUE     | string  |                 |                            | Datacenter name to use                                                                            |
+| external_vsphere_kubernetes_cluster_id   | TRUE     | string  |                 | "kubernetes-cluster-id"    | Kubernetes cluster ID to use                                                                      |
+| vsphere_csi_enabled                      | TRUE     | boolean |                 | false                      | Enable vSphere CSI                                                                                |
+| external_vsphere_nsxt_enabled            | FALSE    | boolean | "true", "false" | false                      | Will enable NSX-T load balancer (alpha feature)                                                   |
+| external_vsphere_nsxt_insecure           | FALSE    | boolean | "true", "false" |                            | Will disable certificate checks                                                                   |
+| external_vsphere_nsxt_user               | FALSE    | string  |                 |                            | User name for NSX-T (Required if NSX-T load balancer enabled)                                     |
+| external_vsphere_nsxt_password           | FALSE    | string  |                 |                            | Password for NSX-T (Required if NSX-T load balancer enabled)                                      |
+| external_vsphere_nsxt_host               | FALSE    | string  |                 |                            | IP/URL of the NSX-T manager (Required if NSX-T load balancer enabled)                             |
+| external_vsphere_nsxt_pool_name          | FALSE    | string  |                 |                            | Name of the IP Pool to use - if not set a new pool will be created                                |
+| external_vsphere_nsxt_pool_size          | FALSE    | string  |                 |                            | Size of the IP Pool to use(Required if NSX-T load balancer enabled)                               |
+| external_vsphere_nsxt_lb_service_id      | FALSE    | string  |                 |                            | Id of the lb service - mutually exclusive with external_vsphere_nsxt_tier1_gateway_path           |
+| external_vsphere_nsxt_tier1_gateway_path | FALSE    | string  |                 |                            | Path to the tier1 gateway of the lb - mutually exclusive with external_vsphere_nsxt_lb_service_id |
+| external_vsphere_nsxt_tcp_app_profile    | FALSE    | string  |                 | default-tcp-lb-app-profile | (Required if NSX-T load balancer enabled)                                                         |
+| external_vsphere_nsxt_udp_app_profile    | FALSE    | string  |                 | default-udp-lb-app-profile | (Required if NSX-T load balancer enabled)                                                         |
 
 Example configuration:
 

--- a/roles/kubernetes-apps/external_cloud_controller/vsphere/defaults/main.yml
+++ b/roles/kubernetes-apps/external_cloud_controller/vsphere/defaults/main.yml
@@ -3,3 +3,5 @@ external_vsphere_vcenter_port: "443"
 external_vsphere_insecure: "true"
 
 external_vsphere_cloud_controller_image_tag: "latest"
+
+external_vsphere_nsxt_enabled: false

--- a/roles/kubernetes-apps/external_cloud_controller/vsphere/templates/external-vsphere-cloud-controller-manager-ds.yml.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/vsphere/templates/external-vsphere-cloud-controller-manager-ds.yml.j2
@@ -48,6 +48,11 @@ spec:
           resources:
             requests:
               cpu: 200m
+{% if external_vsphere_nsxt_enabled %}
+          env:
+            - name: ENABLE_ALPHA_NSXT_LB
+              value: "true"
+{% endif %}
       hostNetwork: true
       volumes:
       - name: vsphere-config-volume

--- a/roles/kubernetes-apps/external_cloud_controller/vsphere/templates/external-vsphere-cloud-controller-manager-roles.yml.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/vsphere/templates/external-vsphere-cloud-controller-manager-roles.yml.j2
@@ -34,6 +34,17 @@ items:
     - patch
     - update
     - watch
+{% if external_vsphere_nsxt_enabled %}
+  - apiGroups:
+    - ""
+    resources:
+    - services/status
+    verbs:
+    - list
+    - patch
+    - update
+    - watch
+{% endif %}
   - apiGroups:
     - ""
     resources:

--- a/roles/kubernetes-apps/external_cloud_controller/vsphere/templates/external-vsphere-cpi-cloud-config.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/vsphere/templates/external-vsphere-cpi-cloud-config.j2
@@ -6,3 +6,27 @@ secret-namespace = "kube-system"
 
 [VirtualCenter "{{ external_vsphere_vcenter_ip }}"]
 datacenters = "{{ external_vsphere_datacenter }}"
+
+{% if external_vsphere_nsxt_enabled %}
+[NSXT]
+user = "{{ external_vsphere_nsxt_user }}"
+password = "{{ external_vsphere_nsxt_password }}"
+host = "{{ external_vsphere_nsxt_host }}"
+insecure-flag = "{{ external_vsphere_nsxt_insecure }}"
+
+[LoadBalancer]
+{% if external_vsphere_nsxt_pool_name -%}
+ip-pool-name = "{{ external_vsphere_nsxt_pool_name }}"
+{% endif %}
+{% if external_vsphere_nsxt_pool_size -%}
+size = "{{ external_vsphere_nsxt_pool_size }}"
+{% endif %}
+{% if external_vsphere_nsxt_lb_service_id -%}
+lb-service-id = "{{ external_vsphere_nsxt_lb_service_id }}"
+{% endif %}
+{% if external_vsphere_nsxt_tier1_gateway_path -%}
+tier1-gateway-path = "{{ external_vsphere_nsxt_tier1_gateway_path }}"
+{% endif %}
+tcp-app-profile-name = "{{ external_vsphere_nsxt_tcp_app_profile | default('default-tcp-lb-app-profile') }}"
+udp-app-profile-name = "{{ external_vsphere_nsxt_udp_app_profile | default('default-udp-lb-app-profile') }}"
+{% endif %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

This PullRequest adds support for the [NSX-T LoadBalancer](https://github.com/kubernetes/cloud-provider-vsphere/tree/3a383cd1da915545e3ed458758cd53b38065a2e8/pkg/cloudprovider/vsphere/loadbalancer) that is present in the vsphere-cloud-provider.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

This PR adds support for an alpha level feature.

I am not sure if kubespray wants support for something like that - which is why I put the PR as `WIP` (apart from required changes to code-style or similar).

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added configuration options for NSX-T LoadBalancer in the external vsphere cloud provider.

No user action is required if the feature is not activated, otherwise variables must be filled out in accordance to the updated vsphere.md documentation.
```
