### PR TITLE
Migrate node-role.kubernetes.io/master to node-role.kubern…

### DIFF
--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta2.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta2.yaml.j2
@@ -18,8 +18,13 @@ nodeRegistration:
 {% endif %}
 {% if inventory_hostname in groups['kube_control_plane'] and inventory_hostname not in groups['kube_node'] %}
   taints:
+{% if kube_version is version('v1.20.0', '<') %}
   - effect: NoSchedule
     key: node-role.kubernetes.io/master
+{% else %}
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+{% endif %}
 {% else %}
   taints: []
 {% endif %}

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta2.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta2.yaml.j2
@@ -18,13 +18,8 @@ nodeRegistration:
 {% endif %}
 {% if inventory_hostname in groups['kube_control_plane'] and inventory_hostname not in groups['kube_node'] %}
   taints:
-{% if kube_version is version('v1.20.0', '<') %}
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-{% else %}
   - effect: NoSchedule
     key: node-role.kubernetes.io/control-plane
-{% endif %}
 {% else %}
   taints: []
 {% endif %}

--- a/roles/kubernetes/control-plane/templates/kubeadm-controlplane.v1beta2.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-controlplane.v1beta2.yaml.j2
@@ -19,3 +19,15 @@ controlPlane:
 nodeRegistration:
   name: {{ kube_override_hostname|default(inventory_hostname) }}
   criSocket: {{ cri_socket }}
+{% if inventory_hostname in groups['kube_control_plane'] and inventory_hostname not in groups['kube_node'] %}
+  taints:
+{% if kube_version is version('v1.20.0', '<') %}
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+{% else %}
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+{% endif %}
+{% else %}
+  taints: []
+{% endif %}

--- a/roles/kubernetes/control-plane/templates/kubeadm-controlplane.v1beta2.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-controlplane.v1beta2.yaml.j2
@@ -21,13 +21,8 @@ nodeRegistration:
   criSocket: {{ cri_socket }}
 {% if inventory_hostname in groups['kube_control_plane'] and inventory_hostname not in groups['kube_node'] %}
   taints:
-{% if kube_version is version('v1.20.0', '<') %}
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-{% else %}
   - effect: NoSchedule
     key: node-role.kubernetes.io/control-plane
-{% endif %}
 {% else %}
   taints: []
 {% endif %}


### PR DESCRIPTION
**What type of PR is this?**
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

Ensure Control Plane taints is set to `node-role.kubernetes.io/control-plane` instead of `node-role.kubernetes.io/master` to improve naming consistency.

**Special notes for your reviewer**:

In this PR, taints are also set in `kubeadm-controlplane.v1beta2.yaml.j2`. This is needed since kubeadm set `node-role.kubernetes.io/master` taint by default for control plane if no taints are defined.

Kubeadm has not finished Master to Control Plane refactor yet. https://github.com/kubernetes/kubeadm/issues/2200

**Does this PR introduce a user-facing change?**:
```release-note
Migrate node-role.kubernetes.io/master to node-role.kubernetes/control-plane taint
```