### PR TITLE
Promote node.k8s.io API groups from v1beta1 to v1

### DIFF
--- a/roles/kubernetes-apps/container_runtimes/crun/files/runtimeclass-crun.yml
+++ b/roles/kubernetes-apps/container_runtimes/crun/files/runtimeclass-crun.yml
@@ -1,6 +1,6 @@
 ---
 kind: RuntimeClass
-apiVersion: node.k8s.io/v1beta1
+apiVersion: node.k8s.io/v1{{ 'beta1' if kube_version is version('v1.20.0', '<') }}
 metadata:
   name: crun
 handler: crun

--- a/roles/kubernetes-apps/container_runtimes/kata_containers/templates/runtimeclass-kata-qemu.yml.j2
+++ b/roles/kubernetes-apps/container_runtimes/kata_containers/templates/runtimeclass-kata-qemu.yml.j2
@@ -1,6 +1,6 @@
 ---
 kind: RuntimeClass
-apiVersion: node.k8s.io/v1beta1
+apiVersion: node.k8s.io/v1{{ 'beta1' if kube_version is version('v1.20.0', '<') }}
 metadata:
   name: kata-qemu
 handler: kata-qemu


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Remove bunch of deprecated API:
- RuntimeClass feature graduates to General Availability. Promote node.k8s.io API groups from v1beta1 to v1. v1beta1 is now deprecated and will be removed in a future release, please start using v1. (https://github.com/kubernetes/kubernetes/pull/95718, @SergeyKanzhelev)
- The kube-apiserver ability to serve on an insecure port, deprecated since v1.10, has been removed. The insecure address flags `--address` and `--insecure-bind-address` have no effect in kube-apiserver and will be removed in v1.24. The insecure port flags `--port` and `--insecure-port` may only be set to 0 and will be removed in v1.24. (https://github.com/kubernetes/kubernetes/pull/95856, @knight42)
~- Kubectl: deprecate --delete-local-data (https://github.com/kubernetes/kubernetes/pull/95076, @dougsland)~ (will be done in a laster release, otherwise upgrade is a mess to handle)

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:
3 commits for all 3 changes

**Does this PR introduce a user-facing change?**:
```release-note
`kube_apiserver_insecure_port` and `kube_apiserver_insecure_bind_address` have been removed as those parameters are no longer supported by Kubernetes
```
