### PR TITLE
Fix DNS configuration when using resolvconf_mode='host_resolvconf' during scale

### DIFF
--- a/scale.yml
+++ b/scale.yml
@@ -98,3 +98,11 @@
     - { role: kubernetes/kubeadm, tags: kubeadm }
     - { role: kubernetes/node-label, tags: node-label }
     - { role: network_plugin, tags: network }
+
+- hosts: k8s_cluster
+  gather_facts: False
+  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
+  roles:
+    - { role: kubespray-defaults }
+    - { role: kubernetes/preinstall, when: "dns_mode != 'none' and resolvconf_mode == 'host_resolvconf'", tags: resolvconf }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When `resolvconf_mode` is set to `host_resolvconf`, `kubernetes/preinstall` role should be included after `k8s` installation. Both `cluster.yml` and `upgrade-cluster.yml` include the role but `scale.yml` playbook doesn't.

That would cause that new nodes won't be properly configured to use `coredns` or `nodelocaldns` in their dns configuration.

**Special notes for your reviewer**:

I haven't openned an issue. If you consider it neccesary I will be gladed to open it.

**Does this PR introduce a user-facing change?**:

```release-note
Fix DNS configuration when using resolvconf_mode='host_resolvconf' during scale
```
