### PR TITLE
add containerd support for Amazon Linux 2

### DIFF
--- a/roles/container-engine/containerd-common/vars/amazon.yml
+++ b/roles/container-engine/containerd-common/vars/amazon.yml
@@ -1,0 +1,9 @@
+---
+containerd_package: containerd
+containerd_versioned_pkg:
+  'latest': "{{ containerd_package }}"
+  '1.3.2': "{{ containerd_package }}-1.3.2-1.amzn{{ ansible_distribution_major_version }}"
+  '1.4.1': "{{ containerd_package }}-1.4.1-2.amzn{{ ansible_distribution_major_version }}"
+  '1.4.4': "{{ containerd_package }}-1.4.4-1.amzn{{ ansible_distribution_major_version }}"
+  'stable': "{{ containerd_package }}-1.4.4-1.amzn{{ ansible_distribution_major_version }}"
+  'edge': "{{ containerd_package }}-1.4.4-1.amzn{{ ansible_distribution_major_version }}"

--- a/roles/container-engine/containerd/tasks/containerd_repo.yml
+++ b/roles/container-engine/containerd/tasks/containerd_repo.yml
@@ -31,4 +31,4 @@
     dest: "{{ yum_repo_dir }}/containerd.repo"
   when:
     - ansible_os_family == "RedHat"
-    - ansible_distribution != "Fedora"
+    - ansible_distribution not in ["Fedora", "Amazon"]

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -16,7 +16,7 @@
   fail:
     msg: "{{ ansible_distribution }} is not supported by containerd."
   when:
-    - not ansible_distribution in ["CentOS", "OracleLinux", "RedHat", "Ubuntu", "Debian", "Fedora", "AlmaLinux"]
+    - not ansible_distribution in ["CentOS", "OracleLinux", "RedHat", "Ubuntu", "Debian", "Fedora", "AlmaLinux", "Amazon"]
 
 - name: gather os specific variables
   include_vars: "{{ item }}"

--- a/roles/container-engine/containerd/vars/amazon.yml
+++ b/roles/container-engine/containerd/vars/amazon.yml
@@ -1,0 +1,5 @@
+---
+containerd_package_info:
+  enablerepo: "amzn2extra-docker"
+  pkgs:
+    - "{{ containerd_versioned_pkg[containerd_version | string] }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:
While debugging on https://github.com/kubernetes-sigs/kubespray/pull/7589 I realized that we don't have support for containerd on Amazon Linux 2. This PR adds that support to kubespray.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Proof:
```
(venv) [root@ec2-host kubespray]# /usr/local/bin/kubectl get nodes -o wide
NAME                     STATUS   ROLES                  AGE     VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE         KERNEL-VERSION                  CONTAINER-RUNTIME
ec2-host.kaveman.intra   Ready    control-plane,master   6m14s   v1.20.6   192.168.0.245   <none>        Amazon Linux 2   4.14.231-173.361.amzn2.x86_64   containerd://1.4.4
(venv) [root@ec2-host kubespray]# cat /etc/os-release 
NAME="Amazon Linux"
VERSION="2"
ID="amzn"
ID_LIKE="centos rhel fedora"
VERSION_ID="2"
PRETTY_NAME="Amazon Linux 2"
ANSI_COLOR="0;33"
CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2"
HOME_URL="https://amazonlinux.com/"
(venv) [root@ec2-host kubespray]# uname -a
Linux ec2-host.kaveman.intra 4.14.231-173.361.amzn2.x86_64 #1 SMP Mon Apr 26 20:57:08 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
```

This was test tested on an Amazon Linux 2 VM self-hosted on VMware, I don't have access to an EC2 account at the moment but I assume the Amazon Linux image they publish acts like the one on EC2.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add containerd support for Amazon Linux 2
```
