### PR TITLE
Calico : Increase CPU limit to prevent throttling 

### DIFF
--- a/roles/kubernetes-apps/policy_controller/calico/defaults/main.yml
+++ b/roles/kubernetes-apps/policy_controller/calico/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Limits for calico apps
-calico_policy_controller_cpu_limit: 100m
+calico_policy_controller_cpu_limit: 1000m
 calico_policy_controller_memory_limit: 256M
 calico_policy_controller_cpu_requests: 30m
 calico_policy_controller_memory_requests: 64M


### PR DESCRIPTION
Hi,

As reported in #8056 , Calico pods seem to struggle under low CPU limits. We are experiencing about 25% throttling under normal usage.  
This PR may serve as a discussion on if we should increase the CPU limits default defined in kubespray (currently `100m`) and what the new default should be. I personally have no idea what a reasonable default should be as I don't know about the average kubespray user. In our clusters we randomly chose a limit of `3` and throttling disappeared but I don't think a number that high should be necessary (even if it's only a limit, not a request).

Sidenote : for anyone wandering here and being as clueless as I was about CPU limits and throttling, this medium post explained a few basics : https://medium.com/omio-engineering/cpu-limits-and-aggressive-throttling-in-kubernetes-c5b20bd8a718


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[Calico] Increase CPU limit to prevent throttling
```