### PR TITLE
calico: fix NetworkManager check

### DIFF
--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -8,7 +8,7 @@
 
 - name: Calico | Check if host has NetworkManager
   # noqa 303 Should we use service_facts for this?
-  command: systemctl show NetworkManager
+  command: systemctl is-active --quiet NetworkManager.service
   register: nm_check
   failed_when: false
   changed_when: false


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind bug

**What this PR does / why we need it**:
Previous check for presence of NM assumed `systemctl show NetworkManager` would exit with a nonzero status code, which seems not the case anymore with recent Flatcar Container Linux. It outputs skeleton unit config instead, and exits with zero. This causes kubespray to think that NM is present, which is not the case.

This bug prevents 2.15.0 from upgrading (and probably rolling out) on calico+flatcar.

**Which issue(s) this PR fixes**:
Fixes #7076

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
