### PR TITLE
csi_driver / cinder: implement rescan-on-resize variable via

### DIFF
--- a/roles/kubernetes-apps/csi_driver/cinder/defaults/main.yml
+++ b/roles/kubernetes-apps/csi_driver/cinder/defaults/main.yml
@@ -18,3 +18,11 @@ cinder_cacert: "{{ lookup('env','OS_CACERT') }}"
 # For now, only Cinder v3 is supported in Cinder CSI driver
 cinder_blockstorage_version: "v3"
 cinder_csi_controller_replicas: 1
+
+# Optional. Set to true, to rescan block device and verify its size before expanding
+# the filesystem.
+# Not all hypervizors have a /sys/class/block/XXX/device/rescan location, therefore if
+# you enable this option and your hypervizor doesn't support this, you'll get a warning
+# log on resize event. It is recommended to disable this option in this case.
+# Defaults to false
+# cinder_csi_rescan_on_resize: true

--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-cloud-config.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-cloud-config.j2
@@ -39,3 +39,6 @@ ignore-volume-az={{ cinder_csi_ignore_volume_az | bool }}
 {% if node_volume_attach_limit is defined and node_volume_attach_limit != "" %}
 node-volume-attach-limit="{{ node_volume_attach_limit }}"
 {% endif %}
+{% if cinder_csi_rescan_on_resize is defined %}
+rescan-on-resize={{ cinder_csi_rescan_on_resize | bool }}
+{% endif %}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds the ability to set rescan-on-resize variable in the cloud.conf secret
for csi driver cinder via configuration variable cinder_csi_rescan_on_resize

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
[Cinder] Add new variable `cinder_csi_rescan_on_resize` to control `rescan-on-resize` option
```
