### PR TITLE
Use proxy for container pull

### DIFF
--- a/roles/download/tasks/download_container.yml
+++ b/roles/download/tasks/download_container.yml
@@ -62,10 +62,11 @@
       delay: "{{ retry_stagger | random + 3 }}"
       retries: 4
       become: "{{ user_can_become_root | default(false) or not download_localhost }}"
+      environment: "{{ proxy_env }}"
       when:
         - pull_required or download_run_once
         - not image_is_cached
-
+        
     - name: download_container | Save and compress image
       shell: "{{ image_save_command_on_localhost if download_localhost else image_save_command }}"  # noqa 305 image_save_command_on_localhost contains a pipe, therefore requires shell
       delegate_to: "{{ download_delegate }}"


### PR DESCRIPTION
It requires proxy_evn to use "nerdctl pull" command.

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
It requires to use "proxy_env" for command "nerdctl pull".

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
