### PR TITLE
Remove unnecessary condition check when updating server field in kube-proxy kubeconfig

### DIFF
--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -120,7 +120,6 @@
   delegate_to: "{{ groups['kube-master']|first }}"
   delegate_facts: false
   when:
-    - inventory_hostname in groups['kube-master']
     - kubeadm_config_api_fqdn is not defined
     - kubeadm_discovery_address != kube_apiserver_endpoint | replace("https://", "")
     - kube_proxy_deployed
@@ -141,7 +140,6 @@
   delegate_to: "{{ groups['kube-master']|first }}"
   delegate_facts: false
   when:
-    - inventory_hostname in groups['kube-master']
     - kubeadm_config_api_fqdn is not defined
     - kubeadm_discovery_address != kube_apiserver_endpoint | replace("https://", "")
     - kube_proxy_deployed


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When updating cluster, these tasks are skipped since `kubernetes/kubeadm` is only executed for non-master nodes, and the server field in kube-proxy cm is not correctly changed.

Also these tasks are delegated to the first master and run only once, I think there's no need to add this check.

**Which issue(s) this PR fixes**:

Fixes #6731


**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
