### PR TITLE
Fix missing spaces in section heading.

### DIFF
--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -1,9 +1,9 @@
 # Comparison
 
-## Kubespray vs [Kops](https://github.com/kubernetes/kops)
+## Kubespray vs Kops
 
 Kubespray runs on bare metal and most clouds, using Ansible as its substrate for
-provisioning and orchestration. Kops performs the provisioning and orchestration
+provisioning and orchestration. [Kops](https://github.com/kubernetes/kops) performs the provisioning and orchestration
 itself, and as such is less flexible in deployment platforms. For people with
 familiarity with Ansible, existing Ansible deployments or the desire to run a
 Kubernetes cluster across multiple platforms, Kubespray is a good choice. Kops,
@@ -11,9 +11,9 @@ however, is more tightly integrated with the unique features of the clouds it
 supports so it could be a better choice if you know that you will only be using
 one platform for the foreseeable future.
 
-## Kubespray vs [Kubeadm](https://github.com/kubernetes/kubeadm)
+## Kubespray vs Kubeadm
 
-Kubeadm provides domain Knowledge of Kubernetes clusters' life cycle
+[Kubeadm](https://github.com/kubernetes/kubeadm) provides domain Knowledge of Kubernetes clusters' life cycle
 management, including self-hosted layouts, dynamic discovery services and so
 on. Had it belonged to the new [operators world](https://coreos.com/blog/introducing-operators.html),
 it may have been named a "Kubernetes cluster operator". Kubespray however,


### PR DESCRIPTION
When https://kubespray.io/#/docs/comparisons is generated, having the link in the heading creates the following HTML. When displayed there is no space between "vs" and the link. I simply moved the link into the following paragraph.

```
<h2 id="kubespray-vs-kops"><a href="#/docs/comparisons?id=kubespray-vs-kops" data-id="kubespray-vs-kops" class="anchor"><span>Kubespray vs </span></a><a href="https://github.com/kubernetes/kops" target="_blank" rel="noopener">Kops</a></h2>
```

**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Makes the documentation look better.

**Which issue(s) this PR fixes**:

Not applicable.

**Special notes for your reviewer**:

None.

**Does this PR introduce a user-facing change?**:

Yes, if documentation is considered user-facing.

```release-note
Fix missing spaces in section heading of comparison page.
```
