### PR TITLE
Configure PriorityClassName for MetalLB deployment

### DIFF
--- a/roles/kubernetes-apps/metallb/templates/metallb.yml.j2
+++ b/roles/kubernetes-apps/metallb/templates/metallb.yml.j2
@@ -433,6 +433,7 @@ spec:
         app: metallb
         component: controller
     spec:
+      priorityClassName: system-cluster-critical
 {% if metallb_controller_tolerations %}
       tolerations:
         {{ metallb_controller_tolerations | to_nice_yaml(indent=2) | indent(width=8) }}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

As we are already configuring `priorityClassName` for other critical `kubernetes-apps` I consider that MetalLB should configure it too.

**Special notes for your reviewer**:

I decided to configure `priorityClassName` to `system-cluster-critical` but it can be discussed :smile: 

**Does this PR introduce a user-facing change?**:

```release-note
Configure PriorityClassName for MetalLB deployment
```
