### PR TITLE
Helm-apps role for installing helm charts

### DIFF
--- a/roles/helm-apps/README.md
+++ b/roles/helm-apps/README.md
@@ -33,7 +33,7 @@ Playbook example:
       wait_timeout: "5m"
   roles:
     - name: helm-apps
-      helm_charts: "{{ helm_apps }}"
-      helm_repositories: "{{ repos }}"
-      helm_settings: "{{ helm_params }}"
+      charts: "{{ helm_apps }}"
+      repositories: "{{ repos }}"
+      charts_common_opts: "{{ helm_params }}"
 ```

--- a/roles/helm-apps/README.md
+++ b/roles/helm-apps/README.md
@@ -19,7 +19,7 @@ Playbook example:
 
 ```yaml
 ---
-- hosts: kube_controle_plane[0]
+- hosts: kube_control_plane[0]
   gather_facts: no
   vars:
     helm_apps:

--- a/roles/helm-apps/README.md
+++ b/roles/helm-apps/README.md
@@ -21,19 +21,19 @@ Playbook example:
 ---
 - hosts: kube_control_plane[0]
   gather_facts: no
-  vars:
-    helm_apps:
-      - release_name: app
-        release_namespace: app
-        chart_ref: simple-app/simple-app
-    repos:
-      - repo_name: simple-app
-        repo_url: "https://blog.leiwang.info/simple-app"
-    helm_params:
-      wait_timeout: "5m"
   roles:
     - name: helm-apps
-      charts: "{{ helm_apps }}"
+      charts:
+        - release_name: app
+          release_namespace: app
+          chart_ref: simple-app/simple-app
+        - release_name: app2
+          release_namespace: app
+          chart_ref: simple-app/simple-app
+          wait_timeout: "10m" # override the same option in `charts_common_opts`
       repositories: "{{ repos }}"
+        - repo_name: simple-app
+          repo_url: "https://blog.leiwang.info/simple-app"
       charts_common_opts: "{{ helm_params }}"
+        wait_timeout: "5m"
 ```

--- a/roles/helm-apps/README.md
+++ b/roles/helm-apps/README.md
@@ -1,0 +1,39 @@
+Role Name
+=========
+
+This role is intended to be used to fetch and deploy Helm Charts as part of
+cluster installation or upgrading with kubespray.
+
+Requirements
+------------
+
+The role needs to be executed on a host with access to the Kubernetes API, and
+with the helm binary in place.
+
+Role Variables
+--------------
+
+See meta/argument_specs.yml
+
+Playbook example:
+
+```yaml
+---
+- hosts: kube_controle_plane[0]
+  gather_facts: no
+  vars:
+    helm_apps:
+      - release_name: app
+        release_namespace: app
+        chart_ref: simple-app/simple-app
+    repos:
+      - repo_name: simple-app
+        repo_url: "https://blog.leiwang.info/simple-app"
+    helm_settings:
+      wait_timeout: "5m"
+  roles:
+    - name: helm-apps
+      helm_charts: "{{ helm_apps }}"
+      helm_repositories: "{{ repos }}"
+      helm_settings:
+```

--- a/roles/helm-apps/README.md
+++ b/roles/helm-apps/README.md
@@ -29,11 +29,11 @@ Playbook example:
     repos:
       - repo_name: simple-app
         repo_url: "https://blog.leiwang.info/simple-app"
-    helm_settings:
+    helm_params:
       wait_timeout: "5m"
   roles:
     - name: helm-apps
       helm_charts: "{{ helm_apps }}"
       helm_repositories: "{{ repos }}"
-      helm_settings:
+      helm_settings: "{{ helm_params }}"
 ```

--- a/roles/helm-apps/README.md
+++ b/roles/helm-apps/README.md
@@ -23,17 +23,17 @@ Playbook example:
   gather_facts: no
   roles:
     - name: helm-apps
-      charts:
-        - release_name: app
-          release_namespace: app
+      releases:
+        - name: app
+          namespace: app
           chart_ref: simple-app/simple-app
-        - release_name: app2
-          release_namespace: app
+        - name: app2
+          namespace: app
           chart_ref: simple-app/simple-app
-          wait_timeout: "10m" # override the same option in `charts_common_opts`
+          wait_timeout: "10m" # override the same option in `release_common_opts`
       repositories: "{{ repos }}"
         - repo_name: simple-app
           repo_url: "https://blog.leiwang.info/simple-app"
