### PR TITLE
Ubuntu 21.04 changed packagename python-apt in python3-apt

### DIFF
--- a/roles/kubernetes/preinstall/vars/ubuntu-21.04.yml
+++ b/roles/kubernetes/preinstall/vars/ubuntu-21.04.yml
@@ -1,0 +1,7 @@
+---
+required_pkgs:
+  - python3-apt
+  - aufs-tools
+  - apt-transport-https
+  - software-properties-common
+  - conntrack


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
Looking forward to next Ubuntu Version you need do change the package name of python-apt in python3-apt. 


```release-note
NONE
```
