### PR TITLE
Rework proxy support

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -2,21 +2,6 @@
 - name: Check ansible version
   import_playbook: ansible_version.yml
 
-- hosts: all
-  gather_facts: false
-  tags: always
-  tasks:
-    - name: "Set up proxy environment"
-      set_fact:
-        proxy_env:
-          http_proxy: "{{ http_proxy | default ('') }}"
-          HTTP_PROXY: "{{ http_proxy | default ('') }}"
-          https_proxy: "{{ https_proxy | default ('') }}"
-          HTTPS_PROXY: "{{ https_proxy | default ('') }}"
-          no_proxy: "{{ no_proxy | default ('') }}"
-          NO_PROXY: "{{ no_proxy | default ('') }}"
-      no_log: true
-
 - hosts: bastion[0]
   gather_facts: False
   roles:
@@ -43,7 +28,6 @@
     - { role: kubernetes/preinstall, tags: preinstall }
     - { role: "container-engine", tags: "container-engine", when: deploy_container_engine|default(true) }
     - { role: download, tags: download, when: "not skip_downloads" }
-  environment: "{{ proxy_env }}"
 
 - hosts: etcd
   gather_facts: False
@@ -75,7 +59,6 @@
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes/node, tags: node }
-  environment: "{{ proxy_env }}"
 
 - hosts: kube-master
   gather_facts: False
@@ -127,7 +110,6 @@
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes-apps, tags: apps }
-  environment: "{{ proxy_env }}"
 
 - hosts: k8s-cluster
   gather_facts: False

--- a/remove-node.yml
+++ b/remove-node.yml
@@ -2,21 +2,6 @@
 - name: Check ansible version
   import_playbook: ansible_version.yml
 
-- hosts: all
-  gather_facts: false
-  tags: always
-  tasks:
-    - name: "Set up proxy environment"
-      set_fact:
-        proxy_env:
-          http_proxy: "{{ http_proxy | default ('') }}"
-          HTTP_PROXY: "{{ http_proxy | default ('') }}"
-          https_proxy: "{{ https_proxy | default ('') }}"
-          HTTPS_PROXY: "{{ https_proxy | default ('') }}"
-          no_proxy: "{{ no_proxy | default ('') }}"
-          NO_PROXY: "{{ no_proxy | default ('') }}"
-      no_log: true
-
 - hosts: "{{ node | default('etcd:k8s-cluster:calico-rr') }}"
   gather_facts: no
   vars_prompt:

--- a/reset.yml
+++ b/reset.yml
@@ -2,21 +2,6 @@
 - name: Check ansible version
   import_playbook: ansible_version.yml
 
-- hosts: all
-  gather_facts: false
-  tags: always
-  tasks:
-    - name: "Set up proxy environment"
-      set_fact:
-        proxy_env:
-          http_proxy: "{{ http_proxy | default ('') }}"
-          HTTP_PROXY: "{{ http_proxy | default ('') }}"
-          https_proxy: "{{ https_proxy | default ('') }}"
-          HTTPS_PROXY: "{{ https_proxy | default ('') }}"
-          no_proxy: "{{ no_proxy | default ('') }}"
-          NO_PROXY: "{{ no_proxy | default ('') }}"
-      no_log: true
-
 - hosts: bastion[0]
   gather_facts: False
   roles:

--- a/roles/bootstrap-os/tasks/bootstrap-centos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-centos.yml
@@ -24,6 +24,7 @@
     - use_oracle_public_repo|default(true)
     - '"Oracle" in os_release.stdout'
     - (ansible_distribution_version | float) < 7.6
+  environment: "{{ proxy_env }}"
 
 - name: Enable Oracle Linux repo
   ini_file:

--- a/roles/bootstrap-os/tasks/bootstrap-coreos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-coreos.yml
@@ -4,7 +4,6 @@
 - name: Check if bootstrap is needed
   raw: stat /opt/bin/.bootstrapped
   register: need_bootstrap
-  environment: {}
   failed_when: false
   changed_when: false
   tags:
@@ -19,9 +18,7 @@
 - name: Run bootstrap.sh
   script: bootstrap.sh
   become: true
