### PR TITLE
Add 'stable' and 'edge' keys in docker_cli_versioned_pkg dict

### DIFF
--- a/roles/container-engine/docker/vars/debian-stretch.yml
+++ b/roles/container-engine/docker/vars/debian-stretch.yml
@@ -14,6 +14,8 @@ docker_cli_versioned_pkg:
   'latest': docker-ce-cli
   '18.09': docker-ce-cli=5:18.09.9~3-0~debian-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce-cli=5:19.03.15~3-0~debian-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce-cli=5:19.03.15~3-0~debian-{{ ansible_distribution_release|lower }}
+  'edge': docker-ce-cli=5:19.03.15~3-0~debian-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkgs:

--- a/roles/container-engine/docker/vars/debian.yml
+++ b/roles/container-engine/docker/vars/debian.yml
@@ -13,6 +13,8 @@ docker_cli_versioned_pkg:
   '18.09': docker-ce-cli=5:18.09.9~3-0~debian-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce-cli=5:19.03.15~3-0~debian-{{ ansible_distribution_release|lower }}
   '20.10': docker-ce-cli=5:20.10.8~3-0~debian-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce-cli=5:20.10.8~3-0~debian-{{ ansible_distribution_release|lower }}
+  'edge': docker-ce-cli=5:20.10.8~3-0~debian-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkgs:

--- a/roles/container-engine/docker/vars/fedora.yml
+++ b/roles/container-engine/docker/vars/fedora.yml
@@ -12,6 +12,8 @@ docker_cli_versioned_pkg:
   'latest': docker-ce-cli
   '19.03': docker-ce-cli-19.03.15-3.fc{{ ansible_distribution_major_version }}
   '20.10': docker-ce-cli-20.10.8-3.fc{{ ansible_distribution_major_version }}
+  'stable': docker-ce-cli-20.10.8-3.fc{{ ansible_distribution_major_version }}
+  'edge': docker-ce-cli-20.10.8-3.fc{{ ansible_distribution_major_version }}
 
 docker_package_info:
   enablerepo: "docker-ce"

--- a/roles/container-engine/docker/vars/redhat.yml
+++ b/roles/container-engine/docker/vars/redhat.yml
@@ -15,6 +15,8 @@ docker_cli_versioned_pkg:
   '18.09': docker-ce-cli-18.09.9-3.el7
   '19.03': docker-ce-cli-19.03.15-3.el{{ ansible_distribution_major_version }}
   '20.10': docker-ce-cli-20.10.8-3.el{{ ansible_distribution_major_version }}
+  'stable': docker-ce-cli-20.10.8-3.el{{ ansible_distribution_major_version }}
+  'edge': docker-ce-cli-20.10.8-3.el{{ ansible_distribution_major_version }}
 
 docker_package_info:
   enablerepo: "docker-ce"

--- a/roles/container-engine/docker/vars/ubuntu-16.yml
+++ b/roles/container-engine/docker/vars/ubuntu-16.yml
@@ -13,6 +13,8 @@ docker_cli_versioned_pkg:
   '18.09': docker-ce-cli=5:18.09.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce-cli=5:19.03.15~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   '20.10': docker-ce-cli=5:20.10.7~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce-cli=5:20.10.7~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'edge': docker-ce-cli=5:20.10.7~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkgs:

--- a/roles/container-engine/docker/vars/ubuntu.yml
+++ b/roles/container-engine/docker/vars/ubuntu.yml
@@ -13,6 +13,8 @@ docker_cli_versioned_pkg:
   '18.09': docker-ce-cli=5:18.09.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce-cli=5:19.03.15~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   '20.10': docker-ce-cli=5:20.10.8~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce-cli=5:20.10.8~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'edge': docker-ce-cli=5:20.10.8~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkgs:


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Using `stable` value as docker_version configuration value raises the following error:
```bash
fatal: [fv-az39-792]: FAILED! => {"msg": "The conditional check 'docker_package_info.pkgs|length > 0' failed. The error was: error while evaluating conditional (docker_package_info.pkgs|length > 0): AnsibleMapping([('pkgs', ['{{ containerd_versioned_pkg[containerd_version | string] }}', '{{ docker_cli_versioned_pkg[docker_cli_version | string] }}', '{{ docker_versioned_pkg[docker_version | string] }}'])]): 'dict object' has no attribute 'stable'\n\nThe error appears to be in '/opt/kubespray/roles/container-engine/docker/tasks/main.yml': line 107, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: ensure docker packages are installed\n  ^ here\n"}
```
This is caused by missing the entries in the docker_cli_versioned_pkg dictionary.

**Which issue(s) this PR fixes**:
This change adds those values into the dictionaries defined on every distribution

**Special notes for your reviewer**:
This hasn't covered by any Use Case in the CI.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
