### PR TITLE
[2.17] Fix containerd failed to start if apparmor is not installed

### DIFF
--- a/roles/kubernetes/preinstall/vars/debian-11.yml
+++ b/roles/kubernetes/preinstall/vars/debian-11.yml
@@ -6,3 +6,4 @@ required_pkgs:
   - software-properties-common
   - conntrack
   - iptables
+  - apparmor

--- a/roles/kubernetes/preinstall/vars/debian.yml
+++ b/roles/kubernetes/preinstall/vars/debian.yml
@@ -5,3 +5,4 @@ required_pkgs:
   - apt-transport-https
   - software-properties-common
   - conntrack
+  - apparmor

--- a/roles/kubernetes/preinstall/vars/ubuntu.yml
+++ b/roles/kubernetes/preinstall/vars/ubuntu.yml
@@ -5,3 +5,4 @@ required_pkgs:
   - apt-transport-https
   - software-properties-common
   - conntrack
+  - apparmor


### PR DESCRIPTION
> /kind bug

**What this PR does / why we need it**:

Backport of #8011 and #8036 to v2.17.x

**Which issue(s) this PR fixes**:

Fixes #7965