### PR TITLE
Convert numbers to string for calico's inventory check.

### DIFF
--- a/roles/network_plugin/calico/tasks/check.yml
+++ b/roles/network_plugin/calico/tasks/check.yml
@@ -53,7 +53,7 @@
 - name: "Check if inventory match current cluster configuration"
   assert:
     that:
-      - calico_pool_conf.spec.blockSize == (calico_pool_blocksize | default(kube_network_node_prefix))
+      - calico_pool_conf.spec.blockSize|string == (calico_pool_blocksize | default(kube_network_node_prefix | string))
       - calico_pool_conf.spec.cidr == (calico_pool_cidr | default(kube_pods_subnet))
       - not calico_pool_conf.spec.ipipMode is defined or calico_pool_conf.spec.ipipMode == calico_ipip_mode
       - not calico_pool_conf.spec.vxlanMode is defined or calico_pool_conf.spec.vxlanMode == calico_vxlan_mode


### PR DESCRIPTION
Signed-off-by: Julio Morimoto <julio@morimoto.net.br>


**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Calico inventory checks do not always work as expected.

**Which issue(s) this PR fixes**:

Fixes #8119

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix calico's inventory check (Check if inventory match current cluster configuration) conversion
```
