### PR TITLE
Fix busybox for tests to reduce dockerhub calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [cri-o](http://cri-o.io/) v1.19 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)
 - Network Plugin
   - [cni-plugins](https://github.com/containernetworking/plugins) v0.9.1
-  - [calico](https://github.com/projectcalico/calico) v3.17.3
+  - [calico](https://github.com/projectcalico/calico) v3.17.4
   - [canal](https://github.com/projectcalico/canal) (given calico/flannel versions)
   - [cilium](https://github.com/cilium/cilium) v1.8.8
   - [flanneld](https://github.com/coreos/flannel) v0.13.0

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -458,8 +458,6 @@ nodelocaldns_image_tag: "{{ nodelocaldns_version }}"
 dnsautoscaler_version: 1.8.3
 dnsautoscaler_image_repo: "{{ kube_image_repo }}/cpa/cluster-proportional-autoscaler-{{ image_arch }}"
 dnsautoscaler_image_tag: "{{ dnsautoscaler_version }}"
-test_image_repo: "{{ kube_image_repo }}/busybox"
-test_image_tag: latest
 
 registry_image_repo: "{{ docker_image_repo }}/library/registry"
 registry_image_tag: "2.7.1"
@@ -899,13 +897,6 @@ downloads:
     sha256: "{{ dnsautoscaler_digest_checksum|default(None) }}"
     groups:
     - kube_control_plane
-
-  testbox:
-    enabled: false
-    container: true
-    repo: "{{ test_image_repo }}"
-    tag: "{{ test_image_tag }}"
-    sha256: "{{ testbox_digest_checksum|default(None) }}"
 
   helm:
     enabled: "{{ helm_enabled }}"

--- a/tests/testcases/030_check-network.yml
+++ b/tests/testcases/030_check-network.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: kube_control_plane[0]
   vars:
-    test_image_repo: busybox
+    test_image_repo: k8s.gcr.io/busybox
     test_image_tag: latest
 
   tasks:


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
We changed the busybox image for tests to reduce dockerhub call but we forgot that the image path was overridden in the test tasks

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Reduce dockerhub by like 10 for each CI pipeline

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
