### PR TITLE
Clean kubeadm-config cm from removed etcd nodes endPoints

### DIFF
--- a/roles/remove-node/remove-etcd-node/tasks/main.yml
+++ b/roles/remove-node/remove-etcd-node/tasks/main.yml
@@ -62,3 +62,18 @@
   when:
     - inventory_hostname in groups['etcd']
     - etcd_member_id.stdout | length > 0
+
+# Delete node from kubeadm-config
+- name: Update kubeadm-config configmap removing control-plane no longer existing endpoints
+  vars:
+    kubeadm_config_cm_content: "{{ lookup('kubernetes.core.k8s', kind='ConfigMap', namespace='kube-system', resource_name='kubeadm-config', kubeconfig=keos_kubeconfig_path) }}"
+  kubernetes.core.k8s:
+    kubeconfig: "{{ keos_kubeconfig_path }}"
+    definition:
+      api_version: v1
+      kind: ConfigMap
+      metadata:
+        name: kubeadm-config-test
+        namespace: default
+      data:
+        ClusterStatus: "{{ kubeadm_config_cm_content.data.ClusterStatus | regex_replace( node |default(kube_node)  + ':\n' + ' *advertiseAddress: ([0-9]{1,3}.){3}[0-9]{1,3}\n' + ' *bindPort: [0-9]{1,5}' , '') }}"


### PR DESCRIPTION

**What type of PR is this?**
 /kind cleanup

**What this PR does / why we need it**:
This PR cleans the kubeadm-config  configmap from information of etcd-nodes that are no longer present. This avoids issues when trying to rejoining this nodes

**Which issue(s) this PR fixes**:

Fixes #8235


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Cleanup kubeadm-config cm by removing etcd nodes endPoints no longer valid
```
