### PR TITLE
Fix k8scsi/csi-resizer repo

### DIFF
--- a/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-controller-deployment.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-controller-deployment.yml.j2
@@ -53,7 +53,7 @@ spec:
               name: socket-dir
 {% if external_vsphere_version >= "7.0" %}
         - name: csi-resizer
-          image: {{ gcr_image_repo }}/k8scsi/csi-resizer:{{ vsphere_csi_resizer_tag }}
+          image: {{ quay_image_repo }}/k8scsi/csi-resizer:{{ vsphere_csi_resizer_tag }}
           args:
             - "--v=4"
             - "--timeout=300s"


### PR DESCRIPTION

/kind bug

**What this PR does / why we need it**:

If trying to pull k8scsi/csi-resizer image from gcr.io, we face the error like:

```
 $ docker pull gcr.io/k8scsi/csi-resizer:v1.0.0
 Error response from daemon: Head https://gcr.io/v2/k8scsi/csi-resizer/
 manifests/v1.0.0: unknown: Project 'project:k8scsi' not found or deleted.
 $
```

We can pull the image from quay.io instead.
This fixes the issue.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7885

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
