### PR TITLE
Change default OCCM internal and public networks variables to empty lists

### DIFF
--- a/docs/openstack.md
+++ b/docs/openstack.md
@@ -118,10 +118,8 @@ The new cloud provider is configured to have Octavia by default in Kubespray.
 
   ```yaml
   external_openstack_network_ipv6_disabled: false
-  external_openstack_network_internal_networks:
-  - ""
-  external_openstack_network_public_networks:
-  - ""
+  external_openstack_network_internal_networks: []
+  external_openstack_network_public_networks: []
   ```
 
 - You can override the default OpenStack metadata configuration (see [#6338](https://github.com/kubernetes-sigs/kubespray/issues/6338) for explanation):

--- a/inventory/sample/group_vars/all/openstack.yml
+++ b/inventory/sample/group_vars/all/openstack.yml
@@ -29,10 +29,8 @@
 # external_openstack_lbaas_manage_security_groups: false
 # external_openstack_lbaas_internal_lb: false
 # external_openstack_network_ipv6_disabled: false
-# external_openstack_network_internal_networks:
-#   - ""
-# external_openstack_network_public_networks:
-#   - ""
+# external_openstack_network_internal_networks: []
+# external_openstack_network_public_networks: []
 # external_openstack_metadata_search_order: "configDrive,metadataService"
 
 ## Application credentials to authenticate against Keystone API

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -387,10 +387,8 @@ external_openstack_lbaas_monitor_timeout: "30s"
 external_openstack_lbaas_monitor_max_retries: "3"
 external_openstack_network_ipv6_disabled: false
 external_openstack_lbaas_use_octavia: false
-external_openstack_network_internal_networks:
-- ""
-external_openstack_network_public_networks:
-- ""
+external_openstack_network_internal_networks: []
+external_openstack_network_public_networks: []
 
 ## List of authorization modes that must be configured for
 ## the k8s cluster. Only 'AlwaysAllow', 'AlwaysDeny', 'Node' and


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Change the defaults of the following variables:
```
external_openstack_network_internal_networks:
- ""
external_openstack_network_public_networks:
- ""
```
to
```
external_openstack_network_internal_networks: []
external_openstack_network_public_networks: []
```

to mitigate an off-by-one kind of problem when the OCCM (OpenStack Cloud Controller Manager), during node initialization, logs an error and leaving the nodes uninitialized. This happens when you don't want to specify any networks as internal or public and the defaults still adds an element of empty string. Further down the line, in the OCCM, a certain if-condition never evaluates since the resulting `[]string` slice data types are of `len() == 1`.

**Which issue(s) this PR fixes**:

Fixes #7379

**Special notes for your reviewer**:
As i mentioned in the issue, there's work to be done in the OCCM project, i can create an issue there to start with.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
