### PR TITLE
Create ssh-to-XXX scripts to Terraform/AWS contribution.

### DIFF
--- a/contrib/terraform/aws/ssh-to-bastion.sh
+++ b/contrib/terraform/aws/ssh-to-bastion.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+#
+# I am frequently connecting to the servers in the cluster and I tweak settings to
+# improve security or try to understand the innards of kubernetes. Because of this,
+# I wanted a script to hid the complexities of the SSH command. 
+#
+
+#
+# This script connects to the first bastion server in the inventory file.
+#
+# CONFIGURATION IS NEEDED.
+#
+# * Set PKI_PRIVATE_PEM to the location of your PEM file used when creating the cluster.
+
+# * Set KUBESPRAY_INSTALL_DIR to the root directory of the KubeSpray project. This variable
+#   is used so that $KUBESPRAY_INSTALL_DIR/contrib/terraform/aws can be put into your path 
+#   allowing this script to be run from any directory.
+#
+
+
+if [ -z $PKI_PRIVATE_PEM ]; then
+    echo "Missing Environment Variable: PKI_PRIVATE_PEM"
+    echo "  This variable should point to the PEM file for the BASTION server."
+fi
+
+if [ -z $KUBESPRAY_INSTALL_DIR ]; then
+    echo "Missing Environment Variable: KUBESPRAY_INSTALL_DIR"
+    echo "  This variable should point the root of the Kubespray project; where the LICENSE file is."
+fi
+
+INVENTORY="$KUBESPRAY_INSTALL_DIR/inventory/hosts"
+
+if [ ! -f $INVENTORY ]; then
+    echo "Missing file: $INVENTORY"
+    echo "  This file should be created by the Terraform apply command."
+fi
+
+ssh-add $PKI_PRIVATE_PEM
+
+export BASTION_IP=$(grep ^bastion $INVENTORY | head -n 1 | cut -d'=' -f2)
+
+ssh centos@$BASTION_IP

--- a/contrib/terraform/aws/ssh-to-controller.sh
+++ b/contrib/terraform/aws/ssh-to-controller.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+#
+# I am frequently connecting to the servers in the cluster and I tweak settings to
+# improve security or try to understand the innards of kubernetes. Because of this,
+# I wanted a script to hide the complexities of the SSH command. 
+#
+
+#
+# This script connects to the first controller node in the inventory file.
+#
+# CONFIGURATION IS NEEDED.
+#
+# * Set PKI_PRIVATE_PEM to the location of your PEM file used when creating the cluster.
+
+# * Set KUBESPRAY_INSTALL_DIR to the root directory of the KubeSpray project. This variable
+#   is used so that $KUBESPRAY_INSTALL_DIR/contrib/terraform/aws can be put into your path 
+#   allowing this script to be run from any directory.
+#
+
+if [ -z $PKI_PRIVATE_PEM ]; then
+    echo "Missing Environment Variable: PKI_PRIVATE_PEM"
+    echo "  This variable should point to the PEM file for the BASTION server."
+fi
+
+if [ -z $KUBESPRAY_INSTALL_DIR ]; then
+    echo "Missing Environment Variable: KUBESPRAY_INSTALL_DIR"
+    echo "  This variable should point the root of the Kubespray project; where the LICENSE file is."
+fi
+
+INVENTORY="$KUBESPRAY_INSTALL_DIR/inventory/hosts"
+CONF="$KUBESPRAY_INSTALL_DIR/ssh-bastion.conf"
+
+if [ ! -f $INVENTORY ]; then
+    echo "Missing file: $INVENTORY"
+    echo "  This file should be created by the Terraform apply command."
+fi
+
+if [ ! -f $CONF ]; then
+    echo "Missing file: $CONF"
+    echo "  This file should be created by the Terraform apply command."
+fi
+
+ssh-add $PKI_PRIVATE_PEM
+
+HOST_NAME=$(cat $INVENTORY | grep "\[kube-master\]" -A 1 | tail -n 1)
+IP=$(cat $INVENTORY | grep $HOST_NAME | grep ansible_host | cut -d'=' -f2)
+ssh -F $CONF centos@$IP

