### PR TITLE
registry: service add clusterIP, nodePort, loadBalancer support

### DIFF
--- a/roles/kubernetes-apps/registry/defaults/main.yml
+++ b/roles/kubernetes-apps/registry/defaults/main.yml
@@ -5,6 +5,18 @@ registry_storage_access_mode: "ReadWriteOnce"
 registry_disk_size: "10Gi"
 registry_port: 5000
 registry_replica_count: 1
+
+# type of service: ClusterIP, LoadBalancer or NodePort
+registry_service_type: "ClusterIP"
+# you can specify your cluster IP address when registry_service_type is ClusterIP
+registry_service_clusterIP: ""
+# you can specify your cloud provider assigned loadBalancerIP when registry_service_type is LoadBalancer
+registry_service_loadBalancerIP: ""
+# annotations for managing Cloud Load Balancers
+registry_service_annotations: {}
+# you can specify the node port when registry_service_type is NodePort
+registry_service_nodePort: ""
+
 # name of kubernetes secret for registry TLS certs
 registry_tls_secret: ""
 

--- a/roles/kubernetes-apps/registry/defaults/main.yml
+++ b/roles/kubernetes-apps/registry/defaults/main.yml
@@ -9,13 +9,13 @@ registry_replica_count: 1
 # type of service: ClusterIP, LoadBalancer or NodePort
 registry_service_type: "ClusterIP"
 # you can specify your cluster IP address when registry_service_type is ClusterIP
-registry_service_clusterIP: ""
+registry_service_cluster_ip: ""
 # you can specify your cloud provider assigned loadBalancerIP when registry_service_type is LoadBalancer
-registry_service_loadBalancerIP: ""
+registry_service_loadbalancer_ip: ""
 # annotations for managing Cloud Load Balancers
 registry_service_annotations: {}
 # you can specify the node port when registry_service_type is NodePort
-registry_service_nodePort: ""
+registry_service_nodeport: ""
 
 # name of kubernetes secret for registry TLS certs
 registry_tls_secret: ""

--- a/roles/kubernetes-apps/registry/tasks/main.yml
+++ b/roles/kubernetes-apps/registry/tasks/main.yml
@@ -1,4 +1,29 @@
 ---
+- name: Registry | check registry_service_type value
+  fail:
+    msg: "registry_service_type can only be 'ClusterIP', 'LoadBalancer' or 'NodePort'"
+  when: registry_service_type not in ['ClusterIP', 'LoadBalancer', 'NodePort']
+
+- name: Registry | Stop if registry_service_cluster_ip is defined when registry_service_type is not 'ClusterIP'
+  fail:
+    msg: "registry_service_cluster_ip support only compatible with ClusterIP."
+  when:
+    - registry_service_cluster_ip is defined and registry_service_cluster_ip != ""
+    - registry_service_type != "ClusterIP"
+
+- name: Registry | Stop if registry_service_loadbalancer_ip is defined when registry_service_type is not 'LoadBalancer'
+  fail:
+    msg: "registry_service_loadbalancer_ip support only compatible with LoadBalancer."
+  when:
+    - registry_service_loadbalancer_ip is defined and registry_service_loadbalancer_ip != ""
+    - registry_service_type != "LoadBalancer"
+
+- name: Registry | Stop if registry_service_nodeport is defined when registry_service_type is not 'NodePort'
+  fail:
+    msg: "registry_service_nodeport support only compatible with NodePort."
+  when:
+    - registry_service_nodeport is defined and registry_service_nodeport != ""
+    - registry_service_type != "NodePort"
 
 - name: Registry | Create addon dir
   file:

--- a/roles/kubernetes-apps/registry/templates/registry-svc.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-svc.yml.j2
@@ -16,17 +16,17 @@ spec:
   selector:
     k8s-app: registry
   type: {{ registry_service_type }}
-{% if registry_service_type == "ClusterIP" and registry_service_clusterIP != "" %}
-  clusterIP: {{ registry_service_clusterIP }}
+{% if registry_service_type == "ClusterIP" and registry_service_cluster_ip != "" %}
+  clusterIP: {{ registry_service_cluster_ip }}
 {% endif %}
-{% if registry_service_type == "LoadBalancer" and registry_service_loadBalancerIP != "" %}
-  loadBalancerIP: {{ registry_service_loadBalancerIP }}
+{% if registry_service_type == "LoadBalancer" and registry_service_loadbalancer_ip != "" %}
+  loadBalancerIP: {{ registry_service_loadbalancer_ip }}
 {% endif %}
   ports:
     - name: registry
       port: {{ registry_port }}
       protocol: TCP
       targetPort: {{ registry_port }}
-{% if registry_service_type == "NodePort" and registry_service_nodePort != "" %}
-      nodePort: {{ registry_service_nodePort }}
+{% if registry_service_type == "NodePort" and registry_service_nodeport != "" %}
+      nodePort: {{ registry_service_nodeport }}
 {% endif %}

--- a/roles/kubernetes-apps/registry/templates/registry-svc.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-svc.yml.j2
@@ -8,10 +8,25 @@ metadata:
     k8s-app: registry
     addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/name: "KubeRegistry"
+{% if registry_service_annotations %}
+  annotations:
+    {{ registry_service_annotations | to_nice_yaml(indent=2, width=1337) | indent(width=4) }}
+{% endif %}
 spec:
   selector:
     k8s-app: registry
+  type: {{ registry_service_type }}
+{% if registry_service_type == "ClusterIP" and registry_service_clusterIP != "" %}
+  clusterIP: {{ registry_service_clusterIP }}
+{% endif %}
+{% if registry_service_type == "LoadBalancer" and registry_service_loadBalancerIP != "" %}
+  loadBalancerIP: {{ registry_service_loadBalancerIP }}
+{% endif %}
   ports:
     - name: registry
       port: {{ registry_port }}
       protocol: TCP
+      targetPort: {{ registry_port }}
+{% if registry_service_type == "NodePort" and registry_service_nodePort != "" %}
+      nodePort: {{ registry_service_nodePort }}
+{% endif %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR is the second step to implement the proposal #8221 .

User may want to expose registry Service onto an external IP address, that's outside of the cluster, now user can specify `ClusterIP`, `NodePort` or `LoadBalancer` as registry service type. 

The default is ClusterIP, and user can specify it which from the clusterIPPool as a static cluster IP.
LoadBalancer use a cloud provider's load balancer, the cloud provider decides how it is load balanced, user may need to add some annotations to the registry service depending on the cloud Service provider.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add ServiceTypes support to container registry (using new variables `registry_service_type`, `registry_service_clusterIP`, `registry_service_loadBalancerIP`, `registry_service_annotations`, `registry_service_nodePort`)
```
