### PR TITLE
Fix bootstrap-os on Oracle Linux in an offline environment

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-centos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-centos.yml
@@ -51,6 +51,7 @@
     - { option: "enabled", value: "1" }
     - { option: "baseurl", value: "http://yum.oracle.com/repo/OracleLinux/OL{{ ansible_distribution_major_version }}/addons/x86_64/" }
   when:
+    - use_oracle_public_repo|default(true)
     - '"Oracle" in os_release.stdout'
     - (ansible_distribution_version | float) >= 7.6
 
@@ -59,6 +60,7 @@
     name: "oracle-epel-release-el{{ ansible_distribution_major_version }}"
     state: present
   when:
+    - use_oracle_public_repo|default(true)
     - '"Oracle" in os_release.stdout'
     - (ansible_distribution_version | float) >= 7.6
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
With this PR we can use Oracle Linux again in air gapped situations. Since #6198 it is impossible to use Oracle Linux in air gapped installation, even when `use_oracle_public_repo` was set to false as there are now new repositories set which will try to reach yum.oracle.com (which isn't possible in an offline environment)

**Special notes for your reviewer**:
The default value of `use_oracle_public_repo` is still true; which will result in no change. The change is that it now is possible to explicitly not set these repositories as we have our own mirror set in Oracle Linux.

**Does this PR introduce a user-facing change?**:
NONE