### PR TITLE
CI: use images from quay.io to prevent being throttled by docker hub

### DIFF
--- a/roles/container-engine/docker/molecule/default/tests/test_default.py
+++ b/roles/container-engine/docker/molecule/default/tests/test_default.py
@@ -14,6 +14,6 @@ def test_docker_service(host):
 
 def test_docker_run(host):
     with host.sudo():
-        cmd = host.command("docker run hello-world")
+        cmd = host.command("docker run quay.io/kubespray/hello-world:latest")
     assert cmd.rc == 0
-    assert "Hello from Docker!" in cmd.stdout
+    assert "Hello from Docker" in cmd.stdout

--- a/roles/container-engine/gvisor/molecule/default/files/container.json
+++ b/roles/container-engine/gvisor/molecule/default/files/container.json
@@ -3,7 +3,7 @@
     "name": "gvisor1"
   },
   "image": {
-    "image": "docker.io/library/hello-world:latest"
+    "image": "quay.io/kubespray/hello-world:latest"
   },
   "log_path": "gvisor1.0.log",
   "linux": {}

--- a/roles/container-engine/gvisor/molecule/default/tests/test_default.py
+++ b/roles/container-engine/gvisor/molecule/default/tests/test_default.py
@@ -26,4 +26,4 @@ def test_run_pod(host):
       log_f = host.file("/tmp/gvisor1.0.log")
 
       assert log_f.exists
-      assert b"Hello from Docker!" in log_f.content
+      assert b"Hello from Docker" in log_f.content

--- a/roles/container-engine/kata-containers/molecule/default/files/container.json
+++ b/roles/container-engine/kata-containers/molecule/default/files/container.json
@@ -3,7 +3,7 @@
     "name": "kata1"
   },
   "image": {
-    "image": "docker.io/library/hello-world:latest"
+    "image": "quay.io/kubespray/hello-world:latest"
   },
   "log_path": "kata1.0.log",
   "linux": {}

--- a/roles/container-engine/kata-containers/molecule/default/tests/test_default.py
+++ b/roles/container-engine/kata-containers/molecule/default/tests/test_default.py
@@ -34,4 +34,4 @@ def test_run_pod(host):
       log_f = host.file("/tmp/kata1.0.log")
 
       assert log_f.exists
-      assert b"Hello from Docker!" in log_f.content
+      assert b"Hello from Docker" in log_f.content

--- a/tests/common/_docker_hub_registry_mirror.yml
+++ b/tests/common/_docker_hub_registry_mirror.yml
@@ -20,3 +20,6 @@ crio_registries_mirrors:
     mirrors:
       - location: mirror.gcr.io
         insecure: false
+
+netcheck_agent_image_repo: "{{ quay_image_repo }}/kubespray/k8s-netchecker-agent"
+netcheck_server_image_repo: "{{ quay_image_repo }}/kubespray/k8s-netchecker-server"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:
This PR uses specific images in CI for netchecker and hello-world that are cached on quay.io to prevent tripping the docker hub rate limit and wasting valuable CI hours.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
