### PR TITLE
Add auto_renew_certificates_systemd_calendar

### DIFF
--- a/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s-cluster/k8s-cluster.yml
@@ -318,3 +318,5 @@ event_ttl_duration: "1h0m0s"
 
 ## Automatically renew K8S control plane certificates on first Monday of each month
 auto_renew_certificates: false
+# First Monday of each month
+# auto_renew_certificates_systemd_calendar: "Mon *-*-1,2,3,4,5,6,7 03:{{ groups['kube_control_plane'].index(inventory_hostname) }}0:00"

--- a/roles/kubernetes/control-plane/defaults/main/main.yml
+++ b/roles/kubernetes/control-plane/defaults/main/main.yml
@@ -191,3 +191,5 @@ event_ttl_duration: "1h0m0s"
 
 ## Automatically renew K8S control plane certificates on first Monday of each month
 auto_renew_certificates: false
+# First Monday of each month
+auto_renew_certificates_systemd_calendar: "Mon *-*-1,2,3,4,5,6,7 03:{{ groups['kube_control_plane'].index(inventory_hostname) }}0:00"

--- a/roles/kubernetes/control-plane/templates/k8s-certs-renew.timer.j2
+++ b/roles/kubernetes/control-plane/templates/k8s-certs-renew.timer.j2
@@ -2,8 +2,7 @@
 Description=Timer to renew K8S control plane certificates
 
 [Timer]
-# First Monday of each month
-OnCalendar=Mon *-*-1,2,3,4,5,6,7 03:{{ groups['kube_control_plane'].index(inventory_hostname) }}0:00
+OnCalendar={{ auto_renew_certificates_systemd_calendar }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This allow to configure when K8S certificates renewal runs

**Which issue(s) this PR fixes**:
Fixes #7479 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Add auto_renew_certificates_systemd_calendar to configure when K8S certificates renewal runs
```
