### PR TITLE
Fix and document environment variable KUBE_MASTERS

### DIFF
--- a/contrib/inventory_builder/inventory.py
+++ b/contrib/inventory_builder/inventory.py
@@ -63,7 +63,7 @@ def get_var_as_bool(name, default):
 
 
 CONFIG_FILE = os.environ.get("CONFIG_FILE", "./inventory/sample/hosts.yaml")
-KUBE_MASTERS = int(os.environ.get("KUBE_MASTERS_MASTERS", 2))
+KUBE_MASTERS = int(os.environ.get("KUBE_MASTERS", 2))
 # Reconfigures cluster distribution at scale
 SCALE_THRESHOLD = int(os.environ.get("SCALE_THRESHOLD", 50))
 MASSIVE_SCALE_THRESHOLD = int(os.environ.get("MASSIVE_SCALE_THRESHOLD", 200))
@@ -402,6 +402,7 @@ Configurable env vars:
 DEBUG                   Enable debug printing. Default: True
 CONFIG_FILE             File to write config to Default: ./inventory/sample/hosts.yaml
 HOST_PREFIX             Host prefix for generated hosts. Default: node
+KUBE_MASTERS            Set the number of kube-masters. Default: 2
 SCALE_THRESHOLD         Separate ETCD role if # of nodes >= 50
 MASSIVE_SCALE_THRESHOLD Separate K8s master and ETCD if # of nodes >= 200
 '''  # noqa


### PR DESCRIPTION


**What type of PR is this?**
/kind api-change
/kind bug
/kind documentation

**Special notes for your reviewer**:

The variable was introduced in this PR: #5073

**Does this PR introduce a user-facing change?**:

```release-note
Renamed environment variable KUBE_MASTERS_MASTERS used by the inventory builder to KUBE_MASTERS.

Documented KUBE_MASTERS and its default values in the help message of the inventory builder.
```
