### PR TITLE
download run once feature for containerd

### DIFF
--- a/roles/download/tasks/set_container_facts.yml
+++ b/roles/download/tasks/set_container_facts.yml
@@ -26,9 +26,9 @@
   set_fact:
     image_save_command: "{{ containerd_bin_dir }}/ctr -n k8s.io image export {{ image_path_final }} {{ image_reponame }}"
     image_load_command: "{{ containerd_bin_dir }}/ctr -n k8s.io image import --base-name {{ download.repo }} {{ image_path_final }}"
-  when: container_manager in ['crio' ,'containerd']
+  when: container_manager == 'containerd'
 
 - name: Set image save/load command for containerd and crio on localhost
   set_fact:
     image_save_command_on_localhost: "{{ containerd_bin_dir }}/ctr -n k8s.io image export {{ image_path_cached }} {{ image_reponame }}"
-  when: container_manager_on_localhost in ['crio' ,'containerd']
+  when: container_manager_on_localhost == 'containerd'

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -282,8 +282,8 @@
 
 - name: Stop if download_localhost is enabled when container_manager not docker
   assert:
-    that: container_manager == 'docker'
-    msg: "download_run_once support only for docker. See https://github.com/containerd/containerd/issues/4075 for details"
+    that: container_manager in ['containerd', 'docker']
+    msg: "download_run_once support only for docker or containerd"
   when: download_run_once or download_force_cache
 
 - name: Stop if kata_containers_enabled is enabled when container_manager is docker

--- a/tests/files/packet_centos7-flannel-containerd-addons-ha.yml
+++ b/tests/files/packet_centos7-flannel-containerd-addons-ha.yml
@@ -7,6 +7,8 @@ mode: ha
 kubeadm_certificate_key: 3998c58db6497dd17d909394e62d515368c06ec617710d02edea31c06d741085
 kube_proxy_mode: iptables
 kube_network_plugin: flannel
+download_localhost: false
+download_run_once: true
 helm_enabled: true
 kubernetes_audit: true
 container_manager: containerd


### PR DESCRIPTION
Download all images on one server and copy it to all others

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

containerd now version 1.3.x and ctr support multiarch image
docker deprecated in k8s 1.20, so time to extend docker features to other environments
