### PR TITLE
Exclude .git/ from shellcheck

### DIFF
--- a/.gitlab-ci/shellcheck.yml
+++ b/.gitlab-ci/shellcheck.yml
@@ -12,5 +12,5 @@ shellcheck:
     - shellcheck --version
   script:
     # Run shellcheck for all *.sh except contrib/
-    - find . -name '*.sh' -not -path './contrib/*' | xargs shellcheck --severity error
+    - find . -name '*.sh' -not -path './contrib/*' -not -path './.git/*' | xargs shellcheck --severity error
   except: ['triggers', 'master']


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind failing-test

**What this PR does / why we need it**:

If a branch name contains `.sh`, current shellcheck checks the branch file under .git/ and outputs error because the format is not shell script one.
This makes shellcheck exclude files under .git/ to avoid this issue.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
