### PR TITLE
Add most_recent = true while retrieving the latest image

### DIFF
--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -1,10 +1,12 @@
 data "openstack_images_image_v2" "vm_image" {
   count = var.image_uuid == "" ? 1 : 0
+  most_recent = true
   name = var.image
 }
 
 data "openstack_images_image_v2" "gfs_image" {
   count = var.image_gfs_uuid == "" ? var.image_uuid == "" ? 1 : 0 : 0
+  most_recent = true
   name = var.image_gfs == "" ? var.image : var.image_gfs
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
> Right now incase of duplicate images with the same names, the compute module is failing. However, terraform supports most_recent = true to retrieve the latest image from Glance API incase of duplicate images. No impact to the current model as it still works if there are no duplicate images.

From #6941

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Porting of #6941

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
