### PR TITLE
Fix quorum check when recovering broken etcd cluster (with etcd 3.5.x)

### DIFF
--- a/roles/etcd/tasks/join_etcd_member.yml
+++ b/roles/etcd/tasks/join_etcd_member.yml
@@ -32,6 +32,9 @@
   register: etcd_member_in_cluster
   changed_when: false
   check_mode: no
+  retries: "{{ etcd_retries }}"
+  delay: "{{ retry_stagger | random + 3 }}"
+  until: etcd_member_in_cluster.rc == 0
   tags:
     - facts
   environment:

--- a/roles/recover_control_plane/etcd/tasks/main.yml
+++ b/roles/recover_control_plane/etcd/tasks/main.yml
@@ -20,10 +20,9 @@
   when:
     - groups['broken_etcd']
 
-# When there is an error, everything is printed in stderr_lines, even "is healthy" messages.
 - name: Set has_quorum fact
   set_fact:
-    has_quorum: "{{ etcd_endpoint_health.stderr_lines | select('match', '.*is healthy.*') | list | length >= etcd_endpoint_health.stderr_lines | select('match', '.*is unhealthy.*') | list | length }}"
+    has_quorum: "{{ etcd_endpoint_health.stdout_lines | select('match', '.*is healthy.*') | list | length >= etcd_endpoint_health.stderr_lines | select('match', '.*is unhealthy.*') | list | length }}"
   when:
     - groups['broken_etcd']
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Since updating to etcd 3.5.x, the recover broken etcd role is failing.
A bug introduced in 3.4.x has been fixed in 3.5.x, the bug was sending every output to error if the cluster was unhealthy when using the endpoint_health command.

The second changes is related to `etcdctl member list` taking a few seconds to display the newly created members, so retry is now needed.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
`etcdctl endpoint health` for a broken etcd cluster with 3.4.x version:
```
"stderr_lines": ["https://172.30.72.98:2379 is healthy: successfully committed proposal: took = 46.482728ms", "https://172.30.72.101:2379 is healthy: successfully committed proposal: took = 46.596092ms", "https://172.30.72.100:2379 is unhealthy: failed to commit proposal: context deadline exceeded", "Error: unhealthy cluster"]
"stdout_lines": []
```
`etcdctl endpoint health` for a broken etcd cluster with 3.5.x version:
```
"stderr_lines": ["https://172.30.72.95:2379 is unhealthy: failed to commit proposal: context deadline exceeded", "Error: unhealthy cluster"], 
"stdout_lines": ["https://172.30.72.98:2379 is healthy: successfully committed proposal: took = 16.923959ms", "https://172.30.72.92:2379 is healthy: successfully committed proposal: took = 16.786043ms"]
```

**Does this PR introduce a user-facing change?**:
```release-note
Fix quorum check when recovering broken etcd cluster (with etcd 3.5.x)
```
