### PR TITLE
Remove extra parameter kube_proxy_remove

### DIFF
--- a/docs/calico.md
+++ b/docs/calico.md
@@ -295,7 +295,6 @@ To enable the eBPF dataplane support ensure you add the following to your invent
 
 ```yaml
 calico_bpf_enabled: true
-kube_proxy_remove: true
 ```
 
 **NOTE:** there is known incompatibility in using the `kernel-kvm` kernel package on Ubuntu OSes because it is missing support for `CONFIG_NET_SCHED` which is a requirement for Calico eBPF support. When using Calico eBPF with Ubuntu ensure you run the `-generic` kernel.

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -56,16 +56,6 @@
     - kube_network_plugin == 'calico'
     - not ignore_assert_errors
 
-- name: Stop if kube-proxy is enabled when using eBPF dataplane
-  assert:
-    that:
-      - kube_proxy_remove
-    msg: "kube-proxy needs to be disabled when using Calico with eBPF dataplane"
-  when:
-    - calico_bpf_enabled | default(false)
-    - kube_network_plugin == 'calico'
-    - not ignore_assert_errors
-
 - name: Stop if unsupported version of Kubernetes
   assert:
     that: kube_version is version(kube_version_min_required, '>=')

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -32,6 +32,8 @@ kubeadm_init_phases_skip: >-
   {{ kubeadm_init_phases_skip_default }} + [ "addon/kube-proxy" ]
   {%- elif kube_network_plugin == 'cilium' and (cilium_kube_proxy_replacement is defined and cilium_kube_proxy_replacement == 'strict') -%}
   {{ kubeadm_init_phases_skip_default }} + [ "addon/kube-proxy" ]
+  {%- elif kube_network_plugin == 'calico' and (calico_bpf_enabled is defined and calico_bpf_enabled) -%}
+  {{ kubeadm_init_phases_skip_default }} + [ "addon/kube-proxy" ]
   {%- elif kube_proxy_remove is defined and kube_proxy_remove -%}
   {{ kubeadm_init_phases_skip_default }} + [ "addon/kube-proxy" ]
   {%- else -%}

--- a/tests/files/packet_centos8-calico-ha-ebpf.yml
+++ b/tests/files/packet_centos8-calico-ha-ebpf.yml
@@ -9,7 +9,6 @@ kube_network_plugin: calico
 deploy_netchecker: true
 
 calico_bpf_enabled: true
-kube_proxy_remove: true
 loadbalancer_apiserver_localhost: true
 use_localhost_as_kubeapi_loadbalancer: true
 


### PR DESCRIPTION
Signed-off-by: EDGsheryl <edgsheryl@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug
/kind cleanup
/kind documentation

**What this PR does / why we need it**:

I noticed that the runbook failed when I enable the `calico_bpf_enabled`, so I trace the issue, I found that #6512 had removed the kube_proxy_remove, but it still exist in the runbook, so I clean it up.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8149

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
