### PR TITLE
Fix proxy usage when *_PROXY are present in environment

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -4,6 +4,7 @@
 
 - hosts: bastion[0]
   gather_facts: False
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - { role: bastion-ssh-config, tags: ["localhost", "bastion"] }
@@ -12,6 +13,7 @@
   strategy: linear
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   gather_facts: false
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - { role: bootstrap-os, tags: bootstrap-os}
@@ -23,6 +25,7 @@
 - hosts: k8s-cluster:etcd
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes/preinstall, tags: preinstall }
@@ -32,6 +35,7 @@
 - hosts: etcd
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - role: etcd
@@ -44,6 +48,7 @@
 - hosts: k8s-cluster
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - role: etcd
@@ -56,6 +61,7 @@
 - hosts: k8s-cluster
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes/node, tags: node }
@@ -63,6 +69,7 @@
 - hosts: kube-master
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes/control-plane, tags: master }
@@ -72,6 +79,7 @@
 - hosts: k8s-cluster
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes/kubeadm, tags: kubeadm}
@@ -81,6 +89,7 @@
 - hosts: calico-rr
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - { role: network_plugin/calico/rr, tags: ['network', 'calico_rr'] }
@@ -88,6 +97,7 @@
 - hosts: kube-master[0]
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes-apps/rotate_tokens, tags: rotate_tokens, when: "secret_changed|default(false)" }
@@ -96,6 +106,7 @@
 - hosts: kube-master
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes-apps/external_cloud_controller, tags: external-cloud-controller }
@@ -107,6 +118,7 @@
 - hosts: kube-master
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes-apps, tags: apps }
@@ -114,6 +126,7 @@
 - hosts: k8s-cluster
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes/preinstall, when: "dns_mode != 'none' and resolvconf_mode == 'host_resolvconf'", tags: resolvconf, dns_late: true }

--- a/recover-control-plane.yml
+++ b/recover-control-plane.yml
@@ -4,22 +4,26 @@
 
 - hosts: bastion[0]
   gather_facts: False
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults}
     - { role: bastion-ssh-config, tags: ["localhost", "bastion"]}
 
 - hosts: "{{ groups['etcd'] | first }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults}
     - { role: recover_control_plane/etcd }
 
 - hosts: "{{ groups['kube-master'] | first }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: recover_control_plane/control-plane }
 
 - include: cluster.yml
 
 - hosts: "{{ groups['kube-master'] }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults}
     - { role: recover_control_plane/post-recover }

--- a/remove-node.yml
+++ b/remove-node.yml
@@ -4,6 +4,7 @@
 
 - hosts: "{{ node | default('etcd:k8s-cluster:calico-rr') }}"
   gather_facts: no
+  environment: "{{ proxy_disable_env }}"
   vars_prompt:
     name: "delete_nodes_confirmation"
     prompt: "Are you sure you want to delete nodes state? Type 'yes' to delete nodes."
@@ -18,6 +19,7 @@
 
 - hosts: kube-master[0]
   gather_facts: no
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - { role: bootstrap-os, tags: bootstrap-os }
@@ -25,6 +27,7 @@
 
 - hosts: "{{ node | default('kube-node') }}"
   gather_facts: no
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults, when: reset_nodes|default(True)|bool }
     - { role: bootstrap-os, tags: bootstrap-os, when: reset_nodes|default(True)|bool }
@@ -34,6 +37,7 @@
 # Currently cannot remove first master or etcd
 - hosts: "{{ node | default('kube-master[1:]:etcd[1:]') }}"
   gather_facts: no
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults, when: reset_nodes|default(True)|bool }
     - { role: bootstrap-os, tags: bootstrap-os, when: reset_nodes|default(True)|bool }

--- a/reset.yml
+++ b/reset.yml
@@ -4,6 +4,7 @@
 
 - hosts: bastion[0]
   gather_facts: False
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults}
     - { role: bastion-ssh-config, tags: ["localhost", "bastion"]}
@@ -25,6 +26,7 @@
         msg: "Reset confirmation failed"
       when: reset_confirmation != "yes"
 
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults}
     - { role: reset, tags: reset }

--- a/roles/download/tasks/prep_kubeadm_images.yml
+++ b/roles/download/tasks/prep_kubeadm_images.yml
@@ -38,7 +38,6 @@
   shell: "set -o pipefail && {{ bin_dir }}/kubeadm config images list --config={{ kube_config_dir }}/kubeadm-images.yaml | grep -Ev 'coredns|pause'"
   args:
     executable: /bin/bash
-  environment: "{{ proxy_disable_env }}"
   register: kubeadm_images_raw
   run_once: true
   changed_when: false

