### PR TITLE
[2.14] Bump nodelocaldns to 1.16.0

### DIFF
--- a/docs/centos8.md
+++ b/docs/centos8.md
@@ -2,7 +2,7 @@
 
 RHEL / CentOS 8 ships only with iptables-nft (ie without iptables-legacy)
 The only tested configuration for now is using Calico CNI
-You need to use K8S 1.17+ and to add `calico_iptables_backend: "NFT"` to your configuration
+You need to use K8S 1.17+ and to add `calico_iptables_backend: "NFT"` or `calico_iptables_backend: "Auto"` to your configuration
 
 If you have containers that are using iptables in the host network namespace (`hostNetwork=true`),
 you need to ensure they are using iptables-nft.

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -478,8 +478,8 @@ coredns_version: "1.6.7"
 coredns_image_repo: "{{ docker_image_repo }}/coredns/coredns"
 coredns_image_tag: "{{ coredns_version }}"
 
-nodelocaldns_version: "1.15.13"
-nodelocaldns_image_repo: "{{ kube_image_repo }}/k8s-dns-node-cache"
+nodelocaldns_version: "1.16.0"
+nodelocaldns_image_repo: "{{ kube_image_repo }}/dns/k8s-dns-node-cache"
 nodelocaldns_image_tag: "{{ nodelocaldns_version }}"
 
 dnsautoscaler_version: 1.8.1


### PR DESCRIPTION
This new version uses the same base image as kube-proxy
(k8s.gcr.io/build-image/debian-iptables)
This allow to automatically pick iptables-legacy or iptables-nft,
and be compatible with RHEL/CentOS 8
https://github.com/kubernetes/dns/pull/367

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Update nodelocaldns so it's compatible with iptables-nft (CentOS 8)

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Backport of #6916 

**Does this PR introduce a user-facing change?**:
```release-note
Update nodelocaldns to 1.16.0, now compatible with iptables-nft (CentOS 8)
```