### PR TITLE
Switch some image from dockerhub to k8s.gcr (also increase pkg retries)

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s-cluster/addons.yml
@@ -1,7 +1,7 @@
 ---
 # Kubernetes dashboard
 # RBAC required. see docs/getting-started.md for access details.
-dashboard_enabled: true
+# dashboard_enabled: true
 
 # Helm deployment
 helm_enabled: false

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -479,7 +479,7 @@ haproxy_image_tag: 2.2
 # Coredns version should be supported by corefile-migration (or at least work with)
 # bundle with kubeadm; if not 'basic' upgrade can sometimes fail
 coredns_version: "1.7.0"
-coredns_image_repo: "{{ docker_image_repo }}/coredns/coredns"
+coredns_image_repo: "{{ kube_image_repo }}/coredns"
 coredns_image_tag: "{{ coredns_version }}"
 
 nodelocaldns_version: "1.15.16"
@@ -489,10 +489,8 @@ nodelocaldns_image_tag: "{{ nodelocaldns_version }}"
 dnsautoscaler_version: 1.8.3
 dnsautoscaler_image_repo: "{{ kube_image_repo }}/cpa/cluster-proportional-autoscaler-{{ image_arch }}"
 dnsautoscaler_image_tag: "{{ dnsautoscaler_version }}"
-test_image_repo: "{{ docker_image_repo }}/library/busybox"
+test_image_repo: "{{ kube_image_repo }}/busybox"
 test_image_tag: latest
-busybox_image_repo: "{{ docker_image_repo }}/library/busybox"
-busybox_image_tag: 1.32.0
 helm_version: "v3.2.4"
 helm_image_repo: "{{ docker_image_repo }}/lachlanevenson/k8s-helm"
 helm_image_tag: "{{ helm_version }}"
@@ -917,15 +915,6 @@ downloads:
     sha256: "{{ dnsautoscaler_digest_checksum|default(None) }}"
     groups:
     - kube-master
-
-  busybox:
-    enabled: "{{ kube_network_plugin in ['kube-router'] }}"
-    container: true
-    repo: "{{ busybox_image_repo }}"
-    tag: "{{ busybox_image_tag }}"
-    sha256: "{{ busybox_digest_checksum|default(None) }}"
-    groups:
-    - k8s-cluster
 
   testbox:
     enabled: false

--- a/tests/files/packet_centos8-calico.yml
+++ b/tests/files/packet_centos8-calico.yml
@@ -9,6 +9,7 @@ deploy_netchecker: true
 dns_min_replicas: 1
 metrics_server_enabled: true
 dashboard_namespace: "kube-dashboard"
+dashboard_enabled: true
 loadbalancer_apiserver_type: haproxy
 
 # required / not autodetected for now

--- a/tests/files/tf-ovh_ubuntu18-calico.yml
+++ b/tests/files/tf-ovh_ubuntu18-calico.yml
@@ -2,7 +2,7 @@
 dns_min_replicas: 1
 deploy_netchecker: true
 sonobuoy_enabled: true
-pkg_install_retries: 10
+pkg_install_retries: 15
 retry_stagger: 10
 
 # Ignore ping errors


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
We need to implement a more permanent solution, in the meantime this will reduce pull from dockerhub

**Which issue(s) this PR fixes**:
None but this will reduce the pulls from dockerhub by 5 for each CI jobs, reducing the docker rate limit error

**Special notes for your reviewer**:
I also commented the `dashboard_enabled` so that it's not downloaded on each CI job and enable it only in one (the one where we changed the dashboard NS)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
