### PR TITLE
Add docker 20.10 to available packages

### DIFF
--- a/roles/container-engine/docker/vars/debian.yml
+++ b/roles/container-engine/docker/vars/debian.yml
@@ -13,6 +13,7 @@ docker_versioned_pkg:
   '18.06': docker-ce=18.06.2~ce~3-0~debian
   '18.09': docker-ce=5:18.09.9~3-0~debian-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce=5:19.03.14~3-0~debian-{{ ansible_distribution_release|lower }}
+  '20.10': docker-ce=5:20.10.2~3-0~debian-{{ ansible_distribution_release|lower }}
   'stable': docker-ce=5:19.03.14~3-0~debian-{{ ansible_distribution_release|lower }}
   'edge': docker-ce=5:19.03.14~3-0~debian-{{ ansible_distribution_release|lower }}
 
@@ -20,6 +21,7 @@ docker_cli_versioned_pkg:
   'latest': docker-ce-cli
   '18.09': docker-ce-cli=5:18.09.9~3-0~debian-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce-cli=5:19.03.14~3-0~debian-{{ ansible_distribution_release|lower }}
+  '20.10': docker-ce-cli=5:20.10.2~3-0~debian-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkg_mgr: apt

--- a/roles/container-engine/docker/vars/fedora.yml
+++ b/roles/container-engine/docker/vars/fedora.yml
@@ -9,6 +9,7 @@ docker_versioned_pkg:
   '18.06': docker-ce-18.06.2.ce-3.fc{{ ansible_distribution_major_version }}
   '18.09': docker-ce-18.09.7-3.fc{{ ansible_distribution_major_version }}
   '19.03': docker-ce-19.03.14-3.fc{{ ansible_distribution_major_version }}
+  '20.10': docker-ce-20.10.2-3.fc{{ ansible_distribution_major_version }}
   'stable': docker-ce-19.03.14-3.fc{{ ansible_distribution_major_version }}
   'edge': docker-ce-19.03.14-3.fc{{ ansible_distribution_major_version }}
 
@@ -16,6 +17,7 @@ docker_cli_versioned_pkg:
   'latest': docker-ce-cli
   '18.09': docker-ce-cli-19.03.14-3.fc{{ ansible_distribution_major_version }}
   '19.03': docker-ce-cli-19.03.14-3.fc{{ ansible_distribution_major_version }}
+  '20.10': docker-ce-cli-20.10.2-3.fc{{ ansible_distribution_major_version }}
 
 docker_package_info:
   pkg_mgr: dnf

--- a/roles/container-engine/docker/vars/redhat.yml
+++ b/roles/container-engine/docker/vars/redhat.yml
@@ -13,6 +13,7 @@ docker_versioned_pkg:
   '18.06': docker-ce-18.06.3.ce-3.el7
   '18.09': docker-ce-18.09.9-3.el7
   '19.03': docker-ce-19.03.14-3.el{{ ansible_distribution_major_version }}
+  '20.10': docker-ce-20.10.2-3.el{{ ansible_distribution_major_version }}
   'stable': docker-ce-19.03.14-3.el{{ ansible_distribution_major_version }}
   'edge': docker-ce-19.03.14-3.el{{ ansible_distribution_major_version }}
 
@@ -20,6 +21,7 @@ docker_cli_versioned_pkg:
   'latest': docker-ce-cli
   '18.09': docker-ce-cli-18.09.9-3.el7
   '19.03': docker-ce-cli-19.03.14-3.el{{ ansible_distribution_major_version }}
+  '20.10': docker-ce-cli-20.10.2-3.el{{ ansible_distribution_major_version }}
 
 docker_selinux_versioned_pkg:
   'latest': docker-ce-selinux-17.03.3.ce-1.el7

--- a/roles/container-engine/docker/vars/ubuntu-amd64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-amd64.yml
@@ -13,6 +13,7 @@ docker_versioned_pkg:
   '18.06': docker-ce=18.06.2~ce~3-0~ubuntu
   '18.09': docker-ce=5:18.09.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce=5:19.03.14~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '20.10': docker-ce=5:20.10.2~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   'stable': docker-ce=5:19.03.14~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   'edge': docker-ce=5:19.03.14~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
@@ -20,6 +21,7 @@ docker_cli_versioned_pkg:
   'latest': docker-ce-cli
   '18.09': docker-ce-cli=5:18.09.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce-cli=5:19.03.14~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '20.10': docker-ce-cli=5:20.10.2~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkg_mgr: apt

--- a/roles/container-engine/docker/vars/ubuntu-arm64.yml
+++ b/roles/container-engine/docker/vars/ubuntu-arm64.yml
@@ -9,6 +9,7 @@ docker_versioned_pkg:
   '18.06': docker-ce=18.06.2~ce~3-0~ubuntu
   '18.09': docker-ce=5:18.09.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce=5:19.03.14~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '20.10': docker-ce=5:20.10.2~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   'stable': docker-ce=5:19.03.14~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   'edge': docker-ce=5:19.03.14~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
@@ -16,6 +17,7 @@ docker_cli_versioned_pkg:
   'latest': docker-ce-cli
   '18.09': docker-ce-cli=5:18.09.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce-cli=5:19.03.14~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '20.10': docker-ce-cli=5:20.10.2~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkg_mgr: apt


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add docker package, but don't enable them by default (at least for now)

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Didn't found anything for Amazon, but anyway... :)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
