### PR TITLE
Fix cloud_resolver type from str to list (issue #7605)

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
@@ -50,14 +50,9 @@
       {% for d in [ 'default.svc.' + dns_domain, 'svc.' + dns_domain ] + searchdomains|default([]) -%}
       {{ dns_domain }}.{{ d }}./{{ d }}.{{ d }}./com.{{ d }}./
       {%- endfor %}
-    cloud_resolver: >-
-      {%- if cloud_provider is defined and cloud_provider == 'gce' -%}
-        ['169.254.169.254']
-      {%- elif cloud_provider is defined and cloud_provider == 'aws' -%}
-        ['169.254.169.253']
-      {%- else -%}
-        []
-      {%- endif -%}
+    cloud_resolver: "{{ ['169.254.169.254'] if cloud_provider is defined and cloud_provider == 'gce' else
+                        ['169.254.169.253'] if cloud_provider is defined and cloud_provider == 'aws' else
+                        [] }}"
 
 - name: check if kubelet is configured
   stat:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

I've [integrated](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/integration.md) kubespray with my own Ansible repository. I've faced issue with variable type/templating due to that fact, that I use "strict" types in Jinja (`jinja2_native=True` configuration in ansible.cfg) in my repository.
This PR just rewrites `cloud_resolver` definition in the way that the type of result is `list`, not `str`.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/kubespray/issues/7605

**Does this PR introduce a user-facing change?**:
NONE
```release-note
NONE
```
