### PR TITLE
Improving PR 6473

### DIFF
--- a/inventory/sample/group_vars/all/all.yml
+++ b/inventory/sample/group_vars/all/all.yml
@@ -27,6 +27,11 @@ bin_dir: /usr/local/bin
 # valid options are "nginx" or "haproxy"
 # loadbalancer_apiserver_type: nginx  # valid values "nginx" or "haproxy"
 
+## If the cilium is going to be used in strict mode, we can use the
+## localhost connection and not use the external LB. If this parameter is
+## not specified, the first node to connect to kubeapi will be used.
+# use_localhost_as_kubeapi_loadbalancer: true
+
 ## Local loadbalancer should use this port
 ## And must be set port 6443
 loadbalancer_apiserver_port: 6443

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -464,6 +464,8 @@ apiserver_loadbalancer_domain_name: "lb-apiserver.kubernetes.local"
 kube_apiserver_global_endpoint: |-
   {% if loadbalancer_apiserver is defined -%}
       https://{{ apiserver_loadbalancer_domain_name }}:{{ loadbalancer_apiserver.port|default(kube_apiserver_port) }}
+  {%- elif use_localhost_as_kubeapi_loadbalancer is defined -%}
+      https://127.0.0.1:{{ kube_apiserver_port }}
   {%- else -%}
       https://{{ first_kube_master }}:{{ kube_apiserver_port }}
   {%- endif %}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**Which issue(s) this PR fixes**:

Hello
We use cilium as CNI. In #6473 was added cilium strict kube proxy replacement in HA, but only the external LB or first master node is allowed.

Idea for this patch
cilium agent on master use hostnetwork and use 127.0.0.1:6443 to communicate to kubeapi
cilium agent on node use hostnetwork and and use 127.0.0.1:6443 to communicate to kubeapi over ngixn/haproxy
After applying the patch we have KUBERNETES_SERVICE_HOST=127.0.0.1 for the cilium agent and the cilium-operator and we don't need use external LB or only first master.
