### PR TITLE
Fix missing broken_etcd filter in recover control plane task

### DIFF
--- a/roles/recover_control_plane/etcd/tasks/main.yml
+++ b/roles/recover_control_plane/etcd/tasks/main.yml
@@ -24,6 +24,8 @@
 - name: Set has_quorum fact
   set_fact:
     has_quorum: "{{ etcd_endpoint_health.stderr_lines | select('match', '.*is healthy.*') | list | length >= etcd_endpoint_health.stderr_lines | select('match', '.*is unhealthy.*') | list | length }}"
+  when:
+    - groups['broken_etcd']
 
 - include_tasks: recover_lost_quorum.yml
   when:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Fix missing `when` clause in recover control plane play

**Which issue(s) this PR fixes**:
Fixes #7616

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
