### PR TITLE
[2.17] Fix k8s-certs-renew cp path (#7992)

### DIFF
--- a/roles/kubernetes/control-plane/templates/k8s-certs-renew.sh.j2
+++ b/roles/kubernetes/control-plane/templates/k8s-certs-renew.sh.j2
@@ -14,7 +14,7 @@ echo "## Restarting control plane pods managed by kubeadm ##"
 {% endif %}
 
 echo "## Updating /root/.kube/config ##"
-/usr/bin/cp {{ kube_config_dir }}/admin.conf /root/.kube/config
+cp {{ kube_config_dir }}/admin.conf /root/.kube/config
 
 echo "## Waiting for apiserver to be up again ##"
 until printf "" 2>>/dev/null >>/dev/tcp/127.0.0.1/6443; do sleep 1; done


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This is a cherry-pick of 22115047903729f5b316719131e1e69c263f3300

Signed-off-by: Wang Zhen <lazybetrayer@gmail.com>

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7990

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix k8s-certs-renew cp path wrongly using `/usr/bin/`
```
