### PR TITLE
Stop using action / more cleanups

### DIFF
--- a/roles/container-engine/containerd/tasks/containerd_repo.yml
+++ b/roles/container-engine/containerd/tasks/containerd_repo.yml
@@ -1,7 +1,6 @@
 ---
 - name: ensure containerd repository public key is installed
-  action: "{{ containerd_repo_key_info.pkg_key }}"
-  args:
+  apt_key:
     id: "{{ item }}"
     url: "{{ containerd_repo_key_info.url }}"
     state: present
@@ -11,8 +10,7 @@
   delay: "{{ retry_stagger | d(3) }}"
   with_items: "{{ containerd_repo_key_info.repo_keys }}"
   environment: "{{ proxy_env }}"
-  when:
-    - ansible_os_family in ['Ubuntu', 'Debian']
+  when: ansible_pkg_mgr == 'apt'
 
 - name: ensure containerd repository is enabled
   action: "{{ containerd_repo_info.pkg_repo }}"

--- a/roles/container-engine/containerd/tasks/containerd_repo.yml
+++ b/roles/container-engine/containerd/tasks/containerd_repo.yml
@@ -13,14 +13,11 @@
   when: ansible_pkg_mgr == 'apt'
 
 - name: ensure containerd repository is enabled
-  action: "{{ containerd_repo_info.pkg_repo }}"
-  args:
+  apt_repository:
     repo: "{{ item }}"
     state: present
   with_items: "{{ containerd_repo_info.repos }}"
-  when:
-    - ansible_os_family in ['Ubuntu', 'Debian']
-    - containerd_repo_info.repos|length > 0
+  when: ansible_pkg_mgr == 'apt'
 
 - name: Configure containerd repository on Fedora
   template:

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -81,14 +81,15 @@
 
 # This is required to ensure any apt upgrade will not break kubernetes
 - name: Set containerd pin priority to apt_preferences on Debian family
-  template:
-    src: "apt_preferences.d/debian_containerd.j2"
+  copy:
+    content: |
+      Package: {{ containerd_package }}
+      Pin: version {{ containerd_version }}*
+      Pin-Priority: 1001
     dest: "/etc/apt/preferences.d/containerd"
     owner: "root"
     mode: 0644
-  when:
-    - ansible_os_family in ['Ubuntu', 'Debian']
-    - not is_ostree
+  when: ansible_pkg_mgr == 'apt'
 
 - name: ensure containerd packages are installed
   action: "{{ containerd_package_info.pkg_mgr }}"

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -115,3 +115,14 @@
 
 - include_role:
     name: container-engine/crictl
+
+# you can sometimes end up in a state where everything is installed
+# but containerd was not started / enabled
+- name: flush handlers
+  meta: flush_handlers
+
+- name: ensure containerd is started and enabled
+  service:
+    name: containerd
+    enabled: yes
+    state: started

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -92,18 +92,22 @@
   when: ansible_pkg_mgr == 'apt'
 
 - name: ensure containerd packages are installed
-  action: "{{ containerd_package_info.pkg_mgr }}"
-  args:
-    pkg: "{{ item.name }}"
-    force: "{{ item.force | default(omit) }}"
+  package:
+    name: "{{ containerd_package_info.pkgs }}"
     state: present
-    update_cache: "{{ omit if ansible_distribution == 'Fedora' else True }}"
-    enablerepo: "{{ item.repo | default(omit) }}"
+  module_defaults:
+    apt:
+      update_cache: true
+    dnf:
+      enablerepo: "{{ containerd_package_info.enablerepo | default(omit) }}"
+    yum:
+      enablerepo: "{{ containerd_package_info.enablerepo | default(omit) }}"
+    zypper:
+      update_cache: true
   register: containerd_task_result
   until: containerd_task_result is succeeded
   retries: 4
   delay: "{{ retry_stagger | d(3) }}"
-  with_items: "{{ containerd_package_info.pkgs }}"
   notify: restart containerd
   when:
     - not is_ostree

--- a/roles/container-engine/containerd/templates/apt_preferences.d/debian_containerd.j2
+++ b/roles/container-engine/containerd/templates/apt_preferences.d/debian_containerd.j2
@@ -1,3 +1,0 @@
-Package: {{ containerd_package }}
-Pin: version {{ containerd_version }}*
-Pin-Priority: 1001

