### PR TITLE
DeprecationWarning occurs when indentfirst=None is specified in coredns-config.yml.j2

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -65,5 +65,5 @@ data:
     }
 {% if dns_etchosts | default(None) %}
   hosts: |
-    {{ dns_etchosts | indent(width=4, indentfirst=None) }}
+    {{ dns_etchosts | indent(width=4, first=False) }}
 {% endif %}

--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2
@@ -163,5 +163,5 @@ data:
 {% endif %}
 {% if dns_etchosts | default(None) %}
   hosts: |
-    {{ dns_etchosts | indent(width=4, indentfirst=None) }}
+    {{ dns_etchosts | indent(width=4, first=False) }}
 {% endif %}

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
@@ -879,7 +879,7 @@ spec:
 apiVersion: v1
 data:
   internal-ca.pem: |
-    {{ cert_manager_trusted_internal_ca | indent(width=4, indentfirst=False) }}
+    {{ cert_manager_trusted_internal_ca | indent(width=4, first=False) }}
 kind: ConfigMap
 metadata:
   name: ca-internal-truststore


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
It's better to specify it with `first=False` for backward compatibility.
https://github.com/kubernetes-sigs/kubespray/blob/master/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2#L68

#### jinja2: do_indent
- jinja2 v2.11.x: `indentfirst=None` is warnings. 
https://github.com/pallets/jinja/blob/2.11.x/src/jinja2/filters.py#L620
```python
def do_indent(s, width=4, first=False, blank=False, indentfirst=None):
    if indentfirst is not None:
        warnings.warn(
            "The 'indentfirst' argument is renamed to 'first' and will"
            " be removed in version 3.0.",
            DeprecationWarning,
            stacklevel=2,
        )
        first = indentfirst
```

- jinja2 v3.0.x: `indentfirst=None` is Error. It should be specified with `first=False`.
https://github.com/pallets/jinja/blob/3.0.x/src/jinja2/filters.py#L808
```python
def do_indent(
    s: str, width: t.Union[int, str] = 4, first: bool = False, blank: bool = False
) -> str:
~~~
```

#### kubespray  requirements.txt
kubespray release-2.17: 
requirements.txt
```txt
~~~
jinja2==2.11.3
~~~
```
https://github.com/kubernetes-sigs/kubespray/blob/release-2.17/requirements.txt

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8223

**Special notes for your reviewer**: 
These fixes are untested.
I would like some advice on how to test if possible.

**Does this PR introduce a user-facing change?**: NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
