### PR TITLE
Update Terraform/Vagrant + increase tf_ovh retries

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,6 +31,8 @@ variables:
   ANSIBLE_LOG_LEVEL: "-vv"
   RECOVER_CONTROL_PLANE_TEST: "false"
   RECOVER_CONTROL_PLANE_TEST_GROUPS: "etcd[2:],kube_control_plane[1:]"
+  TERRAFORM_14_VERSION: 0.14.10
+  TERRAFORM_13_VERSION: 0.13.6
 
 before_script:
   - ./tests/scripts/rebase.sh

--- a/.gitlab-ci/lint.yml
+++ b/.gitlab-ci/lint.yml
@@ -14,7 +14,7 @@ vagrant-validate:
   stage: unit-tests
   tags: [light]
   variables:
-    VAGRANT_VERSION: 2.2.14
+    VAGRANT_VERSION: 2.2.15
   script:
     - ./tests/scripts/vagrant-validate.sh
   except: ['triggers', 'master']

--- a/.gitlab-ci/terraform.yml
+++ b/.gitlab-ci/terraform.yml
@@ -53,113 +53,92 @@
     # Cleanup regardless of exit code
     - chronic ./tests/scripts/testcases_cleanup.sh
 
-tf-validate-openstack:
-  extends: .terraform_validate
-  variables:
-    TF_VERSION: 0.12.30
-    PROVIDER: openstack
-    CLUSTER: $CI_COMMIT_REF_NAME
-
-tf-validate-packet:
-  extends: .terraform_validate
-  variables:
-    TF_VERSION: 0.12.30
-    PROVIDER: packet
-    CLUSTER: $CI_COMMIT_REF_NAME
-
-tf-validate-aws:
-  extends: .terraform_validate
-  variables:
-    TF_VERSION: 0.12.30
-    PROVIDER: aws
-    CLUSTER: $CI_COMMIT_REF_NAME
-
 tf-0.13.x-validate-openstack:
   extends: .terraform_validate
   variables:
-    TF_VERSION: 0.13.5
+    TF_VERSION: $TERRAFORM_13_VERSION
     PROVIDER: openstack
     CLUSTER: $CI_COMMIT_REF_NAME
 
 tf-0.13.x-validate-packet:
   extends: .terraform_validate
   variables:
-    TF_VERSION: 0.13.5
+    TF_VERSION: $TERRAFORM_13_VERSION
     PROVIDER: packet
     CLUSTER: $CI_COMMIT_REF_NAME
 
 tf-0.13.x-validate-aws:
   extends: .terraform_validate
   variables:
-    TF_VERSION: 0.13.5
+    TF_VERSION: $TERRAFORM_13_VERSION
     PROVIDER: aws
     CLUSTER: $CI_COMMIT_REF_NAME
 
 tf-0.13.x-validate-exoscale:
   extends: .terraform_validate
   variables:
-    TF_VERSION: 0.13.5
+    TF_VERSION: $TERRAFORM_13_VERSION
     PROVIDER: exoscale
 
 tf-0.13.x-validate-vsphere:
   extends: .terraform_validate
   variables:
-    TF_VERSION: 0.13.5
+    TF_VERSION: $TERRAFORM_13_VERSION
     PROVIDER: vsphere
     CLUSTER: $CI_COMMIT_REF_NAME
 
 tf-0.13.x-validate-upcloud:
   extends: .terraform_validate
   variables:
-    TF_VERSION: 0.13.5
+    TF_VERSION: $TERRAFORM_13_VERSION
     PROVIDER: upcloud
     CLUSTER: $CI_COMMIT_REF_NAME
 
 tf-0.14.x-validate-openstack:
   extends: .terraform_validate
   variables:
-    TF_VERSION: 0.14.3
+    TF_VERSION: $TERRAFORM_14_VERSION
     PROVIDER: openstack
     CLUSTER: $CI_COMMIT_REF_NAME
 
 tf-0.14.x-validate-packet:
   extends: .terraform_validate
   variables:
-    TF_VERSION: 0.14.3
+    TF_VERSION: $TERRAFORM_14_VERSION
     PROVIDER: packet
     CLUSTER: $CI_COMMIT_REF_NAME
 
 tf-0.14.x-validate-aws:
   extends: .terraform_validate
   variables:
