### PR TITLE
During pre-upgrade add a flag to always cordon

### DIFF
--- a/roles/upgrade/pre-upgrade/defaults/main.yml
+++ b/roles/upgrade/pre-upgrade/defaults/main.yml
@@ -6,6 +6,7 @@ drain_nodes: true
 drain_retries: 3
 drain_retry_delay_seconds: 10
 
+upgrade_node_always_cordon: true
 upgrade_node_uncordon_after_drain_failure: true
 upgrade_node_fail_if_drain_fails: true
 

--- a/roles/upgrade/pre-upgrade/defaults/main.yml
+++ b/roles/upgrade/pre-upgrade/defaults/main.yml
@@ -6,7 +6,7 @@ drain_nodes: true
 drain_retries: 3
 drain_retry_delay_seconds: 10
 
-upgrade_node_always_cordon: true
+upgrade_node_always_cordon: false
 upgrade_node_uncordon_after_drain_failure: true
 upgrade_node_fail_if_drain_fails: true
 

--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -39,7 +39,7 @@
 - name: Set if node needs cordoning
   set_fact:
     needs_cordoning: >-
-      {% if kubectl_node_ready.stdout == "True" and not kubectl_node_schedulable.stdout -%}
+      {% if (kubectl_node_ready.stdout == "True" and not kubectl_node_schedulable.stdout) or upgrade_node_always_cordon -%}
       true
       {%- else -%}
       false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
In some environments there's a pre-processing outside of Kubespray to determine whether a node should be upgraded. Once a node becomes a candidate for an upgrade, it is cordoned, and then passed to Kubespray to upgrade.

The current logic is such that `needs_cordoning` is used for three purposes
1. cordon the node before an upgrade
2. drain the node before an upgrade
3. uncordon the node after an upgrade

In the scenario describe above, `needs_cordoning` is set to `false` because it's already cordoned, thus 2 and 3 are skipped. This results in a situation where the upgraded node remains cordoned.

The new `upgrade_node_always_cordon` allows for always setting `needs_cordoning` to `true`, so that upgrading a node that's pre-cordoned can still be drained and uncordoned by Kubespray.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Setting `roles/upgrade/pre-upgrade/defaults/main.yml:upgrade_node_always_cordon` to `true` causes a node to be drained before an upgrade and uncordoned after an upgrade even if the node is not cordoned when the upgrade begins.
```
