### PR TITLE
Fix external_cloud_controller openstack cloud.conf secret template

### DIFF
--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
@@ -1,6 +1,6 @@
 [Global]
 auth-url="{{ external_openstack_auth_url }}"
-{% if external_openstack_application_credential_id == "" and external_openstack_application_credential_name == "" %}
+{% if (external_openstack_application_credential_id is not defined or external_openstack_application_credential_id == "") and (external_openstack_application_credential_name is not defined or external_openstack_application_credential_name == "") %}
 username="{{ external_openstack_username }}"
 password="{{ external_openstack_password }}"
 {% endif %}


### PR DESCRIPTION
external_openstack_application_credential_id is always defined but is
empty if not supplied

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

the cloud-config secret generated for external cloud controller openstack lacks username and password information
due to a bug in the secret generation template

external_openstack_application_credential_id variable is always defined but empty

cf.
```
external_openstack_application_credential_id: "{{ lookup('env','OS_APPLICATION_CREDENTIAL_ID')  }}"
external_openstack_application_credential_name: "{{ lookup('env','OS_APPLICATION_CREDENTIAL_NAME')  }}"
```

in roles/kubernetes-apps/external_cloud_controller/openstack/defaults/main.yml

this PR fixes this by taking this case into account
