### PR TITLE
Only use stat get_checksum: yes when needed

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-centos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-centos.yml
@@ -69,6 +69,9 @@
 - name: Check presence of fastestmirror.conf
   stat:
     path: /etc/yum/pluginconf.d/fastestmirror.conf
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: fastestmirror
 
 # the fastestmirror plugin can actually slow down Ansible deployments

--- a/roles/bootstrap-os/tasks/bootstrap-opensuse.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-opensuse.yml
@@ -4,6 +4,9 @@
 - name: Check that /etc/sysconfig/proxy file exists
   stat:
     path: /etc/sysconfig/proxy
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: stat_result
 
 - name: Create the /etc/sysconfig/proxy empty file

--- a/roles/bootstrap-os/tasks/bootstrap-redhat.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-redhat.yml
@@ -85,6 +85,9 @@
 - name: Check presence of fastestmirror.conf
   stat:
     path: /etc/yum/pluginconf.d/fastestmirror.conf
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: fastestmirror
 
 # the fastestmirror plugin can actually slow down Ansible deployments

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -2,6 +2,9 @@
 - name: check if fedora coreos
   stat:
     path: /run/ostree-booted
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: ostree
 
 - name: set is_ostree

--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -2,6 +2,9 @@
 - name: check if fedora coreos
   stat:
     path: /run/ostree-booted
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: ostree
 
 - name: set is_ostree
@@ -94,6 +97,9 @@
 - name: Check if already installed
   stat:
     path: "/bin/crio"
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: need_bootstrap_crio
   when: is_ostree
 

--- a/roles/container-engine/crun/tasks/main.yml
+++ b/roles/container-engine/crun/tasks/main.yml
@@ -9,6 +9,9 @@
 - name: Check if binary exists
   stat:
     path: "{{ crun_bin_dir }}/crun"
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: crun_stat
 
 # TODO: use download_file.yml

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -2,6 +2,9 @@
 - name: check if fedora coreos
   stat:
     path: /run/ostree-booted
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: ostree
 
 - name: set is_ostree

--- a/roles/download/tasks/download_container.yml
+++ b/roles/download/tasks/download_container.yml
@@ -24,6 +24,9 @@
     - name: download_container | Determine if image is in cache
       stat:
         path: "{{ image_path_cached }}"
+        get_attributes: no
+        get_checksum: no
+        get_mime: no
       delegate_to: localhost
       connection: local
       delegate_facts: no

--- a/roles/etcd/handlers/backup.yml
+++ b/roles/etcd/handlers/backup.yml
@@ -29,6 +29,9 @@
 - name: Stat etcd v2 data directory
   stat:
     path: "{{ etcd_data_dir }}/member"
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: etcd_data_dir_member
 
 - name: Backup etcd v2 data

--- a/roles/etcd/tasks/check_certs.yml
+++ b/roles/etcd/tasks/check_certs.yml
@@ -17,6 +17,9 @@
 - name: "Check certs | Register ca and etcd admin/member certs on etcd hosts"
   stat:
     path: "{{ etcd_cert_dir }}/{{ item }}"
+    get_attributes: no
+    get_checksum: yes
+    get_mime: no
   register: etcd_member_certs
   when: inventory_hostname in groups['etcd']
   with_items:

--- a/roles/etcdctl/tasks/main.yml
+++ b/roles/etcdctl/tasks/main.yml
@@ -9,6 +9,9 @@
 - name: Check if etcdctl exist
   stat:
     path: "{{ bin_dir }}/etcdctl"
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: stat_etcdctl
 
 - block:
@@ -28,6 +31,9 @@
 - name: Check if etcdctl still exist after version check
   stat:
     path: "{{ bin_dir }}/etcdctl"
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: stat_etcdctl
 
 - block:

--- a/roles/kubernetes-apps/helm/tasks/main.yml
+++ b/roles/kubernetes-apps/helm/tasks/main.yml
@@ -17,6 +17,9 @@
 - name: Check if bash_completion.d folder exists  # noqa 503
   stat:
     path: "/etc/bash_completion.d/"
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: stat_result
 
 - name: Get helm completion

--- a/roles/kubernetes/control-plane/tasks/encrypt-at-rest.yml
+++ b/roles/kubernetes/control-plane/tasks/encrypt-at-rest.yml
@@ -2,6 +2,9 @@
 - name: Check if secret for encrypting data at rest already exist
   stat:
     path: "{{ kube_cert_dir }}/secrets_encryption.yaml"
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: secrets_encryption_file
 
 - name: Slurp secrets_encryption file if it exists

--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -2,6 +2,9 @@
 - name: kubeadm | Check if old apiserver cert exists on host
   stat:
     path: "{{ kube_cert_dir }}/apiserver.pem"
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: old_apiserver_cert
   delegate_to: "{{ groups['kube-master'] | first }}"
   run_once: true
