### PR TITLE
Added possibility to specify vSphere credentials via env variables

### DIFF
--- a/docs/vsphere-csi.md
+++ b/docs/vsphere-csi.md
@@ -8,26 +8,26 @@ To set the number of replicas for the vSphere CSI controller, you can change `vs
 
 You need to source the vSphere credentials you use to deploy your machines that will host Kubernetes.
 
-| Variable                                    | Required | Type    | Choices                    | Default                   | Comment                                                        |
-|---------------------------------------------|----------|---------|----------------------------|---------------------------|----------------------------------------------------------------|
-| external_vsphere_vcenter_ip                 | TRUE     | string  |                            |                           | IP/URL of the vCenter                                          |
-| external_vsphere_vcenter_port               | TRUE     | string  |                            | "443"                     | Port of the vCenter API                                        |
-| external_vsphere_insecure                   | TRUE     | string  | "true", "false"            | "true"                    | set to "true" if the host above uses a self-signed cert        |
-| external_vsphere_user                       | TRUE     | string  |                            |                           | User name for vCenter with required privileges                 |
-| external_vsphere_password                   | TRUE     | string  |                            |                           | Password for vCenter                                           |
-| external_vsphere_datacenter                 | TRUE     | string  |                            |                           | Datacenter name to use                                         |
-| external_vsphere_kubernetes_cluster_id      | TRUE     | string  |                            | "kubernetes-cluster-id"   | Kubernetes cluster ID to use                                   |
-| external_vsphere_version          | TRUE     | string  |                            | "6.7u3"                  | Vmware Vsphere version where located all VMs                                   |
-| vsphere_cloud_controller_image_tag          | TRUE     | string  |                            | "latest"                  | Kubernetes cluster ID to use                                   |
-| vsphere_syncer_image_tag                    | TRUE     | string  |                            | "v1.0.2"                  | Syncer image tag to use                                        |
-| vsphere_csi_attacher_image_tag              | TRUE     | string  |                            | "v1.1.1"                  | CSI attacher image tag to use                                  |
-| vsphere_csi_controller                      | TRUE     | string  |                            | "v1.0.2"                  | CSI controller image tag to use                                |
-| vsphere_csi_controller_replicas             | TRUE     | integer |                            | 1                         | Number of pods Kubernetes should deploy for the CSI controller |
-| vsphere_csi_liveness_probe_image_tag        | TRUE     | string  |                            | "v1.1.0"                  | CSI liveness probe image tag to use                            |
-| vsphere_csi_provisioner_image_tag           | TRUE     | string  |                            | "v1.2.2"                  | CSI provisioner image tag to use                               |
-| vsphere_csi_node_driver_registrar_image_tag | TRUE     | string  |                            | "v1.1.0"                  | CSI node driver registrat image tag to use                     |
-| vsphere_csi_driver_image_tag                | TRUE     | string  |                            | "v1.0.2"                  | CSI driver image tag to use                                    |
-vsphere_csi_resizer_tag                | TRUE     | string  |                            |  "v1.0.0"                  | CSI resizer image tag to use
+| Variable                                    | Required | Type    | Choices                    | Default                   | Comment                                                                                                             |
+|---------------------------------------------|----------|---------|----------------------------|---------------------------|---------------------------------------------------------------------------------------------------------------------|
+| external_vsphere_vcenter_ip                 | TRUE     | string  |                            |                           | IP/URL of the vCenter                                                                                               |
+| external_vsphere_vcenter_port               | TRUE     | string  |                            | "443"                     | Port of the vCenter API                                                                                             |
+| external_vsphere_insecure                   | TRUE     | string  | "true", "false"            | "true"                    | set to "true" if the host above uses a self-signed cert                                                             |
+| external_vsphere_user                       | TRUE     | string  |                            |                           | User name for vCenter with required privileges (Can also be specified with the `VSPHERE_USER` environment variable) |
+| external_vsphere_password                   | TRUE     | string  |                            |                           | Password for vCenter (Can also be specified with the `VSPHERE_PASSWORD` environment variable)                       |
+| external_vsphere_datacenter                 | TRUE     | string  |                            |                           | Datacenter name to use                                                                                              |
+| external_vsphere_kubernetes_cluster_id      | TRUE     | string  |                            | "kubernetes-cluster-id"   | Kubernetes cluster ID to use                                                                                        |
+| external_vsphere_version                    | TRUE     | string  |                            | "6.7u3"                   | Vmware Vsphere version where located all VMs                                                                        |
+| vsphere_cloud_controller_image_tag          | TRUE     | string  |                            | "latest"                  | Kubernetes cluster ID to use                                                                                        |
+| vsphere_syncer_image_tag                    | TRUE     | string  |                            | "v1.0.2"                  | Syncer image tag to use                                                                                             |
+| vsphere_csi_attacher_image_tag              | TRUE     | string  |                            | "v1.1.1"                  | CSI attacher image tag to use                                                                                       |
+| vsphere_csi_controller                      | TRUE     | string  |                            | "v1.0.2"                  | CSI controller image tag to use                                                                                     |
+| vsphere_csi_controller_replicas             | TRUE     | integer |                            | 1                         | Number of pods Kubernetes should deploy for the CSI controller                                                      |
+| vsphere_csi_liveness_probe_image_tag        | TRUE     | string  |                            | "v1.1.0"                  | CSI liveness probe image tag to use                                                                                 |
+| vsphere_csi_provisioner_image_tag           | TRUE     | string  |                            | "v1.2.2"                  | CSI provisioner image tag to use                                                                                    |
+| vsphere_csi_node_driver_registrar_image_tag | TRUE     | string  |                            | "v1.1.0"                  | CSI node driver registrat image tag to use                                                                          |
+| vsphere_csi_driver_image_tag                | TRUE     | string  |                            | "v1.0.2"                  | CSI driver image tag to use                                                                                         |
+| vsphere_csi_resizer_tag                     | TRUE     | string  |                            | "v1.0.0"                  | CSI resizer image tag to use
 
 ## Usage example
 

--- a/docs/vsphere.md
+++ b/docs/vsphere.md
@@ -30,16 +30,16 @@ external_cloud_provider: "vsphere"
 
 Then, `inventory/sample/group_vars/vsphere.yml`, you need to declare your vCenter credentials and enable the vSphere CSI following the description below.
 
-| Variable                               | Required | Type    | Choices                    | Default | Comment                                                                   |
-|----------------------------------------|----------|---------|----------------------------|---------|---------------------------------------------------------------------------|
-| external_vsphere_vcenter_ip            | TRUE     | string  |                            |                           | IP/URL of the vCenter                                   |
-| external_vsphere_vcenter_port          | TRUE     | string  |                            | "443"                     | Port of the vCenter API                                 |
-| external_vsphere_insecure              | TRUE     | string  | "true", "false"            | "true"                    | set to "true" if the host above uses a self-signed cert |
-| external_vsphere_user                  | TRUE     | string  |                            |                           | User name for vCenter with required privileges          |
-| external_vsphere_password              | TRUE     | string  |                            |                           | Password for vCenter                                    |
-| external_vsphere_datacenter            | TRUE     | string  |                            |                           | Datacenter name to use                                  |
-| external_vsphere_kubernetes_cluster_id | TRUE     | string  |                            | "kubernetes-cluster-id"   | Kubernetes cluster ID to use                            |
-| vsphere_csi_enabled                    | TRUE     | boolean |                            | false                     | Enable vSphere CSI                                      |
+| Variable                               | Required | Type    | Choices                    | Default                   | Comment                                                                                                             |
+|----------------------------------------|----------|---------|----------------------------|---------------------------|---------------------------------------------------------------------------------------------------------------------|
+| external_vsphere_vcenter_ip            | TRUE     | string  |                            |                           | IP/URL of the vCenter                                                                                               |
+| external_vsphere_vcenter_port          | TRUE     | string  |                            | "443"                     | Port of the vCenter API                                                                                             |
+| external_vsphere_insecure              | TRUE     | string  | "true", "false"            | "true"                    | set to "true" if the host above uses a self-signed cert                                                             |
+| external_vsphere_user                  | TRUE     | string  |                            |                           | User name for vCenter with required privileges (Can also be specified with the `VSPHERE_USER` environment variable) |
+| external_vsphere_password              | TRUE     | string  |                            |                           | Password for vCenter (Can also be specified with the `VSPHERE_PASSWORD` environment variable)                       |
+| external_vsphere_datacenter            | TRUE     | string  |                            |                           | Datacenter name to use                                                                                              |
+| external_vsphere_kubernetes_cluster_id | TRUE     | string  |                            | "kubernetes-cluster-id"   | Kubernetes cluster ID to use                                                                                        |
+| vsphere_csi_enabled                    | TRUE     | boolean |                            | false                     | Enable vSphere CSI                                                                                                  |
 
 Example configuration:
 

--- a/inventory/sample/group_vars/all/vsphere.yml
+++ b/inventory/sample/group_vars/all/vsphere.yml
@@ -2,8 +2,8 @@
 # external_vsphere_vcenter_ip: "myvcenter.domain.com"
 # external_vsphere_vcenter_port: "443"
 # external_vsphere_insecure: "true"
-# external_vsphere_user: "administrator@vsphere.local"
-# external_vsphere_password: "K8s_admin"
+# external_vsphere_user: "administrator@vsphere.local" # Can also be set via the `VSPHERE_USER` environment variable
+# external_vsphere_password: "K8s_admin" # Can also be set via the `VSPHERE_PASSWORD` environment variable
 # external_vsphere_datacenter: "DATACENTER_name"
 # external_vsphere_kubernetes_cluster_id: "kubernetes-cluster-id"
 

--- a/roles/kubernetes-apps/external_cloud_controller/vsphere/defaults/main.yml
+++ b/roles/kubernetes-apps/external_cloud_controller/vsphere/defaults/main.yml
@@ -9,3 +9,6 @@ external_vsphere_insecure: "true"
 ##    arg2: "value2"
 external_vsphere_cloud_controller_extra_args: {}
 external_vsphere_cloud_controller_image_tag: "latest"
+
+external_vsphere_user: "{{ lookup('env','VSPHERE_USER')  }}"
+external_vsphere_password: "{{ lookup('env','VSPHERE_PASSWORD')  }}"

--- a/roles/kubernetes-apps/external_cloud_controller/vsphere/defaults/main.yml
+++ b/roles/kubernetes-apps/external_cloud_controller/vsphere/defaults/main.yml
@@ -10,5 +10,5 @@ external_vsphere_insecure: "true"
 external_vsphere_cloud_controller_extra_args: {}
 external_vsphere_cloud_controller_image_tag: "latest"
 
-external_vsphere_user: "{{ lookup('env','VSPHERE_USER')  }}"
-external_vsphere_password: "{{ lookup('env','VSPHERE_PASSWORD')  }}"
+external_vsphere_user: "{{ lookup('env','VSPHERE_USER') }}"
+external_vsphere_password: "{{ lookup('env','VSPHERE_PASSWORD') }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

Since the vSphere password variable is in the plain text config file, it's very easy for a user to set it in plain-text while testing which might lead to unwanted consequences. 

To be able to easily set sensitive credentials via other methods than from config we should be able to set it via environment variables.
This is already the case if you use `--extra-vars foo=${BAR}` but to make this process more straight forward I suggest we add this variable which wouldn't change the current behavior.

I used same approach as [openstack](https://github.com/kubernetes-sigs/kubespray/blob/23cd1d41fb9308fce839dba2f2cdb2036a96d621/roles/kubernetes-apps/external_cloud_controller/openstack/defaults/main.yml#L6-L7) and same naming convention as the [official terraform module](https://registry.terraform.io/providers/hashicorp/vsphere/latest/docs#argument-reference)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
vSphere credentials can now be passed as environment variables
```
