### PR TITLE
facts.yaml: reduce the number of setup calls by ~7x

### DIFF
--- a/facts.yml
+++ b/facts.yml
@@ -7,15 +7,20 @@
       setup:
         gather_subset: '!all'
 
-    - name: Gather necessary facts
+    # filter match the following variables:
+    # ansible_default_ipv4
+    # ansible_default_ipv6
+    # ansible_all_ipv4_addresses
+    # ansible_all_ipv6_addresses
+    - name: Gather necessary facts (network)
       setup:
-        gather_subset: '!all,!min,network,hardware'
-        filter: "{{ item }}"
-      loop:
-        - ansible_distribution_major_version
-        - ansible_default_ipv4
-        - ansible_default_ipv6
-        - ansible_all_ipv4_addresses
-        - ansible_all_ipv6_addresses
-        - ansible_memtotal_mb
-        - ansible_swaptotal_mb
+        gather_subset: '!all,!min,network'
+        filter: "ansible_*_ipv[46]*"
+
+    # filter match the following variables:
+    # ansible_memtotal_mb
+    # ansible_swaptotal_mb
+    - name: Gather necessary facts (hardware)
+      setup:
+        gather_subset: '!all,!min,hardware'
+        filter: "ansible_*total_mb"


### PR DESCRIPTION
Before this commit, we were gathering:
1 !all
7 network
7 hardware

After we are gathering:
1 !all
1 network
1 hardware

ansible_distribution_major_version is gathered by '!all'

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
