### PR TITLE
Add external_openstack_enable_ingress_hostname option for external-openstack-cloud-controller-manager

### DIFF
--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
@@ -62,6 +62,9 @@ use-octavia={{ external_openstack_lbaas_use_octavia }}
 lb-provider=octavia
 use-octavia=true
 {% endif %}
+{% if external_openstack_enable_ingress_hostname is defined %}
+enable-ingress-hostname={{ external_openstack_enable_ingress_hostname | bool }}
+{% endif %}
 
 [Networking]
 ipv6-support-disabled={{ external_openstack_network_ipv6_disabled | string | lower }}

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -391,6 +391,7 @@ openstack_lbaas_monitor_max_retries: "3"
 openstack_cacert: "{{ lookup('env','OS_CACERT') }}"
 
 # Default values for the external OpenStack Cloud Controller
+external_openstack_enable_ingress_hostname: false
 external_openstack_lbaas_create_monitor: false
 external_openstack_lbaas_monitor_delay: "1m"
 external_openstack_lbaas_monitor_timeout: "30s"


### PR DESCRIPTION
Signed-off-by: Cedric Hnyda <cedric.hnyda@itera.io>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

A new config option `enable-ingress-hostname` was introduced to fix issues related to broken headers with PROXY protocol enabled (https://github.com/kubernetes/cloud-provider-openstack/pull/1449)
In PROXY mode, set Hostname field using IP address and a suffix .nip.io to expose the Service of LoadBalancer type if `enable-ingress-hostname` is enabled.

The PR adds the option in kubespray: `external_openstack_enable_ingress_hostname`


**Which issue(s) this PR fixes**:
Solving https://github.com/kubernetes/ingress-nginx/issues/3996 and https://github.com/kubernetes/kubernetes/issues/66607


```
