### PR TITLE
change search call in openstack_cacert retrieval

### DIFF
--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -151,7 +151,7 @@
 
 - name: Test if openstack_cacert is a base64 string
   set_fact:
-    openstack_cacert_is_base64: "{% if openstack_cacert | search ('^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$') %}true{% else %}false{% endif %}"
+    openstack_cacert_is_base64: "{% if openstack_cacert is search ('^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$') %}true{% else %}false{% endif %}"
   when:
     - cloud_provider is defined
     - cloud_provider == 'openstack'


### PR DESCRIPTION
Since ansible 2.9 search cannot be used as filter after a pipe but after `is`.
We then change here the call to use `is`.

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #6990 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
```release-note
Fixes kubespray to fail when importing a specific ca certificate for OpenStack.
```
