### PR TITLE
Remove k8s hooks for versions prior to 1.20

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
@@ -49,11 +49,7 @@ spec:
           - weight: 100
             preference:
               matchExpressions:
-{% if kube_version is version('v1.20.0', '<') %}
-              - key: node-role.kubernetes.io/master
-{% else %}
               - key: node-role.kubernetes.io/control-plane
-{% endif %}
                 operator: In
                 values:
                 - ""

--- a/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
@@ -57,11 +57,7 @@ spec:
           - weight: 100
             preference:
               matchExpressions:
-{% if kube_version is version('v1.20.0', '<') %}
-              - key: node-role.kubernetes.io/master
-{% else %}
               - key: node-role.kubernetes.io/control-plane
-{% endif %}
                 operator: In
                 values:
                 - ""

--- a/roles/kubernetes-apps/cloud_controller/oci/templates/oci-cloud-provider.yml.j2
+++ b/roles/kubernetes-apps/cloud_controller/oci/templates/oci-cloud-provider.yml.j2
@@ -36,11 +36,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       nodeSelector:
-{% if kube_version is version('v1.20.0', '<') %}
-        node-role.kubernetes.io/master: ""
-{% else %}
         node-role.kubernetes.io/control-plane: ""
-{% endif %}
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"

--- a/roles/kubernetes-apps/container_runtimes/crun/templates/runtimeclass-crun.yml
+++ b/roles/kubernetes-apps/container_runtimes/crun/templates/runtimeclass-crun.yml
@@ -1,6 +1,6 @@
 ---
 kind: RuntimeClass
-apiVersion: node.k8s.io/v1{{ 'beta1' if kube_version is version('v1.20.0', '<') else '' }}
+apiVersion: node.k8s.io/v1
 metadata:
   name: crun
 handler: crun

--- a/roles/kubernetes-apps/container_runtimes/gvisor/templates/runtimeclass-gvisor.yml.j2
+++ b/roles/kubernetes-apps/container_runtimes/gvisor/templates/runtimeclass-gvisor.yml.j2
@@ -1,6 +1,6 @@
 ---
 kind: RuntimeClass
-apiVersion: node.k8s.io/v1{{ 'beta1' if kube_version is version('v1.20.0', '<') else '' }}
+apiVersion: node.k8s.io/v1
 metadata:
   name: gvisor
 handler: runsc

--- a/roles/kubernetes-apps/container_runtimes/kata_containers/templates/runtimeclass-kata-qemu.yml.j2
+++ b/roles/kubernetes-apps/container_runtimes/kata_containers/templates/runtimeclass-kata-qemu.yml.j2
@@ -1,6 +1,6 @@
 ---
 kind: RuntimeClass
-apiVersion: node.k8s.io/v1{{ 'beta1' if kube_version is version('v1.20.0', '<') else '' }}
+apiVersion: node.k8s.io/v1
 metadata:
   name: kata-qemu
 handler: kata-qemu

--- a/roles/kubernetes-apps/csi_driver/csi_crd/templates/volumesnapshotclasses.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/csi_crd/templates/volumesnapshotclasses.yml.j2
@@ -58,11 +58,7 @@ spec:
         - driver
         type: object
     served: true
-{% if kube_version is version('v1.20.0', '<') %}
-    storage: false
-{% else %}
     storage: true
-{% endif %}
     subresources: {}
   - additionalPrinterColumns:
     - jsonPath: .driver
@@ -76,13 +72,11 @@ spec:
       name: Age
       type: date
     name: v1beta1
-{% if kube_version is version('v1.20.0', '>=') %}
     # This indicates the v1beta1 version of the custom resource is deprecated.
     # API requests to this version receive a warning in the server response.
     deprecated: true
     # This overrides the default warning returned to clients making v1beta1 API requests.
     deprecationWarning: "snapshot.storage.k8s.io/v1beta1 VolumeSnapshotClass is deprecated; use snapshot.storage.k8s.io/v1 VolumeSnapshotClass"
-{% endif %}
     schema:
       openAPIV3Schema:
         description: VolumeSnapshotClass specifies parameters that a underlying storage system uses when creating a volume snapshot. A specific VolumeSnapshotClass is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses are non-namespaced
@@ -112,11 +106,7 @@ spec:
         - driver
         type: object
     served: true
-{% if kube_version is version('v1.20.0', '<') %}
-    storage: true
-{% else %}
     storage: false
-{% endif %}
     subresources: {}
 status:
   acceptedNames:

--- a/roles/kubernetes-apps/csi_driver/csi_crd/templates/volumesnapshotcontents.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/csi_crd/templates/volumesnapshotcontents.yml.j2
@@ -42,12 +42,10 @@ spec:
       jsonPath: .spec.volumeSnapshotRef.name
       name: VolumeSnapshot
       type: string
-{% if kube_version is version('v1.20.0', '>=') %}
     - description: Namespace of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
       jsonPath: .spec.volumeSnapshotRef.namespace
       name: VolumeSnapshotNamespace
       type: string
