### PR TITLE
Allow configuring CALICO_STARTUP_LOGLEVEL

### DIFF
--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -50,6 +50,7 @@ calico_felix_prometheusprocessmetricsenabled: true
 
 # Set the agent log level. Can be debug, warning, info or fatal
 calico_loglevel: info
+calico_node_startup_loglevel: info
 
 # Enable or disable usage report to 'usage.projectcalico.org'
 calico_usage_reporting: false

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -205,6 +205,9 @@ spec:
             # Set Felix logging to "info"
             - name: FELIX_LOGSEVERITYSCREEN
               value: "{{ calico_loglevel }}"
+            # Set Calico startup logging to "info"
+            - name: CALICO_STARTUP_LOGLEVEL
+              value: "{{ calico_node_startup_loglevel }}"
             # Enable or disable usage report
             - name: FELIX_USAGEREPORTINGENABLED
               value: "{{ calico_usage_reporting }}"


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
Allow configuring [CALICO_STARTUP_LOGLEVEL ](https://docs.projectcalico.org/reference/node/configuration#configuring-logging)via new variable: `calico_node_startup_loglevel`.  Setting to `info` by default which is also the Calico default.  `Warning` or higher is needed to stop outputting [monitor-addresses ](https://github.com/projectcalico/node/pull/770)messages

**Which issue(s) this PR fixes**:
Fixes #7528 - Allow quietening Calico Node logs

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```