### PR TITLE
Terraform OpenStack Fix network creation race condition

### DIFF
--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -20,7 +20,6 @@ module "ips" {
   floatingip_pool               = var.floatingip_pool
   number_of_bastions            = var.number_of_bastions
   external_net                  = var.external_net
-  network_name                  = var.network_name
   router_id                     = module.network.router_id
   k8s_nodes                     = var.k8s_nodes
   k8s_master_fips               = var.k8s_master_fips

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -63,7 +63,6 @@ module "compute" {
   flavor_k8s_node                              = var.flavor_k8s_node
   flavor_etcd                                  = var.flavor_etcd
   flavor_gfs_node                              = var.flavor_gfs_node
-  network_name                                 = var.network_name
   flavor_bastion                               = var.flavor_bastion
   k8s_master_fips                              = module.ips.k8s_master_fips
   k8s_master_no_etcd_fips                      = module.ips.k8s_master_no_etcd_fips
@@ -83,8 +82,7 @@ module "compute" {
   use_server_groups                            = var.use_server_groups
   extra_sec_groups                             = var.extra_sec_groups
   extra_sec_groups_name                        = var.extra_sec_groups_name
-
-  network_id = module.network.router_id
+  network_id                                   = module.network.network_id
 }
 
 output "private_subnet_id" {

--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -189,7 +189,7 @@ resource "openstack_compute_instance_v2" "bastion" {
   }
 
   network {
-    name = var.network_name
+    uuid = var.network_id
   }
 
   security_groups = [openstack_networking_secgroup_v2.k8s.name,
@@ -231,7 +231,7 @@ resource "openstack_compute_instance_v2" "k8s_master" {
   }
 
   network {
-    name = var.network_name
+    uuid = var.network_id
   }
 
   security_groups = local.master_sec_groups
@@ -278,7 +278,7 @@ resource "openstack_compute_instance_v2" "k8s_master_no_etcd" {
   }
 
   network {
-    name = var.network_name
+    uuid = var.network_id
   }
 
   security_groups = local.master_sec_groups
@@ -323,7 +323,7 @@ resource "openstack_compute_instance_v2" "etcd" {
   }
 
   network {
-    name = var.network_name
+    uuid = var.network_id
   }
 
   security_groups = [openstack_networking_secgroup_v2.k8s.name]
@@ -365,7 +365,7 @@ resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip" {
   }
 
   network {
-    name = var.network_name
+    uuid = var.network_id
   }
 
   security_groups = local.master_sec_groups
@@ -407,7 +407,7 @@ resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip_no_etcd" {
   }
 
   network {
-    name = var.network_name
+    uuid = var.network_id
   }
 
   security_groups = local.master_sec_groups
@@ -448,7 +448,7 @@ resource "openstack_compute_instance_v2" "k8s_node" {
   }
 
   network {
-    name = var.network_name
+    uuid = var.network_id
   }
 
   security_groups = local.worker_sec_groups
@@ -493,7 +493,7 @@ resource "openstack_compute_instance_v2" "k8s_node_no_floating_ip" {
   }
 
   network {
-    name = var.network_name
+    uuid = var.network_id
   }
 
   security_groups = local.worker_sec_groups
@@ -532,9 +532,8 @@ resource "openstack_compute_instance_v2" "k8s_nodes" {
       delete_on_termination = true
     }
   }
-
   network {
-    name = var.network_name
+    uuid = var.network_id
   }
 
   security_groups = local.worker_sec_groups
@@ -579,7 +578,7 @@ resource "openstack_compute_instance_v2" "glusterfs_node_no_floating_ip" {
   }
 
   network {
-    name = var.network_name
+    uuid = var.network_id
   }
 
   security_groups = [openstack_networking_secgroup_v2.k8s.name]

--- a/contrib/terraform/openstack/modules/compute/variables.tf
+++ b/contrib/terraform/openstack/modules/compute/variables.tf
@@ -58,13 +58,9 @@ variable "flavor_etcd" {}
 
 variable "flavor_gfs_node" {}
 
-variable "network_name" {}
-
 variable "flavor_bastion" {}
 
-variable "network_id" {
-  default = ""
-}
+variable "network_id" {}
 
 variable "k8s_master_fips" {
   type = list

--- a/contrib/terraform/openstack/modules/ips/variables.tf
+++ b/contrib/terraform/openstack/modules/ips/variables.tf
@@ -10,8 +10,6 @@ variable "number_of_bastions" {}
 
 variable "external_net" {}
 
-variable "network_name" {}
-
 variable "router_id" {
   default = ""
 }

--- a/contrib/terraform/openstack/modules/network/outputs.tf
+++ b/contrib/terraform/openstack/modules/network/outputs.tf
@@ -6,6 +6,10 @@ output "router_internal_port_id" {
   value = element(concat(openstack_networking_router_interface_v2.k8s.*.id, [""]), 0)
 }
 
+output "network_id" {
+  value = element(concat(openstack_networking_subnet_v2.k8s.*.network_id, [""]), 0)
+}
+
 output "subnet_id" {
   value = element(concat(openstack_networking_subnet_v2.k8s.*.id, [""]), 0)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Since the `network_name` variable is currently used to create and to assign the network to an instance, it can happen that the network is not yet created.

To address this issue the instances will use the network id now, which will be passed as an output from the subnet resource (inside the network module) to ensure that the network and subnet have been created before creating the actual instance resources (inside the computing module).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # (Issue needs to be created first)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
To be checked whether there could be interrupting changes when applying the new terraform plan on an existing environment.

A dependency from the computing module to the network module has been introduced, which could be a user facing change if modules are "allowed" to be used independently.

```release-note
NONE
```
