### PR TITLE
Pin UID/GID for kubespray created users

### DIFF
--- a/roles/adduser/defaults/main.yml
+++ b/roles/adduser/defaults/main.yml
@@ -9,6 +9,7 @@ addusers:
     createhome: no
     system: yes
     shell: /sbin/nologin
+    uid: 1000
   kube:
     name: kube
     comment: "Kubernetes user"
@@ -16,6 +17,7 @@ addusers:
     system: yes
     shell: /sbin/nologin
     group: "{{ kube_cert_group }}"
+    uid: 1001
 
 adduser:
   name: "{{ user.name }}"

--- a/roles/adduser/tasks/main.yml
+++ b/roles/adduser/tasks/main.yml
@@ -3,6 +3,7 @@
   group:
     name: "{{ user.group|default(user.name) }}"
     system: "{{ user.system|default(omit) }}"
+    gid: "{{ user.uid|default(omit) }}"
 
 - name: User | Create User
   user:
@@ -13,3 +14,4 @@
     shell: "{{ user.shell|default(omit) }}"
     name: "{{ user.name }}"
     system: "{{ user.system|default(omit) }}"
+    uid: "{{ user.uid|default(omit) }}"

--- a/roles/adduser/vars/coreos.yml
+++ b/roles/adduser/vars/coreos.yml
@@ -6,3 +6,4 @@ addusers:
     system: yes
     group: "{{ kube_cert_group }}"
     createhome: no
+    uid: 1001

--- a/roles/adduser/vars/debian.yml
+++ b/roles/adduser/vars/debian.yml
@@ -6,6 +6,7 @@ addusers:
     home: "{{ etcd_data_dir }}"
     system: yes
     shell: /sbin/nologin
+    uid: 1000
 
   - name: kube
     comment: "Kubernetes user"
@@ -13,3 +14,4 @@ addusers:
     system: yes
     shell: /sbin/nologin
     group: "{{ kube_cert_group }}"
+    uid: 1001

--- a/roles/adduser/vars/redhat.yml
+++ b/roles/adduser/vars/redhat.yml
@@ -6,6 +6,7 @@ addusers:
     home: "{{ etcd_data_dir }}"
     system: yes
     shell: /sbin/nologin
+    uid: 1000
 
   - name: kube
     comment: "Kubernetes user"
@@ -13,3 +14,4 @@ addusers:
     system: yes
     shell: /sbin/nologin
     group: "{{ kube_cert_group }}"
+    uid: 1000

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-controller-manager-ds.yml.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-controller-manager-ds.yml.j2
@@ -30,7 +30,7 @@ spec:
         node-role.kubernetes.io/control-plane: ""
 {% endif %}
       securityContext:
-        runAsUser: 999
+        runAsUser: {{ addusers.kube.uid }}
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR pins the UID and GID for the `etcd` and `kube` created users to avoid a race condition when users are created on the target systems and ensure that the external cloud controller can access externally managed certificates.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7553

**Special notes for your reviewer**:
This may not be the right solution for the issue identified in https://github.com/kubernetes-sigs/kubespray/issues/7553 and will have implications for upgrades.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Pin the UID/GID of the etcd and kube users.
```
