### PR TITLE
Remove hyperkube from codebase

### DIFF
--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -116,7 +116,6 @@ The following tags are defined in playbooks:
 |                    facts | Gathering facts and misc check results
 |                  flannel | Network plugin flannel
 |                      gce | Cloud-provider GCP
-|                hyperkube | Manipulations with K8s hyperkube image
 |          k8s-pre-upgrade | Upgrading K8s cluster
 |              k8s-secrets | Configuring K8s certs/keys
 |           kube-apiserver | Configuring static pod kube-apiserver

--- a/docs/vars.md
+++ b/docs/vars.md
@@ -22,7 +22,7 @@ Some variables of note include:
 * *ipip* - Enables Calico ipip encapsulation by default
 * *kube_network_plugin* - Sets k8s network plugin (default Calico)
 * *kube_proxy_mode* - Changes k8s proxy mode to iptables mode
-* *kube_version* - Specify a given Kubernetes hyperkube version
+* *kube_version* - Specify a given Kubernetes version
 * *searchdomains* - Array of DNS domains to search when looking up hostnames
 * *nameservers* - Array of nameservers to use for DNS lookup
 * *preinstall_selinux_state* - Set selinux state, permitted values are permissive and disabled.

--- a/roles/download/templates/kubeadm-images.yaml.j2
+++ b/roles/download/templates/kubeadm-images.yaml.j2
@@ -7,7 +7,6 @@ apiVersion: kubeadm.k8s.io/v1beta2
 kind: ClusterConfiguration
 imageRepository: {{ kube_image_repo }}
 kubernetesVersion: {{ kube_version }}
-useHyperKubeImage: {{ kubeadm_use_hyperkube_image }}
 etcd:
 {% if etcd_kubeadm_enabled %}
   local:

--- a/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.v1beta2.yaml.j2
@@ -98,7 +98,6 @@ controlPlaneEndpoint: {{ ip | default(fallback_ips[inventory_hostname]) }}:{{ ku
 {% endif %}
 certificatesDir: {{ kube_cert_dir }}
 imageRepository: {{ kube_image_repo }}
-useHyperKubeImage: {{ kubeadm_use_hyperkube_image }}
 apiServer:
   extraArgs:
 {% if kube_api_anonymous_auth is defined %}

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -20,9 +20,6 @@ kube_version: v1.19.3
 ## The minimum version working
 kube_version_min_required: v1.17.0
 
-# use HyperKube image to control plane containers
-kubeadm_use_hyperkube_image: False
-
 ## Kube Proxy mode One of ['iptables','ipvs']
 kube_proxy_mode: ipvs
 

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -251,7 +251,6 @@
     - "{{ bin_dir }}/kubernetes-scripts"
     - "{{ bin_dir }}/kubectl"
     - "{{ bin_dir }}/kubeadm"
-    - "{{ bin_dir }}/hyperkube"
     - "{{ bin_dir }}/helm"
     - "{{ bin_dir }}/calicoctl"
     - "{{ bin_dir }}/calicoctl.sh"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Hyerkube is no longer supported as of 1.19
https://github.com/kubernetes/kubernetes/pull/88676
```
Kubernetes no longer supports building hyperkube images (#88676, @dims) [SIG Cluster Lifecycle and Release]
```

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
Hyperkube is no longer supported
```
