### PR TITLE
[2.17] fix imageRepository path for CoreDNS v1.8.0 #8182

### DIFF
--- a/roles/download/templates/kubeadm-images.yaml.j2
+++ b/roles/download/templates/kubeadm-images.yaml.j2
@@ -21,5 +21,5 @@ etcd:
 {% endif %}
 dns:
   type: CoreDNS
-  imageRepository: {{ coredns_image_repo | regex_replace('/coredns.*$','') }}
+  imageRepository: {{ coredns_image_repo | regex_replace('/coredns$','') }}
   imageTag: {{ coredns_image_tag }}


### PR DESCRIPTION
Thanks to the fix, I can now deploy the Kubernetes cluster as kubeadm can download the coredns image.
Resulting `/etc/kubernetes/kubeadm-images.yaml`:
```
apiVersion: kubeadm.k8s.io/v1beta2
kind: InitConfiguration
nodeRegistration:
  criSocket: /var/run/containerd/containerd.sock
---
apiVersion: kubeadm.k8s.io/v1beta2
kind: ClusterConfiguration
imageRepository: k8s.gcr.io
kubernetesVersion: v1.21.6
etcd:
  local:
    imageRepository: "quay.io/coreos"
    imageTag: "v3.4.13"
dns:
  type: CoreDNS
  imageRepository: k8s.gcr.io/coredns
  imageTag: v1.8.0
```