### PR TITLE
fix typo error in role ingress-nginx

### DIFF
--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/role-ingress-nginx.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/role-ingress-nginx.yml.j2
@@ -16,7 +16,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["services"]
-    verbs: ["get", "list", watch"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["extensions", "networking.k8s.io"]
     resources: ["ingresses"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Error in role ingress-nginx

```
- apiGroups:
  - ""
  resources:
  - services
  verbs:
  - get
  - list
  - watch"
```
