### PR TITLE
Fix calico-kube-controller becomes error with Canal

### DIFF
--- a/roles/network_plugin/canal/tasks/main.yml
+++ b/roles/network_plugin/canal/tasks/main.yml
@@ -20,6 +20,7 @@
     src: "{{ etcd_cert_dir }}/{{ item.s }}"
     dest: "{{ canal_cert_dir }}/{{ item.d }}"
     state: hard
+    mode: 0640
     force: yes
   with_items:
     - {s: "{{ kube_etcd_cacert_file }}", d: "ca_cert.crt"}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
We forgot Canal in https://github.com/kubernetes-sigs/kubespray/pull/7548

**Which issue(s) this PR fixes**:
Fixes a bug in nightly CI job https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/1217873236

**Special notes for your reviewer**:
n/a

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
