### PR TITLE
Mitogen: deprecate the use of mitogen and remove coverage from CI

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -39,8 +39,6 @@ packet_centos7-flannel-containerd-addons-ha:
   extends: .packet_pr
   stage: deploy-part2
   when: on_success
-  variables:
-    MITOGEN_ENABLE: "true"
   allow_failure: true
 
 packet_centos8-crio:
@@ -52,8 +50,6 @@ packet_ubuntu18-crio:
   extends: .packet_pr
   stage: deploy-part2
   when: manual
-  variables:
-    MITOGEN_ENABLE: "true"
 
 packet_ubuntu16-canal-kubeadm-ha:
   stage: deploy-part2
@@ -89,8 +85,6 @@ packet_debian10-containerd:
   stage: deploy-part2
   extends: .packet_pr
   when: on_success
-  variables:
-    MITOGEN_ENABLE: "true"
 
 packet_debian11-calico:
   stage: deploy-part2
@@ -214,15 +208,12 @@ packet_centos7-weave-upgrade-ha:
   when: on_success
   variables:
     UPGRADE_TEST: basic
-    MITOGEN_ENABLE: "false"
 
 # Calico HA Wireguard
 packet_ubuntu20-calico-ha-wireguard:
   stage: deploy-part2
   extends: .packet_pr
   when: manual
-  variables:
-    MITOGEN_ENABLE: "true"
 
 packet_debian9-calico-upgrade:
   stage: deploy-part3
@@ -230,7 +221,6 @@ packet_debian9-calico-upgrade:
   when: on_success
   variables:
     UPGRADE_TEST: graceful
-    MITOGEN_ENABLE: "false"
 
 packet_debian9-calico-upgrade-once:
   stage: deploy-part3
@@ -238,7 +228,6 @@ packet_debian9-calico-upgrade-once:
   when: on_success
   variables:
     UPGRADE_TEST: graceful
-    MITOGEN_ENABLE: "false"
 
 packet_ubuntu18-calico-ha-recover:
   stage: deploy-part3

--- a/.gitlab-ci/terraform.yml
+++ b/.gitlab-ci/terraform.yml
@@ -146,10 +146,6 @@ tf-validate-upcloud:
   OS_INTERFACE: public
   OS_IDENTITY_API_VERSION: "3"
   TF_VAR_router_id: "ab95917c-41fb-4881-b507-3a6dfe9403df"
-  # Since ELASTX is in Stockholm, Mitogen helps with latency
-  MITOGEN_ENABLE: "false"
-  # Mitogen doesn't support interpreter discovery yet
-  ANSIBLE_PYTHON_INTERPRETER: "/usr/bin/python3"
 
 tf-elastx_cleanup:
   stage: unit-tests

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 mitogen:
-	ansible-playbook -c local mitogen.yml -vv
+	@echo Mitogen support is deprecated.
+	@echo Please run the following command manually:
+	@echo   ansible-playbook -c local mitogen.yml -vv
 clean:
 	rm -rf dist/
 	rm *.retry

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,7 +3,6 @@ pipelining=True
 ssh_args = -o ControlMaster=auto -o ControlPersist=30m -o ConnectionAttempts=100 -o UserKnownHostsFile=/dev/null
 #control_path = ~/.ssh/ansible-%%r@%%h:%%p
 [defaults]
-strategy_plugins = plugins/mitogen/ansible_mitogen/plugins/strategy
 # https://github.com/ansible/ansible/issues/56930 (to ignore group names with - and .)
 force_valid_group_names = ignore
 

--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -251,7 +251,7 @@ For more information about Ansible and bastion hosts, read
 
 ## Mitogen
 
-You can use [mitogen](/docs/mitogen.md) to speed up kubespray.
+Mitogen support is deprecated, please see [mitogen related docs](/docs/mitogen.md) for useage and reasons for deprecation.
 
 ## Beyond ansible 2.9
 

--- a/docs/mitogen.md
+++ b/docs/mitogen.md
@@ -1,11 +1,28 @@
 # Mitogen
 
+*Warning:* Mitogen support is now deprecated in kubespray due to upstream not releasing an updated version to support ansible 4.x (ansible-base 2.11.x) and above. The CI support has been stripped for mitogen and we are no longer validating any support or regressions for it. The supporting mitogen install playbook and integration documentation will be removed in a later version.
+
 [Mitogen for Ansible](https://mitogen.networkgenomics.com/ansible_detailed.html) allow a 1.25x - 7x speedup and a CPU usage reduction of at least 2x, depending on network conditions, modules executed, and time already spent by targets on useful work. Mitogen cannot improve a module once it is executing, it can only ensure the module executes as quickly as possible.
 
 ## Install
 
 ```ShellSession
 ansible-playbook mitogen.yml
+```
+
+Ensure to enable mitogen use by environment varialbles:
+
+```ShellSession
+export ANSIBLE_STRATEGY=mitogen_linear
+export ANSIBLE_STRATEGY_PLUGINS=plugins/mitogen/ansible_mitogen/plugins/strategy
+```
+
+... or `ansible.cfg` setup:
+
+```ini
+[defaults]
+strategy_plugins = plugins/mitogen/ansible_mitogen/plugins/strategy
+strategy=mitogen_linear
 ```
 
 ## Limitation

--- a/tests/scripts/testcases_run.sh
+++ b/tests/scripts/testcases_run.sh
@@ -50,13 +50,6 @@ test "${UPGRADE_TEST}" != "false" && git fetch --all && git checkout "$KUBESPRAY
 test "${UPGRADE_TEST}" != "false" && git checkout "${CI_BUILD_REF}" tests/files/${CI_JOB_NAME}.yml
 test "${UPGRADE_TEST}" != "false" && git checkout "${CI_BUILD_REF}" ${CI_TEST_REGISTRY_MIRROR}
 
-# Install mitogen ansible plugin
-if [ "${MITOGEN_ENABLE}" = "true" ]; then
-  ansible-playbook ${ANSIBLE_LOG_LEVEL} mitogen.yml
-  export ANSIBLE_STRATEGY=mitogen_linear
-  export ANSIBLE_STRATEGY_PLUGINS=plugins/mitogen/ansible_mitogen/plugins/strategy
-fi
-
 # Create cluster
 ansible-playbook ${ANSIBLE_LOG_LEVEL} -e @${CI_TEST_REGISTRY_MIRROR} -e @${CI_TEST_VARS} -e local_release_dir=${PWD}/downloads --limit "all:!fake_hosts" cluster.yml
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Mitogen upsteam is not seeing any new releases and our continued support for it hinders adoption of newer Ansible versions that would in turn give us support for newer Enterprise Linux versions like Rocky. This PR deprecates the use of mitogen in our CI and explicitly marks it as deprecated in the docs. The install playbook as well as the 3 workarounds are still left in place and I plan to remove them after we tag 2.18.

Related discussion in https://github.com/kubernetes-sigs/kubespray/pull/7887 and https://github.com/kubernetes-sigs/kubespray/issues/8125

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Mitogen: support for the mitogen playbook accelerator is now deprecated in preparation of ansible upgrades, please clean up your playbooks that depend on it.
```
