### PR TITLE
Replace KUBE_MASTERS with KUBE_CONTROL_HOSTS

### DIFF
--- a/contrib/inventory_builder/tests/test_inventory.py
+++ b/contrib/inventory_builder/tests/test_inventory.py
@@ -222,11 +222,11 @@ class TestInventory(unittest.TestCase):
             self.inv.yaml_config['all']['children'][group]['hosts'].get(host),
             None)
 
-    def test_set_kube_master(self):
+    def test_set_kube_control_plane(self):
         group = 'kube-master'
         host = 'node1'
 
-        self.inv.set_kube_master([host])
+        self.inv.set_kube_control_plane([host])
         self.assertIn(
             host, self.inv.yaml_config['all']['children'][group]['hosts'])
 
@@ -275,7 +275,7 @@ class TestInventory(unittest.TestCase):
 
         self.inv.set_all(hosts)
         self.inv.set_etcd(list(hosts.keys())[0:3])
-        self.inv.set_kube_master(list(hosts.keys())[0:2])
+        self.inv.set_kube_control_plane(list(hosts.keys())[0:2])
         self.inv.set_kube_node(hosts.keys())
         for h in range(3):
             self.assertFalse(
@@ -291,7 +291,7 @@ class TestInventory(unittest.TestCase):
 
         self.inv.set_all(hosts)
         self.inv.set_etcd(list(hosts.keys())[0:3])
-        self.inv.set_kube_master(list(hosts.keys())[3:5])
+        self.inv.set_kube_control_plane(list(hosts.keys())[3:5])
         self.inv.set_kube_node(hosts.keys())
         for h in range(5):
             self.assertFalse(


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This replaces KUBE_MASTERS with KUBE_CONTROL_HOSTS because of [1]:

```
  The Kubernetes project is moving away from wording that is
  considered offensive. A new working group WG Naming was created
  to track this work, and the word "master" was declared as offensive.
  A proposal was formalized for replacing the word "master" with
  "control plane". This means it should be removed from source code,
  documentation, and user-facing configuration from Kubernetes and
  its sub-projects.
```

[1]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint/README.md#motivation

Ref: https://github.com/kubernetes-sigs/kubespray/issues/7157

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
inventory_builder starts referring the environment variable KUBE_CONTROL_HOSTS to get the number of control-plane nodes.
It still refers KUBE_MASTERS but it will be not referred after some deprecation cycles.
Please specify KUBE_CONTROL_HOSTS if now specifying KUBE_MASTERS.
```
