### PR TITLE
Improve scale flow and documentation

### DIFF
--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -83,7 +83,7 @@ That's it.
 
 Append the new host to the inventory and run `cluster.yml`. You can NOT use `scale.yml` for that.
 
-### 3) Restart kube-system/nginx-proxy
+### 2) Restart kube-system/nginx-proxy
 
 In all hosts, restart nginx-proxy pod. This pod is a local proxy for the apiserver. Kubespray will update its static config, but it needs to be restarted in order to reload.
 
@@ -92,7 +92,7 @@ In all hosts, restart nginx-proxy pod. This pod is a local proxy for the apiserv
 docker ps | grep k8s_nginx-proxy_nginx-proxy | awk '{print $1}' | xargs docker restart
 ```
 
-### 4) Remove old master nodes
+### 3) Remove old master nodes
 
 With the old node still in the inventory, run `remove-node.yml`. You need to pass `-e node=NODE_NAME` to the playbook to limit the execution to the node being removed.
 If the node you want to remove is not online, you should add `reset_nodes=false` to your extra-vars.
@@ -106,7 +106,7 @@ You need to make sure there are always an odd number of etcd nodes in the cluste
 Update the inventory and run `cluster.yml` passing `--limit=etcd,kube_control_plane -e ignore_assert_errors=yes`.
 If the node you want to add as an etcd node is already a worker or master node in your cluster, you have to remove him first using `remove-node.yml`.
 
-Run `upgrade-cluster.yml` also passing `--limit=etcd,kube_control_plane -e ignore_assert_errors=yes`. This is necessary to update all etcd configuration in the cluster.  
+Run `upgrade-cluster.yml` also passing `--limit=etcd,kube_control_plane -e ignore_assert_errors=yes`. This is necessary to update all etcd configuration in the cluster.
 
 At this point, you will have an even number of nodes.
 Everything should still be working, and you should only have problems if the cluster decides to elect a new etcd leader before you remove a node.
@@ -114,6 +114,10 @@ Even so, running applications should continue to be available.
 
 If you add multiple ectd nodes with one run, you might want to append `-e etcd_retries=10` to increase the amount of retries between each ectd node join.
 Otherwise the etcd cluster might still be processing the first join and fail on subsequent nodes. `etcd_retries=10` might work to join 3 new nodes.
+
+### 2) Add the new node to apiserver config
+
+In every master node, edit `/etc/kubernetes/manifests/kube-apiserver.yaml`. Make sure the new etcd nodes are present in the apiserver command line parameter `--etcd-servers=...`.
 
 ## Removing an etcd node
 
@@ -130,6 +134,10 @@ Remove `NODE_NAME` from your inventory file.
 
 Run `cluster.yml` to regenerate the configuration files on all remaining nodes.
 
-### 4) Shutdown the old instance
+### 4) Remove the old etcd node from apiserver config
+
+In every master node, edit `/etc/kubernetes/manifests/kube-apiserver.yaml`. Make sure only active etcd nodes are still present in the apiserver command line parameter `--etcd-servers=...`.
+
+### 5) Shutdown the old instance
 
 That's it.

--- a/remove-node.yml
+++ b/remove-node.yml
@@ -5,6 +5,23 @@
 - name: Ensure compatibility with old groups
   import_playbook: legacy_groups.yml
 
+- hosts: "{{ node | default('etcd:k8s_cluster:calico_rr') }}"
+  gather_facts: no
+  environment: "{{ proxy_disable_env }}"
+  tasks:
+    - name: Confirm Execution
+      pause:
+        prompt: "Are you sure you want to delete nodes state? Type 'yes' to delete nodes."
+      register: pause_result
+      run_once: True
+      when:
+        - not (skip_confirmation | default(false) | bool)
+
+    - name: Fail if user does not confirm deletion
+      fail:
+        msg: "Delete nodes confirmation failed"
+      when: pause_result.user_input | default('yes') != 'yes'
+
 - hosts: kube_control_plane[0]
   gather_facts: no
   environment: "{{ proxy_disable_env }}"

--- a/remove-node.yml
+++ b/remove-node.yml
@@ -5,27 +5,11 @@
 - name: Ensure compatibility with old groups
   import_playbook: legacy_groups.yml
 
-- hosts: "{{ node | default('etcd:k8s_cluster:calico_rr') }}"
-  gather_facts: no
-  environment: "{{ proxy_disable_env }}"
-  vars_prompt:
-    name: "delete_nodes_confirmation"
-    prompt: "Are you sure you want to delete nodes state? Type 'yes' to delete nodes."
-    default: "no"
-    private: no
-
-  pre_tasks:
-    - name: check confirmation
-      fail:
-        msg: "Delete nodes confirmation failed"
-      when: delete_nodes_confirmation != "yes"
-
 - hosts: kube_control_plane[0]
   gather_facts: no
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
-    - { role: bootstrap-os, tags: bootstrap-os }
     - { role: remove-node/pre-remove, tags: pre-remove }
 
 - hosts: "{{ node | default('kube_node') }}"
@@ -33,7 +17,6 @@
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults, when: reset_nodes|default(True)|bool }
-    - { role: bootstrap-os, tags: bootstrap-os, when: reset_nodes|default(True)|bool }
     - { role: remove-node/remove-etcd-node }
     - { role: reset, tags: reset, when: reset_nodes|default(True)|bool }
 
@@ -43,5 +26,4 @@
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults, when: reset_nodes|default(True)|bool }
-    - { role: bootstrap-os, tags: bootstrap-os, when: reset_nodes|default(True)|bool }
     - { role: remove-node/post-remove, tags: post-remove }

--- a/roles/remove-node/remove-etcd-node/tasks/main.yml
+++ b/roles/remove-node/remove-etcd-node/tasks/main.yml
@@ -34,10 +34,12 @@
     - facts
   environment:
     ETCDCTL_API: 3
-    ETCDCTL_CERT: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
-    ETCDCTL_KEY: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
+    ETCDCTL_CERT: "{{ etcd_cert_dir }}/admin-{{ groups['etcd']|first }}.pem"
+    ETCDCTL_KEY: "{{ etcd_cert_dir }}/admin-{{ groups['etcd']|first }}-key.pem"
     ETCDCTL_CACERT: "{{ etcd_cert_dir }}/ca.pem"
-    ETCDCTL_ENDPOINTS: "{{ etcd_access_addresses }}"
+    ETCDCTL_ENDPOINTS: "https://{{ hostvars[groups['etcd']|first]['etcd_access_address'] |
+                                   default(hostvars[groups['etcd']|first]['ip']) |
+                                   default(hostvars[groups['etcd']|first]['fallback_ips'][groups['etcd']|first]) }}:2379"
   delegate_to: "{{ groups['etcd']|first }}"
   when: inventory_hostname in groups['etcd']
 
@@ -50,10 +52,12 @@
     - facts
   environment:
     ETCDCTL_API: 3
-    ETCDCTL_CERT: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
-    ETCDCTL_KEY: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
+    ETCDCTL_CERT: "{{ etcd_cert_dir }}/admin-{{ groups['etcd']|first }}.pem"
+    ETCDCTL_KEY: "{{ etcd_cert_dir }}/admin-{{ groups['etcd']|first }}-key.pem"
     ETCDCTL_CACERT: "{{ etcd_cert_dir }}/ca.pem"
-    ETCDCTL_ENDPOINTS: "{{ etcd_access_addresses }}"
+    ETCDCTL_ENDPOINTS: "https://{{ hostvars[groups['etcd']|first]['etcd_access_address'] |
+                                   default(hostvars[groups['etcd']|first]['ip']) |
+                                   default(hostvars[groups['etcd']|first]['fallback_ips'][groups['etcd']|first]) }}:2379"
   delegate_to: "{{ groups['etcd']|first }}"
   when:
     - inventory_hostname in groups['etcd']


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR fixes some issues when removing nodes commented in the issue #7569.
I also removed the `check confirmation` part. I think there is no other task that includes this option and it makes difficult to automate or integrate kubespray with other tools.
I also included some changes to `Adding/replacing a node` documentation. When adding/removing etcd members, apiserver manifest field `--etcd-servers=` is not updated, so i think it's important to know this.

**Which issue(s) this PR fixes**:
#7569

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NO
