### PR TITLE
Add support for CRI-O user namespaces

### DIFF
--- a/docs/cri-o.md
+++ b/docs/cri-o.md
@@ -60,3 +60,24 @@ crio_pids_limit: 4096
 
 [CRI-O]: https://cri-o.io/
 [cri-o#1921]: https://github.com/cri-o/cri-o/issues/1921
+
+## Note about user namespaces
+
+CRI-O has support for user namespaces. This feature is optional and can be enabled by setting the following two variables.
+
+```yaml
+crio_runtimes:
+  - name: runc
+    path: /usr/bin/runc
+    type: oci
+    root: /run/runc
+    allowed_annotations:
+    - "io.kubernetes.cri-o.userns-mode"
+
+crio_remap_enable: true
+```
+
+The `allowed_annotations` configures `crio.conf` accordingly.
+
+The `crio_remap_enable` configures the `/etc/subuid` and `/etc/subgid` files to add an entry for the **containers** user.
+By default, 16M uids and gids are reserved for user namespaces (256 pods * 65536 uids/gids) at the end of the uid/gid space.

--- a/roles/container-engine/cri-o/defaults/main.yml
+++ b/roles/container-engine/cri-o/defaults/main.yml
@@ -97,3 +97,12 @@ skopeo_packages:
 # Configure the cri-o pids limit, increase this for heavily multi-threaded workloads
 # see https://github.com/cri-o/cri-o/issues/1921
 crio_pids_limit: 1024
+
+# Reserve 16M uids and gids for user namespaces (256 pods * 65536 uids/gids)
+# at the end of the uid/gid space
+crio_remap_enable: false
+crio_remap_user: containers
+crio_subuid_start: 2130706432
+crio_subuid_length: 16777216
+crio_subgid_start: 2130706432
+crio_subgid_length: 16777216

--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -189,10 +189,10 @@
     regex: '^\s*{{ crio_remap_user }}:'
     state: '{{ "present" if crio_remap_enable | bool else "absent" }}'
   loop:
-  - path: /etc/subuid
-    entry: '{{ crio_remap_user }}:{{ crio_subuid_start }}:{{ crio_subuid_length }}'
-  - path: /etc/subgid
-    entry: '{{ crio_remap_user }}:{{ crio_subgid_start }}:{{ crio_subgid_length }}'
+    - path: /etc/subuid
+      entry: '{{ crio_remap_user }}:{{ crio_subuid_start }}:{{ crio_subuid_length }}'
+    - path: /etc/subgid
+      entry: '{{ crio_remap_user }}:{{ crio_subgid_start }}:{{ crio_subgid_length }}'
   loop_control:
     label: '{{ item.path }}'
 

--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -182,6 +182,20 @@
   notify: restart crio
   when: http_proxy is defined or https_proxy is defined
 
+- name: Configure the uid/gid space for user namespaces
+  lineinfile:
+    path: '{{ item.path }}'
+    line: '{{ item.entry }}'
+    regex: '^\s*{{ crio_remap_user }}:'
+    state: '{{ "present" if crio_remap_enable | bool else "absent" }}'
+  loop:
+  - path: /etc/subuid
+    entry: '{{ crio_remap_user }}:{{ crio_subuid_start }}:{{ crio_subuid_length }}'
+  - path: /etc/subgid
+    entry: '{{ crio_remap_user }}:{{ crio_subgid_start }}:{{ crio_subgid_length }}'
+  loop_control:
+    label: '{{ item.path }}'
+
 - name: Ensure crio service is started and enabled
   service:
     name: crio

--- a/roles/container-engine/cri-o/templates/crio.conf.j2
+++ b/roles/container-engine/cri-o/templates/crio.conf.j2
@@ -294,6 +294,7 @@ runtime_path = "{{ runtime.path }}"
 runtime_type = "{{ runtime.type }}"
 runtime_root = "{{ runtime.root }}"
 privileged_without_host_devices = {{ runtime.privileged_without_host_devices|default(false)|lower }}
+allowed_annotations = {{ runtime.allowed_annotations|default([])|to_json }}
 {% endfor %}
 
 # Kata Containers with the Firecracker VMM


### PR DESCRIPTION
This Pull Request is about adding support for user namespaces for CRI-O.

## Description

Support for user namespaces in CRI-O has been introduced with cri-o/cri-o#3944 and refined in cri-o/cri-o#4281.

As explained in cri-o/cri-o#4281, there is a configuration option in crio.conf to enable this feature.

> add allowed_annotations option to runtime handler structure, which allows admins
> to gate which runtime classes interpret the annotation io.kubernetes.cri-o.userns-mode.
> In doing so, also drop the experimental allow_userns_annotation option.

This PR does two things:

- it modifies /etc/crio/crio.conf to add the `allowed_annotations` directive.
- it adds an entry to /etc/subuid and /etc/subgid files.

This behavior is controlled by the `crio_runtimes[*].allowed_annotations` variable (default value: empty) and the `crio_remap_enable` variable (default value: false).

The default values introduce no change to existing deployments.

## Documentation

`cri-o.md` has been updated.

## Testing

In your `group_vars/all/crio.yaml`, add:

```yaml
crio_runtimes:
  - name: runc
    path: /usr/bin/runc
    type: oci
    root: /run/runc
    allowed_annotations:
    - "io.kubernetes.cri-o.userns-mode"

crio_remap_enable: true
```

Then, create a pod like this:

```yaml
apiVersion: v1
kind: Pod
metadata:
  generateName: test-
  labels:
    test-pod: "true"
  annotations:
    io.kubernetes.cri-o.userns-mode: "auto:keep-id=true"
spec:
  containers:
  - name: alpine
    image: docker.io/library/alpine:latest
    command:
    - /bin/sleep
    - "3600"
    securityContext:
      runAsUser: 1000
      runAsGroup: 1000
  restartPolicy: OnFailure
```

On the Kubernetes node running this pod, use the `lsns` command to list user namespaces.
In the following example, I created two pods that have their own namespace and their own uid/gid space.

```
[root@kube-cicd ~]# lsns -t user
        NS TYPE  NPROCS   PID USER       COMMAND
4026531837 user     180     1 root       /usr/lib/systemd/systemd --switched-root --system --
4026532579 user       1 70662 2130772967 /bin/sleep 3600
4026532658 user       1 72674 2130838503 /bin/sleep 3600
```

Cleanup with:

```sh
kubectl delete pod -l test-pod=true
```

## Tested configurations

- Kubernetes 1.22
- CentOS Stream 8
- CRI-O 1.21 and 1.22

## Caveats

There is packaging glitch with CRI-O 1.22 (containers/common#789) which should be fixed later. In the meantime, I had to comment the `[machine]` section in `/usr/share/containers/containers.conf`.

Also, with CRI-O 1.22, I could not manage to have the "map-to-root" feature working (`io.kubernetes.cri-o.userns-mode: "auto:map-to-root=true"`) while it was working on CRI-O 1.21

```release-note
[cri-o] Add support for cri-o user namespaces
```

/kind feature

