### PR TITLE
Rotate kubelet self-signed certificate

### DIFF
--- a/roles/kubernetes/node/templates/kubelet.service.j2
+++ b/roles/kubernetes/node/templates/kubelet.service.j2
@@ -11,6 +11,9 @@ Wants={{ container_manager }}.service
 [Service]
 User=root
 EnvironmentFile=-{{ kube_config_dir }}/kubelet.env
+{% if not kubelet_rotate_server_certificates %}
+ExecStartPre=-/usr/bin/rm -f /var/lib/kubelet/pki/kubelet.{crt,key}
+{% endif %}
 ExecStart={{ bin_dir }}/kubelet \
 		$KUBE_LOGTOSTDERR \
 		$KUBE_LOG_LEVEL \


### PR DESCRIPTION
Looking at k8s code I can only see code generating kubelet
self-signed cert but nothing rotating it.
https://github.com/kubernetes/kubernetes/blob/e7cc2117a02bc5c74a8235a2725834b1841c459e/cmd/kubelet/app/server.go#L985-L990

Just delete the cert and let kubelet recreate it

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/99418

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
kubelet.service systemd unit now deletes /var/lib/kubelet/pki/kubelet.{crt,key} on startup. This allow to rotate this self-signed certicate auto generated by kubelet on startup. 
```
