### PR TITLE
Backport remove local lb privileged to release-2.15

### DIFF
--- a/roles/kubernetes/node/templates/manifests/haproxy.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/haproxy.manifest.j2
@@ -22,8 +22,6 @@ spec:
       requests:
         cpu: {{ loadbalancer_apiserver_cpu_requests }}
         memory: {{ loadbalancer_apiserver_memory_requests }}
-    securityContext:
-      privileged: true
     {% if loadbalancer_apiserver_healthcheck_port is defined -%}
     livenessProbe:
       httpGet:

--- a/roles/kubernetes/node/templates/manifests/nginx-proxy.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/nginx-proxy.manifest.j2
@@ -22,8 +22,6 @@ spec:
       requests:
         cpu: {{ loadbalancer_apiserver_cpu_requests }}
         memory: {{ loadbalancer_apiserver_memory_requests }}
-    securityContext:
-      privileged: true
     {% if loadbalancer_apiserver_healthcheck_port is defined -%}
     livenessProbe:
       httpGet:


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> 
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Backporting the PR that removed the local lb's privileged field to the 2.15 release branch


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7381

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
