### PR TITLE
Calico:  update files to handle multi-asn bgp peering conditions.

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/k8s-net-calico.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-net-calico.yml
@@ -23,6 +23,10 @@
 # Global as_num (/calico/bgp/v1/global/as_num)
 # global_as_num: "64512"
 
+# If doing peering with node-assigned asn where the globas does not match your nodes, you want this
+# to be true.  All other cases, false.
+# calico_no_global_as_num: false
+
 # You can set MTU value here. If left undefined or empty, it will
 # not be specified in calico CNI config, so Calico will use built-in
 # defaults. The value should be a number, not a string.

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -168,7 +168,7 @@
     - inventory_hostname in groups['k8s-cluster']
   run_once: yes
 
-- name: Calico | Set global as_num
+- name: Calico | Set BGP Configuration with global as number defined
   command:
     cmd: "{{ bin_dir }}/calicoctl.sh apply -f -"
     stdin: >
@@ -185,6 +185,25 @@
   changed_when: false
   when:
     - inventory_hostname == groups['kube-master'][0]
+    - not calico_no_global_as_num|default(false)
+
+- name: Calico | Set BGP Configuration without global as number defined
+  command:
+    cmd: "{{ bin_dir }}/calicoctl.sh apply -f -"
+    stdin: >
+      { "kind": "BGPConfiguration",
+        "apiVersion": "projectcalico.org/v3",
+        "metadata": {
+          "name": "default"
+        },
+      "spec": {
+          "logSeverityScreen": "Info",
+          "nodeToNodeMeshEnabled": {{ nodeToNodeMeshEnabled|default('true') }} ,
+          "serviceExternalIPs": {{ _service_external_ips|default([]) }} }}
+  changed_when: false
+  when:
+    - inventory_hostname == groups['kube-master'][0]
+    - calico_no_global_as_num|default(false)
 
 - name: Calico | Configure peering with router(s) at global scope
   command:
@@ -306,7 +325,7 @@
     - inventory_hostname not in groups['kube-master']
     - calico_datastore == "kdd"
 
-- name: Calico | Configure node asNumber for per node peering
+- name: Calico | Configure node asNumber for per node peering for hard-set values
   command:
     cmd: "{{ bin_dir }}/calicoctl.sh apply -f -"
     stdin: >
@@ -330,6 +349,35 @@
     - inventory_hostname in groups['k8s-cluster']
     - local_as is defined
     - groups['calico-rr'] | default([]) | length == 0
+
+- name: Calico | Configure node asNumber for per node peering automatically
+  command:
+    cmd: "{{ bin_dir }}/calicoctl.sh apply -f -"
+    stdin: >
+      {"apiVersion": "projectcalico.org/v3",
+      "kind": "Node",
+      "metadata": {
+        "name": "{{ inventory_hostname }}"
+      },
+      "spec": {
+        "bgp": {
+          "asNumber": "{{ item.as }}"
+        },
+        "orchRefs":[{"nodeName":"{{ inventory_hostname }}","orchestrator":"k8s"}]
+      }}
+  register: output
+  retries: 4
+  until: output.rc == 0
+  delay: "{{ retry_stagger | random + 3 }}"
+  with_items:
+    - "{{ peers|selectattr('scope','undefined')|list|default([]) | union(peers|selectattr('scope','defined')|selectattr('scop\
+e','equalto', 'node')|list|default([])) }}"
+  when:
+    - peer_with_router|default(false)
+    - inventory_hostname in groups['k8s-cluster']
+    - groups['calico-rr'] | default([]) | length == 0
+    - local_as is not defined
+    - item.as is defined
 
 - name: Calico | Configure peering with router(s) at node scope
   command:

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -179,7 +179,7 @@
       },
       "spec": {
           "logSeverityScreen": "Info",
-          {% if calico_no_global_as_num|default(false) %}"asNumber": {{ global_as_num }},{% endif %}
+          {% if not calico_no_global_as_num|default(false) %}"asNumber": {{ global_as_num }},{% endif %}
           "nodeToNodeMeshEnabled": {{ nodeToNodeMeshEnabled|default('true') }} ,
           "serviceExternalIPs": {{ _service_external_ips|default([]) }},
           "serviceClusterIPs": [{"cidr": {{ kube_service_addresses }} }] }}

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -179,33 +179,13 @@
       },
       "spec": {
           "logSeverityScreen": "Info",
+          {% if calico_no_global_as_num|default(false) %}"asNumber": {{ global_as_num }},{% endif %}
           "nodeToNodeMeshEnabled": {{ nodeToNodeMeshEnabled|default('true') }} ,
           "serviceExternalIPs": {{ _service_external_ips|default([]) }},
-          "serviceClusterIPs": [{"cidr": {{ kube_service_addresses }} }],
-          "asNumber": {{ global_as_num }} }}
+          "serviceClusterIPs": [{"cidr": {{ kube_service_addresses }} }] }}
   changed_when: false
   when:
     - inventory_hostname == groups['kube-master'][0]
-    - not calico_no_global_as_num|default(false)
-
-- name: Calico | Set BGP Configuration without global as number defined
-  command:
-    cmd: "{{ bin_dir }}/calicoctl.sh apply -f -"
-    stdin: >
-      { "kind": "BGPConfiguration",
-        "apiVersion": "projectcalico.org/v3",
-        "metadata": {
-          "name": "default"
-        },
-      "spec": {
-          "logSeverityScreen": "Info",
-          "nodeToNodeMeshEnabled": {{ nodeToNodeMeshEnabled|default('true') }} ,
-          "serviceClusterIPs": [{"cidr": {{ kube_service_addresses }} }],
-          "serviceExternalIPs": {{ _service_external_ips|default([]) }} }}
-  changed_when: false
-  when:
-    - inventory_hostname == groups['kube-master'][0]
-    - calico_no_global_as_num|default(false)
 
 - name: Calico | Configure peering with router(s) at global scope
   command:
