### PR TITLE
Fix reset cluster task failed

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -301,7 +301,7 @@
     - /etc/bash_completion.d/kubectl.sh
     - /etc/bash_completion.d/crictl
     - /etc/bash_completion.d/nerdctl
-    - "{{ krew_root_dir }}"
+    - "{{ krew_root_dir | default('/usr/local/krew') }}"
   ignore_errors: yes
   tags:
     - files


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

When reset cluster, krew_root_dir is undefined, this will result in `reset | delete some files and directories` task failed, files and directories not be deleted, such as /var/lib/kubelet, /etc/kubernetes, /var/lib/etcd and more, these files and directories will still exist. If the cluster is redeployed, the old data still exists.

```shell
TASK [reset | delete some files and directories] *********************************************************************************************************************************
fatal: [kube-control-3]: FAILED! => {"msg": "'krew_root_dir' is undefined"}
...ignoring
fatal: [kube-control-2]: FAILED! => {"msg": "'krew_root_dir' is undefined"}
...ignoring
fatal: [kube-control-1]: FAILED! => {"msg": "'krew_root_dir' is undefined"}
...ignoring
fatal: [kube-node-1]: FAILED! => {"msg": "'krew_root_dir' is undefined"}
...ignoring
Monday 10 May 2021  03:57:01 +0000 (0:00:00.143)       0:00:46.617 ************
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kubespray/pull/7464

**Special notes for your reviewer**:

/cc @liupeng0518 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
