### PR TITLE
Use 'inventory_hostnames' query for remove-node

### DIFF
--- a/roles/remove-node/pre-remove/tasks/main.yml
+++ b/roles/remove-node/pre-remove/tasks/main.yml
@@ -15,7 +15,7 @@
       --grace-period {{ drain_grace_period }}
       --timeout {{ drain_timeout }}
       --delete-emptydir-data {{ hostvars[item]['kube_override_hostname']|default(item) }}
-  loop: "{{ node.split(',') | default(groups['kube_node']) }}"
+  loop: "{{ query('inventory_hostnames', (node | default('kube_node')) }}"
   # ignore servers that are not nodes
   when: hostvars[item]['kube_override_hostname']|default(item) in nodes.stdout_lines
   register: result


### PR DESCRIPTION
Using the 'inventory_hostnames' lookup instead of manual splitting
allows us to use ansible patterns ; we are no longer forced to
explicitely spell out hostnames (but doing so still works).


**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

It allows more flexibility for the remove-node.yml playbook. We can use
`kube_master[1]` instead of explicitely specifying `my_kube_master_01` for
example.

**Special notes for your reviewer**:

This is a draft because the `inventory_hostnames`  lookup don't really work properly
until [this commit](https://github.com/ansible/ansible/commit/db98433e7a99731dbbbbc571b1a03bd7ff9f827c)
in ansible, which is in ansible 2.11.0. So this is dependant on switching to
ansible 2.11

**Does this PR introduce a user-facing change?**:
```release-note
Ansible patterns can now be used in the `node` variables for the `remove-node.yml`
playbook.
```
