### PR TITLE
Add vxlanEnabled spec in FelixConfiguration

### DIFF
--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -159,7 +159,8 @@
           "bpfEnabled": {{ calico_bpf_enabled | bool }},
           "bpfExternalServiceMode": "{{ calico_bpf_service_mode }}",
           "wireguardEnabled": {{ calico_wireguard_enabled | bool }},
-          "logSeverityScreen": "{{ calico_felix_log_severity_screen }}" }}
+          "logSeverityScreen": "{{ calico_felix_log_severity_screen }}",
+          "vxlanEnabled": {{ calico_vxlan_mode != 'Never' }} }}
   when:
     - inventory_hostname == groups['kube_control_plane'][0]
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Adding `vxlanEnabled` spec to `FelixConfiguration` CRD.

When using vxlan mode in Calico CNI, the entire Calico network stops working if we upgrade the cluster with the playbook `upgrade-cluster.yml`.

This is because `vxlanEnabled` disappeared  in `FelixConfiguration` CRD spec. The related network settings(network interfaces, routing tables, etc.) are removed together and then the whole Pod network stops working. 

**More details(Why the spec `vxlanEnabled` is removed in `FelixConfiguration` CRD)**

Currently, the spec `vxlanEnabled: true` is not configured in [the task defining FelixConfiguration CRD](https://github.com/kubernetes-sigs/kubespray/blob/58390c79d0f7cd8c92a4c47814453a123481e092/roles/network_plugin/calico/tasks/install.yml#L144-L164)

The reason VXLAN mode works well at the initial installation is that the spec `vxlanEnabled: true` is automatically(or dynamically) added to FelixConfiguration CRD when running [the task configuring Calico network pool](https://github.com/kubernetes-sigs/kubespray/blob/58390c79d0f7cd8c92a4c47814453a123481e092/roles/network_plugin/calico/tasks/install.yml#L166-L185). It seems like [the behavior of `libcalico`]( https://github.com/projectcalico/libcalico-go/blob/45c7e116840b097c330431e94c55eb5c847b596d/lib/clientv3/ippool.go#L572-L574)

However, the task for Calico network pool is not triggered if [the IPPool is already exists](https://github.com/kubernetes-sigs/kubespray/blob/58390c79d0f7cd8c92a4c47814453a123481e092/roles/network_plugin/calico/tasks/install.yml#L185)(i.e. when upgrading cluster).

I added `vxlanEnabled: true` to the `FelixConfiguration` spec template in [the task defining FelixConfiguration CRD](https://github.com/kubernetes-sigs/kubespray/blob/58390c79d0f7cd8c92a4c47814453a123481e092/roles/network_plugin/calico/tasks/install.yml#L144-L164) so that it does not disappear even when the cluster is upgraded.

Reproduce:

Set up a new Kubernetes cluster with the following variables to set VXLAN mode in Calico:
```yaml
calico_network_backend: vxlan
calico_ipip_mode: Never
calico_vxlan_mode: Always
```

After initial installation, we can see "vxlanEnabled: true" in the `felixConfiguration` object. 
```bash
$ kubectl get felixConfiguration default -o yaml
...
spec:
  ...
  ipipEnabled: false
  vxlanEnabled: true  # this spec is removed after running `upgrade-cluster.yml`
  ...
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[Calico] Add vxlanEnabled spec in FelixConfiguration to prevent calico network (when using vxlan) from crashing after upgrading the cluster
```