### PR TITLE
bump calico version to 3.16.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [cri-o](http://cri-o.io/) v1.19 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)
 - Network Plugin
   - [cni-plugins](https://github.com/containernetworking/plugins) v0.8.7
-  - [calico](https://github.com/projectcalico/calico) v3.16.4
+  - [calico](https://github.com/projectcalico/calico) v3.16.5
   - [canal](https://github.com/projectcalico/canal) (given calico/flannel versions)
   - [cilium](https://github.com/cilium/cilium) v1.8.5
   - [contiv](https://github.com/contiv/install) v1.2.1

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -65,7 +65,7 @@ quay_image_repo: "quay.io"
 
 # TODO(mattymo): Move calico versions to roles/network_plugins/calico/defaults
 # after migration to container download
-calico_version: "v3.16.4"
+calico_version: "v3.16.5"
 calico_ctl_version: "{{ calico_version }}"
 calico_cni_version: "{{ calico_version }}"
 calico_policy_version: "{{ calico_version }}"
@@ -387,14 +387,17 @@ cni_binary_checksums:
   amd64: 977824932d5667c7a37aa6a3cbba40100a6873e7bd97e83e8be837e3e7afd0a8
 calicoctl_binary_checksums:
   arm:
+    v3.16.5: 0
     v3.16.4: 0
     v3.16.2: 0
     v3.15.2: 0
   amd64:
+    v3.16.5: d4175559ad0cf69a1352be3d824ae0a794305d6cd5b17ea0ffc6a153b21d2ae7
     v3.16.4: a502749420e7424090a73644a8bdc1270c6ef679f8f1d33f753d48d60c930377
     v3.16.2: 801b059a4fd0dac8795693026c69a79a00dd2353eff597cc36b79fcb6ec53a0a
     v3.15.2: 219ae954501cbe15daeda0ad52e13ec65f99c77548c7d3cbfc4ced5c7149fdf1
   arm64:
+    v3.16.5: 230579d8761e1cee5ffd447af5a1b92af76ed89f6b7e51771d590017aca5cbb9
     v3.16.4: 003f16a501e876af0da67324b7fed6ca72f5547c15bbe3b798a8eeb707056d43
     v3.16.2: aa5695940ec8a36393725a5ce7b156f776fed8da38b994c0828d7f3a60e59bc6
     v3.15.2: 49165f9e4ad55402248b578310fcf68a57363f54e66be04ac24be9714899b4d5


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind feature

**What this PR does / why we need it**:

Upgrades calico version to `3.16.5` to fix major regression in 3.16

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6943 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Upgrades default Calico version to `3.16.5`
```
