### PR TITLE
[2.14] Backport: 6758, 6853 and 7003 to fix CRI-O pkg

### DIFF
--- a/docs/cri-o.md
+++ b/docs/cri-o.md
@@ -4,10 +4,9 @@
 Kubespray supports basic functionality for using CRI-O as the default container runtime in a cluster.
 
 * Kubernetes supports CRI-O on v1.11.1 or later.
-* Helm and other tools may not function as normal due to dependency on Docker.
 * `scale.yml` and `upgrade-cluster.yml` are not supported on clusters using CRI-O.
 
-_To use CRI-O instead of Docker, set the following variables:_
+_To use the CRI-O container runtime set the following variables:_
 
 ## all.yml
 

--- a/roles/container-engine/cri-o/defaults/main.yml
+++ b/roles/container-engine/cri-o/defaults/main.yml
@@ -21,6 +21,7 @@ crio_stream_port: "10010"
 crio_required_version: "{{ kube_version | regex_replace('^v(?P<major>\\d+).(?P<minor>\\d+).(?P<patch>\\d+)$', '\\g<major>.\\g<minor>') }}"
 
 crio_kubernetes_version_matrix:
+  "1.19": "1.19"
   "1.18": "1.18"
   "1.17": "1.17"
   "1.16": "1.16"

--- a/roles/container-engine/cri-o/tasks/crio_repo.yml
+++ b/roles/container-engine/cri-o/tasks/crio_repo.yml
@@ -5,7 +5,7 @@
     crio_kubic_debian_repo_name: "{{ ((ansible_distribution == 'Ubuntu') | ternary('x','')) ~ ansible_distribution ~ '_' ~ ansible_distribution_version }}"
   when: ansible_os_family == "Debian"
 
-- name: Add CRI-O kubic repo key
+- name: Add CRI-O kubic apt repo key
   apt_key:
     url: "https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/{{ crio_kubic_debian_repo_name }}/Release.key"
     state: present
@@ -15,14 +15,21 @@
   retries: 4
   delay: "{{ retry_stagger | d(3) }}"
 
-- name: Add CRI-O kubic repo
+- name: Add CRI-O kubic apt repo
   apt_repository:
     repo: "deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/{{ crio_kubic_debian_repo_name }}/ /"
     state: present
-    filename: devel:kubic:libcontainers:stable
+    filename: devel-kubic-libcontainers-stable
   when: crio_kubic_debian_repo_name is defined
 
-- name: Add CRI-O kubic repo
+- name: Add CRI-O kubic cri-o apt repo
+  apt_repository:
+    repo: "deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/{{ crio_version }}/{{ crio_kubic_debian_repo_name }}/ /"
+    state: present
+    filename: devel-kubic-libcontainers-stable-cri-o
+  when: crio_kubic_debian_repo_name is defined
+
+- name: Add CRI-O kubic yum repo
   yum_repository:
     name: devel_kubic_libcontainers_stable
     description: Stable Releases of Upstream github.com/containers packages (CentOS_$releasever)
@@ -32,7 +39,7 @@
     keepcache: false
   when: ansible_distribution in ["CentOS"]
 
-- name: Add CRI-O kubic repo
+- name: Add CRI-O kubic yum repo
   yum_repository:
     name: "devel_kubic_libcontainers_stable_cri-o_{{ crio_version }}"
     description: "CRI-O {{ crio_version }} (CentOS_$releasever)"

--- a/roles/container-engine/cri-o/vars/centos-7.yml
+++ b/roles/container-engine/cri-o/vars/centos-7.yml
@@ -1,5 +1,5 @@
 ---
+default_crio_packages:
+  - cri-o-1.19.0
 
-crio_packages:
-  - cri-o
-  - oci-systemd-hook
+crio_packages: "{{ centos_crio_packages | default(default_crio_packages) }}"

--- a/roles/container-engine/cri-o/vars/centos-7.yml
+++ b/roles/container-engine/cri-o/vars/centos-7.yml
@@ -1,5 +1,12 @@
 ---
-default_crio_packages:
-  - cri-o-1.19.0
+crio_versioned_pkg:
+  "1.19":
+    - "cri-o-1.19.*"
+  "1.18":
+    - "cri-o-1.18.*"
+  "1.17":
+    - "cri-o-1.17.*"
+
+default_crio_packages: "{{ crio_versioned_pkg[crio_version] }}"
 
 crio_packages: "{{ centos_crio_packages | default(default_crio_packages) }}"