-  environment:
-    http_proxy: "{{ http_proxy | default('') }}"
-    https_proxy: "{{ https_proxy | default('') }}"
+  environment: "{{ proxy_env }}"
   when:
     - need_bootstrap.rc != 0
 

--- a/roles/bootstrap-os/tasks/bootstrap-debian.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-debian.yml
@@ -8,7 +8,6 @@
   changed_when: false
   # This command should always run, even in check mode
   check_mode: false
-  environment: {}
   tags:
     - facts
 
@@ -19,12 +18,10 @@
   changed_when: false
   # This command should always run, even in check mode
   check_mode: false
-  environment: {}
 
 - name: Add http_proxy to /etc/apt/apt.conf if http_proxy is defined
   raw: echo 'Acquire::http::proxy "{{ http_proxy }}";' >> /etc/apt/apt.conf
   become: true
-  environment: {}
   when:
     - http_proxy is defined
     - need_http_proxy.rc != 0
@@ -37,12 +34,10 @@
   changed_when: false
   # This command should always run, even in check mode
   check_mode: false
-  environment: {}
 
 - name: Add https_proxy to /etc/apt/apt.conf if https_proxy is defined
   raw: echo 'Acquire::https::proxy "{{ https_proxy }}";' >> /etc/apt/apt.conf
   become: true
-  environment: {}
   when:
     - https_proxy is defined
     - need_https_proxy.rc != 0
@@ -55,14 +50,12 @@
   changed_when: false
   # This command should always run, even in check mode
   check_mode: false
-  environment: {}
   when:
     - '"bionic" in os_release.stdout'
 
 - name: Change Network Name Resolution configuration
   raw: sed -i 's/^DNSSEC=yes/DNSSEC=allow-downgrade/g' /etc/systemd/resolved.conf
   become: true
-  environment: {}
   when:
     - '"bionic" in os_release.stdout'
     - need_dnssec_allow_downgrade.rc
@@ -70,7 +63,6 @@
 - name: Restart systemd-resolved service
   raw: systemctl restart systemd-resolved
   become: true
-  environment: {}
   when:
     - '"bionic" in os_release.stdout'
     - need_dnssec_allow_downgrade.rc
@@ -80,7 +72,6 @@
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y python3-minimal
   become: true
-  environment: {}
   when:
     - need_bootstrap.rc != 0
 

--- a/roles/bootstrap-os/tasks/bootstrap-fedora.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-fedora.yml
@@ -6,7 +6,6 @@
   register: need_bootstrap
   failed_when: false
   changed_when: false
-  environment: {}
   tags:
     - facts
 
@@ -24,7 +23,6 @@
 - name: Install python3 on fedora
   raw: "dnf install --assumeyes --quiet python3"
   become: true
-  environment: {}
   when:
     - need_bootstrap.rc != 0
 

--- a/roles/bootstrap-os/tasks/bootstrap-flatcar.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-flatcar.yml
@@ -4,7 +4,6 @@
 - name: Check if bootstrap is needed
   raw: stat /opt/bin/.bootstrapped
   register: need_bootstrap
-  environment: {}
   failed_when: false
   changed_when: false
   tags:
@@ -19,9 +18,7 @@
 - name: Run bootstrap.sh
   script: bootstrap.sh
   become: true
-  environment:
-    http_proxy: "{{ http_proxy | default('') }}"
-    https_proxy: "{{ https_proxy | default('') }}"
+  environment: "{{ proxy_env }}"
   when:
     - need_bootstrap.rc != 0
 

--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -5,7 +5,6 @@
   changed_when: false
   # This command should always run, even in check mode
   check_mode: false
-  environment: {}
 
 - include_tasks: bootstrap-centos.yml
   when: '"CentOS" in os_release.stdout or "Oracle" in os_release.stdout'

--- a/roles/container-engine/containerd/tasks/containerd_repo.yml
+++ b/roles/container-engine/containerd/tasks/containerd_repo.yml
@@ -10,6 +10,7 @@
   retries: 4
   delay: "{{ retry_stagger | d(3) }}"
   with_items: "{{ containerd_repo_key_info.repo_keys }}"