--- a/roles/container-engine/containerd/vars/debian.yml
+++ b/roles/container-engine/containerd/vars/debian.yml
@@ -4,7 +4,6 @@ containerd_package_info:
     - "{{ containerd_versioned_pkg[containerd_version | string] }}"
 
 containerd_repo_key_info:
-  pkg_key: apt_key
   url: '{{ containerd_debian_repo_gpgkey }}'
   repo_keys:
     - '{{ containerd_debian_repo_repokey }}'

--- a/roles/container-engine/containerd/vars/debian.yml
+++ b/roles/container-engine/containerd/vars/debian.yml
@@ -9,7 +9,6 @@ containerd_repo_key_info:
     - '{{ containerd_debian_repo_repokey }}'
 
 containerd_repo_info:
-  pkg_repo: apt_repository
   repos:
     - >
       deb {{ containerd_debian_repo_base_url }}

--- a/roles/container-engine/containerd/vars/debian.yml
+++ b/roles/container-engine/containerd/vars/debian.yml
@@ -1,9 +1,7 @@
 ---
 containerd_package_info:
-  pkg_mgr: apt
   pkgs:
-    - name: "{{ containerd_versioned_pkg[containerd_version | string] }}"
-      force: false
+    - "{{ containerd_versioned_pkg[containerd_version | string] }}"
 
 containerd_repo_key_info:
   pkg_key: apt_key

--- a/roles/container-engine/containerd/vars/fedora.yml
+++ b/roles/container-engine/containerd/vars/fedora.yml
@@ -1,6 +1,5 @@
 ---
 containerd_package_info:
-  pkg_mgr: dnf
+  enablerepo: "docker-ce"
   pkgs:
-    - name: "{{ containerd_versioned_pkg[containerd_version | string] }}"
-      repo: "docker-ce"
+    - "{{ containerd_versioned_pkg[containerd_version | string] }}"

--- a/roles/container-engine/containerd/vars/redhat.yml
+++ b/roles/container-engine/containerd/vars/redhat.yml
@@ -3,7 +3,3 @@ containerd_package_info:
   enablerepo: "docker-ce"
   pkgs:
     - "{{ containerd_versioned_pkg[containerd_version | string] }}"
-
-containerd_repo_info:
-  pkg_repo: ''
-  repos: []

--- a/roles/container-engine/containerd/vars/redhat.yml
+++ b/roles/container-engine/containerd/vars/redhat.yml
@@ -1,9 +1,8 @@
 ---
 containerd_package_info:
-  pkg_mgr: yum
+  enablerepo: "docker-ce"
   pkgs:
-    - name: "{{ containerd_versioned_pkg[containerd_version | string] }}"
-      repo: "docker-ce"
+    - "{{ containerd_versioned_pkg[containerd_version | string] }}"
 
 containerd_repo_key_info:
   pkg_key: ''

--- a/roles/container-engine/containerd/vars/redhat.yml
+++ b/roles/container-engine/containerd/vars/redhat.yml
@@ -4,10 +4,6 @@ containerd_package_info:
   pkgs:
     - "{{ containerd_versioned_pkg[containerd_version | string] }}"
 
-containerd_repo_key_info:
-  pkg_key: ''
-  repo_keys: []
-
 containerd_repo_info:
   pkg_repo: ''
   repos: []

--- a/roles/container-engine/containerd/vars/suse.yml
+++ b/roles/container-engine/containerd/vars/suse.yml
@@ -3,10 +3,8 @@
 containerd_package: containerd
 
 containerd_package_info:
-  pkg_mgr: zypper
   pkgs:
-    - name: "{{ containerd_package }}"
-      state: latest
+    - "{{ containerd_package }}"
 
 containerd_repo_key_info:
   pkg_key: ''

--- a/roles/container-engine/containerd/vars/suse.yml
+++ b/roles/container-engine/containerd/vars/suse.yml
@@ -5,7 +5,3 @@ containerd_package: containerd
 containerd_package_info:
   pkgs:
     - "{{ containerd_package }}"
-
-containerd_repo_info:
-  pkg_repo: ''
-  repos: []

