### PR TITLE
allow non existing etcd group

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -1,13 +1,21 @@
 ---
-- name: Stop if either kube-master, kube-node or etcd is empty
+- name: Stop if either kube-master or kube-node group is empty
   assert:
-    that: groups.get('{{ item }}')
+    that: "groups.get('{{ item }}')"
   with_items:
     - kube-master
     - kube-node
-    - etcd
   run_once: true
   when: not ignore_assert_errors
+
+- name: Stop if etcd group is empty in external etcd mode
+  assert:
+    that: groups.get('etcd')
+    fail_msg: "Group 'etcd' cannot be empty in external etcd mode"
+  run_once: true
+  when:
+    - not ignore_assert_errors
+    - not etcd_kubeadm_enabled
 
 - name: Stop if non systemd OS type
   assert:
@@ -61,6 +69,7 @@
     that: groups.etcd|length is not divisibleby 2
   when:
     - not ignore_assert_errors
+    - groups.get('etcd')
     - inventory_hostname in groups['etcd']
 
 - name: Stop if memory is too small for masters

--- a/roles/kubernetes/preinstall/tasks/0090-etchosts.yml
+++ b/roles/kubernetes/preinstall/tasks/0090-etchosts.yml
@@ -2,7 +2,7 @@
 - name: Hosts | create list from inventory
   set_fact:
     etc_hosts_inventory_block: |-
-      {% for item in (groups['k8s-cluster'] + groups['etcd'] + groups['calico-rr']|default([]))|unique -%}
+      {% for item in (groups['k8s-cluster'] + groups['etcd']|default([]) + groups['calico-rr']|default([]))|unique -%}
       {% if 'access_ip' in hostvars[item] or 'ip' in hostvars[item] or 'ansible_default_ipv4' in hostvars[item] -%}
       {{ hostvars[item]['access_ip'] | default(hostvars[item]['ip'] | default(hostvars[item]['ansible_default_ipv4']['address'])) }}
       {%- if ('ansible_hostname' in hostvars[item] and item != hostvars[item]['ansible_hostname']) %} {{ hostvars[item]['ansible_hostname'] }}.{{ dns_domain }} {{ hostvars[item]['ansible_hostname'] }}{% endif %} {{ item }}.{{ dns_domain }} {{ item }}

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -472,6 +472,9 @@ kube_apiserver_client_key: "{{ kube_cert_dir }}/ca.key"
 # Set to true to deploy etcd-events cluster
 etcd_events_cluster_enabled: false
 
+# etcd group can be empty when kubeadm manages etcd
+etcd_hosts: "{{ groups['etcd'] | default(groups['kube-master']) }}"
+
 # Vars for pointing to etcd endpoints
 is_etcd_master: "{{ inventory_hostname in groups['etcd'] }}"
 etcd_address: "{{ ip | default(fallback_ips[inventory_hostname]) }}"
@@ -482,12 +485,12 @@ etcd_client_url: "https://{{ etcd_access_address }}:2379"
 etcd_events_peer_url: "https://{{ etcd_events_access_address }}:2382"
 etcd_events_client_url: "https://{{ etcd_events_access_address }}:2381"
 etcd_access_addresses: |-
-  {% for item in groups['etcd'] -%}
+  {% for item in etcd_hosts -%}
     https://{{ hostvars[item]['access_ip'] | default(hostvars[item]['ip'] | default(fallback_ips[item])) }}:2379{% if not loop.last %},{% endif %}
   {%- endfor %}
 etcd_events_access_addresses_list: |-
   [
-  {% for item in groups['etcd'] -%}
+  {% for item in etcd_hosts -%}
     'https://{{ hostvars[item]['access_ip'] | default(hostvars[item]['ip'] | default(fallback_ips[item])) }}:2381'{% if not loop.last %},{% endif %}
   {%- endfor %}
   ]

--- a/roles/kubespray-defaults/tasks/no_proxy.yml
+++ b/roles/kubespray-defaults/tasks/no_proxy.yml
@@ -11,7 +11,7 @@
       {% else %}
       {% set cluster_or_master = 'k8s-cluster' %}
       {% endif %}
-      {%- for item in (groups[cluster_or_master] + groups['etcd'] + groups['calico-rr']|default([]))|unique -%}
+      {%- for item in (groups[cluster_or_master] + groups['etcd']|default([]) + groups['calico-rr']|default([]))|unique -%}
       {{ hostvars[item]['access_ip'] | default(hostvars[item]['ip'] | default(fallback_ips[item])) }},
       {%-   if item != hostvars[item].get('ansible_hostname', '') -%}
       {{ hostvars[item]['ansible_hostname'] }},

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -18,8 +18,9 @@ spec:
       labels:
         k8s-app: calico-node
       annotations:
-        # Mark pod as critical for rescheduling (Will have no effect starting with kubernetes 1.12)
+{% if calico_datastore == "etcd" %}
         kubespray.etcd-cert/serial: "{{ etcd_client_cert_serial }}"
+{% endif %}
 {% if calico_felix_prometheusmetricsenabled %}
         prometheus.io/scrape: 'true'
         prometheus.io/port: "{{ calico_felix_prometheusmetricsport }}"


### PR DESCRIPTION
When using kubeadm managed etcd, configuring an etcd group can now
be skipped.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:

When kubeadm manages etcd, there should be no need to configure etcd in the inventory.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Tested:
* cluster.yml - kubeadm managed etcd, calico using kdd datastore
* scale.yml

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
