### PR TITLE
Update some docker defaults

### DIFF
--- a/inventory/sample/group_vars/all/docker.yml
+++ b/inventory/sample/group_vars/all/docker.yml
@@ -14,7 +14,8 @@ docker_container_storage_setup: false
 ## Valid options are systemd or cgroupfs, default is systemd
 # docker_cgroup_driver: systemd
 
-## Uncomment this if you have more than 3 nameservers, then we'll only use the first 3.
+## Only set this if you have more than 3 nameservers:
+## If true Kubespray will only use the first 3, otherwise it will fail
 docker_dns_servers_strict: false
 
 # Path used to store Docker data
@@ -32,7 +33,7 @@ docker_bin_dir: "/usr/bin"
 
 # keep docker packages after installation; speeds up repeated ansible provisioning runs when '1'
 # kubespray deletes the docker package on each run, so caching the package makes sense
-docker_rpm_keepcache: 0
+docker_rpm_keepcache: 1
 
 ## An obvious use case is allowing insecure-registry access to self hosted registries.
 ## Can be ipaddress and domain_name.

--- a/roles/container-engine/docker/defaults/main.yml
+++ b/roles/container-engine/docker/defaults/main.yml
@@ -13,10 +13,6 @@ docker_repo_info:
 
 docker_cgroup_driver: systemd
 
-docker_dns_servers_strict: true
-
-docker_container_storage_setup: false
-
 yum_repo_dir: /etc/yum.repos.d
 
 # Fedora docker-ce repo

--- a/roles/container-engine/docker/tasks/set_facts_dns.yml
+++ b/roles/container-engine/docker/tasks/set_facts_dns.yml
@@ -47,7 +47,7 @@
 
 - name: check number of nameservers
   fail:
-    msg: "Too many nameservers. You can relax this check by set docker_dns_servers_strict=false in all.yml and we will only use the first 3."
+    msg: "Too many nameservers. You can relax this check by set docker_dns_servers_strict=false in docker.yml and we will only use the first 3."
   when: docker_dns_servers|length > 3 and docker_dns_servers_strict|bool
 
 - name: rtrim number of nameservers to 3

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -265,7 +265,8 @@ docker_container_storage_setup: false
 ## Otherwise docker-storage-setup will be executed incorrectly.
 # docker_container_storage_setup_devs: /dev/vdb
 
-## Uncomment this if you have more than 3 nameservers, then we'll only use the first 3.
+## Only set this if you have more than 3 nameservers:
+## If true Kubespray will only use the first 3, otherwise it will fail
 docker_dns_servers_strict: false
 
 # Path used to store Docker data


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
Found some weird docker default (either double default or mismatch ones)

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
Docker: `docker_dns_servers_strict` had different default values, the default value is now the same everywhere: `false`
```
