### PR TITLE
Fixup cri-o metacopy mount options

### DIFF
--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -140,15 +140,13 @@
     owner: root
     mode: 0755
 
-- name: Remove metacopy mount options for older kernels
+# metacopy=on is available since 4.19 and was backported to RHEL 4.18 kernel
+- name: Set metacopy mount options correctly
   ini_file:
     dest: /etc/containers/storage.conf
     section: storage.options.overlay
     option: mountopt
-    value: "\"nodev\""
-  when:
-    - ansible_distribution == "CentOS"
-    - ansible_distribution_major_version == "7"
+    value: '{{ ''"nodev"'' if ansible_kernel is version_compare(("4.18" if ansible_os_family == "RedHat" else "4.19"), "<") else ''"nodev,metacopy=on"'' }}'
 
 - name: Create directory registries configs
   file:


### PR DESCRIPTION
Ubuntu 18.04 crio package ships with 'mountopt = "nodev,metacopy=on"'
even if GA kernel is 4.15 (HWE Kernel can be more recent)

Fedora package ships without metacopy=on

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
cri-o: set "metacopy=on" depending on kernel version
```
