### PR TITLE
Chmod kubeconfig to avoid group-readable

### DIFF
--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -87,7 +87,7 @@
   copy:
     content: "{{ final_admin_kubeconfig | to_nice_yaml(indent=2) }}"
     dest: "{{ artifacts_dir }}/admin.conf"
-    mode: 0640
+    mode: 0600
   delegate_to: localhost
   connection: local
   become: no


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

After upgrading to newer Kubernetes(v1.17 at least), kubectl command shows the following warning message:

```
  WARNING: Kubernetes configuration file is group-readable.
  This is insecure. Location: /home/foo/.kube/config
```

The kubeconfig was copied from {{ artifacts_dir }}/admin.conf with kubeconfig_localhost feature. It is better to set valid file mode at getting it on Kubespray.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
