### PR TITLE
Fix kubespray flatcar ansible_os_family and ansible_distribution

### DIFF
--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -57,7 +57,7 @@
     name: "{{ inventory_hostname }}"
   when:
     - override_system_hostname
-    - ansible_os_family not in ['Suse', 'Flatcar Container Linux by Kinvolk', 'ClearLinux'] and not is_fedora_coreos
+    - ansible_os_family not in ['Suse', 'Flatcar', 'Flatcar Container Linux by Kinvolk', 'ClearLinux'] and not is_fedora_coreos
 
 # (2/3)
 - name: Assign inventory name to unconfigured hostnames (CoreOS, Flatcar, Suse and ClearLinux only)
@@ -67,7 +67,7 @@
   changed_when: false
   when:
     - override_system_hostname
-    - ansible_os_family in ['Suse', 'Flatcar Container Linux by Kinvolk', 'ClearLinux'] or is_fedora_coreos
+    - ansible_os_family in ['Suse', 'Flatcar', 'Flatcar Container Linux by Kinvolk', 'ClearLinux'] or is_fedora_coreos
 
 # (3/3)
 - name: Update hostname fact (CoreOS, Flatcar, Suse and ClearLinux only)
@@ -76,7 +76,7 @@
     filter: ansible_hostname
   when:
     - override_system_hostname
-    - ansible_os_family in ['Suse', 'Flatcar Container Linux by Kinvolk', 'ClearLinux'] or is_fedora_coreos
+    - ansible_os_family in ['Suse', 'Flatcar', 'Flatcar Container Linux by Kinvolk', 'ClearLinux'] or is_fedora_coreos
 
 - name: "Install ceph-commmon package"
   package:

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -15,7 +15,7 @@
   fail:
     msg: "{{ ansible_distribution }} is not supported by containerd."
   when:
-    - not ansible_distribution in ["CentOS", "OracleLinux", "RedHat", "Ubuntu", "Debian", "Fedora", "AlmaLinux", "Amazon", "Flatcar Container Linux by Kinvolk"]
+    - not ansible_distribution in ["CentOS", "OracleLinux", "RedHat", "Ubuntu", "Debian", "Fedora", "AlmaLinux", "Amazon", "Flatcar", "Flatcar Container Linux by Kinvolk"]
 
 - name: gather os specific variables
   include_vars: "{{ item }}"
@@ -53,7 +53,7 @@
     - not is_ostree
 
 - include_tasks: containerd_repo.yml
-  when: not (is_ostree or (ansible_distribution == "Flatcar Container Linux by Kinvolk"))
+  when: not (is_ostree or (ansible_distribution == "Flatcar Container Linux by Kinvolk") or (ansible_distribution == "Flatcar"))
 
 - name: Create containerd service systemd directory if it doesn't exist
   file:
@@ -116,7 +116,7 @@
   delay: "{{ retry_stagger | d(3) }}"
   notify: restart containerd
   when:
-    - not (is_ostree or (ansible_distribution == "Flatcar Container Linux by Kinvolk"))
+    - not (is_ostree or (ansible_distribution == "Flatcar Container Linux by Kinvolk") or (ansible_distribution == "Flatcar"))
     - containerd_package_info.pkgs|length > 0
 
 - include_role:  # noqa unnamed-task

--- a/roles/container-engine/docker/handlers/main.yml
+++ b/roles/container-engine/docker/handlers/main.yml
@@ -15,7 +15,7 @@
   service:
     name: docker.socket
     state: restarted
-  when: ansible_os_family in ['Flatcar Container Linux by Kinvolk'] or is_fedora_coreos
+  when: ansible_os_family in ['Flatcar', 'Flatcar Container Linux by Kinvolk'] or is_fedora_coreos
 
 - name: Docker | reload docker
   service:

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -123,7 +123,7 @@
   delay: "{{ retry_stagger | d(3) }}"
   notify: restart docker
   when:
-    - not ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
+    - not ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
     - not is_ostree
     - docker_package_info.pkgs|length > 0
 

--- a/roles/container-engine/docker/tasks/systemd.yml
+++ b/roles/container-engine/docker/tasks/systemd.yml
@@ -31,7 +31,7 @@
   register: docker_service_file
   notify: restart docker
   when:
-    - not ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
+    - not ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
     - not is_fedora_coreos
 
 - name: Write docker options systemd drop-in

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -1111,7 +1111,7 @@ downloads:
     - k8s_cluster
 
   install_socat:
-    enabled: "{{ ansible_os_family in ['Flatcar Container Linux by Kinvolk'] }}"
+    enabled: "{{ ansible_os_family in ['Flatcar', 'Flatcar Container Linux by Kinvolk'] }}"
     container: true
     repo: "{{ install_socat_image_repo }}"
     tag: "{{ install_socat_image_tag }}"

