### PR TITLE
Calico: use --allow-version-mismatch in calicoctl.sh to allow upgrades

### DIFF
--- a/roles/network_plugin/calico/templates/calicoctl.etcd.sh.j2
+++ b/roles/network_plugin/calico/templates/calicoctl.etcd.sh.j2
@@ -3,4 +3,4 @@ ETCD_ENDPOINTS={{ etcd_access_addresses }} \
 ETCD_CA_CERT_FILE={{ calico_cert_dir }}/ca_cert.crt \
 ETCD_CERT_FILE={{ calico_cert_dir }}/cert.crt \
 ETCD_KEY_FILE={{ calico_cert_dir }}/key.pem \
-{{ bin_dir }}/calicoctl "$@"
+{{ bin_dir }}/calicoctl {% if calico_version is version('v3.20.0', '>=') %}--allow-version-mismatch{% endif %} "$@"

--- a/roles/network_plugin/calico/templates/calicoctl.kdd.sh.j2
+++ b/roles/network_plugin/calico/templates/calicoctl.kdd.sh.j2
@@ -5,4 +5,4 @@ KUBECONFIG=/etc/kubernetes/admin.conf \
 {% else %}
 KUBECONFIG=/etc/cni/net.d/calico-kubeconfig \
 {% endif %}
-{{ bin_dir }}/calicoctl "$@"
+{{ bin_dir }}/calicoctl {% if calico_version is version('v3.20.0', '>=') %}--allow-version-mismatch{% endif %} "$@"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Calico 3.20 introduced a feature to protect clusters from being modified by incompatible `calicoctl` versions. This has an impact in upgrading Calico from earlier versions to 3.20.
The change proposed here modifies the wrapper used (`calicoctl.sh`) which in effect reverts back to the old behavior. An alternative would be to modify the calls to `calicoctl.sh` from our playbooks to add the `--allow-version-mismatch` flag.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
I submit this change to get some feedback on the two approaches and I'm open to moving to the alternative if reviewers see fit.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
