### PR TITLE
Move cilium kvstore settings to configmap

### DIFF
--- a/roles/network_plugin/cilium/templates/cilium-config.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-config.yml.j2
@@ -25,6 +25,11 @@ data:
     key-file: "{{ cilium_cert_dir }}/key.pem"
     cert-file: "{{ cilium_cert_dir }}/cert.crt"
 
+  # kvstore
+  # https://docs.cilium.io/en/latest/cmdref/kvstore/
+  kvstore: etcd
+  kvstore-opt: '{"etcd.config": "/var/lib/etcd-config/etcd.config"}'
+
   # If you want metrics enabled in all of your Cilium agents, set the port for
   # which the Cilium agents will have their metrics exposed.
   # This option deprecates the "prometheus-serve-addr" in the

--- a/roles/network_plugin/cilium/templates/cilium-deploy.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-deploy.yml.j2
@@ -45,8 +45,6 @@ spec:
         - args:
             - --debug=$(CILIUM_DEBUG)
             - --config-dir=/tmp/cilium/config-map
-            - --kvstore=etcd
-            - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
           command:
             - cilium-operator
           env:


### PR DESCRIPTION
This PR is to move the cilium kvstore options to the configmap
rather than specifying them in the deployment as args. This
is not technically necessary but keeping all the options in
one place is probably not a bad idea.

Tested with cilium 1.9.5.