@@ -24,12 +27,18 @@
 - name: kubeadm | Check serviceaccount key
   stat:
     path: "{{ kube_cert_dir }}/sa.key"
+    get_attributes: no
+    get_checksum: yes
+    get_mime: no
   register: sa_key_before
   run_once: true
 
 - name: kubeadm | Check if kubeadm has already run
   stat:
     path: "/var/lib/kubelet/config.yaml"
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: kubeadm_already_run
 
 - name: kubeadm | Delete old admin.conf
@@ -211,6 +220,9 @@
 - name: kubeadm | Check serviceaccount key again
   stat:
     path: "{{ kube_cert_dir }}/sa.key"
+    get_attributes: no
+    get_checksum: yes
+    get_mime: no
   register: sa_key_after
   run_once: true
 

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -13,11 +13,17 @@
 - name: Check if kubelet.conf exists
   stat:
     path: "{{ kube_config_dir }}/kubelet.conf"
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: kubelet_conf
 
 - name: Check if kubeadm CA cert is accessible
   stat:
     path: "{{ kube_cert_dir }}/ca.crt"
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: kubeadm_ca_stat
   delegate_to: "{{ groups['kube-master'][0] }}"
   run_once: true

--- a/roles/kubernetes/node/tasks/loadbalancer/haproxy.yml
+++ b/roles/kubernetes/node/tasks/loadbalancer/haproxy.yml
@@ -22,6 +22,9 @@
 - name: haproxy | Get checksum from config
   stat:
     path: "{{ haproxy_config_dir }}/haproxy.cfg"
+    get_attributes: no
+    get_checksum: yes
+    get_mime: no
   register: haproxy_stat
 
 - name: haproxy | Write static pod

--- a/roles/kubernetes/node/tasks/loadbalancer/nginx-proxy.yml
+++ b/roles/kubernetes/node/tasks/loadbalancer/nginx-proxy.yml
@@ -22,6 +22,9 @@
 - name: nginx-proxy | Get checksum from config
   stat:
     path: "{{ nginx_config_dir }}/nginx.conf"
+    get_attributes: no
+    get_checksum: yes
+    get_mime: no
   register: nginx_stat
 
 - name: nginx-proxy | Write static pod

--- a/roles/kubernetes/preinstall/handlers/main.yml
+++ b/roles/kubernetes/preinstall/handlers/main.yml
@@ -50,13 +50,21 @@
 
 # FIXME(mattymo): Also restart for kubeadm mode
 - name: Preinstall | kube-apiserver configured
-  stat: path="{{ kube_manifest_dir }}/kube-apiserver.manifest"
+  stat:
+    path: "{{ kube_manifest_dir }}/kube-apiserver.manifest"
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: kube_apiserver_set
   when: inventory_hostname in groups['kube-master'] and dns_mode != 'none' and resolvconf_mode == 'host_resolvconf'
 
 # FIXME(mattymo): Also restart for kubeadm mode
 - name: Preinstall | kube-controller configured
-  stat: path="{{ kube_manifest_dir }}/kube-controller-manager.manifest"
+  stat:
+    path: "{{ kube_manifest_dir }}/kube-controller-manager.manifest"
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: kube_controller_set
   when: inventory_hostname in groups['kube-master'] and dns_mode != 'none' and resolvconf_mode == 'host_resolvconf'
 

--- a/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
@@ -9,6 +9,9 @@
 - name: check if booted with ostree
   stat:
     path: /run/ostree-booted
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: ostree
 
 - name: set is_fedora_coreos
@@ -59,6 +62,9 @@
 - name: check if kubelet is configured
   stat:
     path: "{{ kube_config_dir }}/kubelet.env"
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: kubelet_configured
   changed_when: false
 
@@ -84,6 +90,9 @@
 - name: check if /etc/dhclient.conf exists
   stat:
     path: /etc/dhclient.conf
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: dhclient_stat
 
 - name: target dhclient conf file for /etc/dhclient.conf
@@ -94,6 +103,9 @@
 - name: check if /etc/dhcp/dhclient.conf exists
   stat:
     path: /etc/dhcp/dhclient.conf
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: dhcp_dhclient_stat
 
 - name: target dhclient conf file for /etc/dhcp/dhclient.conf
@@ -170,6 +182,9 @@
 - name: check /usr readonly
   stat:
     path: "/usr"
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: usr
 
 - name: set alternate flexvolume path

--- a/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
+++ b/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
@@ -46,6 +46,9 @@
 - name: Check if kubernetes kubeadm compat cert dir exists
   stat:
     path: "{{ kube_cert_compat_dir }}"
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: kube_cert_compat_dir_check
   when:
     - inventory_hostname in groups['k8s-cluster']

