### PR TITLE
Add proxy for subscription-manager

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-redhat.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-redhat.yml
@@ -16,6 +16,13 @@
   become: true
   when: not skip_http_proxy_on_os_packages
 
+- name: Add proxy to RHEL subscription-manager if http_proxy is defined
+  command: /sbin/subscription-manager config --server.proxy_hostname={{ http_proxy | regex_replace(':\\d+$') }} --server.proxy_port={{ http_proxy | regex_replace('^.*:') }}
+  become: true
+  when:
+    - not skip_http_proxy_on_os_packages
+    - http_proxy is defined
+
 - name: Check RHEL subscription-manager status
   command: /sbin/subscription-manager status
   register: rh_subscription_status


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

If using proxy, it is necessary to configure it before running "subscription-manager status" command.
This adds the step.

Reference: https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html-single/rhsm/index#repos-proxy

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7900

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add missing proxy settings for subscription-manager in RHEL OS (if http_proxy is defined)
```
