### PR TITLE
Allow 'stable' and 'edge' ContainerD values on validation

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -334,7 +334,7 @@
     msg: "containerd_version is too low. Minimum version {{ containerd_min_version_required }}"
   run_once: yes
   when:
-    - containerd_version != 'latest'
+    - containerd_version not in ['latest', 'edge', 'stable']
     - container_manager == 'containerd'
 
 - name: Stop if using deprecated containerd_config variable


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
The `containerd_versioned_pkg` [configuration](https://github.com/kubernetes-sigs/kubespray/tree/master/roles/container-engine/containerd-common/vars) parameter supports `stable` and `edge` key values but the validation restricts them to only use `latest`.

**Which issue(s) this PR fixes**:
This change allows to use `stable` or `edge` as `containerd_version` value skipping the "Ensure minimum containerd version" validation

**Special notes for your reviewer**:
NA

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
