### PR TITLE
Added ability to define custom kubelet config extra args by host variable

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -69,6 +69,9 @@ kubelet_config_extra_args: {}
 ## Support parameters to be passed to kubelet via kubelet-config.yaml only on nodes, not masters
 kubelet_node_config_extra_args: {}
 
+## Support parameters to be passed to kubelet via kubelet-config.yaml only if hostvar 'extra_kubelet_configs=true' defined
+kubelet_custom_config_extra_args: {}
+
 # Maximum number of container log files that can be present for a container.
 kubelet_logfiles_max_nr: 5
 

--- a/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
@@ -78,11 +78,14 @@ systemReserved:
 {% endif %}
 {% endif %}
 resolvConf: "{{ kube_resolv_conf }}"
-{% if kubelet_config_extra_args %}
+{% if kubelet_config_extra_args and not kubelet_custom_config_extra_args %}
 {{ kubelet_config_extra_args | to_nice_yaml(indent=2) }}
 {% endif %}
-{% if inventory_hostname in groups['kube-node'] and kubelet_node_config_extra_args %}
+{% if inventory_hostname in groups['kube-node'] and kubelet_node_config_extra_args and not kubelet_custom_config_extra_args %}
 {{ kubelet_node_config_extra_args | to_nice_yaml(indent=2) }}
+{% endif %}
+{% if hostvars[inventory_hostname]['extra_kubelet_configs'] is defined and kubelet_custom_config_extra_args and not kubelet_config_extra_args %}
+{{ kubelet_custom_config_extra_args | to_nice_yaml(indent=2) }}
 {% endif %}
 {% if tls_min_version is defined %}
 tlsMinVersion: {{ tls_min_version }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
Ability to define kubelet extra args for separate nodes selected by host variable in inventory.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```NONE

```
