### PR TITLE
Remove some kubespray create files when reset cluster

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -237,6 +237,18 @@
     - enable_nodelocaldns|default(false)|bool
     - nodelocaldns_device.stat.exists
 
+- name: reset | gather /etc/hosts backup files
+  shell: find /etc -maxdepth 1 -type f -name 'hosts.*@*~'
+  args:
+    executable: /bin/bash
+    warn: false
+  check_mode: no
+  register: hosts_backup_files
+  failed_when: false
+  tags:
+    - files
+    - dns
+
 - name: reset | delete some files and directories
   file:
     path: "{{ item }}"
@@ -298,6 +310,7 @@
     - /run/calico
     - /etc/bash_completion.d/kubectl.sh
     - /etc/bash_completion.d/crictl
+    - "{{ hosts_backup_files.stdout_lines }}"
   ignore_errors: yes
   tags:
     - files


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

Remove some /etc/hosts backup files when reset cluster.

```bash
[root@kube-control-1 etc]# find /etc -maxdepth 1 -type f -name 'hosts.*@*~'
/etc/hosts.8114.2021-04-16@05:29:36~
/etc/hosts.8126.2021-04-16@05:29:39~
/etc/hosts.8133.2021-04-16@05:29:40~
/etc/hosts.23155.2021-04-16@06:38:27~
/etc/hosts.8280.2021-04-16@07:17:15~
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

@floryut

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
