### PR TITLE
Docker: replace the use of containerd_version with docker_containerd_version

### DIFF
--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -7,7 +7,8 @@ You can also individually control versions of components by explicitly defining 
 versions. Here are all version vars for each component:
 
 * docker_version
-* containerd_version
+* docker_containerd_version (relevant when `container_manager` == `docker`)
+* containerd_version (relevant when `container_manager` == `containerd`)
 * kube_version
 * etcd_version
 * calico_version

--- a/docs/vars.md
+++ b/docs/vars.md
@@ -18,7 +18,8 @@ Some variables of note include:
 * *docker_version* - Specify version of Docker to used (should be quoted
   string). Must match one of the keys defined for *docker_versioned_pkg*
   in `roles/container-engine/docker/vars/*.yml`.
-* *containerd_version* - Specify version of Containerd to use
+* *containerd_version* - Specify version of containerd to use when setting `container_manager` to `containerd`
+* *docker_containerd_version* - Specify which version of containerd to use when setting `container_manager` to `docker`
 * *etcd_version* - Specify version of ETCD to use
 * *ipip* - Enables Calico ipip encapsulation by default
 * *kube_network_plugin* - Sets k8s network plugin (default Calico)

--- a/roles/container-engine/docker/vars/debian-stretch.yml
+++ b/roles/container-engine/docker/vars/debian-stretch.yml
@@ -28,7 +28,7 @@ docker_cli_versioned_pkg:
 
 docker_package_info:
   pkgs:
-    - "{{ containerd_versioned_pkg[containerd_version | string] }}"
+    - "{{ containerd_versioned_pkg[docker_containerd_version | string] }}"
     - "{{ docker_cli_versioned_pkg[docker_cli_version | string] }}"
     - "{{ docker_versioned_pkg[docker_version | string] }}"
 

--- a/roles/container-engine/docker/vars/debian.yml
+++ b/roles/container-engine/docker/vars/debian.yml
@@ -30,7 +30,7 @@ docker_cli_versioned_pkg:
 
 docker_package_info:
   pkgs:
-    - "{{ containerd_versioned_pkg[containerd_version | string] }}"
+    - "{{ containerd_versioned_pkg[docker_containerd_version | string] }}"
     - "{{ docker_cli_versioned_pkg[docker_cli_version | string] }}"
     - "{{ docker_versioned_pkg[docker_version | string] }}"
 

--- a/roles/container-engine/docker/vars/fedora.yml
+++ b/roles/container-engine/docker/vars/fedora.yml
@@ -30,6 +30,6 @@ docker_cli_versioned_pkg:
 docker_package_info:
   enablerepo: "docker-ce"
   pkgs:
-    - "{{ containerd_versioned_pkg[containerd_version | string] }}"
+    - "{{ containerd_versioned_pkg[docker_containerd_version | string] }}"
     - "{{ docker_cli_versioned_pkg[docker_cli_version | string] }}"
     - "{{ docker_versioned_pkg[docker_version | string] }}"

--- a/roles/container-engine/docker/vars/redhat.yml
+++ b/roles/container-engine/docker/vars/redhat.yml
@@ -33,6 +33,6 @@ docker_cli_versioned_pkg:
 docker_package_info:
   enablerepo: "docker-ce"
   pkgs:
-    - "{{ containerd_versioned_pkg[containerd_version | string] }}"
+    - "{{ containerd_versioned_pkg[docker_containerd_version | string] }}"
     - "{{ docker_cli_versioned_pkg[docker_cli_version | string] }}"
     - "{{ docker_versioned_pkg[docker_version | string] }}"

--- a/roles/container-engine/docker/vars/ubuntu-16.yml
+++ b/roles/container-engine/docker/vars/ubuntu-16.yml
@@ -29,7 +29,7 @@ docker_cli_versioned_pkg:
 
 docker_package_info:
   pkgs:
-    - "{{ containerd_versioned_pkg[containerd_version | string] }}"
+    - "{{ containerd_versioned_pkg[docker_containerd_version | string] }}"
     - "{{ docker_cli_versioned_pkg[docker_cli_version | string] }}"
     - "{{ docker_versioned_pkg[docker_version | string] }}"
 

--- a/roles/container-engine/docker/vars/ubuntu.yml
+++ b/roles/container-engine/docker/vars/ubuntu.yml
@@ -30,7 +30,7 @@ docker_cli_versioned_pkg:
 
 docker_package_info:
   pkgs:
-    - "{{ containerd_versioned_pkg[containerd_version | string] }}"
+    - "{{ containerd_versioned_pkg[docker_containerd_version | string] }}"
     - "{{ docker_cli_versioned_pkg[docker_cli_version | string] }}"
     - "{{ docker_versioned_pkg[docker_version | string] }}"
 

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -447,18 +447,14 @@ nerdctl_archive_checksums:
   amd64:
     0.12.1: 868dc5997c3edb0bd06f75012e71c2b15ee0885b83bad191fbe2a1d6d5f4f2ac
 
