### PR TITLE
Remove obsolete DNSSEC config management in bootstrap-debian.yml

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-debian.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-debian.yml
@@ -43,30 +43,6 @@
     - need_https_proxy.rc != 0
     - not skip_http_proxy_on_os_packages
 
-- name: Check Network Name Resolution configuration
-  raw: grep '^DNSSEC=allow-downgrade' /etc/systemd/resolved.conf
-  register: need_dnssec_allow_downgrade
-  failed_when: false
-  changed_when: false
-  # This command should always run, even in check mode
-  check_mode: false
-  when:
-    - '''UBUNTU_CODENAME=bionic'' in os_release.stdout_lines'
-
-- name: Change Network Name Resolution configuration
-  raw: sed -i 's/^DNSSEC=yes/DNSSEC=allow-downgrade/g' /etc/systemd/resolved.conf
-  become: true
-  when:
-    - '''UBUNTU_CODENAME=bionic'' in os_release.stdout_lines'
-    - need_dnssec_allow_downgrade.rc
-
-- name: Restart systemd-resolved service
-  raw: systemctl restart systemd-resolved
-  become: true
-  when:
-    - '''UBUNTU_CODENAME=bionic'' in os_release.stdout_lines'
-    - need_dnssec_allow_downgrade.rc
-
 - name: Install python3
   raw:
     apt-get update && \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

Currently the `roles/bootstrap-os/tasks/bootstrap-debian.yml` will reconfigure `/etc/systemd/resolved.conf` so that if
`^DNSSEC=allow-downgrade` is _not_ present it will subsequently run 
```
sed -i 's/^DNSSEC=yes/DNSSEC=allow-downgrade/g' /etc/systemd/resolved.conf
```
 using the `raw` module. 

Although the task is idempotent, this has the problem that if `^DNSSEC=no` is present, the line is not present at all or commented out, it will run `sed` regardless and reporting `CHANGED` on every run (even though sed doesn't actually make any changes). ~~This PR improves the behaviour so that it will only run sed if `^DNSSEC=yes` _is_ present, and hence will skip the task if it is already in the correct state or on reruns of Ansible.~~

**Edit:** DNSSEC is off by default on ubuntu/bionic64 (18.04) as per resolved.conf(5). These tasks are artefacts of obsolete infra configuration, and no longer needed. This PR removes the DNSSEC config management tasks


**Which issue(s) this PR fixes**:
Fixes #7407

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
