### PR TITLE
[2.17] Fixed default DNS min replica for single node cluster

### DIFF
--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -3,7 +3,7 @@
 dns_memory_limit: 170Mi
 dns_cpu_requests: 100m
 dns_memory_requests: 70Mi
-dns_min_replicas: 2
+dns_min_replicas: "{{ [ 2, groups['k8s_cluster'] | length ] | min }}"
 dns_nodes_per_replica: 16
 dns_cores_per_replica: 256
 dns_prevent_single_point_failure: "{{ 'true' if dns_min_replicas|int > 1 else 'false' }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Single node cluster don't need 2 coreDNS pods.
This PR compares `2` (current absolute default value) and the length of the `k8s_cluster` inventory group and uses the minimum as the default value for `dns_min_replicas`

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
