### PR TITLE
Fix proxy and module_hotfixes

### DIFF
--- a/roles/container-engine/containerd/templates/rh_containerd.repo.j2
+++ b/roles/container-engine/containerd/templates/rh_containerd.repo.j2
@@ -5,5 +5,9 @@ enabled=1
 gpgcheck={{ '1' if docker_rh_repo_gpgkey else '0' }}
 keepcache={{ docker_rpm_keepcache | default('1') }}
 gpgkey={{ docker_rh_repo_gpgkey }}
-{% if http_proxy is defined %}proxy={{ http_proxy }}{% endif %}
-{% if ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 8 %}module_hotfixes=True{% endif %}
+{% if http_proxy is defined %}
+proxy={{ http_proxy }}
+{% endif %}
+{% if ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 8 %}
+module_hotfixes=True
+{% endif %}

--- a/roles/container-engine/docker/templates/rh_docker.repo.j2
+++ b/roles/container-engine/docker/templates/rh_docker.repo.j2
@@ -5,6 +5,9 @@ enabled=1
 gpgcheck={{ '1' if docker_rh_repo_gpgkey else '0' }}
 keepcache={{ docker_rpm_keepcache | default('1') }}
 gpgkey={{ docker_rh_repo_gpgkey }}
-{% if http_proxy is defined %}proxy={{ http_proxy }}{% endif %}
-
-{% if ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 8 %}module_hotfixes=True{% endif %}
+{% if http_proxy is defined %}
+proxy={{ http_proxy }}
+{% endif %}
+{% if ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 8 %}
+module_hotfixes=True
+{% endif %}


### PR DESCRIPTION


On CentOS 8 with proxy ansible render inline `proxy` and `module_hotfixes` options.

For example:
```
proxy=http://127.0.0.1:3128module_hotfixes=True
```

But expected result:
```
proxy=http://127.0.0.1:3128
module_hotfixes=True
```

Signed-off-by: Etienne Champetier <champetier.etienne@gmail.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This fixes the Containerd + EL8 case that was missed in 7d1ab3374e0b8c35ecbd7fb2339fc93c367c5c19

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
