### PR TITLE
Fixes issue #7573 - Made Calico permissions compatible with v3.18.x

### DIFF
--- a/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-cr.yml.j2
+++ b/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-cr.yml.j2
@@ -63,6 +63,7 @@ rules:
       - create
       - update
       - delete
+      - watch
   # kube-controllers manages hostendpoints.
   - apiGroups: ["crd.projectcalico.org"]
     resources:


### PR DESCRIPTION
See https://github.com/projectcalico/calico/issues/4557.  Specifically, granted watch to custom resources: blockaffinities, ipamblocks & ipamhandles.

**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
Existing permissions cause a "connection is unauthorized" message to be logged many times per second by pod: kube-system/calico-kube-controllers

**Which issue(s) this PR fixes**:
Fixes #7573

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```