### PR TITLE
Fix Oracle yum disabled repository file after EPEL install

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-centos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-centos.yml
@@ -41,6 +41,15 @@
     - '''ID="ol"'' in os_release.stdout_lines'
     - (ansible_distribution_version | float) < 7.6
 
+- name: Install EPEL for Oracle Linux repo package
+  package:
+    name: "oracle-epel-release-el{{ ansible_distribution_major_version }}"
+    state: present
+  when:
+    - use_oracle_public_repo|default(true)
+    - '''ID="ol"'' in os_release.stdout_lines'
+    - (ansible_distribution_version | float) >= 7.6
+
 - name: Enable Oracle Linux repo
   ini_file:
     dest: "/etc/yum.repos.d/oracle-linux-ol{{ ansible_distribution_major_version }}.repo"
@@ -48,17 +57,9 @@
     option: "{{ item.option }}"
     value: "{{ item.value }}"
   with_items:
+    - { option: "name", value: "ol{{ ansible_distribution_major_version }}_addons" }
     - { option: "enabled", value: "1" }
     - { option: "baseurl", value: "http://yum.oracle.com/repo/OracleLinux/OL{{ ansible_distribution_major_version }}/addons/x86_64/" }
-  when:
-    - use_oracle_public_repo|default(true)
-    - '''ID="ol"'' in os_release.stdout_lines'
-    - (ansible_distribution_version | float) >= 7.6
-
-- name: Install EPEL for Oracle Linux repo package
-  package:
-    name: "oracle-epel-release-el{{ ansible_distribution_major_version }}"
-    state: present
   when:
     - use_oracle_public_repo|default(true)
     - '''ID="ol"'' in os_release.stdout_lines'


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix CI job error with oracle and selinux https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/1282351980

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
We are running into issue describe here https://oracle-base.com/articles/linux/download-the-latest-oracle-linux-repo-file
Repos are flagged as ".disabled" and then nothing can be done, so enabling olx_addons after running EPEL install is cleaner.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
