### PR TITLE
Added support for calico serviceExternalIPs

### DIFF
--- a/docs/calico.md
+++ b/docs/calico.md
@@ -93,6 +93,15 @@ This can be enabled by setting the following variable as follow in group_vars (k
 calico_advertise_cluster_ips: true
 ```
 
+Since calico 3.10, Calico supports advertising Kubernetes service ExternalIPs over BGP in addition to cluster IPs advertising.
+This can be enabled by setting the following variable in group_vars (k8s-cluster/k8s-net-calico.yml)
+
+```yml
+calico_advertise_service_external_ips:
+- x.x.x.x/24
+- y.y.y.y/32
+```
+
 ### Optional : Define global AS number
 
 Optional parameter `global_as_num` defines Calico global AS number (`/calico/bgp/v1/global/as_num` etcd key).

--- a/inventory/sample/group_vars/k8s-cluster/k8s-net-calico.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-net-calico.yml
@@ -38,6 +38,11 @@
 # Advertise Cluster IPs
 # calico_advertise_cluster_ips: true
 
+# Advertise Service External IPs
+# calico_advertise_service_external_ips:
+# - x.x.x.x/24
+# - y.y.y.y/32
+
 # Choose data store type for calico: "etcd" or "kdd" (kubernetes datastore)
 # calico_datastore: "etcd"
 

--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -22,6 +22,9 @@ global_as_num: "64512"
 # defaults. The value should be a number, not a string.
 # calico_mtu: 1500
 
+# Advertise Service External IPs
+calico_advertise_service_external_ips: []
+
 # Limits for apps
 calico_node_memory_limit: 500M
 calico_node_cpu_limit: 300m

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -154,6 +154,12 @@
     - inventory_hostname == groups['kube-master'][0]
     - 'calico_conf.stdout == "0"'
 
+- name: Populate Service External IPs
+  set_fact:
+    _service_external_ips: "{{ _service_external_ips|default([]) + [ {'cidr': item} ] }}"
+  with_items: "{{ calico_advertise_service_external_ips }}"
+  run_once: yes
+
 - name: "Determine nodeToNodeMesh needed state"
   set_fact:
     nodeToNodeMeshEnabled: "false"
@@ -174,6 +180,7 @@
       "spec": {
           "logSeverityScreen": "Info",
           "nodeToNodeMeshEnabled": {{ nodeToNodeMeshEnabled|default('true') }} ,
+          "serviceExternalIPs": {{ _service_external_ips|default([]) }},
           "asNumber": {{ global_as_num }} }}
   changed_when: false
   when:


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add support of advertising Kubernetes service ExternalIPs over BGP using calico CNI

[Calico doc|Advertise service external IP addresses](https://docs.projectcalico.org/networking/advertise-service-ips#advertise-service-external-ip-addresses)


**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:

```
Added ability to configure Service ExternalIPs for calico CNI
```
