### PR TITLE
Configure etcd data dir to correct owner and permissions

### DIFF
--- a/roles/etcd/tasks/configure.yml
+++ b/roles/etcd/tasks/configure.yml
@@ -164,3 +164,12 @@
   include_tasks: join_etcd-events_member.yml
   with_items: "{{ groups['etcd'] }}"
   when: inventory_hostname == item and etcd_events_cluster_setup and etcd_events_member_in_cluster.rc != 0 and etcd_events_cluster_is_healthy.rc == 0
+
+- name: Configure | Set etcd data dir permissions
+  file:
+    path: "{{ etcd_data_dir }}"
+    state: directory
+    recurse: yes
+    owner: etcd
+    group: etcd
+    mode: 0700


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Fix etcd data dir permissions and ownership

**Which issue(s) this PR fixes**:
Fixes #7450

**Special notes for your reviewer**:
Already done and reverted in https://github.com/kubernetes-sigs/kubespray/pull/1778
But I don't see why it was reverted 🤷 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
