### PR TITLE
Update kubespray image with git + add retry to vagrant and periodic job (nigthly)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,6 +52,7 @@ before_script:
 
 .testcases: &testcases
   <<: *job
+  retry: 1
   before_script:
     - update-alternatives --install /usr/bin/python python /usr/bin/python3 1
     - ./tests/scripts/rebase.sh

--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -11,7 +11,6 @@
 # CI template for PRs
 .packet_pr:
   only: [/^pr-.*$/]
-  retry: 1
   extends: .packet
 
 # CI template for periodic CI jobs

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:bionic-20200807
 RUN apt update -y \
     && apt install -y \
     libssl-dev python3-dev sshpass apt-transport-https jq moreutils \
-    ca-certificates curl gnupg2 software-properties-common python3-pip rsync \
+    ca-certificates curl gnupg2 software-properties-common python3-pip rsync git \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
     && add-apt-repository \


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Kubespray image needs git as it's use in CI, otherwise everything fails when releasing a version
Also add retry to periodic packet and vagrant jobs, as it's already wonderful to have that on pr packet jobs!

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
