### PR TITLE
Ensure libseccomp is installed before starting containerd on CentOS 8

### DIFF
--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -129,4 +129,20 @@
     - not is_ostree
     - not runc_stat.stat.exists
 
+- name: Gather the rpm package facts
+  package_facts:
+    manager: auto
+  when:
+    - ansible_distribution == "CentOS"
+    - ansible_distribution_major_version == "8"
+
+- name: Ensure latest version of libseccomp installed  # noqa 303
+  command: "yum update -y libseccomp"
+  when:
+    - not is_ostree
+    - ansible_distribution == "CentOS"
+    - ansible_distribution_major_version == "8"
+    - ansible_facts.packages['libseccomp'] | map(attribute='version') | map('regex_replace','^(?P<major>\\d+).(?P<minor>\\d+).(?P<patch>\\d+)$', '\\g<major>.\\g<minor>') | list | first == '2.3'
+  notify: restart containerd
+
 - include_tasks: crictl.yml

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -129,20 +129,13 @@
     - not is_ostree
     - not runc_stat.stat.exists
 
-- name: Gather the rpm package facts
-  package_facts:
-    manager: auto
+- name: Ensure latest version of libseccomp installed  # noqa 403
+  package:
+    name: libseccomp
+    state: latest
   when:
     - ansible_distribution == "CentOS"
     - ansible_distribution_major_version == "8"
-
-- name: Ensure latest version of libseccomp installed  # noqa 303
-  command: "yum update -y libseccomp"
-  when:
-    - not is_ostree
-    - ansible_distribution == "CentOS"
-    - ansible_distribution_major_version == "8"
-    - ansible_facts.packages['libseccomp'] | map(attribute='version') | map('regex_replace','^(?P<major>\\d+).(?P<minor>\\d+).(?P<patch>\\d+)$', '\\g<major>.\\g<minor>') | list | first == '2.3'
   notify: restart containerd
 
 - include_tasks: crictl.yml

--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -75,19 +75,13 @@
   retries: 4
   delay: "{{ retry_stagger | d(3) }}"
 
-- name: Gather the rpm package facts
-  package_facts:
-    manager: auto
+- name: Ensure latest version of libseccomp installed  # noqa 403
+  package:
+    name: libseccomp
+    state: latest
   when:
     - ansible_distribution == "CentOS"
     - ansible_distribution_major_version == "8"
-
-- name: Ensure latest version of libseccom installed  # noqa 303
-  command: "yum update -y libseccomp"
-  when:
-    - ansible_distribution == "CentOS"
-    - ansible_distribution_major_version == "8"
-    - ansible_facts.packages['libseccomp'] | map(attribute='version') | map('regex_replace','^(?P<major>\\d+).(?P<minor>\\d+).(?P<patch>\\d+)$', '\\g<major>.\\g<minor>') | list | first == '2.3'
   notify: restart crio
 
 - name: Check if already installed

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -211,6 +211,21 @@
     selection: hold
   when: ansible_os_family in ["Debian"]
 
+- name: Gather the rpm package facts
+  package_facts:
+    manager: auto
+  when:
+    - ansible_distribution == "CentOS"
+    - ansible_distribution_major_version == "8"
+
+- name: Ensure latest version of libseccomp installed  # noqa 303
+  command: "yum update -y libseccomp"
+  when:
+    - ansible_distribution == "CentOS"
+    - ansible_distribution_major_version == "8"
+    - ansible_facts.packages['libseccomp'] | map(attribute='version') | map('regex_replace','^(?P<major>\\d+).(?P<minor>\\d+).(?P<patch>\\d+)$', '\\g<major>.\\g<minor>') | list | first == '2.3'
+  notify: restart docker
+
 - name: ensure docker started, remove our config if docker start failed and try again
   block:
     - name: ensure service is started if docker packages are already present

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -211,19 +211,13 @@
     selection: hold
   when: ansible_os_family in ["Debian"]
 
-- name: Gather the rpm package facts
-  package_facts:
-    manager: auto
+- name: Ensure latest version of libseccomp installed  # noqa 403
+  package:
+    name: libseccomp
+    state: latest
   when:
     - ansible_distribution == "CentOS"
     - ansible_distribution_major_version == "8"
-
-- name: Ensure latest version of libseccomp installed  # noqa 303
-  command: "yum update -y libseccomp"
-  when:
-    - ansible_distribution == "CentOS"
-    - ansible_distribution_major_version == "8"
-    - ansible_facts.packages['libseccomp'] | map(attribute='version') | map('regex_replace','^(?P<major>\\d+).(?P<minor>\\d+).(?P<patch>\\d+)$', '\\g<major>.\\g<minor>') | list | first == '2.3'
   notify: restart docker
 
 - name: ensure docker started, remove our config if docker start failed and try again


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Starting containerd (and therefore docker, which requires containerd) currently fails on Centos 8 due to a missing dependency. This PR copies what we already do for CRI-O to ensure libseccomp is installed.

To test, create `vagrant/config.rb` containing the line `$os = "centos8"` and provision, as described in issue #6920 

**Which issue(s) this PR fixes**:
Fixes #6920

**Special notes for your reviewer**:
Please flag if there's any way I can introduce better tests for this.

I had hoped to make sure it was covered, but it seems molecule only tests against ubuntu (reasonably enough, since it's meant to be fast), and I was unclear on whether CI currently tests against Centos 8.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```