### PR TITLE
Only deploy container engine if needed on etcd nodes

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -38,7 +38,11 @@
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes/preinstall, tags: preinstall }
-    - { role: "container-engine", tags: "container-engine", when: deploy_container_engine|default(true) }
+    - role: "container-engine"
+      tags: "container-engine"
+      when:
+        - deploy_container_engine|default(true)
+        - etcd_deployment_type != "host" or "k8s-cluster" in group_names
     - { role: download, tags: download, when: "not skip_downloads" }
 
 - hosts: etcd


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

If the etcd cluster is separate and the etcd_deployment_type is "host",
there is no need for a container engine on the etcd nodes


**Which issue(s) this PR fixes**:

Fixes #7314
The issue was closed by its author, but it is not solved

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Container engine is no longer installed on separate etcd nodes when using
`etcd_deployment_type: host`
```
