### PR TITLE
Issue 6925 inventory builder tests failing

### DIFF
--- a/contrib/inventory_builder/tests/test_inventory.py
+++ b/contrib/inventory_builder/tests/test_inventory.py
@@ -51,7 +51,7 @@ class TestInventory(unittest.TestCase):
         groups = ['group1', 'group2']
         self.inv.ensure_required_groups(groups)
         for group in groups:
-            self.assertTrue(group in self.inv.yaml_config['all']['children'])
+            self.assertIn(group, self.inv.yaml_config['all']['children'])
 
     def test_get_host_id(self):
         hostnames = ['node99', 'no99de01', '01node01', 'node1.domain',
@@ -227,8 +227,9 @@ class TestInventory(unittest.TestCase):
         host = 'node1'
 
         self.inv.set_kube_master([host])
-        self.assertTrue(
-            host in self.inv.yaml_config['all']['children'][group]['hosts'])
+        self.assertIn(
+            host,
+            self.inv.yaml_config['all']['children'][group]['hosts'])
 
     def test_set_all(self):
         hosts = OrderedDict([
@@ -246,8 +247,8 @@ class TestInventory(unittest.TestCase):
 
         self.inv.set_k8s_cluster()
         for host in expected_hosts:
-            self.assertTrue(
-                host in
+            self.assertIn(
+                host,
                 self.inv.yaml_config['all']['children'][group]['children'])
 
     def test_set_kube_node(self):
@@ -255,16 +256,18 @@ class TestInventory(unittest.TestCase):
         host = 'node1'
 
         self.inv.set_kube_node([host])
-        self.assertTrue(
-            host in self.inv.yaml_config['all']['children'][group]['hosts'])
+        self.assertIn(
+            host,
+            self.inv.yaml_config['all']['children'][group]['hosts'])
 
     def test_set_etcd(self):
         group = 'etcd'
         host = 'node1'
 
         self.inv.set_etcd([host])
-        self.assertTrue(
-            host in self.inv.yaml_config['all']['children'][group]['hosts'])
+        self.assertIn(
+            host,
+            self.inv.yaml_config['all']['children'][group]['hosts'])
 
     def test_scale_scenario_one(self):
         num_nodes = 50

--- a/contrib/inventory_builder/tox.ini
+++ b/contrib/inventory_builder/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 1.6
 skipsdist = True
-envlist = pep8, py33
+envlist = pep8, py3
 
 [testenv]
 whitelist_externals = py.test


### PR DESCRIPTION
**What type of PR is this?**
> /kind failing-test

**What this PR does / why we need it**:
- Fixes some very minor PEP8 problems that were causing CI to fail
- Changes `tox`'s Python requirement from 3.3 (deprecated) to 3.x

**Which issue(s) this PR fixes**: 
Fixes #6925 

**Special notes for your reviewer**:

The PEP8 parts are minor, and the Python version change is probably the biggest change here. 

For the initial PR I've gone with whatever `python3` means on a user's system as this caters for a wide range of developer platforms (Ubuntu 20.04 ships with Python 3.8, CentOS 8 ships with Python 3.6 and so on) and should mean less maintenance in future as Python keeps moving.

However this opens us up to CI failures and potential inconsistencies if in future there are breaking changes between Python versions. 

Personally I get the impression that the inventory-builder is a small enough and infrequently-enough changed piece of code that it's probably preferable to take the more simple path, and to be notified by CI pain if something breaks in future. However I'm happy to change this and pin to a more specific version if anyone feels strongly.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```