@@ -351,35 +331,6 @@
     - inventory_hostname in groups['k8s-cluster']
     - local_as is defined
     - groups['calico-rr'] | default([]) | length == 0
-
-- name: Calico | Configure node asNumber for per node peering automatically
-  command:
-    cmd: "{{ bin_dir }}/calicoctl.sh apply -f -"
-    stdin: >
-      {"apiVersion": "projectcalico.org/v3",
-      "kind": "Node",
-      "metadata": {
-        "name": "{{ inventory_hostname }}"
-      },
-      "spec": {
-        "bgp": {
-          "asNumber": "{{ item.as }}"
-        },
-        "orchRefs":[{"nodeName":"{{ inventory_hostname }}","orchestrator":"k8s"}]
-      }}
-  register: output
-  retries: 4
-  until: output.rc == 0
-  delay: "{{ retry_stagger | random + 3 }}"
-  with_items:
-    - "{{ peers|selectattr('scope','undefined')|list|default([]) | union(peers|selectattr('scope','defined')|selectattr('scop\
-e','equalto', 'node')|list|default([])) }}"
-  when:
-    - peer_with_router|default(false)
-    - inventory_hostname in groups['k8s-cluster']
-    - groups['calico-rr'] | default([]) | length == 0
-    - local_as is not defined
-    - item.as is defined
 
 - name: Calico | Configure peering with router(s) at node scope
   command:

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -181,6 +181,7 @@
           "logSeverityScreen": "Info",
           "nodeToNodeMeshEnabled": {{ nodeToNodeMeshEnabled|default('true') }} ,
           "serviceExternalIPs": {{ _service_external_ips|default([]) }},
+          "serviceClusterIPs": [{"cidr": {{ kube_service_addresses }} }],
           "asNumber": {{ global_as_num }} }}
   changed_when: false
   when:
@@ -199,6 +200,7 @@
       "spec": {
           "logSeverityScreen": "Info",
           "nodeToNodeMeshEnabled": {{ nodeToNodeMeshEnabled|default('true') }} ,
+          "serviceClusterIPs": [{"cidr": {{ kube_service_addresses }} }],
           "serviceExternalIPs": {{ _service_external_ips|default([]) }} }}
   changed_when: false
   when:

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -181,8 +181,8 @@
           "logSeverityScreen": "Info",
           {% if not calico_no_global_as_num|default(false) %}"asNumber": {{ global_as_num }},{% endif %}
           "nodeToNodeMeshEnabled": {{ nodeToNodeMeshEnabled|default('true') }} ,
-          "serviceExternalIPs": {{ _service_external_ips|default([]) }},
-          "serviceClusterIPs": [{"cidr": {{ kube_service_addresses }} }] }}
+          {% if calico_advertise_cluster_ips|default(false) %}"serviceClusterIPs": [{"cidr": {{ kube_service_addresses }} }],{% endif %}
+          "serviceExternalIPs": {{ _service_external_ips|default([]) }} }}
   changed_when: false
   when:
     - inventory_hostname == groups['kube-master'][0]

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -168,7 +168,7 @@
     - inventory_hostname in groups['k8s-cluster']
   run_once: yes
 
-- name: Calico | Set BGP Configuration with global as number defined
+- name: Calico | Set up BGP Configuration
   command:
     cmd: "{{ bin_dir }}/calicoctl.sh apply -f -"
     stdin: >
@@ -307,7 +307,7 @@
     - inventory_hostname not in groups['kube-master']
     - calico_datastore == "kdd"
 
-- name: Calico | Configure node asNumber for per node peering for hard-set values
+- name: Calico | Configure node asNumber for per node peering
   command:
     cmd: "{{ bin_dir }}/calicoctl.sh apply -f -"
     stdin: >

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -224,10 +224,6 @@ spec:
               value: "{{ calico_felix_prometheusgometricsenabled }}"
             - name: FELIX_PROMETHEUSPROCESSMETRICSENABLED
               value: "{{ calico_felix_prometheusprocessmetricsenabled }}"
-{% if calico_advertise_cluster_ips|default(false) %}
-            - name: CALICO_ADVERTISE_CLUSTER_IPS
-              value: "{{ kube_service_addresses }}"
-{% endif %}
 {% if calico_ip_auto_method is defined %}
             - name: IP_AUTODETECTION_METHOD
               value: "{{ calico_ip_auto_method }}"


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
Without these changes, multi-ASN configs will not work.
* Add in ability for kubespray to configure ASNs according to routers being peered with by the node instead of relying on the user to put in local_as for every single node.
* Add in option to have BGP configured so that we can choose to not have a global ASN.  With multiple ASNs, will not work.

Tested on our little cluster with a switch. Do not see infrastructure in kubepsray proper to test this type of config (needs switch configuration to test). We have an iperf test that works with these changes.

Which issue(s) this PR fixes:

Fixes #
#6845

Special notes for your reviewer:
You may wish to talk to me directly in how to set a switch for testing.

Does this PR introduce a user-facing change?
Yes.

New item in samples shows you can choose not to set a global calico ASN, option named calico_no_global_as_num
No longer need to set local_as per-node. It will pull it in from the tors as they are defined by node. This will make changing servers between racks (or otherwise configuring) less prone to user error.
