### PR TITLE
Fix cilium item loop with 'cilium_ipsec_enabled'

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -134,9 +134,9 @@ packet_ubuntu16-weave-sep:
   when: manual
 
 packet_ubuntu18-cilium-sep:
-  stage: deploy-special
+  stage: unit-tests
   extends: .packet_pr
-  when: manual
+  when: on_success
 
 packet_ubuntu18-flannel-containerd-ha:
   stage: deploy-part2

--- a/roles/network_plugin/cilium/tasks/install.yml
+++ b/roles/network_plugin/cilium/tasks/install.yml
@@ -40,6 +40,7 @@
   register: cilium_node_manifests
   when:
     - inventory_hostname in groups['kube_control_plane']
+    - item.when | default(true)
 
 - name: Cilium | Enable portmap addon
   template:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix CI error with cilium following #7342

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
CI error in nightly jobs https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/1152730075
```
failed: [instance-1] (item={'name': 'cilium', 'file': 'cilium-secret.yml', 'type': 'secret', 'when': 'cilium_ipsec_enabled'}) => {"ansible_loop_var": "item", "changed": false, "item": {"file": "cilium-secret.yml", "name": "cilium", "type": "secret", "when": "cilium_ipsec_enabled"}, "msg": "AnsibleUndefinedVariable: 'cilium_ipsec_key' is undefined"}
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
