### PR TITLE
Replace deprecated --delete-local-data in pre-remove/pre-upgrade tasks

### DIFF
--- a/roles/remove-node/pre-remove/tasks/main.yml
+++ b/roles/remove-node/pre-remove/tasks/main.yml
@@ -14,7 +14,7 @@
       --ignore-daemonsets
       --grace-period {{ drain_grace_period }}
       --timeout {{ drain_timeout }}
-      --delete-local-data {{ hostvars[item]['kube_override_hostname']|default(item) }}
+      --delete-emptydir-data {{ hostvars[item]['kube_override_hostname']|default(item) }}
   loop: "{{ node.split(',') | default(groups['kube_node']) }}"
   # ignore servers that are not nodes
   when: hostvars[item]['kube_override_hostname']|default(item) in nodes.stdout_lines

--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -75,7 +75,7 @@
         --ignore-daemonsets
         --grace-period {{ drain_grace_period }}
         --timeout {{ drain_timeout }}
-        --delete-local-data {{ kube_override_hostname|default(inventory_hostname) }}
+        --delete-emptydir-data {{ kube_override_hostname|default(inventory_hostname) }}
         {% if drain_pod_selector %}--pod-selector '{{ drain_pod_selector }}'{% endif %}
       when: drain_nodes
       register: result


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
During a recent upgrade noticed that the options
` --delete-local-data ` has been deprecated and it should be replaced with ` --delete-emptydir-data `
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/pull/95076 for kubespray

**Does this PR introduce a user-facing change?**:
```release-note
Replace deprecated --delete-local-data in pre-remove/pre-upgrade tasks
```