--- a/roles/download/tasks/prep_download.yml
+++ b/roles/download/tasks/prep_download.yml
@@ -99,7 +99,7 @@
     mode: 0755
     owner: "{{ ansible_ssh_user | default(ansible_user_id) }}"
   when:
-    - ansible_os_family not in ["Flatcar Container Linux by Kinvolk"]
+    - ansible_os_family not in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
 
 - name: prep_download | Create local cache for files and images on control node
   file:

--- a/roles/etcd/meta/main.yml
+++ b/roles/etcd/meta/main.yml
@@ -2,7 +2,7 @@
 dependencies:
   - role: adduser
     user: "{{ addusers.etcd }}"
-    when: not (ansible_os_family in ["Flatcar Container Linux by Kinvolk", "ClearLinux"] or is_fedora_coreos)
+    when: not (ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk", "ClearLinux"] or is_fedora_coreos)
   - role: adduser
     user: "{{ addusers.kube }}"
-    when: not (ansible_os_family in ["Flatcar Container Linux by Kinvolk", "ClearLinux"] or is_fedora_coreos)
+    when: not (ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk", "ClearLinux"] or is_fedora_coreos)

--- a/roles/etcd/tasks/upd_ca_trust.yml
+++ b/roles/etcd/tasks/upd_ca_trust.yml
@@ -6,7 +6,7 @@
       /usr/local/share/ca-certificates/etcd-ca.crt
       {%- elif ansible_os_family == "RedHat" -%}
       /etc/pki/ca-trust/source/anchors/etcd-ca.crt
-      {%- elif ansible_os_family in ["Flatcar Container Linux by Kinvolk"] -%}
+      {%- elif ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"] -%}
       /etc/ssl/certs/etcd-ca.pem
       {%- elif ansible_os_family == "Suse" -%}
       /etc/pki/trust/anchors/etcd-ca.pem
@@ -26,7 +26,7 @@
 
 - name: Gen_certs | update ca-certificates (Debian/Ubuntu/SUSE/Flatcar)  # noqa 503
   command: update-ca-certificates
-  when: etcd_ca_cert.changed and ansible_os_family in ["Debian", "Flatcar Container Linux by Kinvolk", "Suse"]
+  when: etcd_ca_cert.changed and ansible_os_family in ["Debian", "Flatcar", "Flatcar Container Linux by Kinvolk", "Suse"]
 
 - name: Gen_certs | update ca-certificates (RedHat)  # noqa 503
   command: update-ca-trust extract

--- a/roles/kubernetes/node/tasks/install.yml
+++ b/roles/kubernetes/node/tasks/install.yml
@@ -26,7 +26,7 @@
   args:
     creates: "{{ bin_dir }}/socat"
   when:
-    - ansible_os_family in ['Flatcar Container Linux by Kinvolk']
+    - ansible_os_family in ['Flatcar', 'Flatcar Container Linux by Kinvolk']
     - container_manager == "docker"
 
 - name: install | Copy socat wrapper for Container Linux with Containerd
@@ -34,7 +34,7 @@
   args:
     creates: "{{ bin_dir }}/socat"
   when:
-    - ansible_os_family in ['Flatcar Container Linux by Kinvolk']
+    - ansible_os_family in ['Flatcar', 'Flatcar Container Linux by Kinvolk']
     - container_manager == "containerd"
 
 - name: install | Copy socat wrapper for Container Linux with crio
@@ -42,5 +42,5 @@
   args:
     creates: "{{ bin_dir }}/socat"
   when:
-    - ansible_os_family in ['Flatcar Container Linux by Kinvolk']
+    - ansible_os_family in ['Flatcar', 'Flatcar Container Linux by Kinvolk']
     - container_manager == "crio"

--- a/roles/kubernetes/preinstall/handlers/main.yml
+++ b/roles/kubernetes/preinstall/handlers/main.yml
@@ -9,18 +9,18 @@
     - Preinstall | restart kube-controller-manager crio/containerd
     - Preinstall | restart kube-apiserver docker
     - Preinstall | restart kube-apiserver crio/containerd
-  when: not ansible_os_family in ["Flatcar Container Linux by Kinvolk"] and not is_fedora_coreos
+  when: not ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"] and not is_fedora_coreos
 
 - name: Preinstall | update resolvconf for Flatcar Container Linux by Kinvolk
   command: /bin/true
   notify:
     - Preinstall | apply resolvconf cloud-init
     - Preinstall | reload kubelet
-  when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
+  when: ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
 
 - name: Preinstall | apply resolvconf cloud-init
   command: /usr/bin/coreos-cloudinit --from-file {{ resolveconf_cloud_init_conf }}
-  when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
+  when: ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
 
 - name: Preinstall | update resolvconf for Fedora CoreOS
   command: /bin/true

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -24,7 +24,7 @@
 
 - name: Stop if unknown OS
   assert:
-    that: ansible_distribution in ['RedHat', 'CentOS', 'Fedora', 'Ubuntu', 'Debian', 'Flatcar Container Linux by Kinvolk', 'Suse', 'openSUSE Leap', 'ClearLinux', 'OracleLinux', 'AlmaLinux', 'Amazon']
+    that: ansible_distribution in ['RedHat', 'CentOS', 'Fedora', 'Ubuntu', 'Debian', 'Flatcar', 'Flatcar Container Linux by Kinvolk', 'Suse', 'openSUSE Leap', 'ClearLinux', 'OracleLinux', 'AlmaLinux', 'Amazon']
     msg: "{{ ansible_distribution }} is not a known OS"
   when: not ignore_assert_errors
 
@@ -337,7 +337,7 @@
 
 - name: Stop if download_localhost is enabled for Flatcar Container Linux
   assert:
-    that: ansible_os_family not in ["Flatcar Container Linux by Kinvolk"]
+    that: ansible_os_family not in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
     msg: "download_run_once not supported for Flatcar Container Linux"
   when: download_run_once or download_force_cache
 

--- a/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
@@ -2,7 +2,7 @@
 - name: Force binaries directory for Flatcar Container Linux by Kinvolk
   set_fact:
     bin_dir: "/opt/bin"
-  when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
+  when: ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
   tags:
     - facts
 
@@ -75,12 +75,12 @@
       {%- if resolvconf|bool -%}/etc/resolvconf/resolv.conf.d/base{%- endif -%}
     head: >-
       {%- if resolvconf|bool -%}/etc/resolvconf/resolv.conf.d/head{%- endif -%}
-  when: not ansible_os_family in ["Flatcar Container Linux by Kinvolk"] and not is_fedora_coreos
+  when: not ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"] and not is_fedora_coreos
 
 - name: target temporary resolvconf cloud init file (Flatcar Container Linux by Kinvolk / Fedora CoreOS)
   set_fact:
     resolvconffile: /tmp/resolveconf_cloud_init_conf
-  when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"] or is_fedora_coreos
+  when: ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"] or is_fedora_coreos
 
 - name: check if /etc/dhclient.conf exists
   stat:

--- a/roles/kubernetes/preinstall/tasks/0060-resolvconf.yml
+++ b/roles/kubernetes/preinstall/tasks/0060-resolvconf.yml
@@ -1,7 +1,7 @@
 ---
 - name: create temporary resolveconf cloud init file
   command: cp -f /etc/resolv.conf "{{ resolvconffile }}"
-  when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
+  when: ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
 
 - name: Add domain/search/nameservers/options to resolv.conf
   blockinfile:
@@ -46,7 +46,7 @@
 - name: get temporary resolveconf cloud init file content
   command: cat {{ resolvconffile }}
   register: cloud_config
-  when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
+  when: ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
 
 - name: persist resolvconf cloud init file
   template:
@@ -55,4 +55,4 @@
     owner: root
     mode: 0644
   notify: Preinstall | update resolvconf for Flatcar Container Linux by Kinvolk
-  when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
+  when: ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]

--- a/roles/kubernetes/preinstall/tasks/0070-system-packages.yml
+++ b/roles/kubernetes/preinstall/tasks/0070-system-packages.yml
@@ -63,7 +63,7 @@
   until: pkgs_task_result is succeeded
   retries: "{{ pkg_install_retries }}"
   delay: "{{ retry_stagger | random + 3 }}"
-  when: not (ansible_os_family in ["Flatcar Container Linux by Kinvolk", "ClearLinux"] or is_fedora_coreos)
+  when: not (ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk", "ClearLinux"] or is_fedora_coreos)
   tags:
     - bootstrap-os
 

--- a/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
+++ b/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
@@ -33,7 +33,7 @@
     mode: 0644
   when:
     - disable_ipv6_dns
-    - not ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
+    - not ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
   tags:
     - bootstrap-os
 

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -75,7 +75,7 @@
   when:
     - dns_mode != 'none'
     - resolvconf_mode == 'host_resolvconf'
-    - not ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
+    - not ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
   tags:
     - bootstrap-os
     - resolvconf
@@ -84,7 +84,7 @@
   when:
     - dns_mode != 'none'
     - resolvconf_mode != 'host_resolvconf'
-    - not ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
+    - not ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
   tags:
     - bootstrap-os
     - resolvconf

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -458,7 +458,7 @@ weave_password: EnterPasswordHere
 
 ssl_ca_dirs: |-
   [
-  {% if ansible_os_family in ['Flatcar Container Linux by Kinvolk'] -%}
+  {% if ansible_os_family in ['Flatcar', 'Flatcar Container Linux by Kinvolk'] -%}
   '/usr/share/ca-certificates',
   {% elif ansible_os_family == 'RedHat' -%}
   '/etc/pki/tls',

--- a/roles/network_plugin/macvlan/handlers/main.yml
+++ b/roles/network_plugin/macvlan/handlers/main.yml
@@ -3,7 +3,7 @@
   command: /bin/true
   notify:
     - Macvlan | reload network
-  when: not ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
+  when: not ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
 
 - name: Macvlan | reload network
   service:
@@ -16,4 +16,4 @@
       networking
       {%- endif %}
     state: restarted
-  when: not ansible_os_family in ["Flatcar Container Linux by Kinvolk"] and kube_network_plugin not in ['canal', 'calico']
+  when: not ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"] and kube_network_plugin not in ['canal', 'calico']

--- a/roles/network_plugin/macvlan/tasks/main.yml
+++ b/roles/network_plugin/macvlan/tasks/main.yml
@@ -61,14 +61,14 @@
   template:
     src: coreos-service-nat_ouside.j2
     dest: /etc/systemd/system/enable_nat_ouside.service
-  when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"] and enable_nat_default_gateway
+  when: ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"] and enable_nat_default_gateway
 
 - name: Macvlan | Enable service nat via gateway on Flatcar Container Linux
   command: "{{ item }}"
   with_items:
     - systemctl daemon-reload
     - systemctl enable enable_nat_ouside.service
-  when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"] and enable_nat_default_gateway
+  when: ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"] and enable_nat_default_gateway
 
 - name: Macvlan | Install network gateway interface on Flatcar Container Linux
   template:
@@ -79,7 +79,7 @@
     - {src: coreos-interface-macvlan.cfg, dst: output.network }
     - {src: coreos-network-macvlan.cfg, dst: macvlan.network }
   notify: Macvlan | restart network
-  when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
+  when: ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
 
 - name: Macvlan | Install cni definition for Macvlan
   template:

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -355,7 +355,7 @@
       {%- endif %}
     state: restarted
   when:
-    - ansible_os_family not in ["Flatcar Container Linux by Kinvolk"]
+    - ansible_os_family not in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
     - reset_restart_network
   tags:
     - services

--- a/tests/testcases/015_check-nodes-ready.yml
+++ b/tests/testcases/015_check-nodes-ready.yml
@@ -5,12 +5,12 @@
   - name: Force binaries directory for Flatcar Container Linux by Kinvolk
     set_fact:
       bin_dir: "/opt/bin"
-    when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
+    when: ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
 
   - name: Force binaries directory for other hosts
     set_fact:
       bin_dir: "/usr/local/bin"
-    when: not ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
+    when: not ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
 
   - import_role:  # noqa unnamed-task
       name: cluster-dump

--- a/tests/testcases/020_check-pods-running.yml
+++ b/tests/testcases/020_check-pods-running.yml
@@ -5,12 +5,12 @@
   - name: Force binaries directory for Flatcar Container Linux by Kinvolk
     set_fact:
       bin_dir: "/opt/bin"
-    when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
+    when: ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
 
   - name: Force binaries directory for other hosts
     set_fact:
       bin_dir: "/usr/local/bin"
-    when: not ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
+    when: not ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
 
   - import_role:  # noqa unnamed-task
       name: cluster-dump

--- a/tests/testcases/030_check-network.yml
+++ b/tests/testcases/030_check-network.yml
@@ -8,12 +8,12 @@
   - name: Force binaries directory for Flatcar Container Linux by Kinvolk
     set_fact:
       bin_dir: "/opt/bin"
-    when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
+    when: ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
 
   - name: Force binaries directory for other hosts
     set_fact:
       bin_dir: "/usr/local/bin"
-    when: not ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
+    when: not ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
 
   - name: Approve kubelet serving certificates
     block:

--- a/tests/testcases/040_check-network-adv.yml
+++ b/tests/testcases/040_check-network-adv.yml
@@ -19,12 +19,12 @@
     - name: Force binaries directory for Container Linux by CoreOS and Flatcar
       set_fact:
         bin_dir: "/opt/bin"
-      when: ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
+      when: ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
 
     - name: Force binaries directory on other hosts
       set_fact:
         bin_dir: "/usr/local/bin"
-      when: not ansible_os_family in ["Flatcar Container Linux by Kinvolk"]
+      when: not ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
 
     - import_role:  # noqa unnamed-task
         name: cluster-dump


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Compatibility with all flatcar verions as `ansible_os_family` and `ansible_distribution` are set to Flatcar instead of to Flatcar Container Linux by Kinvolk for several versions

**Which issue(s) this PR fixes**:
Fixes #8028

**Special notes for your reviewer**:
This commit was already merged into master (https://github.com/kubernetes-sigs/kubespray/pull/8029) on 2021-10-01 but did not show up in v2.17.1 released on 2021-11-02.