### PR TITLE
Update kubernetes version to 1.21.1 (CoreDNS to 1.8.0, Docker to 20.10, CRI-O to 1.21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Note: Upstart/SysV init based OS types are not supported.
 - Core
   - [kubernetes](https://github.com/kubernetes/kubernetes) v1.21.1
   - [etcd](https://github.com/coreos/etcd) v3.4.13
-  - [docker](https://www.docker.com/) v19.03 (see note)
+  - [docker](https://www.docker.com/) v20.10 (see note)
   - [containerd](https://containerd.io/) v1.4.4
   - [cri-o](http://cri-o.io/) v1.21 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)
 - Network Plugin
@@ -156,7 +156,7 @@ Note: Upstart/SysV init based OS types are not supported.
 
 ## Container Runtime Notes
 
-- The list of available docker version is 18.09, 19.03 and 20.10. The recommended docker version is 19.03. The kubelet might break on docker's non-standard version numbering (it no longer uses semantic versioning). To ensure auto-updates don't break your cluster look into e.g. yum versionlock plugin or apt pin).
+- The list of available docker version is 18.09, 19.03 and 20.10. The recommended docker version is 20.10. The kubelet might break on docker's non-standard version numbering (it no longer uses semantic versioning). To ensure auto-updates don't break your cluster look into e.g. yum versionlock plugin or apt pin).
 - The cri-o version should be aligned with the respective kubernetes version (i.e. kube_version=1.20.x, crio_version=1.20)
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [etcd](https://github.com/coreos/etcd) v3.4.13
   - [docker](https://www.docker.com/) v19.03 (see note)
   - [containerd](https://containerd.io/) v1.4.4
-  - [cri-o](http://cri-o.io/) v1.20 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)
+  - [cri-o](http://cri-o.io/) v1.21 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)
 - Network Plugin
   - [cni-plugins](https://github.com/containernetworking/plugins) v0.9.1
   - [calico](https://github.com/projectcalico/calico) v3.17.4

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Note: Upstart/SysV init based OS types are not supported.
 ## Supported Components
 
 - Core
-  - [kubernetes](https://github.com/kubernetes/kubernetes) v1.20.7
+  - [kubernetes](https://github.com/kubernetes/kubernetes) v1.21.1
   - [etcd](https://github.com/coreos/etcd) v3.4.13
   - [docker](https://www.docker.com/) v19.03 (see note)
   - [containerd](https://containerd.io/) v1.4.4

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [cephfs-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.0-k8s1.11
   - [rbd-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.1-k8s1.11
   - [cert-manager](https://github.com/jetstack/cert-manager) v0.16.1
-  - [coredns](https://github.com/coredns/coredns) v1.7.0
+  - [coredns](https://github.com/coredns/coredns) v1.8.0
   - [ingress-nginx](https://github.com/kubernetes/ingress-nginx) v0.43.0
 
 ## Container Runtime Notes

--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -17,7 +17,7 @@ kube_token_dir: "{{ kube_config_dir }}/tokens"
 kube_api_anonymous_auth: true
 
 ## Change this to use another Kubernetes version, e.g. a current beta release
-kube_version: v1.20.7
+kube_version: v1.21.1
 
 # Where the binaries will be downloaded.
 # Note: ensure that you've enough disk space (about 1G)

--- a/roles/container-engine/cri-o/defaults/main.yml
+++ b/roles/container-engine/cri-o/defaults/main.yml
@@ -43,7 +43,7 @@ crio_kubernetes_version_matrix:
   "1.20": "1.20"
   "1.19": "1.19"
 
-crio_version: "{{ crio_kubernetes_version_matrix[crio_required_version] | default('1.20') }}"
+crio_version: "{{ crio_kubernetes_version_matrix[crio_required_version] | default('1.21') }}"
 
 # The crio_runtimes variable defines a list of OCI compatible runtimes.
 crio_runtimes:

--- a/roles/container-engine/cri-o/vars/fedora.yml
+++ b/roles/container-engine/cri-o/vars/fedora.yml
@@ -4,3 +4,10 @@ crio_packages:
   - cri-tools
 
 crio_conmon: /usr/libexec/crio/conmon
+
+# Fedora doesn't have cri-o 1.21 packages
+crio_kubernetes_version_matrix:
+  "1.21": "1.20"
+  "1.20": "1.20"
+  "1.19": "1.19"
+crio_version: "{{ crio_kubernetes_version_matrix[crio_required_version] | default('1.20') }}"

--- a/roles/container-engine/docker/defaults/main.yml
+++ b/roles/container-engine/docker/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-docker_version: '19.03'
+docker_version: '20.10'
 docker_cli_version: "{{ docker_version }}"
 
 docker_package_info:

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -492,7 +492,7 @@ haproxy_image_tag: 2.3
 # bundle with kubeadm; if not 'basic' upgrade can sometimes fail
 coredns_image_is_namespaced: "{{ (kube_major_version | regex_replace('^v', '') | float) >= 1.21 }}"
 
-coredns_version: "v1.7.0"
+coredns_version: "v1.8.0"
 coredns_image_repo: "{{ kube_image_repo }}{{'/coredns/coredns' if (coredns_image_is_namespaced | bool) else '/coredns' }}"
 coredns_image_tag: "{{ coredns_version if (coredns_image_is_namespaced | bool) else (coredns_version | regex_replace('^v', '')) }}"
 

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -15,7 +15,7 @@ is_fedora_coreos: false
 disable_swap: true
 
 ## Change this to use another Kubernetes version, e.g. a current beta release
-kube_version: v1.20.7
+kube_version: v1.21.1
 
 ## The minimum version working
 kube_version_min_required: v1.19.0

--- a/tests/files/packet_debian9-calico-upgrade.yml
+++ b/tests/files/packet_debian9-calico-upgrade.yml
@@ -7,3 +7,6 @@ mode: default
 kube_network_plugin: calico
 deploy_netchecker: true
 dns_min_replicas: 1
+
+# Only docker package 19.03 for Debian9
+docker_version: '19.03'

--- a/tests/files/packet_fedora33-calico.yml
+++ b/tests/files/packet_fedora33-calico.yml
@@ -8,7 +8,4 @@ deploy_netchecker: true
 dns_min_replicas: 1
 kube_network_plugin: calico
 
-# Only docker package 20.10 for Fedora33
-docker_version: '20.10'
-
 auto_renew_certificates: true


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Update default version to 1.21.1 and deps:
- CoreDNS to 1.8.0
- Docker to 20.10
- CRI-O to 1.21

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
