### PR TITLE
Fix crictl paths and some of docker paths

### DIFF
--- a/roles/etcdctl/tasks/main.yml
+++ b/roles/etcdctl/tasks/main.yml
@@ -32,11 +32,11 @@
 
 - block:
   - name: Copy etcdctl script to host
-    shell: "docker exec \"$(docker ps -qf ancestor={{ etcd_image_repo }}:{{ etcd_image_tag }})\" cp /usr/local/bin/etcdctl {{ etcd_data_dir }}"
+    shell: "{{ docker_bin_dir }}/docker exec \"$({{ docker_bin_dir }}/docker ps -qf ancestor={{ etcd_image_repo }}:{{ etcd_image_tag }})\" cp /usr/local/bin/etcdctl {{ etcd_data_dir }}"
     when: container_manager ==  "docker"
 
   - name: Copy etcdctl script to host
-    shell: "crictl exec \"$(crictl ps -q --image {{ etcd_image_repo }}:{{ etcd_image_tag }})\" cp /usr/local/bin/etcdctl {{ etcd_data_dir }}"
+    shell: "{{ bin_dir }}/crictl exec \"$({{ bin_dir }}/crictl ps -q --image {{ etcd_image_repo }}:{{ etcd_image_tag }})\" cp /usr/local/bin/etcdctl {{ etcd_data_dir }}"
     when: container_manager in ['crio', 'containerd']
 
   - name: Copy etcdctl to {{ bin_dir }}

--- a/roles/kubernetes/master/handlers/main.yml
+++ b/roles/kubernetes/master/handlers/main.yml
@@ -52,7 +52,7 @@
   when: container_manager == "docker"
 
 - name: Master | Remove apiserver container containerd/crio
-  shell: crictl pods --name kube-apiserver* -q | xargs -I% --no-run-if-empty bash -c 'crictl stopp % && crictl rmp %'
+  shell: "{{ bin_dir }}/crictl pods --name kube-apiserver* -q | xargs -I% --no-run-if-empty bash -c '{{ bin_dir }}/crictl stopp % && {{ bin_dir }}/crictl rmp %'"
   register: remove_apiserver_container
   retries: 10
   until: remove_apiserver_container.rc == 0
@@ -60,7 +60,7 @@
   when: container_manager in ['containerd', 'crio']
 
 - name: Master | Remove scheduler container docker
-  shell: "docker ps -af name=k8s_kube-scheduler* -q | xargs --no-run-if-empty docker rm -f"
+  shell: "{{ docker_bin_dir }}/docker ps -af name=k8s_kube-scheduler* -q | xargs --no-run-if-empty {{ docker_bin_dir }}/docker rm -f"
   register: remove_scheduler_container
   retries: 10
   until: remove_scheduler_container.rc == 0
@@ -68,7 +68,7 @@
   when: container_manager == "docker"
 
 - name: Master | Remove scheduler container containerd/crio
-  shell: crictl pods --name kube-scheduler* -q | xargs -I% --no-run-if-empty bash -c 'crictl stopp % && crictl rmp %'
+  shell: "{{ bin_dir }}/crictl pods --name kube-scheduler* -q | xargs -I% --no-run-if-empty bash -c '{{ bin_dir }}/crictl stopp % && {{ bin_dir }}/crictl rmp %'"
   register: remove_scheduler_container
   retries: 10
   until: remove_scheduler_container.rc == 0
@@ -76,7 +76,7 @@
   when: container_manager in ['containerd', 'crio']
 
 - name: Master | Remove controller manager container docker
-  shell: "docker ps -af name=k8s_kube-controller-manager* -q | xargs --no-run-if-empty docker rm -f"
+  shell: "{{ docker_bin_dir }}/docker ps -af name=k8s_kube-controller-manager* -q | xargs --no-run-if-empty {{ docker_bin_dir }}/docker rm -f"
   register: remove_cm_container
   retries: 10
   until: remove_cm_container.rc == 0
@@ -84,7 +84,7 @@
   when: container_manager == "docker"
 
 - name: Master | Remove controller manager container containerd/crio
