### PR TITLE
Enable crun support on CRI-O

### DIFF
--- a/roles/container-engine/cri-o/defaults/main.yml
+++ b/roles/container-engine/cri-o/defaults/main.yml
@@ -54,6 +54,13 @@ kata_runtimes:
     type: oci
     root: /run/kata-containers
 
+# crun is a fast and low-memory footprint OCI Container Runtime fully written in C.
+crun_runtime:
+  name: crun
+  path: /usr/bin/crun
+  type: oci
+  root: /run/crun
+
 # When this is true, CRI-O package repositories are added. Set this to false when using an
 # environment with preconfigured CRI-O package repositories.
 crio_add_repos: true

--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -45,11 +45,17 @@
 
 - import_tasks: "crictl.yml"
 
-- name: Build a list of crio runtimes
+- name: Build a list of crio runtimes with Katacontainers runtimes
   set_fact:
     crio_runtimes: "{{ crio_runtimes + kata_runtimes  }}"
   when:
     - kata_containers_enabled
+
+- name: Build a list of crio runtimes with crun runtime
+  set_fact:
+    crio_runtimes: "{{ crio_runtimes + [crun_runtime] }}"
+  when:
+    - crun_enabled
 
 - name: Make sure needed folders exist in the system
   with_items:

--- a/roles/container-engine/crun/defaults/main.yml
+++ b/roles/container-engine/crun/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+
+crun_version: 0.15
+crun_release_url: https://github.com/containers/crun/releases/download/{{ crun_version }}/crun-{{ crun_version }}-linux-{{ host_architecture }}
+crun_bin_dir: /usr/bin/

--- a/roles/container-engine/crun/tasks/main.yml
+++ b/roles/container-engine/crun/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Create binary destination folder
+  file:
+    mode: '0755'
+    state: directory
+    path: "{{ crun_bin_dir }}"
+
+- name: Check if binary exists
+  stat:
+    path: "{{ crun_bin_dir }}/crun"
+  register: crun_stat
+
+- name: Download binary
+  get_url:
+    url: "{{ crun_release_url }}"
+    dest: "{{ crun_bin_dir }}/crun"
+    mode: '0755'
+  when: not crun_stat.stat.exists

--- a/roles/container-engine/meta/main.yml
+++ b/roles/container-engine/meta/main.yml
@@ -7,6 +7,13 @@ dependencies:
       - container-engine
       - kata-containers
 
+  - role: container-engine/crun
+    when:
+      - crun_enabled
+    tags:
+      - container-engine
+      - crun
+
   - role: container-engine/cri-o
     when:
       - container_manager == 'crio'

--- a/roles/kubernetes-apps/container_runtimes/crun/files/runtimeclass-crun.yml
+++ b/roles/kubernetes-apps/container_runtimes/crun/files/runtimeclass-crun.yml
@@ -1,0 +1,6 @@
+---
+kind: RuntimeClass
+apiVersion: node.k8s.io/v1beta1
+metadata:
+  name: crun
+handler: crun

--- a/roles/kubernetes-apps/container_runtimes/crun/tasks/main.yaml
+++ b/roles/kubernetes-apps/container_runtimes/crun/tasks/main.yaml
@@ -1,0 +1,19 @@
+---
+
+- name: crun | Copy runtime class manifest
+  copy:
+    src: runtimeclass-crun.yml
+    dest: "{{ kube_config_dir }}/runtimeclass-crun.yml"
+    mode: preserve
+  when:
+    - inventory_hostname == groups['kube-master'][0]
+
+- name: crun | Apply manifests
+  kube:
+    name: "runtimeclass-crun"
+    kubectl: "{{ bin_dir }}/kubectl"
+    resource: "runtimeclass"
+    filename: "{{ kube_config_dir }}/runtimeclass-crun.yml"
+    state: "latest"
+  when:
+    - inventory_hostname == groups['kube-master'][0]

--- a/roles/kubernetes-apps/container_runtimes/meta/main.yml
+++ b/roles/kubernetes-apps/container_runtimes/meta/main.yml
@@ -6,3 +6,10 @@ dependencies:
       - apps
       - kata-containers
       - container-runtimes
+
+  - role: kubernetes-apps/container_runtimes/crun
+    when: crun_enabled
+    tags:
+      - apps
+      - crun
+      - container-runtimes

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -224,6 +224,10 @@ container_manager: docker
 # When enabled, it requires `container_manager` different than Docker
 kata_containers_enabled: false
 
