### PR TITLE
Replace cluster_name by dns_domain

### DIFF
--- a/roles/kubernetes-apps/registry/templates/registry-proxy-ds.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-proxy-ds.yml.j2
@@ -27,7 +27,7 @@ spec:
           imagePullPolicy: {{ k8s_image_pull_policy }}
           env:
             - name: REGISTRY_HOST
-              value: registry.{{ registry_namespace }}.svc.{{ cluster_name }}
+              value: registry.{{ registry_namespace }}.svc.{{ dns_domain }}
             - name: REGISTRY_PORT
               value: "{{ registry_port }}"
           ports:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

`cluster_name` defaults to `dns_domain` value (see [here][1] and [here][2]) but they could have different values.

`dns_domain` should be used here instead of `cluster_name` because the DNS resolution is configured to use `dns_domain`.

[1]: https://github.com/kubernetes-sigs/kubespray/blob/0ef7af76bc234efa06183e7329e557df87f9c0ee/roles/kubespray-defaults/defaults/main.yaml#L104
[2]: https://github.com/kubernetes-sigs/kubespray/blob/1afdb05ea9e1678b97e0224191d0a9341ce84f41/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml#L196

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
