### PR TITLE
Registry add TLS and authentication support

### DIFF
--- a/roles/kubernetes-apps/registry/defaults/main.yml
+++ b/roles/kubernetes-apps/registry/defaults/main.yml
@@ -5,3 +5,5 @@ registry_storage_access_mode: "ReadWriteOnce"
 registry_disk_size: "10Gi"
 registry_port: 5000
 registry_replica_count: 1
+# name of kubernetes secret for registry TLS certs
+registry_tls_secret: ""

--- a/roles/kubernetes-apps/registry/defaults/main.yml
+++ b/roles/kubernetes-apps/registry/defaults/main.yml
@@ -7,3 +7,25 @@ registry_port: 5000
 registry_replica_count: 1
 # name of kubernetes secret for registry TLS certs
 registry_tls_secret: ""
+
+registry_htpasswd: ""
+
+# registry configuration
+# see: https://docs.docker.com/registry/configuration/#list-of-configuration-options
+registry_config:
+  version: 0.1
+  log:
+    fields:
+      service: registry
+  storage:
+    cache:
+      blobdescriptor: inmemory
+  http:
+    addr: :{{ registry_port }}
+    headers:
+      X-Content-Type-Options: [nosniff]
+  health:
+    storagedriver:
+      enabled: true
+      interval: 10s
+      threshold: 3

--- a/roles/kubernetes-apps/registry/tasks/main.yml
+++ b/roles/kubernetes-apps/registry/tasks/main.yml
@@ -15,6 +15,8 @@
       - { name: registry-sa, file: registry-sa.yml, type: sa }
       - { name: registry-proxy-sa, file: registry-proxy-sa.yml, type: sa }
       - { name: registry-svc, file: registry-svc.yml, type: svc }
+      - { name: registry-secrets, file: registry-secrets.yml, type: secrets }
+      - { name: registry-cm, file: registry-cm.yml, type: cm }
       - { name: registry-rs, file: registry-rs.yml, type: rs }
       - { name: registry-proxy-ds, file: registry-proxy-ds.yml, type: ds }
     registry_templates_for_psp:

--- a/roles/kubernetes-apps/registry/templates/registry-cm.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-cm.yml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: registry-config
+  namespace: {{ registry_namespace }}
+{% if registry_config %}
+data:
+  config.yml: |-
+    {{ registry_config | to_yaml(indent=2, width=1337) | indent(width=4) }}
+{% endif %}

--- a/roles/kubernetes-apps/registry/templates/registry-rs.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-rs.yml.j2
@@ -38,19 +38,36 @@ spec:
               value: :{{ registry_port }}
             - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
               value: /var/lib/registry
+{% if registry_tls_secret != "" %}
+            - name: REGISTRY_HTTP_TLS_CERTIFICATE
+              value: /etc/ssl/docker/tls.crt
+            - name: REGISTRY_HTTP_TLS_KEY
+              value: /etc/ssl/docker/tls.key
+{% endif %}
           volumeMounts:
             - name: registry-pvc
               mountPath: /var/lib/registry
+{% if registry_tls_secret != "" %}
+            - name: tls-cert
+              mountPath: /etc/ssl/docker
+              readOnly: true
+{% endif %}
           ports:
             - containerPort: {{ registry_port }}
               name: registry
               protocol: TCP
           livenessProbe:
             httpGet:
+{% if registry_tls_secret != "" %}
+              scheme: HTTPS
+{% endif %}
               path: /
               port: {{ registry_port }}
           readinessProbe:
             httpGet:
+{% if registry_tls_secret != "" %}
+              scheme: HTTPS
+{% endif %}
               path: /
               port: {{ registry_port }}
       volumes:
@@ -60,4 +77,9 @@ spec:
             claimName: registry-pvc
 {% else %}
           emptyDir: {}
+{% endif %}
+{% if registry_tls_secret != "" %}
+        - name: tls-cert
+          secret:
+            secretName: {{ registry_tls_secret }}
 {% endif %}

--- a/roles/kubernetes-apps/registry/templates/registry-rs.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-rs.yml.j2
@@ -33,11 +33,23 @@ spec:
         - name: registry
           image: {{ registry_image_repo }}:{{ registry_image_tag }}
           imagePullPolicy: {{ k8s_image_pull_policy }}
+          command:
+          - /bin/registry
+          - serve
+          - /etc/docker/registry/config.yml
           env:
             - name: REGISTRY_HTTP_ADDR
               value: :{{ registry_port }}
             - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
               value: /var/lib/registry
+{% if registry_htpasswd != "" %}
+            - name: REGISTRY_AUTH
+              value: "htpasswd"
+            - name: REGISTRY_AUTH_HTPASSWD_REALM
+              value: "Registry Realm"
+            - name: REGISTRY_AUTH_HTPASSWD_PATH
+              value: "/auth/htpasswd"
+{% endif %}
 {% if registry_tls_secret != "" %}
             - name: REGISTRY_HTTP_TLS_CERTIFICATE
               value: /etc/ssl/docker/tls.crt
@@ -47,6 +59,13 @@ spec:
           volumeMounts:
             - name: registry-pvc
               mountPath: /var/lib/registry
+            - name: registry-config
+              mountPath: /etc/docker/registry
+{% if registry_htpasswd != "" %}
+            - name: auth
+              mountPath: /auth
+              readOnly: true
+{% endif %}
 {% if registry_tls_secret != "" %}
             - name: tls-cert
               mountPath: /etc/ssl/docker
@@ -77,6 +96,17 @@ spec:
             claimName: registry-pvc
 {% else %}
           emptyDir: {}
+{% endif %}
+        - name: registry-config
+          configMap:
+            name: registry-config
+{% if registry_htpasswd != "" %}
+        - name: auth
+          secret:
+            secretName: registry-secret
+            items:
+            - key: htpasswd
+              path: htpasswd
 {% endif %}
 {% if registry_tls_secret != "" %}
         - name: tls-cert

--- a/roles/kubernetes-apps/registry/templates/registry-secrets.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-secrets.yml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: registry-secret
+  namespace: {{ registry_namespace }}
+type: Opaque
+data:
+{% if registry_htpasswd != "" %}
+  htpasswd: {{ registry_htpasswd | b64encode }}
+{% endif %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

This PR is the first step to implement the proposal #8221 .

includes:

1. now registry can use the [TLS secrets](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets) by user created, and listen on port 443 by default with the TLS certificate.

2. now registry supports `htpasswd` as basic authentication.

3. now registry strips out the configuration items to `ConfigMap`, user has a more detailed configuration strategy.

**Special notes for your reviewer**:

I'd like to test this feature at CI, but I don't know how to add the testcase, any suggestions are greatly appreciated. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add TLS and authentication support to container registry (using new variables `registry_tls_secret`, `registry_htpasswd`, `registry_config`)
```
