### PR TITLE
Add cilium_ipam_mode variable

### DIFF
--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -54,3 +54,7 @@ cilium_native_routing_cidr: ""
 
 # IPsec based transparent encryption between nodes
 cilium_ipsec_enabled: false
+
+# IP address management mode for v1.9+.
+# https://docs.cilium.io/en/v1.9/concepts/networking/ipam/
+cilium_ipam_mode: kubernetes

--- a/roles/network_plugin/cilium/templates/cilium-config.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-config.yml.j2
@@ -162,3 +162,8 @@ data:
   ipsec-key-file: /etc/ipsec/keys
   encrypt-node: "false"
 {% endif %}
+
+  # IPAM settings
+{% if cilium_version | regex_replace('v') is version('1.9', '>=') %}
+  ipam: "{{ cilium_ipam_mode }}"
+{% endif %}

--- a/roles/network_plugin/cilium/templates/cilium-deploy.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-deploy.yml.j2
@@ -44,6 +44,7 @@ spec:
       containers:
         - args:
             - --debug=$(CILIUM_DEBUG)
+            - --config-dir=/tmp/cilium/config-map
             - --kvstore=etcd
             - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
           command:
@@ -142,6 +143,9 @@ spec:
             - mountPath: "{{cilium_cert_dir}}"
               name: etcd-secrets
               readOnly: true
+            - mountPath: /tmp/cilium/config-map
+              name: cilium-config-path
+              readOnly: true
       dnsPolicy: ClusterFirst
       priorityClassName: system-node-critical
       restartPolicy: Always
@@ -163,3 +167,6 @@ spec:
         - name: etcd-secrets
           hostPath:
             path: "{{cilium_cert_dir}}"
+        - configMap:
+            name: cilium-config
+          name: cilium-config-path


### PR DESCRIPTION
Starting with Cilium v1.9 the default ipam mode has changed to "Cluster
Scope". See:

https://docs.cilium.io/en/v1.9/concepts/networking/ipam/

With this ipam mode Cilium handles assigning subnets to nodes to use
for pod ip addresses. The default Kubespray deploy uses the Kube
Controller Manager for this (the --allocate-node-cidrs
kube-controller-manager flag is set). This makes the proper ipam mode
for kubespray using cilium v1.9+ "kubernetes".

Tested with Cilium 1.9.5.

This PR also mounts the cilium-config ConfigMap for this variable
to be read properly.
  
In the future we can probably remove the kvstore and kvstore-opt
Cilium Operator args since they can be in the ConfigMap. I will tackle
that after this merges.
