### PR TITLE
add support for configuring cri-o pids_limit

### DIFF
--- a/docs/cri-o.md
+++ b/docs/cri-o.md
@@ -45,4 +45,18 @@ crio_registries_mirrors:
         insecure: false
 ```
 
+## Note about pids_limit
+
+For heavily mult-threaded workloads like databases, the default of 1024 for pids-limit is too low.
+This parameter controls not just the number of processes but also the amount of threads
+(since a thread is technically a process with shared memory). See [cri-o#1921]
+
+In order to increase the default `pids_limit` for cri-o based deployments you need to set the `crio_pids_limit`
+for your `k8s-cluster` ansible group or per node depending on the use case.
+
+```yaml
+crio_pids_limit: 4096
+```
+
 [CRI-O]: https://cri-o.io/
+[cri-o#1921]: https://github.com/cri-o/cri-o/issues/1921

--- a/roles/container-engine/cri-o/defaults/main.yml
+++ b/roles/container-engine/cri-o/defaults/main.yml
@@ -81,3 +81,7 @@ crio_add_repos: true
 # skopeo need for save/load images when download_run_once=true
 skopeo_packages:
   - "skopeo"
+
+# Configure the cri-o pids limit, increase this for heavily multi-threaded workloads
+# see https://github.com/cri-o/cri-o/issues/1921
+crio_pids_limit: 1024

--- a/roles/container-engine/cri-o/templates/crio.conf.j2
+++ b/roles/container-engine/cri-o/templates/crio.conf.j2
@@ -202,7 +202,7 @@ default_mounts = [
 #default_mounts_file = ""
 
 # Maximum number of processes allowed in a container.
-pids_limit = 1024
+pids_limit = {{ crio_pids_limit }}
 
 # Maximum sized allowed for the container log file. Negative numbers indicate
 # that no size limit is imposed. If it is positive, it must be >= 8192 to


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

This PR introduces a way to override cri-o `pids_limit` which is currently hardcoded to 1024.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7511

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Allow changing pids_limit for the cri-o container engine.
```
