### PR TITLE
Add cinder_csi_ignore_volume_az

### DIFF
--- a/docs/openstack.md
+++ b/docs/openstack.md
@@ -104,6 +104,12 @@ The new cloud provider is configured to have Octavia by default in Kubespray.
   cinder_topology: true
   ```
 
+- Enabling `cinder_csi_ignore_volume_az: true`, ignores volumeAZ and schedules on any of the available node AZ.
+
+  ```yaml
+  cinder_csi_ignore_volume_az: true
+  ```
+
 - If you are using OpenStack loadbalancer(s) replace the `openstack_lbaas_subnet_id` with the new `external_openstack_lbaas_subnet_id`. **Note** The new cloud provider is using Octavia instead of Neutron LBaaS by default!
 - Enable 3 feature gates to allow migration of all volumes and storage classes (if you have any feature gates already set just add the 3 listed below):
 

--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-cloud-config.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-cloud-config.j2
@@ -22,6 +22,9 @@ ca-file="{{ kube_config_dir }}/cinder-cacert.pem"
 {% if cinder_blockstorage_version is defined %}
 bs-version={{ cinder_blockstorage_version }}
 {% endif %}
+{% if cinder_csi_ignore_volume_az is defined %}
+ignore-volume-az={{ cinder_csi_ignore_volume_az | bool }}
+{% endif %}
 {% if node_volume_attach_limit is defined and node_volume_attach_limit != "" %}
 node-volume-attach-limit="{{ node_volume_attach_limit }}"
 {% endif %}

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -375,6 +375,7 @@ openstack_blockstorage_ignore_volume_az: "{{ volume_cross_zone_attachment | defa
 # Set Cinder topology zones (can be multiple zones, default not set)
 # cinder_topology_zones:
 #   - nova
+cinder_csi_ignore_volume_az: "{{ volume_cross_zone_attachment | default('false') }}"
 
 ## When OpenStack is used, if LBaaSv2 is available you can enable it with the following 2 variables.
 openstack_lbaas_enabled: false


### PR DESCRIPTION
Signed-off-by: Cedric Hnyda <cedric.hnyda@itera.io>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

The PR adds the option in kubespray: `cinder_ignore_volume_az` introduced by https://github.com/kubernetes/cloud-provider-openstack/pull/1307.

Optional. When `Topology` feature enabled, by default, PV volume node affinity is populated with volume accessible topology, which is volume AZ. But, some of the openstack users do not have compute zones named exactly the same as volume zones. This might cause pods to go in pending state as no nodes available in volume AZ. Enabling `ignore-volume-az=true`, ignores volumeAZ and schedules on any of the available node AZ.

It concerns cinder csi configuration.


```
