### PR TITLE
Add possibility of automation creation of Load Balancers on Google Compute Engine

### DIFF
--- a/docs/gcp-lb.md
+++ b/docs/gcp-lb.md
@@ -1,0 +1,16 @@
+# GCP Load Balancers for type=LoadBalacer of Kubernetes Services
+
+Google Cloud Platform can be used for creation of Kubernetes Service Load Balancer.
+
+This feature is able to deliver by adding parameters to kube-controller-manager and kubelet. You need specify:
+
+    --cloud-provider=gce
+    --cloud-config=/etc/kubernetes/cloud-config
+
+To get working it in kubespray, you need to add tag to GCE instances and specify it in kubespray group vars and also set cloud_provider to gce. So for example, in file group_vars/all/gcp.yml:
+
+    cloud_provider: gce
+    gce_node_tags: k8s-lb
+
+When you will setup it and create SVC in Kubernetes with type=LoadBalancer, cloud provider will create public IP and will set firewall.
+Note: Cloud provider run under VM service account, so this account needs to have correct permissions to be able to create all GCP resources.

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta2.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta2.yaml.j2
@@ -197,7 +197,7 @@ apiServer:
 {% if kube_feature_gates %}
     feature-gates: {{ kube_feature_gates|join(',') }}
 {% endif %}
-{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws"] %}
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws", "gce"] %}
     cloud-provider: {{ cloud_provider }}
     cloud-config: {{ kube_config_dir }}/cloud_config
 {% endif %}
@@ -214,9 +214,9 @@ apiServer:
 {% if kubelet_rotate_server_certificates %}
     kubelet-certificate-authority: {{ kube_cert_dir }}/ca.crt
 {% endif %}
-{% if kubernetes_audit or kube_token_auth|default(true) or kube_webhook_token_auth|default(false) or ( cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws"] ) or apiserver_extra_volumes or ssl_ca_dirs|length %}
+{% if kubernetes_audit or kube_token_auth|default(true) or kube_webhook_token_auth|default(false) or ( cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws", "gce"] ) or apiserver_extra_volumes or ssl_ca_dirs|length %}
   extraVolumes:
-{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws"] %}
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws", "gce"] %}
   - name: cloud-config
     hostPath: {{ kube_config_dir }}/cloud_config
     mountPath: {{ kube_config_dir }}/cloud_config
@@ -290,7 +290,7 @@ controllerManager:
 {% for key in kube_kubeadm_controller_extra_args %}
     {{ key }}: "{{ kube_kubeadm_controller_extra_args[key] }}"
 {% endfor %}
-{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws"] %}
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws", "gce"] %}
     cloud-provider: {{ cloud_provider }}
     cloud-config: {{ kube_config_dir }}/cloud_config
 {% endif %}
@@ -307,14 +307,14 @@ controllerManager:
     tls-cipher-suites: {% for tls in tls_cipher_suites %}{{ tls }}{{ "," if not loop.last else "" }}{% endfor %}
 
 {% endif %}
-{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws"] or controller_manager_extra_volumes %}
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws", "gce"] or controller_manager_extra_volumes %}
   extraVolumes:
 {% if cloud_provider is defined and cloud_provider in ["openstack"] and openstack_cacert is defined %}
   - name: openstackcacert
     hostPath: "{{ kube_config_dir }}/openstack-cacert.pem"
     mountPath: "{{ kube_config_dir }}/openstack-cacert.pem"
 {% endif %}
-{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws"] %}
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws", "gce"] %}
   - name: cloud-config
     hostPath: {{ kube_config_dir }}/cloud_config
     mountPath: {{ kube_config_dir }}/cloud_config

--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -173,7 +173,7 @@
     mode: 0640
   when:
     - cloud_provider is defined
-    - cloud_provider in [ 'openstack', 'azure', 'vsphere', 'aws' ]
+    - cloud_provider in [ 'openstack', 'azure', 'vsphere', 'aws', 'gce' ]
   notify: Node | restart kubelet
   tags:
     - cloud-provider

--- a/roles/kubernetes/node/templates/cloud-configs/gce-cloud-config.j2
+++ b/roles/kubernetes/node/templates/cloud-configs/gce-cloud-config.j2
@@ -1,0 +1,3 @@
+[global]
+node-tags = {{ gce_node_tags }} 
+

--- a/roles/kubernetes/node/templates/kubelet.env.v1beta1.j2
+++ b/roles/kubernetes/node/templates/kubelet.env.v1beta1.j2
@@ -43,7 +43,7 @@ KUBELET_NETWORK_PLUGIN="--network-plugin=cni --cni-conf-dir=/etc/cni/net.d --cni
 {% elif kube_network_plugin is defined and kube_network_plugin == "cloud" %}
 KUBELET_NETWORK_PLUGIN="--hairpin-mode=promiscuous-bridge --network-plugin=kubenet"
 {% endif %}
-{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws", "external"] %}
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws", "gce", "external"] %}
 KUBELET_CLOUDPROVIDER="--cloud-provider={{ cloud_provider }} --cloud-config={{ kube_config_dir }}/cloud_config"
 {% else %}
 KUBELET_CLOUDPROVIDER=""


### PR DESCRIPTION
What this PR does / why we need it: adding cloud_provider: gce (Google Cloud Platform's Google Compute Engine) to possible cloud providers to get working Load Balancers creation.
 
/kind feature

Fixes #8169 
