### PR TITLE
Simplify usage of pre-remove role

### DIFF
--- a/remove-node.yml
+++ b/remove-node.yml
@@ -21,13 +21,6 @@
         msg: "Delete nodes confirmation failed"
       when: pause_result.user_input | default('yes') != 'yes'
 
-- hosts: kube_control_plane[0]
-  gather_facts: no
-  environment: "{{ proxy_disable_env }}"
-  roles:
-    - { role: kubespray-defaults }
-    - { role: remove-node/pre-remove, tags: pre-remove }
-
 - name: Gather facts
   import_playbook: facts.yml
 
@@ -36,6 +29,7 @@
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults, when: reset_nodes|default(True)|bool }
+    - { role: remove-node/pre-remove, tags: pre-remove }
     - { role: remove-node/remove-etcd-node }
     - { role: reset, tags: reset, when: reset_nodes|default(True)|bool }
 

--- a/roles/remove-node/pre-remove/tasks/main.yml
+++ b/roles/remove-node/pre-remove/tasks/main.yml
@@ -14,14 +14,12 @@
       --ignore-daemonsets
       --grace-period {{ drain_grace_period }}
       --timeout {{ drain_timeout }}
-      --delete-emptydir-data {{ hostvars[item]['kube_override_hostname']|default(item) }}
-  loop: "{{ node.split(',') | default(groups['kube_node']) }}"
+      --delete-emptydir-data {{ kube_override_hostname|default(inventory_hostname) }}
   # ignore servers that are not nodes
-  when: hostvars[item]['kube_override_hostname']|default(item) in nodes.stdout_lines
+  when: kube_override_hostname|default(inventory_hostname) in nodes.stdout_lines
   register: result
   failed_when: result.rc != 0 and not allow_ungraceful_removal
   delegate_to: "{{ groups['kube_control_plane']|first }}"
-  run_once: true
   until: result.rc == 0 or allow_ungraceful_removal
   retries: "{{ drain_retries }}"
   delay: "{{ drain_retry_delay_seconds }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
- Use builtin task scheduling of ansible (same task on each host)
  instead of manual looping on master

Benefits:
- One less play in remove-node.yml playbook
- Parrallel node drain
- Drain parameters (timeout, grace period, retries,
  allow_ungraceful_removal) can be adjusted separately for each node
  with ansible variables

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Nodes are now drained in parallel when using the playbook `remove-node.yml`
```
