### PR TITLE
Download crun using download_file.yml

### DIFF
--- a/roles/container-engine/crun/defaults/main.yml
+++ b/roles/container-engine/crun/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-crun_version: 0.18
+
 crun_bin_dir: /usr/bin/

--- a/roles/container-engine/crun/defaults/main.yml
+++ b/roles/container-engine/crun/defaults/main.yml
@@ -1,5 +1,3 @@
 ---
-
 crun_version: 0.18
-crun_release_url: https://github.com/containers/crun/releases/download/{{ crun_version }}/crun-{{ crun_version }}-linux-{{ host_architecture }}
 crun_bin_dir: /usr/bin/

--- a/roles/container-engine/crun/tasks/main.yml
+++ b/roles/container-engine/crun/tasks/main.yml
@@ -1,24 +1,5 @@
 ---
-
-- name: Create binary destination folder
-  file:
-    mode: '0755'
-    state: directory
-    path: "{{ crun_bin_dir }}"
-
-- name: Check if binary exists
-  stat:
-    path: "{{ crun_bin_dir }}/crun"
-    get_attributes: no
-    get_checksum: no
-    get_mime: no
-  register: crun_stat
-
-# TODO: use download_file.yml
-- name: Download binary
-  get_url:
-    url: "{{ crun_release_url }}"
-    dest: "{{ crun_bin_dir }}/crun"
-    mode: '0755'
-  when: not crun_stat.stat.exists
-  environment: "{{ proxy_env }}"
+- name: crun | Download crun binary
+  include_tasks: "../../../download/tasks/download_file.yml"
+  vars:
+    download: "{{ download_defaults | combine(downloads.crun) }}"

--- a/roles/container-engine/crun/tasks/main.yml
+++ b/roles/container-engine/crun/tasks/main.yml
@@ -3,3 +3,10 @@
   include_tasks: "../../../download/tasks/download_file.yml"
   vars:
     download: "{{ download_defaults | combine(downloads.crun) }}"
+
+- name: Copy crun binary from download dir
+  copy:
+    src: "{{ local_release_dir }}/crun"
+    dest: "{{ crun_bin_dir }}/crun"
+    mode: 0755
+    remote_src: true

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -100,6 +100,7 @@ cni_download_url: "https://github.com/containernetworking/plugins/releases/downl
 calicoctl_download_url: "https://github.com/projectcalico/calicoctl/releases/download/{{ calico_ctl_version }}/calicoctl-linux-{{ image_arch }}"
 crictl_download_url: "https://github.com/kubernetes-sigs/cri-tools/releases/download/{{ crictl_version }}/crictl-{{ crictl_version }}-{{ ansible_system | lower }}-{{ image_arch }}.tar.gz"
 helm_download_url: "https://get.helm.sh/helm-{{ helm_version }}-linux-{{ image_arch }}.tar.gz"
+crun_download_url: "https://github.com/containers/crun/releases/download/{{ crun_version }}/crun-{{ crun_version }}-linux-{{ image_arch }}"
 
 crictl_checksums:
   arm:
@@ -435,6 +436,17 @@ helm_archive_checksums:
     v3.5.1: d0ada80576f8016d1cc38a06d225a4379a53e88e3e26b417e6de5db05a090ce4
     v3.5.2: 126a72e2b209194fd2735861f0cf8bd5b5d1386eedd6aed6e0e050dca80d493e
 
+crun_checksums:
+  arm: 0
+  amd64:
+    v0.16: a16508a9c15a2aa898d6ba18bbc394cd37cdb4e3968f177f2fbb7b70a8a0f4fb
+    v0.17: af99d543a41c5ef441e9e653b60392e8d6988a56762819a6959031e3154e94c1
+    v0.18: e94578c013eae98b0a50477f6bc77963a7c85145bf280da39f9855d69d9cab53
+  arm64:
+    v0.16: 0
+    v0.17: 0
+    v0.18: e580157bc8f87114a2f1d8ac28f8a7c4a588dfa21969fc99f78919cb9bf3ed0a
+
 etcd_binary_checksum: "{{ etcd_binary_checksums[image_arch] }}"
 cni_binary_checksum: "{{ cni_binary_checksums[image_arch] }}"
 kubelet_binary_checksum: "{{ kubelet_checksums[image_arch][kube_version] }}"
