### PR TITLE
[2.17] Add vxlanEnabled spec in FelixConfiguration

### DIFF
--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -159,7 +159,8 @@
           "bpfEnabled": {{ calico_bpf_enabled | bool }},
           "bpfExternalServiceMode": "{{ calico_bpf_service_mode }}",
           "wireguardEnabled": {{ calico_wireguard_enabled | bool }},
-          "logSeverityScreen": "{{ calico_felix_log_severity_screen }}" }}
+          "logSeverityScreen": "{{ calico_felix_log_severity_screen }}",
+          "vxlanEnabled": {{ calico_vxlan_mode != 'Never' }} }}
   when:
     - inventory_hostname == groups['kube_control_plane'][0]
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Cherry-picks a commit due to request: https://github.com/kubernetes-sigs/kubespray/issues/8228#issuecomment-979265910
Related to https://github.com/kubernetes-sigs/kubespray/issues/8228

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Ref: https://github.com/kubernetes-sigs/kubespray/pull/8167
https://github.com/kubernetes-sigs/kubespray/issues/8228

**Special notes for your reviewer**:

I got a request: https://github.com/kubernetes-sigs/kubespray/issues/8228#issuecomment-979265910

**Does this PR introduce a user-facing change?**:

same with https://github.com/kubernetes-sigs/kubespray/pull/8167
```
[Calico] Add vxlanEnabled spec in FelixConfiguration to prevent calico network (when using vxlan) from crashing after upgrading the cluster
```
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
