### PR TITLE
Fix mardownlint failures of offline

### DIFF
--- a/contrib/offline/README.md
+++ b/contrib/offline/README.md
@@ -11,11 +11,11 @@ Then we will run step(2) for registering the images to local registry.
 Step(1) can be operated with:
 
 ```shell
-$ ./manage-offline-container-images.sh   create
+manage-offline-container-images.sh   create
 ```
 
 Step(2) can be operated with:
 
 ```shell
-$ ./manage-offline-container-images.sh   register
+manage-offline-container-images.sh   register
 ```


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This fixes the following failures:

```
./contrib/offline/README.md:14:1 MD014/commands-show-output Dollar signs used before commands without showing output [Context: "$ ./manage-offline-container-i..."]
./contrib/offline/README.md:20:1 MD014/commands-show-output Dollar signs used before commands without showing output [Context: "$ ./manage-offline-container-i..."]
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
