### PR TITLE
Update a bunch of tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Note: Upstart/SysV init based OS types are not supported.
 
 - Core
   - [kubernetes](https://github.com/kubernetes/kubernetes) v1.22.2
-  - [etcd](https://github.com/coreos/etcd) v3.4.13
+  - [etcd](https://github.com/coreos/etcd) v3.5.0
   - [docker](https://www.docker.com/) v20.10 (see note)
   - [containerd](https://containerd.io/) v1.4.9
   - [cri-o](http://cri-o.io/) v1.21 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -50,8 +50,8 @@ image_arch: "{{host_architecture | default('amd64')}}"
 
 # Versions
 kubeadm_version: "{{ kube_version }}"
-etcd_version: v3.4.13
-crun_version: 0.21
+etcd_version: v3.5.0
+crun_version: 1.2
 kata_containers_version: 2.2.0
 gvisor_version: 20210921
 
@@ -88,8 +88,8 @@ kube_router_version: "v1.3.1"
 multus_version: "v3.7.2"
 ovn4nfv_ovn_image_version: "v1.0.0"
 ovn4nfv_k8s_plugin_image_version: "v1.1.0"
-helm_version: "v3.6.3"
-nerdctl_version: "0.8.1"
+helm_version: "v3.7.0"
+nerdctl_version: "0.12.1"
 krew_version: "v0.4.1"
 
 # Get kubernetes major version (i.e. 1.17.4 => 1.17)
@@ -340,8 +340,8 @@ etcd_binary_checksums:
   # Etcd does not have arm32 builds at the moment, having some dummy value is
   # required to avoid "no attribute" error
   arm: 0
-  arm64: 1934ebb9f9f6501f706111b78e5e321a7ff8d7792d3d96a76e2d01874e42a300
-  amd64: 2ac029e47bab752dacdb7b30032f230f49e2f457cbc32e8f555c2210bb5ff107
+  arm64: 444e10e6880595d75aaf55762901c722049b29d56fef50b2f23464bb7f9db74d
+  amd64: 864baa0437f8368e0713d44b83afe21dce1fb4ee7dae4ca0f9dd5f0df22d01c4
 cni_binary_checksums:
   arm: 909e800d01cc61ffa26f2629e4a202a58d727e6ccaabd0310ef18d2b1e00943c
   arm64: ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0
@@ -369,11 +369,11 @@ krew_archive_checksums:
 
 helm_archive_checksums:
   arm:
-    v3.6.3: 6918e573a70c309fbf6385a0a0d18d090c10b44d318724f1f73e47ede4809635
+    v3.7.0: c9609757e56fa11036da469c0b7f21b6e21f05618bc437451050a8507441fe1b
   amd64:
-    v3.6.3: 07c100849925623dc1913209cd1a30f0a9b80a5b4d6ff2153c609d11b043e262
+    v3.7.0: 096e30f54c3ccdabe30a8093f8e128dba76bb67af697b85db6ed0453a2701bf9
   arm64:
-    v3.6.3: 6fe647628bc27e7ae77d015da4d5e1c63024f673062ac7bc11453ccc55657713
+    v3.7.0: 03bf55435b4ebef739f862334bdfbf7b7eed714b94340a22298c485b6626aaca
 
 crun_checksums:
   arm: 0
@@ -386,6 +386,7 @@ crun_checksums:
     0.20: a33616f299de8101e834105af984eec80e7c264f57aebc17e2a2077296ab04f9
     0.20.1: 9fac3040c95adbeced9110ceb79fd49556dd5027e39f98473c3c3e1f7edf5d16
     0.21: b96cbdf549b69d20ce5dc81c300a138e5c1fd3d11555674043143ace8303c9a7
+    1.2: 2228a8e0e0f10920b230f9b8bc7c4fd951b603b278ccf0ebdba794339a49c33b
   arm64:
     0.16: 0
     0.17: 0
@@ -395,6 +396,7 @@ crun_checksums:
     0.20: d71fbb32cb3e7efcf6f9e3431d4c64c0c3b938468128b06babd354ff86180602
     0.20.1: bcbb1ad85cbd953c9c2eb8d8651fee2bbc949516c4c6ac4fd03a9dffc7d2ff53
     0.21: 7207d328978ee478be6dcf673ada0674305a624f57ee7ae1660c688751feb725
+    1.2: 3aee1057196b40b9786a08c875569c9046e58f97d29333b454359668b6088fb1
 
 kata_containers_binary_checksums:
   arm:
@@ -428,11 +430,11 @@ gvisor_containerd_shim_binary_checksums:
 
 nerdctl_archive_checksums:
   arm:
-    0.8.1: 27bdad3f9e2667620f70617c48d595c5c4e24a10fbcd00d31202cd8d571c9233
+    0.12.1: 64d6cfdbf9e0ac6eb47d86f05452d36d5c31471bdc31c027fe3a23edfae0d64c
   arm64:
-    0.8.1: b0c35d80da92eaf5ee61873f0d9d6d6ba01d109b62143a31e3c306b2d53a2895
+    0.12.1: 991c1b9ff842ac2546f22ca8842eaaa0d0e20d2fa8e9c1746c40443a6ce24430
   amd64:
-    0.8.1: 7c3573db282749079e06f4c592b4585d53628d13fd762746b30389f854d79a47
+    0.12.1: 868dc5997c3edb0bd06f75012e71c2b15ee0885b83bad191fbe2a1d6d5f4f2ac
 
 etcd_binary_checksum: "{{ etcd_binary_checksums[image_arch] }}"
 cni_binary_checksum: "{{ cni_binary_checksums[image_arch] }}"
@@ -531,7 +533,7 @@ nodelocaldns_version: "1.17.1"
 nodelocaldns_image_repo: "{{ kube_image_repo }}/dns/k8s-dns-node-cache"
 nodelocaldns_image_tag: "{{ nodelocaldns_version }}"
 
-dnsautoscaler_version: 1.8.3
+dnsautoscaler_version: 1.8.5
 dnsautoscaler_image_repo: "{{ kube_image_repo }}/cpa/cluster-proportional-autoscaler-{{ image_arch }}"
 dnsautoscaler_image_tag: "{{ dnsautoscaler_version }}"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Update etcd as the new 1.22 default is 3.5.0
Also update crun/helm/nerdctl and dnsautoscaler 

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
