### PR TITLE
When check kubectl version is skip status, the golbal variable kubect…

### DIFF
--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -53,7 +53,7 @@
 
     - name: Check kubectl version
       command: "{{ bin_dir }}/kubectl version --client --short"
-      register: kubectl_version
+      register: _kubectl_version
       delegate_to: "{{ groups['kube_control_plane'][0] }}"
       run_once: yes
       changed_when: false
@@ -63,7 +63,7 @@
 
     - name: Ensure minimum version for drain label selector if necessary
       assert:
-        that: "kubectl_version.stdout.split(' ')[-1] is version('v1.10.0', '>=')"
+        that: "_kubectl_version.stdout.split(' ')[-1] is version('v1.10.0', '>=')"
       when:
         - drain_nodes
         - drain_pod_selector


### PR DESCRIPTION
…l_version should not be reset.

**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
```json
TASK [upgrade/pre-upgrade : Check kubectl version] ****************************************************************************************************************************************************************
[DEPRECATION WARNING]: evaluating 'drain_pod_selector' as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the future. Also see CONDITIONAL_BARE_VARS
configuration toggle. This feature will be removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
skipping: [demo-kubespray-test1]
```
```json
TASK [upgrade/pre-upgrade : Ensure minimum version for drain label selector if necessary] *************************************************************************************************************************
[DEPRECATION WARNING]: evaluating 'drain_pod_selector' as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the future. Also see CONDITIONAL_BARE_VARS
configuration toggle. This feature will be removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
skipping: [demo-kubespray-test1]
```
```json
TASK [kubernetes/master : Install | Copy kubectl binary from download dir] ****************************************************************************************************************************************
fatal: [demo-kubespray-test1]: FAILED! => {"changed": false, "msg": "Source /tmp/releases/kubectl-{'changed': False, 'skipped': True, 'skip_reason': 'Conditional result was False'}-amd64 not found"}
```

In the  Check kubectl version task, the kubelet_version is reset. but when the  Check kubectl version is skip or faled, the kubelet_version actual value is "{'changed': False, 'skipped': True, 'skip_reason': 'Conditional result was False'}". This is not EXPECTED. we shoud not change the golbal variable kubectl_version, instead of _kubectl_version.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
