### PR TITLE
calico_pool_blocksize must be cast as well in assertion when defined

### DIFF
--- a/roles/network_plugin/calico/tasks/check.yml
+++ b/roles/network_plugin/calico/tasks/check.yml
@@ -53,7 +53,7 @@
 - name: "Check if inventory match current cluster configuration"
   assert:
     that:
-      - calico_pool_conf.spec.blockSize|string == (calico_pool_blocksize | default(kube_network_node_prefix | string))
+      - calico_pool_conf.spec.blockSize|string == (calico_pool_blocksize | default(kube_network_node_prefix) | string)
       - calico_pool_conf.spec.cidr == (calico_pool_cidr | default(kube_pods_subnet))
       - not calico_pool_conf.spec.ipipMode is defined or calico_pool_conf.spec.ipipMode == calico_ipip_mode
       - not calico_pool_conf.spec.vxlanMode is defined or calico_pool_conf.spec.vxlanMode == calico_vxlan_mode

--- a/roles/network_plugin/calico/tasks/check.yml
+++ b/roles/network_plugin/calico/tasks/check.yml
@@ -53,7 +53,7 @@
 - name: "Check if inventory match current cluster configuration"
   assert:
     that:
-      - calico_pool_conf.spec.blockSize|string == (calico_pool_blocksize | default(kube_network_node_prefix) | string)
+      - calico_pool_conf.spec.blockSize|int == (calico_pool_blocksize | default(kube_network_node_prefix) | int)
       - calico_pool_conf.spec.cidr == (calico_pool_cidr | default(kube_pods_subnet))
       - not calico_pool_conf.spec.ipipMode is defined or calico_pool_conf.spec.ipipMode == calico_ipip_mode
       - not calico_pool_conf.spec.vxlanMode is defined or calico_pool_conf.spec.vxlanMode == calico_vxlan_mode


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When calico default pool already exists and `calico_pool_blocksize` is defined in inventory, the assertion on blocksize equality wrongly fails because a string cast is missing

**Which issue(s) this PR fixes**:
None that I know of

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
None
