### PR TITLE
fix image pull url for coredns v1.8.0

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -493,9 +493,10 @@ haproxy_image_tag: 2.3
 
 # Coredns version should be supported by corefile-migration (or at least work with)
 # bundle with kubeadm; if not 'basic' upgrade can sometimes fail
-coredns_image_is_namespaced: "{{ (kube_major_version | regex_replace('^v', '') | float) >= 1.21 }}"
 
 coredns_version: "v1.8.0"
+coredns_image_is_namespaced: "{{ (kube_version is version('v1.21.0','>=')) or (coredns_version is version('v1.7.1','>=')) }}"
+
 coredns_image_repo: "{{ kube_image_repo }}{{'/coredns/coredns' if (coredns_image_is_namespaced | bool) else '/coredns' }}"
 coredns_image_tag: "{{ coredns_version if (coredns_image_is_namespaced | bool) else (coredns_version | regex_replace('^v', '')) }}"
 


### PR DESCRIPTION
The last version v1.7.0 was not yet using a subpath due to it using the legacy promotion.

now have a subpath so it should be available under k8s.gcr.io/coredns/coredns:v1.8.0 and k8s.gcr.io/coredns/coredns:v1.7.1.
https://github.com/kubernetes/k8s.io/pull/1405#issuecomment-725631498

**What type of PR is this?**
/kind bug
