### PR TITLE
Add which molecule test is running

### DIFF
--- a/tests/scripts/molecule_run.sh
+++ b/tests/scripts/molecule_run.sh
@@ -7,6 +7,7 @@ export LANG=C.UTF-8
 for d in $(find roles -name molecule -type d)
 do
     cd $(dirname $d)
+    echo "Running molecule test under $d .."
     molecule test --all
     cd -
 done


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind failing-test

**What this PR does / why we need it**:

Now we are facing broken CI system due to molecule test failures.
This adds which molecule test is failed to know that.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
