### PR TITLE
fix CentOS detect

### DIFF
--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -10,7 +10,7 @@
   when: '"CentOS" in os_release.stdout or "Oracle" in os_release.stdout'
 
 - include_tasks: bootstrap-redhat.yml
-  when: '"Red Hat Enterprise Linux" in os_release.stdout'
+  when: '"Red Hat Enterprise Linux" in os_release.stdout and "CentOS" not in os_release.stdout'
 
 - include_tasks: bootstrap-clearlinux.yml
   when: '"Clear Linux OS" in os_release.stdout'


### PR DESCRIPTION
````
TASK [bootstrap-os : Enable RHEL 8 repos] ***************************************************************************************************************************************************************************************************
fatal: [node6]: FAILED! => {"changed": false, "msg": "This system has no repositories available through subscriptions"}
fatal: [node7]: FAILED! => {"changed": false, "msg": "This system has no repositories available through subscriptions"}
fatal: [node1]: FAILED! => {"changed": false, "msg": "This system has no repositories available through subscriptions"}

[root@node1 kubespray]# cat /etc/os-release
NAME="CentOS Stream"
VERSION="8"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="8"
PLATFORM_ID="platform:el8"
PRETTY_NAME="CentOS Stream 8"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:8"
HOME_URL="https://centos.org/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux 8"
REDHAT_SUPPORT_PRODUCT_VERSION="CentOS Stream"

```

REDHAT_SUPPORT_PRODUCT have Red Hat Enterprise Linux string in Centos 