### PR TITLE
retry to fetch binary if it fails first time

### DIFF
--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -106,6 +106,9 @@
     dest: "{{ artifacts_dir }}/kubectl"
     flat: yes
     validate_checksum: no
+  register: copy_binary_result
+  until: copy_binary_result is not failed
+  retries: 20
   become: no
   run_once: yes
   when: kubectl_localhost


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR introduces an until/retry with a task that fetches binary to ansible host[running kubespray] from k8s master nodes

**Which issue(s) this PR fixes**:

Recently while testing the k8s upgrade with kubespray v2.14.2, I had faced below mentioned issue on my platform.
`TASK [kubernetes/client : Copy kubectl binary to ansible host] *****************
    Friday 09 July 2021  20:53:23 +0000 (0:00:00.400)       0:15:48.785 ***********
    [0;31mAn exception occurred during task execution. To see the full traceback, use -vvv. The error was: OSError: [Errno 26] Text file busy: b'/usr/local/bin/kubectl'[0m
    [0;31mfatal: [m1-kms0001.mgmt.oiaas]: FAILED! => [0m
    [0;31m  msg: Unexpected failure during module execution.[0m
    [0;31m  stdout: ''[0m`
    
By the error it seems that binary is used at the time of execution of this task and hence upgrade process terminated, I have introduced an until/retry to tackle such error and try to fetch binary for at least 20 attempts before terminating the upgrade process.

I am open to suggestions for improvising this task, so as to avoid termination of k8s upgrade due to this task.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
