### PR TITLE
change mount path to kubespray container

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ docker run --rm -it --mount type=bind,source="$(pwd)"/inventory/,dst=/kubespray/
   --mount type=bind,source="${HOME}"/.ssh/id_rsa,dst=/root/.ssh/id_rsa \
   quay.io/kubespray/kubespray:v2.17.1 bash
 # Inside the container you may now run the kubespray playbooks:
-ansible-playbook -i inventory/sample/inventory.ini cluster.yml
+ansible-playbook -i inventory/sample/inventory.ini --become --become-user=root cluster.yml
 ```
 
 ### Vagrant

--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ You will then need to use [bind mounts](https://docs.docker.com/storage/bind-mou
 
 ```ShellSession
 docker pull quay.io/kubespray/kubespray:v2.17.1
-docker run --rm -it --mount type=bind,source="$(pwd)"/inventory/sample,dst=/inventory \
+docker run --rm -it --mount type=bind,source="$(pwd)"/inventory/,dst=/kubespray/inventory/ \
   --mount type=bind,source="${HOME}"/.ssh/id_rsa,dst=/root/.ssh/id_rsa \
   quay.io/kubespray/kubespray:v2.17.1 bash
 # Inside the container you may now run the kubespray playbooks:
-ansible-playbook -i /inventory/inventory.ini --private-key /root/.ssh/id_rsa cluster.yml
+ansible-playbook -i inventory/sample/inventory.ini cluster.yml
 ```
 
 ### Vagrant

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ docker run --rm -it --mount type=bind,source="$(pwd)"/inventory/,dst=/kubespray/
   --mount type=bind,source="${HOME}"/.ssh/id_rsa,dst=/root/.ssh/id_rsa \
   quay.io/kubespray/kubespray:v2.17.1 bash
 # Inside the container you may now run the kubespray playbooks:
-ansible-playbook -i inventory/sample/inventory.ini --become --become-user=root cluster.yml
+ansible-playbook -i inventory/sample/inventory.ini cluster.yml
 ```
 
 ### Vagrant


### PR DESCRIPTION
**What type of PR is this?**
> /kind documentation

**What this PR does / why we need it**:
- inventory is stored in the wrong folder (it should be in /kubespray/inventory/*)
- mount all inventory from local to /kubespray/inventory/
- can interact with container like local use
- add --become to fix bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
None
```
