### PR TITLE
change kubeadm coredns addon images name to `coredns/coredns`

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -447,9 +447,11 @@ haproxy_image_tag: 2.3
 
 # Coredns version should be supported by corefile-migration (or at least work with)
 # bundle with kubeadm; if not 'basic' upgrade can sometimes fail
-coredns_version: "1.7.0"
-coredns_image_repo: "{{ kube_image_repo }}/coredns"
-coredns_image_tag: "{{ coredns_version }}"
+coredns_image_is_namespaced: "{{ (kube_major_version | regex_replace('^v', '') | float) >= 1.21 }}"
+
+coredns_version: "v1.7.0"
+coredns_image_repo: "{{ kube_image_repo }}{{'/coredns/coredns' if (coredns_image_is_namespaced | bool) else '/coredns' }}"
+coredns_image_tag: "{{ coredns_version if (coredns_image_is_namespaced | bool) else (coredns_version | regex_replace('^v', '')) }}"
 
 nodelocaldns_version: "1.17.1"
 nodelocaldns_image_repo: "{{ kube_image_repo }}/dns/k8s-dns-node-cache"

--- a/roles/download/templates/kubeadm-images.yaml.j2
+++ b/roles/download/templates/kubeadm-images.yaml.j2
@@ -21,5 +21,5 @@ etcd:
 {% endif %}
 dns:
   type: CoreDNS
-  imageRepository: {{ coredns_image_repo | regex_replace('/coredns$','') }}
+  imageRepository: {{ coredns_image_repo | regex_replace('/coredns.*$','') }}
   imageTag: {{ coredns_image_tag }}

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta2.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta2.yaml.j2
@@ -84,7 +84,7 @@ etcd:
 {% endif %}
 dns:
   type: CoreDNS
-  imageRepository: {{ coredns_image_repo | regex_replace('/coredns$','') }}
+  imageRepository: {{ coredns_image_repo | regex_replace('/coredns.*$','') }}
   imageTag: {{ coredns_image_tag }}
 networking:
   dnsDomain: {{ dns_domain }}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:
at the moment kubeadm has [hardcoded](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/constants/constants.go#L331) that the name of the coreDNS image
is `coredns/coredns`.
When using `k8s.gcr.io` as image repository this is false for versions
<=1.7.0 which are located at `k8s.gcr.io/coredns:${VERSION}`.
This causes the deployment to be unable to pull images until the
`kubernetes-apps` role ovverrides it with the correct image location

docker.io fullfills the assumptions made by kubeadm that the image is
found under the name `coredns/coredns`

Also on gcr.io newest tags such as +1.8.0 seems not to be available at
the moment, making impossible to upgrade the coredns component
 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
