### PR TITLE
Add option to kubeadm upgrade command to control certificates renewal…

### DIFF
--- a/roles/kubernetes/control-plane/defaults/main/main.yml
+++ b/roles/kubernetes/control-plane/defaults/main/main.yml
@@ -193,3 +193,8 @@ event_ttl_duration: "1h0m0s"
 auto_renew_certificates: false
 # First Monday of each month
 auto_renew_certificates_systemd_calendar: "Mon *-*-1,2,3,4,5,6,7 03:{{ groups['kube_control_plane'].index(inventory_hostname) }}0:00"
+
+# kubeadm renews all the certificates during control plane upgrade. 
+# If we have requirement like without renewing certs upgrade the cluster,
+# we can opt out from the default behavior by setting kubeadm_upgrade_auto_cert_renewal to false
+kubeadm_upgrade_auto_cert_renewal: true

--- a/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
@@ -14,6 +14,7 @@
     timeout -k 600s 600s
     {{ bin_dir }}/kubeadm
     upgrade apply -y {{ kube_version }}
+    --certificate-renewal={{ kubeadm_upgrade_auto_cert_renewal }}
     --config={{ kube_config_dir }}/kubeadm-config.yaml
     --ignore-preflight-errors=all
     --allow-experimental-upgrades
@@ -34,6 +35,7 @@
     timeout -k 600s 600s
     {{ bin_dir }}/kubeadm
     upgrade apply -y {{ kube_version }}
+    --certificate-renewal={{ kubeadm_upgrade_auto_cert_renewal }}
     --config={{ kube_config_dir }}/kubeadm-config.yaml
     --ignore-preflight-errors=all
     --allow-experimental-upgrades


### PR DESCRIPTION
Bydefault, kubeadm renews all the certificates during control plane upgrade. A deployer may want to upgrade cluster without renewing the certificates. This helps deployer while upgrading Kubernetes cluster in modular way. If something fails deployer exactly know where it is failing and so super easy to find why.

**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**: Currently kubespray does not give flexibility to deployer to control certificate renewal during control plane upgrade. 

**Does this PR introduce a user-facing change?**:
```release-note
Add a new option `kubeadm_upgrade_auto_cert_renewal` to control certificates renewal during control plane upgrade
```