### PR TITLE
Add missing proxy environment in crio_repo.yml

### DIFF
--- a/roles/container-engine/cri-o/tasks/crio_repo.yml
+++ b/roles/container-engine/cri-o/tasks/crio_repo.yml
@@ -14,6 +14,7 @@
   until: apt_key_download is succeeded
   retries: 4
   delay: "{{ retry_stagger | d(3) }}"
+  environment: "{{ proxy_env }}"
 
 - name: Add CRI-O kubic apt repo
   apt_repository:


### PR DESCRIPTION

**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
This PR will fix issue with downloading CRI-O kubic apt repo key behind proxy
**Which issue(s) this PR fixes**:
Fixes #7491

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
