### PR TITLE
Fix quote warnings of Calico

### DIFF
--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -149,7 +149,7 @@
           "cidr": "{{ calico_pool_cidr | default(kube_pods_subnet) }}",
           "ipipMode": "{{ calico_ipip_mode }}",
           "vxlanMode": "{{ calico_vxlan_mode }}",
-          "natOutgoing": {{ nat_outgoing|default(false) and not peer_with_router|default(false) }} }}
+          "natOutgoing": "{{ nat_outgoing|default(false) and not peer_with_router|default(false) }}" }}
   when:
     - inventory_hostname == groups['kube-master'][0]
     - 'calico_conf.stdout == "0"'
@@ -179,9 +179,9 @@
       },
       "spec": {
           "logSeverityScreen": "Info",
-          "nodeToNodeMeshEnabled": {{ nodeToNodeMeshEnabled|default('true') }} ,
-          "serviceExternalIPs": {{ _service_external_ips|default([]) }},
-          "asNumber": {{ global_as_num }} }}
+          "nodeToNodeMeshEnabled": "{{ nodeToNodeMeshEnabled|default('true') }}",
+          "serviceExternalIPs": "{{ _service_external_ips|default([]) }}",
+          "asNumber": "{{ global_as_num }} }}"
   changed_when: false
   when:
     - inventory_hostname == groups['kube-master'][0]


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Two Calico tasks output the following warnings, and this fixes them:
```
TASK [network_plugin/calico : Calico | Configure calico network pool (version >= v3.3.0)] *******************************************************************
[WARNING]: The value {'kind': 'IPPool', 'apiVersion': 'projectcalico.org/v3', 'metadata': {'name': 'default-pool'}, 'spec': {'blockSize': 24, 'cidr':
'10.233.64.0/18', 'ipipMode': 'Always', 'vxlanMode': 'Never', 'natOutgoing': True}} (type dict) in a string field was converted to "{'kind': 'IPPool',
'apiVersion': 'projectcalico.org/v3', 'metadata': {'name': 'default-pool'}, 'spec': {'blockSize': 24, 'cidr': '10.233.64.0/18', 'ipipMode': 'Always',
'vxlanMode': 'Never', 'natOutgoing': True}}" (type string). If this does not look like what you expect, quote the entire value to ensure it does not change.

TASK [network_plugin/calico : Calico | Set global as_num] ***************************************************************************************************
[WARNING]: The value {'kind': 'BGPConfiguration', 'apiVersion': 'projectcalico.org/v3', 'metadata': {'name': 'default'}, 'spec': {'logSeverityScreen':
'Info', 'nodeToNodeMeshEnabled': True, 'asNumber': 64512}} (type dict) in a string field was converted to "{'kind': 'BGPConfiguration', 'apiVersion':
'projectcalico.org/v3', 'metadata': {'name': 'default'}, 'spec': {'logSeverityScreen': 'Info', 'nodeToNodeMeshEnabled': True, 'asNumber': 64512}}" (type
string). If this does not look like what you expect, quote the entire value to ensure it does not change.
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
