### PR TITLE
add Gather facts to remove-node.yml

### DIFF
--- a/remove-node.yml
+++ b/remove-node.yml
@@ -28,6 +28,9 @@
     - { role: kubespray-defaults }
     - { role: remove-node/pre-remove, tags: pre-remove }
 
+- name: Gather facts
+  import_playbook: facts.yml
+
 - hosts: "{{ node | default('kube_node') }}"
   gather_facts: no
   environment: "{{ proxy_disable_env }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
If we want to remove node from cluster we should follow [this](https://github.com/IKRozhkov/kubespray/blob/master/docs/nodes.md#3-remove-an-old-node-with-remove-nodeyml) guide, but because of [this](https://github.com/IKRozhkov/kubespray/blob/master/roles/reset/tasks/main.yml#L400-L401) condition it will fail:
> TASK [reset : reset | Restart network] ****************************************************************************************************************************************************************fatal: [mynode1]: FAILED! => {"msg": "The conditional check 'ansible_os_family not in [\"Flatcar\", \"Flatcar Container Linux by Kinvolk\"]' failed. The error was: error while evaluating conditional (ansible_os_family not in [\"Flatcar\", \"Flatcar Container Linux by Kinvolk\"]): 'ansible_os_family' is undefined\n\nThe error appears to be in '/data/mvp/kubespray/roles/reset/tasks/main.yml': line 384, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: reset | Restart network\n  ^ here\n"}

It happens due to the fact that we are not gathering facts about removable node. If we include this task to `remove-node.yml` as in this PR issue will be solved.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add gather facts to remove-node playbook to prevent issue with os evaluation
```
