### PR TITLE
Fix etcd certificates reference to support etcd_kubeadm_enabled:true

### DIFF
--- a/recover-control-plane.yml
+++ b/recover-control-plane.yml
@@ -16,7 +16,7 @@
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults}
-    - { role: recover_control_plane/etcd }
+    - { role: recover_control_plane/etcd, when: "not etcd_kubeadm_enabled|default(false)" }
 
 - hosts: kube_control_plane[0]
   environment: "{{ proxy_disable_env }}"

--- a/roles/etcd/tasks/join_etcd_member.yml
+++ b/roles/etcd/tasks/join_etcd_member.yml
@@ -30,10 +30,6 @@
   args:
     executable: /bin/bash
   register: etcd_member_in_cluster
-  until: etcd_member_in_cluster.rc == 0
-  failed_when: etcd_member_in_cluster.rc != 0
-  retries: "{{ etcd_retries }}"
-  delay: "{{ retry_stagger | random + 3 }}"  
   changed_when: false
   check_mode: no
   retries: "{{ etcd_retries }}"

--- a/roles/etcd/tasks/join_etcd_member.yml
+++ b/roles/etcd/tasks/join_etcd_member.yml
@@ -30,6 +30,10 @@
   args:
     executable: /bin/bash
   register: etcd_member_in_cluster
+  until: etcd_member_in_cluster.rc == 0
+  failed_when: etcd_member_in_cluster.rc != 0
+  retries: "{{ etcd_retries }}"
+  delay: "{{ retry_stagger | random + 3 }}"  
   changed_when: false
   check_mode: no
   retries: "{{ etcd_retries }}"

--- a/roles/network_plugin/canal/tasks/main.yml
+++ b/roles/network_plugin/canal/tasks/main.yml
@@ -42,9 +42,9 @@
   run_once: true
   environment:
     ETCDCTL_API: 2
-    ETCDCTL_CA_FILE: "{{ etcd_cert_dir }}/ca.pem"
-    ETCDCTL_CERT_FILE: "{{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}.pem"
-    ETCDCTL_KEY_FILE: "{{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}-key.pem"
+    ETCDCTL_CA_FILE: "{{ kube_cert_dir + '/etcd/ca.crt' if etcd_kubeadm_enabled else etcd_cert_dir + '/ca.pem' }}"
+    ETCDCTL_CERT_FILE: "{{ kube_cert_dir + '/etcd/server.crt' if etcd_kubeadm_enabled else etcd_cert_dir + '/admin-' + groups['etcd'][0] + '.pem' }}"
+    ETCDCTL_KEY_FILE: "{{ kube_cert_dir + '/etcd/server.key' if etcd_kubeadm_enabled else etcd_cert_dir + '/admin-' + groups['etcd'][0] + '-key.pem' }}"
     ETCDCTL_ENDPOINTS: "{{ etcd_access_addresses }}"
 
 - name: Canal | Create canal node manifests

--- a/roles/remove-node/remove-etcd-node/tasks/main.yml
+++ b/roles/remove-node/remove-etcd-node/tasks/main.yml
@@ -34,8 +34,8 @@
     - facts
   environment:
     ETCDCTL_API: 3
-    ETCDCTL_CERT: "{{ kube_cert_dir + '/etcd/server.crt' if etcd_kubeadm_enabled else etcd_cert_dir + '/admin' + groups['etcd']|first + '.pem' }}"
-    ETCDCTL_KEY: "{{ kube_cert_dir + '/etcd/server.key' if etcd_kubeadm_enabled else etcd_cert_dir + '/admin' + groups['etcd']|first + '-key.pem' }}"
+    ETCDCTL_CERT: "{{ kube_cert_dir + '/etcd/server.crt' if etcd_kubeadm_enabled else etcd_cert_dir + '/admin-' + groups['etcd']|first + '.pem' }}"
+    ETCDCTL_KEY: "{{ kube_cert_dir + '/etcd/server.key' if etcd_kubeadm_enabled else etcd_cert_dir + '/admin-' + groups['etcd']|first + '-key.pem' }}"
     ETCDCTL_CACERT: "{{ kube_cert_dir + '/etcd/ca.crt' if etcd_kubeadm_enabled else etcd_cert_dir + '/ca.pem' }}"
     ETCDCTL_ENDPOINTS: "https://{{ hostvars[groups['etcd']|first]['etcd_access_address'] |
                                    default(hostvars[groups['etcd']|first]['ip']) |
@@ -52,8 +52,8 @@
     - facts
   environment:
     ETCDCTL_API: 3