--- a/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
+++ b/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
@@ -3,6 +3,9 @@
 - name: Confirm selinux deployed
   stat:
     path: /etc/selinux/config
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   when:
     - ansible_os_family == "RedHat"
     - "'Amazon' not in ansible_distribution"
@@ -36,6 +39,9 @@
 - name: Stat sysctl file configuration
   stat:
     path: "{{ sysctl_file_path }}"
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: sysctl_file_stat
   tags:
     - bootstrap-os

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -92,6 +92,9 @@
 - name: Check if we are running inside a Azure VM
   stat:
     path: /var/lib/waagent/
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: azure_check
   when:
     - not dns_late

--- a/roles/kubernetes/tokens/tasks/check-tokens.yml
+++ b/roles/kubernetes/tokens/tasks/check-tokens.yml
@@ -2,6 +2,9 @@
 - name: "Check_tokens | check if the tokens have already been generated on first master"
   stat:
     path: "{{ kube_token_dir }}/known_tokens.csv"
+    get_attributes: no
+    get_checksum: yes
+    get_mime: no
   delegate_to: "{{ groups['kube-master'][0] }}"
   register: known_tokens_master
   run_once: true
@@ -20,6 +23,9 @@
 - name: "Check tokens | check if a cert already exists"
   stat:
     path: "{{ kube_token_dir }}/known_tokens.csv"
+    get_attributes: no
+    get_checksum: yes
+    get_mime: no
   register: known_tokens
 
 - name: "Check_tokens | Set 'sync_tokens' to true"

--- a/roles/network_plugin/calico/tasks/reset.yml
+++ b/roles/network_plugin/calico/tasks/reset.yml
@@ -2,6 +2,9 @@
 - name: reset | check dummy0 network device
   stat:
     path: /sys/class/net/dummy0
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: dummy0
 
 - name: reset | remove the network device created by calico

--- a/roles/network_plugin/cilium/tasks/reset_iface.yml
+++ b/roles/network_plugin/cilium/tasks/reset_iface.yml
@@ -2,6 +2,9 @@
 - name: "reset | check if network device {{ iface }} is present"
   stat:
     path: "/sys/class/net/{{ iface }}"
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: device_remains
 
 - name: "reset | remove network device {{ iface }}"

--- a/roles/network_plugin/flannel/tasks/reset.yml
+++ b/roles/network_plugin/flannel/tasks/reset.yml
@@ -2,6 +2,9 @@
 - name: reset | check cni network device
   stat:
     path: /sys/class/net/cni0
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: cni
 
 - name: reset | remove the network device created by the flannel
@@ -11,6 +14,9 @@
 - name: reset | check flannel network device
   stat:
     path: /sys/class/net/flannel.1
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: flannel
 
 - name: reset | remove the network device created by the flannel

--- a/roles/network_plugin/kube-router/tasks/reset.yml
+++ b/roles/network_plugin/kube-router/tasks/reset.yml
@@ -2,6 +2,9 @@
 - name: reset | check kube-dummy-if network device
   stat:
     path: /sys/class/net/kube-dummy-if
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: kube_dummy_if
 
 - name: reset | remove the network device created by kube-router
@@ -11,6 +14,9 @@
 - name: check kube-bridge exists
   stat:
     path: /sys/class/net/kube-bridge
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: kube_bridge_if
 
 - name: reset | donw the network bridge create by kube-router

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -68,6 +68,9 @@
 - name: reset | check if crictl is present
   stat:
     path: "{{ bin_dir }}/crictl"
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: crictl
 
 - name: reset | stop all cri containers
@@ -204,6 +207,9 @@
 - name: reset | check kube-ipvs0 network device
   stat:
     path: /sys/class/net/kube-ipvs0
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: kube_ipvs0
 
 - name: reset | Remove kube-ipvs0
@@ -215,6 +221,9 @@
 - name: reset | check nodelocaldns network device
   stat:
     path: /sys/class/net/nodelocaldns
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: nodelocaldns_device
 
 - name: reset | Remove nodelocaldns

--- a/tests/cloud_playbooks/roles/packet-ci/tasks/delete-vms.yml
+++ b/tests/cloud_playbooks/roles/packet-ci/tasks/delete-vms.yml
@@ -3,6 +3,9 @@
 - name: Check if temp directory for {{ test_name }} exists
   stat:
     path: "/tmp/{{ test_name }}"
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
   register: temp_dir_details
 
 - name: "Cleanup temp directory for {{ test_name }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
By default Ansible stat module compute checksum, list extended attributes and find mime type
To find all stat invocations that really use one of those:
```
git grep -F stat. | grep -vE 'stat.(islnk|exists|lnk_source|writeable)'
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
