### PR TITLE
Fix invalid documentation links

### DIFF
--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -25,7 +25,7 @@ not _kube_node_.
 
 There are also two special groups:
 
-* **calico_rr** : explained for [advanced Calico networking cases](calico.md)
+* **calico_rr** : explained for [advanced Calico networking cases](/docs/calico.md)
 * **bastion** : configure a bastion host if your nodes are not directly reachable
 
 Below is a complete inventory example:

--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -252,7 +252,7 @@ For more information about Ansible and bastion hosts, read
 
 ## Mitogen
 
-You can use [mitogen](mitogen.md) to speed up kubespray.
+You can use [mitogen](/docs/mitogen.md) to speed up kubespray.
 
 ## Beyond ansible 2.9
 

--- a/docs/calico.md
+++ b/docs/calico.md
@@ -320,7 +320,7 @@ To clean up any ipvs leftovers:
 
 Calico node, typha and kube-controllers need to be able to talk to the kubernetes API. Please reference the [Enabling eBPF Calico Docs](https://docs.projectcalico.org/maintenance/ebpf/enabling-bpf) for guidelines on how to do this.
 
-Kubespray sets up the `kubernetes-services-endpoint` configmap based on the contents of the `loadbalancer_apiserver` inventory variable documented in [HA Mode](./ha-mode.md).
+Kubespray sets up the `kubernetes-services-endpoint` configmap based on the contents of the `loadbalancer_apiserver` inventory variable documented in [HA Mode](/docs/ha-mode.md).
 
 If no external loadbalancer is used, Calico eBPF can also use the localhost loadbalancer option. In this case Calico Automatic Host Endpoints need to be enabled to allow services like `coredns` and `metrics-server` to communicate with the kubernetes host endpoint. See [this blog post](https://www.projectcalico.org/securing-kubernetes-nodes-with-calico-automatic-host-endpoints/) on enabling automatic host endpoints.
 

--- a/docs/large-deployments.md
+++ b/docs/large-deployments.md
@@ -32,7 +32,7 @@ For a large scaled deployments, consider the following configuration changes:
   ``kube_controller_node_monitor_period``,
   ``kube_apiserver_pod_eviction_not_ready_timeout_seconds`` &
   ``kube_apiserver_pod_eviction_unreachable_timeout_seconds`` for better Kubernetes reliability.
-  Check out [Kubernetes Reliability](kubernetes-reliability.md)
+  Check out [Kubernetes Reliability](/docs/kubernetes-reliability.md)
 
 * Tune network prefix sizes. Those are ``kube_network_node_prefix``,
   ``kube_service_addresses`` and ``kube_pods_subnet``.
@@ -43,7 +43,7 @@ For a large scaled deployments, consider the following configuration changes:
   etcd role is okay).
 
 * Check out the
-  [Inventory](getting-started.md#building-your-own-inventory)
+  [Inventory](/docs/getting-started.md#building-your-own-inventory)
   section of the Getting started guide for tips on creating a large scale
   Ansible inventory.
 

--- a/docs/vars.md
+++ b/docs/vars.md
@@ -3,7 +3,7 @@
 ## Generic Ansible variables
 
 You can view facts gathered by Ansible automatically
-[here](https://docs.ansible.com/ansible/latest/playbooks_variables.html#information-discovered-from-systems-facts).
+[here](https://docs.ansible.com/ansible/latest/user_guide/playbooks_vars_facts.html#ansible-facts).
 
 Some variables of note include:
 

--- a/docs/vsphere.md
+++ b/docs/vsphere.md
@@ -54,7 +54,7 @@ external_vsphere_kubernetes_cluster_id: "kubernetes-cluster-id"
 vsphere_csi_enabled: true
 ```
 
-For a more fine-grained CSI setup, refer to the [vsphere-csi](vsphere-csi.md) documentation.
+For a more fine-grained CSI setup, refer to the [vsphere-csi](/docs/vsphere-csi.md) documentation.
 
 ### Deployment
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This PR fixes invalid links to documentation pages on website, without breaking links on Github.
It also updates an outdated link to ansible documentation.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

I found 3 more dead links, but couldn't find target files. Relevant files/lines are the following:

- [`docs/ingress_controller/ingress_nginx.md` at line 162](https://github.com/kubernetes-sigs/kubespray/blame/master/docs/ingress_controller/ingress_nginx.md#L162): `./baremetal.md` doesn’t exist
- [`docs/kubernetes-apps/cephfs_provisioner.md` at line 43](https://github.com/kubernetes-sigs/kubespray/blame/master/docs/kubernetes-apps/cephfs_provisioner.md#L43): `deploy/README.md` doesn’t exist
- [`docs/kubernetes-apps/rbd_provisioner.md` at line 55](https://github.com/kubernetes-sigs/kubespray/blame/master/docs/kubernetes-apps/rbd_provisioner.md#L55): `deploy/README.md` doesn’t exist

This is the reason I marked this PR as WIP.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```