### PR TITLE
add CI test for auto_renew_certificates

### DIFF
--- a/roles/kubernetes/control-plane/templates/k8s-certs-renew.sh.j2
+++ b/roles/kubernetes/control-plane/templates/k8s-certs-renew.sh.j2
@@ -8,7 +8,7 @@ echo "## Renewing certificates managed by kubeadm ##"
 
 echo "## Restarting control plane pods managed by kubeadm ##"
 {% if container_manager == "docker" %}
-{{ docker_bin_dir }}/docker ps -af 'name=k8s_POD_(kube-apiserver|kube-controller-manager|kube-scheduler|etcd)-*' -q | /usr/bin/xargs {{ docker_bin_dir }}/docker rm -f"
+{{ docker_bin_dir }}/docker ps -af 'name=k8s_POD_(kube-apiserver|kube-controller-manager|kube-scheduler|etcd)-*' -q | /usr/bin/xargs {{ docker_bin_dir }}/docker rm -f
 {% else %}
 {{ bin_dir }}/crictl pods --namespace kube-system --name 'kube-scheduler-*|kube-controller-manager-*|kube-apiserver-*|etcd-*' -q | /usr/bin/xargs {{ bin_dir }}/crictl rmp -f
 {% endif %}

--- a/roles/kubernetes/control-plane/templates/k8s-certs-renew.timer.j2
+++ b/roles/kubernetes/control-plane/templates/k8s-certs-renew.timer.j2
@@ -3,7 +3,7 @@ Description=Timer to renew K8S control plane certificates
 
 [Timer]
 # First Monday of each month
-OnCalendar=Mon *-*-1..7 03:{{ groups['kube_control_plane'].index(inventory_hostname) }}0:00
+OnCalendar=Mon *-*-1,2,3,4,5,6,7 03:{{ groups['kube_control_plane'].index(inventory_hostname) }}0:00
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/files/packet_centos7-calico-ha-once-localhost.yml
+++ b/tests/files/packet_centos7-calico-ha-once-localhost.yml
@@ -13,3 +13,5 @@ typha_enabled: true
 calico_backend: kdd
 typha_secure: true
 disable_ipv6_dns: true
+
+auto_renew_certificates: true

--- a/tests/files/packet_centos7-calico-ha.yml
+++ b/tests/files/packet_centos7-calico-ha.yml
@@ -12,3 +12,5 @@ dns_min_replicas: 1
 typha_enabled: true
 calico_backend: kdd
 typha_secure: true
+
+auto_renew_certificates: true

--- a/tests/files/packet_centos8-crio.yml
+++ b/tests/files/packet_centos8-crio.yml
@@ -13,3 +13,5 @@ etcd_deployment_type: host
 
 # required
 calico_iptables_backend: "Auto"
+
+auto_renew_certificates: true

--- a/tests/files/packet_debian10-containerd.yml
+++ b/tests/files/packet_debian10-containerd.yml
@@ -14,3 +14,5 @@ helm_enabled: true
 # https://gitlab.com/miouge/kubespray-ci/-/blob/a4fd5ed6857807f1c353cb60848aedebaf7d2c94/manifests/http-proxy.yml#L42
 http_proxy: http://172.30.30.30:8888
 https_proxy: http://172.30.30.30:8888
+
+auto_renew_certificates: true

--- a/tests/files/packet_debian9-macvlan.yml
+++ b/tests/files/packet_debian9-macvlan.yml
@@ -10,3 +10,5 @@ enable_nodelocaldns: false
 dns_min_replicas: 1
 kube_proxy_masquerade_all: true
 macvlan_interface: "eth0"
+
+auto_renew_certificates: true

--- a/tests/files/packet_fedora33-calico.yml
+++ b/tests/files/packet_fedora33-calico.yml
@@ -10,3 +10,5 @@ kube_network_plugin: calico
 
 # Only docker package 20.10 for Fedora33
 docker_version: '20.10'
+
+auto_renew_certificates: true

--- a/tests/files/packet_opensuse-canal.yml
+++ b/tests/files/packet_opensuse-canal.yml
@@ -11,3 +11,5 @@ dns_min_replicas: 1
 
 # test Ambassador
 ingress_ambassador_enabled: true
+
+auto_renew_certificates: true

--- a/tests/files/packet_oracle7-canal-ha.yml
+++ b/tests/files/packet_oracle7-canal-ha.yml
@@ -9,3 +9,5 @@ kube_network_plugin: canal
 dynamic_kubelet_configuration: true
 deploy_netchecker: true
 dns_min_replicas: 1
+
+auto_renew_certificates: true

--- a/tests/files/packet_ubuntu16-weave-sep.yml
+++ b/tests/files/packet_ubuntu16-weave-sep.yml
@@ -7,3 +7,5 @@ mode: separate
 kube_network_plugin: weave
 deploy_netchecker: true
 dns_min_replicas: 1
+
+auto_renew_certificates: true

--- a/tests/files/packet_ubuntu18-cilium-sep.yml
+++ b/tests/files/packet_ubuntu18-cilium-sep.yml
@@ -8,3 +8,5 @@ kube_network_plugin: cilium
 deploy_netchecker: true
 enable_network_policy: true
 dns_min_replicas: 1
+
+auto_renew_certificates: true

--- a/tests/files/packet_ubuntu20-calico-aio.yml
+++ b/tests/files/packet_ubuntu20-calico-aio.yml
@@ -12,3 +12,5 @@ dns_min_replicas: 1
 # Currently ipvs not available on KVM: https://packages.ubuntu.com/search?suite=focal&arch=amd64&mode=exactfilename&searchon=contents&keywords=ip_vs_sh.ko
 kube_proxy_mode: iptables
 enable_nodelocaldns: False
+
+auto_renew_certificates: true


### PR DESCRIPTION
On Centos 7 timer unit fail with message

[/etc/systemd/system/k8s-certs-renew.timer:6] Failed to parse calendar specification, ignoring: `Mon *-*-1..7 03:00:00`
/kind bug

so. first add CI test,
next change cron to `Mon *-*-1,2,3,4,5,6,7 03:00:00`