### PR TITLE
Configure PKI directory and file to correct owner and permissions

### DIFF
--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -128,12 +128,38 @@
   tags:
     - kube-proxy
 
-- name: Set ca.crt file permission
+- name: Display paths of all .crt files in dir
+  debug: msg={{ lookup('fileglob', '{{ kube_cert_dir }}/*.crt') }}
+- name: Display paths of all .key files in dir
+  debug: msg={{ lookup('fileglob', '{{ kube_cert_dir }}/*.key') }}
+
+- name: Find PKI certificate files
+  find:
+    paths: "{{ kube_cert_dir }}"
+    patterns: "*.crt"
+  register: pki_certificate_files
+
+- name: Set PKI certificate files permission
   file:
-    path: "{{ kube_cert_dir }}/ca.crt"
+    path: "{{ item.path }}"
     owner: root
     group: root
-    mode: "0644"
+    mode: 0644
+  with_items: "{{ pki_certificate_files.files }}"
+
+- name: Find PKI key files
+  find:
+    paths: "{{ kube_cert_dir }}"
+    patterns: "*.key"
+  register: pki_key_files
+
+- name: Set PKI key files permission
+  file:
+    path: "{{ item.path }}"
+    owner: root
+    group: root
+    mode: 0600
+  with_items: "{{ pki_key_files.files }}"
 
 - name: Restart all kube-proxy pods to ensure that they load the new configmap
   command: "{{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf delete pod -n kube-system -l k8s-app=kube-proxy --force --grace-period=0"

--- a/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
+++ b/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
@@ -18,7 +18,6 @@
     - node
   with_items:
     - "{{ kube_config_dir }}"
-    - "{{ kube_cert_dir }}"
     - "{{ kube_manifest_dir }}"
     - "{{ kube_script_dir }}"
     - "{{ kubelet_flexvolumes_plugins_dir }}"
@@ -42,6 +41,7 @@
     - node
   with_items:
     - "{{ bin_dir }}"
+    - "{{ kube_cert_dir }}"
 
 - name: Check if kubernetes kubeadm compat cert dir exists
   stat:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Configure pki directory to root:root instead of kube:root
Change file permissions to 600 for *.key and 644 for *.crt

**Which issue(s) this PR fixes**:
Fixes #7451

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
