### PR TITLE
Fix crictl with Docker

### DIFF
--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -10,7 +10,9 @@
 - name: install crictl
   import_role:
     name: container-engine/crictl
-  when: not skip_downloads|default(false)
+  when:
+    - not skip_downloads|default(false)
+    - container_manager in ['containerd', 'crio']
 
 - name: download | Get kubeadm binary and list of required images
   include_tasks: prep_kubeadm_images.yml


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
crictl isn't really needed with Docker, let's put the conditional check back (it was remove a few weeks ago)

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Opensuse tests are failing because of this https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/892943018
```
TASK [container-engine/crictl : Install crictl config] *************************
task path: /builds/kargo-ci/kubernetes-sigs-kubespray/roles/container-engine/crictl/tasks/crictl.yml:7
Sunday 06 December 2020  01:17:51 +0000 (0:00:03.938)       0:07:43.906 ******* 
fatal: [instance-2]: FAILED! => {"changed": false, "checksum": "454ee70fdf6277bfaf2464deb617079a4f12bcec", "gid": 0, "group": "root", "mode": "0644", "msg": "chown failed: failed to look up user bin", "owner": "root", "path": "/etc/crictl.yaml", "size": 123, "state": "file", "uid": 0}
```

Even if this won't fix that, it will allow docker install on opensuse, we still have to fix (in another PR) containerd/crio install on Opensuse.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
