### PR TITLE
up vagrant box to fedora/33-cloud-base in cri-o molecule tests

### DIFF
--- a/roles/container-engine/cri-o/molecule/default/molecule.yml
+++ b/roles/container-engine/cri-o/molecule/default/molecule.yml
@@ -26,7 +26,7 @@ platforms:
     groups:
       - kube-master
   - name: fedora
-    box: fedora/31-cloud-base
+    box: fedora/33-cloud-base
     cpus: 2
     memory: 1024
     groups:


### PR DESCRIPTION

/kind failing-test

**What this PR does / why we need it**:
31 fedora vagrant box is archived and now not able to download

Fix CI process