@@ -443,6 +455,7 @@ kubeadm_binary_checksum: "{{ kubeadm_checksums[image_arch][kubeadm_version] }}"
 calicoctl_binary_checksum: "{{ calicoctl_binary_checksums[image_arch][calico_ctl_version] }}"
 crictl_binary_checksum: "{{ crictl_checksums[image_arch][crictl_version] }}"
 helm_archive_checksum: "{{ helm_archive_checksums[image_arch][helm_version] }}"
+crun_binary_checksum: "{{ crun_checksums[image_arch][crun_version] }}"
 
 # Containers
 # In some cases, we need a way to set --registry-mirror or --insecure-registry for docker,

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -51,6 +51,7 @@ image_arch: "{{host_architecture | default('amd64')}}"
 # Versions
 kubeadm_version: "{{ kube_version }}"
 etcd_version: v3.4.13
+crun_version: 0.18
 
 # gcr and kubernetes image repo define
 gcr_image_repo: "gcr.io"

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -439,13 +439,13 @@ helm_archive_checksums:
 crun_checksums:
   arm: 0
   amd64:
-    v0.16: a16508a9c15a2aa898d6ba18bbc394cd37cdb4e3968f177f2fbb7b70a8a0f4fb
-    v0.17: af99d543a41c5ef441e9e653b60392e8d6988a56762819a6959031e3154e94c1
-    v0.18: e94578c013eae98b0a50477f6bc77963a7c85145bf280da39f9855d69d9cab53
+    0.16: a16508a9c15a2aa898d6ba18bbc394cd37cdb4e3968f177f2fbb7b70a8a0f4fb
+    0.17: af99d543a41c5ef441e9e653b60392e8d6988a56762819a6959031e3154e94c1
+    0.18: e94578c013eae98b0a50477f6bc77963a7c85145bf280da39f9855d69d9cab53
   arm64:
-    v0.16: 0
-    v0.17: 0
-    v0.18: e580157bc8f87114a2f1d8ac28f8a7c4a588dfa21969fc99f78919cb9bf3ed0a
+    0.16: 0
+    0.17: 0
+    0.18: e580157bc8f87114a2f1d8ac28f8a7c4a588dfa21969fc99f78919cb9bf3ed0a
 
 etcd_binary_checksum: "{{ etcd_binary_checksums[image_arch] }}"
 cni_binary_checksum: "{{ cni_binary_checksums[image_arch] }}"

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -710,6 +710,19 @@ downloads:
     groups:
     - k8s-cluster
 
+  crun:
+    file: true
+    enabled: "{{ crun_enabled }}"
+    version: "{{ crun_version }}"
+    dest: "{{crun_bin_dir}}/crun"
+    sha256: "{{ crun_binary_checksum }}"
+    url: "{{ crun_download_url }}"
+    unarchive: false
+    owner: "root"
+    mode: "0755"
+    groups:
+    - k8s-cluster
+
   cilium:
     enabled: "{{ kube_network_plugin == 'cilium' or cilium_deploy_additionally | default(false) | bool }}"
     container: true

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -715,7 +715,7 @@ downloads:
     file: true
     enabled: "{{ crun_enabled }}"
     version: "{{ crun_version }}"
-    dest: "{{crun_bin_dir}}/crun"
+    dest: "{{ local_release_dir }}/crun"
     sha256: "{{ crun_binary_checksum }}"
     url: "{{ crun_download_url }}"
     unarchive: false


### PR DESCRIPTION
**What type of PR is this?**

 /kind feature

**What this PR does / why we need it**:

It is needed to standardize the download process. It also is marked as a [TODO](https://github.com/kubernetes-sigs/kubespray/blob/master/roles/container-engine/crun/tasks/main.yml#L17) item.

**Which issue(s) this PR fixes**:

Fixes #7345

**Special notes for your reviewer**:

The versioning format is up for consideration. The versions of other software downloaded with download_file.yml start with 'v' meanwhile crun does not. There are three options here:
- Use the native versioning. `crun_version: 0.18`
- Use the native versioning for the variable, prepend 'v' in `roles/download/defaults/main.yml`. This is achievable with a filter. `crun_binary_checksum: "{{ crun_checksums[image_arch]['v' + (crun_version|string)] }}"`
- Use prepended version. `crun_version: v0.18` This is the dirtiest option, download URL requires native versioning.

I have decided to use the native versioning. It is possible to switch between different options with ease.

**Does this PR introduce a user-facing change?**

"crun_release_url" variable  is replaced with "crun_download_url" 

```release-note
- Replaced the download URL of Crun. "crun_release_url" - > "crun_download_url" 
```
