### PR TITLE
Fix hostname module when OS is Rocky Linux

### DIFF
--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -55,6 +55,7 @@
 - name: Assign inventory name to unconfigured hostnames (non-CoreOS, non-Flatcar, Suse and ClearLinux, non-Fedora)
   hostname:
     name: "{{ inventory_hostname }}"
+    use: '{{ "systemd" if ''ID="rocky"'' in os_release.stdout_lines else omit }}'
   when:
     - override_system_hostname
     - ansible_os_family not in ['Suse', 'Flatcar', 'Flatcar Container Linux by Kinvolk', 'ClearLinux']


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes an error with the `hostname` module when running kubespray against a Rocky Linux OS:

```shell
TASK [bootstrap-os : Assign inventory name to unconfigured hostnames (non-CoreOS, non-Flatcar, Suse and ClearLinux, non-Fedora)] *********************************************************************************************************************************************************************************************
fatal: [master1]: FAILED! => {"changed": false, "msg": "hostname module cannot be used on platform Linux (Rocky)"}
fatal: [worker1]: FAILED! => {"changed": false, "msg": "hostname module cannot be used on platform Linux (Rocky)"}
fatal: [worker2]: FAILED! => {"changed": false, "msg": "hostname module cannot be used on platform Linux (Rocky)"}
```

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

I tried to make it apply only when running against Rocky Linux, but as I’m not an Ansible expert, I’m not sure it won’t break anything else.

**Does this PR introduce a user-facing change?**:

```release-note
Fix 'hostname module cannot be used' when OS is Rocky Linux
```
