### PR TITLE
fix error in docker build .

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Use imutable image tags rather than mutable tags (like ubuntu:18.04)
 FROM ubuntu:bionic-20200807
+# Some tools like yamllint need this
+ENV LANG=C.UTF-8
 
 RUN apt update -y \
     && apt install -y \
@@ -25,6 +27,3 @@ RUN KUBE_VERSION=$(sed -n 's/^kube_version: //p' roles/kubespray-defaults/defaul
     && curl -LO https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/amd64/kubectl \
     && chmod a+x kubectl \
     && mv kubectl /usr/local/bin/kubectl
-
-# Some tools like yamllint need this
-ENV LANG=C.UTF-8


### PR DESCRIPTION
UnicodeEncodeError: 'ascii' codec can't encode character '\xe9' in position 117: ordinal not in range(128)

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

docker build fail when pip install ansible-base-2.10

```
Collecting ansible-base==2.10.11
  Downloading ansible-base-2.10.11.tar.gz (6.0 MB)
ERROR: Exception:
Traceback (most recent call last):
...
  File "/usr/local/lib/python3.6/dist-packages/pip/_internal/utils/unpacking.py", line 226, in untar_file
    with open(path, "wb") as destfp:
UnicodeEncodeError: 'ascii' codec can't encode character '\xe9' in position 117: ordinal not in range(128)
The command '/bin/sh -c /usr/bin/python3 -m pip install --no-cache-dir pip -U     && /usr/bin/python3 -m pip install --no-cache-dir -r tests/requirements.txt     && python3 -m pip install --no-cache-dir -r requirements.txt     && update-alternatives --install /usr/bin/python python /usr/bin/python3 1' returned a non-zero code: 2
```
