### PR TITLE
Move ovn4nfv crd from v1beta1 to v1

### DIFF
--- a/roles/network_plugin/ovn4nfv/templates/ovn4nfv-k8s-plugin.yml.j2
+++ b/roles/network_plugin/ovn4nfv/templates/ovn4nfv-k8s-plugin.yml.j2
@@ -1,7 +1,7 @@
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: networks.k8s.plugin.opnfv.org
@@ -13,115 +13,115 @@ spec:
     plural: networks
     singular: network
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            cniType:
-              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                Important: Run "operator-sdk generate k8s" to regenerate code after
-                modifying this file Add custom validation using kubebuilder tags:
-                https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
-              type: string
-            dns:
-              properties:
-                domain:
-                  type: string
-                nameservers:
-                  items:
-                    type: string
-                  type: array
-                options:
-                  items:
-                    type: string
-                  type: array
-                search:
-                  items:
-                    type: string
-                  type: array
-              type: object
-            ipv4Subnets:
-              items:
-                properties:
-                  excludeIps:
-                    type: string
-                  gateway:
-                    type: string
-                  name:
-                    type: string
-                  subnet:
-                    type: string
-                required:
-                - name
-                - subnet
-                type: object
-              type: array
-            ipv6Subnets:
-              items:
-                properties:
-                  excludeIps:
-                    type: string
-                  gateway:
-                    type: string
-                  name:
-                    type: string
-                  subnet:
-                    type: string
-                required:
-                - name
-                - subnet
-                type: object
-              type: array
-            routes:
-              items:
-                properties:
-                  dst:
-                    type: string
-                  gw:
-                    type: string
-                required:
-                - dst
-                type: object
-              type: array
-          required:
-          - cniType
-          - ipv4Subnets
-          type: object
-        status:
-          properties:
-            state:
-              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                of cluster Important: Run "operator-sdk generate k8s" to regenerate
-                code after modifying this file Add custom validation using kubebuilder
-                tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
-              type: string
-          required:
-          - state
-          type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                cniType:
+                  description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                    Important: Run "operator-sdk generate k8s" to regenerate code after
+                    modifying this file Add custom validation using kubebuilder tags:
+                    https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                  type: string
+                dns:
+                  properties:
+                    domain:
+                      type: string
+                    nameservers:
+                      items:
+                        type: string
+                      type: array
+                    options:
+                      items:
+                        type: string
+                      type: array
+                    search:
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                ipv4Subnets:
+                  items:
+                    properties:
+                      excludeIps:
+                        type: string
+                      gateway:
+                        type: string
+                      name:
+                        type: string
+                      subnet:
+                        type: string
+                    required:
+                    - name
+                    - subnet
+                    type: object
+                  type: array
+                ipv6Subnets:
+                  items:
+                    properties:
+                      excludeIps:
+                        type: string
+                      gateway:
+                        type: string
+                      name:
+                        type: string
+                      subnet:
+                        type: string
+                    required:
+                    - name
+                    - subnet
+                    type: object
+                  type: array
+                routes:
+                  items:
+                    properties:
+                      dst:
+                        type: string
+                      gw:
+                        type: string
+                    required:
+                    - dst
+                    type: object
+                  type: array
+              required:
+              - cniType
+              - ipv4Subnets
+              type: object
+            status:
+              properties:
+                state:
+                  description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                    of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                    code after modifying this file Add custom validation using kubebuilder
+                    tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                  type: string
+              required:
+              - state
+              type: object
 
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: providernetworks.k8s.plugin.opnfv.org
@@ -133,151 +133,150 @@ spec:
     plural: providernetworks
     singular: providernetwork
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ProviderNetwork is the Schema for the providernetworks API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ProviderNetworkSpec defines the desired state of ProviderNetwork
-          properties:
-            cniType:
-              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                Important: Run "operator-sdk generate k8s" to regenerate code after
-                modifying this file Add custom validation using kubebuilder tags:
-                https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
-              type: string
-            direct:
-              properties:
-                directNodeSelector:
-                  type: string
-                nodeLabelList:
-                  items:
-                    type: string
-                  type: array
-                providerInterfaceName:
-                  type: string
-              required:
-              - directNodeSelector
-              - providerInterfaceName
-              type: object
-            dns:
-              properties:
-                domain:
-                  type: string
-                nameservers:
-                  items:
-                    type: string
-                  type: array
-                options:
-                  items:
-                    type: string
-                  type: array
-                search:
-                  items:
-                    type: string
-                  type: array
-              type: object
-            ipv4Subnets:
-              items:
-                properties:
-                  excludeIps:
-                    type: string
-                  gateway:
-                    type: string
-                  name:
-                    type: string
-                  subnet:
-                    type: string
-                required:
-                - name
-                - subnet
-                type: object
-              type: array
-            ipv6Subnets:
-              items:
-                properties:
-                  excludeIps:
-                    type: string
-                  gateway:
-                    type: string
-                  name:
-                    type: string
-                  subnet:
-                    type: string
-                required:
-                - name
-                - subnet
-                type: object
-              type: array
-            providerNetType:
-              type: string
-            routes:
-              items:
-                properties:
-                  dst:
-                    type: string
-                  gw:
-                    type: string
-                required:
-                - dst
-                type: object
-              type: array
-            vlan:
-              properties:
-                logicalInterfaceName:
-                  type: string
-                nodeLabelList:
-                  items:
-                    type: string
-                  type: array
-                providerInterfaceName:
-                  type: string
-                vlanId:
-                  type: string
-                vlanNodeSelector:
-                  type: string
-              required:
-              - providerInterfaceName
-              - vlanId
-              - vlanNodeSelector
-              type: object
-          required:
-          - cniType
-          - ipv4Subnets
-          - providerNetType
-          type: object
-        status:
-          description: ProviderNetworkStatus defines the observed state of ProviderNetwork
-          properties:
-            state:
-              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                of cluster Important: Run "operator-sdk generate k8s" to regenerate
-                code after modifying this file Add custom validation using kubebuilder
-                tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
-              type: string
-          required:
-          - state
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: ProviderNetwork is the Schema for the providernetworks API
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ProviderNetworkSpec defines the desired state of ProviderNetwork
+              properties:
+                cniType:
+                  description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                    Important: Run "operator-sdk generate k8s" to regenerate code after
+                    modifying this file Add custom validation using kubebuilder tags:
+                    https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                  type: string
+                direct:
+                  properties:
+                    directNodeSelector:
+                      type: string
+                    nodeLabelList:
+                      items:
+                        type: string
+                      type: array
+                    providerInterfaceName:
+                      type: string
+                  required:
+                  - directNodeSelector
+                  - providerInterfaceName
+                  type: object
+                dns:
+                  properties:
+                    domain:
+                      type: string
+                    nameservers:
+                      items:
+                        type: string
+                      type: array
+                    options:
+                      items:
+                        type: string
+                      type: array
+                    search:
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                ipv4Subnets:
+                  items:
+                    properties:
+                      excludeIps:
+                        type: string
+                      gateway:
+                        type: string
+                      name:
+                        type: string
+                      subnet:
+                        type: string
+                    required:
+                    - name
+                    - subnet
+                    type: object
+                  type: array
+                ipv6Subnets:
+                  items:
+                    properties:
+                      excludeIps:
+                        type: string
+                      gateway:
+                        type: string
+                      name:
+                        type: string
+                      subnet:
+                        type: string
+                    required:
+                    - name
+                    - subnet
+                    type: object
+                  type: array
+                providerNetType:
+                  type: string
+                routes:
+                  items:
+                    properties:
+                      dst:
+                        type: string
+                      gw:
+                        type: string
+                    required:
+                    - dst
+                    type: object
+                  type: array
+                vlan:
+                  properties:
+                    logicalInterfaceName:
+                      type: string
+                    nodeLabelList:
+                      items:
+                        type: string
+                      type: array
+                    providerInterfaceName:
+                      type: string
+                    vlanId:
+                      type: string
+                    vlanNodeSelector:
+                      type: string
+                  required:
+                  - providerInterfaceName
+                  - vlanId
+                  - vlanNodeSelector
+                  type: object
+              required:
+              - cniType
+              - ipv4Subnets
+              - providerNetType
+              type: object
+            status:
+              description: ProviderNetworkStatus defines the observed state of ProviderNetwork
+              properties:
+                state:
+                  description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                    of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                    code after modifying this file Add custom validation using kubebuilder
+                    tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                  type: string
+              required:
+              - state
+              type: object
 ---
 
 apiVersion: v1


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
crd under v1beta1 are now removed as they were deprecated for a few versions

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
[ovn4nfv] Move crd API to v1, update crd spec
```