-{% endif %}
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -155,11 +153,7 @@ spec:
         - spec
         type: object
     served: true
-{% if kube_version is version('v1.20.0', '<') %}
-    storage: false
-{% else %}
     storage: true
-{% endif %}
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -187,12 +181,10 @@ spec:
       jsonPath: .spec.volumeSnapshotRef.name
       name: VolumeSnapshot
       type: string
-{% if kube_version is version('v1.20.0', '>=') %}
     - description: Namespace of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
       jsonPath: .spec.volumeSnapshotRef.namespace
       name: VolumeSnapshotNamespace
       type: string
-{% endif %}
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -302,11 +294,7 @@ spec:
         - spec
         type: object
     served: true
-{% if kube_version is version('v1.20.0', '<') %}
-    storage: true
-{% else %}
     storage: false
-{% endif %}
     subresources:
       status: {}
 status:

--- a/roles/kubernetes-apps/csi_driver/csi_crd/templates/volumesnapshots.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/csi_crd/templates/volumesnapshots.yml.j2
@@ -116,11 +116,7 @@ spec:
         - spec
         type: object
     served: true
-{% if kube_version is version('v1.20.0','<') %}
-    storage: false
-{% else %}
     storage: true
-{% endif %}
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -156,13 +152,11 @@ spec:
       name: Age
       type: date
     name: v1beta1
-{% if kube_version is version('v1.20.0','>=') %}
     # This indicates the v1beta1 version of the custom resource is deprecated.
     # API requests to this version receive a warning in the server response.
     deprecated: true
     # This overrides the default warning returned to clients making v1beta1 API requests.
     deprecationWarning: "snapshot.storage.k8s.io/v1beta1 VolumeSnapshot is deprecated; use snapshot.storage.k8s.io/v1 VolumeSnapshot"
-{% endif %}
     schema:
       openAPIV3Schema:
         description: VolumeSnapshot is a user's request for either creating a point-in-time snapshot of a persistent volume, or binding to a pre-existing snapshot.
@@ -226,11 +220,7 @@ spec:
         - spec
         type: object
     served: true
-{% if kube_version is version('v1.20.0','<') %}
-    storage: true
-{% else %}
     storage: false
-{% endif %}
     subresources:
       status: {}
 status:

--- a/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-controller-deployment.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-controller-deployment.yml.j2
@@ -16,11 +16,7 @@ spec:
     spec:
       serviceAccountName: vsphere-csi-controller
       nodeSelector:
-{% if kube_version is version('v1.20.0', '<') %}
-        node-role.kubernetes.io/master: ""
-{% else %}
         node-role.kubernetes.io/control-plane: ""
-{% endif %}
       tolerations:
         - operator: "Exists"
           key: node-role.kubernetes.io/master

--- a/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-controller-ss.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-controller-ss.yml.j2
@@ -19,11 +19,7 @@ spec:
     spec:
       serviceAccountName: vsphere-csi-controller
       nodeSelector:
-{% if kube_version is version('v1.20.0', '<') %}
-        node-role.kubernetes.io/master: ""
-{% else %}
         node-role.kubernetes.io/control-plane: ""
-{% endif %}
       tolerations:
         - operator: "Exists"
           key: node-role.kubernetes.io/master

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-controller-manager-ds.yml.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-controller-manager-ds.yml.j2
@@ -24,11 +24,7 @@ spec:
         k8s-app: openstack-cloud-controller-manager
     spec:
       nodeSelector:
-{% if kube_version is version('v1.20.0', '<') %}
-        node-role.kubernetes.io/master: ""
-{% else %}
         node-role.kubernetes.io/control-plane: ""
-{% endif %}
       securityContext:
         runAsUser: 999
       tolerations:

--- a/roles/kubernetes-apps/external_cloud_controller/vsphere/templates/external-vsphere-cloud-controller-manager-ds.yml.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/vsphere/templates/external-vsphere-cloud-controller-manager-ds.yml.j2
@@ -24,11 +24,7 @@ spec:
         k8s-app: vsphere-cloud-controller-manager
     spec:
       nodeSelector:
-{% if kube_version is version('v1.20.0', '<') %}
-        node-role.kubernetes.io/master: ""
-{% else %}
         node-role.kubernetes.io/control-plane: ""
-{% endif %}
       securityContext:
         runAsUser: 0
       tolerations:

--- a/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
@@ -138,11 +138,7 @@ spec:
           - weight: 100
             preference:
               matchExpressions:
-{% if kube_version is version('v1.20.0', '<') %}
-              - key: node-role.kubernetes.io/master
-{% else %}
               - key: node-role.kubernetes.io/control-plane
-{% endif %}
                 operator: In
                 values:
                 - ""


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Kubernetes version supported by spray no longer include 1.19.x so those hooks are no longer needed

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
This PR needs #7980 before being merge

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
