### PR TITLE
Fix Fedora nightly jobs (mitogen issue) and centos8 CI instability 

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -177,15 +177,11 @@ packet_fedora33-calico:
   stage: deploy-part2
   extends: .packet_periodic
   when: on_success
-  variables:
-    MITOGEN_ENABLE: "true"
 
 packet_fedora34-calico-selinux:
   stage: deploy-part2
   extends: .packet_periodic
   when: on_success
-  variables:
-    MITOGEN_ENABLE: "true"
 
 packet_amazon-linux-2-aio:
   stage: deploy-part2

--- a/tests/cloud_playbooks/roles/packet-ci/templates/vm.yml.j2
+++ b/tests/cloud_playbooks/roles/packet-ci/templates/vm.yml.j2
@@ -31,7 +31,7 @@ spec:
         cpu:
             cores: {{ vm_cpu_cores }}
             sockets: {{ vm_cpu_sockets }}
-            threads: {{ vm_cpu_cores }}
+            threads: {{ vm_cpu_threads }}
         resources:
           requests:
             memory: {{ vm_memory * memory_allocation_ratio }}

--- a/tests/files/packet_centos8-calico.yml
+++ b/tests/files/packet_centos8-calico.yml
@@ -2,6 +2,7 @@
 # Instance settings
 cloud_image: centos-8
 mode: default
+vm_memory: 3072Mi
 
 # Kubespray settings
 kube_network_plugin: calico


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
- Seems like dnf and mitogen are weirdly no longer compatible (or maybe because of the switch to ansible 2.11 ?) but anyway not trying to understand why, don't really care let's remove mitogen for fedora jobs
- Looks like centos8 jobs were unstable a lot mainly because centos8 require more memory than 2go, let's set 3go and we'll see (already triggered the job 4 times without any issue, in other PR the job is in success like 1 in 10 times...)
- Also fix a setting for test using cpu_cores instead of cpu_threads

**Which issue(s) this PR fixes**:
Fedora nigthly issue : https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/1543360268
Centos8 CI issue (unstable like A LOT)

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
