### PR TITLE
doc: Update 'Kubespray vs Kubeadm'

### DIFF
--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -21,7 +21,6 @@ does generic configuration management tasks from the "OS operators" ansible
 world, plus some initial K8s clustering (with networking plugins included) and
 control plane bootstrapping.
 
-Kubespray supports `kubeadm` for cluster creation since v2.3
-(and deprecated non-kubeadm deployment starting from v2.8)
+Kubespray has started using `kubeadm` internally for cluster creation since v2.3
 in order to consume life cycle management domain knowledge from it
 and offload generic OS configuration things from it, which hopefully benefits both sides.


### PR DESCRIPTION

**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

non-kubeadm mode has been removed since ddffdb63bfcc65a1731a16d316ce1 2.5 years ago.
The non-kubeadm makes unnecessary confusion today, then this updates the documentation.

**Special notes for your reviewer**:

This pull request comes from https://github.com/kubernetes/website/pull/28831

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
