### PR TITLE
use external_openstack_lbaas_use_octavia for template openstack-cloud…

### DIFF
--- a/docs/openstack.md
+++ b/docs/openstack.md
@@ -129,6 +129,24 @@ The new cloud provider is configured to have Octavia by default in Kubespray.
   ```yaml
   external_openstack_metadata_search_order: "configDrive,metadataService"
   ```
+- Available variables for configuring lbaas:
+
+  ```yaml
+  external_openstack_lbaas_create_monitor: false
+  external_openstack_lbaas_monitor_delay: "1m"
+  external_openstack_lbaas_monitor_timeout: "30s"
+  external_openstack_lbaas_monitor_max_retries: "3"
+  external_openstack_lbaas_provider: octavia
+  external_openstack_lbaas_use_octavia: true
+  external_openstack_lbaas_network_id: "Neutron network ID to create LBaaS VIP"
+  external_openstack_lbaas_subnet_id: "Neutron subnet ID to create LBaaS VIP"
+  external_openstack_lbaas_floating_network_id: "Neutron network ID to get floating IP from"
+  external_openstack_lbaas_floating_subnet_id: "Neutron subnet ID to get floating IP from"
+  external_openstack_lbaas_method: "ROUND_ROBIN"
+  external_openstack_lbaas_manage_security_groups: false
+  external_openstack_lbaas_internal_lb: false
+
+  ```
 
 - Run `source path/to/your/openstack-rc` to read your OpenStack credentials like `OS_AUTH_URL`, `OS_USERNAME`, `OS_PASSWORD`, etc. Those variables are used for accessing OpenStack from the external cloud provider.
 - Run the `cluster.yml` playbook

--- a/docs/openstack.md
+++ b/docs/openstack.md
@@ -125,10 +125,11 @@ The new cloud provider is configured to have Octavia by default in Kubespray.
   ```
 
 - You can override the default OpenStack metadata configuration (see [#6338](https://github.com/kubernetes-sigs/kubespray/issues/6338) for explanation):
-  
+
   ```yaml
   external_openstack_metadata_search_order: "configDrive,metadataService"
   ```
+
 - Available variables for configuring lbaas:
 
   ```yaml

--- a/docs/openstack.md
+++ b/docs/openstack.md
@@ -138,6 +138,7 @@ The new cloud provider is configured to have Octavia by default in Kubespray.
   external_openstack_lbaas_monitor_timeout: "30s"
   external_openstack_lbaas_monitor_max_retries: "3"
   external_openstack_lbaas_provider: octavia
+  external_openstack_lbaas_use_octavia: false
   external_openstack_lbaas_use_octavia: true
   external_openstack_lbaas_network_id: "Neutron network ID to create LBaaS VIP"
   external_openstack_lbaas_subnet_id: "Neutron subnet ID to create LBaaS VIP"

--- a/docs/openstack.md
+++ b/docs/openstack.md
@@ -139,7 +139,6 @@ The new cloud provider is configured to have Octavia by default in Kubespray.
   external_openstack_lbaas_monitor_max_retries: "3"
   external_openstack_lbaas_provider: octavia
   external_openstack_lbaas_use_octavia: false
-  external_openstack_lbaas_use_octavia: true
   external_openstack_lbaas_network_id: "Neutron network ID to create LBaaS VIP"
   external_openstack_lbaas_subnet_id: "Neutron subnet ID to create LBaaS VIP"
   external_openstack_lbaas_floating_network_id: "Neutron network ID to get floating IP from"

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
@@ -57,7 +57,11 @@ internal-lb={{ external_openstack_lbaas_internal_lb }}
 {% endif %}
 {% if external_openstack_lbaas_provider is defined %}
 lb-provider={{ external_openstack_lbaas_provider }}
+{% if external_openstack_lbaas_use_octavia is defined %}
+use-octavia={{ external_openstack_lbaas_use_octavia }}
+{% else %}
 use-octavia={{ external_openstack_lbaas_provider | lower == 'octavia' }}
+{% endif %}
 {% else %}
 lb-provider=octavia
 use-octavia=true

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
@@ -57,11 +57,7 @@ internal-lb={{ external_openstack_lbaas_internal_lb }}
 {% endif %}
 {% if external_openstack_lbaas_provider is defined %}
 lb-provider={{ external_openstack_lbaas_provider }}
-{% if external_openstack_lbaas_use_octavia is defined %}
-use-octavia={{ external_openstack_lbaas_use_octavia }}
-{% else %}
-use-octavia={{ external_openstack_lbaas_provider | lower == 'octavia' }}
-{% endif %}
+use-octavia={{ external_openstack_lbaas_use_octavia | default(False) }}
 {% else %}
 lb-provider=octavia
 use-octavia=true

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
@@ -57,7 +57,7 @@ internal-lb={{ external_openstack_lbaas_internal_lb }}
 {% endif %}
 {% if external_openstack_lbaas_provider is defined %}
 lb-provider={{ external_openstack_lbaas_provider }}
-use-octavia={{ external_openstack_lbaas_use_octavia | default(False) }}
+use-octavia={{ external_openstack_lbaas_use_octavia }}
 {% else %}
 lb-provider=octavia
 use-octavia=true

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -386,6 +386,7 @@ external_openstack_lbaas_monitor_delay: "1m"
 external_openstack_lbaas_monitor_timeout: "30s"
 external_openstack_lbaas_monitor_max_retries: "3"
 external_openstack_network_ipv6_disabled: false
+external_openstack_lbaas_use_octavia: false
 external_openstack_network_internal_networks:
 - ""
 external_openstack_network_public_networks:

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -381,7 +381,6 @@ openstack_lbaas_monitor_max_retries: "3"
 openstack_cacert: "{{ lookup('env','OS_CACERT') }}"
 
 # Default values for the external OpenStack Cloud Controller
-external_openstack_lbaas_use_octavia: true
 external_openstack_lbaas_create_monitor: false
 external_openstack_lbaas_monitor_delay: "1m"
 external_openstack_lbaas_monitor_timeout: "30s"


### PR DESCRIPTION
external_openstack_lbaas_use_octavia defined in roles/kubespray-defaults/defaults/main.yaml but not using

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In my case config must be like this 
```sh
[LoadBalancer]
...
lb-provider=amphora
use-octavia=true
```
**Which issue(s) this PR fixes**:
Without issue

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
"NONE"
```
