### PR TITLE
Disable docker-ce yum repo by default / cleanups

### DIFF
--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -14,7 +14,7 @@ containerd_config:
 containerd_cfg_dir: /etc/containerd
 
 # Path to runc binary
-runc_binary: /usr/sbin/runc
+runc_binary: /usr/bin/runc
 
 
 yum_repo_dir: /etc/yum.repos.d

--- a/roles/container-engine/containerd/tasks/containerd_repo.yml
+++ b/roles/container-engine/containerd/tasks/containerd_repo.yml
@@ -65,18 +65,3 @@
   when:
     - ansible_distribution in ["CentOS","RedHat"]
     - yum_result.results | length == 0
-
-- name: Copy yum.conf for editing
-  copy:
-    src: "{{ yum_conf }}"
-    dest: "{{ containerd_yum_conf }}"
-    remote_src: yes
-  when: ansible_distribution in ["CentOS","RedHat"]
-
-- name: Edit copy of yum.conf to set obsoletes=0
-  lineinfile:
-    path: "{{ containerd_yum_conf }}"
-    state: present
-    regexp: '^obsoletes='
-    line: 'obsoletes=0'
-  when: ansible_distribution in ["CentOS","RedHat"]

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -95,9 +95,9 @@
   args:
     pkg: "{{ item.name }}"
     force: "{{ item.force | default(omit) }}"
-    conf_file: "{{ item.yum_conf | default(omit) }}"
     state: present
     update_cache: "{{ omit if ansible_distribution == 'Fedora' else True }}"
+    enablerepo: "{{ item.repo | default(omit) }}"
   register: containerd_task_result
   until: containerd_task_result is succeeded
   retries: 4
@@ -108,26 +108,6 @@
     - not is_ostree
     - containerd_package_info.pkgs|length > 0
   ignore_errors: true
-
-- name: Check if runc is installed
-  stat:
-    path: "{{ runc_binary }}"
-  register: runc_stat
-
-- name: Install runc package if necessary
-  action: "{{ containerd_package_info.pkg_mgr }}"
-  args:
-    pkg: runc
-    state: present
-    update_cache: "{{ omit if ansible_distribution == 'Fedora' else True }}"
-  register: runc_task_result
-  until: runc_task_result is succeeded
-  retries: 4
-  delay: "{{ retry_stagger | d(3) }}"
-  notify: restart containerd
-  when:
-    - not is_ostree
-    - not runc_stat.stat.exists
 
 - name: Ensure latest version of libseccomp installed  # noqa 403
   package:

--- a/roles/container-engine/containerd/templates/fedora_containerd.repo.j2
+++ b/roles/container-engine/containerd/templates/fedora_containerd.repo.j2
@@ -1,7 +1,7 @@
 [docker-ce]
 name=Docker-CE Repository
 baseurl={{ containerd_fedora_repo_base_url }}
-enabled=1
+enabled=0
 gpgcheck={{ '1' if containerd_fedora_repo_gpgkey else '0' }}
 gpgkey={{ containerd_fedora_repo_gpgkey }}
 {% if http_proxy is defined %}proxy={{ http_proxy }}{% endif %}

--- a/roles/container-engine/containerd/templates/rh_containerd.repo.j2
+++ b/roles/container-engine/containerd/templates/rh_containerd.repo.j2
@@ -1,13 +1,10 @@
 [docker-ce]
 name=Docker-CE Repository
 baseurl={{ docker_rh_repo_base_url }}
-enabled=1
+enabled=0
 gpgcheck={{ '1' if docker_rh_repo_gpgkey else '0' }}
 keepcache={{ docker_rpm_keepcache | default('1') }}
 gpgkey={{ docker_rh_repo_gpgkey }}
 {% if http_proxy is defined %}
 proxy={{ http_proxy }}
-{% endif %}
-{% if ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 8 %}
-module_hotfixes=True
 {% endif %}

--- a/roles/container-engine/containerd/vars/debian.yml
+++ b/roles/container-engine/containerd/vars/debian.yml
@@ -18,5 +18,3 @@ containerd_repo_info:
       deb {{ containerd_debian_repo_base_url }}
       {{ ansible_distribution_release|lower }}
       {{ containerd_debian_repo_component }}
-
-runc_binary: /usr/bin/runc

