### PR TITLE
make Terraform inventory script robust against VMs in Error state

### DIFF
--- a/contrib/terraform/terraform.py
+++ b/contrib/terraform/terraform.py
@@ -323,11 +323,11 @@ def openstack_host(resource, module_name):
     })
 
     # add groups based on attrs
-    groups.append('os_image=' + attrs['image']['id'])
-    groups.append('os_flavor=' + attrs['flavor']['name'])
+    groups.append('os_image=' + str(attrs['image']['id']))
+    groups.append('os_flavor=' + str(attrs['flavor']['name']))
     groups.extend('os_metadata_%s=%s' % item
                   for item in list(attrs['metadata'].items()))
-    groups.append('os_region=' + attrs['region'])
+    groups.append('os_region=' + str(attrs['region']))
 
     # groups specific to kubespray
     for group in attrs['metadata'].get('kubespray_groups', "").split(","):


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Openstack VMs could be created in Error state for various reasons, such as scheduling problems. The result of querying the Openstack API for VMs in Error state is getting python NoneType for various attributes. This causes any Ansible play to fail with an inventory parsing error such as
```
[WARNING]:  * Failed to parse inventory/hosts with script plugin: 
Inventory script (inventory/hosts) had an execution error: 
Traceback (most recent call last):
File "inventory/hosts", line 457, in <module>     main()   
File "inventory/hosts", line 442, in main output = query_list(hosts) 
File "inventory/hosts", line 373, in query_list     for name, attrs, hostgroups in hosts:   
File "inventory/hosts", line 341, in iter_host_ips     for host in hosts:   
File "inventory/hosts", line 113, in iterhosts     yield parser(resource, module_name)   
File "inventory/hosts", line 137, in inner     name, attrs, groups = func(*args, **kwargs)   
File "inventory/hosts", line 327, in openstack_host     groups.append('os_flavor=' + attrs['flavor']['name']) 
TypeError: can only concatenate str (not "NoneType") to str
[WARNING]:  * Failed to parse inventory/hosts with yaml plugin: We were unable to read either as JSON nor YAML
```

If there are Error state VMs, Terraform will already indicate an error to the user, and Terraform can detect and replace the bad VMs too. 
But for Ansible, it is better to be able to run some plays on the good VMs instead of having the inventory crash, preventing all Ansible operations.  This way Ansible plays can proceed and the user will see failures on specific VMs that are in Error state, instead of being unable to use Ansible altogether.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

This only affects grouping of hosts, we will just get a "None" string for some VM groupings instead of an inventory crash.
e.g.
```
    "os_region=RegionOne": {
```
```
    "os_region=None": {
```

but the grouping of the bad VMs doesn't matter anyway since they will be inaccessible and have to be replaced.

**Does this PR introduce a user-facing change?**:
No