### PR TITLE
install etcdctl to host when etcd deployment type is kubeadm

### DIFF
--- a/docs/cri-o.md
+++ b/docs/cri-o.md
@@ -4,7 +4,7 @@
 Kubespray supports basic functionality for using CRI-O as the default container runtime in a cluster.
 
 * Kubernetes supports CRI-O on v1.11.1 or later.
-* `scale.yml` and `upgrade-cluster.yml` are not supported on clusters using CRI-O.
+* etcd: configure either kubeadm managed etcd or host deployment
 
 _To use the CRI-O container runtime set the following variables:_
 
@@ -13,6 +13,7 @@ _To use the CRI-O container runtime set the following variables:_
 ```yaml
 download_container: false
 skip_downloads: false
+etcd_kubeadm_enabled: true
 ```
 
 ## k8s-cluster.yml
@@ -24,7 +25,7 @@ container_manager: crio
 ## etcd.yml
 
 ```yaml
-etcd_deployment_type: host
+etcd_deployment_type: host # optionally and mutually exclusive with etcd_kubeadm_enabled
 ```
 
 [CRI-O]: https://cri-o.io/

--- a/roles/etcdctl/tasks/main.yml
+++ b/roles/etcdctl/tasks/main.yml
@@ -1,0 +1,59 @@
+---
+# To get the binary from container to host, use the etcd data directory mounted
+# rw from host into the container.
+
+- name: Check unintentional include of this role
+  assert:
+    that: etcd_kubeadm_enabled
+
+- name: Check if etcdctl exist
+  stat:
+    path: "{{ bin_dir }}/etcdctl"
+  register: stat_etcdctl
+
+- block:
+  - name: Check version
+    command: "{{ bin_dir }}/etcdctl version"
+    register: etcdctl_version
+    check_mode: no
+    changed_when: false
+
+  - name: Remove old binary if version is not OK
+    file:
+      path: "{{ bin_dir }}/etcdctl"
+      state: absent
+    when: etcd_version.lstrip('v') not in etcdctl_version.stdout
+  when: stat_etcdctl.stat.exists
+
+- name: Check if etcdctl still exist after version check
+  stat:
+    path: "{{ bin_dir }}/etcdctl"
+  register: stat_etcdctl
+
+- block:
+  - name: Copy etcdctl script to host
+    shell: "docker exec \"$(docker ps -qf ancestor={{ etcd_image_repo }}:{{ etcd_image_tag }})\" cp /usr/local/bin/etcdctl {{ etcd_data_dir }}"
+    when: container_manager ==  "docker"
+
+  - name: Copy etcdctl script to host
+    shell: "crictl exec \"$(crictl ps -q --image {{ etcd_image_repo }}:{{ etcd_image_tag }})\" cp /usr/local/bin/etcdctl {{ etcd_data_dir }}"
+    when: container_manager in ['crio', 'containerd']
+
+  - name: Copy etcdctl to {{ bin_dir }}
+    copy:
+      src: "{{ etcd_data_dir }}/etcdctl"
+      dest: "{{ bin_dir }}"
+      remote_src: true
+      mode: 0755
+  when: not stat_etcdctl.stat.exists
+
+- name: Remove binary in etcd data dir
+  file:
+    path: "{{ etcd_data_dir }}/etcdctl"
+    state: absent
+
+- name: Create etcdctl wrapper script
+  template:
+    src: etcdctl.sh.j2
+    dest: "{{ bin_dir }}/etcdctl.sh"
+    mode: 0755

--- a/roles/etcdctl/templates/etcdctl.sh.j2
+++ b/roles/etcdctl/templates/etcdctl.sh.j2
@@ -1,0 +1,8 @@
+#!/bin/bash
+# {{ ansible_managed }}
+# example invocation: etcdctl.sh get --keys-only --from-key ""
+
+etcdctl \
+  --cacert {{ kube_cert_dir }}/etcd/ca.crt \
+  --cert {{ kube_cert_dir }}/etcd/server.crt \
+  --key {{ kube_cert_dir }}/etcd/server.key "$@"

--- a/roles/kubernetes/master/tasks/kubeadm-etcd.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-etcd.yml
@@ -16,7 +16,7 @@
   include_tasks: "{{ role_path }}/../../etcd/tasks/install_host.yml"
   vars:
     etcd_cluster_setup: true
-  when: etcd_deployment_type == "host"
+  when: etcd_deployment_type == "host" and not etcd_kubeadm_enabled
 
 - name: Ensure etcdctl binary is installed
   include_tasks: "{{ role_path }}/../../etcd/tasks/install_etcdctl_docker.yml"
@@ -24,4 +24,9 @@
     etcd_cluster_setup: true
     etcd_retries: 4
   when:
-    - etcd_deployment_type == "docker"
+    - etcd_deployment_type == "docker" and not etcd_kubeadm_enabled
+
+- name: Ensure etcdctl script is installed
+  import_role:
+    name: etcdctl
+  when: etcd_kubeadm_enabled


### PR DESCRIPTION
* create a wrapper script with pki options
* supports all kubespray managed container engines

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:

To enable using etcdctl with kubeadm managed etcd.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Conflicts with stale pr #6151 

Tested in 3 cases (with crio):
- no etcdctl on host
- wrong version on host
- same version on host

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
