### PR TITLE
Fix containerd failed to start if apparmor is not installed

### DIFF
--- a/roles/kubernetes/preinstall/vars/debian-11.yml
+++ b/roles/kubernetes/preinstall/vars/debian-11.yml
@@ -6,3 +6,4 @@ required_pkgs:
   - software-properties-common
   - conntrack
   - iptables
+  - apparmor

--- a/roles/kubernetes/preinstall/vars/debian.yml
+++ b/roles/kubernetes/preinstall/vars/debian.yml
@@ -5,3 +5,4 @@ required_pkgs:
   - apt-transport-https
   - software-properties-common
   - conntrack
+  - apparmor


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

/kind bug

**What this PR does / why we need it**:

Kubespray deployment failed when using `containerd` backend on nodes that `apparmor` was not installed or previously removed.

This PR ensure apparmor is installed by adding it into `required_pkgs` var.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7965

**Special notes for your reviewer**:

I've added `apparmor` to [both variable files](https://github.com/rtsp/kubespray/commit/4a1d321b4181860f8e3fbf16869633bbd324be03) but I only tested on Debian 11. If this patch break Debian 10 pipeline (it shouldn't) I will remove this line from `debian.yml`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix containerd failed to start if apparmor is not installed
```
