### PR TITLE
[2.16] Update vSphere CPI - Backport for the #7838

### DIFF
--- a/docs/vsphere-csi.md
+++ b/docs/vsphere-csi.md
@@ -2,32 +2,38 @@
 
 vSphere CSI driver allows you to provision volumes over a vSphere deployment. The Kubernetes historic in-tree cloud provider is deprecated and will be removed in future versions.
 
+## Prerequisites
+
+The vSphere user for CSI driver requires a set of privileges to perform Cloud Native Storage operations. Follow the [official guide](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/prerequisites.html#roles_and_privileges) to configure those.
+
+## Kubespray configuration
+
 To enable vSphere CSI driver, uncomment the `vsphere_csi_enabled` option in `group_vars/all/vsphere.yml` and set it to `true`.
 
 To set the number of replicas for the vSphere CSI controller, you can change `vsphere_csi_controller_replicas` option in `group_vars/all/vsphere.yml`.
 
 You need to source the vSphere credentials you use to deploy your machines that will host Kubernetes.
 
-| Variable                                    | Required | Type    | Choices                    | Default                   | Comment                                                        |
-|---------------------------------------------|----------|---------|----------------------------|---------------------------|----------------------------------------------------------------|
-| external_vsphere_vcenter_ip                 | TRUE     | string  |                            |                           | IP/URL of the vCenter                                          |
-| external_vsphere_vcenter_port               | TRUE     | string  |                            | "443"                     | Port of the vCenter API                                        |
-| external_vsphere_insecure                   | TRUE     | string  | "true", "false"            | "true"                    | set to "true" if the host above uses a self-signed cert        |
-| external_vsphere_user                       | TRUE     | string  |                            |                           | User name for vCenter with required privileges                 |
-| external_vsphere_password                   | TRUE     | string  |                            |                           | Password for vCenter                                           |
-| external_vsphere_datacenter                 | TRUE     | string  |                            |                           | Datacenter name to use                                         |
-| external_vsphere_kubernetes_cluster_id      | TRUE     | string  |                            | "kubernetes-cluster-id"   | Kubernetes cluster ID to use                                   |
-| external_vsphere_version          | TRUE     | string  |                            | "6.7u3"                  | Vmware Vsphere version where located all VMs                                   |
-| vsphere_cloud_controller_image_tag          | TRUE     | string  |                            | "latest"                  | Kubernetes cluster ID to use                                   |
-| vsphere_syncer_image_tag                    | TRUE     | string  |                            | "v1.0.2"                  | Syncer image tag to use                                        |
-| vsphere_csi_attacher_image_tag              | TRUE     | string  |                            | "v1.1.1"                  | CSI attacher image tag to use                                  |
-| vsphere_csi_controller                      | TRUE     | string  |                            | "v1.0.2"                  | CSI controller image tag to use                                |
-| vsphere_csi_controller_replicas             | TRUE     | integer |                            | 1                         | Number of pods Kubernetes should deploy for the CSI controller |
-| vsphere_csi_liveness_probe_image_tag        | TRUE     | string  |                            | "v1.1.0"                  | CSI liveness probe image tag to use                            |
-| vsphere_csi_provisioner_image_tag           | TRUE     | string  |                            | "v1.2.2"                  | CSI provisioner image tag to use                               |
-| vsphere_csi_node_driver_registrar_image_tag | TRUE     | string  |                            | "v1.1.0"                  | CSI node driver registrat image tag to use                     |
-| vsphere_csi_driver_image_tag                | TRUE     | string  |                            | "v1.0.2"                  | CSI driver image tag to use                                    |
-vsphere_csi_resizer_tag                | TRUE     | string  |                            |  "v1.0.0"                  | CSI resizer image tag to use
+| Variable                                    | Required | Type    | Choices                    | Default                   | Comment                                                                                                             |
+|---------------------------------------------|----------|---------|----------------------------|---------------------------|---------------------------------------------------------------------------------------------------------------------|
+| external_vsphere_vcenter_ip                 | TRUE     | string  |                            |                           | IP/URL of the vCenter                                                                                               |
+| external_vsphere_vcenter_port               | TRUE     | string  |                            | "443"                     | Port of the vCenter API                                                                                             |
+| external_vsphere_insecure                   | TRUE     | string  | "true", "false"            | "true"                    | set to "true" if the host above uses a self-signed cert                                                             |
+| external_vsphere_user                       | TRUE     | string  |                            |                           | User name for vCenter with required privileges |
+| external_vsphere_password                   | TRUE     | string  |                            |                           | Password for vCenter                       |
+| external_vsphere_datacenter                 | TRUE     | string  |                            |                           | Datacenter name to use                                                                                              |
+| external_vsphere_kubernetes_cluster_id      | TRUE     | string  |                            | "kubernetes-cluster-id"   | Kubernetes cluster ID to use                                                                                        |
+| external_vsphere_version                    | TRUE     | string  |                            | "6.7u3"                   | Vmware Vsphere version where located all VMs                                                                        |
+| external_vsphere_cloud_controller_image_tag          | TRUE     | string  |                            | "latest"                  | Kubernetes cluster ID to use                                                                                        |
+| vsphere_syncer_image_tag                    | TRUE     | string  |                            | "v2.2.1"                  | Syncer image tag to use                                                                                             |
+| vsphere_csi_attacher_image_tag              | TRUE     | string  |                            | "v3.1.0"                  | CSI attacher image tag to use                                                                                       |
+| vsphere_csi_controller                      | TRUE     | string  |                            | "v2.2.1"                  | CSI controller image tag to use                                                                                     |
+| vsphere_csi_controller_replicas             | TRUE     | integer |                            | 1                         | Number of pods Kubernetes should deploy for the CSI controller                                                      |
+| vsphere_csi_liveness_probe_image_tag        | TRUE     | string  |                            | "v2.2.0"                  | CSI liveness probe image tag to use                                                                                 |
+| vsphere_csi_provisioner_image_tag           | TRUE     | string  |                            | "v2.1.0"                  | CSI provisioner image tag to use                                                                                    |
+| vsphere_csi_node_driver_registrar_image_tag | TRUE     | string  |                            | "v1.1.0"                  | CSI node driver registrat image tag to use                                                                          |
+| vsphere_csi_driver_image_tag                | TRUE     | string  |                            | "v1.0.2"                  | CSI driver image tag to use                                                                                         |
+| vsphere_csi_resizer_tag                     | TRUE     | string  |                            | "v1.1.0"                  | CSI resizer image tag to use
 
 ## Usage example
 
@@ -61,7 +67,7 @@ spec:
     - containerPort: 80
       protocol: TCP
     volumeMounts:
-      - mountPath: /var/lib/www/html
+      - mountPath: /usr/share/nginx/html
         name: csi-data-vsphere
   volumes:
   - name: csi-data-vsphere
@@ -83,8 +89,8 @@ csi-pvc-vsphere   Bound    pvc-dc7b1d21-ee41-45e1-98d9-e877cc1533ac   1Gi       
 And the volume mounted to the Nginx Pod (wait until the Pod is Running):
 
 ```ShellSession
-kubectl exec -it nginx -- df -h | grep /var/lib/www/html
-/dev/sdb         976M  2.6M  907M   1% /var/lib/www/html
+kubectl exec -it nginx -- df -h | grep /usr/share/nginx/html
+/dev/sdb         976M  2.6M  907M   1% /usr/share/nginx/html
 ```
 
 ## More info

--- a/inventory/sample/group_vars/all/vsphere.yml
+++ b/inventory/sample/group_vars/all/vsphere.yml
@@ -11,13 +11,21 @@
 # external_vsphere_version: "6.7u3"
 
 ## Tags for the external vSphere Cloud Provider images
+## gcr.io/cloud-provider-vsphere/cpi/release/manager
 # external_vsphere_cloud_controller_image_tag: "latest"
-# vsphere_syncer_image_tag: "v1.0.2"
-# vsphere_csi_attacher_image_tag: "v1.1.1"
-# vsphere_csi_controller: "v1.0.2"
-# vsphere_csi_liveness_probe_image_tag: "v1.1.0"
-# vsphere_csi_provisioner_image_tag: "v1.2.2"
-# vsphere_csi_resizer_tag: "v1.0.0"
+## gcr.io/cloud-provider-vsphere/csi/release/syncer
+# vsphere_syncer_image_tag: "v2.2.1"
+## quay.io/k8scsi/csi-attacher
+# vsphere_csi_attacher_image_tag: "v3.1.0"
+## gcr.io/cloud-provider-vsphere/csi/release/driver
+# vsphere_csi_controller: "v2.2.1"
+## quay.io/k8scsi/livenessprobe
+# vsphere_csi_liveness_probe_image_tag: "v2.2.0"
+## quay.io/k8scsi/csi-provisioner
+# vsphere_csi_provisioner_image_tag: "v2.1.0"
+## quay.io/k8scsi/csi-resizer
+## makes sense only for vSphere version >=7.0
+# vsphere_csi_resizer_tag: "v1.1.0"
 
 ## To use vSphere CSI plugin to provision volumes set this value to true
 # vsphere_csi_enabled: true

--- a/roles/kubernetes-apps/external_cloud_controller/vsphere/templates/external-vsphere-cloud-controller-manager-roles.yml.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/vsphere/templates/external-vsphere-cloud-controller-manager-roles.yml.j2
@@ -37,6 +37,12 @@ items:
   - apiGroups:
     - ""
     resources:
+    - services/status
+    verbs:
+    - patch
+  - apiGroups:
+    - ""
+    resources:
     - serviceaccounts
     verbs:
     - create
@@ -71,5 +77,15 @@ items:
     - get
     - list
     - watch
+  - apiGroups:
+    - "coordination.k8s.io"
+    resources:
+    - leases
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
 kind: List
 metadata: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
>
/kind feature
> /kind flake

**What this PR does / why we need it**:

Backport of #7838

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

**Special notes for your reviewer**:

Backport of #7838

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update vSphere CPI ClusterRole according to the latest [official CPI manifests](https://github.com/kubernetes/cloud-provider-vsphere/tree/master/manifests/controller-manager)
```
