### PR TITLE
fix remove-node.yml

### DIFF
--- a/remove-node.yml
+++ b/remove-node.yml
@@ -32,8 +32,7 @@
   gather_facts: no
   environment: "{{ proxy_disable_env }}"
   roles:
-    - { role: kubespray-defaults, when: reset_nodes|default(True)|bool }
-    - { role: bootstrap-os, tags: bootstrap-os, when: reset_nodes|default(True)|bool }
+    - { role: kubespray-defaults }
     - { role: remove-node/remove-etcd-node }
     - { role: reset, tags: reset, when: reset_nodes|default(True)|bool }
 

--- a/roles/remove-node/remove-etcd-node/tasks/main.yml
+++ b/roles/remove-node/remove-etcd-node/tasks/main.yml
@@ -8,7 +8,7 @@
     - inventory_hostname in groups['etcd']
     - ip is not defined
     - access_ip is not defined
-  delegate_to: "{{ groups['kube-master']|first }}"
+  delegate_to: "{{ groups['kube_control_plane']|first }}"
   failed_when: false
 
 - name: Set node IP

--- a/roles/remove-node/remove-etcd-node/tasks/main.yml
+++ b/roles/remove-node/remove-etcd-node/tasks/main.yml
@@ -8,7 +8,7 @@
     - inventory_hostname in groups['etcd']
     - ip is not defined
     - access_ip is not defined
-  delegate_to: "{{ groups['etcd']|first }}"
+  delegate_to: "{{ groups['kube-master']|first }}"
   failed_when: false
 
 - name: Set node IP


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:
- etcd node and kube nodes can be separate.
kubectl execution must be performed in kube-master.
- There is no need for the `bootstrap-os` role for node reset.
`kubepray-defaults` should always be executed regardless of node reset.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6659 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
