### PR TITLE
Ensure addon-resizer 1.8.11 only effective at arch amd64.

### DIFF
--- a/roles/kubernetes-apps/metrics_server/defaults/main.yml
+++ b/roles/kubernetes-apps/metrics_server/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+# metrics_server_resizer only effective in arch amd64
 metrics_server_resizer: false
 metrics_server_kubelet_insecure_tls: true
 metrics_server_kubelet_preferred_address_types: "InternalIP"

--- a/roles/kubernetes-apps/metrics_server/tasks/main.yml
+++ b/roles/kubernetes-apps/metrics_server/tasks/main.yml
@@ -4,6 +4,12 @@
   set_fact:
     masters_are_not_tainted: "{{ groups['kube_node'] | intersect(groups['kube_control_plane']) == groups['kube_control_plane'] }}"
 
+- name: check host_architecture is amd64 for metrics_server_resizer
+  assert:
+    that: host_architecture == "amd64"
+    msg: "metrics_server_resizer is not available on other architectures than amd64"
+  when: metrics_server_resizer
+
 - name: Metrics Server | Delete addon dir
   file:
     path: "{{ kube_config_dir }}/addons/metrics_server"

--- a/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
@@ -81,7 +81,7 @@ spec:
           requests:
             cpu: {{ metrics_server_requests_cpu }}
             memory: {{ metrics_server_requests_memory }}
-{% if metrics_server_resizer %}
+{% if metrics_server_resizer and host_architecture == "amd64" %}
       - name: metrics-server-nanny
         image: {{ addon_resizer_image_repo }}:{{ addon_resizer_image_tag }}
         imagePullPolicy: {{ k8s_image_pull_policy }}

--- a/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
@@ -81,7 +81,7 @@ spec:
           requests:
             cpu: {{ metrics_server_requests_cpu }}
             memory: {{ metrics_server_requests_memory }}
-{% if metrics_server_resizer and host_architecture == "amd64" %}
+{% if metrics_server_resizer %}
       - name: metrics-server-nanny
         image: {{ addon_resizer_image_repo }}:{{ addon_resizer_image_tag }}
         imagePullPolicy: {{ k8s_image_pull_policy }}


### PR DESCRIPTION
k8s.gcr.io/addon-resizer:1.8.11 returns the amd64 image which is not executable at arm64.

Disable addon-resizer when the platform is not amd64.

When metrics-server upgrade and use addon-resizer:2.3, then revert this
commit and `image_arch` will determine the `addon_resizer_image_tag`.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Disable addon-resizer of metrics-server except at platform amd64 because of k8s.gcr.io/addon-resizer:1.8.11 image only support architecture amd64.

**Which issue(s) this PR fixes**:

Fixes #8121

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
