### PR TITLE
exoscale: Rework EIP access from workers

### DIFF
--- a/contrib/terraform/exoscale/modules/kubernetes-cluster/templates/cloud-init.tmpl
+++ b/contrib/terraform/exoscale/modules/kubernetes-cluster/templates/cloud-init.tmpl
@@ -26,16 +26,25 @@ write_files:
         ethernets:
           eth1:
             dhcp4: true
-runcmd:
-  - netplan apply
-  - /sbin/sysctl net.ipv4.conf.all.forwarding=1
 %{ if node_type == "worker" }
   # TODO: When a VM is seen as healthy and is added to the EIP loadbalancer
   #       pool it no longer can send traffic back to itself via the EIP IP
   #       address.
   #       Remove this if it ever gets solved.
-  - iptables -t nat -A PREROUTING -d ${eip_ip_address} -j DNAT --to 127.0.0.1
+  - path: /etc/netplan/20-eip-fix.yaml
+    content: |
+      network:
+        version: 2
+        ethernets:
+          "lo:0":
+            match:
+              name: lo
+            dhcp4: false
+            addresses:
+            - ${eip_ip_address}/32
 %{ endif }
+runcmd:
+  - netplan apply
 %{ if node_local_partition_size > 0 }
   - mkdir -p /mnt/disks/node-local-storage
   - chown nobody:nogroup /mnt/disks/node-local-storage


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Context: Load-balancing in Exoscale is performed by associating many
workers with the same EIP. This works, however, the workers cannot access
themselves via the EIP, which is needed at least for cert-managers
"self-test".

Problem: The old iptables based workaround felt fragile and disappointed
me at least once.

New solution: Add the EIP to a loopback interface on each worker.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Exoscale EIP "workers see themselves" is reworked. If you had issues, you will need to re-apply the Terraform scripts, reboot the worker nodes and re-run cloud-init.
```
