### PR TITLE
Backport 2.15: Implement drain fallback with --disable-eviction to ignore PDBs

### DIFF
--- a/roles/upgrade/pre-upgrade/defaults/main.yml
+++ b/roles/upgrade/pre-upgrade/defaults/main.yml
@@ -3,3 +3,7 @@ drain_grace_period: 300
 drain_timeout: 360s
 drain_pod_selector: ""
 drain_nodes: true
+
+drain_fallback_enabled: false
+drain_fallback_grace_period: 300
+drain_fallback_timeout: 360s

--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -58,12 +58,42 @@
         {{ bin_dir }}/kubectl drain
         --force
         --ignore-daemonsets
-        --grace-period {{ drain_grace_period }}
-        --timeout {{ drain_timeout }}
+        --grace-period {{ hostvars['localhost']['drain_grace_period_after_failure'] | default(drain_grace_period) }}
+        --timeout {{ hostvars['localhost']['drain_timeout_after_failure'] | default(drain_timeout) }}
         --delete-local-data {{ kube_override_hostname|default(inventory_hostname) }}
         {% if drain_pod_selector %}--pod-selector '{{ drain_pod_selector }}'{% endif %}
       when:
         - drain_nodes
+      register: result
+      failed_when:
+        - result.rc != 0
+        - not drain_fallback_enabled
+
+    - name: Drain fallback
+      block:
+        - name: Set facts after regular drain has failed
+          set_fact:
+            drain_grace_period_after_failure: "{{ drain_fallback_grace_period }}"
+            drain_timeout_after_failure: "{{ drain_fallback_timeout }}"
+          delegate_to: localhost
+          delegate_facts: yes
+          run_once: yes
+
+        - name: Drain node - fallback with disabled eviction
+          command: >-
+            {{ bin_dir }}/kubectl drain
+            --force
+            --ignore-daemonsets
+            --grace-period {{ drain_fallback_grace_period }}
+            --timeout {{ drain_fallback_timeout }}
+            --delete-local-data {{ kube_override_hostname|default(inventory_hostname) }}
+            {% if drain_pod_selector %}--pod-selector '{{ drain_pod_selector }}'{% endif %}
+            --disable-eviction
+      when:
+        - drain_nodes
+        - drain_fallback_enabled
+        - result.rc != 0
+
   rescue:
     - name: Set node back to schedulable
       command: "{{ bin_dir }}/kubectl --kubeconfig /etc/kubernetes/admin.conf uncordon {{ inventory_hostname }}"


### PR DESCRIPTION
Signed-off-by: Utku Ozdemir <uoz@protonmail.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
 Backport PR #8094 which resolved the issue #8093 to 2.16

**Which issue(s) this PR fixes**:
Fixes #8093 (backport)

**Special notes for your reviewer**:
The reason I backport this to 2.16 and 2.15 is because we use kubespray at my workplace, and currently are on 2.15. We have a migration path 2.15 -> 2.16 -> 2.17 - if this gets merged we can use the upstream project instead of our fork. Also the community can potentially benefit from the added feature.

**Does this PR introduce a user-facing change?**:
```release-note
Add an optional fallback to node drain during cluster upgrades using `--disable-eviction` flag
```
