### PR TITLE
Implement dns-hosts HA for K8S API (#7696)

### DIFF
--- a/inventory/sample/group_vars/all/all.yml
+++ b/inventory/sample/group_vars/all/all.yml
@@ -25,7 +25,7 @@ bin_dir: /usr/local/bin
 ## Internal loadbalancers for apiservers
 # loadbalancer_apiserver_localhost: true
 # valid options are "nginx" or "haproxy"
-# loadbalancer_apiserver_type: nginx  # valid values "nginx" or "haproxy"
+# loadbalancer_apiserver_type: nginx  # valid values "nginx", "haproxy" or "dns-hosts"
 
 ## If the cilium is going to be used in strict mode, we can use the
 ## localhost connection and not use the external LB. If this parameter is

--- a/roles/kubernetes/node/tasks/loadbalancer/hosts.yml
+++ b/roles/kubernetes/node/tasks/loadbalancer/hosts.yml
@@ -1,0 +1,10 @@
+---
+- name: hosts | Cleanup potentially deployed haproxy
+  file:
+    path: "{{ kube_manifest_dir }}/haproxy.yml"
+    state: absent
+
+- name: hosts | Cleanup potentially deployed nginx-proxy
+  file:
+    path: "{{ kube_manifest_dir }}/nginx-proxy.yml"
+    state: absent

--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -17,6 +17,14 @@
   tags:
     - kubelet
 
+- import_tasks: loadbalancer/hosts.yml
+  when:
+    - not is_kube_master
+    - loadbalancer_apiserver_localhost
+    - loadbalancer_apiserver_type == 'dns-hosts'
+  tags:
+    - dns-hosts
+
 - import_tasks: loadbalancer/nginx-proxy.yml
   when:
     - not is_kube_master

--- a/roles/kubernetes/preinstall/tasks/0090-etchosts.yml
+++ b/roles/kubernetes/preinstall/tasks/0090-etchosts.yml
@@ -5,7 +5,7 @@
       {% for item in (groups['k8s_cluster'] + groups['etcd']|default([]) + groups['calico_rr']|default([]))|unique -%}
       {% if 'access_ip' in hostvars[item] or 'ip' in hostvars[item] or 'ansible_default_ipv4' in hostvars[item] -%}
       {{ hostvars[item]['access_ip'] | default(hostvars[item]['ip'] | default(hostvars[item]['ansible_default_ipv4']['address'])) }}
-      {%- if ('ansible_hostname' in hostvars[item] and item != hostvars[item]['ansible_hostname']) %} {{ hostvars[item]['ansible_hostname'] }}.{{ dns_domain }} {{ hostvars[item]['ansible_hostname'] }}{% endif %} {{ item }}.{{ dns_domain }} {{ item }}
+      {%- if ('ansible_hostname' in hostvars[item] and item != hostvars[item]['ansible_hostname']) %} {{ hostvars[item]['ansible_hostname'] }}.{{ dns_domain }} {{ hostvars[item]['ansible_hostname'] }}{% endif %} {% if item in groups['kube_control_plane'] %}kubernetes.default.svc.{{ dns_domain }} {% endif %}{{ item }}.{{ dns_domain }} {{ item }}
       {% endif %}
       {% endfor %}
   delegate_to: localhost

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -70,6 +70,7 @@
   tags:
     - bootstrap-os
     - etchosts
+    - dns-hosts
 
 - import_tasks: 0100-dhclient-hooks.yml
   when:

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -477,7 +477,11 @@ kube_apiserver_endpoint: |-
   {% if loadbalancer_apiserver is defined -%}
       https://{{ apiserver_loadbalancer_domain_name }}:{{ loadbalancer_apiserver.port|default(kube_apiserver_port) }}
   {%- elif not is_kube_master and loadbalancer_apiserver_localhost -%}
+    {%- if loadbalancer_apiserver_type == "dns-hosts" and loadbalancer_apiserver_localhost -%}
+      kubernetes.default.svc.{{ dns_domain }}:{{ kube_apiserver_port }}
+    {%- else -%}
       https://localhost:{{ loadbalancer_apiserver_port|default(kube_apiserver_port) }}
+    {%- endif -%}
   {%- elif is_kube_master -%}
       https://{{ kube_apiserver_bind_address | regex_replace('0\.0\.0\.0','127.0.0.1') }}:{{ kube_apiserver_port }}
   {%- else -%}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Added simple HA for K8S API without Nginx/Haproxy, only basic DNS/HTTP magic with no point of failure.
In theory, that allows replacing by that some types of K8S API localhost magic in general

**Which issue(s) this PR fixes**:
Fixes #7696

**Special notes for your reviewer**:
I can miss something implemented while look at the project.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
- - -
My main question is "do you need that"?
I personally don't like any additional layers in every possible way, i.e. reverse proxy, ClusterIP & etc when that not really needed and try avoiding use it, as much, as possible