### PR TITLE
Fix debian 9 check for apt cache update

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-debian.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-debian.yml
@@ -56,10 +56,7 @@
   become: true
   when:
     - '''ID=debian'' in os_release.stdout_lines'
-    - (
-        '''VERSION="10'' in os_release.stdout_lines' or
-        '''VERSION="11'' in os_release.stdout_lines'
-      )
+    - '''VERSION_ID="10"'' in os_release.stdout_lines or ''VERSION_ID="11"'' in os_release.stdout_lines'
   register: bootstrap_update_apt_result
   changed_when:
     - '"changed its" in bootstrap_update_apt_result.stdout'


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Debian 9 check is not working for apt cache check

**Which issue(s) this PR fixes**:
```
Friday 19 November 2021  14:29:38 +0000 (0:00:00.085)       0:00:04.995 ******* 
[WARNING]: raw module does not support the environment keyword
[WARNING]: raw module does not support the environment keyword
fatal: [instance-2]: FAILED! => {"changed": false, "msg": "non-zero return code", "rc": 100, "stderr": "Shared connection to 172.30.72.93 closed.\r\n", "stderr_lines": ["Shared connection to 172.30.72.93 closed."], "stdout": "E: Command line option --allow-releaseinfo-change is not understood in combination with the other options\r\n", "stdout_lines": ["E: Command line option --allow-releaseinfo-change is not understood in combination with the other options"]}
...ignoring
fatal: [instance-1]: FAILED! => {"changed": false, "msg": "non-zero return code", "rc": 100, "stderr": "Shared connection to 172.30.72.92 closed.\r\n", "stderr_lines": ["Shared connection to 172.30.72.92 closed."], "stdout": "E: Command line option --allow-releaseinfo-change is not understood in combination with the other options\r\n", "stdout_lines": ["E: Command line option --allow-releaseinfo-change is not understood in combination with the other options"]}
...ignoring
```

**Special notes for your reviewer**:
Check https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/1801186554 (line 8149)

**Does this PR introduce a user-facing change?**:
```release-note
Fix debian 9 check for apt cache update in bootstrap-os
```
