### PR TITLE
kubeadm_feature_gates

### DIFF
--- a/docs/vars.md
+++ b/docs/vars.md
@@ -79,6 +79,8 @@ following default cluster parameters:
   OpenStack (default is unset)
 * *kube_feature_gates* - A list of key=value pairs that describe feature gates for
   alpha/experimental Kubernetes features. (defaults is `[]`)
+* *kubeadm_feature_gates* - A list of key=value pairs that describe feature gates for
+  alpha/experimental Kubeadm features. (defaults is `[]`)
 * *authorization_modes* - A list of [authorization mode](
 https://kubernetes.io/docs/admin/authorization/#using-flags-for-your-authorization-module)
   that the cluster should be configured for. Defaults to `['Node', 'RBAC']`

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta2.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta2.yaml.j2
@@ -90,9 +90,9 @@ networking:
   dnsDomain: {{ dns_domain }}
   serviceSubnet: "{{ kube_service_addresses }}{{ ',' + kube_service_addresses_ipv6 if enable_dual_stack_networks else '' }}"
   podSubnet: "{{ kube_pods_subnet }}{{ ',' + kube_pods_subnet_ipv6 if enable_dual_stack_networks else '' }}"
-{% if kube_feature_gates %}
+{% if kubeadm_feature_gates %}
 featureGates:
-{%   for feature in kube_feature_gates %}
+{%   for feature in kubeadm_feature_gates %}
   {{ feature|replace("=", ": ") }}
 {%   endfor %}
 {% endif %}

--- a/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
@@ -192,9 +192,17 @@
     kubelet_flexvolumes_plugins_dir: /var/lib/kubelet/volumeplugins
   when: not usr.stat.writeable
 
-- name: Ensure IPv6DualStack featureGate is set when enable_dual_stack_networks is true
-  set_fact:
-    kube_feature_gates: "{{ kube_feature_gates + [ 'IPv6DualStack=true' ] }}"
+- block:
+    - name: Ensure IPv6DualStack featureGate is set when enable_dual_stack_networks is true
+      set_fact:
+        kube_feature_gates: "{{ kube_feature_gates + [ 'IPv6DualStack=true' ] }}"
+      when:
+        - not 'IPv6DualStack=true' in kube_feature_gates
+
+    - name: Ensure IPv6DualStack kubeadm featureGate is set when enable_dual_stack_networks is true
+      set_fact:
+        kubeadm_feature_gates: "{{ kubeadm_feature_gates + [ 'IPv6DualStack=true' ] }}"
+      when:
+        - not 'IPv6DualStack=true' in kubeadm_feature_gates
   when:
     - enable_dual_stack_networks
-    - not 'IPv6DualStack=true' in kube_feature_gates

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -420,6 +420,7 @@ kubelet_protect_kernel_defaults: true
 ## List of key=value pairs that describe feature gates for
 ## the k8s cluster.
 kube_feature_gates: []
+kubeadm_feature_gates: []
 
 # Local volume provisioner storage classes
 # Levarages Ansibles string to Python datatype casting. Otherwise the dict_key isn't substituted


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
This introduces `kubeadm_feature_gates` to define featureGates in clusterconfiguration section of kubeadm-config.yaml in order not to interfere with `kube_feature_gates`.
Updates 0040-set_facts.yml when `enable_dual_stack_networks=true` 

**Which issue(s) this PR fixes**:
Fixes #7446

**Special notes for your reviewer**:
If featureGates key is supposed to handle every k8s feature gate, then this PR can be removed and we should wait for a fix in kubeadm.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
