### PR TITLE
Stop using kubeadm to update server in kubeconfigs

### DIFF
--- a/roles/kubernetes/control-plane/tasks/kubeadm-fix-apiserver.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-fix-apiserver.yml
@@ -1,34 +1,11 @@
 ---
-- name: Test if correct apiserver is set in all kubeconfigs
-  shell: >-
-    grep -Fq "{{ kube_apiserver_endpoint }}" {{ kube_config_dir }}/admin.conf &&
-    grep -Fq "{{ kube_apiserver_endpoint }}" {{ kube_config_dir }}/controller-manager.conf &&
-    grep -Fq "{{ kube_apiserver_endpoint }}" {{ kube_config_dir }}/kubelet.conf &&
-    grep -Fq "{{ kube_apiserver_endpoint }}" {{ kube_config_dir }}/scheduler.conf
-  register: kubeconfig_correct_apiserver
-  changed_when: False
-  failed_when: False
 
-- name: Create temporary directory
-  tempfile:
-    state: directory
-  register: kubeconfig_temp_dir
-  when: kubeconfig_correct_apiserver.rc != 0
-
-- name: Generate new kubeconfigs with correct apiserver
-  command: >-
-    {{ bin_dir }}/kubeadm init phase kubeconfig all
-    --config {{ kube_config_dir }}/kubeadm-config.yaml
-    --kubeconfig-dir {{ kubeconfig_temp_dir.path }}
-  when: kubeconfig_correct_apiserver.rc != 0
-
-- name: Copy new kubeconfigs to kube config dir
-  copy:
-    src: "{{ kubeconfig_temp_dir.path }}/{{ item }}"
+- name: Update server field in component kubeconfigs
+  lineinfile:
     dest: "{{ kube_config_dir }}/{{ item }}"
-    mode: 0640
-    remote_src: yes
-  when: kubeconfig_correct_apiserver.rc != 0
+    regexp: '^    server: https'
+    line: '    server: {{ kube_apiserver_endpoint }}'
+    backup: yes
   with_items:
     - admin.conf
     - controller-manager.conf
@@ -38,9 +15,3 @@
     - "Master | Restart kube-controller-manager"
     - "Master | Restart kube-scheduler"
     - "Master | reload kubelet"
-
-- name: Cleanup temporary directory
-  file:
-    path: "{{ kubeconfig_temp_dir.path }}"
-    state: absent
-  when: kubeconfig_correct_apiserver.rc != 0


### PR DESCRIPTION
Using `kubeadm init phase kubeconfig all` breaks kubelet client certificate rotation
as we are missing `kubeadm init phase kubelet-finalize all` to point to `kubelet-client-current.pem`

kubeconfig format is stable so let's just use lineinfile,
this will avoid other future breakage

This revert to the logic before 6fe2248314fb319563a60ae023b552371e34e148

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/99645

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fix kubelet client certificate rotation
```
