### PR TITLE
Bugfix/cinder csi cloud config template

### DIFF
--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-cloud-config.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-cloud-config.j2
@@ -4,28 +4,28 @@ auth-url="{{ cinder_auth_url }}"
 username="{{ cinder_username }}"
 password="{{ cinder_password }}"
 {% endif %}
-{% if cinder_application_credential_id is defined and cinder_application_credential_id != "" %}
+{% if cinder_application_credential_id|length > 0 %}
 application-credential-id={{ cinder_application_credential_id }}
 {% endif %}
-{% if cinder_application_credential_name is defined and cinder_application_credential_name != "" %}
+{% if cinder_application_credential_name|length > 0 %}
 application-credential-name={{ cinder_application_credential_name }}
 {% endif %}
-{% if cinder_application_credential_secret is defined and cinder_application_credential_secret != "" %}
+{% if cinder_application_credential_secret|length > 0 %}
 application-credential-secret={{ cinder_application_credential_secret }}
 {% endif %}
 region="{{ cinder_region }}"
-{% if cinder_tenant_id is defined and cinder_tenant_id != "" %}
+{% if cinder_tenant_id|length > 0 %}
 tenant-id="{{ cinder_tenant_id }}"
 {% endif %}
-{% if cinder_tenant_name is defined and cinder_tenant_name != "" %}
+{% if cinder_tenant_name|length > 0 %}
 tenant-name="{{ cinder_tenant_name }}"
 {% endif %}
-{% if cinder_domain_name is defined and cinder_domain_name != "" %}
+{% if cinder_domain_name|length > 0 %}
 domain-name="{{ cinder_domain_name }}"
-{% elif cinder_domain_id is defined and cinder_domain_id != "" %}
+{% elif cinder_domain_id|length > 0 %}
 domain-id ="{{ cinder_domain_id }}"
 {% endif %}
-{% if cinder_cacert is defined and cinder_cacert != "" %}
+{% if cinder_cacert|length > 0 %}
 ca-file="{{ kube_config_dir }}/cinder-cacert.pem"
 {% endif %}
 

--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-cloud-config.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-cloud-config.j2
@@ -1,6 +1,6 @@
 [Global]
 auth-url="{{ cinder_auth_url }}"
-{% if cinder_application_credential_id is not defined and cinder_application_credential_name is not defined %}
+{% if cinder_application_credential_id|length == 0 and cinder_application_credential_name|length == 0 %}
 username="{{ cinder_username }}"
 password="{{ cinder_password }}"
 {% endif %}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`cinder-csi-controller-plugin` pods are failing:-
```
[root@k8s-master centos]# k get po
NAME                                               READY   STATUS             RESTARTS   AGE
coredns-8474476ff8-4ng8b                           1/1     Terminating        0          11h
coredns-8474476ff8-p2tz5                           1/1     Running            0          5m14s
coredns-8474476ff8-vthhc                           1/1     Running            0          11h
csi-cinder-controllerplugin-75d94948d-hpjhr        4/5     CrashLoopBackOff   5          3m44s
csi-cinder-controllerplugin-99c9dd87b-zqfqs        4/5     CrashLoopBackOff   5          3m44s
csi-cinder-nodeplugin-khdht                        1/2     CrashLoopBackOff   14         23m
csi-cinder-nodeplugin-vs8zb                        1/2     CrashLoopBackOff   14         23m
```
Error Logs:
```
[root@k8s-master centos]# k logs -f csi-cinder-controllerplugin-75d94948d-hpjhr -c cinder-csi-plugin
I0909 03:10:47.234634       1 driver.go:69] Driver: cinder.csi.openstack.org
I0909 03:10:47.234677       1 driver.go:70] Driver version: 1.2.2@v1.20.0
I0909 03:10:47.234682       1 driver.go:71] CSI Spec version: 1.2.0
I0909 03:10:47.234695       1 driver.go:100] Enabling controller service capability: LIST_VOLUMES
I0909 03:10:47.234701       1 driver.go:100] Enabling controller service capability: CREATE_DELETE_VOLUME
I0909 03:10:47.234706       1 driver.go:100] Enabling controller service capability: PUBLISH_UNPUBLISH_VOLUME
I0909 03:10:47.234710       1 driver.go:100] Enabling controller service capability: CREATE_DELETE_SNAPSHOT
I0909 03:10:47.234713       1 driver.go:100] Enabling controller service capability: LIST_SNAPSHOTS
I0909 03:10:47.234717       1 driver.go:100] Enabling controller service capability: EXPAND_VOLUME
I0909 03:10:47.234723       1 driver.go:100] Enabling controller service capability: CLONE_VOLUME
I0909 03:10:47.234726       1 driver.go:100] Enabling controller service capability: LIST_VOLUMES_PUBLISHED_NODES
I0909 03:10:47.234731       1 driver.go:112] Enabling volume access mode: SINGLE_NODE_WRITER
I0909 03:10:47.234746       1 driver.go:122] Enabling node service capability: STAGE_UNSTAGE_VOLUME
I0909 03:10:47.234754       1 driver.go:122] Enabling node service capability: EXPAND_VOLUME
I0909 03:10:47.234758       1 driver.go:122] Enabling node service capability: GET_VOLUME_STATS
I0909 03:10:47.235183       1 openstack.go:88] Block storage opts: {0 false false}
W0909 03:10:47.237346       1 main.go:108] Failed to GetOpenStackProvider: You must provide a password to authenticate
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7954 

**Special notes for your reviewer**:
Also updated other conditionals to use [length filter](https://jinja.palletsprojects.com/en/3.0.x/templates/#jinja-filters.length) to reduce verbosity.
**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
