### PR TITLE
Set ingress-nginx default terminationGracePeriodSeconds to 5 min 

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s_cluster/addons.yml
@@ -116,6 +116,7 @@ ingress_publish_status_address: ""
 #   53: "kube-system/coredns:53"
 # ingress_nginx_extra_args:
 #   - --default-ssl-certificate=default/foo-tls
+# ingress_nginx_termination_grace_period_seconds: 300
 # ingress_nginx_class: nginx
 
 # ALB ingress controller deployment

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
@@ -12,4 +12,5 @@ ingress_nginx_configmap: {}
 ingress_nginx_configmap_tcp_services: {}
 ingress_nginx_configmap_udp_services: {}
 ingress_nginx_extra_args: []
+ingress_nginx_termination_grace_period_seconds: 300
 # ingress_nginx_class: nginx

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
@@ -22,6 +22,7 @@ spec:
         prometheus.io/scrape: "true"
     spec:
       serviceAccountName: ingress-nginx
+      terminationGracePeriodSeconds: {{ ingress_nginx_termination_grace_period_seconds }}
 {% if ingress_nginx_host_network %}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet


### PR DESCRIPTION
**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:

ingress-nginx-controller may have lots of connections, iIt is necessary to provide configuration items to users set the `terminationGracePeriodSeconds`.
This PR set ingress-nginx default terminationGracePeriodSeconds to 5 min for the drain of connection, and If the active connections end before that, the pod will terminate gracefully at that time.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
