### PR TITLE
Add retries to 'Set label for route reflector' task

### DIFF
--- a/roles/network_plugin/calico/rr/tasks/main.yml
+++ b/roles/network_plugin/calico/rr/tasks/main.yml
@@ -9,3 +9,8 @@
   command: >-
     {{ bin_dir }}/calicoctl.sh label node {{ inventory_hostname }}
     'i-am-a-route-reflector=true' --overwrite
+  changed_when: false
+  register: calico_rr_label
+  until: calico_rr_label is succeeded
+  delay: "{{ retry_stagger | random + 3 }}"
+  retries: 10


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR adds retries to the task 'Calico-rr | Set label for route reflector' to fix linked issue.

**Which issue(s) this PR fixes**:
Fixes #7644
