### PR TITLE
Register missing outputs in role "remove-node/pre-remove"

### DIFF
--- a/roles/remove-node/pre-remove/tasks/main.yml
+++ b/roles/remove-node/pre-remove/tasks/main.yml
@@ -4,6 +4,7 @@
     {{ bin_dir }}/kubectl cordon {{ hostvars[item]['kube_override_hostname']|default(item) }}
   with_items:
     - "{{ node.split(',') | default(groups['kube-node']) }}"
+  register: result
   failed_when: result.rc == 0 and not allow_ungraceful_removal
   delegate_to: "{{ groups['kube-master']|first }}"
   run_once: true
@@ -19,6 +20,7 @@
       --delete-local-data {{ hostvars[item]['kube_override_hostname']|default(item) }}
   with_items:
     - "{{ node.split(',') | default(groups['kube-node']) }}"
+  register: result
   failed_when: result.rc == 0 and not allow_ungraceful_removal
   delegate_to: "{{ groups['kube-master']|first }}"
   run_once: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Register missing outputs in role "remove-node/pre-remove".
Running Ansible playbook without this PR contains fatal error:
```
$ ansible-playbook -i inventory/sample/inventory.ini -b remove-node.yml -e 'node=node2'
...
TASK [remove-node/pre-remove : cordon-node | Mark all nodes as unschedulable before drain] ***
fatal: [node1]: FAILED! => {"msg": "The conditional check 'result.rc == 0 and not allow_ungraceful_removal' failed. The error was: error while evaluating conditional (result.rc == 0 and not allow_ungraceful_removal): 'result' is undefined"}
...ignoring
...
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
