### PR TITLE
Fix issue with api token wait check not working

### DIFF
--- a/tests/testcases/030_check-network.yml
+++ b/tests/testcases/030_check-network.yml
@@ -49,7 +49,7 @@
       executable: /bin/bash
     changed_when: false
     register: default_token
-    until: default_token.stdout.find('<none>') == -1
+    until: default_token.stdout | length > 0
     retries: 5
     delay: 5
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
We have a looooot of test failing with centos8, all tests are failing like this https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/1218002822
```
fatal: [instance-1]: FAILED! => {"attempts": 1, "changed": false, "cmd": "set -o pipefail && /usr/local/bin/kubectl describe serviceaccounts default --namespace test | grep Tokens | awk '{print $2}'", "delta": "0:00:00.528763", "end": "2021-04-28 08:21:48.217822", "msg": "non-zero return code", "rc": 1, "start": "2021-04-28 08:21:47.689059", "stderr": "Error from server (NotFound): serviceaccounts \"default\" not found", "stderr_lines": ["Error from server (NotFound): serviceaccounts \"default\" not found"], "stdout": "", "stdout_lines": []}
```

**Which issue(s) this PR fixes**:
Check introduce in #7045

**Special notes for your reviewer**:
Not sure if trying and waiting will work, but at least the test will not break on first attempt  and will retry its 5 tries

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
