### PR TITLE
Add cluster-name to external-openstack-cloud-controller-manager

### DIFF
--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-controller-manager-ds.yml.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-controller-manager-ds.yml.j2
@@ -42,6 +42,7 @@ spec:
             - --v=1
             - --cloud-config=$(CLOUD_CONFIG)
             - --cloud-provider=openstack
+            - --cluster-name={{ cluster_name }}
             - --use-service-account-credentials=true
             - --address=127.0.0.1
 {% for key, value in external_openstack_cloud_controller_extra_args.items() %}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
When using OpenStack's loadbalancer, if cluster-name is not set, the default value `kubernetes` is used.
The loadbalancees created by Kubernetes follow the format :
```kube_service_{{ clusterName }}_{{ serviceNamespace }}_{{ serviceName }}```
If 2 clusters create a loadbalancer for the same service in the same
namespace, they will share the same non-working loadbalancer.

Setting `--cluster-name` in external-openstack-cloud-controller-manager makes sure that clusters with unique `cluster_name` can expose services without colliding with other clusters in the same OpenStack project. 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
