### PR TITLE
Add optional arguments for external cloud controller manager DaemonSet

### DIFF
--- a/roles/kubernetes-apps/external_cloud_controller/openstack/defaults/main.yml
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/defaults/main.yml
@@ -12,4 +12,10 @@ external_openstack_domain_name: "{{ lookup('env','OS_USER_DOMAIN_NAME') }}"
 external_openstack_domain_id: "{{ lookup('env','OS_USER_DOMAIN_ID') }}"
 external_openstack_cacert: "{{ lookup('env','OS_CACERT') }}"
 
+## A dictionary of extra arguments to add to the openstack cloud controller manager daemonset
+## Format:
+##  external_openstack_cloud_controller_extra_args:
+##    arg1: "value1"
+##    arg2: "value2"
+external_openstack_cloud_controller_extra_args: {}
 external_openstack_cloud_controller_image_tag: "v1.18.2"

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-controller-manager-ds.yml.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-controller-manager-ds.yml.j2
@@ -45,7 +45,7 @@ spec:
             - --use-service-account-credentials=true
             - --address=127.0.0.1
 {% for key, value in external_openstack_cloud_controller_extra_args.items() %}
-            - "{{ '--' + key + '=' + value|string }}"
+            - "{{ '--' + key + '=' + value }}"
 {% endfor %}
           volumeMounts:
             - mountPath: /etc/kubernetes/pki

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-controller-manager-ds.yml.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-controller-manager-ds.yml.j2
@@ -44,6 +44,9 @@ spec:
             - --cloud-provider=openstack
             - --use-service-account-credentials=true
             - --address=127.0.0.1
+{% for key, value in external_openstack_cloud_controller_extra_args.items() %}
+            - "{{ '--' + key + '=' + value|string }}"
+{% endfor %}
           volumeMounts:
             - mountPath: /etc/kubernetes/pki
               name: k8s-certs

--- a/roles/kubernetes-apps/external_cloud_controller/vsphere/defaults/main.yml
+++ b/roles/kubernetes-apps/external_cloud_controller/vsphere/defaults/main.yml
@@ -2,4 +2,10 @@
 external_vsphere_vcenter_port: "443"
 external_vsphere_insecure: "true"
 
+## A dictionary of extra arguments to add to the vsphere cloud controller manager daemonset
+## Format:
+##  external_vsphere_cloud_controller_extra_args:
+##    arg1: "value1"
+##    arg2: "value2"
+external_vsphere_cloud_controller_extra_args: {}
 external_vsphere_cloud_controller_image_tag: "latest"

--- a/roles/kubernetes-apps/external_cloud_controller/vsphere/templates/external-vsphere-cloud-controller-manager-ds.yml.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/vsphere/templates/external-vsphere-cloud-controller-manager-ds.yml.j2
@@ -41,6 +41,9 @@ spec:
             - --v=2
             - --cloud-provider=vsphere
             - --cloud-config=/etc/cloud/vsphere.conf
+{% for key, value in external_vsphere_cloud_controller_extra_args.items() %}
+            - "{{ '--' + key + '=' + value }}"
+{% endfor %}
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR allows Kubespray users to set additional arguments to the external cloud controller manager DaemonSet.

It adds two optional dictionaries (default `{}`; no effective change),  `external_openstack_cloud_controller_extra_args` and `external_vsphere_cloud_controller_extra_args`, to add extra arguments to the OpenStack cloud controller manager and the vSphere cloud controller manager, respectively.

**Which issue(s) this PR fixes**:
Fixes #6780

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
