### PR TITLE
Cleanup duplicate task in etcd role

### DIFF
--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -16,19 +16,6 @@
     mode: 0700
   run_once: yes
   when: inventory_hostname == groups['etcd'][0]
-  delegate_to: "{{ groups['etcd'][0] }}"
-
-- name: "Gen_certs | create etcd cert dir (on {{ groups['etcd'][0] }})"
-  file:
-    path: "{{ etcd_cert_dir }}"
-    group: "{{ etcd_cert_group }}"
-    state: directory
-    owner: kube
-    recurse: yes
-    mode: 0700
-  run_once: yes
-  when: inventory_hostname == groups['etcd'][0]
-  delegate_to: "{{ groups['etcd'][0] }}"
 
 - name: Gen_certs | write openssl config
   template:

--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -33,7 +33,6 @@
     dest: "{{ etcd_script_dir }}/make-ssl-etcd.sh"
     mode: 0700
   run_once: yes
-  delegate_to: "{{ groups['etcd'][0] }}"
   when:
     - gen_certs|default(false)
     - inventory_hostname == groups['etcd'][0]


### PR DESCRIPTION
What type of PR is this?

/kind cleanup

What this PR does / why we need it:

1. ETCD cert dir is being created in the first task in this file always and hence third task which is intended to create etcd cert dir on first etcd node is not required because first task creates the dir on first etcd node also.

2. Delegate_to first etcd node is not require when we are executing task on first etcd node itself.

Does this PR introduce a user-facing change?: NONE
