### PR TITLE
Add missing 'ingress-controller' tag to alb

### DIFF
--- a/roles/kubernetes-apps/ingress_controller/meta/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/meta/main.yml
@@ -4,25 +4,26 @@ dependencies:
     when: ingress_nginx_enabled
     tags:
       - apps
-      - ingress-nginx
       - ingress-controller
+      - ingress-nginx
 
   - role: kubernetes-apps/ingress_controller/ambassador
     when: ingress_ambassador_enabled
     tags:
       - apps
-      - ambassador
       - ingress-controller
+      - ambassador
 
   - role: kubernetes-apps/ingress_controller/cert_manager
     when: cert_manager_enabled
     tags:
       - apps
-      - cert-manager
       - ingress-controller
+      - cert-manager
 
   - role: kubernetes-apps/ingress_controller/alb_ingress_controller
     when: ingress_alb_enabled
     tags:
       - apps
+      - ingress-controller
       - ingress_alb


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Seems like ingress_alb (aws) is missing the `ingress-controller` tag

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
