### PR TITLE
fix spelling error

### DIFF
--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -112,7 +112,7 @@
   register: need_bootstrap_crio
   when: is_ostree
 
-- name: Install cri-o packages with osttree
+- name: Install cri-o packages with ostree
   command: "rpm-ostree install {{ crio_packages|join(' ') }}"
   when:
     - is_ostree


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
Fixes spelling error in FCOS code path

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Correct spelling error in cri-o install task name (is_ostree)
```
