### PR TITLE
Fix iptables missing on Debian 11 if APT::Install-Recommends=0

### DIFF
--- a/roles/kubernetes/preinstall/vars/debian-11.yml
+++ b/roles/kubernetes/preinstall/vars/debian-11.yml
@@ -5,3 +5,4 @@ required_pkgs:
   - apt-transport-https
   - software-properties-common
   - conntrack
+  - iptables


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

On Debian 11, `ipset` just [**"recommend"**](https://packages.debian.org/bullseye/ipset) `iptables` so on the system that apt is configured with `APT::Install-Recommends "0";` iptables will not install automatically.

This PR fix the problem above by explicity tell kubespray to install `iptables` during preinstall phase.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7963



**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
