### PR TITLE
Allow changing metallb default pool name

### DIFF
--- a/roles/kubernetes-apps/metallb/defaults/main.yml
+++ b/roles/kubernetes-apps/metallb/defaults/main.yml
@@ -18,3 +18,4 @@ metallb_speaker_tolerations:
     key: node-role.kubernetes.io/control-plane
     operator: Exists
 metallb_controller_tolerations: []
+metallb_pool_name: "loadbalanced"

--- a/roles/kubernetes-apps/metallb/templates/metallb-config.yml.j2
+++ b/roles/kubernetes-apps/metallb/templates/metallb-config.yml.j2
@@ -15,7 +15,7 @@ data:
 {% endfor %}
 {% endif %}
     address-pools:
-    - name: loadbalanced
+    - name: {{ metallb_pool_name }}
       protocol: {{ metallb_protocol }}
       addresses:
 {% for ip_range in metallb_ip_range %}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

It will allow changing default metallb pool name from hardcoded *loadbalanced* name.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[Metallb] Allow changing metallb default pool name (var `metallb_pool_name`)
```
