### PR TITLE
Calico: fixup check when ipipMode / vxlanMode is not present

### DIFF
--- a/roles/network_plugin/calico/tasks/check.yml
+++ b/roles/network_plugin/calico/tasks/check.yml
@@ -55,8 +55,8 @@
     that:
       - calico_pool_conf.spec.blockSize == (calico_pool_blocksize | default(kube_network_node_prefix))
       - calico_pool_conf.spec.cidr == (calico_pool_cidr | default(kube_pods_subnet))
-      - calico_pool_conf.spec.ipipMode == calico_ipip_mode
-      - calico_pool_conf.spec.vxlanMode == calico_vxlan_mode
+      - not calico_pool_conf.spec.ipipMode is defined or calico_pool_conf.spec.ipipMode == calico_ipip_mode
+      - not calico_pool_conf.spec.vxlanMode is defined or calico_pool_conf.spec.vxlanMode == calico_vxlan_mode
     msg: "Your inventory doesn't match the current cluster configuration"
   when:
     - calico_pool_conf is defined


### PR DESCRIPTION
calicoctl.sh get ipPool default-pool -o json
{
  "kind": "IPPool",
  "apiVersion": "projectcalico.org/v3",
  "metadata": {
    "name": "default-pool",
...
  },
  "spec": {
    "cidr": "10.233.64.0/18",
    "ipipMode": "Always",
    "natOutgoing": true,
    "blockSize": 24,
    "nodeSelector": "all()"
  }
}

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #7185

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Calico: fixup check when ipipMode / vxlanMode is not present
```
