### PR TITLE
return the ability to update calico from 3.x.x version

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -184,8 +184,8 @@
 - name: Check that current calico version is enough for upgrade
   assert:
     that:
-      - calico_version_on_server.stdout is version(calico_min_version_required, '>=')
-    msg: "Your version of calico is not fresh enough for upgrade. Minimum version {{ calico_min_version_required }}"
+      - calico_version_on_server.stdout is version( 'v3.0.0', '>=')
+    msg: "Your version of calico is not fresh enough for upgrade. Minimum version is v3.0.0"
   when:
     - kube_network_plugin == 'calico'
     - 'calico_version_on_server.stdout is defined'


### PR DESCRIPTION
version check fixed


/kind bug

**What this PR does / why we need it**:

upgrade cluster from 1.18.3 to 1.19.7 failed with

```
fatal: [master-1]: FAILED! => {
    "assertion": "calico_version_on_server.stdout is version(calico_min_version_required, '>=')",
    "changed": false,
    "evaluated_to": false,
    "msg": "Your version of calico is not fresh enough for upgrade. Minimum version v3.15.2"
}
```

calico version in my cluster is 3.15.1, so is not too old.

before this PR https://github.com/kubernetes-sigs/kubespray/pull/6733

min version set to v2.6.5, afer min version set to CURRENT min version of calico.
Therefore, upgrading from older versions is declared unsupported.
that in fact, complete nonsense, calico perfectly knows how to update from any of version 3.x.x
