### PR TITLE
Add condition for audit_webhook_mode batch

### DIFF
--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta2.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta2.yaml.j2
@@ -186,8 +186,10 @@ apiServer:
 {% if kubernetes_audit_webhook %}
     audit-webhook-config-file: {{ audit_webhook_config_file }}
     audit-webhook-mode: {{ audit_webhook_mode }}
+{% if audit_webhook_mode == "batch" %}
     audit-webhook-batch-max-size: "{{ audit_webhook_batch_max_size }}"
     audit-webhook-batch-max-wait: "{{ audit_webhook_batch_max_wait }}"
+{% endif %}
 {% endif %}
 {% for key in kube_kubeadm_apiserver_extra_args %}
     {{ key }}: "{{ kube_kubeadm_apiserver_extra_args[key] }}"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

According to the [document](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#batching), audit-webhook-batch-max-size and audit-webhook-batch-max-wait are used only in the batch mode.
This adds a condition to avoid unnecessary writting on the config.

This comes from a review process of https://github.com/kubernetes-sigs/kubespray/pull/7434

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
