### PR TITLE
Add reno as release notes management tool

### DIFF
--- a/releasenotes/notes/add-reno-tool-support-to-the-project-3cb1237d67dae237.yaml
+++ b/releasenotes/notes/add-reno-tool-support-to-the-project-3cb1237d67dae237.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Includes support to `reno <https://pypi.org/project/reno/>`__ which is a
+    release notes tool. This tool requires some level of community commitment
+    to enforce the addition of release notes in every patch submitted.


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
The process of writing release notes can be time consuming and sometimes overpass some features or bugs included in the release. Using release notes management tools like [reno](https://pypi.org/project/reno/) can facilitate this process.

**Which issue(s) this PR fixes**:
NA

**Special notes for your reviewer**:
The addition of this tool will require the enforcement of new set of practices for developers and maintainers of this project. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