-    ETCDCTL_CERT: "{{ kube_cert_dir + '/etcd/server.crt' if etcd_kubeadm_enabled else etcd_cert_dir + '/admin' + groups['etcd']|first + '.pem' }}"
-    ETCDCTL_KEY: "{{ kube_cert_dir + '/etcd/server.key' if etcd_kubeadm_enabled else etcd_cert_dir + '/admin' + groups['etcd']|first + '-key.pem' }}"
+    ETCDCTL_CERT: "{{ kube_cert_dir + '/etcd/server.crt' if etcd_kubeadm_enabled else etcd_cert_dir + '/admin-' + groups['etcd']|first + '.pem' }}"
+    ETCDCTL_KEY: "{{ kube_cert_dir + '/etcd/server.key' if etcd_kubeadm_enabled else etcd_cert_dir + '/admin-' + groups['etcd']|first + '-key.pem' }}"
     ETCDCTL_CACERT: "{{ kube_cert_dir + '/etcd/ca.crt' if etcd_kubeadm_enabled else etcd_cert_dir + '/ca.pem' }}"
     ETCDCTL_ENDPOINTS: "https://{{ hostvars[groups['etcd']|first]['etcd_access_address'] |
                                    default(hostvars[groups['etcd']|first]['ip']) |

--- a/roles/remove-node/remove-etcd-node/tasks/main.yml
+++ b/roles/remove-node/remove-etcd-node/tasks/main.yml
@@ -34,9 +34,9 @@
     - facts
   environment:
     ETCDCTL_API: 3
-    ETCDCTL_CERT: "{{ etcd_cert_dir }}/admin-{{ groups['etcd']|first }}.pem"
-    ETCDCTL_KEY: "{{ etcd_cert_dir }}/admin-{{ groups['etcd']|first }}-key.pem"
-    ETCDCTL_CACERT: "{{ etcd_cert_dir }}/ca.pem"
+    ETCDCTL_CERT: "{{ kube_cert_dir + '/etcd/server.crt' if etcd_kubeadm_enabled else etcd_cert_dir + '/admin' + groups['etcd']|first + '.pem' }}"
+    ETCDCTL_KEY: "{{ kube_cert_dir + '/etcd/server.key' if etcd_kubeadm_enabled else etcd_cert_dir + '/admin' + groups['etcd']|first + '-key.pem' }}"
+    ETCDCTL_CACERT: "{{ kube_cert_dir + '/etcd/ca.crt' if etcd_kubeadm_enabled else etcd_cert_dir + '/ca.pem' }}"
     ETCDCTL_ENDPOINTS: "https://{{ hostvars[groups['etcd']|first]['etcd_access_address'] |
                                    default(hostvars[groups['etcd']|first]['ip']) |
                                    default(hostvars[groups['etcd']|first]['fallback_ips'][groups['etcd']|first]) }}:2379"
@@ -52,9 +52,9 @@
     - facts
   environment:
     ETCDCTL_API: 3
-    ETCDCTL_CERT: "{{ etcd_cert_dir }}/admin-{{ groups['etcd']|first }}.pem"
-    ETCDCTL_KEY: "{{ etcd_cert_dir }}/admin-{{ groups['etcd']|first }}-key.pem"
-    ETCDCTL_CACERT: "{{ etcd_cert_dir }}/ca.pem"
+    ETCDCTL_CERT: "{{ kube_cert_dir + '/etcd/server.crt' if etcd_kubeadm_enabled else etcd_cert_dir + '/admin' + groups['etcd']|first + '.pem' }}"
+    ETCDCTL_KEY: "{{ kube_cert_dir + '/etcd/server.key' if etcd_kubeadm_enabled else etcd_cert_dir + '/admin' + groups['etcd']|first + '-key.pem' }}"
+    ETCDCTL_CACERT: "{{ kube_cert_dir + '/etcd/ca.crt' if etcd_kubeadm_enabled else etcd_cert_dir + '/ca.pem' }}"
     ETCDCTL_ENDPOINTS: "https://{{ hostvars[groups['etcd']|first]['etcd_access_address'] |
                                    default(hostvars[groups['etcd']|first]['ip']) |
                                    default(hostvars[groups['etcd']|first]['fallback_ips'][groups['etcd']|first]) }}:2379"


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR fixes some etcd certificates reference, there are many references in other playbooks but i'm not really sure where this replace is needed, please take a look and let me know if these changes are necessary in other playbooks.

**Which issue(s) this PR fixes**:
Fixes #7765

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
  NONE
```
