### PR TITLE
Disable CRI-O restart by Multus

### DIFF
--- a/roles/network_plugin/multus/templates/multus-daemonset.yml.j2
+++ b/roles/network_plugin/multus/templates/multus-daemonset.yml.j2
@@ -35,9 +35,6 @@ spec:
         - "--multus-conf-file={{ multus_conf_file }}"
         - "--multus-kubeconfig-file-host={{ multus_kubeconfig_file_host }}"
         - "--cni-version={{ multus_cni_version }}"
-{% if container_manager == 'crio' %}
-        - "--restart-crio=true"
-{% endif %}
         resources:
           requests:
             cpu: "100m"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Currently, Multus is configured to restart CRI-O when Multus is started. According to the Multus docs, this is non-default behaviour and is rarely necessary. Furthermore, restarting CRI-O during the start of CRI-O causes errors on our side.

**Error**:
```
2020-11-20T14:38:55+0000 Restarting crio
Failed to get D-Bus connection: Operation not permitted
```
**Quote from the docs**:
> When using CRIO, you may need to restart CRIO to get the Multus configuration file to take – this is rarely necessary.
> 
> `--restart-crio=false`

https://intel.github.io/multus-cni/doc/how-to-use.html

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6929

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: no
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
<!--
```release-note

```
-->