### PR TITLE
change nginx default HTTPS protocol from "SSLv2" to "TLSv1.2 TLSv1.3"

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s-cluster/addons.yml
@@ -99,7 +99,7 @@ ingress_publish_status_address: ""
 # ingress_nginx_secure_port: 443
 # ingress_nginx_configmap:
 #   map-hash-bucket-size: "128"
-#   ssl-protocols: "SSLv2"
+#   ssl-protocols: "TLSv1.2 TLSv1.3"
 # ingress_nginx_configmap_tcp_services:
 #   9000: "default/example-go:8080"
 # ingress_nginx_configmap_udp_services:


### PR DESCRIPTION
Cherry-pick of #6912

**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
> In the sample inventory, the addons.yaml (l. 102) installs ingress-nginx with SSLv2 protocol by default. CHanged this to "TLSv1.2 TLSv1.3".

**Which issue(s) this PR fixes**:
Fixes #6904

**Special notes for your reviewer**:
n/a

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
