### PR TITLE
Fix - Search root filesystem device

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0120-growpart-azure-centos-7.yml
+++ b/roles/kubernetes/preinstall/tasks/0120-growpart-azure-centos-7.yml
@@ -7,6 +7,10 @@
     name: cloud-utils-growpart
     state: present
 
+- name: Gather mounts facts
+  setup:
+    gather_subset: 'mounts'
+
 - name: Search root filesystem device
   vars:
     query: "[?mount=='/'].device"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
It fixes task `Search root filesystem device` in file `roles/kubernetes/preinstall/tasks/0120-growpart-azure-centos-7.yml `.

**Which issue(s) this PR fixes**:
Fixes #8365

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
