### PR TITLE
nginx ingress controller should watch kind:ingress without class

### DIFF
--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
@@ -52,6 +52,8 @@ spec:
             - --annotations-prefix=nginx.ingress.kubernetes.io
 {% if ingress_nginx_class is defined %}
             - --ingress-class={{ ingress_nginx_class }}
+{% else %}
+            - --watch-ingress-without-class=true
 {% endif %}
 {% if ingress_nginx_host_network %}
             - --report-node-internal-ip-address


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:

Newly version nginx ingress controller ignoring Kind: ingress without class by default

https://github.com/rancher/rancher/issues/35053
```Ignoring ingress because of error while validating ingress class" ingress="cattle-system/rancher" error="ingress does not contain a valid IngressClass```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[nginx-ingress] Nginx controller now also watch kind:ingress without class
```
