### PR TITLE
Support deploying kubernetes 1.23

### DIFF
--- a/roles/container-engine/cri-o/defaults/main.yml
+++ b/roles/container-engine/cri-o/defaults/main.yml
@@ -45,6 +45,7 @@ crio_stream_port: "10010"
 crio_required_version: "{{ kube_version | regex_replace('^v(?P<major>\\d+).(?P<minor>\\d+).(?P<patch>\\d+)$', '\\g<major>.\\g<minor>') }}"
 
 crio_kubernetes_version_matrix:
+  "1.23": "1.22"
   "1.22": "1.22"
   "1.21": "1.21"
   "1.20": "1.20"

--- a/roles/container-engine/cri-o/vars/fedora.yml
+++ b/roles/container-engine/cri-o/vars/fedora.yml
@@ -4,7 +4,8 @@ crio_packages:
   - cri-tools
 
 crio_kubernetes_version_matrix:
+  "1.23": "1.22"
   "1.22": "1.22"
   "1.21": "1.21"
   "1.20": "1.20"
-crio_version: "{{ crio_kubernetes_version_matrix[crio_required_version] | default('1.20') }}"
+crio_version: "{{ crio_kubernetes_version_matrix[crio_required_version] | default('1.22') }}"

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -94,6 +94,7 @@ krew_version: "v0.4.2"
 # Get kubernetes major version (i.e. 1.17.4 => 1.17)
 kube_major_version: "{{ kube_version | regex_replace('^v([0-9])+\\.([0-9]+)\\.[0-9]+', 'v\\1.\\2') }}"
 crictl_supported_versions:
+  v1.23: "v1.22.0"
   v1.22: "v1.22.0"
   v1.21: "v1.21.0"
   v1.20: "v1.20.0"
@@ -745,6 +746,7 @@ csi_livenessprobe_image_repo: "{{ kube_image_repo }}/sig-storage/livenessprobe"
 csi_livenessprobe_image_tag: "v2.5.0"
 
 snapshot_controller_supported_versions:
+  v1.23: "v4.2.1"
   v1.22: "v4.2.1"
   v1.21: "v4.2.1"
   v1.20: "v4.0.0"

--- a/roles/kubernetes/control-plane/tasks/main.yml
+++ b/roles/kubernetes/control-plane/tasks/main.yml
@@ -22,7 +22,7 @@
 
 - name: Create kube-scheduler config
   template:
-    src: kubescheduler-config.v1beta1.yaml.j2
+    src: kubescheduler-config.yaml.j2
     dest: "{{ kube_config_dir }}/kubescheduler-config.yaml"
     mode: 0644
 

--- a/roles/kubernetes/control-plane/templates/kubescheduler-config.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubescheduler-config.yaml.j2
@@ -1,4 +1,11 @@
-apiVersion: kubescheduler.config.k8s.io/v1beta1
+{% if kube_version is version('v1.22.0', '<') %}
+{% set kubescheduler_config_api_version = "v1beta1" %}
+{% elif kube_version is version('v1.23.0', '<') %}
+{% set kubescheduler_config_api_version = "v1beta2" %}
+{% else %}
+{% set kubescheduler_config_api_version = "v1beta3" %}
+{% endif %}
+apiVersion: kubescheduler.config.k8s.io/{{ kubescheduler_config_api_version|d('v1') }}
 kind: KubeSchedulerConfiguration
 clientConnection:
   kubeconfig: "{{ kube_config_dir }}/scheduler.conf"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Kubernetes 1.23 requires some more work to support and have up-to-date versions for all components but in the meantime lets fix what we can. This PR adds some missing entries and differentiates the `KubeSchedulerConfiguration` api version based on `kube_version`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
We will have some pending dependencies to be added post 2.18 tag for `cri-o`, `crictl` and the `external-snapshot-controller` which have pending releases for 1.23 compatibility but for now, anyone wanting to play with master and 1.23 will need these minimal fixes to have a successful deployment.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
