### PR TITLE
Update Helm version to 3.5.2

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -81,7 +81,7 @@ kube_router_version: "v1.1.1"
 multus_version: "v3.6"
 ovn4nfv_ovn_image_version: "v1.0.0"
 ovn4nfv_k8s_plugin_image_version: "v1.1.0"
-helm_version: "v3.5.0"
+helm_version: "v3.5.2"
 
 # Get kubernetes major version (i.e. 1.17.4 => 1.17)
 kube_major_version: "{{ kube_version | regex_replace('^v([0-9])+\\.([0-9]+)\\.[0-9]+', 'v\\1.\\2') }}"
@@ -386,9 +386,18 @@ calicoctl_binary_checksums:
     v3.15.2: 49165f9e4ad55402248b578310fcf68a57363f54e66be04ac24be9714899b4d5
 
 helm_archive_checksums:
-  arm: ca8792da269b72235987ea7245d1450a859b2c0658f591737d74b6c56cd9b1fa
-  amd64: 3fff0354d5fba4c73ebd5db59a59db72f8a5bbe1117a0b355b0c2983e98db95b
-  arm64: 87811b648ed9f4c84d3cb67bbea9b666bb7f6dd0ff6aca148b65f91058f73953
+  arm:
+    v3.5.0: ca8792da269b72235987ea7245d1450a859b2c0658f591737d74b6c56cd9b1fa
+    v3.5.1: 0b86a5a68df7376484babb6d7ffe1bae36012b4d65f1bcddb4255fb3bbe811db
+    v3.5.2: 98d090fc1769f5bf7451c15f6ed5a173a1ce5175eca32070ac19064d36470f1b
+  amd64:
+    v3.5.0: 3fff0354d5fba4c73ebd5db59a59db72f8a5bbe1117a0b355b0c2983e98db95b
+    v3.5.1: cad8f2f55a87cfd4d79312625c6af62c1e22eb1dab750f00aa1d394c601a2e6b
+    v3.5.2: 01b317c506f8b6ad60b11b1dc3f093276bb703281cb1ae01132752253ec706a2
+  arm64:
+    v3.5.0: 87811b648ed9f4c84d3cb67bbea9b666bb7f6dd0ff6aca148b65f91058f73953
+    v3.5.1: d0ada80576f8016d1cc38a06d225a4379a53e88e3e26b417e6de5db05a090ce4
+    v3.5.2: 126a72e2b209194fd2735861f0cf8bd5b5d1386eedd6aed6e0e050dca80d493e
 
 etcd_binary_checksum: "{{ etcd_binary_checksums[image_arch] }}"
 cni_binary_checksum: "{{ cni_binary_checksums[image_arch] }}"
@@ -397,7 +406,7 @@ kubectl_binary_checksum: "{{ kubectl_checksums[image_arch][kube_version] }}"
 kubeadm_binary_checksum: "{{ kubeadm_checksums[image_arch][kubeadm_version] }}"
 calicoctl_binary_checksum: "{{ calicoctl_binary_checksums[image_arch][calico_ctl_version] }}"
 crictl_binary_checksum: "{{ crictl_checksums[image_arch][crictl_version] }}"
-helm_archive_checksum: "{{ helm_archive_checksums[image_arch] }}"
+helm_archive_checksum: "{{ helm_archive_checksums[image_arch][helm_version] }}"
 
 # Containers
 # In some cases, we need a way to set --registry-mirror or --insecure-registry for docker,


### PR DESCRIPTION
[Helm v3.5.2](https://github.com/helm/helm/releases/tag/v3.5.2) is a security (patch) release. Users are strongly recommended to update to this release. It fixes two security issues in upstream dependencies and one security issue in the Helm codebase.