### PR TITLE
Modify not to remove etcd data dir

### DIFF
--- a/roles/recover_control_plane/etcd/tasks/main.yml
+++ b/roles/recover_control_plane/etcd/tasks/main.yml
@@ -32,17 +32,6 @@
     - groups['broken_etcd']
     - not has_quorum
 
-- name: Remove etcd data dir
-  file:
-    path: "{{ etcd_data_dir }}"
-    state: absent
-  delegate_to: "{{ item }}"
-  with_items: "{{ groups['broken_etcd'] }}"
-  ignore_errors: true
-  when:
-    - groups['broken_etcd']
-    - has_quorum
-
 - name: Delete old certificates
   # noqa 302 - rm is ok here for now
   shell: "rm {{ etcd_cert_dir }}/*{{ item }}*"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
regardless of `has_quorum`, 
the data dir of broken etcd should be removed. **If access to broken etcd is possible!**

if broken etcd is offline and cannot be accessed, remove of data dir fails and recover-control-plane fails.
data dir deletion must be performed through `reset.yml`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

**Special notes for your reviewer**:
NONE
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
