### PR TITLE
Update kubevirt Centos7 from 1809 to 2003

### DIFF
--- a/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
@@ -43,9 +43,9 @@ images:
     converted: true
 
   centos-7:
-    filename: CentOS-7-x86_64-GenericCloud-1809.qcow2
-    url: http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1809.qcow2
-    checksum: sha256:42c062df8a8c36991ec0282009dd52ac488461a3f7ee114fc21a765bfc2671c2
+    filename: CentOS-7-x86_64-GenericCloud-2003.qcow2
+    url: http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-2003.qcow2
+    checksum: sha256:1db30c9c272fb37b00111b93dcebff16c278384755bdbe158559e9c240b73b80
     converted: true
 
   centos-8:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
Centos 2003 is available since few months. We should update kubevirt CI. And maybe give a try to bootstraped  python3  ? 

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
NONE

```release-note

```
