### PR TITLE
Add image_arch in flannel image tag

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -721,7 +721,7 @@ downloads:
     enabled: "{{ kube_network_plugin == 'flannel' or kube_network_plugin == 'canal' }}"
     container: true
     repo: "{{ flannel_image_repo }}"
-    tag: "{{ flannel_image_tag }}"
+    tag: "{{ flannel_image_tag }}-{{ image_arch }}"
     sha256: "{{ flannel_digest_checksum|default(None) }}"
     groups:
     - k8s-cluster

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -401,7 +401,7 @@ kube_proxy_image_repo: "{{ kube_image_repo }}/kube-proxy"
 etcd_image_repo: "{{ quay_image_repo }}/coreos/etcd"
 etcd_image_tag: "{{ etcd_version }}{%- if image_arch != 'amd64' -%}-{{ image_arch }}{%- endif -%}"
 flannel_image_repo: "{{ quay_image_repo }}/coreos/flannel"
-flannel_image_tag: "{{ flannel_version }}"
+flannel_image_tag: "{{ flannel_version }}-{{ image_arch }}"
 calico_node_image_repo: "{{ quay_image_repo }}/calico/node"
 calico_node_image_tag: "{{ calico_version }}{%- if image_arch != 'amd64' -%}-{{ image_arch }}{%- endif -%}"
 calico_cni_image_repo: "{{ quay_image_repo }}/calico/cni"
@@ -721,7 +721,7 @@ downloads:
     enabled: "{{ kube_network_plugin == 'flannel' or kube_network_plugin == 'canal' }}"
     container: true
     repo: "{{ flannel_image_repo }}"
-    tag: "{{ flannel_image_tag }}-{{ image_arch }}"
+    tag: "{{ flannel_image_tag }}"
     sha256: "{{ flannel_digest_checksum|default(None) }}"
     groups:
     - k8s-cluster

--- a/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
+++ b/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
@@ -66,7 +66,7 @@ spec:
       serviceAccountName: flannel
       containers:
       - name: kube-flannel
-        image: {{ flannel_image_repo }}:{{ flannel_image_tag }}-{{ arch }}
+        image: {{ flannel_image_repo }}:{{ flannel_image_tag | regex_replace(image_arch,'') }}{{ arch }}
         imagePullPolicy: {{ k8s_image_pull_policy }}
         resources:
           limits:
@@ -109,7 +109,7 @@ spec:
                       - {{ arch }}
       initContainers:
       - name: install-cni
-        image: {{ flannel_image_repo }}:{{ flannel_image_tag }}-{{ arch }}
+        image: {{ flannel_image_repo }}:{{ flannel_image_tag | regex_replace(image_arch,'') }}{{ arch }}
         command:
         - cp
         args:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

 /kind bug


**What this PR does / why we need it**:

https://github.com/kubernetes-sigs/kubespray/pull/6166 enabled multi-CPU architecture in Flannel CNI

For flannel image, in download image task flannel image tag is `flannel_version`, such as `quay.io/coreos/flannel:v0.13.0` but in `roles/network_plugin/flannel/templates/cni-flannel.yml.j2` file, real image tag is `{{ flannel_image_tag }}-{{ arch }}`, such as `quay.io/coreos/flannel:v0.13.0-amd64` .

This will result in the real image tag is inconsistent with the downloaded image tag especially for offline deploy.

- this is download flannel image task log

> hub.k8s.li is my private docker registry

```shell

TASK [download : check_pull_required | Set pull_required if the desired image is not yet loaded] *********************************************************************************
ok: [kube-control-3]
ok: [kube-control-2]
ok: [kube-control-1]
ok: [kube-node-1]
Tuesday 27 April 2021  09:44:51 +0000 (0:00:00.160)       0:02:03.313 *********
Tuesday 27 April 2021  09:44:51 +0000 (0:00:00.119)       0:02:03.432 *********

TASK [download : debug] **********************************************************************************************************************************************************
ok: [kube-control-3] => {
    "msg": "Pull hub.k8s.li/coreos/flannel:v0.13.0 required is: False"
}
ok: [kube-control-2] => {
    "msg": "Pull hub.k8s.li/coreos/flannel:v0.13.0 required is: False"
}
ok: [kube-control-1] => {
    "msg": "Pull hub.k8s.li/coreos/flannel:v0.13.0 required is: False"
}
ok: [kube-node-1] => {
    "msg": "Pull hub.k8s.li/coreos/flannel:v0.13.0 required is: False"
}
```

- this is kube-flannel status when complete deploy

```shell
kube-system   kube-flannel-47krk                       0/1     Init:ImagePullBackOff   0          48m
kube-system   kube-flannel-cqcjc                       0/1     Init:ImagePullBackOff   0          48m
kube-system   kube-flannel-flpcz                       0/1     Init:ImagePullBackOff   0          48m
kube-system   kube-flannel-xh2pt                       0/1     Init:ImagePullBackOff   0          48m
  Normal   Scheduled  80s                default-scheduler  Successfully assigned kube-system/kube-flannel-lsjxk to kube-control-1
  Normal   Pulling    37s (x3 over 80s)  kubelet            Pulling image "hub.k8s.li/coreos/flannel:v0.13.0-amd64"
  Warning  Failed     34s (x3 over 77s)  kubelet            Failed to pull image "hub.k8s.li/coreos/flannel:v0.13.0-amd64": rpc error: code = NotFound desc = failed to pull and unpack image "hub.k8s.li/coreos/flannel:v0.13.0-amd64": failed to resolve reference "hub.k8s.li/coreos/flannel:v0.13.0-amd64": hub.k8s.li/coreos/flannel:v0.13.0-amd64: not found
  Warning  Failed     34s (x3 over 77s)  kubelet            Error: ErrImagePull
  Normal   BackOff    8s (x4 over 77s)   kubelet            Back-off pulling image "hub.k8s.li/coreos/flannel:v0.13.0-amd64"
  Warning  Failed     8s (x4 over 77s)   kubelet            Error: ImagePullBackOff
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #



**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
