### PR TITLE
Increase Ansible timeout to 30 seconds

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -7,6 +7,7 @@ strategy_plugins = plugins/mitogen/ansible_mitogen/plugins/strategy
 # https://github.com/ansible/ansible/issues/56930 (to ignore group names with - and .)
 force_valid_group_names = ignore
 
+timeout = 30
 host_key_checking=False
 gathering = smart
 fact_caching = jsonfile


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

Now we are facing the following error on molecule test jobs:

```
    TASK [Bootstrap python for Ansible] ********************************************
    ok: [ubuntu16]
    ok: [centos7]
    ok: [ubuntu18]
    ok: [ubuntu20]
 fatal: [debian10]: FAILED! => {"msg": "Timeout (12s) waiting for privilege escalation prompt: "}
 fatal: [debian9]: FAILED! => {"msg": "Timeout (12s) waiting for privilege escalation prompt: "}
```

This increases the timeout to 30 seconds from the default 10 seconds to avoid this issue.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
