### PR TITLE
Fixup one more missing kubespray-defaults

### DIFF
--- a/scale.yml
+++ b/scale.yml
@@ -68,6 +68,8 @@
   environment: "{{ proxy_disable_env }}"
   gather_facts: False
   tags: kubeadm
+  roles:
+    - { role: kubespray-defaults }
   tasks:
     - name: include needed vars
       include_vars: roles/kubespray-defaults/defaults/main.yaml


### PR DESCRIPTION
"The error was: 'proxy_disable_env' is undefined\n\nThe error appears to
be in '<censored>scale.yml': line 72, column 7"

Fixes 067db686f6e8149b7a94d43d74f89e55595a95ad

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #7309 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
