### PR TITLE
Fixup kubelet.conf to point to kubelet-client-current.pem

### DIFF
--- a/roles/kubernetes/control-plane/tasks/kubelet-fix-client-cert-rotation.yml
+++ b/roles/kubernetes/control-plane/tasks/kubelet-fix-client-cert-rotation.yml
@@ -1,0 +1,18 @@
+---
+- name: Fixup kubelet client cert rotation 1/2
+  lineinfile:
+    path: "{{ kube_config_dir }}/kubelet.conf"
+    regexp: '^    client-certificate-data: '
+    line: '    client-certificate: /var/lib/kubelet/pki/kubelet-client-current.pem'
+    backup: yes
+  notify:
+    - "Master | reload kubelet"
+
+- name: Fixup kubelet client cert rotation 2/2
+  lineinfile:
+    path: "{{ kube_config_dir }}/kubelet.conf"
+    regexp: '^    client-key-data: '
+    line: '    client-key: /var/lib/kubelet/pki/kubelet-client-current.pem'
+    backup: yes
+  notify:
+    - "Master | reload kubelet"

--- a/roles/kubernetes/control-plane/tasks/main.yml
+++ b/roles/kubernetes/control-plane/tasks/main.yml
@@ -62,3 +62,7 @@
 
 - name: Include kubeadm secondary server apiserver fixes
   include_tasks: kubeadm-fix-apiserver.yml
+
+- name: Include kubelet client cert rotation fixes
+  include_tasks: kubelet-fix-client-cert-rotation.yml
+  when: kubelet_rotate_certificates


### PR DESCRIPTION
c9c0c01de019e502b2e73e6fd65e9bf52e063bb6 only fix the problem for new clusters

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #7338

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fix kubelet client certificate rotation
```