--- a/roles/container-engine/containerd/vars/suse.yml
+++ b/roles/container-engine/containerd/vars/suse.yml
@@ -6,10 +6,6 @@ containerd_package_info:
   pkgs:
     - "{{ containerd_package }}"
 
-containerd_repo_key_info:
-  pkg_key: ''
-  repo_keys: []
-
 containerd_repo_info:
   pkg_repo: ''
   repos: []

--- a/roles/container-engine/containerd/vars/ubuntu.yml
+++ b/roles/container-engine/containerd/vars/ubuntu.yml
@@ -9,7 +9,6 @@ containerd_repo_key_info:
     - '{{ containerd_ubuntu_repo_repokey }}'
 
 containerd_repo_info:
-  pkg_repo: apt_repository
   repos:
     - >
       deb {{ containerd_ubuntu_repo_base_url }}

--- a/roles/container-engine/containerd/vars/ubuntu.yml
+++ b/roles/container-engine/containerd/vars/ubuntu.yml
@@ -1,9 +1,7 @@
 ---
 containerd_package_info:
-  pkg_mgr: apt
   pkgs:
-    - name: "{{ containerd_versioned_pkg[containerd_version | string] }}"
-      force: false
+    - "{{ containerd_versioned_pkg[containerd_version | string] }}"
 
 containerd_repo_key_info:
   pkg_key: apt_key

--- a/roles/container-engine/containerd/vars/ubuntu.yml
+++ b/roles/container-engine/containerd/vars/ubuntu.yml
@@ -4,7 +4,6 @@ containerd_package_info:
     - "{{ containerd_versioned_pkg[containerd_version | string] }}"
 
 containerd_repo_key_info:
-  pkg_key: apt_key
   url: '{{ containerd_ubuntu_repo_gpgkey }}'
   repo_keys:
     - '{{ containerd_ubuntu_repo_repokey }}'

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -108,6 +108,17 @@
     - ansible_distribution in ["CentOS","RedHat"] and not is_ostree
     - yum_result.results | length == 0
 
+- name: Remove dpkg hold
+  dpkg_selections:
+    name: "{{ item }}"
+    selection: install
+  when: ansible_pkg_mgr == 'apt'
+  changed_when: false
+  with_items:
+    - containerd
+    - docker-ce
+    - docker-ce-cli
+
 - name: ensure docker packages are installed
   action: "{{ docker_package_info.pkg_mgr }}"
   args:
@@ -142,7 +153,8 @@
   dpkg_selections:
     name: "{{ item }}"
     selection: hold
-  when: ansible_os_family in ["Debian"]
+  when: ansible_pkg_mgr == 'apt'
+  changed_when: false
   with_items:
     - docker-ce
     - docker-ce-cli

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -54,8 +54,7 @@
 - import_tasks: pre-upgrade.yml
 
 - name: ensure docker-ce repository public key is installed
-  action: "{{ docker_repo_key_info.pkg_key }}"
-  args:
+  apt_key:
     id: "{{ item }}"
     url: "{{ docker_repo_key_info.url }}"
     state: present
@@ -65,7 +64,7 @@
   delay: "{{ retry_stagger | d(3) }}"
   with_items: "{{ docker_repo_key_info.repo_keys }}"
   environment: "{{ proxy_env }}"
-  when: not (ansible_os_family in ["Flatcar Container Linux by Kinvolk", "RedHat", "Suse", "ClearLinux"] or is_ostree)
+  when: ansible_pkg_mgr == 'apt'
 
 - name: ensure docker-ce repository is enabled
   action: "{{ docker_repo_info.pkg_repo }}"

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -67,12 +67,11 @@
   when: ansible_pkg_mgr == 'apt'
 
 - name: ensure docker-ce repository is enabled
-  action: "{{ docker_repo_info.pkg_repo }}"
-  args:
+  apt_repository:
     repo: "{{ item }}"
     state: present
   with_items: "{{ docker_repo_info.repos }}"
-  when: not (ansible_os_family in ["Flatcar Container Linux by Kinvolk", "RedHat", "Suse", "ClearLinux"] or is_ostree) and (docker_repo_info.repos|length > 0)
+  when: ansible_pkg_mgr == 'apt'
 
 - name: Configure docker repository on Fedora
   template:

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -120,33 +120,27 @@
     - docker-ce-cli
 
 - name: ensure docker packages are installed
