### PR TITLE
Support arbitrary containerd registry configuration

### DIFF
--- a/docs/containerd.md
+++ b/docs/containerd.md
@@ -19,7 +19,7 @@ etcd_deployment_type: host
 
 ## Containerd config
 
-Example: define registry mirror for docker hub
+Example: define registry mirror for docker hub, and an insecure internal registry:
 
 ```yaml
 containerd_config:
@@ -32,6 +32,19 @@ containerd_config:
     "docker.io":
       - "https://mirror.gcr.io"
       - "https://registry-1.docker.io"
+    "registry.internal":
+      endpoint:
+        - registry.internal
+      # ca_file: "ca.pem"
+      # cert_file: "cert.pem"
+      # key_file: "key.pem"
+      insecure_skip_verify: true
+      # username: ""
+      # password: ""
+      # auth: ""
+      # identitytoken: ""
 ```
+
+All available configuration items are documented [here](https://github.com/containerd/containerd/blob/master/docs/cri/registry.md).
 
 [containerd]: https://containerd.io/

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -65,9 +65,15 @@ disabled_plugins = ["restart"]
 {% if 'registries' in containerd_config %}
 [plugins.cri.registry]
 [plugins.cri.registry.mirrors]
-{% for registry, addr in containerd_config.registries.items() %}
+{% for registry, mirror_config in containerd_config.registries.items() %}
 [plugins.cri.registry.mirrors."{{ registry }}"]
-  endpoint = ["{{ ([ addr ] | flatten ) | join('","') }}"]
+{% if mirror_config is mapping %}
+{% for mirror_key, mirror_value in mirror_config.items() %}
+  {{ mirror_key }} = {{ mirror_value | to_json }}
+{% endfor %}
+{% else %}
+  endpoint = ["{{ ([ mirror_config ] | flatten ) | join('","') }}"]
+{% endif %}
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

`containerd` registry mirrors can be configured using several items. Only `endpoint` is supported currently. This PR adds support for arbitrary items.

**Which issue(s) this PR fixes**:

Support `insecure_skip_verify` (Fixes: #7060). 

**Special notes for your reviewer**:

Backward compatibility is preserved.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
