### PR TITLE
CRI-O: Install libseccomp2 from backports on Debian 10

### DIFF
--- a/roles/container-engine/cri-o/tasks/crio_repo.yml
+++ b/roles/container-engine/cri-o/tasks/crio_repo.yml
@@ -6,9 +6,6 @@
         repo: "deb http://deb.debian.org/debian {{ ansible_distribution_release }}-backports main"
         state: present
         filename: debian-backports
-      when:
-        - ansible_distribution == "Debian"
-        - ansible_distribution_version == "10"
 
     - name: Set libseccomp2 pin priority to apt_preferences on Debian buster
       copy:

--- a/roles/container-engine/cri-o/tasks/crio_repo.yml
+++ b/roles/container-engine/cri-o/tasks/crio_repo.yml
@@ -1,5 +1,28 @@
 ---
 
+- block:
+    - name: Add Debian Backports apt repo
+      apt_repository:
+        repo: "deb http://deb.debian.org/debian {{ ansible_distribution_release }}-backports main"
+        state: present
+        filename: debian-backports
+      when:
+        - ansible_distribution == "Debian"
+        - ansible_distribution_version == "10"
+
+    - name: Set libseccomp2 pin priority to apt_preferences on Debian buster
+      copy:
+        content: |
+          Package: libseccomp2
+          Pin: release a={{ ansible_distribution_release }}-backports
+          Pin-Priority: 1001
+        dest: "/etc/apt/preferences.d/libseccomp2"
+        owner: "root"
+        mode: 0644
+  when:
+    - ansible_distribution == "Debian"
+    - ansible_distribution_version == "10"
+
 - name: CRI-O kubic repo name for debian os family
   set_fact:
     crio_kubic_debian_repo_name: "{{ ((ansible_distribution == 'Ubuntu') | ternary('x','')) ~ ansible_distribution ~ '_' ~ ansible_distribution_version }}"

--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -87,6 +87,13 @@
     - not skip_downloads|default(false)
     - download_run_once
 
+- name: Add libseccomp2 package from Debian Backports to install
+  set_fact:
+    crio_packages: "{{ crio_debian_buster_backports_packages + crio_packages }}"
+  when:
+    - ansible_distribution == "Debian"
+    - ansible_distribution_version == "10"
+
 - name: Install cri-o packages
   package:
     name: "{{ item }}"

--- a/roles/container-engine/cri-o/vars/debian.yml
+++ b/roles/container-engine/cri-o/vars/debian.yml
@@ -10,6 +10,9 @@ crio_versioned_pkg:
     - "cri-o=1.19*"
     - cri-o-runc
 
+crio_debian_buster_backports_packages:
+  - "libseccomp2"
+
 default_crio_packages: "{{ crio_versioned_pkg[crio_version] }}"
 
 crio_packages: "{{ debian_crio_packages | default(default_crio_packages) }}"


### PR DESCRIPTION
libseccomp2 is a required dependency of cri-o-runc package

The one provided in Debian 10 repositories is outdated

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

I wrote to Podman and CRI-O package maintainer, aka @lsm5 / https://github.com/lsm5 about this issue on Debian 10, and he told me enabling the buster backport was necessary and pointed me to https://podman.io/blogs/2021/03/02/podman-support-for-older-distros.html

Thanks !

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
