### PR TITLE
Improve calico-rr flow

### DIFF
--- a/roles/network_plugin/calico/rr/tasks/main.yml
+++ b/roles/network_plugin/calico/rr/tasks/main.yml
@@ -4,13 +4,3 @@
 
 - name: Calico-rr | Configuring node tasks
   include_tasks: update-node.yml
-
-- name: Calico-rr | Set label for route reflector  # noqa 301
-  command: >-
-    {{ bin_dir }}/calicoctl.sh label node {{ inventory_hostname }}
-    'i-am-a-route-reflector=true' --overwrite
-  changed_when: false
-  register: calico_rr_label
-  until: calico_rr_label is succeeded
-  delay: "{{ retry_stagger | random + 3 }}"
-  retries: 10

--- a/roles/network_plugin/calico/rr/tasks/update-node.yml
+++ b/roles/network_plugin/calico/rr/tasks/update-node.yml
@@ -14,11 +14,12 @@
     delay: "{{ retry_stagger | random + 3 }}"
     retries: 10
 
-  - name: Calico-rr | Set route reflector cluster ID
+  - name: Calico-rr | Set route reflector cluster ID and label
     set_fact:
       calico_rr_node_patched: >-
         {{ calico_rr_node.stdout | from_json | combine({ 'spec': { 'bgp':
-        { 'routeReflectorClusterID': cluster_id }}}, recursive=True) }}
+        { 'routeReflectorClusterID': cluster_id }}}, recursive=True) |
+        combine({ 'metadata': { 'labels': { 'i-am-a-route-reflector': 'true' }}}, recursive=True) }}
 
   - name: Calico-rr | Configure route reflector  # noqa 301 305
     shell: "{{ bin_dir }}/calicoctl.sh replace -f-"


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Hi, i open some days ago this PR: https://github.com/kubernetes-sigs/kubespray/pull/7645 adding retries to 'Set label for route reflector' because sometimes it failed due to the unavailability of calico after applying the change in 'Set route reflector cluster ID'.
After some tests, i think its better to execute both changes in the same operation (Set route reflector cluster ID and label) to make things faster and avoid having to use retries.