-  action: "{{ docker_package_info.pkg_mgr }}"
-  args:
-    pkg: "{{ item.name }}"
-    force: "{{ item.force|default(omit) }}"
-    state: "{{ item.state | default('present') }}"
-    update_cache: "{{ omit if ansible_distribution == 'Fedora' else True }}"
-    enablerepo: "{{ item.repo | default(omit) }}"
-  register: docker_task_result
-  until: docker_task_result is succeeded
-  retries: 4
-  delay: "{{ retry_stagger | d(3) }}"
-  with_items: "{{ docker_package_info.pkgs }}"
-  notify: restart docker
-  when: not (ansible_os_family in ["Flatcar Container Linux by Kinvolk", "ClearLinux"] or is_ostree) and (docker_package_info.pkgs|length > 0)
-
-- name: Ensure docker packages are installed
-  action: "{{ docker_package_info.pkg_mgr }}"
-  args:
-    name: "{{ item.name }}"
-    state: "{{ item.state | default('present') }}"
-  with_items: "{{ docker_package_info.pkgs }}"
+  package:
+    name: "{{ docker_package_info.pkgs }}"
+    state: "{{ docker_package_info.state | default('present') }}"
+  module_defaults:
+    apt:
+      update_cache: true
+    dnf:
+      enablerepo: "{{ docker_package_info.enablerepo | default(omit) }}"
+    yum:
+      enablerepo: "{{ docker_package_info.enablerepo | default(omit) }}"
+    zypper:
+      update_cache: true
   register: docker_task_result
   until: docker_task_result is succeeded
   retries: 4
   delay: "{{ retry_stagger | d(3) }}"
   notify: restart docker
-  when: ansible_os_family in ["ClearLinux"]
+  when:
+    - not ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
+    - not is_ostree
+    - docker_package_info.pkgs|length > 0
 
 # This is required to ensure any apt upgrade will not break kubernetes
 - name: Tell Debian hosts not to change the docker version with apt upgrade

--- a/roles/container-engine/docker/vars/amazon.yml
+++ b/roles/container-engine/docker/vars/amazon.yml
@@ -9,6 +9,5 @@ docker_versioned_pkg:
 docker_version: "latest"
 
 docker_package_info:
-  pkg_mgr: yum
   pkgs:
-    - name: "{{ docker_versioned_pkg[docker_version | string] }}"
+    - "{{ docker_versioned_pkg[docker_version | string] }}"

--- a/roles/container-engine/docker/vars/clearlinux.yml
+++ b/roles/container-engine/docker/vars/clearlinux.yml
@@ -1,5 +1,4 @@
 ---
 docker_package_info:
-  pkg_mgr: swupd
   pkgs:
-    - name: "containers-basic"
+    - "containers-basic"

--- a/roles/container-engine/docker/vars/debian.yml
+++ b/roles/container-engine/docker/vars/debian.yml
@@ -21,7 +21,6 @@ docker_package_info:
     - "{{ docker_versioned_pkg[docker_version | string] }}"
 
 docker_repo_key_info:
-  pkg_key: apt_key
   url: '{{ docker_debian_repo_gpgkey }}'
   repo_keys:
     - 9DC858229FC7DD38854AE2D88D81803C0EBFCD88

--- a/roles/container-engine/docker/vars/debian.yml
+++ b/roles/container-engine/docker/vars/debian.yml
@@ -18,11 +18,8 @@ docker_package_info:
   pkg_mgr: apt
   pkgs:
     - name: "{{ containerd_versioned_pkg[containerd_version | string] }}"
-      force: yes
     - name: "{{ docker_cli_versioned_pkg[docker_cli_version | string] }}"
-      force: yes
     - name: "{{ docker_versioned_pkg[docker_version | string] }}"
-      force: yes
 
 docker_repo_key_info:
   pkg_key: apt_key

--- a/roles/container-engine/docker/vars/debian.yml
+++ b/roles/container-engine/docker/vars/debian.yml
@@ -15,11 +15,10 @@ docker_cli_versioned_pkg:
   '20.10': docker-ce-cli=5:20.10.2~3-0~debian-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
-  pkg_mgr: apt
   pkgs:
