### PR TITLE
Fix hash of pypy3.6-v7.3.2-linux64 archive.

### DIFF
--- a/roles/bootstrap-os/files/bootstrap.sh
+++ b/roles/bootstrap-os/files/bootstrap.sh
@@ -4,7 +4,7 @@ set -e
 BINDIR="/opt/bin"
 PYPY_VERSION=7.3.2
 PYPI_URL="https://downloads.python.org/pypy/pypy3.6-v${PYPY_VERSION}-linux64.tar.bz2"
-PYPI_HASH=f67cf1664a336a3e939b58b3cabfe47d893356bdc01f2e17bc912aaa6605db12
+PYPI_HASH=d7a91f179076aaa28115ffc0a81e46c6a787785b2bc995c926fe3b02f0e9ad83
 
 mkdir -p $BINDIR
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

PR #6801 updated PyPy3.6 to version 7.3.2, but did not change the expected SHA256 hash. This PR updates said hash. See https://www.pypy.org/download.html for the hash of the current release.

**Which issue(s) this PR fixes**:
Fixes #6896

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
