### PR TITLE
Enable experimental modules when rpm-ostree version >= 2021.9

### DIFF
--- a/roles/container-engine/cri-o/tasks/crio_repo.yml
+++ b/roles/container-engine/cri-o/tasks/crio_repo.yml
@@ -149,6 +149,13 @@
     - repo: "fedora-modular"
       section: "fedora-modular"
 
+- name: Enable CRI-O ex module
+  command: "rpm-ostree ex module enable cri-o:{{ crio_version }}"
+  become: true
+  when:
+    - is_ostree
+    - ostree_version is version('2021.9', '>=')
+
 - name: Enable CRI-O module
   command: "dnf -y module enable cri-o:{{ crio_version }}"
   args:

--- a/roles/container-engine/cri-o/tasks/crio_repo.yml
+++ b/roles/container-engine/cri-o/tasks/crio_repo.yml
@@ -154,7 +154,7 @@
   become: true
   when:
     - is_ostree
-    - ostree_version is version('2021.9', '>=')
+    - ostree_version is defined and ostree_version.stdout is version('2021.9', '>=')
 
 - name: Enable CRI-O module
   command: "dnf -y module enable cri-o:{{ crio_version }}"

--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -12,19 +12,11 @@
     is_ostree: "{{ ostree.stat.exists }}"
 
 - name: get ostree version
-  shell: "set -o pipefail && rpm-ostree --version |grep 'Version:' |awk '{print $2}'| sed \"s/'//g\" "
+  shell: "set -o pipefail && rpm-ostree --version | awk -F\\' '/Version/{print $2}'"
   args:
     executable: /bin/bash
-  register: ostree_version_on_server
+  register: ostree_version
   when: is_ostree
-
-- name: set ostree version
-  set_fact:
-    ostree_version: "{{ ostree_version_on_server.stdout }}"
-  when:
-    - is_ostree
-    - 'ostree_version_on_server.stdout is defined'
-    - ostree_version_on_server.stdout
 
 - name: gather os specific variables
   include_vars: "{{ item }}"

--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -11,6 +11,21 @@
   set_fact:
     is_ostree: "{{ ostree.stat.exists }}"
 
+- name: get ostree version
+  shell: "set -o pipefail && rpm-ostree --version |grep 'Version:' |awk '{print $2}'| sed \"s/'//g\" "
+  args:
+    executable: /bin/bash
+  register: ostree_version_on_server
+  when: is_ostree
+
+- name: set ostree version
+  set_fact:
+    ostree_version: "{{ ostree_version_on_server.stdout }}"
+  when:
+    - is_ostree
+    - 'ostree_version_on_server.stdout is defined'
+    - ostree_version_on_server.stdout
+
 - name: gather os specific variables
   include_vars: "{{ item }}"
   with_first_found:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

rpm-ostree provides experimental support for modules since version 2021.9, so we should use command `rpm-ostree ex module enable ` to enable the cri-o stream first and then install from that stream.

refer: https://discussion.fedoraproject.org/t/cri-o-no-longer-available-through-rpm-ostree/33908

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8197

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[cri-o] Enable experimental modules when rpm-ostree version >= 2021.9
```
