### PR TITLE
Fix ownership related to Calico

### DIFF
--- a/roles/container-engine/gvisor/molecule/default/prepare.yml
+++ b/roles/container-engine/gvisor/molecule/default/prepare.yml
@@ -36,7 +36,7 @@
       file:
         path: /etc/cni/net.d
         state: directory
-        owner: kube
+        owner: root
         mode: 0755
     - name: Setup CNI
       copy:

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -20,7 +20,7 @@
   template:
     src: "cni-calico.conflist.j2"
     dest: "/etc/cni/net.d/calico.conflist.template"
-    owner: kube
+    owner: root
   register: calico_conflist
   notify: reset_calico_cni
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

kube-bench scan outputs warning related to Calico like:

* text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)"
* text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8070

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[Calico] Fix Kube-bench security warnings on calico controller (file ownership/permissions)
```
