### PR TITLE
Remove old groups from test inventory

### DIFF
--- a/tests/cloud_playbooks/roles/packet-ci/templates/inventory.j2
+++ b/tests/cloud_playbooks/roles/packet-ci/templates/inventory.j2
@@ -7,14 +7,6 @@ instance-{{ loop.index }} ansible_ssh_host={{instance.stdout}}
 [kube_control_plane]
 instance-1
 
-# TODO(oomichi): Remove all kube-master groups from this file after releasing v2.16.
-[kube-master]
-instance-1
-
-# TODO(cristicalin): Remove kube-node,k8s-cluster groups from this file after releasing v2.16.
-[kube-node]
-instance-2
-
 [kube_node]
 instance-2
 
@@ -24,13 +16,6 @@ instance-3
 [kube_control_plane]
 instance-1
 instance-2
-
-[kube-master]
-instance-1
-instance-2
-
-[kube-node]
-instance-3
 
 [kube_node]
 instance-3
@@ -43,12 +28,6 @@ instance-3
 [kube_control_plane]
 instance-1
 
-[kube-master]
-instance-1
-
-[kube-node]
-instance-2
-
 [kube_node]
 instance-2
 
@@ -56,12 +35,6 @@ instance-2
 instance-1
 {% elif mode == "aio" %}
 [kube_control_plane]
-instance-1
-
-[kube-master]
-instance-1
-
-[kube-node]
 instance-1
 
 [kube_node]
@@ -73,13 +46,6 @@ instance-1
 [kube_control_plane]
 instance-1
 instance-2
-
-[kube-master]
-instance-1
-instance-2
-
-[kube-node]
-instance-3
 
 [kube_node]
 instance-3
@@ -100,14 +66,6 @@ instance-3
 instance-1
 instance-2
 
-[kube-master]
-instance-3
-instance-1
-instance-2
-
-[kube-node]
-instance-3
-
 [kube_node]
 instance-3
 
@@ -125,14 +83,9 @@ instance-1 etcd_member_name=etcd2
 instance-2 etcd_member_name=etcd3
 {% endif %}
 
-[k8s-cluster:children]
-kube-node
-kube-master
-calico-rr
-
 [k8s_cluster:children]
 kube_node
-kube_master
+kube_control_plane
 calico_rr
 
 [calico_rr]


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

We have released v2.16 of Kubespray already, so we can remove those
old groups from the test inventory as the TODO says.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
