### PR TITLE
Kata-Containers: update versions 2.2.0 (default) and 2.1.1

### DIFF
--- a/roles/container-engine/kata-containers/templates/configuration-qemu.toml.j2
+++ b/roles/container-engine/kata-containers/templates/configuration-qemu.toml.j2
@@ -14,7 +14,7 @@
 path = "/opt/kata/bin/qemu-system-x86_64"
 kernel = "/opt/kata/share/kata-containers/vmlinuz.container"
 image = "/opt/kata/share/kata-containers/kata-containers.img"
-machine_type = "pc"
+machine_type = "q35"
 
 # Optional space-separated list of options to pass to the guest kernel.
 # For example, use `kernel_params = "vsyscall=emulate"` if you are having

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -52,7 +52,7 @@ image_arch: "{{host_architecture | default('amd64')}}"
 kubeadm_version: "{{ kube_version }}"
 etcd_version: v3.4.13
 crun_version: 0.21
-kata_containers_version: 2.1.0
+kata_containers_version: 2.2.0
 gvisor_version: 20210518.0
 
 # gcr and kubernetes image repo define
@@ -400,12 +400,15 @@ kata_containers_binary_checksums:
   arm:
     2.0.4: 0
     2.1.0: 0
+    2.2.0: 0
   amd64:
     2.0.4: 022a60c2d92a5ab9a5eb83d5a95154a2d06fdc2206b2a473d902ccc86766371a
     2.1.0: c954cdd723bad4ee20e57f107fe1064f0a00f4c349c1826b7a0f89d02f94dec0
+    2.2.0: 50163e2a430e96447117f7169a4ed5a8bdea09267d62a39221d5b8b3b3f88c0e
   arm64:
     2.0.4: 0
     2.1.0: 0
+    2.2.0: 0
 
 gvisor_runsc_binary_checksums:
   arm:

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -399,15 +399,15 @@ crun_checksums:
 kata_containers_binary_checksums:
   arm:
     2.0.4: 0
-    2.1.0: 0
+    2.1.1: 0
     2.2.0: 0
   amd64:
     2.0.4: 022a60c2d92a5ab9a5eb83d5a95154a2d06fdc2206b2a473d902ccc86766371a
-    2.1.0: c954cdd723bad4ee20e57f107fe1064f0a00f4c349c1826b7a0f89d02f94dec0
+    2.1.1: a83591d968cd0f1adfb5025d7aa33ca1385d4b1165ff10d74602302fc3c0373f
     2.2.0: 50163e2a430e96447117f7169a4ed5a8bdea09267d62a39221d5b8b3b3f88c0e
   arm64:
     2.0.4: 0
-    2.1.0: 0
+    2.1.1: 0
     2.2.0: 0
 
 gvisor_runsc_binary_checksums:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
This PR updates the Kata Containers runtime with versions 2.2.0 (new default) and 2.1.1 (bugfix replacing 2.1.0).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Originally I tried swapping the ubuntu18 test case for a centos8 testcase but this seems to fail which is something I was not able to reproduce on my local machine when running `molecule test`. For now it seems ubuntu based molecule tests are enough.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[Kata-Containers] Update versions 2.2.0 (new default) and 2.1.1 (bugfix replacing 2.1.0).
```
