### PR TITLE
Check if python netaddr and recent enough jinja are installed

### DIFF
--- a/ansible_version.yml
+++ b/ansible_version.yml
@@ -15,3 +15,18 @@
           - ansible_version.string is version(maximal_ansible_version, "<")
       tags:
         - check
+
+    - name: "Check that python netaddr is installed"
+      assert:
+        msg: "Python netaddr is not present"
+        that: "'127.0.0.1' | ipaddr"
+      tags:
+        - check
+
+    # CentOS 7 provides too old jinja version
+    - name: "Check that jinja is not too old (install via pip)"
+      assert:
+        msg: "Your Jinja version is too old, install via pip"
+        that: "{% set test %}It works{% endset %}{{ test == 'It works' }}"
+      tags:
+        - check


### PR DESCRIPTION
CentOS 7 provides up to date Ansible with really old jinja version

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Check if python netaddr is installed and if Jinja is recent enough
```
