### PR TITLE
change owner to root for bin_dir directory

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
+++ b/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
@@ -17,12 +17,31 @@
     - master
     - node
   with_items:
-    - "{{ bin_dir }}"
     - "{{ kube_config_dir }}"
     - "{{ kube_cert_dir }}"
     - "{{ kube_manifest_dir }}"
     - "{{ kube_script_dir }}"
     - "{{ kubelet_flexvolumes_plugins_dir }}"
+
+- name: Create other directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+  when: inventory_hostname in groups['k8s-cluster']
+  become: true
+  tags:
+    - kubelet
+    - k8s-secrets
+    - kube-controller-manager
+    - kube-apiserver
+    - bootstrap-os
+    - apps
+    - network
+    - master
+    - node
+  with_items:
+    - "{{ bin_dir }}"
 
 - name: Check if kubernetes kubeadm compat cert dir exists
   stat:


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

kubespray change owner directory `/usr/local/bin` to user `kube`
fix it
