### PR TITLE
cert-manager: add trusted internal ca when configured

### DIFF
--- a/docs/cert_manager.md
+++ b/docs/cert_manager.md
@@ -88,6 +88,20 @@ Certificates issued by public ACME servers are typically trusted by client’s c
   - [DNS01 Challenges](https://cert-manager.io/v1.5-docs/configuration/acme/dns01/)
 - [ACME FAQ](https://cert-manager.io/v1.5-docs/faq/acme/)
 
+#### ACME With An Internal Certificate Authority
+
+The ACME Issuer with an internal certificate authority requires cert-manager to trust the certificate authority. This trust must be done at the cert-manager deployment level.
+To add a trusted certificate authority to cert-manager, add it's certificate to `group_vars/k8s-cluster/addons.yml`:
+
+```yaml
+cert_manager_trusted_internal_ca: |
+  -----BEGIN CERTIFICATE-----
+  [REPLACE with your CA certificate]
+  -----END CERTIFICATE-----
+```
+
+Once the CA is trusted, you can define your issuer normally.
+
 ### Create New TLS Root CA Certificate and Key
 
 #### Install Cloudflare PKI/TLS `cfssl` Toolkit

--- a/inventory/sample/group_vars/k8s_cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s_cluster/addons.yml
@@ -129,6 +129,10 @@ ingress_alb_enabled: false
 # Cert manager deployment
 cert_manager_enabled: false
 # cert_manager_namespace: "cert-manager"
+# cert_manager_trusted_internal_ca: |
+#   -----BEGIN CERTIFICATE-----
+#   [REPLACE with your CA certificate]
+#   -----END CERTIFICATE-----
 
 # MetalLB deployment
 metallb_enabled: false

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
@@ -875,6 +875,17 @@ spec:
           resources:
             {}
 ---
+{% if cert_manager_trusted_internal_ca is defined %}
+apiVersion: v1
+data:
+  internal-ca.pem: |
+    {{ cert_manager_trusted_internal_ca | indent(width=4, indentfirst=False) }}
+kind: ConfigMap
+metadata:
+  name: ca-internal-truststore
+  namespace: {{ cert_manager_namespace }}
+---
+{% endif %}
 # Source: cert-manager/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -928,6 +939,17 @@ spec:
                 fieldPath: metadata.namespace
           resources:
             {}
+{% if cert_manager_internal_ca is defined %}
+          volumeMounts:
+          - mountPath: /etc/ssl/certs/internal-ca.pem
+            name: ca-internal-truststore
+            subPath: internal-ca.pem
+        volumes:
+        - configMap:
+            defaultMode: 420
+            name: ca-internal-truststore
+          name: ca-internal-truststore
+{% endif %}
 ---
 # Source: cert-manager/templates/webhook-deployment.yaml
 apiVersion: apps/v1

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
@@ -939,7 +939,7 @@ spec:
                 fieldPath: metadata.namespace
           resources:
             {}
-{% if cert_manager_internal_ca is defined %}
+{% if cert_manager_trusted_internal_ca is defined %}
           volumeMounts:
           - mountPath: /etc/ssl/certs/internal-ca.pem
             name: ca-internal-truststore


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
In order to use an acme issuer with an internal authority, the CA of the authority must be trusted by cert-manager.
If not, the issuer with throw errors saying the certificate of the acme uri is unknown.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
I tried to keep it simple.
One additional variable in the addon inventory to specify the trusted internal ca.
A configmap is create with the content of the ca.
This configmap is mounted in the cert-manager container in /etc/ssl/certs in order to be trusted.
As not everyone will use acme with an internal authority, the cm and mount are not defined if the variable is not defined.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add a new option `cert_manager_trusted_internal_ca` to specify trusted internal ca of cert_manager.
```
