### PR TITLE
add python requirement ruamel.yaml.clib==0.2.2 to keep python 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ netaddr==0.7.19
 pbr==5.4.4
 jmespath==0.9.5
 ruamel.yaml==0.16.10
+ruamel.yaml.clib==0.2.2
 MarkupSafe==1.1.1


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

ruamel.yaml.clib 0.2.3  and above drop compatibility with python 2.7.
fix version in requirements.txt
