### PR TITLE
fixed bug in etcd retention where backups are not sorted by date

### DIFF
--- a/roles/etcd/handlers/backup.yml
+++ b/roles/etcd/handlers/backup.yml
@@ -62,5 +62,5 @@
 - name: Remove old etcd backups
   shell:
     chdir: "{{ etcd_backup_prefix }}"
-    cmd: "find . -name 'etcd-*' | head -n -{{ etcd_backup_retention_count }} | xargs rm -rf"
+    cmd: "find . -name 'etcd-*' | sort -n | head -n -{{ etcd_backup_retention_count }} | xargs rm -rf"
   when: etcd_backup_retention_count >= 0

--- a/roles/etcd/handlers/backup.yml
+++ b/roles/etcd/handlers/backup.yml
@@ -62,5 +62,5 @@
 - name: Remove old etcd backups
   shell:
     chdir: "{{ etcd_backup_prefix }}"
-    cmd: "find . -name 'etcd-*' | sort -n | head -n -{{ etcd_backup_retention_count }} | xargs rm -rf"
+    cmd: "find . -name 'etcd-*' -type d | sort -n | head -n -{{ etcd_backup_retention_count }} | xargs rm -rf"
   when: etcd_backup_retention_count >= 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Last week PR #6836 was merged. Due to a last minute refactor, a bug snuck in: `find` does give a sorted output like `ls` did before the refactor. This causes the wrong backups to be deleted, rather than the oldest. This PR corrects this bug by adding a `sort` to the backup deletion command.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes a bug in #6836 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
