### PR TITLE
update containerd to version 1.4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [kubernetes](https://github.com/kubernetes/kubernetes) v1.21.1
   - [etcd](https://github.com/coreos/etcd) v3.4.13
   - [docker](https://www.docker.com/) v20.10 (see note)
-  - [containerd](https://containerd.io/) v1.4.4
+  - [containerd](https://containerd.io/) v1.4.6
   - [cri-o](http://cri-o.io/) v1.21 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)
 - Network Plugin
   - [cni-plugins](https://github.com/containernetworking/plugins) v0.9.1

--- a/roles/container-engine/containerd-common/vars/amazon.yml
+++ b/roles/container-engine/containerd-common/vars/amazon.yml
@@ -5,5 +5,6 @@ containerd_versioned_pkg:
   '1.3.2': "{{ containerd_package }}-1.3.2-1.amzn{{ ansible_distribution_major_version }}"
   '1.4.1': "{{ containerd_package }}-1.4.1-2.amzn{{ ansible_distribution_major_version }}"
   '1.4.4': "{{ containerd_package }}-1.4.4-1.amzn{{ ansible_distribution_major_version }}"
-  'stable': "{{ containerd_package }}-1.4.4-1.amzn{{ ansible_distribution_major_version }}"
-  'edge': "{{ containerd_package }}-1.4.4-1.amzn{{ ansible_distribution_major_version }}"
+  '1.4.6': "{{ containerd_package }}-1.4.6-1.amzn{{ ansible_distribution_major_version }}"
+  'stable': "{{ containerd_package }}-1.4.6-1.amzn{{ ansible_distribution_major_version }}"
+  'edge': "{{ containerd_package }}-1.4.6-1.amzn{{ ansible_distribution_major_version }}"

--- a/roles/container-engine/containerd-common/vars/debian.yml
+++ b/roles/container-engine/containerd-common/vars/debian.yml
@@ -5,5 +5,6 @@ containerd_versioned_pkg:
   '1.3.9': "{{ containerd_package }}=1.3.9-1"
   '1.4.3': "{{ containerd_package }}=1.4.3-2"
   '1.4.4': "{{ containerd_package }}=1.4.4-1"
-  'stable': "{{ containerd_package }}=1.4.4-1"
-  'edge': "{{ containerd_package }}=1.4.4-1"
+  '1.4.6': "{{ containerd_package }}=1.4.6-1"
+  'stable': "{{ containerd_package }}=1.4.6-1"
+  'edge': "{{ containerd_package }}=1.4.6-1"

--- a/roles/container-engine/containerd-common/vars/fedora.yml
+++ b/roles/container-engine/containerd-common/vars/fedora.yml
@@ -5,5 +5,6 @@ containerd_versioned_pkg:
   '1.3.9': "{{ containerd_package }}-1.3.9-3.1.fc{{ ansible_distribution_major_version }}"
   '1.4.3': "{{ containerd_package }}-1.4.3-3.2.fc{{ ansible_distribution_major_version }}"
   '1.4.4': "{{ containerd_package }}-1.4.4-3.1.fc{{ ansible_distribution_major_version }}"
-  'stable': "{{ containerd_package }}-1.4.4-3.1.fc{{ ansible_distribution_major_version }}"
-  'edge': "{{ containerd_package }}-1.4.4-3.1.fc{{ ansible_distribution_major_version }}"
+  '1.4.6': "{{ containerd_package }}-1.4.6-3.1.fc{{ ansible_distribution_major_version }}"
+  'stable': "{{ containerd_package }}-1.4.6-3.1.fc{{ ansible_distribution_major_version }}"
+  'edge': "{{ containerd_package }}-1.4.6-3.1.fc{{ ansible_distribution_major_version }}"

--- a/roles/container-engine/containerd-common/vars/redhat.yml
+++ b/roles/container-engine/containerd-common/vars/redhat.yml
@@ -5,5 +5,6 @@ containerd_versioned_pkg:
   '1.3.9': "{{ containerd_package }}-1.3.9-3.1.el{{ ansible_distribution_major_version }}"
   '1.4.3': "{{ containerd_package }}-1.4.3-3.2.el{{ ansible_distribution_major_version }}"
   '1.4.4': "{{ containerd_package }}-1.4.4-3.1.el{{ ansible_distribution_major_version }}"
-  'stable': "{{ containerd_package }}-1.4.4-3.1.el{{ ansible_distribution_major_version }}"
-  'edge': "{{ containerd_package }}-1.4.4-3.1.el{{ ansible_distribution_major_version }}"
+  '1.4.6': "{{ containerd_package }}-1.4.6-3.1.el{{ ansible_distribution_major_version }}"
+  'stable': "{{ containerd_package }}-1.4.6-3.1.el{{ ansible_distribution_major_version }}"
+  'edge': "{{ containerd_package }}-1.4.6-3.1.el{{ ansible_distribution_major_version }}"

--- a/roles/container-engine/containerd-common/vars/ubuntu.yml
+++ b/roles/container-engine/containerd-common/vars/ubuntu.yml
@@ -5,5 +5,6 @@ containerd_versioned_pkg:
   '1.3.9': "{{ containerd_package }}=1.3.9-1"
   '1.4.3': "{{ containerd_package }}=1.4.3-2"
   '1.4.4': "{{ containerd_package }}=1.4.4-1"
-  'stable': "{{ containerd_package }}=1.4.4-1"
-  'edge': "{{ containerd_package }}=1.4.4-1"
+  '1.4.6': "{{ containerd_package }}=1.4.6-1"
+  'stable': "{{ containerd_package }}=1.4.6-1"
+  'edge': "{{ containerd_package }}=1.4.6-1"

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -310,7 +310,7 @@ docker_plugins: []
 etcd_kubeadm_enabled: false
 
 # Containerd options
-containerd_version: 1.4.4
+containerd_version: 1.4.6
 containerd_use_systemd_cgroup: true
 
 # Settings for containerized control plane (etcd/kubelet/secrets)


### PR DESCRIPTION
Up contanerd to 1.4.6 to fix CVE-2021-30465
