### PR TITLE
Up dashboard version to 2.4.0 - fix forgotten kubeovn version

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [canal](https://github.com/projectcalico/canal) (given calico/flannel versions)
   - [cilium](https://github.com/cilium/cilium) v1.9.10
   - [flanneld](https://github.com/flannel-io/flannel) v0.14.0
-  - [kube-ovn](https://github.com/alauda/kube-ovn) v1.7.2
+  - [kube-ovn](https://github.com/alauda/kube-ovn) v1.8.1
   - [kube-router](https://github.com/cloudnativelabs/kube-router) v1.3.1
   - [multus](https://github.com/intel/multus-cni) v3.8
   - [ovn4nfv](https://github.com/opnfv/ovn4nfv-k8s-plugin) v1.1.0

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -614,9 +614,9 @@ gcp_pd_csi_resizer_image_tag: "v0.4.0-gke.0"
 gcp_pd_csi_registrar_image_tag: "v1.2.0-gke.0"
 
 dashboard_image_repo: "{{ docker_image_repo }}/kubernetesui/dashboard-{{ image_arch }}"
-dashboard_image_tag: "v2.3.1"
+dashboard_image_tag: "v2.4.0"
 dashboard_metrics_scraper_repo: "{{ docker_image_repo }}/kubernetesui/metrics-scraper"
-dashboard_metrics_scraper_tag: "v1.0.6"
+dashboard_metrics_scraper_tag: "v1.0.7"
 
 metallb_speaker_image_repo: "{{ quay_image_repo }}/metallb/speaker"
 metallb_controller_image_repo: "{{ quay_image_repo }}/metallb/controller"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Dashboard 2.4.0 has been released

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
