### PR TITLE
Use fedora/32-cloud-base for molecule-test

### DIFF
--- a/roles/container-engine/cri-o/molecule/default/molecule.yml
+++ b/roles/container-engine/cri-o/molecule/default/molecule.yml
@@ -26,7 +26,7 @@ platforms:
     groups:
       - kube-master
   - name: fedora
-    box: fedora/31-cloud-base
+    box: fedora/32-cloud-base
     cpus: 2
     memory: 1024
     groups:


### PR DESCRIPTION
fedora/31-cloud-base is gone and molecule-test job is failed now due to
NotFound error.
This updates the molecule.yml for using fedora/32-cloud-base to solve the issue.

