### PR TITLE
Do not fail recover-control-plane.yml playbook when broken etcd node is not reachable

### DIFF
--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -28,6 +28,7 @@
     src: "{{ etcd_cert_dir }}/{{ item.s }}"
     dest: "{{ calico_cert_dir }}/{{ item.d }}"
     state: hard
+    mode: 0640
     force: yes
   with_items:
     - {s: "{{ kube_etcd_cacert_file }}", d: "ca_cert.crt"}


### PR DESCRIPTION
What type of PR is this?
/kind failing-test
/assign @yujunz

What this PR does / why we need it:

Currently, recover_control_plane/etcd role fails here this task when broken node is not reachable. Example, if first etcd node broken due to hardware failure and its power-off or not reachable. If we run recover-control-plain playbook to remove/replace that node from healthy cluster and add healthy node to cluster.

Does this PR introduce a user-facing change?: None