### PR TITLE
etcd: enable v2 api only if needed

### DIFF
--- a/roles/etcd/templates/etcd.env.j2
+++ b/roles/etcd/templates/etcd.env.j2
@@ -32,7 +32,7 @@ ETCD_MAX_SNAPSHOTS={{ etcd_max_snapshots }}
 {% if etcd_max_wals is defined %}
 ETCD_MAX_WALS={{ etcd_max_wals }}
 {% endif %}
-{% if hostvars[groups['k8s-cluster'][0]]['kube_network_plugin'] == 'flannel' %}
+{% if hostvars[groups['k8s_cluster'][0]]['kube_network_plugin'] == 'flannel' %}
 ETCD_ENABLE_V2=true
 {% endif %}
 

--- a/roles/etcd/templates/etcd.env.j2
+++ b/roles/etcd/templates/etcd.env.j2
@@ -32,8 +32,9 @@ ETCD_MAX_SNAPSHOTS={{ etcd_max_snapshots }}
 {% if etcd_max_wals is defined %}
 ETCD_MAX_WALS={{ etcd_max_wals }}
 {% endif %}
-# Flannel need etcd v2 API
+{% if hostvars[groups['k8s-cluster'][0]]['kube_network_plugin'] == 'flannel' %}
 ETCD_ENABLE_V2=true
+{% endif %}
 
 # TLS settings
 ETCD_TRUSTED_CA_FILE={{ etcd_cert_dir }}/ca.pem


### PR DESCRIPTION
Only enable v2 API if we have a consumer (flannel)
This reduce the exposed surface for etcd.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
etcd no longer exposes v2 API unless Flannel is used
```
