### PR TITLE
change dns upstream condition for coredns

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -41,7 +41,7 @@ data:
 {% endif %}
         }
         prometheus :9153
-{% if resolvconf_mode == 'host_resolvconf' and upstream_dns_servers is defined and upstream_dns_servers|length > 0 %}
+{% if upstream_dns_servers is defined and upstream_dns_servers|length > 0 %}
         forward . {{ upstream_dns_servers|join(' ') }} {
           prefer_udp
         }


### PR DESCRIPTION
upstream_dns_servers should change corefile config even resolvconf_mode=docker_dns

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
upstream dns should be used even if it is resolvconf_mode: docker_dns

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Change dns upstream condition for coredns (use upstream dns even whern `resolveconf_mode` is set to `docker_dns`)
```
