### PR TITLE
[WIP] Don't bind loadbalancer healthcheck to all interfaсes on the host

### DIFF
--- a/roles/kubernetes/node/templates/loadbalancer/haproxy.cfg.j2
+++ b/roles/kubernetes/node/templates/loadbalancer/haproxy.cfg.j2
@@ -21,7 +21,7 @@ defaults
 
 {% if loadbalancer_apiserver_healthcheck_port is defined -%}
 frontend healthz
-  bind *:{{ loadbalancer_apiserver_healthcheck_port }}
+  bind 127.0.0.1:{{ loadbalancer_apiserver_healthcheck_port }}
   mode http
   monitor-uri /healthz
 {% endif %}

--- a/roles/kubernetes/node/templates/loadbalancer/nginx.conf.j2
+++ b/roles/kubernetes/node/templates/loadbalancer/nginx.conf.j2
@@ -40,7 +40,7 @@ http {
 
   {% if loadbalancer_apiserver_healthcheck_port is defined -%}
   server {
-    listen {{ loadbalancer_apiserver_healthcheck_port }};
+    listen 127.0.0.1:{{ loadbalancer_apiserver_healthcheck_port }};
     location /healthz {
       access_log off;
       return 200;

--- a/roles/kubernetes/node/templates/manifests/haproxy.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/haproxy.manifest.j2
@@ -27,12 +27,14 @@ spec:
     {% if loadbalancer_apiserver_healthcheck_port is defined -%}
     livenessProbe:
       httpGet:
-        path: /healthz
+        host: 127.0.0.1
         port: {{ loadbalancer_apiserver_healthcheck_port }}
+        path: /healthz
     readinessProbe:
       httpGet:
-        path: /healthz
+        host: 127.0.0.1
         port: {{ loadbalancer_apiserver_healthcheck_port }}
+        path: /healthz
     {% endif -%}
     volumeMounts:
     - mountPath: /usr/local/etc/haproxy/

--- a/roles/kubernetes/node/templates/manifests/nginx-proxy.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/nginx-proxy.manifest.j2
@@ -27,12 +27,14 @@ spec:
     {% if loadbalancer_apiserver_healthcheck_port is defined -%}
     livenessProbe:
       httpGet:
-        path: /healthz
+        host: 127.0.0.1
         port: {{ loadbalancer_apiserver_healthcheck_port }}
+        path: /healthz
     readinessProbe:
       httpGet:
-        path: /healthz
+        host: 127.0.0.1
         port: {{ loadbalancer_apiserver_healthcheck_port }}
+        path: /healthz
     {% endif -%}
     volumeMounts:
     - mountPath: /etc/nginx


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This change avoids possible conflict of network ports. If someone wants to deploy deployment/daemonset/pod that uses the host network and port 8081.

apiserver proxy - listens **only** on 127.0.0.1 [nginx.conf.j2#L22
](https://github.com/kubernetes-sigs/kubespray/blob/3b7797b1a1d478493fc9b1510499fe371ddd7e2c/roles/kubernetes/node/templates/loadbalancer/nginx.conf.j2#L22)healthz - listens on **all host** interfaces [nginx.conf.j2#L43](https://github.com/kubernetes-sigs/kubespray/blob/3b7797b1a1d478493fc9b1510499fe371ddd7e2c/roles/kubernetes/node/templates/loadbalancer/nginx.conf.j2#L43)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:
Please wait for the detailed issue, I'll write it later.
Related PR https://github.com/kubernetes-sigs/kubespray/pull/6893

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
No, I think. Except for one case. If someone checks the loadbalancer with an external service (zabbix, etc). But why do it?
