### PR TITLE
Add contrib playbook to disable service firewall

### DIFF
--- a/contrib/os-services/os-services.yml
+++ b/contrib/os-services/os-services.yml
@@ -1,0 +1,4 @@
+---
+- hosts: all
+  roles:
+    - { role: prepare }

--- a/contrib/os-services/roles/prepare/defaults/main.yml
+++ b/contrib/os-services/roles/prepare/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+disable_service_firewall: false

--- a/contrib/os-services/roles/prepare/tasks/main.yml
+++ b/contrib/os-services/roles/prepare/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+- block:
+  - name: List services
+    service_facts:
+
+  - name: Disable service firewalld
+    systemd:
+      name: firewalld
+      state: stopped
+      enabled: no
+    when:
+      "'firewalld.service' in services"
+
+  - name: Disable service ufw
+    systemd:
+      name: ufw
+      state: stopped
+      enabled: no
+    when:
+      "'ufw.service' in services"
+
+  when:
+  - disable_service_firewall


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Basically we need to make necessary TCP/UDP ports open.
However the necessary ports are so many, and sometimes it is difficult to figure out that is due to firewall issues or not if facing deployment issues.
To distinguish a root problem on such situation, this adds a contrib playbook to disable the service firewall for Kubespray development and test.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The contrib playbook os-manage is added to disable service firewall for Kubespray development and test.
```
