### PR TITLE
Add definition check of disable_service_firewall

### DIFF
--- a/contrib/os-services/roles/prepare/tasks/main.yml
+++ b/contrib/os-services/roles/prepare/tasks/main.yml
@@ -20,4 +20,4 @@
       "'ufw.service' in services"
 
   when:
-  - disable_service_firewall
+  - disable_service_firewall is defined and disable_service_firewall


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When not specifying disable_service_firewall, the task is failed.
This adds the definition check.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
