### PR TITLE
etcd: Fix certs always being regenerated

### DIFF
--- a/roles/etcd/tasks/check_certs.yml
+++ b/roles/etcd/tasks/check_certs.yml
@@ -2,7 +2,11 @@
 - name: "Check_certs | check if all certs have already been generated on first master"
   find:
     paths: "{{ etcd_cert_dir }}"
-    patterns: "ca.pem,node*.pem"
+    patterns:
+      - ca.pem
+      - node-*-key.pem
+      - admin-*-key.pem
+      - member-*-key.pem
     get_checksum: true
   delegate_to: "{{ groups['etcd'][0] }}"
   register: etcdcert_master
@@ -29,6 +33,8 @@
   run_once: true
   with_items: "{{ expected_files }}"
   vars:
+    # When changing the list of expected files, make sure to also update the
+    # pattern list in the `find` tasks above!
     expected_files: >-
       ['{{ etcd_cert_dir }}/ca.pem',
       {% set all_etcd_hosts = groups['k8s-cluster']|union(groups['etcd'])|union(groups['calico-rr']|default([]))|unique|sort %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind bug

**What this PR does / why we need it**:

The cert logic (in `roles/etcd/tasks/check_certs.yml`) works like this:

1. Let a list of all certs currently present (via a `find` pattern)
2. Check the list against a list of required/expected certificates
3. On mismatch, regenerate

The `find` pattern and the list of expected certificates has to match.  If the
pattern does not match all entries in the list, the certs will be regenerated
on every run.

**Which issue(s) this PR fixes**:

Fixes #6673

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
