### PR TITLE
Add kubespray-defaults role 

### DIFF
--- a/remove-node.yml
+++ b/remove-node.yml
@@ -16,11 +16,12 @@
       run_once: True
       when:
         - not (skip_confirmation | default(false) | bool)
-
     - name: Fail if user does not confirm deletion
       fail:
         msg: "Delete nodes confirmation failed"
       when: pause_result.user_input | default('yes') != 'yes'
+  roles:
+    - { role: kubespray-defaults }
 
 - hosts: kube_control_plane[0]
   gather_facts: no


### PR DESCRIPTION
Fixes issues where an execution of remove-node.yml fails because a default value is not provided for proxy_disable_env

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> 
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Fixes and issue where remove-node.yml execution fails
**Which issue(s) this PR fixes**:
Fixes #7801

**Special notes for your reviewer**:

Running the tests is beyond me so please can someone do this.  I have tested execution by provisioning, scaling and removing an node and that works fine in my scenario.

**Does this PR introduce a user-facing change?**:
No
```release-note

```
