### PR TITLE
Ensure taint configuration for secondary control-plane acting both as control-plane and node

### DIFF
--- a/roles/kubernetes/control-plane/templates/kubeadm-controlplane.v1beta2.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-controlplane.v1beta2.yaml.j2
@@ -19,3 +19,10 @@ controlPlane:
 nodeRegistration:
   name: {{ kube_override_hostname|default(inventory_hostname) }}
   criSocket: {{ cri_socket }}
+{% if inventory_hostname in groups['kube_control_plane'] and inventory_hostname not in groups['kube_node'] %}
+  taints:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+{% else %}
+  taints: []
+{% endif %}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When installing with more than one `control-plane` acting both as `control-plane` and `node`, taints for secondary `control-plane` are not configured properly.

In this case, secondary `control-plane` will have the following taint:

```
- effect: NoSchedule
  key: node-role.kubernetes.io/master
```

Since we want all our `control-plane` to act both as `control-plane` and `node` this taint should not be present. In order to achieve this, we need to ensure `taints` are set to an empty list within `JoinConfiguration` in case we want our `control-plane` to act both as `control-plane` and `node`

**Special notes for your reviewer**:

I haven't openned an issue. If you consider it neccesary I will be gladed to open it.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
