### PR TITLE
fix large cluster deploy, deploy etcd slow

### DIFF
--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -70,10 +70,13 @@
     - gen_certs|default(false)
   notify: set etcd_secret_changed
 
-- name: Gen_certs | Gather etcd master certs
-  slurp:
+- name: Gen_certs | Write etcd master certs
+  copy:
+    dest: "{{ item }}"
     src: "{{ item }}"
-  register: etcd_master_certs
+    group: "{{ etcd_cert_group }}"
+    owner: kube
+    mode: 0640
   with_items:
     - "{{ etcd_cert_dir }}/ca.pem"
     - "{{ etcd_cert_dir }}/ca-key.pem"
@@ -87,27 +90,10 @@
         '{{ etcd_cert_dir }}/node-{{ node }}.pem',
         '{{ etcd_cert_dir }}/node-{{ node }}-key.pem',
         {% endfor %}]"
-  delegate_to: "{{ groups['etcd'][0] }}"
   when:
     - inventory_hostname in groups['etcd']
     - sync_certs|default(false)
     - inventory_hostname != groups['etcd'][0]
-  notify: set etcd_secret_changed
-
-- name: Gen_certs | Write etcd master certs
-  copy:
-    dest: "{{ item.item }}"
-    content: "{{ item.content | b64decode }}"
-    group: "{{ etcd_cert_group }}"
-    owner: kube
-    mode: 0640
-  with_items: "{{ etcd_master_certs.results }}"
-  when:
-    - inventory_hostname in groups['etcd']
-    - sync_certs|default(false)
-    - inventory_hostname != groups['etcd'][0]
-  loop_control:
-    label: "{{ item.item }}"
 
 - name: Gen_certs | Set cert names per node
   set_fact:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
1. When deploy a large cluster, ansible `copy` the etcd cert requires base64 first and then decode, which is very slow.
2. These are all executed in memory, which consumes a lot of memory and cpu.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6911

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