-  shell: crictl pods --name kube-controller-manager* -q | xargs -I% --no-run-if-empty bash -c 'crictl stopp % && crictl rmp %'
+  shell: "{{ bin_dir }}/crictl pods --name kube-controller-manager* -q | xargs -I% --no-run-if-empty bash -c '{{ bin_dir }}/crictl stopp % && {{ bin_dir }}/crictl rmp %'"
   register: remove_cm_container
   retries: 10
   until: remove_cm_container.rc == 0

--- a/roles/kubernetes/node/tasks/pre_upgrade.yml
+++ b/roles/kubernetes/node/tasks/pre_upgrade.yml
@@ -3,9 +3,9 @@
   shell: >-
     set -o pipefail &&
     {% if container_manager in ['crio', 'docker'] %}
-    docker ps -af name=kubelet | grep kubelet
+    {{ docker_bin_dir }}/docker ps -af name=kubelet | grep kubelet
     {% elif container_manager == 'containerd' %}
-    crictl ps --all --name kubelet | grep kubelet
+    {{ bin_dir }}/crictl ps --all --name kubelet | grep kubelet
     {% endif %}
   args:
     executable: /bin/bash
@@ -34,9 +34,9 @@
 - name: "Pre-upgrade | ensure kubelet container is removed if using host deployment"
   shell: >-
     {% if container_manager in ['crio', 'docker'] %}
-    docker rm -fv kubelet
+    {{ docker_bin_dir }}/docker rm -fv kubelet
     {% elif container_manager == 'containerd' %}
-    crictl stop kubelet && crictl rm kubelet
+    {{ bin_dir }}/crictl stop kubelet && {{ bin_dir }}/crictl rm kubelet
     {% endif %}
   failed_when: false
   changed_when: false

--- a/roles/kubernetes/preinstall/handlers/main.yml
+++ b/roles/kubernetes/preinstall/handlers/main.yml
@@ -61,7 +61,7 @@
   when: inventory_hostname in groups['kube-master'] and dns_mode != 'none' and resolvconf_mode == 'host_resolvconf'
 
 - name: Preinstall | restart kube-controller-manager docker
-  shell: "docker ps -f name=k8s_POD_kube-controller-manager* -q | xargs --no-run-if-empty docker rm -f"
+  shell: "{{ docker_bin_dir }}/docker ps -f name=k8s_POD_kube-controller-manager* -q | xargs --no-run-if-empty {{ docker_bin_dir }}/docker rm -f"
   when:
     - container_manager == "docker"
     - inventory_hostname in groups['kube-master']
@@ -70,7 +70,7 @@
     - kube_controller_set.stat.exists
 
 - name: Preinstall | restart kube-controller-manager crio/containerd
-  shell: crictl pods --name kube-controller-manager* -q | xargs -I% --no-run-if-empty bash -c 'crictl stopp % && crictl rmp %'
+  shell: "{{ bin_dir }}/crictl pods --name kube-controller-manager* -q | xargs -I% --no-run-if-empty bash -c '{{ bin_dir }}/crictl stopp % && {{ bin_dir }}/crictl rmp %'"
   when:
     - container_manager in ['crio', 'containerd']
     - inventory_hostname in groups['kube-master']
@@ -79,7 +79,7 @@
     - kube_controller_set.stat.exists
 
 - name: Preinstall | restart kube-apiserver docker
-  shell: "docker ps -f name=k8s_POD_kube-apiserver* -q | xargs --no-run-if-empty docker rm -f"
+  shell: "{{ docker_bin_dir }}/docker ps -f name=k8s_POD_kube-apiserver* -q | xargs --no-run-if-empty {{ docker_bin_dir }}/docker rm -f"
   when:
     - container_manager == "docker"
     - inventory_hostname in groups['kube-master']
@@ -87,7 +87,7 @@
     - resolvconf_mode == 'host_resolvconf'
 
 - name: Preinstall | restart kube-apiserver crio/containerd
-  shell: crictl pods --name kube-apiserver* -q | xargs -I% --no-run-if-empty bash -c 'crictl stopp % && crictl rmp %'
+  shell: "{{ bin_dir }}/crictl pods --name kube-apiserver* -q | xargs -I% --no-run-if-empty bash -c '{{ bin_dir }}/crictl stopp % && {{ bin_dir }}/crictl rmp %'"
   when:
     - container_manager in ['crio', 'containerd']
     - inventory_hostname in groups['kube-master']

