### PR TITLE
Update k8s-certs-renew.sh.j2

### DIFF
--- a/roles/kubernetes/control-plane/templates/k8s-certs-renew.sh.j2
+++ b/roles/kubernetes/control-plane/templates/k8s-certs-renew.sh.j2
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 echo "## Expiration before renewal ##"
-{{ bin_dir }}/kubeadm {{ 'alpha ' if kube_version is version('v1.20.0', '<') }}certs check-expiration
+{{ bin_dir }}/kubeadm {{ 'alpha ' if kube_version is version('v1.20.0', '<') else '' }}certs check-expiration
 
 echo "## Renewing certificates managed by kubeadm ##"
-{{ bin_dir }}/kubeadm {{ 'alpha ' if kube_version is version('v1.20.0', '<') }}certs renew all
+{{ bin_dir }}/kubeadm {{ 'alpha ' if kube_version is version('v1.20.0', '<') else '' }}certs renew all
 
 echo "## Restarting control plane pods managed by kubeadm ##"
 {% if container_manager == "docker" %}
@@ -20,4 +20,4 @@ echo "## Waiting for apiserver to be up again ##"
 until printf "" 2>>/dev/null >>/dev/tcp/127.0.0.1/6443; do sleep 1; done
 
 echo "## Expiration after renewal ##"
-{{ bin_dir }}/kubeadm {{ 'alpha ' if kube_version is version('v1.20.0', '<') }}certs check-expiration
+{{ bin_dir }}/kubeadm {{ 'alpha ' if kube_version is version('v1.20.0', '<') else '' }}certs check-expiration


### PR DESCRIPTION
fixes: fatal: [master1]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: the inline if-expression on line 23 evaluated to false and no else section was defined."}

introduced by: https://github.com/kubernetes-sigs/kubespray/commit/2d1597bf103a1b892b237fbae9dccffdca3ad374
if you run a cluster above 1.20.x ansible failed with the AnsibleUndefinedVariable


**What type of PR is this?**
/kind bug