-      charts_common_opts: "{{ helm_params }}"
+      release_common_opts: "{{ helm_params }}"
         wait_timeout: "5m"
 ```

--- a/roles/helm-apps/meta/argument_specs.yml
+++ b/roles/helm-apps/meta/argument_specs.yml
@@ -1,0 +1,24 @@
+---
+argument_specs:
+  main:
+    short_description: Install a list of Helm charts.
+    options:
+      helm_charts:
+        type: list
+        elements: dict
+        required: true
+        description: |
+          List of dictionaries passed as arguments passed to kubernetes.core.helm.
+          Arguments passed here will supersede those in `helm_settings`
+      helm_repositories:
+        type: list
+        elements: dict
+        description: |
+          List of dictionaries passed as arguments passed to kubernetes.core.helm_repository.
+        default: []
+      helm_settings:
+        type: dict
+        description: |
+          Arguments dictionary to kubernetes.core.helm to inject for all Helm
+          charts.
+        default: {}

--- a/roles/helm-apps/meta/argument_specs.yml
+++ b/roles/helm-apps/meta/argument_specs.yml
@@ -3,23 +3,91 @@ argument_specs:
   main:
     short_description: Install a list of Helm charts.
     options:
-      helm_charts:
+      charts:
         type: list
         elements: dict
         required: true
         description: |
           List of dictionaries passed as arguments to kubernetes.core.helm.
-          Arguments passed here will supersede those in `helm_settings`
-      helm_repositories:
+          Arguments passed here will override  those in `helm_settings`.  For
+          structure of the dictionary, see the documentation for
+          kubernetes.core.helm ansible module.
+        options:
+          chart_ref:
+            type: path
+            required: true
+          chart_version:
+            type: str
+          release_name:
+            type: str
+            required: true
+          release_namespace:
+            type: str
+            required: true
+          values:
+            type: dict
+          # Possibly general options
+          create_namespace:
+            type: bool
+          chart_repo_url:
+            type: str
+          disable_hook:
+            type: bool
+          history_max:
+            type: int
+          purge:
+            type: bool
+          replace:
+            type: bool
+          skip_crds:
+            type: bool
+          wait:
+            type: bool
+            default: true
+          wait_timeout:
+            type: str
+
+      repositories:
         type: list
         elements: dict
         description: |
           List of dictionaries passed as arguments to
           kubernetes.core.helm_repository.
         default: []
-      helm_settings:
+        options:
+          name:
+            type: str
+            required: true
+          password:
+            type: str
+          username:
+            type: str
+          url:
+            type: str
+      chart_common_opts:
         type: dict
         description: |
-          Arguments dictionary to kubernetes.core.helm to inject for all Helm
-          charts.
+          Common arguments for every helm invocation.
         default: {}
+        options:
+          create_namespace:
+            type: bool
+            default: true
+          chart_repo_url:
+            type: str
+          disable_hook:
+            type: bool
+          history_max:
+            type: int
+          purge:
+            type: bool
+          replace:
+            type: bool
+          skip_crds:
+            type: bool
+          wait:
+            type: bool
+            default: true
+          wait_timeout:
+            type: str
+            default: "5m"

--- a/roles/helm-apps/meta/argument_specs.yml
+++ b/roles/helm-apps/meta/argument_specs.yml
@@ -8,13 +8,14 @@ argument_specs:
         elements: dict
         required: true
         description: |
-          List of dictionaries passed as arguments passed to kubernetes.core.helm.
+          List of dictionaries passed as arguments to kubernetes.core.helm.
           Arguments passed here will supersede those in `helm_settings`
       helm_repositories:
         type: list
         elements: dict
         description: |
-          List of dictionaries passed as arguments passed to kubernetes.core.helm_repository.
+          List of dictionaries passed as arguments to
+          kubernetes.core.helm_repository.
         default: []
       helm_settings:
         type: dict

--- a/roles/helm-apps/meta/argument_specs.yml
+++ b/roles/helm-apps/meta/argument_specs.yml
@@ -3,7 +3,7 @@ argument_specs:
   main:
     short_description: Install a list of Helm charts.
     options:
-      charts:
+      releases:
         type: list
         elements: dict
         required: true
@@ -18,10 +18,10 @@ argument_specs:
             required: true
           chart_version:
             type: str
-          release_name:
+          name:
             type: str
             required: true
-          release_namespace:
+          namespace:
             type: str
             required: true
           values:
@@ -64,7 +64,7 @@ argument_specs:
             type: str
           url:
             type: str
-      chart_common_opts:
+      release_common_opts:
         type: dict
         description: |
           Common arguments for every helm invocation.

--- a/roles/helm-apps/tasks/main.yml
+++ b/roles/helm-apps/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- name: Add Helm repositories
+  kubernetes.core.helm_repository: "{{ helm_repository_defaults | combine(item) }}"
+  loop: "{{ helm_repositories }}"
+
+- name: Update Helm repositories
+  kubernetes.core.helm:
+    state: absent
+    binary_path: "{{ bin_dir }}/helm"
+    release_name: dummy  # trick needed to refresh in separate step
+    release_namespace: kube-system
+    update_repo_cache: true
+  when: helm_repositories != []
+
+- name: Install Helm Applications
+  kubernetes.core.helm: "{{ helm_defaults | combine(helm_settings, item) }}"
+  loop: "{{ helm_apps }}"

--- a/roles/helm-apps/tasks/main.yml
+++ b/roles/helm-apps/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add Helm repositories
   kubernetes.core.helm_repository: "{{ helm_repository_defaults | combine(item) }}"
-  loop: "{{ helm_repositories }}"
+  loop: "{{ repositories }}"
 
 - name: Update Helm repositories
   kubernetes.core.helm:
@@ -10,8 +10,8 @@
     release_name: dummy  # trick needed to refresh in separate step
     release_namespace: kube-system
     update_repo_cache: true
-  when: helm_repositories != []
+  when: repositories != []
 
 - name: Install Helm Applications
-  kubernetes.core.helm: "{{ helm_defaults | combine(helm_settings, item) }}"
-  loop: "{{ helm_apps }}"
+  kubernetes.core.helm: "{{ helm_defaults | combine(chart_common_opts, item) }}"
+  loop: "{{ charts }}"

--- a/roles/helm-apps/tasks/main.yml
+++ b/roles/helm-apps/tasks/main.yml
@@ -13,5 +13,5 @@
   when: repositories != []
 
 - name: Install Helm Applications
-  kubernetes.core.helm: "{{ helm_defaults | combine(chart_common_opts, item) }}"
-  loop: "{{ charts }}"
+  kubernetes.core.helm: "{{ helm_defaults | combine(release_common_opts, item) }}"
+  loop: "{{ releases }}"

--- a/roles/helm-apps/vars/main.yml
+++ b/roles/helm-apps/vars/main.yml
@@ -1,0 +1,10 @@
+---
+helm_defaults:
+  atomic: true
+  binary_path: "{{ bin_dir }}/helm"
+  wait: true
+  wait_timeout: "10m"
+  create_namespace: true
+
+helm_repository_defaults:
+  binary_path: "{{ bin_dir }}/helm"

--- a/roles/helm-apps/vars/main.yml
+++ b/roles/helm-apps/vars/main.yml
@@ -2,9 +2,6 @@
 helm_defaults:
   atomic: true
   binary_path: "{{ bin_dir }}/helm"
-  wait: true
-  wait_timeout: "10m"
-  create_namespace: true
 
 helm_repository_defaults:
   binary_path: "{{ bin_dir }}/helm"


### PR DESCRIPTION
**What type of PR is this?**
/kind design
/kind feature

**What this PR does / why we need it**:

This introduces the `helm-apps` role.
As discussed in #6400 and #7741, this would allow to use upstream Helm chart for
various projects instead of maintaining YAML manifests in kubespray.

The general idea is to be as transparent as possible and simply exposes all
parameters of `kubernetes.core.helm*` modules by passing composed dictionnaries.
(sane defaults inside the role, allow general settings and per chart
settings).

The role is meant to be usable in several invocations if needed, for example to
separate critical charts (CNI, etc) from the others.

The eventuals default for a list of chart and a list of repositories should not
live inside the role, in my opinion.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7741 (Hopefully)

**Special notes for your reviewer**:

This is a work in progress; if there is still interest for going in that
direction, I'd like feedback on the role interface before working more on
this.

If the general direction is agreed upon, I think we need:
- [ ] invoke `kubernetes.core.helm` in parallel using async (for performance)
- [ ] have at least one the current kubernetes-apps converted to this, as a
  proof of concept (~~not sure~~ definitely).
  This will help me flesh out the usage of the role and will provide a way to test for reviewers.
  I'm probably gonna use `nginx-ingress` for that purpose.
- [ ] Document various usage of the role :
      - by default with kubespray-provided parameters (chart list, helm settings, charts values)
      - particular use cases (offline install, with one chart repository where all chart are uploaded)
      - TO BE COMPLETED
- [ ] See how to handle chart dependency 
- [ ] Add tests 
- [ ] Modify cluster.yml/upgrade-cluster.yml to integrate the role.
- ... (to be completed)

Non-goals:
- convert all kubernetes-apps. This can be accomplished in a second time, I
  think.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TO BE DONE
```
