### PR TITLE
Add get-checksums-for-k8s-version.sh in misc

### DIFF
--- a/contrib/misc/get-checksums-for-k8s-version.sh
+++ b/contrib/misc/get-checksums-for-k8s-version.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+K8S_RELEASE=${K8S_RELEASE:-"v1.21.6"}
+CMDS="kubectl kubeadm kubelet"
+ARCHS="arm arm64 amd64"
+
+for cmd in $(echo ${CMDS}); do
+    for arch in $(echo ${ARCHS}); do
+        wget -O "${cmd}-${arch}" "https://storage.googleapis.com/kubernetes-release/release/${K8S_RELEASE}/bin/linux/${arch}/${cmd}"
+    done
+done
+
+for cmd in $(echo ${CMDS}); do
+    echo "Add the following lines to ${cmd}_checksums in roles/download/defaults/main.yml"
+    for arch in $(echo ${ARCHS}); do
+        CHECKSUM=$(sha256sum "${cmd}-${arch}" | awk '{print $1}')
+        echo "  ${arch}:"
+        echo "    ${K8S_RELEASE}: ${CHECKSUM}"
+        rm "${cmd}-${arch}"
+    done
+done


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

To add checksums of kube binaries easily for new release,
this adds get-checksums-for-k8s-version.sh for outputting these checksums.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
