### PR TITLE
containerd insecure registry support

### DIFF
--- a/inventory/sample/group_vars/all/containerd.yml
+++ b/inventory/sample/group_vars/all/containerd.yml
@@ -28,6 +28,14 @@
 
 # containerd_metrics_grpc_histogram: false
 
+## An obvious use case is allowing insecure-registry access to self hosted registries.
+## Can be ipaddress and domain_name.
+## example define mirror.registry.io or 172.19.16.11:5000
+## Port number is also needed if the default HTTPS port is not used.
+# containerd_insecure_registries:
+#   - mirror.registry.io
+#   - 172.19.16.11:5000
+
 # containerd_registries:
 #   "docker.io": "https://registry-1.docker.io"
 

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -54,6 +54,12 @@ oom_score = {{ containerd_oom_score }}
         [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ registry }}"]
           endpoint = ["{{ ([ addr ] | flatten ) | join('","') }}"]
 {% endfor %}
+{% for addr in containerd_insecure_registries %}
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ addr }}"]
+          endpoint = ["{{ ([ addr ] | flatten ) | join('","') }}"]
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ addr }}".tls]
+          insecure_skip_verify = true
+{% endfor %}
 {% for registry in containerd_registry_auth if registry['registry'] is defined %}
 {% if (registry['username'] is defined and registry['password'] is defined) or registry['auth'] is defined %}
       [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ registry['registry'] }}".auth]

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -346,6 +346,15 @@ containerd_use_systemd_cgroup: true
 # Docker options - this is relevant when container_manager == 'docker'
 docker_containerd_version: 1.4.12
 
+## An obvious use case is allowing insecure-registry access to self hosted registries.
+## Can be ipaddress and domain_name.
+## example define mirror.registry.io or 172.19.16.11:5000
+## Port number is also needed if the default HTTPS port is not used.
+# containerd_insecure_registries:
+#   - mirror.registry.io
+#   - 172.19.16.11:5000
+containerd_insecure_registries: []
+
 # Settings for containerized control plane (etcd/kubelet/secrets)
 # deployment type for legacy etcd mode
 etcd_deployment_type: host


### PR DESCRIPTION
Containerd supports the insecure registry option for container registries/endpoints.

**What type of PR is this?**
/kind feature

**Which issue(s) this PR fixes**:
Fixes #7835

**Special notes for your reviewer**:
n/a

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[containerd] Insecure registry support
```