### PR TITLE
[2.17] Fix-CI: python was upgraded in CI to 3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ netaddr==0.7.19
 pbr==5.4.4
 jmespath==0.9.5
 ruamel.yaml==0.16.10
-ruamel.yaml.clib==0.2.2
+ruamel.yaml.clib==0.2.4
 MarkupSafe==1.1.1

--- a/tests/scripts/md-table/requirements.txt
+++ b/tests/scripts/md-table/requirements.txt
@@ -1,4 +1,4 @@
 pyaml
 jinja2
-pathlib
+pathlib ; python_version < '3.10'
 pydblite


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

This is a cherry-pick of both 2ed211ba15271071eb186625bdca25fb5fcb8b65 and 145267a66d02875c100024a33197fd2ff9bb8055 to fix Kubespray CI of release-2.17 branch.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
