### PR TITLE
Ubuntu changed package name python-apt to python3-apt 

### DIFF
--- a/roles/kubernetes/preinstall/vars/ubuntu-21.04.yml
+++ b/roles/kubernetes/preinstall/vars/ubuntu-21.04.yml
@@ -1,7 +1,0 @@
----
-required_pkgs:
-  - python3-apt
-  - aufs-tools
-  - apt-transport-https
-  - software-properties-common
-  - conntrack

--- a/roles/kubernetes/preinstall/vars/ubuntu.yml
+++ b/roles/kubernetes/preinstall/vars/ubuntu.yml
@@ -1,6 +1,6 @@
 ---
 required_pkgs:
-  - python-apt
+  - python3-apt
   - aufs-tools
   - apt-transport-https
   - software-properties-common


### PR DESCRIPTION
/kind feature

What this PR does / why we need it:
Looking forward to next Ubuntu Version you need do change the package name of python-apt in python3-apt.

Issue was resolved for ubuntu20.04.yml but not ubuntu.yml

Original issue that fixed only 1 of the ubuntu variable files: https://github.com/kubernetes-sigs/kubespray/pull/7715