### PR TITLE
FIX: Bastion undefined variable

### DIFF
--- a/inventory/sample/inventory.ini
+++ b/inventory/sample/inventory.ini
@@ -10,6 +10,7 @@
 # node6 ansible_host=95.54.0.17  # ip=10.3.0.6 etcd_member_name=etcd6
 
 # ## configure a bastion host if your nodes are not directly reachable
+# [bastion]
 # bastion ansible_host=x.x.x.x ansible_user=some_user
 
 [kube-master]


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
Fixes the following error when using Bastion Node with the sample config.

**Which issue(s) this PR fixes**:
```
fatal: [bastion]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'bastion'\n\nThe error appears to be in '..../kubespray/roles/bastion-ssh-config/tasks/main.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: set bastion host IP\n  ^ here\n"}
```
**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
