### PR TITLE
fixed MarkupSafe version to 1.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ netaddr==0.7.19
 pbr==5.4.4
 jmespath==0.9.5
 ruamel.yaml==0.16.10
+MarkupSafe==1.1.1


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
in MarkupSafe version 2.0.0 drop python 2.7, 3.4, 3.5 support
https://github.com/pallets/markupsafe/blob/main/CHANGES.rst#version-200

But python 2.7 is default version for Centos7, so need to fixup MarkSafe version to 1.1.1
