### PR TITLE
[2.17] Remove allowPrivilegeEscalation from metrics-server (#8014)

### DIFF
--- a/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
@@ -67,7 +67,6 @@ spec:
           failureThreshold: 3
           initialDelaySeconds: 40
         securityContext:
-          allowPrivilegeEscalation: false
           capabilities:
             drop: ["all"]
             add: ["NET_BIND_SERVICE"]


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

"allowPrivilegeEscalation: false" blocks deploying metrics-server on CentOS7.
In addition, the original metrics-server manifest doesn't contain it as [1]. This removes it.

[1]: https://github.com/kubernetes-sigs/metrics-server/blob/527679e5e8a103919c935d0575c20741796bc25d/manifests/base/deployment.yaml

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7988

**Special notes for your reviewer**:

This is a backporting pull request of https://github.com/kubernetes-sigs/kubespray/pull/8014 for release-2.17 branch.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix CentOS7 issue with allowPrivilegeEscalation value from metrics-server
```
