### PR TITLE
[2.17] Check if openstack application credentials are empty  (#8021)

### DIFF
--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
@@ -1,6 +1,6 @@
 [Global]
 auth-url="{{ external_openstack_auth_url }}"
-{% if external_openstack_application_credential_id is not defined and external_openstack_application_credential_name is not defined %}
+{% if external_openstack_application_credential_id == "" and external_openstack_application_credential_name == "" %}
 username="{{ external_openstack_username }}"
 password="{{ external_openstack_password }}"
 {% endif %}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR makes it possible to use the Openstack cloud provider with username/password and not only application credentials.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7945

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[OpenStack] Fix a bug where Openstack cloud provider could not be used with username/password
```
