### PR TITLE
Prefer nodelocaldns as dns server over coredns when defined

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
@@ -147,7 +147,7 @@
 - name: generate nameservers to resolvconf
   set_fact:
     nameserverentries:
-      nameserver {{ ( coredns_server|d([]) + nameservers|d([]) + cloud_resolver|d([])) | unique | join(',nameserver ') }}
+      nameserver {{ ( ( [nodelocaldns_ip] if enable_nodelocaldns else []) + coredns_server|d([]) + nameservers|d([]) + cloud_resolver|d([])) | unique | join(',nameserver ') }}
     supersede_nameserver:
       supersede domain-name-servers {{ ( coredns_server|d([]) + nameservers|d([]) + cloud_resolver|d([])) | unique | join(', ') }};
 

--- a/roles/kubernetes/preinstall/templates/resolved.conf.j2
+++ b/roles/kubernetes/preinstall/templates/resolved.conf.j2
@@ -1,5 +1,5 @@
 [Resolve]
-DNS={{ coredns_server | list | join(' ') }}
+DNS={{ (nodelocaldns_ip |default(coredns_server) )| list | join(' ') }}
 FallbackDNS={{ ( nameservers|d([]) + cloud_resolver|d([])) | unique | join(' ') }}
 Domains={{ ([ 'default.svc.' + dns_domain, 'svc.' + dns_domain ] + searchdomains|default([])) | join(' ') }}
 #LLMNR=no


### PR DESCRIPTION
 /kind feature

**What this PR does / why we need it**: This PR gives preferral to ```nodelocaldns``` when defined over ```coredns``` as dns_server for the **kube-nodes** and **kube-control-plane** when resolving internal k8s dns addresses

**Which issue(s) this PR fixes**:
https://github.com/kubernetes-sigs/kubespray/issues/7730


**Does this PR introduce a user-facing change?**:
```release-note
Prefer nodelocaldns as dns server over coredns when defined
```
