### PR TITLE
Allow configuring CRI-O for use in offline environments

### DIFF
--- a/roles/container-engine/cri-o/defaults/main.yml
+++ b/roles/container-engine/cri-o/defaults/main.yml
@@ -11,6 +11,9 @@ crio_pause_image: "{{ pod_infra_image_repo }}:{{ pod_infra_version }}"
 # By default unqualified images are not allowed for security reasons
 crio_registries: []
 
+# Configure insecure registries.
+crio_insecure_registries: []
+
 crio_seccomp_profile: ""
 crio_selinux: "{{ (preinstall_selinux_state == 'enforcing')|lower }}"
 crio_signature_policy: "{% if ansible_os_family == 'ClearLinux' %}/usr/share/defaults/crio/policy.json{% endif %}"
@@ -50,3 +53,7 @@ kata_runtimes:
     path: /opt/kata/bin/kata-qemu
     type: oci
     root: /run/kata-containers
+
+# When this is true, CRI-O package repositories are added. Set this to false when using an
+# environment with preconfigured CRI-O package repositories.
+crio_add_repos: true

--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -39,7 +39,9 @@
     - (ansible_distribution_major_version | int) >= 31
     - ansible_proc_cmdline['systemd.unified_cgroup_hierarchy'] is not defined or ansible_proc_cmdline['systemd.unified_cgroup_hierarchy'] != '0'
 
-- import_tasks: "crio_repo.yml"
+- name: import crio repo
+  import_tasks: "crio_repo.yml"
+  when: crio_add_repos
 
 - import_tasks: "crictl.yml"
 

--- a/roles/container-engine/cri-o/templates/crio.conf.j2
+++ b/roles/container-engine/cri-o/templates/crio.conf.j2
@@ -339,7 +339,11 @@ signature_policy = "{{ crio_signature_policy }}"
 # List of registries to skip TLS verification for pulling images. Please
 # consider configuring the registries via /etc/containers/registries.conf before
 # changing them here.
-#insecure_registries = "[]"
+insecure_registries = [
+  {% for insecure_registry in crio_insecure_registries %}
+  "{{ insecure_registry }}",
+  {% endfor %}
+]
 
 # Controls how image volumes are handled. The valid values are mkdir, bind and
 # ignore; the latter will ignore volumes entirely.


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
In order to be able to install Kubernetes using Kubespray in an offline environment, we need to introduce two configuration variables:

- **crio_add_repos** (default true): this allows for disabling configuring package repositories for CRI-O, so that custom internal package repositories can be used.
- **crio_insecure_registries**: this allows for configuring insecure registries for CRI-O, so that an internal container image registry can be used in a way that would be insecure for publishing on the internet.

**Which issue(s) this PR fixes**:
Fixes #6233

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Allow disabling configuring CRI-O package repositories
Allow setting insecure contaner image registries for CRI-O
```
