### PR TITLE
Remove libseccomp install tasks

### DIFF
--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -109,14 +109,5 @@
     - containerd_package_info.pkgs|length > 0
   ignore_errors: true
 
-- name: Ensure latest version of libseccomp installed  # noqa 403
-  package:
-    name: libseccomp
-    state: latest
-  when:
-    - ansible_distribution == "CentOS"
-    - ansible_distribution_major_version == "8"
-  notify: restart containerd
-
 - include_role:
     name: container-engine/crictl

--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -91,15 +91,6 @@
   retries: 4
   delay: "{{ retry_stagger | d(3) }}"
 
-- name: Ensure latest version of libseccomp installed  # noqa 403
-  package:
-    name: libseccomp
-    state: latest
-  when:
-    - ansible_distribution == "CentOS"
-    - ansible_distribution_major_version == "8"
-  notify: restart crio
-
 - name: Check if already installed
   stat:
     path: "/bin/crio"

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -215,15 +215,6 @@
     - docker-ce
     - docker-ce-cli
 
-- name: Ensure latest version of libseccomp installed  # noqa 403
-  package:
-    name: libseccomp
-    state: latest
-  when:
-    - ansible_distribution == "CentOS"
-    - ansible_distribution_major_version == "8"
-  notify: restart docker
-
 - name: ensure docker started, remove our config if docker start failed and try again
   block:
     - name: ensure service is started if docker packages are already present


### PR DESCRIPTION
All packages have proper dependencies in latest versions
Currently working installations will continue to work, new installations should not deploy old containerd anyway given the recent CVE

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #6922

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
None
```