### PR TITLE
Remove TF 0.14/0.15 support - Add TF 1.x support only

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,8 +31,7 @@ variables:
   ANSIBLE_LOG_LEVEL: "-vv"
   RECOVER_CONTROL_PLANE_TEST: "false"
   RECOVER_CONTROL_PLANE_TEST_GROUPS: "etcd[2:],kube_control_plane[1:]"
-  TERRAFORM_14_VERSION: 0.14.11
-  TERRAFORM_15_VERSION: 0.15.5
+  TERRAFORM_VERSION: 1.0.8
 
 before_script:
   - ./tests/scripts/rebase.sh

--- a/.gitlab-ci/terraform.yml
+++ b/.gitlab-ci/terraform.yml
@@ -53,92 +53,51 @@
     # Cleanup regardless of exit code
     - chronic ./tests/scripts/testcases_cleanup.sh
 
-tf-0.15.x-validate-openstack:
+tf-validate-openstack:
   extends: .terraform_validate
   variables:
-    TF_VERSION: $TERRAFORM_15_VERSION
+    TF_VERSION: $TERRAFORM_VERSION
     PROVIDER: openstack
     CLUSTER: $CI_COMMIT_REF_NAME
 
-tf-0.15.x-validate-packet:
+tf-validate-packet:
   extends: .terraform_validate
   variables:
-    TF_VERSION: $TERRAFORM_15_VERSION
+    TF_VERSION: $TERRAFORM_VERSION
     PROVIDER: packet
     CLUSTER: $CI_COMMIT_REF_NAME
 
-tf-0.15.x-validate-aws:
+tf-validate-aws:
   extends: .terraform_validate
   variables:
-    TF_VERSION: $TERRAFORM_15_VERSION
+    TF_VERSION: $TERRAFORM_VERSION
     PROVIDER: aws
     CLUSTER: $CI_COMMIT_REF_NAME
 
-tf-0.15.x-validate-exoscale:
+tf-validate-exoscale:
   extends: .terraform_validate
   variables:
-    TF_VERSION: $TERRAFORM_15_VERSION
+    TF_VERSION: $TERRAFORM_VERSION
     PROVIDER: exoscale
 
-tf-0.15.x-validate-vsphere:
+tf-validate-vsphere:
   extends: .terraform_validate
   variables:
-    TF_VERSION: $TERRAFORM_15_VERSION
+    TF_VERSION: $TERRAFORM_VERSION
     PROVIDER: vsphere
     CLUSTER: $CI_COMMIT_REF_NAME
 
-tf-0.15.x-validate-upcloud:
+tf-validate-upcloud:
   extends: .terraform_validate
   variables:
-    TF_VERSION: $TERRAFORM_15_VERSION
-    PROVIDER: upcloud
-    CLUSTER: $CI_COMMIT_REF_NAME
-
-tf-0.14.x-validate-openstack:
-  extends: .terraform_validate
-  variables:
-    TF_VERSION: $TERRAFORM_14_VERSION
-    PROVIDER: openstack
-    CLUSTER: $CI_COMMIT_REF_NAME
-
-tf-0.14.x-validate-packet:
-  extends: .terraform_validate
-  variables:
-    TF_VERSION: $TERRAFORM_14_VERSION
-    PROVIDER: packet
-    CLUSTER: $CI_COMMIT_REF_NAME
-
-tf-0.14.x-validate-aws:
-  extends: .terraform_validate
-  variables:
-    TF_VERSION: $TERRAFORM_14_VERSION
-    PROVIDER: aws
-    CLUSTER: $CI_COMMIT_REF_NAME
-
-tf-0.14.x-validate-exoscale:
-  extends: .terraform_validate
-  variables:
-    TF_VERSION: $TERRAFORM_14_VERSION
-    PROVIDER: exoscale
-
-tf-0.14.x-validate-vsphere:
-  extends: .terraform_validate
-  variables:
-    TF_VERSION: $TERRAFORM_14_VERSION
-    PROVIDER: vsphere
-    CLUSTER: $CI_COMMIT_REF_NAME
-
-tf-0.14.x-validate-upcloud:
-  extends: .terraform_validate
-  variables:
-    TF_VERSION: $TERRAFORM_14_VERSION
+    TF_VERSION: $TERRAFORM_VERSION
     PROVIDER: upcloud
     CLUSTER: $CI_COMMIT_REF_NAME
 
 # tf-packet-ubuntu16-default:
 #   extends: .terraform_apply
 #   variables:
-#     TF_VERSION: $TERRAFORM_14_VERSION
+#     TF_VERSION: $TERRAFORM_VERSION
 #     PROVIDER: packet
 #     CLUSTER: $CI_COMMIT_REF_NAME
 #     TF_VAR_number_of_k8s_masters: "1"
@@ -152,7 +111,7 @@ tf-0.14.x-validate-upcloud:
 # tf-packet-ubuntu18-default:
 #   extends: .terraform_apply
 #   variables:
-#     TF_VERSION: $TERRAFORM_14_VERSION
+#     TF_VERSION: $TERRAFORM_VERSION
 #     PROVIDER: packet
 #     CLUSTER: $CI_COMMIT_REF_NAME
 #     TF_VAR_number_of_k8s_masters: "1"
@@ -210,7 +169,7 @@ tf-elastx_ubuntu18-calico:
   allow_failure: true
   variables:
     <<: *elastx_variables
-    TF_VERSION: $TERRAFORM_15_VERSION
+    TF_VERSION: $TERRAFORM_VERSION
     PROVIDER: openstack
     CLUSTER: $CI_COMMIT_REF_NAME
     ANSIBLE_TIMEOUT: "60"
@@ -256,7 +215,7 @@ tf-elastx_ubuntu18-calico:
 #  environment: ovh
 #  variables:
 #    <<: *ovh_variables
-#    TF_VERSION: $TERRAFORM_14_VERSION
+#    TF_VERSION: $TERRAFORM_VERSION
 #    PROVIDER: openstack
 #    CLUSTER: $CI_COMMIT_REF_NAME
 #    ANSIBLE_TIMEOUT: "60"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Remove support for TF 0.14 and 0.15 now that 1.x is released.
Add 1.x to all jobs

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
Remove Terraform 0.14/0.15 support and CI -> Add TF 1.x
```
