### PR TITLE
Adding other masters sequentially, not in parallel

### DIFF
--- a/roles/kubernetes/master/tasks/kubeadm-secondary.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-secondary.yml
@@ -59,6 +59,7 @@
     --ignore-preflight-errors=all
   register: kubeadm_join_control_plane
   retries: 3
+  throttle: 1
   until: kubeadm_join_control_plane is succeeded
   when:
     - inventory_hostname != groups['kube-master']|first


### PR DESCRIPTION
/kind bug
/kind feature

**What this PR does / why we need it**:

Sometimes, when installing 3 masters, kubeadm crashed with an error, because the second and third masters were added at the same time.

Ansible 2.9 has a wonderful instruction that allows you to execute a specific task sequentially on all hosts
