### PR TITLE
Add cleanup of openstack network ports in CI

### DIFF
--- a/scripts/openstack-cleanup/main.py
+++ b/scripts/openstack-cleanup/main.py
@@ -42,6 +42,10 @@ def main():
     map_if_old(conn.network.delete_security_group,
                conn.network.security_groups())
 
+    print('Ports...')
+    map_if_old(conn.network.delete_port,
+               conn.network.ports())
+
     print('Subnets...')
     map_if_old(conn.network.delete_subnet,
                conn.network.subnets())


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test
/kind flake

**What this PR does / why we need it**:
Sometimes OpenStack ports are left orphaned (failed terraform destroy, cancelled job, whatever). Which then blocks the deletion of the subnet containing the port, and requires manual cleanup.


**Special notes for your reviewer**:

The [docs](https://docs.openstack.org/openstacksdk/latest/user/proxies/network.html#port-operations) says that there is a call to list and delete ports, so let's use that to clean things up. Here is a run with a test network, subnet and port:

```
This will delete resources... (ctrl+c to cancel)
Servers...
Security groups...
Ports...
Will delete test-maxime2 (f5f7447a-3ee4-40d4-b7c1-12b8399e9813)
Subnets...
Will delete test-maxime (36b36b37-9af5-4e70-bb92-ae9be616dfd1)
Networks...
Will delete test-maxime (a5b7ff3a-c605-44fc-b899-81afa81f1f54)
```