### PR TITLE
Fix debian docker available version

### DIFF
--- a/roles/container-engine/containerd-common/vars/debian-stretch.yml
+++ b/roles/container-engine/containerd-common/vars/debian-stretch.yml
@@ -1,4 +1,6 @@
 ---
+containerd_version: 1.4.3
+
 containerd_versioned_pkg:
   'latest': "{{ containerd_package }}"
   '1.3.7': "{{ containerd_package }}=1.3.7-1"

--- a/roles/container-engine/docker/vars/debian-stretch.yml
+++ b/roles/container-engine/docker/vars/debian-stretch.yml
@@ -1,18 +1,19 @@
 ---
+docker_version: 19.03
+docker_cli_version: 19.03
+
 # https://download.docker.com/linux/debian/
 docker_versioned_pkg:
   'latest': docker-ce
   '18.09': docker-ce=5:18.09.9~3-0~debian-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce=5:19.03.15~3-0~debian-{{ ansible_distribution_release|lower }}
-  '20.10': docker-ce=5:20.10.6~3-0~debian-{{ ansible_distribution_release|lower }}
-  'stable': docker-ce=5:20.10.6~3-0~debian-{{ ansible_distribution_release|lower }}
-  'edge': docker-ce=5:20.10.6~3-0~debian-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce=5:19.03.15~3-0~debian-{{ ansible_distribution_release|lower }}
+  'edge': docker-ce=5:19.03.15~3-0~debian-{{ ansible_distribution_release|lower }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
   '18.09': docker-ce-cli=5:18.09.9~3-0~debian-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce-cli=5:19.03.15~3-0~debian-{{ ansible_distribution_release|lower }}
-  '20.10': docker-ce-cli=5:20.10.6~3-0~debian-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkgs:

--- a/roles/container-engine/docker/vars/fedora.yml
+++ b/roles/container-engine/docker/vars/fedora.yml
@@ -5,8 +5,8 @@ docker_versioned_pkg:
   'latest': docker-ce
   '19.03': docker-ce-19.03.15-3.fc{{ ansible_distribution_major_version }}
   '20.10': docker-ce-20.10.6-3.fc{{ ansible_distribution_major_version }}
-  'stable': docker-ce-19.03.15-3.fc{{ ansible_distribution_major_version }}
-  'edge': docker-ce-19.03.15-3.fc{{ ansible_distribution_major_version }}
+  'stable': docker-ce-20.10.6-3.fc{{ ansible_distribution_major_version }}
+  'edge': docker-ce-20.10.6-3.fc{{ ansible_distribution_major_version }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli

--- a/roles/container-engine/docker/vars/redhat.yml
+++ b/roles/container-engine/docker/vars/redhat.yml
@@ -7,8 +7,8 @@ docker_versioned_pkg:
   '18.09': docker-ce-18.09.9-3.el7
   '19.03': docker-ce-19.03.15-3.el{{ ansible_distribution_major_version }}
   '20.10': docker-ce-20.10.6-3.el{{ ansible_distribution_major_version }}
-  'stable': docker-ce-19.03.15-3.el{{ ansible_distribution_major_version }}
-  'edge': docker-ce-19.03.15-3.el{{ ansible_distribution_major_version }}
+  'stable': docker-ce-20.10.6-3.el{{ ansible_distribution_major_version }}
+  'edge': docker-ce-20.10.6-3.el{{ ansible_distribution_major_version }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli

--- a/roles/container-engine/docker/vars/ubuntu.yml
+++ b/roles/container-engine/docker/vars/ubuntu.yml
@@ -5,8 +5,8 @@ docker_versioned_pkg:
   '18.09': docker-ce=5:18.09.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce=5:19.03.15~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   '20.10': docker-ce=5:20.10.6~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'stable': docker-ce=5:19.03.15~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'edge': docker-ce=5:19.03.15~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce=5:20.10.6~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'edge': docker-ce=5:20.10.6~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -310,12 +310,7 @@ docker_plugins: []
 etcd_kubeadm_enabled: false
 
 # Containerd options
-containerd_version: >-
-  {%- if ansible_os_family == "Debian" and ansible_distribution_release == "stretch" -%}
-  1.4.3
-  {%- else -%}
-  1.4.4
-  {%- endif -%}
+containerd_version: 1.4.4
 containerd_use_systemd_cgroup: true
 
 # Settings for containerized control plane (etcd/kubelet/secrets)

--- a/tests/files/packet_debian9-calico-upgrade.yml
+++ b/tests/files/packet_debian9-calico-upgrade.yml
@@ -7,6 +7,3 @@ mode: default
 kube_network_plugin: calico
 deploy_netchecker: true
 dns_min_replicas: 1
-
-# Only docker package 19.03 for Debian9
-docker_version: '19.03'


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix CI bug with docker version, only max 19.03 available for debian9

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
