### PR TITLE
Separate gvisor_download_url for runsc and shim

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -110,7 +110,8 @@ helm_download_url: "https://get.helm.sh/helm-{{ helm_version }}-linux-{{ image_a
 crun_download_url: "https://github.com/containers/crun/releases/download/{{ crun_version }}/crun-{{ crun_version }}-linux-{{ image_arch }}"
 kata_containers_download_url: "https://github.com/kata-containers/kata-containers/releases/download/{{ kata_containers_version }}/kata-static-{{ kata_containers_version }}-{{ ansible_architecture }}.tar.xz"
 # gVisor only supports amd64 and uses x86_64 to in the download link
-gvisor_download_url: "https://storage.googleapis.com/gvisor/releases/release/{{ gvisor_version }}/{{ ansible_architecture }}"
+gvisor_runsc_download_url: "https://storage.googleapis.com/gvisor/releases/release/{{ gvisor_version }}/{{ ansible_architecture }}/runsc"
+gvisor_containerd_shim_runsc_download_url: "https://storage.googleapis.com/gvisor/releases/release/{{ gvisor_version }}/{{ ansible_architecture }}/containerd-shim-runsc-v1"
 nerdctl_download_url: "https://github.com/containerd/nerdctl/releases/download/v{{ nerdctl_version }}/nerdctl-{{ nerdctl_version }}-{{ ansible_system | lower }}-{{ image_arch }}.tar.gz"
 krew_download_url: "https://github.com/kubernetes-sigs/krew/releases/download/{{ krew_version }}/krew.tar.gz"
 
@@ -742,7 +743,7 @@ downloads:
     version: "{{ gvisor_version }}"
     dest: "{{ local_release_dir }}/gvisor-runsc"
     sha256: "{{ gvisor_runsc_binary_checksum }}"
-    url: "{{ gvisor_download_url }}/runsc"
+    url: "{{ gvisor_runsc_download_url }}"
     unarchive: false
     owner: "root"
     mode: 755
@@ -755,7 +756,7 @@ downloads:
     version: "{{ gvisor_version }}"
     dest: "{{ local_release_dir }}/gvisor-containerd-shim-runsc-v1"
     sha256: "{{ gvisor_containerd_shim_binary_checksum }}"
-    url: "{{ gvisor_download_url }}/containerd-shim-runsc-v1"
+    url: "{{ gvisor_containerd_shim_runsc_download_url }}"
     unarchive: false
     owner: "root"
     mode: 755


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

To download necessary files in advance for offline deployment, we can see all file URLs with contrib/offline/generate_list.sh
Most URLs are downloadable, but gvisor's one is not because the URL is a part of full URLs for gvisor.
To download gvisor's files from the URLs directory, this separates into two URLs for runsc and the shim.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
