### PR TITLE
Upgrade ruamel.yaml.clib to work with Python 3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ netaddr==0.7.19
 pbr==5.4.4
 jmespath==0.9.5
 ruamel.yaml==0.16.10
-ruamel.yaml.clib==0.2.2
+ruamel.yaml.clib==0.2.4
 MarkupSafe==1.1.1


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This commit upgrades `ruamel.yaml.clib` to work with the upcoming Python 3.10.

Cf. https://sourceforge.net/p/ruamel-yaml-clib/tickets/5/

**Which issue(s) this PR fixes**:

N∕A

**Special notes for your reviewer**:

`ruamel.yaml.clib==0.2.4` fixes the Python 3.10 issue and works with Python 3.9.
It does not work with Python 3.7 (cf https://sourceforge.net/p/ruamel-yaml-clib/tickets/6/) but currently Kubespray requires Python >= 3.9.

**Does this PR introduce a user-facing change?**:
```release-note
Support Python 3.10 -  `ruamel.yaml.clib` need to be updated to 0.2.4
```
