### PR TITLE
Move centos7-crio CI job to centos8

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -42,12 +42,10 @@ packet_centos7-flannel-containerd-addons-ha:
   variables:
     MITOGEN_ENABLE: "true"
 
-packet_centos7-crio:
+packet_centos8-crio:
   extends: .packet_pr
   stage: deploy-part2
   when: on_success
-  variables:
-    MITOGEN_ENABLE: "true"
 
 packet_ubuntu18-crio:
   extends: .packet_pr

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -24,8 +24,8 @@ ubuntu20 |  :white_check_mark: | :x: | :x: | :white_check_mark: | :x: | :x: | :x
 | OS / CNI | calico | canal | cilium | flannel | kube-ovn | kube-router | macvlan | ovn4nfv | weave |
 |---| --- | --- | --- | --- | --- | --- | --- | --- | --- |
 amazon |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
-centos7 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
-centos8 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
+centos7 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
+centos8 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian10 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian9 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 fedora32 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |

--- a/tests/files/packet_centos8-calico.yml
+++ b/tests/files/packet_centos8-calico.yml
@@ -12,5 +12,5 @@ dashboard_namespace: "kube-dashboard"
 dashboard_enabled: true
 loadbalancer_apiserver_type: haproxy
 
-# required / not autodetected for now
-calico_iptables_backend: "NFT"
+# required
+calico_iptables_backend: "Auto"

--- a/tests/files/packet_centos8-crio.yml
+++ b/tests/files/packet_centos8-crio.yml
@@ -1,6 +1,6 @@
 ---
 # Instance settings
-cloud_image: centos-7
+cloud_image: centos-8
 mode: default
 
 # Kubespray settings
@@ -8,8 +8,8 @@ deploy_netchecker: true
 dns_min_replicas: 1
 container_manager: crio
 
-download_localhost: false
-download_run_once: true
-
 # CRI-O requirements
 etcd_deployment_type: host
+
+# required
+calico_iptables_backend: "Auto"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Move centos7 crio CI job to centos8

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
CRI-O are considering removing centos7 "support", CI is broken twice a week with centos7-crio, stop this madness.

**Does this PR introduce a user-facing change?**:
```release-note
Maybe warn users about centos7 and crio..
```
