### PR TITLE
Update snapshot-controller repository and image versions

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -694,11 +694,11 @@ csi_livenessprobe_image_repo: "{{ quay_image_repo }}/k8scsi/livenessprobe"
 csi_livenessprobe_image_tag: "v2.0.0"
 
 snapshot_controller_supported_versions:
-  v1.22: "v4.2.0"
-  v1.21: "v4.2.0"
-  v1.20: "v4.2.0"
+  v1.22: "v4.2.1"
+  v1.21: "v4.2.1"
+  v1.20: "v4.0.0"
   v1.19: "v4.0.0"
-snapshot_controller_image_repo: "{{ quay_image_repo }}/k8scsi/snapshot-controller"
+snapshot_controller_image_repo: "{{ kube_image_repo }}/sig-storage/snapshot-controller"
 snapshot_controller_image_tag: "{{ snapshot_controller_supported_versions[kube_major_version] }}"
 
 cinder_csi_plugin_image_repo: "{{ docker_image_repo }}/k8scloudprovider/cinder-csi-plugin"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
[quay.io](https://quay.io/repository/k8scsi/snapshot-controller?tab=tags) is not updated with the latest `snapshot-controller` images. [k8s.gcr.io](https://kubernetes-csi.github.io/docs/snapshot-controller.html) seems to be a better choice. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7956 

**Special notes for your reviewer**:
```
docker pull quay.io/k8scsi/snapshot-controller:v4.2.0 # DOESN'T WORK
docker pull k8s.gcr.io/sig-storage/snapshot-controller:v4.2.0 # WORKS
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
