### PR TITLE
Scale down workflow fails when ipvsadm utility not found on node

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -206,6 +206,7 @@
 
 - name: Clear IPVS virtual server table
   command: "ipvsadm -C"
+  ignore_errors: yes
   when:
     - kube_proxy_mode == 'ipvs' and inventory_hostname in groups['k8s_cluster']
 


### PR DESCRIPTION
**What type of PR is this?**
> /kind failing-test

**What this PR does / why we need it**:
When we run remove-node.yml playbook i.e scale-down workflow this playbook fails if utility `ipvsadm` does not exist on node. This scenario comes when we run scale down workflow on reprovision(reimage) node.
Detailed steps to reproduce this scenario:
1. Let's assume one of our control plane node is broken because of hardware failure.
2. OS provisioning team has fixed the node issue by reprovisioning the node. When node reprovisioned all the installed package and configuration will be cleaned up.
3. Now, to attach this node to the cluster first of all you will run remove-node.yml to make sure that node is properly removed from cluster and node is clean. Here you will hit the issue because in step 2 ipvsadm package is already removed. 


**Does this PR introduce a user-facing change?**: NONE

