### PR TITLE
Add nodeSelector for other services and node labels before CNI setup

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -86,8 +86,8 @@
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes/kubeadm, tags: kubeadm}
-    - { role: network_plugin, tags: network }
     - { role: kubernetes/node-label, tags: node-label }
+    - { role: network_plugin, tags: network }
 
 - hosts: calico_rr
   gather_facts: False

--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -10,15 +10,18 @@ dns_prevent_single_point_failure: "{{ 'true' if dns_min_replicas|int > 1 else 'f
 enable_coredns_reverse_dns_lookups: true
 coredns_ordinal_suffix: ""
 # dns_extra_tolerations: [{effect: NoSchedule, operator: "Exists"}]
+coredns_deployment_nodeselector: "kubernetes.io/os: linux"
 
 # nodelocaldns
 nodelocaldns_cpu_requests: 100m
 nodelocaldns_memory_limit: 170Mi
-nodelocaldnsdns_memory_requests: 70Mi
+nodelocaldns_memory_requests: 70Mi
+nodelocaldns_ds_nodeselector: "kubernetes.io/os: linux"
 
 # Limits for dns-autoscaler
 dns_autoscaler_cpu_requests: 20m
 dns_autoscaler_memory_requests: 10Mi
+dns_autoscaler_deployment_nodeselector: "kubernetes.io/os: linux"
 
 # Netchecker
 deploy_netchecker: false

--- a/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
@@ -25,9 +25,9 @@ spec:
         seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
         createdby: 'kubespray'
     spec:
-      priorityClassName: system-cluster-critical
       nodeSelector:
-        kubernetes.io/os: linux
+        {{ coredns_deployment_nodeselector }}
+      priorityClassName: system-cluster-critical
       serviceAccountName: coredns
       tolerations:
         - key: node-role.kubernetes.io/master

--- a/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
@@ -32,6 +32,8 @@ spec:
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
     spec:
+      nodeSelector:
+        {{ dns_autoscaler_deployment_nodeselector}}
       priorityClassName: system-cluster-critical
       securityContext:
         supplementalGroups: [ 65534 ]

--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-daemonset.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-daemonset.yml.j2
@@ -18,6 +18,8 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9253'
     spec:
+      nodeSelector:
+        {{ nodelocaldns_ds_nodeselector }}
       priorityClassName: system-cluster-critical
       serviceAccountName: nodelocaldns
       hostNetwork: true
@@ -35,7 +37,7 @@ spec:
             memory: {{ nodelocaldns_memory_limit }}
           requests:
             cpu: {{ nodelocaldns_cpu_requests }}
-            memory: {{ nodelocaldnsdns_memory_requests }}
+            memory: {{ nodelocaldns_memory_requests }}
         args: [ "-localip", "{{ nodelocaldns_ip }}", "-conf", "/etc/coredns/Corefile", "-upstreamsvc", "coredns" ]
         securityContext:
           privileged: true

--- a/roles/kubernetes-apps/policy_controller/calico/defaults/main.yml
+++ b/roles/kubernetes-apps/policy_controller/calico/defaults/main.yml
@@ -4,6 +4,7 @@ calico_policy_controller_cpu_limit: 100m
 calico_policy_controller_memory_limit: 256M
 calico_policy_controller_cpu_requests: 30m
 calico_policy_controller_memory_requests: 64M
+calico_policy_controller_deployment_nodeselector: "kubernetes.io/os: linux"
 
 # SSL
 calico_cert_dir: "/etc/calico/certs"

--- a/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-controllers.yml.j2
+++ b/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-controllers.yml.j2
@@ -20,7 +20,7 @@ spec:
         k8s-app: calico-kube-controllers
     spec:
       nodeSelector:
-        kubernetes.io/os: linux
+        {{ calico_policy_controller_deployment_nodeselector }}
       hostNetwork: true
       serviceAccountName: calico-kube-controllers
       tolerations:

--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -39,6 +39,9 @@ calico_node_memory_requests: 64M
 calico_node_cpu_requests: 150m
 calico_felix_chaininsertmode: Insert
 
+# Calico daemonset nodeselector
+calico_ds_nodeselector: "kubernetes.io/os: linux"
+
 # Virtual network ID to use for VXLAN traffic. A value of 0 means “use the kernel default”.
 calico_vxlan_vni: 4096
 

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -26,6 +26,8 @@ spec:
         prometheus.io/port: "{{ calico_felix_prometheusmetricsport }}"
 {% endif %}
     spec:
+      nodeSelector:
+        {{ calico_ds_nodeselector }}
       priorityClassName: system-node-critical
       hostNetwork: true
       serviceAccountName: calico-node

--- a/scale.yml
+++ b/scale.yml
@@ -96,5 +96,5 @@
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes/kubeadm, tags: kubeadm }
-    - { role: network_plugin, tags: network }
     - { role: kubernetes/node-label, tags: node-label }
+    - { role: network_plugin, tags: network }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

* Add user-define nodeSelector for calico, calico-node-controllers, coredns, dns-autoscaler, nodelocaldns
* Add node labels before CNI setup
* Fix variable name `nodelocaldns dns_memory requests` to `nodelocaldns memory requests`

**Which issue(s) this PR fixes**:

Fixes #7611

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note

User-define nodeSelector for calico, calico-node-controllers, coredns, dns-autoscaler, nodelocaldns

action required: Replace, please nodelocaldnsdns_memory_requests to nodelocaldns_memory_requests
```
