### PR TITLE
Fixed: checking the correct value of use_localhost_as_kubeapi_loadbalancer

### DIFF
--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -461,7 +461,7 @@ apiserver_loadbalancer_domain_name: "lb-apiserver.kubernetes.local"
 kube_apiserver_global_endpoint: |-
   {% if loadbalancer_apiserver is defined -%}
       https://{{ apiserver_loadbalancer_domain_name }}:{{ loadbalancer_apiserver.port|default(kube_apiserver_port) }}
-  {%- elif use_localhost_as_kubeapi_loadbalancer is defined -%}
+  {%- elif use_localhost_as_kubeapi_loadbalancer|default(False)|bool -%}
       https://127.0.0.1:{{ kube_apiserver_port }}
   {%- else -%}
       https://{{ first_kube_master }}:{{ kube_apiserver_port }}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
Now use 127.0.0.1 as LB for kubeapi whenever use_localhost_as_kubeapi_loadbalancer is defined. This change will only allow 127.0.0.1 to be used when use_localhost_as_kubeapi_loadbalancer is true

**Which issue(s) this PR fixes:**
Fixes #7259

Special notes for your reviewer: