### PR TITLE
MetalLB: keep nodeSelector in one place

### DIFF
--- a/roles/kubernetes-apps/metallb/defaults/main.yml
+++ b/roles/kubernetes-apps/metallb/defaults/main.yml
@@ -6,8 +6,10 @@ metallb_port: "7472"
 metallb_memberlist_port: "7946"
 metallb_peers: []
 metallb_speaker_enabled: true
-metallb_speaker_nodeselector: {}
-metallb_controller_nodeselector: {}
+metallb_speaker_nodeselector:
+  kubernetes.io/os: "linux"
+metallb_controller_nodeselector:
+  kubernetes.io/os: "linux"
 metallb_speaker_tolerations:
   - effect: NoSchedule
     key: node-role.kubernetes.io/master

--- a/roles/kubernetes-apps/metallb/templates/metallb.yml.j2
+++ b/roles/kubernetes-apps/metallb/templates/metallb.yml.j2
@@ -398,14 +398,12 @@ spec:
             - ALL
           readOnlyRootFilesystem: true
       hostNetwork: true
-      nodeSelector:
-        kubernetes.io/os: linux
-      serviceAccountName: speaker
-      terminationGracePeriodSeconds: 2
 {% if metallb_speaker_nodeselector %}
       nodeSelector:
         {{ metallb_speaker_nodeselector | to_nice_yaml | indent(width=8) }}
 {%- endif %}
+      serviceAccountName: speaker
+      terminationGracePeriodSeconds: 2
 {% if metallb_speaker_tolerations %}
       tolerations:
         {{ metallb_speaker_tolerations | to_nice_yaml(indent=2) | indent(width=8) }}
@@ -435,10 +433,6 @@ spec:
         app: metallb
         component: controller
     spec:
-{% if metallb_controller_nodeselector %}
-      nodeSelector:
-        {{ metallb_controller_nodeselector | to_nice_yaml | indent(width=8) }}
-{%- endif %}
 {% if metallb_controller_tolerations %}
       tolerations:
         {{ metallb_controller_tolerations | to_nice_yaml(indent=2) | indent(width=8) }}
@@ -463,8 +457,10 @@ spec:
             drop:
             - all
           readOnlyRootFilesystem: true
+{% if metallb_controller_nodeselector %}
       nodeSelector:
-        kubernetes.io/os: linux
+        {{ metallb_controller_nodeselector | to_nice_yaml | indent(width=8) }}
+{%- endif %}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Generated manifests might have two 'nodeSelector' sections both for controller and speaker. This PR moves all selector into one section. As an side-effect there are less differences between the template and the upstream manifest.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
