### PR TITLE
fix removing (worker) nodes

### DIFF
--- a/roles/remove-node/pre-remove/tasks/main.yml
+++ b/roles/remove-node/pre-remove/tasks/main.yml
@@ -3,9 +3,13 @@
   set_fact:
     nodes_to_drain: []
 
+- name: Make sure jq is installed
+  package:
+    name: jq
+    state: present
+
 - name: remove-node | Identify nodes to drain, ignore non-cluster nodes
   shell: |
-    set -o pipefail
     {{ bin_dir }}/kubectl get nodes -o json \
                   | jq .items[].metadata.name \
                   | jq "select(. | test(\"^{{ hostvars[item]['kube_override_hostname']|default(item) }}$\"))"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue with a missing dependency on jq when removing nodes, as well as fixing the syntax that has produced the following error:

`failed: [control-plane-2] (item=worker-2) => {"ansible_loop_var": "item", "changed": false, "cmd": "set -o pipefail\n/usr/local/bin/kubectl get nodes -o json              | jq .items[].metadata.name              | jq \"select(. | test(\\\"^worker-2$\\\"))\"\n", "delta": "0:00:00.009442", "end": "2021-03-21 18:24:49.586123", "item": "worker-2", "msg": "non-zero return code", "rc": 2, "start": "2021-03-21 18:24:49.576681", "stderr": "/bin/sh: 1: set: Illegal option -o pipefail", "stderr_lines": ["/bin/sh: 1: set: Illegal option -o pipefail"], "stdout": "", "stdout_lines": []}`
