### PR TITLE
Scale cluster playbook failed when etcd installed by kubeadm

### DIFF
--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -64,10 +64,3 @@
 # state instead of `new`.
 - include_tasks: refresh_config.yml
   when: is_etcd_master
-
-- name: Install etcdctl binary from etcd role
-  include_tasks: install_host.yml
-  vars:
-    etcd_cluster_setup: true
-  when:
-    - etcd_kubeadm_enabled


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

add worker node to cluster failed when 
```etcd_kubeadm_enabled: true```

try to install etcdctl  on etcd nodes in role etcd is not need.

When etcd setup by kubedamd - etcdctl installed from docker image, but in scale.yml playbook this task try to install from archive `etcd_download_url:`. 

when install cluster with ```etcd_kubeadm_enabled: true``` etcd role not played.
so do not need install etcdctl when add worker node.