-    - name: "{{ containerd_versioned_pkg[containerd_version | string] }}"
-    - name: "{{ docker_cli_versioned_pkg[docker_cli_version | string] }}"
-    - name: "{{ docker_versioned_pkg[docker_version | string] }}"
+    - "{{ containerd_versioned_pkg[containerd_version | string] }}"
+    - "{{ docker_cli_versioned_pkg[docker_cli_version | string] }}"
+    - "{{ docker_versioned_pkg[docker_version | string] }}"
 
 docker_repo_key_info:
   pkg_key: apt_key

--- a/roles/container-engine/docker/vars/debian.yml
+++ b/roles/container-engine/docker/vars/debian.yml
@@ -26,7 +26,6 @@ docker_repo_key_info:
     - 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
 
 docker_repo_info:
-  pkg_repo: apt_repository
   repos:
     - >
       deb {{ docker_debian_repo_base_url }}

--- a/roles/container-engine/docker/vars/fedora.yml
+++ b/roles/container-engine/docker/vars/fedora.yml
@@ -14,8 +14,8 @@ docker_cli_versioned_pkg:
   '20.10': docker-ce-cli-20.10.2-3.fc{{ ansible_distribution_major_version }}
 
 docker_package_info:
-  pkg_mgr: dnf
+  enablerepo: "docker-ce"
   pkgs:
-    - name: "{{ containerd_versioned_pkg[containerd_version | string] }}"
-    - name: "{{ docker_cli_versioned_pkg[docker_cli_version | string] }}"
-    - name: "{{ docker_versioned_pkg[docker_version | string] }}"
+    - "{{ containerd_versioned_pkg[containerd_version | string] }}"
+    - "{{ docker_cli_versioned_pkg[docker_cli_version | string] }}"
+    - "{{ docker_versioned_pkg[docker_version | string] }}"

--- a/roles/container-engine/docker/vars/redhat.yml
+++ b/roles/container-engine/docker/vars/redhat.yml
@@ -17,14 +17,11 @@ docker_cli_versioned_pkg:
   '20.10': docker-ce-cli-20.10.2-3.el{{ ansible_distribution_major_version }}
 
 docker_package_info:
-  pkg_mgr: yum
+  enablerepo: "docker-ce"
   pkgs:
-    - name: "{{ containerd_versioned_pkg[containerd_version | string] }}"
-      repo: "docker-ce"
-    - name: "{{ docker_cli_versioned_pkg[docker_cli_version | string] }}"
-      repo: "docker-ce"
-    - name: "{{ docker_versioned_pkg[docker_version | string] }}"
-      repo: "docker-ce"
+    - "{{ containerd_versioned_pkg[containerd_version | string] }}"
+    - "{{ docker_cli_versioned_pkg[docker_cli_version | string] }}"
+    - "{{ docker_versioned_pkg[docker_version | string] }}"
 
 docker_repo_key_info:
   pkg_key: ''

--- a/roles/container-engine/docker/vars/redhat.yml
+++ b/roles/container-engine/docker/vars/redhat.yml
@@ -22,7 +22,3 @@ docker_package_info:
     - "{{ containerd_versioned_pkg[containerd_version | string] }}"
     - "{{ docker_cli_versioned_pkg[docker_cli_version | string] }}"
     - "{{ docker_versioned_pkg[docker_version | string] }}"
-
-docker_repo_info:
-  pkg_repo: ''
-  repos: []

--- a/roles/container-engine/docker/vars/redhat.yml
+++ b/roles/container-engine/docker/vars/redhat.yml
@@ -23,10 +23,6 @@ docker_package_info:
     - "{{ docker_cli_versioned_pkg[docker_cli_version | string] }}"
     - "{{ docker_versioned_pkg[docker_version | string] }}"
 
-docker_repo_key_info:
-  pkg_key: ''
-  repo_keys: []
-
 docker_repo_info:
   pkg_repo: ''
   repos: []

--- a/roles/container-engine/docker/vars/suse.yml
+++ b/roles/container-engine/docker/vars/suse.yml
@@ -4,7 +4,3 @@ docker_package_info:
   pkgs:
     - docker
     - containerd
-
-docker_repo_info:
-  pkg_repo: ''
-  repos: []

