### PR TITLE
add default empty value for etc_hosts_localhosts_dict_target

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0090-etchosts.yml
+++ b/roles/kubernetes/preinstall/tasks/0090-etchosts.yml
@@ -66,7 +66,7 @@
     state: present
     backup: yes
     unsafe_writes: yes
-  loop: "{{ etc_hosts_localhosts_dict_target|dict2items }}"
+  loop: "{{ etc_hosts_localhosts_dict_target|default({})|dict2items }}"
 
 # gather facts to update ansible_fqdn
 - name: Update facts


### PR DESCRIPTION
/kind bug

add default value

playbook upgrade cluster fail, when download_run_once=true
at https://github.com/kubernetes-sigs/kubespray/blob/dfeed1c1a479d75c972ab246e4f321d23f7ec243/upgrade-cluster.yml#L45

because import_task: with when: staticaly added task to play with additional when clause

todo: change import_tasks to include_tasks