### PR TITLE
Fix yaml syntax error when use multilines in dns_etchosts

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -65,5 +65,5 @@ data:
     }
 {% if dns_etchosts | default(None) %}
   hosts: |
-   {{ dns_etchosts }}
+    {{ dns_etchosts | indent(width=4, indentfirst=None) }}
 {% endif %}

--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2
@@ -85,5 +85,5 @@ data:
     }
 {% if dns_etchosts | default(None) %}
   hosts: |
-   {{ dns_etchosts }}
+    {{ dns_etchosts | indent(width=4, indentfirst=None) }}
 {% endif %}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Allow user use multilines in dns_etchosts

Example:
```yaml
dns_etchosts: |
  192.168.0.100 api.example.com
  192.168.0.200 ingress.example.com
```
will generate correct manifest:
```yaml
   hosts: |
     192.168.0.100 api.example.com
     192.168.0.200 ingress.example.com
```

**Which issue(s) this PR fixes**:
Fixes #6958


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