--- a/roles/container-engine/docker/vars/suse.yml
+++ b/roles/container-engine/docker/vars/suse.yml
@@ -5,10 +5,6 @@ docker_package_info:
     - docker
     - containerd
 
-docker_repo_key_info:
-  pkg_key: ''
-  repo_keys: []
-
 docker_repo_info:
   pkg_repo: ''
   repos: []

--- a/roles/container-engine/docker/vars/suse.yml
+++ b/roles/container-engine/docker/vars/suse.yml
@@ -1,10 +1,9 @@
 ---
 docker_package_info:
-  pkg_mgr: zypper
+  state: latest
   pkgs:
-    - name: docker
-    - name: containerd
-      state: latest
+    - docker
+    - containerd
 
 docker_repo_key_info:
   pkg_key: ''

--- a/roles/container-engine/docker/vars/ubuntu.yml
+++ b/roles/container-engine/docker/vars/ubuntu.yml
@@ -18,11 +18,8 @@ docker_package_info:
   pkg_mgr: apt
   pkgs:
     - name: "{{ containerd_versioned_pkg[containerd_version | string] }}"
-      force: yes
     - name: "{{ docker_cli_versioned_pkg[docker_cli_version | string] }}"
-      force: yes
     - name: "{{ docker_versioned_pkg[docker_version | string] }}"
-      force: yes
 
 docker_repo_key_info:
   pkg_key: apt_key

--- a/roles/container-engine/docker/vars/ubuntu.yml
+++ b/roles/container-engine/docker/vars/ubuntu.yml
@@ -21,7 +21,6 @@ docker_package_info:
     - "{{ docker_versioned_pkg[docker_version | string] }}"
 
 docker_repo_key_info:
-  pkg_key: apt_key
   url: '{{ docker_ubuntu_repo_gpgkey }}'
   repo_keys:
     - 9DC858229FC7DD38854AE2D88D81803C0EBFCD88

--- a/roles/container-engine/docker/vars/ubuntu.yml
+++ b/roles/container-engine/docker/vars/ubuntu.yml
@@ -15,11 +15,10 @@ docker_cli_versioned_pkg:
   '20.10': docker-ce-cli=5:20.10.2~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
-  pkg_mgr: apt
   pkgs:
-    - name: "{{ containerd_versioned_pkg[containerd_version | string] }}"
-    - name: "{{ docker_cli_versioned_pkg[docker_cli_version | string] }}"
-    - name: "{{ docker_versioned_pkg[docker_version | string] }}"
+    - "{{ containerd_versioned_pkg[containerd_version | string] }}"
+    - "{{ docker_cli_versioned_pkg[docker_cli_version | string] }}"
+    - "{{ docker_versioned_pkg[docker_version | string] }}"
 
 docker_repo_key_info:
   pkg_key: apt_key

--- a/roles/container-engine/docker/vars/ubuntu.yml
+++ b/roles/container-engine/docker/vars/ubuntu.yml
@@ -26,7 +26,6 @@ docker_repo_key_info:
     - 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
 
 docker_repo_info:
-  pkg_repo: apt_repository
   repos:
     - >
       deb [arch={{ host_architecture }}] {{ docker_ubuntu_repo_base_url }}

--- a/roles/kubernetes/preinstall/tasks/0070-system-packages.yml
+++ b/roles/kubernetes/preinstall/tasks/0070-system-packages.yml
@@ -40,7 +40,7 @@
     - bootstrap-os
 
 - name: Install epel-release on RedHat/CentOS
-  yum:
+  package:
     name: epel-release
     state: present
   when:
@@ -56,10 +56,9 @@
   when: kube_proxy_mode == 'ipvs'
 
 - name: Install packages requirements
-  action:
-    module: "{{ ansible_pkg_mgr }}"
+  package:
     name: "{{ required_pkgs | default([]) | union(common_required_pkgs|default([])) }}"
-    state: latest
+    state: present
   register: pkgs_task_result
   until: pkgs_task_result is succeeded
   retries: "{{ pkg_install_retries }}"
@@ -69,7 +68,7 @@
     - bootstrap-os
 
 - name: Install ipvsadm for ClearLinux
-  swupd:
+  package:
     name: ipvsadm
     state: present
   when:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
I find the usage of ansible `action` make the playbook hard to read
module_defaults is clearer IMO

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
