### PR TITLE
Enable calico CNI kubeconfig token monitor

### DIFF
--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -259,6 +259,8 @@ spec:
               value: "true"
             - name: FELIX_IGNORELOOSERPF
               value: "{{ calico_node_ignorelooserpf }}"
+            - name: CALICO_MANAGE_CNI
+              value: "true"
 {% if calico_node_extra_envs is defined %}
 {% for key in calico_node_extra_envs %}
             - name: {{ key }}
@@ -309,6 +311,8 @@ spec:
             - name: xtables-lock
               mountPath: /run/xtables.lock
               readOnly: false
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
 {% if typha_secure %}
             - name: typha-client
               mountPath: /etc/typha-client


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
It enables Calico serviceAccount token monitoring and update of /etc/cni/net.d/calico-kubeconfig if need be.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Since K8S 1.21, BoundServiceAccountTokenVolume feature gate is in beta stage, thus activated by default (anyone who follows CSI guidelines has enabled AllAlpha and faced the issue before 1.21).
With this feature, SA tokens are regenerated every hour.
As a consequence for Calico CNI, token in /etc/cni/net.d/calico-kubeconfig copied from /var/run/secrets/kubernetes.io/serviceaccount in install-cni initContainer expires after one hour and any pod creation fails due to unauthorization.
Calico pods need to be restarted so that /etc/cni/net.d/calico-kubeconfig is updated with the new SA token.

**Does this PR introduce a user-facing change?**:
None that I know of
