### PR TITLE
fix etcd vars gen_cert always true

### DIFF
--- a/roles/etcd/tasks/check_certs.yml
+++ b/roles/etcd/tasks/check_certs.yml
@@ -71,16 +71,10 @@
     gen_certs: true
   when: item | list
   run_once: true
-  with_items: "{{ expected_files }}"
-  vars:
-    expected_files: >-
-      ["{%- for m in groups['etcd'] %}
-                  {%- if gen_master_certs[m] %}
-                    {{ m }}
-                  {%- endif %}
-                {%- endfor %}"
-      "{%- for h in (groups['k8s-cluster'] + groups['calico-rr']|default([]))|unique %}
-                {%- if gen_node_certs[h] %}
-                    {{ h }}
-                {%- endif %}
-              {%- endfor %}"]
+  with_items:
+    - "[{%- for m in groups['etcd'] %}
+        '{%- if gen_master_certs[m] %}{{ m }}{%- endif %}',
+        {%- endfor %}]"
+    - "[{%- for h in (groups['k8s-cluster'] + groups['calico-rr']|default([]))|unique %}
+        '{%- if gen_node_certs[h] %}{{ h }}{%- endif %}',
+        {%- endfor %}]"

--- a/roles/etcd/tasks/check_certs.yml
+++ b/roles/etcd/tasks/check_certs.yml
@@ -2,7 +2,7 @@
 - name: "Check_certs | check if all certs have already been generated on first master"
   find:
     paths: "{{ etcd_cert_dir }}"
-    patterns: "ca.pem,node*.pem"
+    patterns: "ca.pem,node*.pem,admin*.pem,member*.pem"
     get_checksum: true
   delegate_to: "{{ groups['etcd'][0] }}"
   register: etcdcert_master
@@ -22,28 +22,11 @@
     - ca.pem
     - node-{{ inventory_hostname }}-key.pem
 
-- name: "Check_certs | Set 'gen_certs' to true"
-  set_fact:
-    gen_certs: true
-  when: not item in etcdcert_master.files|map(attribute='path') | list
-  run_once: true
-  with_items: "{{ expected_files }}"
-  vars:
-    expected_files: >-
-      ['{{ etcd_cert_dir }}/ca.pem',
-      {% set all_etcd_hosts = groups['k8s-cluster']|union(groups['etcd'])|union(groups['calico-rr']|default([]))|unique|sort %}
-      {% for host in all_etcd_hosts %}
-        '{{ etcd_cert_dir }}/node-{{ host }}-key.pem',
-        '{{ etcd_cert_dir }}/admin-{{ host }}-key.pem',
-        '{{ etcd_cert_dir }}/member-{{ host }}-key.pem'
-        {% if not loop.last %}{{','}}{% endif %}
-      {% endfor %}]
-
 - name: "Check_certs | Set 'gen_master_certs' to true"
   set_fact:
     gen_master_certs: |-
       {
-      {% set all_etcd_hosts = groups['k8s-cluster']|union(groups['etcd'])|union(groups['calico-rr']|default([]))|unique|sort -%}
+      {% set all_etcd_hosts = groups['etcd']|unique|sort -%}
       {% set existing_certs = etcdcert_master.files|map(attribute='path')|list|sort %}
       {% for host in all_etcd_hosts -%}
         {% set host_cert = "%s/member-%s-key.pem"|format(etcd_cert_dir, host) %}
@@ -60,7 +43,7 @@
   set_fact:
     gen_node_certs: |-
       {
-      {% set all_etcd_hosts = groups['k8s-cluster']|union(groups['etcd'])|union(groups['calico-rr']|default([]))|unique|sort -%}
+      {% set all_etcd_hosts = groups['k8s-cluster']|union(groups['calico-rr']|default([]))|unique|sort -%}
       {% set existing_certs = etcdcert_master.files|map(attribute='path')|list|sort %}
       {% for host in all_etcd_hosts -%}
         {% set host_cert = "%s/node-%s-key.pem"|format(etcd_cert_dir, host) %}
@@ -77,8 +60,27 @@
   set_fact:
     sync_certs: true
   when:
-    - gen_node_certs[inventory_hostname] or
-      gen_master_certs[inventory_hostname] or
+    - gen_node_certs[inventory_hostname]|default(false) or
+      gen_master_certs[inventory_hostname]|default(false) or
       (not etcdcert_node.results[0].stat.exists|default(false)) or
       (not etcdcert_node.results[1].stat.exists|default(false)) or
       (etcdcert_node.results[1].stat.checksum|default('') != etcdcert_master.files|selectattr("path", "equalto", etcdcert_node.results[1].stat.path)|map(attribute="checksum")|first|default(''))
+
+- name: "Check_certs | Set 'gen_certs' to true"
+  set_fact:
+    gen_certs: true
+  when: item | list
+  run_once: true
+  with_items: "{{ expected_files }}"
+  vars:
+    expected_files: >-
+      ["{%- for m in groups['etcd'] %}
+                  {%- if gen_master_certs[m] %}
+                    {{ m }}
+                  {%- endif %}
+                {%- endfor %}"
+      "{%- for h in (groups['k8s-cluster'] + groups['calico-rr']|default([]))|unique %}
+                {%- if gen_node_certs[h] %}
+                    {{ h }}
+                {%- endif %}
+              {%- endfor %}"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**


 /kind bug

**What this PR does / why we need it**:
Fix: sometimes etcd vars `gen_cert` always `true`.
- `gen_master_certs `: only etcd member have member-*.pem files
- `gen_node_certs`: when etcd not a k8s worker ,etcd has no node-*.pem files

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
