### PR TITLE
Update cilium-operator clusterrole

### DIFF
--- a/roles/network_plugin/cilium/templates/cilium-cr.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-cr.yml.j2
@@ -66,8 +66,10 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
+  - create
   - get
   - list
+  - update
   - watch
 {% if cilium_version | regex_replace('v') is version('1.8', '>=') %}
   # For cilium-operator running in HA mode.


### PR DESCRIPTION
When upgrading cilium from 1.8.8 to 1.9.5 I ran into the following
error:

level=error msg="Unable to update CRD" error="customresourcedefinitions.apiextensions.k8s.io
\"ciliumnodes.cilium.io\" is forbidden: User \"system:serviceaccount:kube-system:cilium-operator\"
cannot update resource \"customresourcedefinitions\" in API group \"apiextensions.k8s.io\" at the
cluster scope" name=CiliumNode/v2 subsys=k8s

The fix was to add the update verb to the clusterrole. I also added
create to match the clusterrole created by the cilium helm chart.