### PR TITLE
Fix warning of mkdir usage

### DIFF
--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -47,10 +47,16 @@
     port: "{{ kube_apiserver_port }}"
     timeout: 180
 
+- name: Create external_kubeconfig dir
+  file:
+    path: "{{ kube_config_dir }}/external_kubeconfig"
+    mode: "0750"
+    state: directory
+  when: kubeconfig_localhost
+
 # NOTE(mattymo): Please forgive this workaround
 - name: Generate admin kubeconfig with external api endpoint  # noqa 302
   shell: >-
-    mkdir -p {{ kube_config_dir }}/external_kubeconfig &&
     {{ bin_dir }}/kubeadm
     init phase
     kubeconfig admin


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This fixes the following warning:
```
  [kubernetes/client : Generate admin kubeconfig with external api endpoint]
  [WARNING]: Consider using the file module with state=directory rather than running 'mkdir'.
  If you need to use command because file is insufficient you can
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
