### PR TITLE
registry: add ingress support

### DIFF
--- a/roles/kubernetes-apps/registry/defaults/main.yml
+++ b/roles/kubernetes-apps/registry/defaults/main.yml
@@ -41,3 +41,8 @@ registry_config:
       enabled: true
       interval: 10s
       threshold: 3
+
+registry_ingress_annotations: {}
+registry_ingress_host: ""
+# name of kubernetes secret for registry ingress TLS certs
+registry_ingress_tls_secret: ""

--- a/roles/kubernetes-apps/registry/tasks/main.yml
+++ b/roles/kubernetes-apps/registry/tasks/main.yml
@@ -59,6 +59,13 @@
     - podsecuritypolicy_enabled
     - registry_namespace != "kube-system"
 
+- name: Registry | Append nginx ingress templates to Registry Templates list when ingress enabled
+  set_fact:
+    registry_templates: "{{ registry_templates + [item] }}"
+  with_items:
+    - [{ name: registry-ing, file: registry-ing.yml, type: ing }]
+  when: ingress_nginx_enabled == true or ingress_alb_enabled == true
+
 - name: Registry | Create manifests
   template:
     src: "{{ item.file }}.j2"

--- a/roles/kubernetes-apps/registry/templates/registry-ing.yml.j2
+++ b/roles/kubernetes-apps/registry/templates/registry-ing.yml.j2
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: registry
+  namespace: {{ registry_namespace }}
+{% if registry_ingress_annotations %}
+  annotations:
+    {{ registry_ingress_annotations | to_nice_yaml(indent=2, width=1337) | indent(width=4) }}
+{% endif %}
+spec:
+{% if registry_ingress_tls_secret %}
+  tls:
+  - hosts:
+      - {{ registry_ingress_host }}
+    secretName: {{ registry_ingress_tls_secret }}
+{% endif %}
+  rules:
+  - host: {{ registry_ingress_host }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: registry
+            port:
+              number: {{ registry_port }}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR is the third step to implement the proposal #8221 .

Now user can configure an Ingress to give Registry Services externally-reachable traffic (with or without SSL / TLS) and offer name-based virtual hosting.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add Ingress support to container registry (using new variables `registry_ingress_annotations`, `registry_ingress_host`, `registry_ingress_tls_secret`)
```
