### PR TITLE
Update bunch of dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [cri-o](http://cri-o.io/) v1.19 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)
 - Network Plugin
   - [cni-plugins](https://github.com/containernetworking/plugins) v0.9.0
-  - [calico](https://github.com/projectcalico/calico) v3.16.5
+  - [calico](https://github.com/projectcalico/calico) v3.16.6
   - [canal](https://github.com/projectcalico/canal) (given calico/flannel versions)
   - [cilium](https://github.com/cilium/cilium) v1.8.6
   - [flanneld](https://github.com/coreos/flannel) v0.13.0

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -64,7 +64,7 @@ quay_image_repo: "quay.io"
 
 # TODO(mattymo): Move calico versions to roles/network_plugins/calico/defaults
 # after migration to container download
-calico_version: "v3.16.5"
+calico_version: "v3.16.6"
 calico_ctl_version: "{{ calico_version }}"
 calico_cni_version: "{{ calico_version }}"
 calico_policy_version: "{{ calico_version }}"
@@ -81,7 +81,7 @@ kube_router_version: "v1.1.1"
 multus_version: "v3.6"
 ovn4nfv_ovn_image_version: "v1.0.0"
 ovn4nfv_k8s_plugin_image_version: "v1.1.0"
-helm_version: "v3.3.4"
+helm_version: "v3.5.0"
 
 # Get kubernetes major version (i.e. 1.17.4 => 1.17)
 kube_major_version: "{{ kube_version | regex_replace('^v([0-9])+\\.([0-9]+)\\.[0-9]+', 'v\\1.\\2') }}"
@@ -376,25 +376,19 @@ cni_binary_checksums:
   amd64: 58a58d389895ba9f9bbd3ef330f186c0bb7484136d0bfb9b50152eed55d9ec24
 calicoctl_binary_checksums:
   arm:
-    v3.16.5: 0
-    v3.16.4: 0
-    v3.16.2: 0
+    v3.16.6: 0
     v3.15.2: 0
   amd64:
-    v3.16.5: d4175559ad0cf69a1352be3d824ae0a794305d6cd5b17ea0ffc6a153b21d2ae7
-    v3.16.4: a502749420e7424090a73644a8bdc1270c6ef679f8f1d33f753d48d60c930377
-    v3.16.2: 801b059a4fd0dac8795693026c69a79a00dd2353eff597cc36b79fcb6ec53a0a
+    v3.16.6: 9b82230446d4749a1043dddd8d466d275a460e570a412e6ced003368ab9c72d8
     v3.15.2: 219ae954501cbe15daeda0ad52e13ec65f99c77548c7d3cbfc4ced5c7149fdf1
   arm64:
-    v3.16.5: 230579d8761e1cee5ffd447af5a1b92af76ed89f6b7e51771d590017aca5cbb9
-    v3.16.4: 003f16a501e876af0da67324b7fed6ca72f5547c15bbe3b798a8eeb707056d43
-    v3.16.2: aa5695940ec8a36393725a5ce7b156f776fed8da38b994c0828d7f3a60e59bc6
+    v3.16.6: 4dd0548390a4ff7c6264c967da80498d10612dbd86f6d1ed4e5503352cdf947b
     v3.15.2: 49165f9e4ad55402248b578310fcf68a57363f54e66be04ac24be9714899b4d5
 
 helm_archive_checksums:
-  arm: 9da6cc39a796f85b6c4e6d48fd8e4888f1003bfb7a193bb6c427cdd752ad40bb
-  amd64: b664632683c36446deeb85c406871590d879491e3de18978b426769e43a1e82c
-  arm64: bdd00b8ff422171b4be5b649a42e5261394a89d7ea57944005fc34d34d1f8160
+  arm: ca8792da269b72235987ea7245d1450a859b2c0658f591737d74b6c56cd9b1fa
+  amd64: 3fff0354d5fba4c73ebd5db59a59db72f8a5bbe1117a0b355b0c2983e98db95b
+  arm64: 87811b648ed9f4c84d3cb67bbea9b666bb7f6dd0ff6aca148b65f91058f73953
 
 etcd_binary_checksum: "{{ etcd_binary_checksums[image_arch] }}"
 cni_binary_checksum: "{{ cni_binary_checksums[image_arch] }}"
@@ -459,7 +453,7 @@ ovn4nfv_k8s_plugin_image_tag: "{{ ovn4nfv_k8s_plugin_image_version }}"
 nginx_image_repo: "{{ docker_image_repo }}/library/nginx"
 nginx_image_tag: 1.19
 haproxy_image_repo: "{{ docker_image_repo }}/library/haproxy"
-haproxy_image_tag: 2.2
+haproxy_image_tag: 2.3
 
 # Coredns version should be supported by corefile-migration (or at least work with)
 # bundle with kubeadm; if not 'basic' upgrade can sometimes fail
@@ -491,7 +485,7 @@ cephfs_provisioner_image_tag: "v2.1.0-k8s1.11"
 rbd_provisioner_image_repo: "{{ quay_image_repo }}/external_storage/rbd-provisioner"
 rbd_provisioner_image_tag: "v2.1.1-k8s1.11"
 local_path_provisioner_image_repo: "{{ docker_image_repo }}/rancher/local-path-provisioner"
-local_path_provisioner_image_tag: "v0.0.17"
+local_path_provisioner_image_tag: "v0.0.19"
 ingress_nginx_controller_image_repo: "{{ kube_image_repo }}/ingress-nginx/controller"
 ingress_nginx_controller_image_tag: "v0.41.2"
 ingress_ambassador_image_repo: "{{ quay_image_repo }}/datawire/ambassador-operator"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Update bunch of dependencies, major will be done in separate PR
- Calico from 3.16.5 to 3.16.6 (3.17.x in a future PR)
- helm from 3.3.4 to 3.5.0
- haproxy from 2.2 to 2.3
- local-path-provisioner from 0.0.17 to 0.0.19

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
