### PR TITLE
local-path-provisioner change default version to v0.0.19 and update config template

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s-cluster/addons.yml
@@ -26,7 +26,7 @@ local_path_provisioner_enabled: false
 # local_path_provisioner_claim_root: /opt/local-path-provisioner/
 # local_path_provisioner_debug: false
 # local_path_provisioner_image_repo: "rancher/local-path-provisioner"
-# local_path_provisioner_image_tag: "v0.0.14"
+# local_path_provisioner_image_tag: "v0.0.19"
 # local_path_provisioner_helper_image_repo: "busybox"
 # local_path_provisioner_helper_image_tag: "latest"
 

--- a/roles/kubernetes-apps/external_provisioner/local_path_provisioner/templates/local-path-storage-cm.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_path_provisioner/templates/local-path-storage-cm.yml.j2
@@ -11,6 +11,57 @@ data:
                 {
                         "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
                         "paths":["{{ local_path_provisioner_claim_root }}"]
+                },
+                {
+                        "node":"yasker-lp-dev1",
+                        "paths":["{{ local_path_provisioner_claim_root }}", "/data1"]
+                },
+                {
+                        "node":"yasker-lp-dev3",
+                        "paths":[]
                 }
                 ]
         }
+  setup: |-
+        #!/bin/sh
+        while getopts "m:s:p:" opt
+        do
+            case $opt in
+                p)
+                absolutePath=$OPTARG
+                ;;
+                s)
+                sizeInBytes=$OPTARG
+                ;;
+                m)
+                volMode=$OPTARG
+                ;;
+            esac
+        done
+        mkdir -m 0777 -p ${absolutePath}
+  teardown: |-
+        #!/bin/sh
+        while getopts "m:s:p:" opt
+        do
+            case $opt in
+                p)
+                absolutePath=$OPTARG
+                ;;
+                s)
+                sizeInBytes=$OPTARG
+                ;;
+                m)
+                volMode=$OPTARG
+                ;;
+            esac
+        done
+        rm -rf ${absolutePath}
+  helperPod.yaml: |-
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: helper-pod
+        spec:
+          containers:
+          - name: helper-pod
+            image: busybox

--- a/roles/kubernetes-apps/external_provisioner/local_path_provisioner/templates/local-path-storage-cm.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_path_provisioner/templates/local-path-storage-cm.yml.j2
@@ -11,14 +11,6 @@ data:
                 {
                         "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
                         "paths":["{{ local_path_provisioner_claim_root }}"]
-                },
-                {
-                        "node":"yasker-lp-dev1",
-                        "paths":["{{ local_path_provisioner_claim_root }}", "/data1"]
-                },
-                {
-                        "node":"yasker-lp-dev3",
-                        "paths":[]
                 }
                 ]
         }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Which issue(s) this PR fixes**:

Fixes #7237 

**Does this PR introduce a user-facing change?**:
Yes, will use local-path-provisioner v0.0.19 as default version. v0.0.14 can not be used anymore.

```release-note
Fixed: default version for local-path-provisioner changed to "v0.0.19" and updated config template to work with v0.0.19 out of the box after provisioning
```
