### PR TITLE
[2.15] Backport: Check kube-apiserver up on all masters before upgrade

### DIFF
--- a/roles/kubernetes/master/tasks/kubeadm-upgrade.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-upgrade.yml
@@ -3,7 +3,7 @@
   uri:
     url: "https://{{ ip | default(fallback_ips[inventory_hostname]) }}:{{ kube_apiserver_port }}/healthz"
     validate_certs: false
-  when: inventory_hostname == groups['kube-master']|first
+  when: inventory_hostname == groups['kube-master']
   register: _result
   retries: 60
   delay: 5


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Only checking the Kubernetes api on the first master when upgrading is not enough.
Each master needs to be checked before it's upgrade, otherwise the upgrade can fail if the api-server is not ready.

**Which issue(s) this PR fixes**:
#7099 for release 2.15

**Special notes for your reviewer:**
Cherry-pick/backport of #7193 (#7110) for the release-2.15 branch.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```