### PR TITLE
Update containerd to 1.4.9

### DIFF
--- a/roles/container-engine/containerd-common/vars/debian.yml
+++ b/roles/container-engine/containerd-common/vars/debian.yml
@@ -6,5 +6,6 @@ containerd_versioned_pkg:
   '1.4.3': "{{ containerd_package }}=1.4.3-2"
   '1.4.4': "{{ containerd_package }}=1.4.4-1"
   '1.4.6': "{{ containerd_package }}=1.4.6-1"
-  'stable': "{{ containerd_package }}=1.4.6-1"
-  'edge': "{{ containerd_package }}=1.4.6-1"
+  '1.4.9': "{{ containerd_package }}=1.4.9-1"
+  'stable': "{{ containerd_package }}=1.4.9-1"
+  'edge': "{{ containerd_package }}=1.4.9-1"

--- a/roles/container-engine/containerd-common/vars/fedora.yml
+++ b/roles/container-engine/containerd-common/vars/fedora.yml
@@ -6,5 +6,6 @@ containerd_versioned_pkg:
   '1.4.3': "{{ containerd_package }}-1.4.3-3.2.fc{{ ansible_distribution_major_version }}"
   '1.4.4': "{{ containerd_package }}-1.4.4-3.1.fc{{ ansible_distribution_major_version }}"
   '1.4.6': "{{ containerd_package }}-1.4.6-3.1.fc{{ ansible_distribution_major_version }}"
-  'stable': "{{ containerd_package }}-1.4.6-3.1.fc{{ ansible_distribution_major_version }}"
-  'edge': "{{ containerd_package }}-1.4.6-3.1.fc{{ ansible_distribution_major_version }}"
+  '1.4.9': "{{ containerd_package }}-1.4.9-3.1.fc{{ ansible_distribution_major_version }}"
+  'stable': "{{ containerd_package }}-1.4.9-3.1.fc{{ ansible_distribution_major_version }}"
+  'edge': "{{ containerd_package }}-1.4.9-3.1.fc{{ ansible_distribution_major_version }}"

--- a/roles/container-engine/containerd-common/vars/redhat.yml
+++ b/roles/container-engine/containerd-common/vars/redhat.yml
@@ -6,5 +6,6 @@ containerd_versioned_pkg:
   '1.4.3': "{{ containerd_package }}-1.4.3-3.2.el{{ ansible_distribution_major_version }}"
   '1.4.4': "{{ containerd_package }}-1.4.4-3.1.el{{ ansible_distribution_major_version }}"
   '1.4.6': "{{ containerd_package }}-1.4.6-3.1.el{{ ansible_distribution_major_version }}"
-  'stable': "{{ containerd_package }}-1.4.6-3.1.el{{ ansible_distribution_major_version }}"
-  'edge': "{{ containerd_package }}-1.4.6-3.1.el{{ ansible_distribution_major_version }}"
+  '1.4.9': "{{ containerd_package }}-1.4.9-3.1.el{{ ansible_distribution_major_version }}"
+  'stable': "{{ containerd_package }}-1.4.9-3.1.el{{ ansible_distribution_major_version }}"
+  'edge': "{{ containerd_package }}-1.4.9-3.1.el{{ ansible_distribution_major_version }}"

--- a/roles/container-engine/containerd-common/vars/ubuntu.yml
+++ b/roles/container-engine/containerd-common/vars/ubuntu.yml
@@ -6,5 +6,6 @@ containerd_versioned_pkg:
   '1.4.3': "{{ containerd_package }}=1.4.3-2"
   '1.4.4': "{{ containerd_package }}=1.4.4-1"
   '1.4.6': "{{ containerd_package }}=1.4.6-1"
-  'stable': "{{ containerd_package }}=1.4.6-1"
-  'edge': "{{ containerd_package }}=1.4.6-1"
+  '1.4.9': "{{ containerd_package }}=1.4.9-1"
+  'stable': "{{ containerd_package }}=1.4.9-1"
+  'edge': "{{ containerd_package }}=1.4.9-1"

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -322,7 +322,7 @@ docker_plugins: []
 etcd_kubeadm_enabled: false
 
 # Containerd options
-containerd_version: 1.4.6
+containerd_version: 1.4.9
 containerd_use_systemd_cgroup: true
 
 # Settings for containerized control plane (etcd/kubelet/secrets)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
This PR bumps containerd to 1.4.9 which is now available from docker binary builds for most distributions.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Amazon Linux repos are behind the docker ones and are missing support for 1.4.9, this is why the amazon linux specific env file is not updated in this PR.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Containerd: bump version to 1.4.9
```
