### PR TITLE
added destination filename to cp command

### DIFF
--- a/roles/etcdctl/tasks/main.yml
+++ b/roles/etcdctl/tasks/main.yml
@@ -38,11 +38,11 @@
 
 - block:
   - name: Copy etcdctl script to host
-    shell: "{{ docker_bin_dir }}/docker exec \"$({{ docker_bin_dir }}/docker ps -qf ancestor={{ etcd_image_repo }}:{{ etcd_image_tag }})\" cp /usr/local/bin/etcdctl {{ etcd_data_dir }}"
+    shell: "{{ docker_bin_dir }}/docker exec \"$({{ docker_bin_dir }}/docker ps -qf ancestor={{ etcd_image_repo }}:{{ etcd_image_tag }})\" cp /usr/local/bin/etcdctl {{ etcd_data_dir }}/etcdctl"
     when: container_manager ==  "docker"
 
   - name: Copy etcdctl script to host
-    shell: "{{ bin_dir }}/crictl exec \"$({{ bin_dir }}/crictl ps -q --image {{ etcd_image_repo }}:{{ etcd_image_tag }})\" cp /usr/local/bin/etcdctl {{ etcd_data_dir }}"
+    shell: "{{ bin_dir }}/crictl exec \"$({{ bin_dir }}/crictl ps -q --image {{ etcd_image_repo }}:{{ etcd_image_tag }})\" cp /usr/local/bin/etcdctl {{ etcd_data_dir }}/etcdctl"
     when: container_manager in ['crio', 'containerd']
 
   - name: Copy etcdctl to {{ bin_dir }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

 /kind bug

**What this PR does / why we need it**:

if you use an etcd image from k8s.gcr.io/etcd  there is an error appears

```
TASK [Copy etcdctl script to host] 
***********
fatal: [ubuntu20-spray1]: FAILED! => {"changed": true, "cmd": "/usr/local/bin/crictl exec \"$(/usr/local/bin/crictl ps -q --image  
192.168.1.38/system/coreos/etcd:3.4.13-0)\" cp /usr/local/bin/etcdctl /var/lib/etcd", "delta": "0:00:00.092829", "end":  
"2021-06-30 09:19:55.993133", "msg": "non-zero return code", "rc": 1, "start": "2021-06-30 09:19:55.900304", "stderr":   
"2021/06/30 09:19:55 unable to create destination file [/usr/local/bin/etcdctl]: \"open /var/lib/etcd: is a directory\"\ntime=  
\"2021-06-30T09:19:55Z\" level=fatal msg=\"execing command in container: command terminated with exit code 1\"",   
"stderr_lines": ["2021/06/30 09:19:55 unable to create destination file [/usr/local/bin/etcdctl]: \"open /var/lib/etcd: is a directory\"",   
"time=\"2021-06-30T09:19:55Z\" level=fatal msg=\"execing command in container: command terminated with exit code 1\""],   
"stdout": "", "stdout_lines": []}
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
