### PR TITLE
Add log for molecule_test

### DIFF
--- a/tests/scripts/molecule_run.sh
+++ b/tests/scripts/molecule_run.sh
@@ -7,6 +7,7 @@ export LANG=C.UTF-8
 for d in $(find roles -name molecule -type d)
 do
     cd $(dirname $d)
+    echo "Testing under $d .."
     molecule test --all
     cd -
 done


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind failing-test

**What this PR does / why we need it**:

To investigate what molecule test is failed, this adds log for the test path.

Ref: https://github.com/kubernetes-sigs/kubespray/issues/7734

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