+  environment: "{{ proxy_env }}"
   when:
     - ansible_os_family in ['Ubuntu', 'Debian']
 

--- a/roles/container-engine/crun/tasks/main.yml
+++ b/roles/container-engine/crun/tasks/main.yml
@@ -11,9 +11,11 @@
     path: "{{ crun_bin_dir }}/crun"
   register: crun_stat
 
+# TODO: use download_file.yml
 - name: Download binary
   get_url:
     url: "{{ crun_release_url }}"
     dest: "{{ crun_bin_dir }}/crun"
     mode: '0755'
   when: not crun_stat.stat.exists
+  environment: "{{ proxy_env }}"

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -74,6 +74,7 @@
   retries: 4
   delay: "{{ retry_stagger | d(3) }}"
   with_items: "{{ docker_repo_key_info.repo_keys }}"
+  environment: "{{ proxy_env }}"
   when: not (ansible_os_family in ["Flatcar Container Linux by Kinvolk", "RedHat", "Suse", "ClearLinux"] or is_ostree)
 
 - name: ensure docker-ce repository is enabled
@@ -95,6 +96,7 @@
   retries: 4
   delay: "{{ retry_stagger | d(3) }}"
   with_items: "{{ dockerproject_repo_key_info.repo_keys }}"
+  environment: "{{ proxy_env }}"
   when:
     - not (ansible_os_family in ["Flatcar Container Linux by Kinvolk", "RedHat", "Suse", "ClearLinux"] or is_ostree)
     - use_docker_engine is defined and use_docker_engine

--- a/roles/download/tasks/download_file.yml
+++ b/roles/download/tasks/download_file.yml
@@ -66,6 +66,7 @@
     until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
     retries: 4
     delay: "{{ retry_stagger | default(5) }}"
+    environment: "{{ proxy_env }}"
 
   - name: download_file | Copy file back to ansible host file cache
     synchronize:

--- a/roles/kubespray-defaults/tasks/main.yaml
+++ b/roles/kubespray-defaults/tasks/main.yaml
@@ -5,6 +5,19 @@
   tags:
     - always
 
+- name: "Set up proxy environment"
+  set_fact:
+    proxy_env:
+      http_proxy: "{{ http_proxy | default ('') }}"
+      HTTP_PROXY: "{{ http_proxy | default ('') }}"
+      https_proxy: "{{ https_proxy | default ('') }}"
+      HTTPS_PROXY: "{{ https_proxy | default ('') }}"
+      no_proxy: "{{ no_proxy | default ('') }}"
+      NO_PROXY: "{{ no_proxy | default ('') }}"
+  no_log: true
+  tags:
+    - always
+
 # do not run gather facts when bootstrap-os in roles
 - name: set fallback_ips
   import_tasks: fallback_ips.yml

--- a/scale.yml
+++ b/scale.yml
@@ -2,21 +2,6 @@
 - name: Check ansible version
   import_playbook: ansible_version.yml
 
-- hosts: all
-  gather_facts: false
-  tags: always
-  tasks:
-    - name: "Set up proxy environment"
-      set_fact:
-        proxy_env:
-          http_proxy: "{{ http_proxy | default ('') }}"
-          HTTP_PROXY: "{{ http_proxy | default ('') }}"
-          https_proxy: "{{ https_proxy | default ('') }}"
-          HTTPS_PROXY: "{{ https_proxy | default ('') }}"
-          no_proxy: "{{ no_proxy | default ('') }}"
-          NO_PROXY: "{{ no_proxy | default ('') }}"
-      no_log: true
-
 - hosts: bastion[0]
   gather_facts: False
   roles:
@@ -63,7 +48,6 @@
     - { role: container-engine, tags: "container-engine", when: deploy_container_engine|default(true) }
     - { role: download, tags: download, when: "not skip_downloads" }
     - { role: etcd, tags: etcd, etcd_cluster_setup: false, when: "not etcd_kubeadm_enabled|default(false)" }
-  environment: "{{ proxy_env }}"
 
 - name: Target only workers to get kubelet installed and checking in on any new nodes(node)
   hosts: kube-node
