### PR TITLE
change nodeSelector label from deprecated beta.kubernetes.io

### DIFF
--- a/roles/kubernetes-apps/metallb/templates/metallb.yml.j2
+++ b/roles/kubernetes-apps/metallb/templates/metallb.yml.j2
@@ -339,7 +339,7 @@ spec:
           readOnlyRootFilesystem: true
       hostNetwork: true
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        {{ 'beta.' if kube_version is version('v1.18.0', '<') }}kubernetes.io/os: linux
       serviceAccountName: speaker
       terminationGracePeriodSeconds: 2
       tolerations:
@@ -390,7 +390,7 @@ spec:
             - all
           readOnlyRootFilesystem: true
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        {{ 'beta.' if kube_version is version('v1.18.0', '<') }}kubernetes.io/os: linux
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/roles/network_plugin/ovn4nfv/templates/ovn-daemonset.yml.j2
+++ b/roles/network_plugin/ovn4nfv/templates/ovn-daemonset.yml.j2
@@ -118,7 +118,7 @@ spec:
             periodSeconds: 7
             failureThreshold: 5
       nodeSelector:
-        beta.kubernetes.io/os: "linux"
+        {{ 'beta.' if kube_version is version('v1.18.0', '<') }}kubernetes.io/os: "linux"
         ovn4nfv-k8s-plugin: ovn-control-plane
       volumes:
         - name: host-run-ovs
@@ -214,7 +214,7 @@ spec:
               cpu: {{ ovn_controller_cpu_limit }}
               memory: {{ ovn_controller_memory_limit }}
       nodeSelector:
-        beta.kubernetes.io/os: "linux"
+        {{ 'beta.' if kube_version is version('v1.18.0', '<') }}kubernetes.io/os: "linux"
       volumes:
         - name: host-modules
           hostPath:

--- a/roles/network_plugin/ovn4nfv/templates/ovn4nfv-k8s-plugin.yml.j2
+++ b/roles/network_plugin/ovn4nfv/templates/ovn4nfv-k8s-plugin.yml.j2
@@ -482,7 +482,7 @@ spec:
     spec:
       hostNetwork: true
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
+        {{ 'beta.' if kube_version is version('v1.18.0', '<') }}kubernetes.io/arch: amd64
       tolerations:
       - operator: Exists
         effect: NoSchedule
@@ -556,7 +556,7 @@ spec:
       hostNetwork: true
       hostPID: true
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
+        {{ 'beta.' if kube_version is version('v1.18.0', '<') }}kubernetes.io/arch: amd64
       tolerations:
       - operator: Exists
         effect: NoSchedule


### PR DESCRIPTION
change nodeSelector label from deprecated beta.kubernetes.io/os and arch to kubernetes.io prefix

/kind feature
