### PR TITLE
Fix scale when nodes are not available

### DIFF
--- a/remove-node.yml
+++ b/remove-node.yml
@@ -25,7 +25,7 @@
   gather_facts: no
   environment: "{{ proxy_disable_env }}"
   roles:
-    - { role: kubespray-defaults }
+    - { role: kubespray-defaults, when: reset_nodes|default(True)|bool }
     - { role: remove-node/pre-remove, tags: pre-remove }
 
 - name: Gather facts


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When removing a node which is not online we are using both `reset_nodes=false` and `allow_ungraceful_removal=true` extravars.

If we don't avoid including `kubespray-defaults` role when `reset_nodes=false` this role will try to get all nodes `facts` altough the playbook is set just to `kube_control_plane[0]`:

```
- name: Gather ansible_default_ipv4 from all hosts
  tags: always
  include_tasks: fallback_ips_gather.yml
  when: hostvars[delegate_host_to_gather_facts].ansible_default_ipv4 is not defined
  loop: "{{ groups['k8s_cluster']|default([]) + groups['etcd']|default([]) + groups['calico_rr']|default([]) }}"
  loop_control:
    loop_var: delegate_host_to_gather_facts
  run_once: yes
```

This will fail since we don't have access to de node which is trying to be deleted.

**Special notes for your reviewer**:

I haven't openned an issue. If you consider it neccesary I will be gladed to open it.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
