### PR TITLE
Upgrade Cilium to 1.11.0

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
@@ -1,1 +1,3 @@
 # see roles/network_plugin/cilium/defaults/main.yml
+
+# cilium_version: "v1.11.0"

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -83,7 +83,7 @@ flannel_version: "v0.14.0"
 cni_version: "v0.9.1"
 weave_version: 2.8.1
 pod_infra_version: "3.3"
-cilium_version: "v1.9.11"
+cilium_version: "v1.11.0"
 kube_ovn_version: "v1.8.1"
 kube_router_version: "v1.3.2"
 multus_version: "v3.8"

--- a/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
@@ -32,8 +32,6 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
       - args:
-        - --kvstore=etcd
-        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
         - --config-dir=/tmp/cilium/config-map
 {% if cilium_mtu != "" %}
         - --mtu={{ cilium_mtu }}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
It upgrades Cilium to 1.11.0. 
**Which issue(s) this PR fixes**:
Fixes #8353

**Special notes for your reviewer**:
Kvstore args mess up with Cilium deployments on 1.11.0. We removed these arguments in DaemonSets. They were already removed from deployments in [PR7462](https://github.com/kubernetes-sigs/kubespray/pull/7462/files). These values already exist in the ConfigMap.


**Does this PR introduce a user-facing change?**:
```release-note
cilium: upgrade to 1.11.0
```
