### PR TITLE
Add prompt to upgrade node or delay before upgrade

### DIFF
--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -56,6 +56,11 @@ Client Version: version.Info{Major:"1", Minor:"6", GitVersion:"v1.6.0", GitCommi
 Server Version: version.Info{Major:"1", Minor:"6", GitVersion:"v1.6.0+coreos.0", GitCommit:"8031716957d697332f9234ddf85febb07ac6c3e3", GitTreeState:"clean", BuildDate:"2017-03-29T04:33:09Z", GoVersion:"go1.7.5", Compiler:"gc", Platform:"linux/amd64"}
 ```
 
+If you want to manually control the upgrade procedure, you can use the variables `upgrade_node_confirm` or `upgrade_node_pause_seconds`:
+
+`upgrade_node_confirm: true` - waiting to confirmation to upgrade next node
+`upgrade_node_pause_seconds: 60` - pause 60 seconds before upgrade next node
+
 ## Multiple upgrades
 
 :warning: [Do not skip releases when upgrading--upgrade by one tag at a time.](https://github.com/kubernetes-sigs/kubespray/issues/3849#issuecomment-451386515) :warning:

--- a/roles/upgrade/pre-upgrade/defaults/main.yml
+++ b/roles/upgrade/pre-upgrade/defaults/main.yml
@@ -3,3 +3,6 @@ drain_grace_period: 300
 drain_timeout: 360s
 drain_pod_selector: ""
 drain_nodes: true
+
+upgrade_node_confirm: false
+upgrade_node_pause_seconds: 0

--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -1,4 +1,19 @@
 ---
+# Wait for upgrade
+- name: Confirm node upgrade
+  pause:
+    echo: yes
+    prompt: "Ready to upgrade node ?"
+  when:
+    - upgrade_node_confirm
+
+- name: Wait before upgrade node
+  pause:
+    seconds: "{{ upgrade_node_pause_seconds }}"
+  when:
+    - not upgrade_node_confirm
+    - upgrade_node_pause_seconds != 0
+
 # Node Ready: type = ready, status = True
 # Node NotReady: type = ready, status = Unknown
 - name: See if node is in ready state


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

I want control process of upgrade cluster,  and I want to be able to check the work of the updated node, before starting the next update.

Also, sometimes you need to wait a little for all the pods to running, before starting the drain of the next node
