### PR TITLE
Valuating conditional (need_https_proxy.rc != 0) fail if http_proxy set and skip_http_proxy_on_os_packages is true

### DIFF
--- a/inventory/sample/group_vars/all/all.yml
+++ b/inventory/sample/group_vars/all/all.yml
@@ -71,7 +71,7 @@ loadbalancer_apiserver_healthcheck_port: 8081
 ## If you need to disable proxying of os package repositories but are still behind an http_proxy set
 ## skip_http_proxy_on_os_packages to true
 ## This will cause kubespray not to set proxy environment in /etc/yum.conf for centos and in /etc/apt/apt.conf for debian/ubuntu
-## Special information for debian/ubuntu - you have to set the no_proxy then apt package will install from your source of your wish
+## Special information for debian/ubuntu - you have to set the no_proxy variable, then apt package will install from your source of wish
 # skip_http_proxy_on_os_packages: false
 
 ## Since workers are included in the no_proxy variable by default, docker engine will be restarted on all nodes (all

--- a/inventory/sample/group_vars/all/all.yml
+++ b/inventory/sample/group_vars/all/all.yml
@@ -70,7 +70,8 @@ loadbalancer_apiserver_healthcheck_port: 8081
 
 ## If you need to disable proxying of os package repositories but are still behind an http_proxy set
 ## skip_http_proxy_on_os_packages to true
-## This will cause kubespray not to set proxy environment in /etc/yum.conf for centos
+## This will cause kubespray not to set proxy environment in /etc/yum.conf for centos and in /etc/apt/apt.conf for debian/ubuntu
+## Special information for debian/ubuntu - you have to set the no_proxy then apt package will install from your source of your wish
 # skip_http_proxy_on_os_packages: false
 
 ## Since workers are included in the no_proxy variable by default, docker engine will be restarted on all nodes (all

--- a/roles/bootstrap-os/tasks/bootstrap-debian.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-debian.yml
@@ -20,9 +20,6 @@
   # This command should always run, even in check mode
   check_mode: false
   environment: {}
-  when:
-    - http_proxy is defined
-    - not skip_http_proxy_on_os_packages
 
 - name: Add http_proxy to /etc/apt/apt.conf if http_proxy is defined
   raw: echo 'Acquire::http::proxy "{{ http_proxy }}";' >> /etc/apt/apt.conf
@@ -41,9 +38,6 @@
   # This command should always run, even in check mode
   check_mode: false
   environment: {}
-  when:
-    - https_proxy is defined
-    - not skip_http_proxy_on_os_packages
 
 - name: Add https_proxy to /etc/apt/apt.conf if https_proxy is defined
   raw: echo 'Acquire::https::proxy "{{ https_proxy }}";' >> /etc/apt/apt.conf


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This bug happens if you using ubuntu or debian. 
If you set the **http_proxy**, **https_proxy** and the **skip_http_proxy_on_os_packages=true** , than you got an error.

`
FAILED! => {"msg": "The conditional check 'need_https_proxy.rc != 0' failed. The error was: error while evaluating conditional (need_https_proxy.rc != 0): 'dict object' has no attribute 'rc'\n\nThe error appears to be in '/home/felix/dev/kubespray/kubespray/roles/bootstrap-os/tasks/bootstrap-debian.yml': line 46, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Add https_proxy to /etc/apt/apt.conf if https_proxy is defined\n  ^ here\n"}
`

Because the task to define the variable  **need_https_proxy.rc/need_http_proxy.rc**  will never run. 
The when statement is worng. 

**kubespray/roles/bootstrap-os/tasks/bootstrap-debian.yml**: 
```
- name: Check http::proxy in apt configuration files
  raw: apt-config dump | grep -qsi 'Acquire::http::proxy'
  register: need_http_proxy
  failed_when: false
  changed_when: false
  # This command should always run, even in check mode
  check_mode: false
  environment: {}
  when:
    - http_proxy is defined
    - not skip_http_proxy_on_os_packages

```

**Special notes for your reviewer**:
I fix the sample comment with **skip_http_proxy_on_os_packages** also. (not only centos will work with this parameter) 

**Does this PR introduce a user-facing change?**:
NONE
