### PR TITLE
Add kube_add_control_plane_label

### DIFF
--- a/inventory/sample/group_vars/all/all.yml
+++ b/inventory/sample/group_vars/all/all.yml
@@ -113,7 +113,7 @@ no_proxy_exclude_workers: false
 ## Check if access_ip responds to ping. Set false if your firewall blocks ICMP.
 # ping_access_ip: true
 
-## Webhooks operating in the kube-system namespace are a receipt for disaster:
+## Webhooks operating in the kube-system namespace are a recipe for disaster:
 ## https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#avoiding-operating-on-the-kube-system-namespace
 ## A common way to address this is to add the `control-plane: true` label on
 ## the `kube-system` namespace.

--- a/inventory/sample/group_vars/all/all.yml
+++ b/inventory/sample/group_vars/all/all.yml
@@ -112,3 +112,9 @@ no_proxy_exclude_workers: false
 
 ## Check if access_ip responds to ping. Set false if your firewall blocks ICMP.
 # ping_access_ip: true
+
+## Webhooks operating in the kube-system namespace are a receipt for disaster:
+## https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#avoiding-operating-on-the-kube-system-namespace
+## A common way to address this is to add the `control-plane: true` label on
+## the `kube-system` namespace.
+# kube_add_control_plane_label: false

--- a/roles/kubernetes/master/defaults/main/main.yml
+++ b/roles/kubernetes/master/defaults/main/main.yml
@@ -197,7 +197,7 @@ event_ttl_duration: "1h0m0s"
 ##  Force regeneration of kubernetes control plane certificates without the need of bumping the cluster version
 force_certificate_regeneration: false
 
-## Webhooks operating in the kube-system namespace are a receipt for disaster:
+## Webhooks operating in the kube-system namespace are a recipe for disaster:
 ## https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#avoiding-operating-on-the-kube-system-namespace
 ## A common way to address this is to add the `control-plane: true` label on
 ## the `kube-system` namespace.

--- a/roles/kubernetes/master/defaults/main/main.yml
+++ b/roles/kubernetes/master/defaults/main/main.yml
@@ -196,3 +196,9 @@ secrets_encryption_query: "resources[*].providers[0].{{kube_encryption_algorithm
 event_ttl_duration: "1h0m0s"
 ##  Force regeneration of kubernetes control plane certificates without the need of bumping the cluster version
 force_certificate_regeneration: false
+
+## Webhooks operating in the kube-system namespace are a receipt for disaster:
+## https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#avoiding-operating-on-the-kube-system-namespace
+## A common way to address this is to add the `control-plane: true` label on
+## the `kube-system` namespace.
+kube_add_control_plane_label: false

--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -230,3 +230,11 @@
   delegate_to: "{{ groups['kube-master'] | first }}"
   when: inventory_hostname in groups['kube-node']
   failed_when: false
+
+# https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#avoiding-operating-on-the-kube-system-namespace
+- name: kubeadm | Add control-plane label to kube-system namespace
+  command: "{{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf label namespace kube-system control-plane=true --overwrite=true"
+  delegate_to: "{{ groups['kube-master'] | first }}"
+  register: result
+  changed_when: "'not labeled' not in result.stdout"
+  when: kube_add_control_plane_label


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

Webhooks operating in the kube-system namespace are a receipt for disaster:

https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#avoiding-operating-on-the-kube-system-namespace

A common way to address this is to add the `control-plane: true` label on the `kube-system` namespace.

This patch adds an option to add such a label. By default, it is false
to preserve the old (no labeling) behavior.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

I tested this patch as follows:
1. Kubespray-ed a fresh VM with default settings. As expected, the label was not applied.
2. I changed the option to true and re-kubespray-ed the VM. As expected, the task was changed and the label was applied.
3. I re-kubespray-ed the VM. As expected, the task was unchanged and the label stayed the same.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add kube_add_control_plane_label to label `kube-system` with `control-plane: true`, to avoid most webhooks from causing harm.
```
