### PR TITLE
Fix handlers naming issue for Kubeadm | kubelet

### DIFF
--- a/roles/kubernetes/kubeadm/handlers/main.yml
+++ b/roles/kubernetes/kubeadm/handlers/main.yml
@@ -3,13 +3,13 @@
   command: /bin/true
   notify:
     - Kubeadm | reload systemd
-    - Kubeadm | restart kubelet
+    - Kubeadm | reload kubelet
 
 - name: Kubeadm | reload systemd
   systemd:
     daemon_reload: true
 
-- name: Kubeadm | restart kubelet
+- name: Kubeadm | reload kubelet
   service:
     name: kubelet
     state: restarted


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

Handlers with the same name (Kubeadm | restart kubelet) leads to incorrect playbook execution. As a result, after completing the tasks, kubelet does not restart. This PR fix this behavior

**Which issue(s) this PR fixes:**
<!--
*Automatically closes linked issue when PR is merged.
Usage: Fixes #<issue number>, or Fixes (paste link of issue).
_If PR is about failing-tests or flakes, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer:**

**Does this PR introduce a user-facing change?:**