### PR TITLE
Wait for available API token in a new namespace

### DIFF
--- a/tests/testcases/030_check-network.yml
+++ b/tests/testcases/030_check-network.yml
@@ -43,6 +43,16 @@
     command: "{{ bin_dir }}/kubectl create namespace test"
     changed_when: false
 
+  - name: Wait for API token of test namespace
+    shell: "set -o pipefail && {{ bin_dir }}/kubectl describe serviceaccounts default --namespace test | grep Tokens | awk '{print $2}'"
+    args:
+      executable: /bin/bash
+    changed_when: false
+    register: default_token
+    until: default_token.stdout.find('<none>') == -1
+    retries: 5
+    delay: 5
+
   - name: Run 2 busybox pods in test ns
     command: "{{ bin_dir }}/kubectl run {{ item }} --image={{ test_image_repo }}:{{ test_image_tag }} --namespace test --command -- tail -f /dev/null"
     changed_when: false


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test
/kind flake

**What this PR does / why we need it**:

Just after creating a namespace, the corresponding token could not be created and sometimes the pod creation might be failed.
This adds check of the token in the new namespace to make this test case stable.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7043

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