@@ -72,7 +56,6 @@
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes/node, tags: node }
-  environment: "{{ proxy_env }}"
 
 - name: Upload control plane certs and retrieve encryption key
   hosts: kube-master | first
@@ -102,4 +85,3 @@
     - { role: kubernetes/kubeadm, tags: kubeadm }
     - { role: network_plugin, tags: network }
     - { role: kubernetes/node-label, tags: node-label }
-  environment: "{{ proxy_env }}"

--- a/upgrade-cluster.yml
+++ b/upgrade-cluster.yml
@@ -2,21 +2,6 @@
 - name: Check ansible version
   import_playbook: ansible_version.yml
 
-- hosts: all
-  gather_facts: false
-  tags: always
-  tasks:
-    - name: "Set up proxy environment"
-      set_fact:
-        proxy_env:
-          http_proxy: "{{ http_proxy | default ('') }}"
-          HTTP_PROXY: "{{ http_proxy | default ('') }}"
-          https_proxy: "{{ https_proxy | default ('') }}"
-          HTTPS_PROXY: "{{ https_proxy | default ('') }}"
-          no_proxy: "{{ no_proxy | default ('') }}"
-          NO_PROXY: "{{ no_proxy | default ('') }}"
-      no_log: true
-
 - hosts: bastion[0]
   gather_facts: False
   roles:
@@ -47,7 +32,6 @@
     - { role: kubespray-defaults, when: "not skip_downloads and download_run_once and not download_localhost"}
     - { role: kubernetes/preinstall, tags: preinstall, when: "not skip_downloads and download_run_once and not download_localhost" }
     - { role: download, tags: download, when: "not skip_downloads and download_run_once and not download_localhost" }
-  environment: "{{ proxy_env }}"
 
 - name: Prepare nodes for upgrade
   hosts: k8s-cluster:etcd:calico-rr
@@ -57,7 +41,6 @@
     - { role: kubespray-defaults }
     - { role: kubernetes/preinstall, tags: preinstall }
     - { role: download, tags: download, when: "not skip_downloads" }
-  environment: "{{ proxy_env }}"
 
 - name: Upgrade container engine on non-cluster nodes
   hosts: etcd:calico-rr:!k8s-cluster
@@ -67,7 +50,6 @@
   roles:
     - { role: kubespray-defaults }
     - { role: container-engine, tags: "container-engine", when: deploy_container_engine|default(true) }
-  environment: "{{ proxy_env }}"
 
 - hosts: etcd
   gather_facts: False
@@ -109,7 +91,6 @@
     - { role: kubernetes-apps/cluster_roles, tags: cluster-roles }
     - { role: kubernetes-apps, tags: csi-driver }
     - { role: upgrade/post-upgrade, tags: post-upgrade }
-  environment: "{{ proxy_env }}"
 
 - name: Upgrade calico and external cloud provider on all masters, calico-rrs, and nodes
   hosts: kube-master:calico-rr:kube-node
@@ -136,7 +117,6 @@
     - { role: kubernetes/kubeadm, tags: kubeadm }
     - { role: kubernetes/node-label, tags: node-label }
     - { role: upgrade/post-upgrade, tags: post-upgrade }
-  environment: "{{ proxy_env }}"
 
 - hosts: kube-master[0]
   gather_facts: False
@@ -152,7 +132,6 @@
   roles:
     - { role: kubespray-defaults }
     - { role: network_plugin/calico/rr, tags: network }
-  environment: "{{ proxy_env }}"
 
 - hosts: kube-master
   gather_facts: False
@@ -160,7 +139,6 @@
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes-apps, tags: apps }
-  environment: "{{ proxy_env }}"
 
 - hosts: k8s-cluster
   gather_facts: False


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
no_proxy is a pain to get right, and having proxy variables present can have side effect
It's better to only configure what require proxy:
- the runtime (containerd/docker/crio)
- the package manager
- the download tasks

**Which issue(s) this PR fixes**:
Fixes #7100 

**Special notes for your reviewer**:
Only tested on CentOS 8 for now (cluster and upgrade)

**Does this PR introduce a user-facing change?**:
```release-note
Rework proxy support
```
