### PR TITLE
Add tag for test-infra images and docker logout

### DIFF
--- a/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
@@ -11,69 +11,81 @@ images:
     url: https://storage.googleapis.com/kubespray-images/ubuntu/xenial-server-cloudimg-amd64-disk1.img
     checksum: sha256:c0d099383cd064390b568e20d1c39a9c68ba864764404b70f754a7b1b2f808f7
     converted: false
+    tag: "latest"
 
   ubuntu-1804:
     filename: bionic-server-cloudimg-amd64.img
     url: https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img
     checksum: sha256:c3d0e03f4245ffaabd7647e6dabf346b944a62b9934d0a89f3a04b4236386af2
     converted: false
+    tag: "latest"
 
   ubuntu-2004:
     filename: focal-server-cloudimg-amd64.img
     url: https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64-disk-kvm.img
     checksum: sha256:8faf1f5a27c956ad0c49dac3114a355fbaf1b2d21709e10a18e67213fbb95b81
     converted: false
+    tag: "latest"
 
   fedora-31:
     filename: Fedora-Cloud-Base-31-1.9.x86_64.qcow2
     url: https://download.fedoraproject.org/pub/fedora/linux/releases/31/Cloud/x86_64/images/Fedora-Cloud-Base-31-1.9.x86_64.qcow2
     checksum: sha256:e3c1b309d9203604922d6e255c2c5d098a309c2d46215d8fc026954f3c5c27a0
     converted: true
+    tag: "latest"
 
   fedora-32:
     filename: Fedora-Cloud-Base-32-1.6.x86_64.qcow2
     url: https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2
     checksum: sha256:423a4ce32fa32c50c11e3d3ff392db97a762533b81bef9d00599de518a7469c8
     converted: true
+    tag: "latest"
 
   fedora-coreos:
     filename: fedora-coreos-32.20200601.3.0-openstack.x86_64.qcow2.xz
     url: https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-openstack.x86_64.qcow2.xz
     checksum: sha256:fe78c348189d745eb5f6f80ff9eb2af67da8e84880d264f4301faaf7c2a72646
     converted: true
+    tag: "latest"
 
   centos-7:
     filename: CentOS-7-x86_64-GenericCloud-1809.qcow2
     url: http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1809.qcow2
     checksum: sha256:42c062df8a8c36991ec0282009dd52ac488461a3f7ee114fc21a765bfc2671c2
     converted: true
+    tag: "latest"
 
   centos-8:
     filename: CentOS-8-GenericCloud-8.1.1911-20200113.3.x86_64.qcow2
     url: http://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.1.1911-20200113.3.x86_64.qcow2
     checksum: sha256:e2cf1081645b1089f574918fb808b32d247169ec4ec1a13bca9e14a74df6530e
     converted: true
+    tag: "latest"
 
   debian-9:
     filename: debian-9-openstack-amd64.qcow2
     url: https://cdimage.debian.org/cdimage/openstack/current-9/debian-9-openstack-amd64.qcow2
     checksum: sha256:01d9345ba7a6523d214d2eaabe07fe7b4b69b28e63d7a6b322521e99e5768719
     converted: true
+    tag: "latest"
 
   debian-10:
     filename: debian-10-openstack-amd64.qcow2
     url: https://cdimage.debian.org/cdimage/openstack/current-10/debian-10-openstack-amd64.qcow2
     checksum: sha512:296ad8345cb49e52464a0cb8bf4365eb0b9e4220c47ebdd73d134d51effc756d5554aee15027fffd038fef4ad5fa984c94208bce60572d58b2ab26f74bb2a5de
     converted: true
+    tag: "latest"
 
   oracle-7:
     filename: oracle-linux-76.qcow2
     url: https://storage.googleapis.com/born-images/oracle76/oracle-linux-76.qcow2
     checksum: sha256:f396c03e907fa2a0c94d6807b9f62622f23ee3499df4456ae2a15da381fbdca5
     converted: true
+    tag: "latest"
 
   opensuse-leap-15:
     filename: openSUSE-Leap-15.1-OpenStack.x86_64-0.0.4-Build6.106.qcow2
     url: https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.1/images/openSUSE-Leap-15.1-OpenStack.x86_64-0.0.4-Build6.106.qcow2
     checksum: sha256:e3c016a889505c5ae51dafe6eedc836a9e9546ab951fdc96f07eb35e34d12b8c
     converted: true
+    tag: "latest"

--- a/test-infra/image-builder/roles/kubevirt-images/tasks/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/tasks/main.yml
@@ -46,7 +46,7 @@
     dest: "{{ images_dir }}/Dockerfile"
 
 - name: Create docker images for each OS  # noqa 301
-  command: docker build -t {{ registry }}/vm-{{ item.key }} --build-arg cloud_image="{{ item.key }}.qcow2" {{ images_dir }}
+  command: docker build -t {{ registry }}/vm-{{ item.key }}:{{ item.value.tag }} --build-arg cloud_image="{{ item.key }}.qcow2" {{ images_dir }}
   with_dict:
     - "{{ images }}"
 
@@ -54,6 +54,9 @@
   command: docker login -u="{{ docker_user }}" -p="{{ docker_password }}" "{{ docker_host }}"
 
 - name: docker push image  # noqa 301
-  command: docker push {{ registry }}/vm-{{ item.key }}:latest
+  command: docker push {{ registry }}/vm-{{ item.key }}:{{ item.value.tag }}
   with_dict:
     - "{{ images }}"
+
+- name: docker logout  # noqa 301
+  command: docker logout -u="{{ docker_user }}" "{{ docker_host }}"


### PR DESCRIPTION
**What type of PR is this?**
 /kind feature

**What this PR does / why we need it**:
Adding `docker logout` is needed to cleanup docker credentials and adding a `tag` field is useful when doing pre-release builds.