### PR TITLE
kubernetes/preinstall: Add Debian 11 (bullseye) support

### DIFF
--- a/roles/kubernetes/preinstall/vars/debian-11.yml
+++ b/roles/kubernetes/preinstall/vars/debian-11.yml
@@ -1,0 +1,7 @@
+---
+required_pkgs:
+  - python3-apt
+  - gnupg
+  - apt-transport-https
+  - software-properties-common
+  - conntrack


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

Several packages was removed from Debian 11 (bullseye) resulting to kubespray deploy failed on bullseye target.

This PR just add a new `required_pkgs` vars file specifically for Debian 11 and fix these issues

- `python-apt` removed => change to `python3-apt`
- `aufs-tools` removed => remove from a list (previously used in older version of Docker)
- `gnupg` not installed by default => install `gnupg` before running `apt_key`
  - This fix `container-engine/containerd : ensure containerd repository public key is installed` task failed

https://github.com/kubernetes-sigs/kubespray/blob/b72f8cdc152640e9eb76490e51b4961bf714feb2/roles/kubernetes/preinstall/vars/debian-11.yml#L1-L7


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A


**Special notes for your reviewer**:

This PR was successfully tested on my cluster with following details

My Test Cluster

- 3 nodes - 3 masters, worker in master node (4 CPU, 4 GB each)
- Debian 11 (bullseye) netinst+ssh
- Restore from snapshot to clean-install state before each test

Inventory Configuration & Add-ons

1. k8s v1.21.1 with containerd + etcd(host)
2. k8s v1.21.3 with containerd + etcd(host)
3. k8s v1.21.3 with containerd + etcd(host) + helm + metrics_server + ingress_nginx + cert_manager + metallb
4. k8s v.1.21.3 with docker + etcd(docker) 
5. k8s v.1.21.3 with docker + etcd(docker) + helm + metrics_server + ingress_nginx + cert_manager + metallb 


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add Debian 11 support
```
