### PR TITLE
Disable conmon location override for Redhat and Fedora

### DIFF
--- a/roles/container-engine/cri-o/vars/fedora.yml
+++ b/roles/container-engine/cri-o/vars/fedora.yml
@@ -3,8 +3,6 @@ crio_packages:
   - cri-o
   - cri-tools
 
-crio_conmon: /usr/libexec/crio/conmon
-
 # Fedora doesn't have cri-o 1.21 packages
 crio_kubernetes_version_matrix:
   "1.21": "1.20"

--- a/roles/container-engine/cri-o/vars/redhat.yml
+++ b/roles/container-engine/cri-o/vars/redhat.yml
@@ -2,5 +2,3 @@
 crio_packages:
   - cri-o
   - oci-systemd-hook
-
-crio_conmon: /usr/libexec/crio/conmon


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Redhat and derivatives including Fedora have provided `conmon` in `/usr/bin/conmon` for a long time and we don't need to use the special `/usr/libexec/crio/conmon` location anymore. In recent versions of the package this location is no longer valid. I tested this as far back as conmon `2.0.8`.

This PR reverts the old overrides.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7690

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Revert conmon location to /usr/bin on Redhat and Fedora.
```
