### PR TITLE
Update dashboard_enabled on sample

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s-cluster/addons.yml
@@ -1,7 +1,7 @@
 ---
 # Kubernetes dashboard
 # RBAC required. see docs/getting-started.md for access details.
-# dashboard_enabled: true
+# dashboard_enabled: false
 
 # Helm deployment
 helm_enabled: false


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Since https://github.com/kubernetes-sigs/kubespray/pull/6804 dashboard_enabled has been false by default.
However we forgot to update it on sample inventory and it made confusion.
This updates the sample inventory.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