--- a/roles/container-engine/containerd/vars/fedora.yml
+++ b/roles/container-engine/containerd/vars/fedora.yml
@@ -3,5 +3,3 @@ containerd_package_info:
   pkg_mgr: dnf
   pkgs:
     - name: "{{ containerd_versioned_pkg[containerd_version | string] }}"
-
-runc_binary: /usr/bin/runc

--- a/roles/container-engine/containerd/vars/redhat.yml
+++ b/roles/container-engine/containerd/vars/redhat.yml
@@ -3,10 +3,7 @@ containerd_package_info:
   pkg_mgr: yum
   pkgs:
     - name: "{{ containerd_versioned_pkg[containerd_version | string] }}"
-
-containerd_pkgs:
-  - name: "{{ containerd_versioned_pkg[containerd_version | string] }}"
-    yum_conf: "{{ containerd_yum_conf }}"
+      repo: "docker-ce"
 
 containerd_repo_key_info:
   pkg_key: ''
@@ -15,5 +12,3 @@ containerd_repo_key_info:
 containerd_repo_info:
   pkg_repo: ''
   repos: []
-
-runc_binary: /bin/runc

--- a/roles/container-engine/containerd/vars/ubuntu-amd64.yml
+++ b/roles/container-engine/containerd/vars/ubuntu-amd64.yml
@@ -18,5 +18,3 @@ containerd_repo_info:
       deb {{ containerd_ubuntu_repo_base_url }}
       {{ ansible_distribution_release|lower }}
       {{ containerd_ubuntu_repo_component }}
-
-runc_binary: /usr/bin/runc

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -166,6 +166,7 @@
     conf_file: "{{ item.yum_conf|default(omit) }}"
     state: "{{ item.state | default('present') }}"
     update_cache: "{{ omit if ansible_distribution == 'Fedora' else True }}"
+    enablerepo: "{{ item.repo | default(omit) }}"
   register: docker_task_result
   until: docker_task_result is succeeded
   retries: 4

--- a/roles/container-engine/docker/templates/rh_docker.repo.j2
+++ b/roles/container-engine/docker/templates/rh_docker.repo.j2
@@ -1,13 +1,10 @@
 [docker-ce]
 name=Docker-CE Repository
 baseurl={{ docker_rh_repo_base_url }}
-enabled=1
+enabled=0
 gpgcheck={{ '1' if docker_rh_repo_gpgkey else '0' }}
 keepcache={{ docker_rpm_keepcache | default('1') }}
 gpgkey={{ docker_rh_repo_gpgkey }}
 {% if http_proxy is defined %}
 proxy={{ http_proxy }}
-{% endif %}
-{% if ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 8 %}
-module_hotfixes=True
 {% endif %}

--- a/roles/container-engine/docker/vars/redhat.yml
+++ b/roles/container-engine/docker/vars/redhat.yml
@@ -30,16 +30,21 @@ docker_selinux_versioned_pkg:
 docker_pkgs_use_docker_ce:
   - name: "{{ docker_selinux_versioned_pkg[docker_selinux_version | string] }}"
     yum_conf: "{{ docker_yum_conf }}"
+    repo: "docker-ce"
   - name: "{{ docker_versioned_pkg[docker_version | string] }}"
     yum_conf: "{{ docker_yum_conf }}"
+    repo: "docker-ce"
 
 docker_pkgs:
   - name: "{{ containerd_versioned_pkg[containerd_version | string] }}"
     yum_conf: "{{ docker_yum_conf }}"
+    repo: "docker-ce"
   - name: "{{ docker_cli_versioned_pkg[docker_cli_version | string] }}"
     yum_conf: "{{ docker_yum_conf }}"
+    repo: "docker-ce"
   - name: "{{ docker_versioned_pkg[docker_version | string] }}"
     yum_conf: "{{ docker_yum_conf }}"
+    repo: "docker-ce"
 
 docker_package_info:
   pkg_mgr: yum


### PR DESCRIPTION
Upgrading docker / containerd without adapting the configuration might break the node,
so disable docker-ce repo by default.
We are already using dpkg hold for Debian.

All containerd.io packages provide /usr/bin/runc, so no need to check

yum_conf was never used for containerd

module_hotfixes should not be needed with the EL8 repo

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Disable docker-ce yum repo by default
```
