### PR TITLE
Allow the eventRecordQPS setting to be set.

### DIFF
--- a/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
@@ -91,3 +91,6 @@ tlsCipherSuites:
 - {{ tls }}
 {% endfor %}
 {% endif %}
+{% if kubelet_event_record_qps %}
+eventRecordQPS: {{ kubelet_event_record_qps }}
+{% endif %}

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -534,3 +534,7 @@ host_architecture: >-
   {%- else -%}
   {{ ansible_architecture }}
   {%- endif -%}
+
+# Sets the eventRecordQPS parameter in kubelet-config.yaml. The default value is 5 (see types.go)
+# Setting it to 0 allows unlimited requests per second.
+kubelet_event_record_qps: 5


### PR DESCRIPTION
The eventRecordQPS parameter controls rate limiting for event recording. When zero, unlimited events can cause denial-of-service situations. For my situation, I don't need more than a setting of "5". This change allows me to configure the setting before creating the cluster.

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds the ability to set the eventRecordQPS parameter before the cluster is created.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

Note there might be other places in the project where it might be appropriate to set this parameter. I have only tested this change with an AWS EC2 cluster.

**Does this PR introduce a user-facing change?**:

No.

```release-note
NONE
```
