### PR TITLE
added hirsute in restart network

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -388,7 +388,7 @@
       {%- else -%}
       network
       {%- endif -%}
-      {%- elif ansible_distribution == "Ubuntu" and ansible_distribution_release in ["bionic", "focal"] -%}
+      {%- elif ansible_distribution == "Ubuntu" and ansible_distribution_release in ["hirsute","bionic", "focal"] -%}
       systemd-networkd
       {%- elif ansible_os_family == "Debian" -%}
       networking


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
restarting network in ubuntu 21.04 fails and checked the restart menu and found that hirsute was missing in the argument : )

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
 I just added "hirsute" in the "restart network" task 

**Does this PR introduce a user-facing change?**:
```release-note
Added Ubuntu 21.04 (hirsute) in restart network task (reset role)
```