--- a/roles/container-engine/cri-o/vars/centos-8.yml
+++ b/roles/container-engine/cri-o/vars/centos-8.yml
@@ -1,4 +1,5 @@
 ---
+default_crio_packages:
+  - cri-o-1.19.0
 
-crio_packages:
-  - cri-o
+crio_packages: "{{ centos_crio_packages | default(default_crio_packages) }}"

--- a/roles/container-engine/cri-o/vars/centos-8.yml
+++ b/roles/container-engine/cri-o/vars/centos-8.yml
@@ -1,5 +1,12 @@
 ---
-default_crio_packages:
-  - cri-o-1.19.0
+crio_versioned_pkg:
+  "1.19":
+    - "cri-o-1.19.*"
+  "1.18":
+    - "cri-o-1.18.*"
+  "1.17":
+    - "cri-o-1.17.*"
+
+default_crio_packages: "{{ crio_versioned_pkg[crio_version] }}"
 
 crio_packages: "{{ centos_crio_packages | default(default_crio_packages) }}"

--- a/roles/container-engine/cri-o/vars/debian.yml
+++ b/roles/container-engine/cri-o/vars/debian.yml
@@ -1,7 +1,7 @@
 ---
 
 crio_packages:
-  - "cri-o-{{ crio_version }}"
-  - runc
+  - "cri-o"
+  - "cri-o-runc"
 
 crio_runc_path: /usr/sbin/runc

--- a/roles/container-engine/cri-o/vars/debian.yml
+++ b/roles/container-engine/cri-o/vars/debian.yml
@@ -1,7 +1,17 @@
 ---
+# Debian-10 has pkg only for cri-o 1.19
+crio_kubernetes_version_matrix:
+  "1.19": "1.19"
+  "1.18": "1.19"
+  "1.17": "1.19"
 
-crio_packages:
-  - "cri-o"
-  - "cri-o-runc"
+crio_versioned_pkg:
+  "1.19":
+    - "cri-o=1.19*"
+    - cri-o-runc
+
+default_crio_packages: "{{ crio_versioned_pkg[crio_version] }}"
+
+crio_packages: "{{ debian_crio_packages | default(default_crio_packages) }}"
 
 crio_runc_path: /usr/sbin/runc

--- a/roles/container-engine/cri-o/vars/fedora.yml
+++ b/roles/container-engine/cri-o/vars/fedora.yml
@@ -4,3 +4,10 @@ crio_packages:
   - cri-tools
 
 crio_conmon: /usr/libexec/crio/conmon
+
+# TODO: remove crio_kubernetes_version_matrix and crio_version once Fedora supports 1.19
+crio_kubernetes_version_matrix:
+  "1.18": "1.18"
+  "1.17": "1.17"
+
+crio_version: "{{ crio_kubernetes_version_matrix[crio_required_version] | default('1.17') }}"

--- a/roles/container-engine/cri-o/vars/ubuntu.yml
+++ b/roles/container-engine/cri-o/vars/ubuntu.yml
@@ -1,7 +1,16 @@
 ---
-default_crio_packages:
-  - "cri-o=1.19.0~0"
-  - "cri-o-runc=1.0.0-6"
+crio_versioned_pkg:
+  "1.19":
+    - "cri-o=1.19*"
+    - cri-o-runc
+  "1.18":
+    - "cri-o=1.18*"
+    - cri-o-runc
+  "1.17":
+    - "cri-o=1.17*"
+    - cri-o-runc
+
+default_crio_packages: "{{ crio_versioned_pkg[crio_version] }}"
 
 crio_packages: "{{ ubuntu_crio_packages | default(default_crio_packages) }}"
 

--- a/roles/container-engine/cri-o/vars/ubuntu.yml
+++ b/roles/container-engine/cri-o/vars/ubuntu.yml
@@ -1,7 +1,9 @@
 ---
+default_crio_packages:
+  - "cri-o=1.19.0~0"
+  - "cri-o-runc=1.0.0-6"
 
-crio_packages:
-  - "cri-o-{{ crio_version }}"
+crio_packages: "{{ ubuntu_crio_packages | default(default_crio_packages) }}"
 
 crio_runc_path: /usr/sbin/runc
 


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

I am running into issues with the Kubespray CI with [PR-7197](https://github.com/kubernetes-sigs/kubespray/pull/7197).
I have created this PR to (cherry-pick) backport PR #6758, PR #6853 and PR #7003 into `release-2.14`

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```