### PR TITLE
Calico: fix node ip subnet detection

### DIFF
--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -230,10 +230,14 @@ spec:
             - name: IP
               value: "autodetect"
 {% else %}
-            - name: IP
+            - name: NODEIP
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: IP_AUTODETECTION_METHOD
+              value: "can-reach=$(NODEIP)"
+            - name: IP
+              value: "autodetect"
 {% endif %}
 {% if calico_use_default_route_src_ipaddr|default(false) %}
             - name: FELIX_DEVICEROUTESOURCEADDRESS


### PR DESCRIPTION
We are currently setting the IP variable to hostIP,
Before https://github.com/projectcalico/node/pull/593 (not yet released)
Calico interpret that as hostIP/32
Using 'can-reach' we get the future behavior
This fixes vxlan and IPIP CrossSubnet modes

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix Calico node ip subnet detection

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
This will be the future behavior in Calico 3.18, I don't expect any breakage but if any this is a preview I think ;)

**Does this PR introduce a user-facing change?**:
```release-note
Calico: fix vxlan and IPIP CrossSubnet modes
```
