### PR TITLE
Fixes 6621 etcd backup directory is consuming much rootfs disk space

### DIFF
--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -9,6 +9,8 @@ etcd_events_cluster_enabled: false
 etcd_backup_prefix: "/var/backups"
 etcd_data_dir: "/var/lib/etcd"
 
+# Number of etcd backups to retain. Set to a value < 0 to retain all backups
+etcd_backup_retention_count: -1
 
 etcd_config_dir: /etc/ssl/etcd
 etcd_cert_dir: "{{ etcd_config_dir }}/ssl"

--- a/roles/etcd/handlers/backup.yml
+++ b/roles/etcd/handlers/backup.yml
@@ -62,5 +62,5 @@
 - name: Remove old etcd backups
   shell:
     chdir: "{{ etcd_backup_prefix }}"
-    cmd: "ls | grep etcd- | head -n -{{ etcd_backup_retention_count }} | xargs rm -rf"
+    cmd: "find . -name 'etcd-*' | head -n -{{ etcd_backup_retention_count }} | xargs rm -rf"
   when: etcd_backup_retention_count >= 0

--- a/roles/etcd/handlers/backup.yml
+++ b/roles/etcd/handlers/backup.yml
@@ -8,6 +8,7 @@
     - Stat etcd v2 data directory
     - Backup etcd v2 data
     - Backup etcd v3 data
+    - Remove old etcd backups
   when: etcd_cluster_is_healthy.rc == 0
 
 - name: Refresh Time Fact
@@ -57,3 +58,9 @@
   register: etcd_backup_v3_command
   until: etcd_backup_v3_command.rc == 0
   delay: "{{ retry_stagger | random + 3 }}"
+
+- name: Remove old etcd backups
+  shell:
+    chdir: "{{ etcd_backup_prefix }}"
+    cmd: "ls | grep etcd- | head -n -{{ etcd_backup_retention_count }} | xargs rm -rf"
+  when: etcd_backup_retention_count >= 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

Etcd backups are made for every kubespray run. Currently, they are never removed by kubespray. This causes the master disks to fill up. The kubespray user has to manage this by themself.

This PR adds a variable to control the retention of etcd backups: `etcd_backup_retention_count`. The variable indicates the number of historical etcd backups that should be retained in the backups directory. Older backups are removed by kubespray automatically. The default value is set to -1, indicating that all backups should be retained. This is the current kubespray behavior, thus this PR will not impact any current users of kubespray.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6621 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added the option to remove old etcd backups
```
