### PR TITLE
Fix bad indentation in cert-manager when trusted internal ca is defined

### DIFF
--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
@@ -944,11 +944,11 @@ spec:
           - mountPath: /etc/ssl/certs/internal-ca.pem
             name: ca-internal-truststore
             subPath: internal-ca.pem
-        volumes:
-        - configMap:
-            defaultMode: 420
-            name: ca-internal-truststore
+      volumes:
+      - configMap:
+          defaultMode: 420
           name: ca-internal-truststore
+        name: ca-internal-truststore
 {% endif %}
 ---
 # Source: cert-manager/templates/webhook-deployment.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind bug

**What this PR does / why we need it**:
Deployment of cert-manager fails if a trusted internal ca is defined
Failure:
TASK [kubernetes-apps/ingress_controller/cert_manager : Cert Manager | Apply manifests] ***********************************************************************************
failed: [k8s-control01] (item={'diff': [], 'dest': '/etc/kubernetes/addons/cert_manager/cert-manager.yml', 'src': '/home/admin.monkey/.ansible/tmp/ansible-tmp-1639729826.653066-112952-113797090066415/source', 'md5sum': '8830e968c0f516e62cb48b21384fe629', 'checksum': '1bfb4613a52d53e763d68597bc4ebb8e23193a4f', 'changed': True, 'uid': 0, 'gid': 0, 'owner': 'root', 'group': 'root', 'mode': '0644', 'state': 'file', 'size': 37737, 'invocation': {'module_args': {'src': '/home/admin.monkey/.ansible/tmp/ansible-tmp-1639729826.653066-112952-113797090066415/source', 'dest': '/etc/kubernetes/addons/cert_manager/cert-manager.yml', 'mode': None, 'follow': False, '_original_basename': 'cert-manager.yml.j2', 'checksum': '1bfb4613a52d53e763d68597bc4ebb8e23193a4f', 'backup': False, 'force': True, 'unsafe_writes': False, 'content': None, 'validate': None, 'directory_mode': None, 'remote_src': None, 'local_follow': None, 'owner': None, 'group': None, 'seuser': None, 'serole': None, 'selevel': None, 'setype': None, 'attributes': None}}, 'failed': False, 'item': {'name': 'cert-manager', 'file': 'cert-manager.yml', 'type': 'all'}, 'ansible_loop_var': 'item'}) => {"ansible_loop_var": "item", "changed": false, "item": {"ansible_loop_var": "item", "changed": true, "checksum": "1bfb4613a52d53e763d68597bc4ebb8e23193a4f", "dest": "/etc/kubernetes/addons/cert_manager/cert-manager.yml", "diff": [], "failed": false, "gid": 0, "group": "root", "invocation": {"module_args": {"_original_basename": "cert-manager.yml.j2", "attributes": null, "backup": false, "checksum": "1bfb4613a52d53e763d68597bc4ebb8e23193a4f", "content": null, "dest": "/etc/kubernetes/addons/cert_manager/cert-manager.yml", "directory_mode": null, "follow": false, "force": true, "group": null, "local_follow": null, "mode": null, "owner": null, "remote_src": null, "selevel": null, "serole": null, "setype": null, "seuser": null, "src": "/home/admin.monkey/.ansible/tmp/ansible-tmp-1639729826.653066-112952-113797090066415/source", "unsafe_writes": false, "validate": null}}, "item": {"file": "cert-manager.yml", "name": "cert-manager", "type": "all"}, "md5sum": "8830e968c0f516e62cb48b21384fe629", "mode": "0644", "owner": "root", "size": 37737, "src": "/home/admin.monkey/.ansible/tmp/ansible-tmp-1639729826.653066-112952-113797090066415/source", "state": "file", "uid": 0}, "msg": "error running kubectl (/usr/local/bin/kubectl apply --force --filename=/etc/kubernetes/addons/cert_manager/cert-manager.yml) command (rc=1), out='namespace/cert-manager created\nserviceaccount/cert-manager-cainjector created\nserviceaccount/cert-manager created\nserviceaccount/cert-manager-webhook created\nclusterrole.rbac.authorization.k8s.io/cert-manager-cainjector unchanged\nclusterrole.rbac.authorization.k8s.io/cert-manager-controller-issuers unchanged\nclusterrole.rbac.authorization.k8s.io/cert-manager-controller-clusterissuers unchanged\nclusterrole.rbac.authorization.k8s.io/cert-manager-controller-certificates unchanged\nclusterrole.rbac.authorization.k8s.io/cert-manager-controller-orders unchanged\nclusterrole.rbac.authorization.k8s.io/cert-manager-controller-challenges unchanged\nclusterrole.rbac.authorization.k8s.io/cert-manager-controller-ingress-shim unchanged\nclusterrole.rbac.authorization.k8s.io/cert-manager-view unchanged\nclusterrole.rbac.authorization.k8s.io/cert-manager-edit unchanged\nclusterrole.rbac.authorization.k8s.io/cert-manager-controller-approve:cert-manager-io unchanged\nclusterrole.rbac.authorization.k8s.io/cert-manager-controller-certificatesigningrequests unchanged\nclusterrole.rbac.authorization.k8s.io/cert-manager-webhook:subjectaccessreviews unchanged\nclusterrolebinding.rbac.authorization.k8s.io/cert-manager-cainjector unchanged\nclusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-issuers unchanged\nclusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-clusterissuers unchanged\nclusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-certificates unchanged\nclusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-orders unchanged\nclusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-challenges unchanged\nclusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-ingress-shim unchanged\nclusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-approve:cert-manager-io unchanged\nclusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-certificatesigningrequests unchanged\nclusterrolebinding.rbac.authorization.k8s.io/cert-manager-webhook:subjectaccessreviews configured\nrole.rbac.authorization.k8s.io/cert-manager-cainjector:leaderelection created\nrole.rbac.authorization.k8s.io/cert-manager:leaderelection created\nrole.rbac.authorization.k8s.io/cert-manager-webhook:dynamic-serving created\nrolebinding.rbac.authorization.k8s.io/cert-manager-cainjector:leaderelection created\nrolebinding.rbac.authorization.k8s.io/cert-manager:leaderelection created\nrolebinding.rbac.authorization.k8s.io/cert-manager-webhook:dynamic-serving created\nservice/cert-manager created\nservice/cert-manager-webhook created\ndeployment.apps/cert-manager-cainjector created\nconfigmap/ca-internal-truststore created\n', err='error: error parsing /etc/kubernetes/addons/cert_manager/cert-manager.yml: error converting YAML to JSON: yaml: line 57: did not find expected '-' indicator\n'"}

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
I noticed this bug when deploying from the dev branch.
I made the original change for that feature

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix bad indentation in cert-manager when trusted internal ca is defined
```
