### PR TITLE
allow overriding calico peers names and avoid ipv6 naming issues

### DIFF
--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -227,7 +227,7 @@
       {"apiVersion": "projectcalico.org/v3",
       "kind": "BGPPeer",
       "metadata": {
-        "name": "global-{{ item.router_id }}"
+        "name": "global-{{ item.name | default(item.router_id|replace(':','-')) }}"
       },
       "spec": {
         "asNumber": "{{ item.as }}",
@@ -381,7 +381,7 @@
       {"apiVersion": "projectcalico.org/v3",
       "kind": "BGPPeer",
       "metadata": {
-        "name": "{{ inventory_hostname }}-{{ item.router_id }}"
+        "name": "{{ inventory_hostname }}-{{ item.name | default(item.router_id|replace(':','-')) }}"
       },
       "spec": {
         "asNumber": "{{ item.as }}",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
There is an issue with using IPv6 address in the calico peer names which does not allow using `:`. This PR allows the deployer to specify a custom name in the `peers` structure for each peer as well as sanitises any IPv6 address in the name by replacing `:` with `-` that is allowed by the calico validation regex.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7585

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Calico: allow specifying overriding BGP peer name
```
