### PR TITLE
Add Kata Containers support to CRI-O runtime

### DIFF
--- a/roles/container-engine/cri-o/defaults/main.yml
+++ b/roles/container-engine/cri-o/defaults/main.yml
@@ -11,7 +11,6 @@ crio_pause_image: "{{ pod_infra_image_repo }}:{{ pod_infra_version }}"
 # By default unqualified images are not allowed for security reasons
 crio_registries: []
 
-crio_runc_path: "/usr/bin/runc"
 crio_seccomp_profile: ""
 crio_selinux: "{{ (preinstall_selinux_state == 'enforcing')|lower }}"
 crio_signature_policy: "{% if ansible_os_family == 'ClearLinux' %}/usr/share/defaults/crio/policy.json{% endif %}"
@@ -29,3 +28,25 @@ crio_kubernetes_version_matrix:
   "1.17": "1.17"
 
 crio_version: "{{ crio_kubernetes_version_matrix[crio_required_version] | default('1.19') }}"
+
+# The crio_runtimes variable defines a list of OCI compatible runtimes.
+crio_runtimes:
+  - name: runc
+    path: /usr/bin/runc
+    type: oci
+    root: /run/runc
+
+# Kata Containers is an OCI runtime, where containers are run inside lightweight
+# VMs. Kata provides additional isolation towards the host, minimizing the host attack
+# surface and mitigating the consequences of containers breakout.
+kata_runtimes:
+  # Kata Containers with the default configured VMM
+  - name: kata-runtime
+    path: /opt/kata/bin/kata-runtime
+    type: oci
+    root: /run/kata-containers
+  # Kata Containers with the QEMU VMM
+  - name: kata-qemu
+    path: /opt/kata/bin/kata-qemu
+    type: oci
+    root: /run/kata-containers

--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -29,6 +29,12 @@
 
 - import_tasks: "crictl.yml"
 
+- name: Build a list of crio runtimes
+  set_fact:
+    crio_runtimes: "{{ crio_runtimes + kata_runtimes  }}"
+  when:
+    - kata_containers_enabled
+
 - name: Make sure needed folders exist in the system
   with_items:
     - /etc/crio

--- a/roles/container-engine/cri-o/templates/crio.conf.j2
+++ b/roles/container-engine/cri-o/templates/crio.conf.j2
@@ -280,22 +280,12 @@ pinns_path = ""
 # - runtime_root (optional, string): root directory for storage of containers
 #   state.
 
-
-[crio.runtime.runtimes.runc]
-runtime_path = "{{ crio_runc_path }}"
-runtime_type = "oci"
-runtime_root = "/run/runc"
-
-
-# Kata Containers is an OCI runtime, where containers are run inside lightweight
-# VMs. Kata provides additional isolation towards the host, minimizing the host attack
-# surface and mitigating the consequences of containers breakout.
-
-# Kata Containers with the default configured VMM
-#[crio.runtime.runtimes.kata-runtime]
-
-# Kata Containers with the QEMU VMM
-#[crio.runtime.runtimes.kata-qemu]
+{% for runtime in crio_runtimes %}
+[crio.runtime.runtimes.{{ runtime.name }}]
+runtime_path = "{{ runtime.path }}"
+runtime_type = "{{ runtime.type }}"
+runtime_root = "{{ runtime.root }}"
+{% endfor %}
 
 # Kata Containers with the Firecracker VMM
 #[crio.runtime.runtimes.kata-fc]

--- a/roles/container-engine/cri-o/vars/debian.yml
+++ b/roles/container-engine/cri-o/vars/debian.yml
@@ -4,4 +4,9 @@ crio_packages:
   - "cri-o"
   - "cri-o-runc"
 
-crio_runc_path: /usr/sbin/runc
+# The crio_runtimes variable defines a list of OCI compatible runtimes.
+crio_runtimes:
+  - name: runc
+    path: /usr/sbin/runc
+    type: oci
+    root: /run/runc

--- a/roles/container-engine/cri-o/vars/ubuntu.yml
+++ b/roles/container-engine/cri-o/vars/ubuntu.yml
@@ -4,4 +4,9 @@ crio_packages:
   - "cri-o"
   - "cri-o-runc"
 
-crio_runc_path: /usr/sbin/runc
+# The crio_runtimes variable defines a list of OCI compatible runtimes.
+crio_runtimes:
+  - name: runc
+    path: /usr/sbin/runc
+    type: oci
+    root: /run/runc

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -277,6 +277,12 @@
     msg: "download_run_once support only for docker. See https://github.com/containerd/containerd/issues/4075 for details"
   when: download_run_once or download_force_cache
 
+- name: Stop if kata_containers_enabled is enabled when container_manager is docker
+  assert:
+    that: container_manager != 'docker'
+    msg: "kata_containers_enabled support only for containerd and crio-o. See https://github.com/kata-containers/documentation/blob/1.11.4/how-to/run-kata-with-k8s.md#install-a-cri-implementation for details"
+  when: kata_containers_enabled
+
 - name: Stop if download_localhost is enabled for Flatcar Container Linux
   assert:
     that: ansible_os_family not in ["Flatcar Container Linux by Kinvolk"]

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -221,7 +221,7 @@ kube_profiling: false
 container_manager: docker
 
 # Enable Kata Containers as additional container runtime
-# When enabled, it requires container_manager=containerd
+# When enabled, it requires `container_manager` different than Docker
 kata_containers_enabled: false
 
 # Container on localhost (download images when download_localhost is true)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
This change enables Kata Containers runtime for CRI-O container manager. Kata Containers is an OCI runtime where containers are run inside lightweight VMs resulting in an extra security layer. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
This change requires to setup the following variables:
```
container_manager: crio
kata_containers_enabled: true
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE
```release-note

```
