### PR TITLE
Remove old note related to offline installation

### DIFF
--- a/docs/offline-environment.md
+++ b/docs/offline-environment.md
@@ -110,5 +110,3 @@ If you use [Kubespray Container Image](#recommended-way:-kubespray-container-ima
 ```bash
 docker run --rm -it -v path_to_inventory/my_airgap_cluster:inventory/my_airgap_cluster myprivateregisry.com/kubespray/kubespray:v2.14.0 ansible-playbook -i inventory/my_airgap_cluster/hosts.yaml -b cluster.yml
 ```
-
-## Please Note: Offline installation doesn't support CRI-O container runtime at the moment (see [this issue](https://github.com/kubernetes-sigs/kubespray/issues/6233))


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind documentation

**What this PR does / why we need it**:

The PR https://github.com/kubernetes-sigs/kubespray/pull/6927 has been merged and the issue https://github.com/kubernetes-sigs/kubespray/issues/6233 was fixed.
This removes unnecessary note for the above PR.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
