### PR TITLE
Use Kubespray v2.15.0 as base image for CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ stages:
   - deploy-special
 
 variables:
-  KUBESPRAY_VERSION: v2.14.1
+  KUBESPRAY_VERSION: v2.15.0
   FAILFASTCI_NAMESPACE: 'kargo-ci'
   GITLAB_REPOSITORY: 'kargo-ci/kubernetes-sigs-kubespray'
   ANSIBLE_FORCE_COLOR: "true"


### PR DESCRIPTION
Now that v2.15 is released, we should update .gitlab-ci.yml as per RELEASE.md