### PR TITLE
Fix CI template for etcd recover jobs (kube-master rename)

### DIFF
--- a/tests/cloud_playbooks/roles/packet-ci/templates/inventory.j2
+++ b/tests/cloud_playbooks/roles/packet-ci/templates/inventory.j2
@@ -73,7 +73,7 @@ instance-3
 instance-1
 instance-2
 
-[broken_kube-master]
+[broken_kube_control_plane]
 instance-2
 
 [broken_etcd]
@@ -97,7 +97,7 @@ instance-3
 instance-1
 instance-2
 
-[broken_kube-master]
+[broken_kube_control_plane]
 instance-1
 instance-2
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix missing occurence after merging https://github.com/kubernetes-sigs/kubespray/pull/7256

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Error in CI : https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/1122484969
```
fatal: [instance-1]: FAILED! => {"msg": "The conditional check 'groups['broken_kube_control_plane']' failed. The error was: error while evaluating conditional (groups['broken_kube_control_plane']): 'dict object' has no attribute 'broken_kube_control_plane'\n\nThe error appears to be in '/builds/kargo-ci/kubernetes-sigs-kubespray/roles/recover_control_plane/control-plane/tasks/main.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: Wait for apiserver\n  ^ here\n"}
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