+# Enable crun as additional container runtime
+# When enabled, it requires container_manager=crio
+crun_enabled: false
+
 # Container on localhost (download images when download_localhost is true)
 container_manager_on_localhost: "{{ container_manager }}"
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
This change provides instructions to install and configure [crun](https://github.com/containers/crun). This container runtime has lower footprint, better performance and cgroup2 support among other [things](https://www.redhat.com/sysadmin/introduction-crun). 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
The current implementation is only offered for CRI-O thru the `crun_enabled` configuration value.
```yaml
container_manager: crio
crun_enabled: true
```
Once the cluster is deployed is possible to create workloads like the following:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: crun-pod
spec:
  runtimeClassName: crun
  containers:
    - name: test
      image: busybox
      command: ["sleep"]
      args: ["infity"]
```
and the assigned worker node will show the follows:
```bash
$ ps -ef | grep crun
root       21406       1  0 16:28 ?        00:00:00 /usr/bin/conmon -b /var/run/containers/storage/overlay-containers/c1e62f2a41ede66645a2178c1eafb51a8035aff88fef4c1edc2856428d8211d1/userdata -c c1e62f2a41ede66645a2178c1eafb51a8035aff88fef4c1edc2856428d8211d1 --exit-dir /var/run/crio/exits -l /var/log/pods/default_crun-pod_deb438b6-76a8-4fd0-abda-777a922c4c70/c1e62f2a41ede66645a2178c1eafb51a8035aff88fef4c1edc2856428d8211d1.log --log-level info -n k8s_POD_crun-pod_default_deb438b6-76a8-4fd0-abda-777a922c4c70_0 -P /var/run/containers/storage/overlay-containers/c1e62f2a41ede66645a2178c1eafb51a8035aff88fef4c1edc2856428d8211d1/userdata/conmon-pidfile -p /var/run/containers/storage/overlay-containers/c1e62f2a41ede66645a2178c1eafb51a8035aff88fef4c1edc2856428d8211d1/userdata/pidfile --persist-dir /var/lib/containers/storage/overlay-containers/c1e62f2a41ede66645a2178c1eafb51a8035aff88fef4c1edc2856428d8211d1/userdata -r /usr/bin/crun --runtime-arg --root=/run/crun --socket-dir-path /var/run/crio -u c1e62f2a41ede66645a2178c1eafb51a8035aff88fef4c1edc2856428d8211d1 -s
root       21469       1  0 16:28 ?        00:00:00 /usr/bin/conmon -b /var/run/containers/storage/overlay-containers/37a3aa028967d8ae1028ed618152bdd25016f91971135985ae9b02d823e2d095/userdata -c 37a3aa028967d8ae1028ed618152bdd25016f91971135985ae9b02d823e2d095 --exit-dir /var/run/crio/exits -l /var/log/pods/default_crun-pod_deb438b6-76a8-4fd0-abda-777a922c4c70/test/0.log --log-level info -n k8s_test_crun-pod_default_deb438b6-76a8-4fd0-abda-777a922c4c70_0 -P /var/run/containers/storage/overlay-containers/37a3aa028967d8ae1028ed618152bdd25016f91971135985ae9b02d823e2d095/userdata/conmon-pidfile -p /var/run/containers/storage/overlay-containers/37a3aa028967d8ae1028ed618152bdd25016f91971135985ae9b02d823e2d095/userdata/pidfile --persist-dir /var/lib/containers/storage/overlay-containers/37a3aa028967d8ae1028ed618152bdd25016f91971135985ae9b02d823e2d095/userdata -r /usr/bin/crun --runtime-arg --root=/run/crun --socket-dir-path /var/run/crio -u 37a3aa028967d8ae1028ed618152bdd25016f91971135985ae9b02d823e2d095 -s
$ sudo crun --version
crun version 0.15
commit: 56ca95e61639510c7dbd39ff512f80f626404969
spec: 1.0.0
+SYSTEMD +SELINUX +APPARMOR +CAP +SECCOMP +EBPF +CRIU +YAJL
$ sudo crun list
NAME                                                             PID       STATUS   BUNDLE PATH                            
c1e62f2a41ede66645a2178c1eafb51a8035aff88fef4c1edc2856428d8211d1 21416     running  /run/containers/storage/overlay-containers/c1e62f2a41ede66645a2178c1eafb51a8035aff88fef4c1edc2856428d8211d1/userdata
37a3aa028967d8ae1028ed618152bdd25016f91971135985ae9b02d823e2d095 21477     running  /run/containers/storage/overlay-containers/37a3aa028967d8ae1028ed618152bdd25016f91971135985ae9b02d823e2d095/userdata

```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
