### PR TITLE
Feature DynamicKubeletConfig is deprecated in 1.22 and will not move to GA

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -211,6 +211,9 @@ k8s_image_pull_policy: IfNotPresent
 kubernetes_audit: false
 
 # dynamic kubelet configuration
+# Note: Feature DynamicKubeletConfig is deprecated in 1.22 and will not move to GA.
+# It is planned to be removed from Kubernetes in the version 1.23.
+# Please use alternative ways to update kubelet configuration.
 dynamic_kubelet_configuration: false
 
 # define kubelet config dir for dynamic kubelet

--- a/roles/kubernetes/node/tasks/kubelet.yml
+++ b/roles/kubernetes/node/tasks/kubelet.yml
@@ -4,7 +4,9 @@
     path: "{{ dynamic_kubelet_configuration_dir }}"
     mode: 0600
     state: directory
-  when: dynamic_kubelet_configuration
+  when:
+    - dynamic_kubelet_configuration
+    - kube_version is version('v1.22.0', '<')
 
 - name: Set kubelet api version to v1beta1
   set_fact:

--- a/roles/kubernetes/node/templates/kubelet.env.v1beta1.j2
+++ b/roles/kubernetes/node/templates/kubelet.env.v1beta1.j2
@@ -18,7 +18,7 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 --container-runtime=remote \
 --container-runtime-endpoint=unix://{{ cri_socket }} \
 {% endif %}
-{% if dynamic_kubelet_configuration %}
+{% if dynamic_kubelet_configuration and kube_version is version('v1.22.0', '<') %}
 --dynamic-config-dir={{ dynamic_kubelet_configuration_dir }} \
 {% endif %}
 --runtime-cgroups={{ kubelet_runtime_cgroups }} \

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -114,6 +114,16 @@
   when:
     - kube_version is version('v1.21.0', '>=')
 
+- name: Stop when dynamic_kubelet_configuration enabled for kubernetes >= 1.22
+  assert:
+    that: not dynamic_kubelet_configuration
+    msg: >
+      Feature DynamicKubeletConfig is deprecated in 1.22 and will not move to GA.
+      It is planned to be removed from Kubernetes in the version 1.23.
+      Please use alternative ways to update kubelet configuration.
+  when:
+    - kube_version is version('v1.22.0', '>=')
+
 # This assertion will fail on the safe side: One can indeed schedule more pods
 # on a node than the CIDR-range has space for when additional pods use the host
 # network namespace. It is impossible to ascertain the number of such pods at

--- a/tests/files/packet_oracle7-canal-ha.yml
+++ b/tests/files/packet_oracle7-canal-ha.yml
@@ -6,7 +6,6 @@ mode: ha
 # Kubespray settings
 calico_datastore: etcd
 kube_network_plugin: canal
-dynamic_kubelet_configuration: true
 deploy_netchecker: true
 dns_min_replicas: 1
 

--- a/tests/files/packet_ubuntu16-canal-kubeadm-ha.yml
+++ b/tests/files/packet_ubuntu16-canal-kubeadm-ha.yml
@@ -6,6 +6,5 @@ mode: ha
 # Kubespray settings
 calico_datastore: etcd
 kube_network_plugin: canal
-dynamic_kubelet_configuration: true
 deploy_netchecker: true
 dns_min_replicas: 1


### PR DESCRIPTION
Flag --dynamic-config-dir has been deprecated, Feature DynamicKubeletConfig is deprecated in 1.22 and will not move to GA. It is planned to be removed from Kubernetes in the version 1.23. Please use alternative ways to update kubelet configuration.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR addressed the deprecation of kubelet dynamic configuration in K8S 1.22 and ensures this feature is not accidentally enabled beyond 1.22 which could cause the kubelet to fail to start or worse break kubernetes upgrades.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7937

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Flag --dynamic-config-dir has been deprecated, Feature DynamicKubeletConfig is deprecated in 1.22 and will not move to GA. It is planned to be removed from Kubernetes in the version 1.23. Please use alternative ways to update kubelet configuration.
```
