### PR TITLE
Fix recover-control-plane undefined 'proxy_disable_env' variable

### DIFF
--- a/recover-control-plane.yml
+++ b/recover-control-plane.yml
@@ -18,6 +18,7 @@
 - hosts: "{{ groups['kube-master'] | first }}"
   environment: "{{ proxy_disable_env }}"
   roles:
+    - { role: kubespray-defaults}
     - { role: recover_control_plane/control-plane }
 
 - include: cluster.yml


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix CI error with proxy variable
```
fatal: [instance-1]: FAILED! => {"msg": "The field 'environment' has an invalid value, which includes an undefined variable. The error was: 'proxy_disable_env' is undefined"}
```
https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/1057372700
https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/1057372694

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Running fine in unit tests
https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/1058725298
https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/1058725303

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
