### PR TITLE
fix scaling in kubeadm etcd mode

### DIFF
--- a/roles/kubernetes/kubeadm/defaults/main.yml
+++ b/roles/kubernetes/kubeadm/defaults/main.yml
@@ -11,8 +11,5 @@ kube_override_hostname: >-
   {{ inventory_hostname }}
   {%- endif -%}
 
-# Requests a fresh upload of certificates from first master
-kubeadm_etcd_refresh_cert_key: true
-
 # Experimental kubeadm etcd deployment mode. Available only for new deployment
 etcd_kubeadm_enabled: false

--- a/roles/kubernetes/kubeadm/tasks/kubeadm_etcd_node.yml
+++ b/roles/kubernetes/kubeadm/tasks/kubeadm_etcd_node.yml
@@ -1,18 +1,7 @@
 ---
-- name: Refresh certificates so they are fresh and not expired
-  command: >-
-    {{ bin_dir }}/kubeadm init phase
-    --config {{ kube_config_dir }}/kubeadm-config.yaml
-    upload-certs
-    --upload-certs
-  register: kubeadm_upload_cert
-  delegate_to: "{{ groups['kube-master'][0] }}"
-  when: kubeadm_etcd_refresh_cert_key
-  run_once: yes
-
 - name: Parse certificate key if not set
   set_fact:
-    kubeadm_certificate_key: "{{ hostvars[groups['kube-master'][0]]['kubeadm_upload_cert'].stdout_lines[-1] | trim }}"
+    kubeadm_certificate_key: "{{ hostvars[groups['kube-master'][0]]['kubeadm_certificate_key'] }}"
   when: kubeadm_certificate_key is undefined
 
 - name: Pull control plane certs down

--- a/scale.yml
+++ b/scale.yml
@@ -74,6 +74,25 @@
     - { role: kubernetes/node, tags: node }
   environment: "{{ proxy_env }}"
 
+- name: Upload control plane certs and retrieve encryption key
+  hosts: kube-master | first
+  tags: kubeadm
+  tasks:
+    - name: include needed vars
+      include_vars: roles/kubespray-defaults/defaults/main.yaml
+    - name: Upload control plane certificates
+      command: >-
+        {{ bin_dir }}/kubeadm init phase
+        --config {{ kube_config_dir }}/kubeadm-config.yaml
+        upload-certs
+        --upload-certs
+      register: kubeadm_upload_cert
+      changed_when: false
+    - name: set fact 'kubeadm_certificate_key' for later use
+      set_fact:
+        kubeadm_certificate_key: "{{ kubeadm_upload_cert.stdout_lines[-1] | trim }}"
+      when: kubeadm_certificate_key is not defined
+
 - name: Target only workers to get kubelet installed and checking in on any new nodes(network)
   hosts: kube-node
   gather_facts: False


### PR DESCRIPTION
'ansible.vars.hostvars.HostVarsVars object' has no attribute 'kubeadm_upload_cert'

kubeadm_upload_cert will never be found as a hostvar for the first
master since the task is executed for a worker.

Fix by executing the upload task for the first master and register
the needed key. After that, workers can read hostvars for the master

Var kubeadm_etcd_refresh_cert_key removed since it no longer has
any use.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6820 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
