### PR TITLE
Add nodeselector and tolerations for metallb

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s-cluster/addons.yml
@@ -132,6 +132,28 @@ cert_manager_enabled: false
 metallb_enabled: false
 # metallb_ip_range:
 #   - "10.5.0.50-10.5.0.99"
+# metallb_speaker_nodeselector:
+#   kubernetes.io/os: "linux"
+# metallb_controller_nodeselector:
+#   kubernetes.io/os: "linux"
+# metallb_speaker_tolerations:
+#   - key: "node-role.kubernetes.io/master"
+#     operator: "Equal"
+#     value: ""
+#     effect: "NoSchedule"
+#   - key: "node-role.kubernetes.io/control-plane"
+#     operator: "Equal"
+#     value: ""
+#     effect: "NoSchedule"
+# metallb_controller_tolerations:
+#   - key: "node-role.kubernetes.io/master"
+#     operator: "Equal"
+#     value: ""
+#     effect: "NoSchedule"
+#   - key: "node-role.kubernetes.io/control-plane"
+#     operator: "Equal"
+#     value: ""
+#     effect: "NoSchedule"
 # metallb_version: v0.9.5
 # metallb_protocol: "layer2"
 # metallb_port: "7472"

--- a/roles/kubernetes-apps/metallb/defaults/main.yml
+++ b/roles/kubernetes-apps/metallb/defaults/main.yml
@@ -8,5 +8,9 @@ metallb_limits_mem: "100Mi"
 metallb_peers: []
 metallb_speaker_nodeselector: {}
 metallb_controller_nodeselector: {}
-metallb_speaker_tolerations: []
+metallb_speaker_tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
 metallb_controller_tolerations: []

--- a/roles/kubernetes-apps/metallb/defaults/main.yml
+++ b/roles/kubernetes-apps/metallb/defaults/main.yml
@@ -6,3 +6,7 @@ metallb_port: "7472"
 metallb_limits_cpu: "100m"
 metallb_limits_mem: "100Mi"
 metallb_peers: []
+metallb_speaker_nodeselector: {}
+metallb_controller_nodeselector: {}
+metallb_speaker_tolerations: []
+metallb_controller_tolerations: []

--- a/roles/kubernetes-apps/metallb/templates/metallb.yml.j2
+++ b/roles/kubernetes-apps/metallb/templates/metallb.yml.j2
@@ -353,11 +353,6 @@ spec:
       tolerations:
         {{ metallb_speaker_tolerations | to_nice_yaml(indent=2) | indent(width=8) }}
 {% endif %}
-      # tolerations:
-      # - effect: NoSchedule
-      #   key: node-role.kubernetes.io/master
-      # - effect: NoSchedule
-      #   key: node-role.kubernetes.io/control-plane
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/roles/kubernetes-apps/metallb/templates/metallb.yml.j2
+++ b/roles/kubernetes-apps/metallb/templates/metallb.yml.j2
@@ -345,11 +345,19 @@ spec:
         kubernetes.io/os: linux
       serviceAccountName: speaker
       terminationGracePeriodSeconds: 2
+{% if metallb_speaker_nodeselector %}
+      nodeSelector:
+        {{ metallb_speaker_nodeselector | to_nice_yaml | indent(width=8) }}
+{%- endif %}
+{% if metallb_speaker_tolerations %}
       tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
+        {{ metallb_speaker_tolerations | to_nice_yaml(indent=2) | indent(width=8) }}
+{% endif %}
+      # tolerations:
+      # - effect: NoSchedule
+      #   key: node-role.kubernetes.io/master
+      # - effect: NoSchedule
+      #   key: node-role.kubernetes.io/control-plane
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -374,6 +382,14 @@ spec:
         app: metallb
         component: controller
     spec:
+{% if metallb_controller_nodeselector %}
+      nodeSelector:
+        {{ metallb_controller_nodeselector | to_nice_yaml | indent(width=8) }}
+{%- endif %}
+{% if metallb_controller_tolerations %}
+      tolerations:
+        {{ metallb_controller_tolerations | to_nice_yaml(indent=2) | indent(width=8) }}
+{% endif %}
       containers:
       - args:
         - --port={{ metallb_port }}


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
This PR introduces variables to set `tolerations` and `nodeSelector` for metallb components (`controller` and `speaker`).
Variables are:
- `metallb_speaker_nodeselector`
- `metallb_controller_nodeselector`
- `metallb_speaker_tolerations`
- `metallb_controller_tolerations`


**Which issue(s) this PR fixes**:
Fixes #6806 

**Special notes for your reviewer**:
Followed the same logic as the ingress_nginx addon, e.g. #3742

**Does this PR introduce a user-facing change?**:

```release-note
Introduces optional `tolerations` and `nodeSelector` for metallb components (`controller` and `speaker`).
```
