### PR TITLE
Updage docker packages to 20.10.7

### DIFF
--- a/roles/container-engine/docker/vars/debian.yml
+++ b/roles/container-engine/docker/vars/debian.yml
@@ -4,15 +4,15 @@ docker_versioned_pkg:
   'latest': docker-ce
   '18.09': docker-ce=5:18.09.9~3-0~debian-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce=5:19.03.15~3-0~debian-{{ ansible_distribution_release|lower }}
-  '20.10': docker-ce=5:20.10.6~3-0~debian-{{ ansible_distribution_release|lower }}
-  'stable': docker-ce=5:20.10.6~3-0~debian-{{ ansible_distribution_release|lower }}
-  'edge': docker-ce=5:20.10.6~3-0~debian-{{ ansible_distribution_release|lower }}
+  '20.10': docker-ce=5:20.10.7~3-0~debian-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce=5:20.10.7~3-0~debian-{{ ansible_distribution_release|lower }}
+  'edge': docker-ce=5:20.10.7~3-0~debian-{{ ansible_distribution_release|lower }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
   '18.09': docker-ce-cli=5:18.09.9~3-0~debian-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce-cli=5:19.03.15~3-0~debian-{{ ansible_distribution_release|lower }}
-  '20.10': docker-ce-cli=5:20.10.6~3-0~debian-{{ ansible_distribution_release|lower }}
+  '20.10': docker-ce-cli=5:20.10.7~3-0~debian-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkgs:

--- a/roles/container-engine/docker/vars/fedora.yml
+++ b/roles/container-engine/docker/vars/fedora.yml
@@ -4,14 +4,14 @@
 docker_versioned_pkg:
   'latest': docker-ce
   '19.03': docker-ce-19.03.15-3.fc{{ ansible_distribution_major_version }}
-  '20.10': docker-ce-20.10.6-3.fc{{ ansible_distribution_major_version }}
-  'stable': docker-ce-20.10.6-3.fc{{ ansible_distribution_major_version }}
-  'edge': docker-ce-20.10.6-3.fc{{ ansible_distribution_major_version }}
+  '20.10': docker-ce-20.10.7-3.fc{{ ansible_distribution_major_version }}
+  'stable': docker-ce-20.10.7-3.fc{{ ansible_distribution_major_version }}
+  'edge': docker-ce-20.10.7-3.fc{{ ansible_distribution_major_version }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
   '19.03': docker-ce-cli-19.03.15-3.fc{{ ansible_distribution_major_version }}
-  '20.10': docker-ce-cli-20.10.6-3.fc{{ ansible_distribution_major_version }}
+  '20.10': docker-ce-cli-20.10.7-3.fc{{ ansible_distribution_major_version }}
 
 docker_package_info:
   enablerepo: "docker-ce"

--- a/roles/container-engine/docker/vars/redhat.yml
+++ b/roles/container-engine/docker/vars/redhat.yml
@@ -6,15 +6,15 @@ docker_versioned_pkg:
   'latest': docker-ce
   '18.09': docker-ce-18.09.9-3.el7
   '19.03': docker-ce-19.03.15-3.el{{ ansible_distribution_major_version }}
-  '20.10': docker-ce-20.10.6-3.el{{ ansible_distribution_major_version }}
-  'stable': docker-ce-20.10.6-3.el{{ ansible_distribution_major_version }}
-  'edge': docker-ce-20.10.6-3.el{{ ansible_distribution_major_version }}
+  '20.10': docker-ce-20.10.7-3.el{{ ansible_distribution_major_version }}
+  'stable': docker-ce-20.10.7-3.el{{ ansible_distribution_major_version }}
+  'edge': docker-ce-20.10.7-3.el{{ ansible_distribution_major_version }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
   '18.09': docker-ce-cli-18.09.9-3.el7
   '19.03': docker-ce-cli-19.03.15-3.el{{ ansible_distribution_major_version }}
-  '20.10': docker-ce-cli-20.10.6-3.el{{ ansible_distribution_major_version }}
+  '20.10': docker-ce-cli-20.10.7-3.el{{ ansible_distribution_major_version }}
 
 docker_package_info:
   enablerepo: "docker-ce"

--- a/roles/container-engine/docker/vars/ubuntu.yml
+++ b/roles/container-engine/docker/vars/ubuntu.yml
@@ -4,15 +4,15 @@ docker_versioned_pkg:
   'latest': docker-ce
   '18.09': docker-ce=5:18.09.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce=5:19.03.15~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  '20.10': docker-ce=5:20.10.6~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'stable': docker-ce=5:20.10.6~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'edge': docker-ce=5:20.10.6~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '20.10': docker-ce=5:20.10.7~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce=5:20.10.7~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'edge': docker-ce=5:20.10.7~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
   '18.09': docker-ce-cli=5:18.09.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce-cli=5:19.03.15~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  '20.10': docker-ce-cli=5:20.10.6~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '20.10': docker-ce-cli=5:20.10.7~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkgs:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Update docker packages to 20.10.7
https://docs.docker.com/engine/release-notes/#20107

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
