### PR TITLE
Fix warning of "Enable ip forwarding"

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
+++ b/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
@@ -58,7 +58,7 @@
   sysctl:
     sysctl_file: "{{ sysctl_file_path }}"
     name: net.ipv4.ip_forward
-    value: 1
+    value: "1"
     state: present
     reload: yes
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The task outputs the following warning:
```
  TASK [kubernetes/preinstall : Enable ip forwarding]
  [WARNING]: The value 1 (type int) in a string field was converted to u'1' (type string). If this does not look like what you expect,
  quote the entire value to ensure it does not change.
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
