### PR TITLE
Add bash-completion package

### DIFF
--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -14,6 +14,7 @@ common_required_pkgs:
   - e2fsprogs
   - xfsprogs
   - ebtables
+  - bash-completion
 
 # Set to true if your network does not support IPv6
 # This maybe necessary for pulling Docker images from


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Many OS min install,not install bash-completion, So bash_completion.d will not work.

```
root@node1:kubespray# grep -r bash_completion
Binary file inventory/mycluster/artifacts/kubectl matches
roles/kubernetes/master/tasks/main.yml:  shell: "{{ bin_dir }}/kubectl completion bash >/etc/bash_completion.d/kubectl.sh"
roles/kubernetes/master/tasks/main.yml:    path: /etc/bash_completion.d/kubectl.sh
roles/container-engine/crictl/handlers/main.yml:    dest: /etc/bash_completion.d/crictl
roles/bootstrap-os/tasks/main.yml:- name: Ensure bash_completion.d folder exists
roles/bootstrap-os/tasks/main.yml:    name: /etc/bash_completion.d/
roles/kubernetes-apps/helm/tasks/main.yml:- name: Check if bash_completion.d folder exists  # noqa 503
roles/kubernetes-apps/helm/tasks/main.yml:    path: "/etc/bash_completion.d/"
roles/kubernetes-apps/helm/tasks/main.yml:    dest: /etc/bash_completion.d/helm.sh
roles/kubernetes-apps/krew/tasks/krew.yml:    dest: /etc/bash_completion.d/krew
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
