### PR TITLE
Fix Cilium operator metrics activation

### DIFF
--- a/roles/network_plugin/cilium/templates/cilium-config.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-config.yml.j2
@@ -38,6 +38,8 @@ data:
   # scheduled.
 {% if cilium_enable_prometheus %}
   prometheus-serve-addr: ":9090"
+  operator-prometheus-serve-addr: ":6942"
+  enable-metrics: "true"
 {% endif %}
 
   # If you want to run cilium in debug mode change this value to true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This PR aims to solve bad metrics activation for Cilium operator.

Scraping annotations are enabled here https://github.com/Infomaniak/kubespray/blob/master/roles/network_plugin/cilium/templates/cilium-deploy.yml.j2#L23

Port is opened declared: 
https://github.com/Infomaniak/kubespray/blob/master/roles/network_plugin/cilium/templates/cilium-deploy.yml.j2#L117

**But** metrics are not enabled. In the official helm chart they enable it in the configmap here: https://github.com/cilium/cilium/blob/1.8.12/install/kubernetes/cilium/charts/config/templates/configmap.yaml#L137

It result in an `Connection refused` error when trying to query the `:6942/metrics` endpoint. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes none

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[Cilium] Fix operator metrics activation (`enable-metrics` key missing)
```
