### PR TITLE
Allow failure on tf-elax_ubuntu18-calico

### DIFF
--- a/.gitlab-ci/terraform.yml
+++ b/.gitlab-ci/terraform.yml
@@ -207,6 +207,7 @@ tf-elastx_ubuntu18-calico:
   extends: .terraform_apply
   stage: deploy-part3
   when: on_success
+  allow_failure: true
   variables:
     <<: *elastx_variables
     TF_VERSION: $TERRAFORM_14_VERSION


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

tf-elax_ubuntu18-calico is so flake today.
The test job is failed due to SSH connectivity check error after deploying virtual machines which are used for Kubernetes nodes.
This allows failure on the job to see the test situation without pull request merger failures.

Ref: https://github.com/kubernetes-sigs/kubespray/issues/7811

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
