### PR TITLE
specify runAsGroup, allow safe sysctls by default

### DIFF
--- a/roles/kubernetes-apps/cluster_roles/defaults/main.yml
+++ b/roles/kubernetes-apps/cluster_roles/defaults/main.yml
@@ -19,6 +19,11 @@ podsecuritypolicy_restricted_spec:
     rule: 'MustRunAsNonRoot'
   seLinux:
     rule: 'RunAsAny'
+  runAsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
   supplementalGroups:
     rule: 'MustRunAs'
     ranges:
@@ -30,8 +35,6 @@ podsecuritypolicy_restricted_spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
-  forbiddenSysctls:
-    - '*'
 
 podsecuritypolicy_privileged_spec:
   privileged: true
@@ -49,6 +52,8 @@ podsecuritypolicy_privileged_spec:
   runAsUser:
     rule: 'RunAsAny'
   seLinux:
+    rule: 'RunAsAny'
+  runAsGroup:
     rule: 'RunAsAny'
   supplementalGroups:
     rule: 'RunAsAny'


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Specification of runAsGroup was left out of the kubespray PSPs .  The restricted PSP did not apply any limit on runAsGroup, allowing processes to run with GID 0, which occurred by default.  Depending on file permissions in container images this could allow processes to read or write files in the root group which was probably not intended to happen in the restricted PSP.

Now runAsGroup will be specified the same way as fsgroup and supplemental groups, improving security and consistency.


Also: https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/#podsecuritypolicy
"By default, all safe sysctls are allowed."
So it is not necessary for the restricted PSP to block all sysctls. Kubespray should follow the default behaviour of Kubernetes, allowing safe sysctls by default.


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
Only if people relied on the (possibly unexpected) behaviour of processes running with  GID 0  but non-zero PID.
