### PR TITLE
fix error metrics server capabilities name

### DIFF
--- a/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
@@ -70,7 +70,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop: ["all"]
-            add: ["CAP_NET_BIND_SERVICE"]
+            add: ["NET_BIND_SERVICE"]
           readOnlyRootFilesystem: true
           runAsGroup: 10001
           runAsNonRoot: true


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
metrics server not started becouse right capabilites name is NET_BIND_SERVICE
https://kubernetes.io/docs/concepts/security/pod-security-standards/

#7864 
