### PR TITLE
Update kata-containers to 1.12.1

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -52,7 +52,7 @@ image_arch: "{{host_architecture | default('amd64')}}"
 kubeadm_version: "{{ kube_version }}"
 etcd_version: v3.4.13
 crun_version: 0.18
-kata_containers_version: 1.11.3
+kata_containers_version: 1.12.1
 
 # gcr and kubernetes image repo define
 gcr_image_repo: "gcr.io"
@@ -478,10 +478,13 @@ crun_checksums:
 kata_containers_binary_checksums:
   arm:
     1.11.3: 0
+    1.12.1: 0
   amd64:
     1.11.3: edbee010e913de980ab104958d7a6fc8394ea069038ad8c6210db36620284364
+    1.12.1: 9b9c8e061dd77a4feb4ded8e5b175ad302edbd7b6be862fc39ee448631f160e4
   arm64:
     1.11.3: 0
+    1.12.1: 0
 
 etcd_binary_checksum: "{{ etcd_binary_checksums[image_arch] }}"
 cni_binary_checksum: "{{ cni_binary_checksums[image_arch] }}"


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
/kind feature

**What this PR does / why we need it**:
Update KataContainers to 1.12.1

**Special notes for your reviewer**:
This PR can be tested with Molecule using nested virutalization and Libvirt.

1. As first, configure KVM nested virtualization where Vagrant will be executed, following the KVM [documentantion](https://www.linux-kvm.org/page/Nested_Guests).
2. Run molecule inside KataContainers role:
```bash
cd roles/container-engine/kata-containers/
molecule test
```

**Does this PR introduce a user-facing change?**:
```release-note
Update kata-containers version to 1.12.1
```