--- a/contrib/terraform/aws/ssh-to-etcd.sh
+++ b/contrib/terraform/aws/ssh-to-etcd.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+#
+# I am frequently connecting to the servers in the cluster and I tweak settings to
+# improve security or try to understand the innards of kubernetes. Because of this,
+# I wanted a script to hide the complexities of the SSH command. 
+#
+
+#
+# This script connects to the first controller node in the inventory file.
+#
+# CONFIGURATION IS NEEDED.
+#
+# * Set PKI_PRIVATE_PEM to the location of your PEM file used when creating the cluster.
+
+# * Set KUBESPRAY_INSTALL_DIR to the root directory of the KubeSpray project. This variable
+#   is used so that $KUBESPRAY_INSTALL_DIR/contrib/terraform/aws can be put into your path 
+#   allowing this script to be run from any directory.
+#
+
+if [ -z $PKI_PRIVATE_PEM ]; then
+    echo "Missing Environment Variable: PKI_PRIVATE_PEM"
+    echo "  This variable should point to the PEM file for the BASTION server."
+fi
+
+if [ -z $KUBESPRAY_INSTALL_DIR ]; then
+    echo "Missing Environment Variable: KUBESPRAY_INSTALL_DIR"
+    echo "  This variable should point the root of the Kubespray project; where the LICENSE file is."
+fi
+
+INVENTORY="$KUBESPRAY_INSTALL_DIR/inventory/hosts"
+CONF="$KUBESPRAY_INSTALL_DIR/ssh-bastion.conf"
+
+if [ ! -f $INVENTORY ]; then
+    echo "Missing file: $INVENTORY"
+    echo "  This file should be created by the Terraform apply command."
+fi
+
+if [ ! -f $CONF ]; then
+    echo "Missing file: $CONF"
+    echo "  This file should be created by the Terraform apply command."
+fi
+
+ssh-add $PKI_PRIVATE_PEM
+
+HOST_NAME=$(cat $INVENTORY | grep "\[etcd\]" -A 1 | tail -n 1)
+IP=$(cat $INVENTORY | grep $HOST_NAME | grep ansible_host | cut -d'=' -f2)
+ssh -F $CONF centos@$IP

--- a/contrib/terraform/aws/ssh-to-etcd.sh
+++ b/contrib/terraform/aws/ssh-to-etcd.sh
@@ -7,7 +7,7 @@
 #
 
 #
-# This script connects to the first controller node in the inventory file.
+# This script connects to the first etcd node in the inventory file.
 #
 # CONFIGURATION IS NEEDED.
 #

--- a/contrib/terraform/aws/ssh-to-worker.sh
+++ b/contrib/terraform/aws/ssh-to-worker.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+#
+# I am frequently connecting to the servers in the cluster and I tweak settings to
+# improve security or try to understand the innards of kubernetes. Because of this,
+# I wanted a script to hide the complexities of the SSH command. 
+#
+
+#
+# This script connects to the first worker node in the inventory file.
+#
+# CONFIGURATION IS NEEDED.
+#
+# * Set PKI_PRIVATE_PEM to the location of your PEM file used when creating the cluster.
+
+# * Set KUBESPRAY_INSTALL_DIR to the root directory of the KubeSpray project. This variable
+#   is used so that $KUBESPRAY_INSTALL_DIR/contrib/terraform/aws can be put into your path 
+#   allowing this script to be run from any directory.
+#
+
+if [ -z $PKI_PRIVATE_PEM ]; then
+    echo "Missing Environment Variable: PKI_PRIVATE_PEM"
+    echo "  This variable should point to the PEM file for the BASTION server."
+fi
+
+if [ -z $KUBESPRAY_INSTALL_DIR ]; then
+    echo "Missing Environment Variable: KUBESPRAY_INSTALL_DIR"
+    echo "  This variable should point the root of the Kubespray project; where the LICENSE file is."
+fi
+
+INVENTORY="$KUBESPRAY_INSTALL_DIR/inventory/hosts"
+CONF="$KUBESPRAY_INSTALL_DIR/ssh-bastion.conf"
+
+if [ ! -f $INVENTORY ]; then
+    echo "Missing file: $INVENTORY"
+    echo "  This file should be created by the Terraform apply command."
+fi
+
+if [ ! -f $CONF ]; then
+    echo "Missing file: $CONF"
+    echo "  This file should be created by the Terraform apply command."
+fi
+
+ssh-add $PKI_PRIVATE_PEM
+
+HOST_NAME=$(cat $INVENTORY | grep "\[kube-node\]" -A 1 | tail -n 1)
+IP=$(cat $INVENTORY | grep $HOST_NAME | grep ansible_host | cut -d'=' -f2)
+ssh -F $CONF centos@$IP


### PR DESCRIPTION
This set of scripts hides the complexity of finding the IP address of nodes and using the bastion configuration file for SSH connections. As I seek to understand Kubernetes and respond to KubeBench findings, I frequently SSH into the nodes. I have found these scripts time-saving and they are helpful to others.

I would call this PR an enhancement but that is not in the list. So I am using feature. Please correct if needed.

**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:

Provides an easy way for DevSecOps people to SSH into the cluster.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

None.

**Does this PR introduce a user-facing change?**:

Yes.

```release-note
Add scripts for Terraform/AWS to easily SSH to Bastion, Controller, Worker, and Etcd nodes.
```
