### PR TITLE
[2.14] Fix nf_conntrack_ipv4 modprobe

### DIFF
--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -103,23 +103,13 @@
   tags:
     - kube-proxy
 
-- name: Modprobe nf_conntrack_ipv4 for kernels < 4.19
+- name: Modprobe nf_conntrack_ipv4
   modprobe:
     name: nf_conntrack_ipv4
     state: present
-  register: enable_nf_conntrack
+  register: modprobe_nf_conntrack_ipv4
+  ignore_errors: yes
   when:
-    - ansible_kernel.split('.')[0:3] | join('.')  < '4.19'
-    - kube_proxy_mode == 'ipvs'
-  tags:
-    - kube-proxy
-
-- name: Modprobe nf_conntrack for kernels >= 4.19
-  modprobe:
-    name: nf_conntrack
-    state: present
-  when:
-    - ansible_kernel.split('.')[0:3] | join('.')  >= '4.19'
     - kube_proxy_mode == 'ipvs'
   tags:
     - kube-proxy
@@ -132,9 +122,7 @@
       ip_vs_rr
       ip_vs_wrr
       ip_vs_sh
-      {% if enable_nf_conntrack is failed -%}
-      nf_conntrack
-      {%-   else -%}
+      {% if modprobe_nf_conntrack_ipv4 is success -%}
       nf_conntrack_ipv4
       {%-   endif -%}
   when: kube_proxy_mode == 'ipvs'


### PR DESCRIPTION
RedHat 8.3 merged nf_conntrack_ipv4 in nf_conntrack but still advertise 4.18
so just try to modprobe and decide depending on the success
Also nf_conntrack is a dependency of ip_vs, so no need to care about it

(cherry picked from commit 00e0f3bd2bf3ce4f83359c30e34545f32af20d20)



**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
 Support EL8.3

**Which issue(s) this PR fixes**:
Fixes #6934

**Special notes for your reviewer**:
Backport of #6988

**Does this PR introduce a user-facing change?**:
```release-note
Fix nf_conntrack_ipv4 detection to support EL8.3+
```
