### PR TITLE
Reduce calico bird route removal time to improving Kubernetes node removal performance

### DIFF
--- a/roles/network_plugin/calico/tasks/reset.yml
+++ b/roles/network_plugin/calico/tasks/reset.yml
@@ -11,13 +11,6 @@
   command: ip link del dummy0
   when: dummy0.stat.exists
 
-- name: reset | get remaining routes set by bird
-  command: ip route show proto bird
+- name: reset | get and remove remaining routes set by bird
+  shell: ip route show proto bird | xargs -i bash -c "ip route del {} proto bird "
   changed_when: false
-  register: bird_routes
-
-- name: reset | remove remaining routes set by bird  # noqa 301
-  command: "ip route del {{ bird_route }} proto bird"
-  with_items: "{{ bird_routes.stdout_lines }}"
-  loop_control:
-    loop_var: bird_route


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

As part of Kubernetes node removal, calico bird route cleanup on large clusters(3000+ pods running) takes 45+ minutes. This PR reduces the reset playbook runtime to less than one minute.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # [8116](https://github.com/kubernetes-sigs/kubespray/issues/8116)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[Calico] Reduced calico bird route removal time on large clusters to less than one minute improving Kubernetes node removal performance
```
