### PR TITLE
Limit kubectl delete node to k8s nodes

### DIFF
--- a/roles/remove-node/post-remove/tasks/main.yml
+++ b/roles/remove-node/post-remove/tasks/main.yml
@@ -3,3 +3,4 @@
   command: "{{ bin_dir }}/kubectl delete node {{ kube_override_hostname|default(inventory_hostname) }}"
   delegate_to: "{{ groups['kube_control_plane']|first }}"
   ignore_errors: true
+  when: inventory_hostname in groups['k8s_cluster']

--- a/roles/remove-node/post-remove/tasks/main.yml
+++ b/roles/remove-node/post-remove/tasks/main.yml
@@ -3,3 +3,8 @@
   command: "{{ bin_dir }}/kubectl delete node {{ kube_override_hostname|default(inventory_hostname) }}"
   delegate_to: "{{ groups['kube_control_plane']|first }}"
   when: inventory_hostname in groups['k8s_cluster']
+  retries: 10
+  # Sometimes the api-server can have a short window of indisponibility when we delete a master node
+  delay: 3
+  register: result
+  until: result is not failed

--- a/roles/remove-node/post-remove/tasks/main.yml
+++ b/roles/remove-node/post-remove/tasks/main.yml
@@ -1,6 +1,5 @@
 ---
-- name: Delete node  # noqa 301 ignore-errors
+- name: Delete node
   command: "{{ bin_dir }}/kubectl delete node {{ kube_override_hostname|default(inventory_hostname) }}"
   delegate_to: "{{ groups['kube_control_plane']|first }}"
-  ignore_errors: true
   when: inventory_hostname in groups['k8s_cluster']


### PR DESCRIPTION
This avoids the use of `kubectl delete node` when removing etcd nodes
which are not part of the cluser (separate etcd)

**What type of PR is this?**
/kind cleanup


**Does this PR introduce a user-facing change?**:
```release-note
Limit `kubectl delete node` to k8s nodes and not etcd
```
