### PR TITLE
Added tolerations for cinder-csi-nodeplugin DaemonSet

### DIFF
--- a/roles/kubernetes-apps/csi_driver/cinder/defaults/main.yml
+++ b/roles/kubernetes-apps/csi_driver/cinder/defaults/main.yml
@@ -26,3 +26,5 @@ cinder_csi_controller_replicas: 1
 # log on resize event. It is recommended to disable this option in this case.
 # Defaults to false
 # cinder_csi_rescan_on_resize: true
+
+cinder_tolerations: []

--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-nodeplugin.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-nodeplugin.yml.j2
@@ -121,3 +121,7 @@ spec:
             path: {{ kube_config_dir }}/cinder-cacert.pem
             type: FileOrCreate
 {% endif %}
+{% if cinder_tolerations %}
+      tolerations:
+        {{ cinder_tolerations | to_nice_yaml(indent=2) | indent(width=8) }}
+{% endif %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**: Adds tolerations for the `cinder-csi-nodeplugin` DaemonSet. This is so that if a node needs to be tainted, the user can ensure that the `cinder-csi-nodeplugin` Pods still run on all nodes. By default it's set to an empty list, so it won't cause any change unless the user specifies their desired tolerations.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
none

**Special notes for your reviewer**: Any chance that this can fit into the `2.17.1` patch release?

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added variable cinder_tolerations that sets tolerations for cinder-csi-nodeplugin DaemonSet (no tolerations by default)
```
