### PR TITLE
Move opensuse CI to docker and fix ubuntu16 containerd version for docker

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -159,6 +159,11 @@ packet_opensuse-canal:
   extends: .packet_periodic
   when: on_success
 
+packet_opensuse-docker-cilium:
+  stage: deploy-part2
+  extends: .packet_pr
+  when: manual
+
 packet_ubuntu18-ovn4nfv:
   stage: deploy-part2
   extends: .packet_periodic

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -50,7 +50,7 @@ debian11 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian9 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 fedora34 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: |
 fedora35 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
-opensuse |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
+opensuse |  :x: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
 oracle7 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 ubuntu16 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: |
 ubuntu18 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |

--- a/tests/files/packet_opensuse-docker-cilium.yml
+++ b/tests/files/packet_opensuse-docker-cilium.yml
@@ -1,0 +1,11 @@
+---
+# Instance settings
+cloud_image: opensuse-leap-15
+mode: default
+
+# Kubespray settings
+kube_network_plugin: cilium
+
+# Docker specific settings:
+container_manager: docker
+etcd_deployment_type: docker

--- a/tests/files/packet_ubuntu16-docker-weave-sep.yml
+++ b/tests/files/packet_ubuntu16-docker-weave-sep.yml
@@ -10,3 +10,6 @@ auto_renew_certificates: true
 # Docker specific settings:
 container_manager: docker
 etcd_deployment_type: docker
+
+# Ubuntu 16 - docker containerd package available stopped at 1.4.6
+docker_containerd_version: latest


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Opensuse isn't fully supported in code, maybe try to fix that, in the meantime moving it back to docker job
Ubuntu16 is limited to 1.4.6 in download.docker.com for containerd package

**Which issue(s) this PR fixes**:
https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/1836042042
https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/1836994219

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