--- a/roles/network_plugin/kube-router/handlers/main.yml
+++ b/roles/network_plugin/kube-router/handlers/main.yml
@@ -6,14 +6,14 @@
     - containerd | delete kube-router containers
 
 - name: docker | delete kube-router containers
-  shell: "docker ps -af name=k8s_POD_kube-router* -q | xargs --no-run-if-empty docker rm -f"
+  shell: "{{ docker_bin_dir }}/docker ps -af name=k8s_POD_kube-router* -q | xargs --no-run-if-empty docker rm -f"
   register: docker_kube_router_remove
   until: docker_kube_router_remove is succeeded
   retries: 5
   when: container_manager in ["docker"]
 
 - name: containerd | delete kube-router containers
-  shell: 'crictl pods --name kube-router* -q | xargs -I% --no-run-if-empty bash -c "crictl stopp % && crictl rmp %"'
+  shell: '{{ bin_dir }}/crictl pods --name kube-router* -q | xargs -I% --no-run-if-empty bash -c "{{ bin_dir }}/crictl stopp % && {{ bin_dir }}/crictl rmp %"'
   register: crictl_kube_router_remove
   until: crictl_kube_router_remove is succeeded
   retries: 5

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -67,7 +67,7 @@
     - docker
 
 - name: reset | stop all cri containers
-  shell: "set -o pipefail && crictl ps -aq | xargs -r crictl -t 60s stop"
+  shell: "set -o pipefail && {{ bin_dir }}/crictl ps -aq | xargs -r {{ bin_dir }}/crictl -t 60s stop"
   args:
     executable: /bin/bash
   register: remove_all_cri_containers
@@ -80,7 +80,7 @@
   when: container_manager in ["crio", "containerd"]
 
 - name: reset | remove all cri containers
-  shell: "set -o pipefail && crictl ps -aq | xargs -r crictl -t 60s rm"
+  shell: "set -o pipefail && {{ bin_dir }}/crictl ps -aq | xargs -r {{ bin_dir }}/crictl -t 60s rm"
   args:
     executable: /bin/bash
   register: remove_all_cri_containers
@@ -108,7 +108,7 @@
   when: container_manager == "crio"
 
 - name: reset | stop all cri pods
-  shell: "set -o pipefail && crictl pods -q | xargs -r crictl -t 60s stopp"
+  shell: "set -o pipefail && {{ bin_dir }}/crictl pods -q | xargs -r {{ bin_dir }}/crictl -t 60s stopp"
   args:
     executable: /bin/bash
   register: remove_all_cri_containers
@@ -119,7 +119,7 @@
   when: container_manager == "containerd"
 
 - name: reset | remove all cri pods
-  shell: "set -o pipefail && crictl pods -q | xargs -r crictl -t 60s rmp"
+  shell: "set -o pipefail && {{ bin_dir }}/crictl pods -q | xargs -r {{ bin_dir }}/crictl -t 60s rmp"
   args:
     executable: /bin/bash
   register: remove_all_cri_containers


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

If crictl (and docker) binaries are deployed to the directories
that are not in standard PATH (e.g. /usr/local/bin), it is required
to specify full path to the binaries.

**Which issue(s) this PR fixes**:
There are several similar errors with CentOS 7 and deployment of crictl to /usr/local/bin (which is not in default PATH for root)
```
fatal: [k8s-c1]: FAILED! => {"changed": true, "cmd": "crictl exec \"$(crictl ps -q --image quay.io/coreos/etcd:v3.4.13)\" cp /usr/local/bin/etcdctl /var/lib/etcd", "delta": "0:00:00.015656", "end": "2020-11-27 14:58:22.712346", "msg": "non-zero return code", "rc": 127, "start": "2020-11-27 14:58:22.696690", "stderr": "/bin/sh: crictl: command not found\n/bin/sh: crictl: command not found", "stderr_lines": ["/bin/sh: crictl: command not found", "/bin/sh: crictl: command not found"], "stdout": "", "stdout_lines": []}

```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
- Fix invocation of crictl if it is installed in directory that is not in default PATH.
```
