### PR TITLE
Vagrantfile: Fix incorrect references to 'rhel' variable as 'redhat'

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -179,7 +179,7 @@ Vagrant.configure("2") do |config|
         node.vm.network "forwarded_port", guest: guest, host: host, auto_correct: true
       end
 
-      if ["redhat7","redhat8"].include? $os
+      if ["rhel7","rhel8"].include? $os
         # Vagrant synced_folder rsync options cannot be used for RHEL boxes as Rsync package cannot
         # be installed until the host is registered with a valid Red Hat support subscription
         node.vm.synced_folder ".", "/vagrant", disabled: false
@@ -200,7 +200,7 @@ Vagrant.configure("2") do |config|
       node.vm.provision "shell", inline: "swapoff -a"
 
       # Disable firewalld on oraclelinux/redhat vms
-      if ["oraclelinux","oraclelinux8","redhat7","redhat8"].include? $os
+      if ["oraclelinux","oraclelinux8","rhel7","rhel8"].include? $os
         node.vm.provision "shell", inline: "systemctl stop firewalld; systemctl disable firewalld"
       end
 


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
https://github.com/kubernetes-sigs/kubespray/commit/eb16986f3244bf5158b15349d515dabbe7e0c9ee recently introduced support for RHEL subscription registration, and added RHEL7 and RHEL8 to the Vagrantfile for testing.

To use Red Hat 7 or 8 the user sets `$os` to either `rhel7` or `rhel8`. There is some special handling for these distributions further on, guarded by a conditional check to see against the contents of `$os`.

However, the check is looking for `redhat` rather than `rhel` in both cases:
https://github.com/kubernetes-sigs/kubespray/blob/eb16986f3244bf5158b15349d515dabbe7e0c9ee/Vagrantfile#L35-L36

https://github.com/kubernetes-sigs/kubespray/blob/eb16986f3244bf5158b15349d515dabbe7e0c9ee/Vagrantfile#L182
https://github.com/kubernetes-sigs/kubespray/blob/eb16986f3244bf5158b15349d515dabbe7e0c9ee/Vagrantfile#L202-L203

The end result is that this code path is never triggered and installation of RHEL on Vagrant currently fails.
This PR changes the checks to use `rhel{7,8}`.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