-    TF_VERSION: 0.14.3
+    TF_VERSION: $TERRAFORM_14_VERSION
     PROVIDER: aws
     CLUSTER: $CI_COMMIT_REF_NAME
 
 tf-0.14.x-validate-exoscale:
   extends: .terraform_validate
   variables:
-    TF_VERSION: 0.14.3
+    TF_VERSION: $TERRAFORM_14_VERSION
     PROVIDER: exoscale
 
 tf-0.14.x-validate-vsphere:
   extends: .terraform_validate
   variables:
-    TF_VERSION: 0.14.3
+    TF_VERSION: $TERRAFORM_14_VERSION
     PROVIDER: vsphere
     CLUSTER: $CI_COMMIT_REF_NAME
 
 tf-0.14.x-validate-upcloud:
   extends: .terraform_validate
   variables:
-    TF_VERSION: 0.14.3
+    TF_VERSION: $TERRAFORM_14_VERSION
     PROVIDER: upcloud
     CLUSTER: $CI_COMMIT_REF_NAME
 
 # tf-packet-ubuntu16-default:
 #   extends: .terraform_apply
 #   variables:
-#     TF_VERSION: 0.12.30
+#     TF_VERSION: $TERRAFORM_14_VERSION
 #     PROVIDER: packet
 #     CLUSTER: $CI_COMMIT_REF_NAME
 #     TF_VAR_number_of_k8s_masters: "1"
@@ -173,7 +152,7 @@ tf-0.14.x-validate-upcloud:
 # tf-packet-ubuntu18-default:
 #   extends: .terraform_apply
 #   variables:
-#     TF_VERSION: 0.12.30
+#     TF_VERSION: $TERRAFORM_14_VERSION
 #     PROVIDER: packet
 #     CLUSTER: $CI_COMMIT_REF_NAME
 #     TF_VAR_number_of_k8s_masters: "1"
@@ -230,7 +209,7 @@ tf-elastx_ubuntu18-calico:
   when: on_success
   variables:
     <<: *elastx_variables
-    TF_VERSION: 0.12.30
+    TF_VERSION: $TERRAFORM_14_VERSION
     PROVIDER: openstack
     CLUSTER: $CI_COMMIT_REF_NAME
     ANSIBLE_TIMEOUT: "60"
@@ -275,7 +254,7 @@ tf-ovh_ubuntu18-calico:
   environment: ovh
   variables:
     <<: *ovh_variables
-    TF_VERSION: 0.12.30
+    TF_VERSION: $TERRAFORM_14_VERSION
     PROVIDER: openstack
     CLUSTER: $CI_COMMIT_REF_NAME
     ANSIBLE_TIMEOUT: "60"

--- a/docs/packet.md
+++ b/docs/packet.md
@@ -40,7 +40,7 @@ Grab the latest version of Terraform and install it.
 ```bash
 echo "https://releases.hashicorp.com/terraform/$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r -M '.current_version')/terraform_$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r -M '.current_version')_linux_amd64.zip"
 sudo yum install unzip
-sudo unzip terraform_0.12.30_linux_amd64.zip -d /usr/local/bin/
+sudo unzip terraform_0.14.10_linux_amd64.zip -d /usr/local/bin/
 ```
 
 ## Download Kubespray

--- a/test-infra/vagrant-docker/Dockerfile
+++ b/test-infra/vagrant-docker/Dockerfile
@@ -3,7 +3,7 @@
 ARG KUBESPRAY_VERSION
 FROM quay.io/kubespray/kubespray:${KUBESPRAY_VERSION}
 
-ENV VAGRANT_VERSION=2.2.14
+ENV VAGRANT_VERSION=2.2.15
 ENV VAGRANT_DEFAULT_PROVIDER=libvirt
 
 RUN apt-get update && apt-get install -y wget libvirt-dev openssh-client rsync git

--- a/tests/files/tf-ovh_ubuntu18-calico.yml
+++ b/tests/files/tf-ovh_ubuntu18-calico.yml
@@ -2,7 +2,7 @@
 dns_min_replicas: 1
 deploy_netchecker: true
 sonobuoy_enabled: true
-pkg_install_retries: 15
+pkg_install_retries: 25
 retry_stagger: 10
 
 # Ignore ping errors


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Cleanup terraform and use 0.14 by default
Increase tf_ovh package retries, to mitigate CI job retries ~~
Update:
- Vagrant from 2.2.14 to 2.2.15
- Terraform from 0.13.5 to 0.13.6 and from 0.14.3 to 0.14.10


**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
