### PR TITLE
Added comment to clarify supported Kubernetes versions in download role

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -117,7 +117,8 @@ crictl_checksums:
     v1.18.0: 876dd2b3d0d1c2590371f940fb1bf1fbd5f15aebfbe456703ee465d959700f4a
     v1.17.0: 7b72073797f638f099ed19550d52e9b9067672523fc51b746e65d7aa0bafa414
 
-# Checksums
+# Checksum
+# Kubernetes versions above Kubespray's current target version are untested and should be used with caution.
 kubelet_checksums:
   arm:
     v1.19.2: 631e686c34911a40a798817dcff89532c88bb649885f93ec66b339e227ebd974


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation


**What this PR does / why we need it**:
This PR adds a comment to roles/download/defaults/main.yml above the checksum block to avoid confusion about Kubespray's supported Kubernetes versions for upgrading, as included versions above the current target version are untested.

**Which issue(s) this PR fixes**:
Fixes #6777

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
