### PR TITLE
Add synchronized time checking

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -282,3 +282,16 @@
     that: ansible_os_family not in ["Flatcar Container Linux by Kinvolk"]
     msg: "download_run_once not supported for Flatcar Container Linux"
   when: download_run_once or download_force_cache
+
+- name: Verify synchronized time before install/upgrade
+  shell: "set -o pipefail && timedatectl status | grep synchronized | awk -F ': ' '{ print $2 }' | tr -d ' '"
+  args:
+    executable: /bin/bash
+  register: result
+  changed_when: false
+  failed_when: false
+
+- name: Stop if it does not have synchronized time
+  assert:
+    that: result.stdout in ['yes']
+    msg: "Kubespray stop any further actions for a node if it does not have synchronized time."


### PR DESCRIPTION


**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
Verify synchronized time
- Kubespray should stop any further actions for a node if it does not have synchronized time. Proceeding most likely creates strange errors with certificates that are not yet valid or similar. 

**Which issue(s) this PR fixes**:

Fixes #6767 #6489 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
