### PR TITLE
Require 2.9.0 <= Ansible version < 2.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Note: The list of validated [docker versions](https://kubernetes.io/docs/setup/p
 ## Requirements
 
 - **Minimum required version of Kubernetes is v1.17**
-- **Ansible v2.9+, Jinja 2.11+ and python-netaddr is installed on the machine that will run Ansible commands**
+- **Ansible v2.9.x, Jinja 2.11+ and python-netaddr is installed on the machine that will run Ansible commands, Ansible 2.10.x is not supported for now**
 - The target servers must have **access to the Internet** in order to pull docker images. Otherwise, additional configuration is required (See [Offline Environment](docs/offline-environment.md))
 - The target servers are configured to allow **IPv4 forwarding**.
 - The **firewalls are not managed**, you'll need to implement your own rules the way you used to.

--- a/ansible_version.yml
+++ b/ansible_version.yml
@@ -3,13 +3,15 @@
   gather_facts: false
   become: no
   vars:
-    minimal_ansible_version: 2.8.0
+    minimal_ansible_version: 2.9.0
+    maximal_ansible_version: 2.10.0
     ansible_connection: local
   tasks:
-    - name: "Check ansible version >={{ minimal_ansible_version }}"
+    - name: "Check {{ minimal_ansible_version }} <= Ansible version < {{ maximal_ansible_version }}"
       assert:
-        msg: "Ansible must be {{ minimal_ansible_version }} or higher"
+        msg: "Ansible must be between {{ minimal_ansible_version }} and {{ maximal_ansible_version }}"
         that:
           - ansible_version.string is version(minimal_ansible_version, ">=")
+          - ansible_version.string is version(maximal_ansible_version, "<")
       tags:
         - check


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
We have multiple breakage report with Ansible 2.10+ in #6762

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
We could also put the minimum to 2.9.16 (see #7128), but it causes less breakage.
One of my teammate used 2.10+ and Ansible ended up installing docker instead of containerd, needing some manual cleanup

**Does this PR introduce a user-facing change?**:
```release-note
Require 2.9.0 <= Ansible version < 2.10.0
```