--- a/roles/kubernetes/control-plane/tasks/kubeadm-fix-apiserver.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-fix-apiserver.yml
@@ -20,7 +20,6 @@
     {{ bin_dir }}/kubeadm init phase kubeconfig all
     --config {{ kube_config_dir }}/kubeadm-config.yaml
     --kubeconfig-dir {{ kubeconfig_temp_dir.path }}
-  environment: "{{ proxy_disable_env }}"
   when: kubeconfig_correct_apiserver.rc != 0
 
 - name: Copy new kubeconfigs to kube config dir

--- a/roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml
@@ -16,7 +16,6 @@
     --config {{ kube_config_dir }}/kubeadm-config.yaml
     upload-certs
     --upload-certs
-  environment: "{{ proxy_disable_env }}"
   register: kubeadm_upload_cert
   when:
     - inventory_hostname == groups['kube-master']|first
@@ -58,7 +57,8 @@
     {{ bin_dir }}/kubeadm join
     --config {{ kube_config_dir }}/kubeadm-controlplane.yaml
     --ignore-preflight-errors=all
-  environment: '{{ proxy_disable_env | combine({"PATH": "{{ bin_dir }}:{{ ansible_env.PATH }}"}) }}'
+  environment:
+    PATH: "{{ bin_dir }}:{{ ansible_env.PATH }}"
   register: kubeadm_join_control_plane
   retries: 3
   throttle: 1

--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -165,7 +165,8 @@
   until: kubeadm_init is succeeded or "field is immutable" in kubeadm_init.stderr
   when: inventory_hostname == groups['kube-master']|first and not kubeadm_already_run.stat.exists
   failed_when: kubeadm_init.rc != 0 and "field is immutable" not in kubeadm_init.stderr
-  environment: '{{ proxy_disable_env | combine({"PATH": "{{ bin_dir }}:{{ ansible_env.PATH }}"}) }}'
+  environment:
+    PATH: "{{ bin_dir }}:{{ ansible_env.PATH }}"
   notify: Master | restart kubelet
 
 - name: set kubeadm certificate key
@@ -180,7 +181,6 @@
   shell: >-
     {{ bin_dir }}/kubeadm --kubeconfig /etc/kubernetes/admin.conf token delete {{ kubeadm_token }} || :;
     {{ bin_dir }}/kubeadm --kubeconfig /etc/kubernetes/admin.conf token create {{ kubeadm_token }}
-  environment: "{{ proxy_disable_env }}"
   changed_when: false
   when:
     - inventory_hostname == groups['kube-master']|first
@@ -191,7 +191,6 @@
 
 - name: Create kubeadm token for joining nodes with 24h expiration (default)
   command: "{{ bin_dir }}/kubeadm --kubeconfig /etc/kubernetes/admin.conf token create"
-  environment: "{{ proxy_disable_env }}"
   changed_when: false
   register: temp_token
   retries: 5

--- a/roles/kubernetes/control-plane/tasks/kubeadm-version.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-version.yml
@@ -1,7 +1,6 @@
 ---
 - name: Get the kubeadm version
   command: "{{ bin_dir }}/kubeadm version -o short"
-  environment: "{{ proxy_disable_env }}"
   register: kubeadm_output
   changed_when: false
 

--- a/roles/kubernetes/kubeadm/tasks/kubeadm_etcd_node.yml
+++ b/roles/kubernetes/kubeadm/tasks/kubeadm_etcd_node.yml
@@ -22,7 +22,6 @@
     {{ kubeadm_discovery_address }}
   args:
     creates: "{{ kube_cert_dir }}/apiserver-etcd-client.key"
-  environment: "{{ proxy_disable_env }}"
 
 - name: Delete unneeded certificates
   file:

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -42,7 +42,6 @@
 
 - name: Create kubeadm token for joining nodes with 24h expiration (default)
   command: "{{ bin_dir }}/kubeadm token create"
-  environment: "{{ proxy_disable_env }}"
   register: temp_token
   delegate_to: "{{ groups['kube-master'][0] }}"
   when: kubeadm_token is not defined
@@ -55,7 +54,6 @@
 
 - name: Get the kubeadm version
   command: "{{ bin_dir }}/kubeadm version -o short"
-  environment: "{{ proxy_disable_env }}"
   register: kubeadm_output
   changed_when: false
 
@@ -71,7 +69,8 @@
   when: not is_kube_master
 
 - name: Join to cluster if needed
-  environment: '{{ proxy_disable_env | combine({"PATH": "{{ bin_dir }}:{{ ansible_env.PATH }}:/sbin"}) }}'
+  environment:
+    PATH: "{{ bin_dir }}:{{ ansible_env.PATH }}:/sbin"
   when: not is_kube_master and (not kubelet_conf.stat.exists)
   block:
 

--- a/roles/kubernetes/node/tasks/kubelet.yml
+++ b/roles/kubernetes/node/tasks/kubelet.yml
@@ -8,7 +8,6 @@
 
 - name: Get the kubeadm version
   command: "{{ bin_dir }}/kubeadm version -o short"
