### PR TITLE
Add privileged_without_host_devices support

### DIFF
--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -65,6 +65,7 @@ containerd_default_runtime:
 #     type: io.containerd.kata.v2
 #     engine: ""
 #     root: ""
+#     privileged_without_host_devices: true
 containerd_runtimes: []
 
 containerd_untrusted_runtime_type: ''

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -42,6 +42,7 @@ disabled_plugins = ["restart"]
   runtime_type = "{{ containerd_default_runtime.type }}"
   runtime_engine = "{{ containerd_default_runtime.engine }}"
   runtime_root = "{{ containerd_default_runtime.root }}"
+  privileged_without_host_devices = {{ containerd_default_runtime.privileged_without_host_devices|default(false)|lower }}
 
 {% if kata_containers_enabled %}
 [plugins.cri.containerd.runtimes.kata-qemu]
@@ -55,6 +56,7 @@ disabled_plugins = ["restart"]
   runtime_type = "{{ runtime.type }}"
   runtime_engine = "{{ runtime.engine }}"
   runtime_root = "{{ runtime.root }}"
+  privileged_without_host_devices = {{ runtime.privileged_without_host_devices|default(false)|lower }}
 {% endfor %}
 
 [plugins.cri.containerd.untrusted_workload_runtime]

--- a/roles/container-engine/cri-o/templates/crio.conf.j2
+++ b/roles/container-engine/cri-o/templates/crio.conf.j2
@@ -293,6 +293,7 @@ pinns_path = ""
 runtime_path = "{{ runtime.path }}"
 runtime_type = "{{ runtime.type }}"
 runtime_root = "{{ runtime.root }}"
+privileged_without_host_devices = {{ runtime.privileged_without_host_devices|default(false)|lower }}
 {% endfor %}
 
 # Kata Containers with the Firecracker VMM


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
The `privileged_without_host_devices` container managers' flag prevents host devices from being passed to privileged containers.

More information:
* [CRI-O](https://github.com/containerd/cri/pull/1225)
* [ContainerD](https://github.com/cri-o/cri-o/commit/1d0f68156ba382651c776a44f156614c4fcf981d)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
This requires to use `crio` and/or `containerd` as container manager

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
