### PR TITLE
Add capability to use swap, requires Kube 1.22

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -229,6 +229,11 @@ packet_fedora34-calico-selinux:
   extends: .packet_periodic
   when: on_success
 
+packet_fedora35-calico-swap-selinux:
+  stage: deploy-part2
+  extends: .packet_pr
+  when: manual
+
 packet_amazon-linux-2-aio:
   stage: deploy-part2
   extends: .packet_pr

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -14,7 +14,7 @@ debian11 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian9 |  :x: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x: |
 fedora33 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 fedora34 |  :white_check_mark: | :x: | :x: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: |
-fedora35 |  :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x: | :x: |
+fedora35 |  :white_check_mark: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x: | :x: |
 opensuse |  :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 oracle7 |  :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 ubuntu16 |  :x: | :white_check_mark: | :x: | :white_check_mark: | :x: | :white_check_mark: | :x: | :x: | :x: |

--- a/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
@@ -106,3 +106,7 @@ eventRecordQPS: {{ kubelet_event_record_qps }}
 shutdownGracePeriod: {{ kubelet_shutdown_grace_period }}
 shutdownGracePeriodCriticalPods: {{ kubelet_shutdown_grace_period_critical_pods }}
 {% endif %}
+{% if not kubelet_fail_swap_on|default(true) %}
+memorySwap:
+  swapBehavior: {{ kubelet_swap_behavior|default("LimitedSwap") }}
+{% endif %}

--- a/roles/kubernetes/preinstall/tasks/0010-swapoff.yml
+++ b/roles/kubernetes/preinstall/tasks/0010-swapoff.yml
@@ -13,11 +13,17 @@
   command: /sbin/swapon -s
   register: swapon
   changed_when: no
+
 - name: Disable swap
   command: /sbin/swapoff -a
-  when: swapon.stdout
+  when:
+    - swapon.stdout
+    - kubelet_fail_swap_on | default(True)
   ignore_errors: "{{ ansible_check_mode }}"  # noqa ignore-errors
 
 - name: Disable swapOnZram for Fedora
   command: touch /etc/systemd/zram-generator.conf
-  when: swapon.stdout and ansible_distribution in ['Fedora']
+  when:
+    - swapon.stdout
+    - ansible_distribution in ['Fedora']
+    - kubelet_fail_swap_on | default(True)

--- a/tests/files/packet_fedora35-calico-swap-selinux.yml
+++ b/tests/files/packet_fedora35-calico-swap-selinux.yml
@@ -1,0 +1,15 @@
+---
+# Instance settings
+cloud_image: fedora-35
+mode: default
+
+# Kubespray settings
+auto_renew_certificates: true
+
+# Test with SELinux in enforcing mode
+preinstall_selinux_state: enforcing
+
+# Test Alpha swap feature by leveraging zswap default config in Fedora 35
+kubelet_fail_swap_on: False
+kube_feature_gates:
+  - "NodeSwap=True"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Since Fedora 35 now comes default with Swap-on-ZRam and we have an alpha feature in kube 1.22 (https://kubernetes.io/docs/concepts/architecture/nodes/#swap-memory) to use node swap, this PS adds the necessary support bits in place and exercises the feature in CI (manually to avoid extra unneeded run time).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add capability to use node swap with kubernetes 1.22+ (using new variable `kubelet_fail_swap_on`, default to true)
```