-  environment: "{{ proxy_disable_env }}"
   register: kubeadm_output
   changed_when: false
 

--- a/scale.yml
+++ b/scale.yml
@@ -4,6 +4,7 @@
 
 - hosts: bastion[0]
   gather_facts: False
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - { role: bastion-ssh-config, tags: ["localhost", "bastion"] }
@@ -13,6 +14,7 @@
   strategy: linear
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   gather_facts: false
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - { role: bootstrap-os, tags: bootstrap-os }
@@ -25,6 +27,7 @@
   hosts: etcd
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - { role: etcd, tags: etcd, etcd_cluster_setup: false }
@@ -33,6 +36,7 @@
   hosts: kube-master[0]
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults, when: "not skip_downloads and download_run_once and not download_localhost" }
     - { role: kubernetes/preinstall, tags: preinstall, when: "not skip_downloads and download_run_once and not download_localhost" }
@@ -42,6 +46,7 @@
   hosts: kube-node
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes/preinstall, tags: preinstall }
@@ -53,12 +58,14 @@
   hosts: kube-node
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes/node, tags: node }
 
 - name: Upload control plane certs and retrieve encryption key
   hosts: kube-master | first
+  environment: "{{ proxy_disable_env }}"
   tags: kubeadm
   tasks:
     - name: include needed vars
@@ -81,6 +88,7 @@
   hosts: kube-node
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes/kubeadm, tags: kubeadm }

--- a/upgrade-cluster.yml
+++ b/upgrade-cluster.yml
@@ -4,6 +4,7 @@
 
 - hosts: bastion[0]
   gather_facts: False
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - { role: bastion-ssh-config, tags: ["localhost", "bastion"] }
@@ -12,6 +13,7 @@
   strategy: linear
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   gather_facts: false
+  environment: "{{ proxy_disable_env }}"
   vars:
     # Need to disable pipelining for bootstrap-os as some systems have requiretty in sudoers set, which makes pipelining
     # fail. bootstrap-os fixes this on these systems, so in later plays it can be enabled.
@@ -28,6 +30,7 @@
   hosts: kube-master[0]
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults, when: "not skip_downloads and download_run_once and not download_localhost"}
     - { role: kubernetes/preinstall, tags: preinstall, when: "not skip_downloads and download_run_once and not download_localhost" }
@@ -37,6 +40,7 @@
   hosts: k8s-cluster:etcd:calico-rr
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes/preinstall, tags: preinstall }
@@ -46,6 +50,7 @@
   hosts: etcd:calico-rr:!k8s-cluster
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   serial: "{{ serial | default('20%') }}"
   roles:
     - { role: kubespray-defaults }
@@ -54,6 +59,7 @@
 - hosts: etcd
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - role: etcd
@@ -66,6 +72,7 @@
 - hosts: k8s-cluster
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - role: etcd
@@ -79,6 +86,7 @@
   gather_facts: False
   hosts: kube-master
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   serial: 1
   roles:
     - { role: kubespray-defaults }
@@ -97,6 +105,7 @@
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   serial: "{{ serial | default('20%') }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes-apps/external_cloud_controller, tags: external-cloud-controller }
@@ -108,6 +117,7 @@
   hosts: kube-node:calico-rr:!kube-master
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   serial: "{{ serial | default('20%') }}"
   roles:
     - { role: kubespray-defaults }
@@ -121,6 +131,7 @@
 - hosts: kube-master[0]
   gather_facts: False
   any_errors_fatal: true
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes-apps/rotate_tokens, tags: rotate_tokens, when: "secret_changed|default(false)" }
@@ -129,6 +140,7 @@
 - hosts: calico-rr
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - { role: network_plugin/calico/rr, tags: network }
@@ -136,6 +148,7 @@
 - hosts: kube-master
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes-apps, tags: apps }
@@ -143,6 +156,7 @@
 - hosts: k8s-cluster
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes/preinstall, when: "dns_mode != 'none' and resolvconf_mode == 'host_resolvconf'", tags: resolvconf }


### PR DESCRIPTION
Since a790935d02dc2787f6de41695ec955dc49fc93b1 all proxy users
should be properly configured

Now when you have *_PROXY vars in your environment it can leads to failure
if NO_PROXY is not correct, or to persistent configuration changes
as seen with kubeadm in 1c5391dda78b43fc629320dd59f1234e81afb2ad

Instead of playing constant whack-a-bug, inject empty *_PROXY vars everywhere
at the play level, and override at the task level when needed

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Thisshould really work this time :)

**Does this PR introduce a user-facing change?**:
```release-note
Kubespray now ignores *_PROXY vars found in your environment and only uses proxy configuration from the inventory
```
