### PR TITLE
DEBUG: test for debug purposes

### DIFF
--- a/docs/cert_manager.md
+++ b/docs/cert_manager.md
@@ -180,3 +180,6 @@ Certificate:
                 D4:38:B5:E2:26:49:5E:0D:E3:DC:D9:70:73:3B:C4:19:6A:43:4A:F2
                 ...
 ```
+
+
+This is a test of the matrix-ci.

--- a/tests/scripts/md-table/requirements.txt
+++ b/tests/scripts/md-table/requirements.txt
@@ -1,4 +1,4 @@
 pyaml
 jinja2
-pathlib
+pathlib ; python_version < '3.10'
 pydblite


### PR DESCRIPTION
This is a test for matrix-ci failure: https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/1741399593

```
+ pip install -r ./tests/scripts/md-table/requirements.txt
Install requirements...
Collecting pyaml
  Downloading pyaml-21.10.1-py2.py3-none-any.whl (24 kB)
Requirement already satisfied: jinja2 in /usr/local/lib/python3.10/site-packages (from -r ./tests/scripts/md-table/requirements.txt (line 2)) (2.11.3)
Collecting pathlib
  Downloading pathlib-1.0.1.tar.gz (49 kB)
    ERROR: Command errored out with exit status 1:
     command: /usr/local/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-fa9glbu6/pathlib_084dbcc595f44fefaf54afc11d0ab9d0/setup.py'"'"'; __file__='"'"'/tmp/pip-install-fa9glbu6/pathlib_084dbcc595f44fefaf54afc11d0ab9d0/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-vu0323bt
         cwd: /tmp/pip-install-fa9glbu6/pathlib_084dbcc595f44fefaf54afc11d0ab9d0/
    Complete output (13 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/usr/local/lib/python3.10/site-packages/setuptools/__init__.py", line 16, in <module>
        import setuptools.version
      File "/usr/local/lib/python3.10/site-packages/setuptools/version.py", line 1, in <module>
        import pkg_resources
      File "/usr/local/lib/python3.10/site-packages/pkg_resources/__init__.py", line 23, in <module>
        import zipfile
      File "/usr/local/lib/python3.10/zipfile.py", line 19, in <module>
        import pathlib
      File "/tmp/pip-install-fa9glbu6/pathlib_084dbcc595f44fefaf54afc11d0ab9d0/pathlib.py", line 10, in <module>
        from collections import Sequence
    ImportError: cannot import name 'Sequence' from 'collections' (/usr/local/lib/python3.10/collections/__init__.py)
    ----------------------------------------
```

I think upgrading python3.10 in the CI is breaking pathlib dependency.