### PR TITLE
[2.17] check if 'plugins' key exists in calico_cni_config object (#7717)

### DIFF
--- a/roles/network_plugin/calico/tasks/pre.yml
+++ b/roles/network_plugin/calico/tasks/pre.yml
@@ -12,7 +12,9 @@
   - name: Set fact calico_datastore to etcd if needed
     set_fact:
       calico_datastore: etcd
-    when: "'etcd_endpoints' in calico_cni_config.plugins.0"
+    when:
+    - "'plugins' in calico_cni_config"
+    - "'etcd_endpoints' in calico_cni_config.plugins.0"
   when: calico_cni_config_slurp.content is defined
 
 - name: Calico | Get kubelet hostname


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Allows users to add nodes to cluster using cluster.yml as well as scale.yml

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7711

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[Calico] Check if 'plugins' key exists in `calico_cni_config` object allowing user to add nodes using both playbooks
```
