### PR TITLE
Fix Calico's FelixConfiguration when "IP in IP" is disabled

### DIFF
--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -153,7 +153,7 @@
           "name": "default",
         },
         "spec": {
-          "ipipEnabled": {{ calico_ipip_mode != 'Never' | bool }},
+          "ipipEnabled": {{ calico_ipip_mode != 'Never' }},
           "reportingInterval": "{{ calico_felix_reporting_interval }}",
           "bpfLogLevel": "{{ calico_bpf_log_level }}",
           "bpfEnabled": {{ calico_bpf_enabled | bool }},


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

When using Calico with:

- `calico_network_backend: vxlan`,
- `calico_ipip_mode: "Never"`,
- `calico_vxlan_mode: "Always"`,

the `FelixConfiguration` object has `ipipEnabled: true`, when it should be false:

```bash
$ kubectl get felixconfigurations.crd.projectcalico.org default -o jsonpath='{.spec.ipipEnabled}' -n kube-system
true
```

This is caused by an error in the `| bool` conversion in the install task: when `calico_ipip_mode` is `Never`, 
`{{ calico_ipip_mode != 'Never' | bool }}` evaluates to `true`:

https://github.com/kubernetes-sigs/kubespray/blob/9d3888a756c3dbbec449c11161ce1ab1422f8fc6/roles/network_plugin/calico/tasks/install.yml#L156

**More details:**

```
$ ansible localhost -m debug -e "calico_ipip_mode=Never" -a "msg={{ calico_ipip_mode != 'Never' | bool }}"
localhost | SUCCESS => {
    "msg": true
}

$ ansible localhost -m debug -e "calico_ipip_mode=Always" -a "msg={{ calico_ipip_mode != 'Never' | bool }}"
localhost | SUCCESS => {
    "msg": true
}
```

This is caused by the operator priority (thanks @pbriet), and could be fixed by adding parenthesis:

```
$ ansible localhost -m debug -e "calico_ipip_mode=Never" -a "msg={{ (calico_ipip_mode != 'Never') | bool }}"
localhost | SUCCESS => {
    "msg": false
}

$ ansible localhost -m debug -e "calico_ipip_mode=Always" -a "msg={{ (calico_ipip_mode != 'Never') | bool }}"
localhost | SUCCESS => {
    "msg": true
}
```

But as `calico_ipip_mode != 'Never'` is already a boolean, the `| bool` is useless anyway:

```
$ ansible localhost -m debug -e "calico_ipip_mode=Never" -a "msg={{ calico_ipip_mode != 'Never' }}"
localhost | SUCCESS => {
    "msg": false
}

$ ansible localhost -m debug -e "calico_ipip_mode=Always" -a "msg={{ calico_ipip_mode != 'Never' }}"
localhost | SUCCESS => {
    "msg": true
}
```

**Does this PR introduce a user-facing change?**:
```release-note
[Calico] Fix FelixConfiguration when "IP in IP" is disabled
```
