### PR TITLE
[2.17] Fix cilium operator metrics activation (#8000)

### DIFF
--- a/roles/network_plugin/cilium/templates/cilium-config.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-config.yml.j2
@@ -38,6 +38,8 @@ data:
   # scheduled.
 {% if cilium_enable_prometheus %}
   prometheus-serve-addr: ":9090"
+  operator-prometheus-serve-addr: ":6942"
+  enable-metrics: "true"
 {% endif %}
 
   # If you want to run cilium in debug mode change this value to true


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This is a cherry-pick of 598f178054f522e64a3a9dfc1b973732fd52afd8

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[Cilium] Fix operator metrics activation (`enable-metrics` key missing)
```
