### PR TITLE
Fix pull_by_digest variable type to boolean instead of str

### DIFF
--- a/roles/download/tasks/set_container_facts.yml
+++ b/roles/download/tasks/set_container_facts.yml
@@ -5,8 +5,7 @@
 
 - name: set_container_facts | Set if containers should be pulled by digest
   set_fact:
-    pull_by_digest: >-
-      {%- if download.sha256 is defined and download.sha256 -%}true{%- else -%}false{%- endif -%}
+    pull_by_digest: "{{ download.sha256 is defined and download.sha256 }}"
 
 - name: set_container_facts | Define by what name to pull the image
   set_fact:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
I've [integrated](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/integration.md) kubespray with my own Ansible repository. I've faced a couple of issues with variable type/templating due to that fact, that I use "strict" types in Jinja (`jinja2_native=True` configuration in ansible.cfg) in my repository.
This PR just rewrites `pull_by_digest` definition in the way that the type of result is `bool`, not `str`.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/kubespray/issues/7609

**Special notes for your reviewer**:
This is the second my PR, the first one is https://github.com/kubernetes-sigs/kubespray/pull/7606.
Both this patches togeter make possible to use kubespray with `jinja2_native=True` Ansible setting.

**Does this PR introduce a user-facing change?**:
NONE