### PR TITLE
Packet renamed

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 If you have questions, check the documentation at [kubespray.io](https://kubespray.io) and join us on the [kubernetes slack](https://kubernetes.slack.com), channel **\#kubespray**.
 You can get your invite [here](http://slack.k8s.io/)
 
-- Can be deployed on **[AWS](docs/aws.md), GCE, [Azure](docs/azure.md), [OpenStack](docs/openstack.md), [vSphere](docs/vsphere.md), [Packet](docs/packet.md) (bare metal), Oracle Cloud Infrastructure (Experimental), or Baremetal**
+- Can be deployed on **[AWS](docs/aws.md), GCE, [Azure](docs/azure.md), [OpenStack](docs/openstack.md), [vSphere](docs/vsphere.md), [Equinx Metal](docs/equinix-metal.md) (bare metal), Oracle Cloud Infrastructure (Experimental), or Baremetal**
 - **Highly available** cluster
 - **Composable** (Choice of the network plugin for instance)
 - Supports most popular **Linux distributions**
@@ -105,7 +105,7 @@ vagrant up
 - [AWS](docs/aws.md)
 - [Azure](docs/azure.md)
 - [vSphere](docs/vsphere.md)
-- [Packet Host](docs/packet.md)
+- [Equinix Metal](docs/equinix-metal.md)
 - [Large deployments](docs/large-deployments.md)
 - [Adding/replacing a node](docs/nodes.md)
 - [Upgrades basics](docs/upgrades.md)
@@ -239,6 +239,6 @@ See also [Network checker](docs/netcheck.md).
 
 [![Build graphs](https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/badges/master/pipeline.svg)](https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/pipelines)
 
-CI/end-to-end tests sponsored by: [CNCF](https://cncf.io), [Packet](https://www.packet.com/), [OVHcloud](https://www.ovhcloud.com/), [ELASTX](https://elastx.se/).
+CI/end-to-end tests sponsored by: [CNCF](https://cncf.io), [Equinix Metal](https://metal.equinix.com/), [OVHcloud](https://www.ovhcloud.com/), [ELASTX](https://elastx.se/).
 
 See the [test matrix](docs/test_cases.md) for details.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 If you have questions, check the documentation at [kubespray.io](https://kubespray.io) and join us on the [kubernetes slack](https://kubernetes.slack.com), channel **\#kubespray**.
 You can get your invite [here](http://slack.k8s.io/)
 
-- Can be deployed on **[AWS](docs/aws.md), GCE, [Azure](docs/azure.md), [OpenStack](docs/openstack.md), [vSphere](docs/vsphere.md), [Equinx Metal](docs/equinix-metal.md) (bare metal), Oracle Cloud Infrastructure (Experimental), or Baremetal**
+- Can be deployed on **[AWS](docs/aws.md), GCE, [Azure](docs/azure.md), [OpenStack](docs/openstack.md), [vSphere](docs/vsphere.md), [Equinix Metal](docs/equinix-metal.md) (bare metal), Oracle Cloud Infrastructure (Experimental), or Baremetal**
 - **Highly available** cluster
 - **Composable** (Choice of the network plugin for instance)
 - Supports most popular **Linux distributions**

--- a/contrib/terraform/packet/README.md
+++ b/contrib/terraform/packet/README.md
@@ -1,16 +1,16 @@
-# Kubernetes on Packet with Terraform
+# Kubernetes on Equinix Metal with Terraform
 
 Provision a Kubernetes cluster with [Terraform](https://www.terraform.io) on
-[Packet](https://www.packet.com).
+[Equinix Metal](https://metal.equinix.com) ([formerly Packet](https://blog.equinix.com/blog/2020/10/06/equinix-metal-metal-and-more/)).
 
 ## Status
 
-This will install a Kubernetes cluster on Packet bare metal. It should work in all locations and on most server types.
+This will install a Kubernetes cluster on Equinix Metal. It should work in all locations and on most server types.
 
 ## Approach
 
 The terraform configuration inspects variables found in
-[variables.tf](variables.tf) to create resources in your Packet project.
+[variables.tf](variables.tf) to create resources in your Equinix Metal project.
 There is a [python script](../terraform.py) that reads the generated`.tfstate`
 file to generate a dynamic inventory that is consumed by [cluster.yml](../../..//cluster.yml)
 to actually install Kubernetes with Kubespray.
@@ -36,12 +36,12 @@ now six total etcd replicas.
 
 - [Install Terraform](https://www.terraform.io/intro/getting-started/install.html)
 - Install dependencies: `sudo pip install -r requirements.txt`
-- Account with Packet Host
+- Account with Equinix Metal
 - An SSH key pair
 
 ## SSH Key Setup
 
-An SSH keypair is required so Ansible can access the newly provisioned nodes (bare metal Packet hosts). By default, the public SSH key defined in cluster.tfvars will be installed in authorized_key on the newly provisioned nodes (~/.ssh/id_rsa.pub). Terraform will upload this public key and then it will be distributed out to all the nodes. If you have already set this public key in Packet (i.e. via the portal), then set the public keyfile name in cluster.tfvars to blank to prevent the duplicate key from being uploaded which will cause an error.
+An SSH keypair is required so Ansible can access the newly provisioned nodes (Equinix Metal hosts). By default, the public SSH key defined in cluster.tfvars will be installed in authorized_key on the newly provisioned nodes (~/.ssh/id_rsa.pub). Terraform will upload this public key and then it will be distributed out to all the nodes. If you have already set this public key in Equinix Metal (i.e. via the portal), then set the public keyfile name in cluster.tfvars to blank to prevent the duplicate key from being uploaded which will cause an error.
 
 If you don't already have a keypair generated (~/.ssh/id_rsa and ~/.ssh/id_rsa.pub), then a new keypair can be generated with the command:
 
@@ -51,7 +51,7 @@ ssh-keygen -f ~/.ssh/id_rsa
 
 ## Terraform
 
-Terraform will be used to provision all of the Packet resources with base software as appropriate.
+Terraform will be used to provision all of the Equinix Metal resources with base software as appropriate.
 
 ### Configuration
 
@@ -67,18 +67,18 @@ ln -s ../../contrib/terraform/packet/hosts
 
 This will be the base for subsequent Terraform commands.
 
-#### Packet API access
+#### Equinix Metal API access
 
-Your Packet API key must be available in the `PACKET_AUTH_TOKEN` environment variable.
+Your Equinix Metal API key must be available in the `PACKET_AUTH_TOKEN` environment variable.
 This key is typically stored outside of the code repo since it is considered secret.
 If someone gets this key, they can startup/shutdown hosts in your project!
 
 For more information on how to generate an API key or find your project ID, please see
-[API Integrations](https://support.packet.com/kb/articles/api-integrations)
+[Accounts Index](https://metal.equinix.com/developers/docs/accounts/).
 
-The Packet Project ID associated with the key will be set later in cluster.tfvars.
+The Equinix Metal Project ID associated with the key will be set later in `cluster.tfvars`.
 
-For more information about the API, please see [Packet API](https://www.packet.com/developers/api/)
+For more information about the API, please see [Equinix Metal API](https://metal.equinix.com/developers/api/).
 
 Example:
 
@@ -101,7 +101,7 @@ This helps when identifying which hosts are associated with each cluster.
 While the defaults in variables.tf will successfully deploy a cluster, it is recommended to set the following values:
 
 - cluster_name = the name of the inventory directory created above as $CLUSTER
-- packet_project_id = the Packet Project ID associated with the Packet API token above
+- packet_project_id = the Equinix Metal Project ID associated with the Equinix Metal API token above
 
 #### Enable localhost access
 

--- a/contrib/terraform/packet/kubespray.tf
+++ b/contrib/terraform/packet/kubespray.tf
@@ -1,4 +1,4 @@
-# Configure the Packet Provider
+# Configure the Equinix Metal Provider
 provider "packet" {
   version = "~> 2.0"
 }

--- a/contrib/terraform/packet/sample-inventory/cluster.tfvars
+++ b/contrib/terraform/packet/sample-inventory/cluster.tfvars
@@ -1,12 +1,12 @@
 # your Kubernetes cluster name here
 cluster_name = "mycluster"
 
-# Your Packet project ID. See https://support.packet.com/kb/articles/api-integrations
+# Your Equinix Metal project ID. See hhttps://metal.equinix.com/developers/docs/accounts/
 packet_project_id = "Example-API-Token"
 
-# The public SSH key to be uploaded into authorized_keys in bare metal Packet nodes provisioned
-# leave this value blank if the public key is already setup in the Packet project
-# Terraform will complain if the public key is setup in Packet
+# The public SSH key to be uploaded into authorized_keys in bare metal Equinix Metal nodes provisioned
+# leave this value blank if the public key is already setup in the Equinix Metal project
+# Terraform will complain if the public key is setup in Equinix Metal
 public_key_path = "~/.ssh/id_rsa.pub"
 
 # cluster location

--- a/contrib/terraform/packet/variables.tf
+++ b/contrib/terraform/packet/variables.tf
@@ -3,7 +3,7 @@ variable "cluster_name" {
 }
 
 variable "packet_project_id" {
-  description = "Your Packet project ID. See https://support.packet.com/kb/articles/api-integrations"
+  description = "Your Equinix Metal project ID. See https://metal.equinix.com/developers/docs/accounts/"
 }
 
 variable "operating_system" {

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -22,7 +22,7 @@
   * [AWS](docs/aws.md)
   * [Azure](docs/azure.md)
   * [OpenStack](/docs/openstack.md)
-  * [Packet](/docs/packet.md)
+  * [Equinix Metal](/docs/equinix-metal.md)
   * [vSphere](/docs/vsphere.md)
 * Operating Systems
   * [Debian](docs/debian.md)

--- a/docs/equinix-metal.md
+++ b/docs/equinix-metal.md
@@ -1,15 +1,15 @@
-# Packet
+# Equinix Metal
 
-Kubespray provides support for bare metal deployments using the [Packet bare metal cloud](http://www.packet.com).
+Kubespray provides support for bare metal deployments using the [Equinix Metal](http://metal.equinix.com).
 Deploying upon bare metal allows Kubernetes to run at locations where an existing public or private cloud might not exist such
-as cell tower, edge collocated installations. The deployment mechanism used by Kubespray for Packet is similar to that used for
-AWS and OpenStack clouds (notably using Terraform to deploy the infrastructure). Terraform uses the Packet provider plugin
+as cell tower, edge collocated installations. The deployment mechanism used by Kubespray for Equinix Metal is similar to that used for
+AWS and OpenStack clouds (notably using Terraform to deploy the infrastructure). Terraform uses the Equinix Metal provider plugin
 to provision and configure hosts which are then used by the Kubespray Ansible playbooks. The Ansible inventory is generated
 dynamically from the Terraform state file.
 
 ## Local Host Configuration
 
-To perform this installation, you will need a localhost to run Terraform/Ansible (laptop, VM, etc) and an account with Packet.
+To perform this installation, you will need a localhost to run Terraform/Ansible (laptop, VM, etc) and an account with Equinix Metal.
 In this example, we're using an m1.large CentOS 7 OpenStack VM as the localhost to kickoff the Kubernetes installation.
 You'll need Ansible, Git, and PIP.
 
@@ -64,7 +64,7 @@ ln -s ../../contrib/terraform/packet/hosts
 ```
 
 Details about the cluster, such as the name, as well as the authentication tokens and project ID
-for Packet need to be defined. To find these values see [Packet API Integration](https://support.packet.com/kb/articles/api-integrations)
+for Equinix Metal need to be defined. To find these values see [Equinix Metal API Accounts](https://metal.equinix.com/developers/docs/accounts/).
 
 ```bash
 vi cluster.tfvars

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,7 +14,7 @@
   - [ ] GCE
   - [x] AWS (contrib/terraform/aws)
   - [x] OpenStack (contrib/terraform/openstack)
-  - [x] Packet
+  - [x] Equinix Metal
   - [ ] Digital Ocean
   - [ ] Azure
 - [ ] On AWS autoscaling, multi AZ


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:
This PR picks up the work started in #6902 (by @vielmetti) and renames Packet to Equinix Metal in more contexts, including web links.

**Which issue(s) this PR fixes**:
Fixes #6901

**Special notes for your reviewer**:

* No code changes are made to the Terraform configs  (only comments and documentation changes).
  * An Equinix Metal TF provider exists, which is mostly compatible with the TF code in this project but "packet_" resources would need to be renamed to "metal_".  While that change would be trivial to introduce for the benefit of new clusters, existing clusters could have problems since their state would reflect the wrong TF resources/provider.
    How should we proceed there?
* The roadmap list has also been updated. Would it be better perhaps to keep parenthesized "Packet" there for context?
* The `docs/packet.md` file has been renamed to `docs/equinix-metal.md`.  Does the documentation site use front-matter to redirect from .../packet to .../equinix-metal?

**Does this PR introduce a user-facing change?**:


```release-note
Packet has been renamed to Equinix Metal throughout the documentation
```
