### PR TITLE
Fix Opensuse not working with ansible_distribution

### DIFF
--- a/roles/kubernetes-apps/ingress_controller/ambassador/templates/deploy-ambassador.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ambassador/templates/deploy-ambassador.yml.j2
@@ -32,13 +32,13 @@ spec:
           imagePullPolicy: {{ k8s_image_pull_policy }}
           env:
             - name: WATCH_NAMESPACE
-              {%- if ingress_ambassador_multi_namespaces %}
+{% if ingress_ambassador_multi_namespaces %}
               value: ''
-              {%- else %}
+{% else %}
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-              {%- end %}
+{% endif %}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -24,7 +24,7 @@
 
 - name: Stop if unknown OS
   assert:
-    that: ansible_distribution in ['RedHat', 'CentOS', 'Fedora', 'Ubuntu', 'Debian', 'Flatcar Container Linux by Kinvolk', 'Suse', 'ClearLinux', 'OracleLinux', 'AlmaLinux']
+    that: ansible_distribution in ['RedHat', 'CentOS', 'Fedora', 'Ubuntu', 'Debian', 'Flatcar Container Linux by Kinvolk', 'Suse', 'openSUSE Leap', 'ClearLinux', 'OracleLinux', 'AlmaLinux']
     msg: "{{ ansible_distribution }} is not a known OS"
   when: not ignore_assert_errors
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix bug with Opensuse (Leap)

**Which issue(s) this PR fixes**:
Nightly jobs failing https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/1210564741
```
fatal: [instance-2]: FAILED! => {
    "assertion": "ansible_distribution in ['RedHat', 'CentOS', 'Fedora', 'Ubuntu', 'Debian', 'Flatcar Container Linux by Kinvolk', 'Suse', 'ClearLinux', 'OracleLinux', 'AlmaLinux']",
    "changed": false,
    "evaluated_to": false,
    "msg": "openSUSE Leap is not a known OS"
}
```

Then I encountered an error on this [job](https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/1211158602)
```
failed: [instance-1] (item={'name': 'deploy-ambassador', 'file': 'deploy-ambassador.yml', 'type': 'deploy'}) => {"ansible_loop_var": "item", "changed": false, "item": {"file": "deploy-ambassador.yml", "name": "deploy-ambassador", "type": "deploy"}, "msg": "AnsibleError: template error while templating string: Encountered unknown tag 'end'. Jinja was looking for the following tags: 'endif'. The innermost block that needs to be closed is 'if'.. String
```

**Special notes for your reviewer**:
Running "manually" to validate the fix [here](https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/1212032377)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
