### PR TITLE
Set check_mode to false in [kubernetes/preinstall : NetworkManager | Ensure NetworkManager conf.d dir] TASK

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0062-networkmanager-unmanaged-devices.yml
+++ b/roles/kubernetes/preinstall/tasks/0062-networkmanager-unmanaged-devices.yml
@@ -5,6 +5,7 @@
   register: nm_check
   failed_when: false
   changed_when: false
+  check_mode: false
 
 - name: NetworkManager | Ensure NetworkManager conf.d dir
   file:


### PR DESCRIPTION
>
> bug

**What this PR does / why we need it**:

Fix errors when running in check mode.

**Special notes for  reviewer**:

When run playbook with `--check` flag, it fails at **[kubernetes/preinstall : NetworkManager | Ensure NetworkManager conf.d dir]** TASK with following error:

`fatal: [node1]: FAILED! => {"msg": "The conditional check 'nm_check.rc == 0' failed. The error was: error while evaluating conditional (nm_check.rc == 0): 'dict object' has no attribute 'rc'\n\nThe error appears to be in '/Users/me/ansible/kubespray/roles/kubernetes/preinstall/tasks/0062-networkmanager-unmanaged-devices.yml': line 9, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: NetworkManager | Ensure NetworkManager conf.d dir\n  ^ here\n"}
`

**Does this PR introduce a user-facing change?**:

No

```release-note
NetworkManager tasks can now be run with ansible `check_mode`
```
