### PR TITLE
Fix keepcache values of yum_repository

### DIFF
--- a/roles/container-engine/cri-o/tasks/crio_repo.yml
+++ b/roles/container-engine/cri-o/tasks/crio_repo.yml
@@ -78,7 +78,7 @@
     baseurl: http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_$releasever/
     gpgcheck: yes
     gpgkey: http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_$releasever/repodata/repomd.xml.key
-    keepcache: false
+    keepcache: '0'
   when: ansible_distribution in ["CentOS"]
 
 - name: Add CRI-O kubic yum repo
@@ -97,7 +97,7 @@
     baseurl: http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_7/
     gpgcheck: yes
     gpgkey: http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_7/repodata/repomd.xml.key
-    keepcache: false
+    keepcache: '0'
   when: ansible_distribution in ["Amazon"]
 
 - name: Add CRI-O kubic yum repo


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

As the official document[1], the parameter keepcache should be
'0' or '1' as string. To avoid the following warning message,
this fixes the parameter value:

```
  [WARNING]: The value False (type bool) in a string field was
  converted to u'False' (type string). If this does not look
  like what you expect, quote the entire value to ensure it
  does not change.
```

https://docs.ansible.com/ansible/latest/collections/ansible/builtin/yum_repository_module.html

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7505

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
