### PR TITLE
Remove calico-rr from local inventory hosts file

### DIFF
--- a/inventory/local/hosts.ini
+++ b/inventory/local/hosts.ini
@@ -12,4 +12,3 @@ node1
 [k8s-cluster:children]
 kube-node
 kube_control_plane
-calico-rr


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Remove calico-rr from local inventory hosts file since calico-rr is not defined in this file.

**Does this PR introduce a user-facing change?**:
```release-note
None
```
