### PR TITLE
Add documentation for audit webhook variables

### DIFF
--- a/docs/vars.md
+++ b/docs/vars.md
@@ -164,6 +164,14 @@ node_taints:
   * `audit_policy_file`: "{{ kube_config_dir }}/audit-policy/apiserver-audit-policy.yaml"
 
   By default, the `audit_policy_file` contains [default rules](https://github.com/kubernetes-sigs/kubespray/blob/master/roles/kubernetes/control-plane/templates/apiserver-audit-policy.yaml.j2) that can be overridden with the `audit_policy_custom_rules` variable.
+* *kubernetes_audit_webhook* - When set to `true`, enables the webhook audit backend.
+  The webhook parameters can be tuned via the following variables (which default values are shown below):
+  * `audit_webhook_config_file`: "{{ kube_config_dir }}/audit-policy/apiserver-audit-webhook-config.yaml"
+  * `audit_webhook_server_url`: "https://audit.app"
+  * `audit_webhook_server_extra_args`: {}
+  * `audit_webhook_mode`: batch
+  * `audit_webhook_batch_max_size`: 100
+  * `audit_webhook_batch_max_wait`
 
 ### Custom flags for Kube Components
 

--- a/docs/vars.md
+++ b/docs/vars.md
@@ -167,7 +167,7 @@ node_taints:
 * *kubernetes_audit_webhook* - When set to `true`, enables the webhook audit backend.
   The webhook parameters can be tuned via the following variables (which default values are shown below):
   * `audit_webhook_config_file`: "{{ kube_config_dir }}/audit-policy/apiserver-audit-webhook-config.yaml"
-  * `audit_webhook_server_url`: "https://audit.app"
+  * `audit_webhook_server_url`: `"https://audit.app"`
   * `audit_webhook_server_extra_args`: {}
   * `audit_webhook_mode`: batch
   * `audit_webhook_batch_max_size`: 100

--- a/docs/vars.md
+++ b/docs/vars.md
@@ -171,7 +171,7 @@ node_taints:
   * `audit_webhook_server_extra_args`: {}
   * `audit_webhook_mode`: batch
   * `audit_webhook_batch_max_size`: 100
-  * `audit_webhook_batch_max_wait`
+  * `audit_webhook_batch_max_wait`: 1s
 
 ### Custom flags for Kube Components
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind documentation

**What this PR does / why we need it**:
Variables for the audit webhooks are not present in the documentation. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
