### PR TITLE
Fix OpenStack StyleGuide rule H216 (On by default in latest version)

### DIFF
--- a/contrib/inventory_builder/tests/test_inventory.py
+++ b/contrib/inventory_builder/tests/test_inventory.py
@@ -13,8 +13,8 @@
 # under the License.
 
 import inventory
-import mock
 import unittest
+from unittest import mock
 
 from collections import OrderedDict
 import sys


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix CI issue https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/1199464723

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
https://opendev.org/openstack/hacking/commit/b921c4de513c9cc624d6ecf68e4f4493e6e72c0d

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
