### PR TITLE
Update cilium to 1.9.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [cni-plugins](https://github.com/containernetworking/plugins) v0.9.1
   - [calico](https://github.com/projectcalico/calico) v3.17.4
   - [canal](https://github.com/projectcalico/canal) (given calico/flannel versions)
-  - [cilium](https://github.com/cilium/cilium) v1.8.9
+  - [cilium](https://github.com/cilium/cilium) v1.9.9
   - [flanneld](https://github.com/flannel-io/flannel) v0.14.0
   - [kube-ovn](https://github.com/alauda/kube-ovn) v1.7.1
   - [kube-router](https://github.com/cloudnativelabs/kube-router) v1.3.0

--- a/docs/cilium.md
+++ b/docs/cilium.md
@@ -15,7 +15,7 @@ balancer deployed by Kubespray and **only contacts the first master**.
 ## Choose Cilium version
 
 ```yml
-cilium_version: v1.8.9 ## or v1.9.6
+cilium_version: v1.9.9
 ```
 
 ## Add variable to config

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -82,7 +82,7 @@ flannel_version: "v0.14.0"
 cni_version: "v0.9.1"
 weave_version: 2.8.1
 pod_infra_version: "3.3"
-cilium_version: "v1.8.9"
+cilium_version: "v1.9.9"
 kube_ovn_version: "v1.7.0"
 kube_router_version: "v1.3.0"
 multus_version: "v3.7.2"


### PR DESCRIPTION
Now that 1.10 is out this is to make 1.9.9 the default. I am running
this version successfully.