### PR TITLE
Delete "kubeadm alpha certs" code

### DIFF
--- a/roles/kubernetes/control-plane/templates/k8s-certs-renew.sh.j2
+++ b/roles/kubernetes/control-plane/templates/k8s-certs-renew.sh.j2
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 echo "## Expiration before renewal ##"
-{{ bin_dir }}/kubeadm {{ 'alpha ' if kube_version is version('v1.20.0', '<') else '' }}certs check-expiration
+{{ bin_dir }}/kubeadm certs check-expiration
 
 echo "## Renewing certificates managed by kubeadm ##"
-{{ bin_dir }}/kubeadm {{ 'alpha ' if kube_version is version('v1.20.0', '<') else '' }}certs renew all
+{{ bin_dir }}/kubeadm certs renew all
 
 echo "## Restarting control plane pods managed by kubeadm ##"
 {% if container_manager == "docker" %}
@@ -20,4 +20,4 @@ echo "## Waiting for apiserver to be up again ##"
 until printf "" 2>>/dev/null >>/dev/tcp/127.0.0.1/6443; do sleep 1; done
 
 echo "## Expiration after renewal ##"
-{{ bin_dir }}/kubeadm {{ 'alpha ' if kube_version is version('v1.20.0', '<') else '' }}certs check-expiration
+{{ bin_dir }}/kubeadm certs check-expiration


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

"kubeadm alpha certs" command has been promoted to "kubeadm certs" command, and "kubeadm alpha certs" has been deprecated since Kubernetes v1.20 as [1].
In addition, Kubespray supports Kubernetes v1.20+.
This deletes the unused deprecated command for cleanup.

[1]: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md#deprecation

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