-# TODO(cristicalin): remove compatibility entries once debian9 and ubuntu16 jobs are dropped or docker is dropped
 containerd_archive_checksums:
   arm:
-    latest: 0  # this is needed to make debian9 and ubuntu16 CI jobs happy
     1.4.9: 0
     1.5.5: 0
   arm64:
-    latest: 0  # this is needed to make debian9 and ubuntu16 CI jobs happy
     1.4.9: 0
     1.5.5: 0
   amd64:
-    latest: 0  # this is needed to make debian9 and ubuntu16 CI jobs happy
     1.4.9: 346f88ad5b973960ff81b5539d4177af5941ec2e4703b479ca9a6081ff1d023b
     1.5.5: 8efc527ffb772a82021800f0151374a3113ed2439922497ff08f2596a70f10f1
 

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -330,9 +330,12 @@ docker_plugins: []
 # Experimental kubeadm etcd deployment mode. Available only for new deployment
 etcd_kubeadm_enabled: false
 
-# Containerd options
+# Containerd options - thse are relevant when container_manager == 'containerd'
 containerd_version: 1.4.9
 containerd_use_systemd_cgroup: true
+
+# Docker options - this is relevant when container_manager == 'docker'
+docker_containerd_version: 1.4.9
 
 # Settings for containerized control plane (etcd/kubelet/secrets)
 # deployment type for legacy etcd mode

--- a/tests/files/packet_debian9-calico-upgrade-once.yml
+++ b/tests/files/packet_debian9-calico-upgrade-once.yml
@@ -10,4 +10,4 @@ dns_min_replicas: 1
 download_run_once: true
 
 # Make docker happy
-containerd_version: latest
+docker_containerd_version: latest

--- a/tests/files/packet_debian9-calico-upgrade.yml
+++ b/tests/files/packet_debian9-calico-upgrade.yml
@@ -9,4 +9,4 @@ deploy_netchecker: true
 dns_min_replicas: 1
 
 # Make docker happy
-containerd_version: latest
+docker_containerd_version: latest

--- a/tests/files/packet_debian9-macvlan.yml
+++ b/tests/files/packet_debian9-macvlan.yml
@@ -14,4 +14,4 @@ macvlan_interface: "eth0"
 auto_renew_certificates: true
 
 # Make docker happy
-containerd_version: latest
+docker_containerd_version: latest

--- a/tests/files/packet_ubuntu16-canal-kubeadm-ha.yml
+++ b/tests/files/packet_ubuntu16-canal-kubeadm-ha.yml
@@ -10,4 +10,4 @@ deploy_netchecker: true
 dns_min_replicas: 1
 
 # Make docker jobs happy
-containerd_version: latest
+docker_containerd_version: latest

--- a/tests/files/packet_ubuntu16-canal-sep.yml
+++ b/tests/files/packet_ubuntu16-canal-sep.yml
@@ -10,4 +10,4 @@ deploy_netchecker: true
 dns_min_replicas: 1
 
 # Make docker jobs happy
-containerd_version: latest
+docker_containerd_version: latest

--- a/tests/files/packet_ubuntu16-flannel-ha.yml
+++ b/tests/files/packet_ubuntu16-flannel-ha.yml
@@ -12,4 +12,4 @@ deploy_netchecker: true
 dns_min_replicas: 1
 
 # Make docker jobs happy
-containerd_version: latest
+docker_containerd_version: latest

--- a/tests/files/packet_ubuntu16-kube-router-sep.yml
+++ b/tests/files/packet_ubuntu16-kube-router-sep.yml
@@ -10,4 +10,4 @@ deploy_netchecker: true
 dns_min_replicas: 1
 
 # Make docker jobs happy
-containerd_version: latest
+docker_containerd_version: latest

--- a/tests/files/packet_ubuntu16-kube-router-svc-proxy.yml
+++ b/tests/files/packet_ubuntu16-kube-router-svc-proxy.yml
@@ -12,4 +12,4 @@ dns_min_replicas: 1
 kube_router_run_service_proxy: true
 
 # Make docker jobs happy
-containerd_version: latest
+docker_containerd_version: latest

--- a/tests/files/packet_ubuntu16-weave-sep.yml
+++ b/tests/files/packet_ubuntu16-weave-sep.yml
@@ -11,4 +11,4 @@ dns_min_replicas: 1
 auto_renew_certificates: true
 
 # Make docker jobs happy
-containerd_version: latest
+docker_containerd_version: latest


### PR DESCRIPTION
Avoid causing conflicts when bumping `containerd_version` when docker does not keep up with the latest containerd releases.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
With the change of using containerd from upstream instead of the docker repos, we are now able to move faster than docker for the containerd runtime but we want to avoid breaking the docker deployment experience when bumping our default containerd version. As such I split the `containerd_version` into a dedicated deployment variable called `docker_containerd_version` which is used when the `containerd_manager` == `docker`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[Docker] When using `containerd_manager==docker` (default config) you will now need to use `docker_containerd_version` to change the containerd version instead of the established `containerd_version`
```
