### PR TITLE
Add configmaps to local-path-provisioner CR

### DIFF
--- a/roles/kubernetes-apps/external_provisioner/local_path_provisioner/templates/local-path-storage-cr.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_path_provisioner/templates/local-path-storage-cr.yml.j2
@@ -5,7 +5,7 @@ metadata:
   name: local-path-provisioner-role
 rules:
 - apiGroups: [""]
-  resources: ["nodes", "persistentvolumeclaims"]
+  resources: ["nodes", "persistentvolumeclaims", "configmaps"]
   verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources: ["endpoints", "persistentvolumes", "pods"]


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
/kind bug

**What this PR does / why we need it**:
Fix forgotten resource in localpathprovisioner CR
cf https://github.com/rancher/local-path-provisioner/blob/874088575ce38ca3fab3ed774e731c1c3b571dc8/deploy/chart/templates/clusterrole.yaml#L10

**Which issue(s) this PR fixes**:
Fixes #7321

**Special notes for your reviewer**:
Following update in #7238

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
