### PR TITLE
Adding to coredns deployment the nodeselector option

### DIFF
--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -10,7 +10,7 @@ dns_prevent_single_point_failure: "{{ 'true' if dns_min_replicas|int > 1 else 'f
 enable_coredns_reverse_dns_lookups: true
 coredns_ordinal_suffix: ""
 # dns_extra_tolerations: [{effect: NoSchedule, operator: "Exists"}]
-dns_extra_tolerations: [{effect: NoExecute, key: "node-role.kubernetes.io/node"}]
+dns_extra_tolerations: {}
 
 # nodelocaldns
 nodelocaldns_cpu_requests: 100m

--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -10,7 +10,7 @@ dns_prevent_single_point_failure: "{{ 'true' if dns_min_replicas|int > 1 else 'f
 enable_coredns_reverse_dns_lookups: true
 coredns_ordinal_suffix: ""
 # dns_extra_tolerations: [{effect: NoSchedule, operator: "Exists"}]
-dns_extra_nodeselector: {}
+dns_extra_tolerations: [{effect: NoExecute, key: "node-role.kubernetes.io/node"}]
 
 # nodelocaldns
 nodelocaldns_cpu_requests: 100m

--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -12,7 +12,6 @@ coredns_ordinal_suffix: ""
 # dns_extra_tolerations: [{effect: NoSchedule, operator: "Exists"}]
 dns_extra_nodeselector: {}
 
-
 # nodelocaldns
 nodelocaldns_cpu_requests: 100m
 nodelocaldns_memory_limit: 170Mi

--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -10,6 +10,7 @@ dns_prevent_single_point_failure: "{{ 'true' if dns_min_replicas|int > 1 else 'f
 enable_coredns_reverse_dns_lookups: true
 coredns_ordinal_suffix: ""
 # dns_extra_tolerations: [{effect: NoSchedule, operator: "Exists"}]
+# dns_extra_nodeselector
 
 # nodelocaldns
 nodelocaldns_cpu_requests: 100m

--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -10,7 +10,8 @@ dns_prevent_single_point_failure: "{{ 'true' if dns_min_replicas|int > 1 else 'f
 enable_coredns_reverse_dns_lookups: true
 coredns_ordinal_suffix: ""
 # dns_extra_tolerations: [{effect: NoSchedule, operator: "Exists"}]
-# dns_extra_nodeselector
+dns_extra_nodeselector: {}
+
 
 # nodelocaldns
 nodelocaldns_cpu_requests: 100m

--- a/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
@@ -28,6 +28,9 @@ spec:
       priorityClassName: system-cluster-critical
       nodeSelector:
         kubernetes.io/os: linux
+{% if dns_extra_nodeselector %}
+        {{ dns_extra_nodeselector | list | to_nice_yaml(indent=2) | indent(8) }}
+{% endif %}
       serviceAccountName: coredns
       tolerations:
         - key: node-role.kubernetes.io/master


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

kind bug

**What this PR does / why we need it**:
This PR is to implement the nodeselector to the coredns deployment.
Because if we are using different environments splitted by nodeselector, (production, dev, stage,...) we want to have the option to specify where will be running the coredns pod in our case in production machines.

to see more details, please check:

https://github.com/kubernetes-sigs/kubespray/issues/7631


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
