### PR TITLE
Update cilium_ipsec_enabled check

### DIFF
--- a/roles/network_plugin/cilium/tasks/install.yml
+++ b/roles/network_plugin/cilium/tasks/install.yml
@@ -33,13 +33,14 @@
     - {name: cilium, file: cilium-config.yml, type: cm}
     - {name: cilium, file: cilium-crb.yml, type: clusterrolebinding}
     - {name: cilium, file: cilium-cr.yml, type: clusterrole}
-    - {name: cilium, file: cilium-secret.yml, type: secret, when: cilium_ipsec_enabled}
+    - {name: cilium, file: cilium-secret.yml, type: secret}
     - {name: cilium, file: cilium-ds.yml, type: ds}
     - {name: cilium, file: cilium-deploy.yml, type: deploy}
     - {name: cilium, file: cilium-sa.yml, type: sa}
   register: cilium_node_manifests
   when:
     - inventory_hostname in groups['kube_control_plane']
+    - item.file != "cilium-secret.yml" or (item.file == "cilium-secret.yml" and cilium_ipsec_enabled)
 
 - name: Cilium | Enable portmap addon
   template:


### PR DESCRIPTION
When attempting a fresh install without cilium_ipsec_enabled I ran
into the following error:

failed: [k8m01] (item={'name': 'cilium', 'file': 'cilium-secret.yml', 'type': 'secret', 'when': 'cilium_ipsec_enabled'}) =>
{"ansible_loop_var": "item", "changed": false, "item": {"file": "cilium-secret.yml", "name": "cilium", "type": "secret",
"when": "cilium_ipsec_enabled"},"msg": "AnsibleUndefinedVariable: 'cilium_ipsec_key' is undefined"}

Moving the when condition from the item level to the task level solved
the issue.
