### PR TITLE
Remove unnecessary failed_when

### DIFF
--- a/roles/download/tasks/check_pull_required.yml
+++ b/roles/download/tasks/check_pull_required.yml
@@ -6,9 +6,7 @@
 # nginx:1.15,gcr.io/google-containers/kube-proxy:v1.14.1,gcr.io/google-containers/kube-proxy@sha256:44af2833c6cbd9a7fc2e9d2f5244a39dfd2e31ad91bf9d4b7d810678db738ee9,gcr.io/google-containers/kube-apiserver:v1.14.1,etc...
 - name: check_pull_required |  Generate a list of information about the images on a node  # noqa 305 image_info_command contains a pipe, therefore requiring shell
   shell: "{{ image_info_command }}"
-  no_log: true
   register: docker_images
-  failed_when: false
   changed_when: false
   check_mode: no
   when: not download_always_pull


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

TASK `[Generate a list of information about the images on a node]` registers list of container images to docker_images.
Then the next TASK `[Set pull_required if the desired image is not yet loaded]` does based on expecting images are registered.
However sometimes the first TASK was failed as [1] but the failure is ignored due to `failed_when: false` and it makes another issue.
This removes this unnecessary failed_when to detect the failure at the point.
In addition, this removes no_log:true also because the output doesn't contain any sensitive data and now it just makes debugging difficult.

[1]: https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/934714534#L2953

Ref: https://github.com/kubernetes-sigs/kubespray/issues/7090

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
