### PR TITLE
Notes About Server In admin.conf

### DIFF
--- a/contrib/terraform/aws/README.md
+++ b/contrib/terraform/aws/README.md
@@ -49,7 +49,10 @@ ansible-playbook -i ./inventory/hosts ./cluster.yml -e ansible_user=ubuntu -b --
 If you want to use another distribution than Ubuntu 18.04 (Bionic) LTS, you can modify the search filters of the 'data "aws_ami" "distro"' in variables.tf.
 
 For example, to use:
+
 - Debian Jessie, replace 'data "aws_ami" "distro"' in variables.tf with
+
+```
 data "aws_ami" "distro" {
   most_recent = true
 
@@ -65,8 +68,11 @@ data "aws_ami" "distro" {
 
   owners = ["379101102735"]
 }
+```
 
 - Ubuntu 16.04, replace 'data "aws_ami" "distro"' in variables.tf with
+
+```
 data "aws_ami" "distro" {
   most_recent = true
 
@@ -82,8 +88,11 @@ data "aws_ami" "distro" {
 
   owners = ["099720109477"]
 }
+```
 
 - Centos 7, replace 'data "aws_ami" "distro"' in variables.tf with
+
+```
 data "aws_ami" "distro" {
   most_recent = true
 
@@ -99,6 +108,31 @@ data "aws_ami" "distro" {
 
   owners = ["688023202711"]
 }
+```
+
+## Connecting to Kubernetes
+
+You can use the following set of commands to get the kubeconfig file from your newly created cluster. Before running the commands, make sure you are in the project's root folder.
+
+```
+# Get the controller's IP address.
+CONTROLLER_HOST_NAME=$(cat ./inventory/hosts | grep "\[kube-master\]" -A 1 | tail -n 1)
+CONTROLLER_IP=$(cat ./inventory/hosts | grep $CONTROLLER_HOST_NAME | grep ansible_host | cut -d'=' -f2)
+
+# Get the hostname of the load balancer.
+LB_HOST=$(cat inventory/hosts | grep apiserver_loadbalancer_domain_name | cut -d'"' -f2)
+
+# Get the controller's SSH fingerprint.
+ssh-keygen -R $CONTROLLER_IP > /dev/null 2>&1
+ssh-keyscan -H $CONTROLLER_IP >> ~/.ssh/known_hosts 2>/dev/null
+
+# Get the kubeconfig from the controller.
+mkdir -p ~/.kube
+ssh -F ssh-bastion.conf centos@$CONTROLLER_IP "sudo chmod 644 /etc/kubernetes/admin.conf"
+scp -F ssh-bastion.conf centos@$CONTROLLER_IP:/etc/kubernetes/admin.conf ~/.kube/config
+sed -i "s^server:.*^server: https://$LB_HOST:6443^" ~/.kube/config
+kubectl get nodes
+```
 
 **Troubleshooting**
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -127,6 +127,8 @@ host and can optionally be configured on your ansible host by setting
 - If `kubeconfig_localhost` enabled `admin.conf` will appear in the `inventory/mycluster/artifacts/` directory after deployment.
 - The location where these files are downloaded to can be configured via the `artifacts_dir` variable.
 
+NOTE: The controller host name in the admin.conf file might be a private IP. If so, change it to use the controller's public IP or the cluster's load balancer.
+
 You can see a list of nodes by running the following commands:
 
 ```ShellSession


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

When I run kubespray, a load balancer is used in front of the master nodes. The admin.conf file has the private ip and will not work unmodified. These changes simply mention that the change is needed. In the contrib/terraform/aws change, commands are shown that will change the admin.conf file locally to allow kubectl to work.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

NONE

```release-note
Update documentation to show terraform/aws users how to connect through load balancer.
```
