### PR TITLE
add option to use calico with azure when using calico in vxlan

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -38,10 +38,13 @@
 
 - name: Stop if incompatible network plugin and cloudprovider
   assert:
-    that: kube_network_plugin != 'calico'
-    msg: "Azure and Calico are not compatible. See https://github.com/projectcalico/calicoctl/issues/949 for details."
+    that:
+      - calico_ipip_mode == 'Never'
+      - calico_vxlan_mode in ['Always', 'CrossSubnet']
+    msg: "When using cloud_provider azure and network_plugin calico calico_ipip_mode must be 'Never' and calico_vxlan_mode 'Always' or 'CrossSubnet'"
   when:
     - cloud_provider is defined and cloud_provider == 'azure'
+    - kube_network_plugin == 'calico'
     - not ignore_assert_errors
 
 - name: Stop if unsupported version of Kubernetes


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
Calico is now supported on azure in vxlan mode. https://docs.projectcalico.org/getting-started/kubernetes/self-managed-public-cloud/azure#calico-networking.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7288 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
