### PR TITLE
Add ssh_public_keys variable

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -8,6 +8,12 @@
     - { role: kubespray-defaults }
     - { role: bastion-ssh-config, tags: ["localhost", "bastion"] }
 
+- hosts: all
+  gather_facts: False
+  roles:
+    - role: ssh_public_keys
+      when: ssh_public_keys is defined
+
 - hosts: k8s-cluster:etcd
   strategy: linear
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"

--- a/inventory/sample/group_vars/all/all.yml
+++ b/inventory/sample/group_vars/all/all.yml
@@ -112,3 +112,12 @@ no_proxy_exclude_workers: false
 
 ## Check if access_ip responds to ping. Set false if your firewall blocks ICMP.
 # ping_access_ip: true
+
+## Manage SSH authorized_keys. If unset (default) does not change authorized_keys.
+## Make sure you have a strategy to avoid locking yourself out. For example:
+## - Leave an SSH connection open.
+## - Ensure you can change SSH authorized_keys via your cloud provider.
+# ssh_public_keys:
+#  - ssh-rsa AAAA admin1@example.com
+#  - ssh-rsa BBBB admin2@example.com
+#  - ssh-rsa CCCC admin3@example.com

--- a/roles/ssh_public_keys/tasks/main.yml
+++ b/roles/ssh_public_keys/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Ensure SSH config folder exists
+  file:
+    path: ~/.ssh
+    state: directory
+    recurse: true
+    mode: 0700
+  become: no
+  tags:
+    - ssh_public_keys
+
+- name: Configure SSH authorized_keys
+  template:
+    src: 'authorized_keys.j2'
+    dest: '~/.ssh/authorized_keys'
+  become: no
+  when: ssh_public_keys is defined
+  tags:
+    - ssh_public_keys

--- a/roles/ssh_public_keys/templates/authorized_keys.j2
+++ b/roles/ssh_public_keys/templates/authorized_keys.j2
@@ -1,0 +1,4 @@
+{{ ansible_managed | comment }}
+{% for ssh_public_key in ssh_public_keys %}
+{{ ssh_public_key }}
+{% endfor %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
As kubespray is becoming the go-to tool for administrators to set up and
manage Kubernetes clusters, it is desirable to have a uniform way for managing
SSH access. Some contributed infrastructure provisioners, e.g.,
`contrib/azurerm`, allow this via variables such as `ssh_public_keys`,
however, this is not consistent throughout all provisioners.

This patch introduces the `ssh_public_keys` variable. If defined, it
will the `authorized_keys` file of all nodes accordingly. It will ensure
that this happens for the right user, e.g., `become: no`. This provides
an infrastructure-agnostic way to manage SSH access.

If unset (default), the previous behaviour is preserved, i.e., SSH
access is not managed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add `ssh_public_keys` as a uniform way to manage SSH access to the bastion host and Kubernetes nodes. If unset, kubespray will not touch SSH access.
```
