### PR TITLE
containerd,docker: stop installing extras repo on CentOS/RHEL

### DIFF
--- a/docs/offline-environment.md
+++ b/docs/offline-environment.md
@@ -30,12 +30,9 @@ crictl_download_url: "{{ files_repo }}/kubernetes/cri-tools/crictl-{{ crictl_ver
 calicoctl_download_url: "{{ files_repo }}/kubernetes/calico/{{ calico_ctl_version }}/calicoctl-linux-{{ image_arch }}"
 
 # CentOS/Redhat
-## Docker
+## Docker / Containerd
 docker_rh_repo_base_url: "{{ yum_repo }}/docker-ce/$releasever/$basearch"
 docker_rh_repo_gpgkey: "{{ yum_repo }}/docker-ce/gpg"
-## Containerd
-extras_rh_repo_base_url: "{{ yum_repo }}/centos/{{ ansible_distribution_major_version }}/extras/$basearch"
-extras_rh_repo_gpgkey: "{{ yum_repo }}/containerd/gpg"
 
 # Fedora
 ## Docker

--- a/inventory/sample/group_vars/k8s-cluster/offline.yml
+++ b/inventory/sample/group_vars/k8s-cluster/offline.yml
@@ -34,12 +34,12 @@
 # calicoctl_download_url: "{{ files_repo }}/kubernetes/calico/{{ calico_ctl_version }}/calicoctl-linux-{{ image_arch }}"
 
 ## CentOS/Redhat
-### Docker
+### For EL7, base and extras repo must be available, for EL8, baseos and appstream
+### By default we enable those repo automatically
+# rhel_enable_repos: false
+### Docker / Containerd
 # docker_rh_repo_base_url: "{{ yum_repo }}/docker-ce/$releasever/$basearch"
 # docker_rh_repo_gpgkey: "{{ yum_repo }}/docker-ce/gpg"
-### Containerd
-# extras_rh_repo_base_url: "{{ yum_repo }}/centos/$releasever/extras/$basearch"
-# extras_rh_repo_gpgkey: "{{ yum_repo }}/containerd/gpg"
 
 ## Fedora
 ### Docker

--- a/roles/bootstrap-os/tasks/bootstrap-redhat.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-redhat.yml
@@ -60,6 +60,28 @@
     - rh_subscription_username is defined
     - rh_subscription_status.changed
 
+# container-selinux is in extras repo
+- name: Enable RHEL 7 repos
+  rhsm_repository:
+    name:
+      - "rhel-7-server-rpms"
+      - "rhel-7-server-extras-rpms"
+    state: enabled
+  when:
+    - rhel_enable_repos | default(True)
+    - ansible_distribution_major_version == "7"
+
+# container-selinux is in appstream repo
+- name: Enable RHEL 8 repos
+  rhsm_repository:
+    name:
+      - "rhel-8-for-*-baseos-rpms"
+      - "rhel-8-for-*-appstream-rpms"
+    state: enabled
+  when:
+    - rhel_enable_repos | default(True)
+    - ansible_distribution_major_version == "8"
+
 - name: Check presence of fastestmirror.conf
   stat:
     path: /etc/yum/pluginconf.d/fastestmirror.conf

--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -34,9 +34,6 @@ containerd_repo_key_info:
 containerd_repo_info:
   repos:
 
-extras_rh_repo_base_url: "http://mirror.centos.org/centos/{{ ansible_distribution_major_version }}/extras/$basearch/"
-extras_rh_repo_gpgkey: "http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-7"
-
 # Ubuntu docker-ce repo
 containerd_ubuntu_repo_base_url: "https://download.docker.com/linux/ubuntu"
 containerd_ubuntu_repo_gpgkey: 'https://download.docker.com/linux/ubuntu/gpg'

--- a/roles/container-engine/containerd/tasks/containerd_repo.yml
+++ b/roles/container-engine/containerd/tasks/containerd_repo.yml
@@ -30,24 +30,3 @@
     src: "rh_containerd.repo.j2"
     dest: "{{ yum_repo_dir }}/containerd.repo"
   when: ansible_distribution in ["CentOS","RedHat"]
-
-- name: check if container-selinux is available
-  yum:
-    list: "container-selinux"
-  register: yum_result
-  when: ansible_distribution in ["CentOS","RedHat"]
-
-- name: Configure extras repository on RedHat/CentOS if container-selinux is not available in current repos
-  yum_repository:
-    name: extras
-    description: "CentOS-{{ ansible_distribution_major_version }} - Extras"
-    state: present
-    baseurl: "{{ extras_rh_repo_base_url }}"
-    file: "extras"
-    gpgcheck: "{{ 'yes' if extras_rh_repo_gpgkey else 'no' }}"
-    gpgkey: "{{ extras_rh_repo_gpgkey }}"
-    keepcache: "{{ containerd_rpm_keepcache | default('1') }}"
-    proxy: " {{ http_proxy | default('_none_') }}"
-  when:
-    - ansible_distribution in ["CentOS","RedHat"]
-    - yum_result.results | length == 0

--- a/roles/container-engine/docker/defaults/main.yml
+++ b/roles/container-engine/docker/defaults/main.yml
@@ -32,9 +32,6 @@ docker_ubuntu_repo_gpgkey: 'https://download.docker.com/linux/ubuntu/gpg'
 docker_debian_repo_base_url: "https://download.docker.com/linux/debian"
 docker_debian_repo_gpgkey: 'https://download.docker.com/linux/debian/gpg'
 docker_bin_dir: "/usr/bin"
-# CentOS/RedHat Extras repo
-extras_rh_repo_base_url: "http://mirror.centos.org/centos/{{ ansible_distribution_major_version }}/extras/$basearch/"
-extras_rh_repo_gpgkey: "http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-7"
 
 # flag to enable/disable docker cleanup
 docker_orphan_clean_up: false

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -85,27 +85,6 @@
     dest: "{{ yum_repo_dir }}/docker-ce.repo"
   when: ansible_distribution in ["CentOS","RedHat","OracleLinux"] and not is_ostree
 
-- name: check if container-selinux is available
-  yum:
-    list: "container-selinux"
-  register: yum_result
-  when: ansible_distribution in ["CentOS","RedHat"] and not is_ostree
-
-- name: Configure extras repository on RedHat/CentOS if container-selinux is not available in current repos
-  yum_repository:
-    name: extras
-    description: "CentOS-{{ ansible_distribution_major_version }} - Extras"
-    state: present
-    baseurl: "{{ extras_rh_repo_base_url }}"
-    file: "extras"
-    gpgcheck: "{{ 'yes' if extras_rh_repo_gpgkey else 'no' }}"
-    gpgkey: "{{ extras_rh_repo_gpgkey }}"
-    keepcache: "{{ docker_rpm_keepcache | default('1') }}"
-    proxy: " {{ http_proxy | default('_none_') }}"
-  when:
-    - ansible_distribution in ["CentOS","RedHat"] and not is_ostree
-    - yum_result.results | length == 0
-
 - name: Remove dpkg hold
   dpkg_selections:
     name: "{{ item }}"


### PR DESCRIPTION
This was introduced in 143e2272ff9d85ba81bfa8c4a67f29994d898d79
Extra repo is enabled by default in CentOS, and is not the right repo for EL8
Instead of adding a CentOS repo to RHEL, enable the needed RHEL repos with rhsm_repository

For RHEL 7, we need the "extras" repo for container-selinux
For RHEL 8, we need the "appstream" repo for container-selinux, ipvsadm and socat

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Enable needed repo on RHEL. To skip (offline install), use `rhel_enable_repos: False`
```
