### PR TITLE
Remove dead code from kubeadm-etcd

### DIFF
--- a/roles/kubernetes/control-plane/tasks/kubeadm-etcd.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-etcd.yml
@@ -12,20 +12,6 @@
   tags:
     - network
 
-- name: Ensure etcdctl binary is installed
-  include_tasks: "{{ role_path }}/../../etcd/tasks/install_host.yml"
-  vars:
-    etcd_cluster_setup: true
-  when: etcd_deployment_type == "host" and not etcd_kubeadm_enabled
-
-- name: Ensure etcdctl binary is installed
-  include_tasks: "{{ role_path }}/../../etcd/tasks/install_etcdctl_docker.yml"
-  vars:
-    etcd_cluster_setup: true
-    etcd_retries: 4
-  when:
-    - etcd_deployment_type == "docker" and not etcd_kubeadm_enabled
-
 - name: Ensure etcdctl script is installed
   import_role:
     name: etcdctl


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
kubeadm-etcd tasks are only triggered when `etcd_kubeadm_enabled` is true.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
