### PR TITLE
Fix risky-file-permissions

### DIFF
--- a/contrib/network-storage/glusterfs/roles/kubernetes-pv/ansible/tasks/main.yaml
+++ b/contrib/network-storage/glusterfs/roles/kubernetes-pv/ansible/tasks/main.yaml
@@ -3,6 +3,7 @@
   template:
     src: "{{ item.file }}"
     dest: "{{ kube_config_dir }}/{{ item.dest }}"
+    mode: 0644
   with_items:
     - { file: glusterfs-kubernetes-endpoint.json.j2, type: ep, dest: glusterfs-kubernetes-endpoint.json}
     - { file: glusterfs-kubernetes-pv.yml.j2, type: pv, dest: glusterfs-kubernetes-pv.yml}

--- a/roles/container-engine/docker-storage/tasks/main.yml
+++ b/roles/container-engine/docker-storage/tasks/main.yml
@@ -10,6 +10,7 @@
   template:
     src: docker-storage-setup.j2
     dest: /etc/sysconfig/docker-storage-setup
+    mode: 0644
 
 - name: docker-storage-override-directory | docker service storage-setup override dir
   file:

--- a/roles/kubernetes-apps/ansible/tasks/coredns.yml
+++ b/roles/kubernetes-apps/ansible/tasks/coredns.yml
@@ -3,6 +3,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 0644
   loop:
     - { name: coredns, file: coredns-clusterrole.yml, type: clusterrole }
     - { name: coredns, file: coredns-clusterrolebinding.yml, type: clusterrolebinding }
@@ -27,6 +28,7 @@
   template:
     src: "{{ item.src }}.j2"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 0644
   with_items:
     - { name: coredns, src: coredns-deployment.yml, file: coredns-deployment-secondary.yml, type: deployment }
     - { name: coredns, src: coredns-svc.yml, file: coredns-svc-secondary.yml, type: svc }

--- a/roles/kubernetes-apps/ansible/tasks/dashboard.yml
+++ b/roles/kubernetes-apps/ansible/tasks/dashboard.yml
@@ -3,6 +3,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 0644
   with_items:
     - { file: dashboard.yml, type: deploy, name: kubernetes-dashboard }
   register: manifests

--- a/roles/kubernetes-apps/ansible/tasks/etcd_metrics.yml
+++ b/roles/kubernetes-apps/ansible/tasks/etcd_metrics.yml
@@ -3,6 +3,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 0644
   with_items:
     - { file: etcd_metrics-endpoints.yml, type: endpoints, name: etcd-metrics }
     - { file: etcd_metrics-service.yml, type: service, name: etcd-metrics }

--- a/roles/kubernetes-apps/ansible/tasks/netchecker.yml
+++ b/roles/kubernetes-apps/ansible/tasks/netchecker.yml
@@ -25,6 +25,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 0644
   with_items: "{{ netchecker_templates }}"
   register: manifests
   when:

--- a/roles/kubernetes-apps/ansible/tasks/nodelocaldns.yml
+++ b/roles/kubernetes-apps/ansible/tasks/nodelocaldns.yml
@@ -19,6 +19,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 0644
   with_items:
     - { name: nodelocaldns, file: nodelocaldns-config.yml, type: configmap }
     - { name: nodelocaldns, file: nodelocaldns-sa.yml, type: sa }
@@ -48,6 +49,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 0644
   with_items:
     - { name: nodelocaldns, file: nodelocaldns-second-daemonset.yml, type: daemonset }
   register: nodelocaldns_second_manifests

--- a/roles/kubernetes-apps/argocd/tasks/main.yml
+++ b/roles/kubernetes-apps/argocd/tasks/main.yml
@@ -23,6 +23,7 @@
   get_url:
     url: "{{ item.url }}"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 0644
   with_items: "{{ argocd_templates | selectattr('url', 'defined') | list }}"
   loop_control:
     label: "{{ item.file }}"
@@ -44,6 +45,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 0644
   with_items: "{{ argocd_templates | selectattr('url', 'undefined') | list }}"
   loop_control:
     label: "{{ item.file }}"

--- a/roles/kubernetes-apps/cloud_controller/oci/tasks/main.yml
+++ b/roles/kubernetes-apps/cloud_controller/oci/tasks/main.yml
@@ -7,6 +7,7 @@
   template:
     src: controller-manager-config.yml.j2
     dest: "{{ kube_config_dir }}/controller-manager-config.yml"
+    mode: 0644
   when: inventory_hostname == groups['kube_control_plane'][0]
   tags: oci
 
@@ -25,6 +26,7 @@
   template:
     src: oci-cloud-provider.yml.j2
     dest: "{{ kube_config_dir }}/oci-cloud-provider.yml"
+    mode: 0644
   when: inventory_hostname == groups['kube_control_plane'][0]
   tags: oci
 

--- a/roles/kubernetes-apps/container_engine_accelerator/nvidia_gpu/tasks/main.yml
+++ b/roles/kubernetes-apps/container_engine_accelerator/nvidia_gpu/tasks/main.yml
@@ -33,6 +33,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/addons/container_engine_accelerator/{{ item.file }}"
+    mode: 0644
   with_items:
     - { name: nvidia-driver-install-daemonset, file: nvidia-driver-install-daemonset.yml, type: daemonset }
     - { name: k8s-device-plugin-nvidia-daemonset, file: k8s-device-plugin-nvidia-daemonset.yml, type: daemonset }

--- a/roles/kubernetes-apps/container_runtimes/gvisor/tasks/main.yaml
+++ b/roles/kubernetes-apps/container_runtimes/gvisor/tasks/main.yaml
@@ -16,6 +16,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir}}/addons/gvisor/{{ item.file }}"
+    mode: 0644
   with_items: "{{ gvisor_templates }}"
   register: gvisor_manifests
   when:

--- a/roles/kubernetes-apps/container_runtimes/kata_containers/tasks/main.yaml
+++ b/roles/kubernetes-apps/container_runtimes/kata_containers/tasks/main.yaml
@@ -17,6 +17,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/addons/kata_containers/{{ item.file }}"
+    mode: 0644
   with_items: "{{ kata_containers_templates }}"
   register: kata_containers_manifests
   when:

--- a/roles/kubernetes-apps/csi_driver/aws_ebs/tasks/main.yml
+++ b/roles/kubernetes-apps/csi_driver/aws_ebs/tasks/main.yml
@@ -3,6 +3,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 0644
   with_items:
     - {name: aws-ebs-csi-driver, file: aws-ebs-csi-driver.yml}
     - {name: aws-ebs-csi-controllerservice, file: aws-ebs-csi-controllerservice-rbac.yml}

--- a/roles/kubernetes-apps/csi_driver/azuredisk/tasks/main.yml
+++ b/roles/kubernetes-apps/csi_driver/azuredisk/tasks/main.yml
@@ -22,6 +22,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 0644
   with_items:
     - {name: azure-csi-azuredisk-driver, file: azure-csi-azuredisk-driver.yml}
     - {name: azure-csi-cloud-config-secret, file: azure-csi-cloud-config-secret.yml}

--- a/roles/kubernetes-apps/csi_driver/cinder/tasks/main.yml
+++ b/roles/kubernetes-apps/csi_driver/cinder/tasks/main.yml
@@ -34,6 +34,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 0644
   with_items:
     - {name: cinder-csi-driver, file: cinder-csi-driver.yml}
     - {name: cinder-csi-cloud-config-secret, file: cinder-csi-cloud-config-secret.yml}

--- a/roles/kubernetes-apps/csi_driver/csi_crd/tasks/main.yml
+++ b/roles/kubernetes-apps/csi_driver/csi_crd/tasks/main.yml
@@ -3,6 +3,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 0644
   with_items:
     - {name: volumesnapshotclasses, file: volumesnapshotclasses.yml}
     - {name: volumesnapshotcontents, file: volumesnapshotcontents.yml}

--- a/roles/kubernetes-apps/csi_driver/gcp_pd/tasks/main.yml
+++ b/roles/kubernetes-apps/csi_driver/gcp_pd/tasks/main.yml
@@ -25,6 +25,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 0644
   with_items:
     - {name: gcp-pd-csi-cred-secret, file: gcp-pd-csi-cred-secret.yml}
     - {name: gcp-pd-csi-setup, file: gcp-pd-csi-setup.yml}

--- a/roles/kubernetes-apps/csi_driver/vsphere/tasks/main.yml
+++ b/roles/kubernetes-apps/csi_driver/vsphere/tasks/main.yml
@@ -16,6 +16,7 @@
   template:
     src: "{{ item }}.j2"
     dest: "{{ kube_config_dir }}/{{ item }}"
+    mode: 0644
   with_items:
     - vsphere-csi-driver.yml
     - vsphere-csi-controller-rbac.yml

--- a/roles/kubernetes-apps/external_cloud_controller/vsphere/tasks/main.yml
+++ b/roles/kubernetes-apps/external_cloud_controller/vsphere/tasks/main.yml
@@ -16,6 +16,7 @@
   template:
     src: "{{ item }}.j2"
     dest: "{{ kube_config_dir }}/{{ item }}"
+    mode: 0644
   with_items:
     - external-vsphere-cpi-cloud-config-secret.yml
     - external-vsphere-cloud-controller-manager-roles.yml

--- a/roles/kubernetes-apps/external_provisioner/cephfs_provisioner/tasks/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/cephfs_provisioner/tasks/main.yml
@@ -63,6 +63,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/addons/cephfs_provisioner/{{ item.file }}"
+    mode: 0644
   with_items: "{{ cephfs_provisioner_templates }}"
   register: cephfs_provisioner_manifests
   when: inventory_hostname == groups['kube_control_plane'][0]

--- a/roles/kubernetes-apps/external_provisioner/local_path_provisioner/tasks/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/local_path_provisioner/tasks/main.yml
@@ -13,6 +13,7 @@
   file:
     path: "{{ local_path_provisioner_claim_root }}"
     state: directory
+    mode: 0755
 
 - name: Local Path Provisioner | Render Template
   set_fact:
@@ -40,6 +41,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/addons/local_path_provisioner/{{ item.file }}"
+    mode: 0644
   with_items: "{{ local_path_provisioner_templates }}"
   register: local_path_provisioner_manifests
   when: inventory_hostname == groups['kube_control_plane'][0]

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/tasks/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/tasks/main.yml
@@ -40,6 +40,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/addons/local_volume_provisioner/{{ item.file }}"
+    mode: 0644
   with_items: "{{ local_volume_provisioner_templates }}"
   register: local_volume_provisioner_manifests
   when: inventory_hostname == groups['kube_control_plane'][0]

--- a/roles/kubernetes-apps/helm/tasks/main.yml
+++ b/roles/kubernetes-apps/helm/tasks/main.yml
@@ -24,4 +24,5 @@
   copy:
     dest: /etc/bash_completion.d/helm.sh
     content: "{{ helm_completion.stdout }}"
+    mode: 0755
   become: True

--- a/roles/kubernetes-apps/ingress_controller/alb_ingress_controller/tasks/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/alb_ingress_controller/tasks/main.yml
@@ -12,6 +12,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/addons/alb_ingress/{{ item.file }}"
+    mode: 0644
   with_items:
     - { name: alb-ingress-clusterrole, file: alb-ingress-clusterrole.yml, type: clusterrole }
     - { name: alb-ingress-clusterrolebinding, file: alb-ingress-clusterrolebinding.yml, type: clusterrolebinding }

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/tasks/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/tasks/main.yml
@@ -38,6 +38,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/addons/cert_manager/{{ item.file }}"
+    mode: 0644
   with_items: "{{ cert_manager_templates }}"
   register: cert_manager_manifests
   when:

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/tasks/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/tasks/main.yml
@@ -35,6 +35,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/addons/ingress_nginx/{{ item.file }}"
+    mode: 0644
   with_items: "{{ ingress_nginx_templates }}"
   register: ingress_nginx_manifests
   when:

--- a/roles/kubernetes-apps/krew/tasks/krew.yml
+++ b/roles/kubernetes-apps/krew/tasks/krew.yml
@@ -8,11 +8,13 @@
   template:
     src: krew.j2
     dest: /etc/bash_completion.d/krew
+    mode: 0644
 
 - name: Krew | Copy krew manifest
   template:
     src: krew.yml.j2
     dest: "{{ local_release_dir }}/krew.yml"
+    mode: 0644
 
 - name: Krew | Install krew  # noqa 301 305
   shell: "{{ local_release_dir }}/krew-{{ host_os }}_{{ image_arch }} install --archive={{ local_release_dir }}/krew-{{ host_os }}_{{ image_arch }}.tar.gz --manifest={{ local_release_dir }}/krew.yml"
@@ -31,5 +33,6 @@
   copy:
     dest: /etc/bash_completion.d/krew.sh
     content: "{{ krew_completion.stdout }}"
+    mode: 0755
   become: True
   when: krew_completion.rc == 0

--- a/roles/kubernetes-apps/metallb/tasks/main.yml
+++ b/roles/kubernetes-apps/metallb/tasks/main.yml
@@ -34,7 +34,10 @@
 
 - name: Kubernetes Apps | Lay Down MetalLB
   become: true
-  template: { src: "{{ item }}.j2", dest: "{{ kube_config_dir }}/{{ item }}" }
+  template:
+    src: "{{ item }}.j2"
+    dest: "{{ kube_config_dir }}/{{ item }}"
+    mode: 0644
   with_items: ["metallb.yml", "metallb-config.yml"]
   register: "rendering"
   when:

--- a/roles/kubernetes-apps/metrics_server/tasks/main.yml
+++ b/roles/kubernetes-apps/metrics_server/tasks/main.yml
@@ -46,6 +46,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/addons/metrics_server/{{ item.file }}"
+    mode: 0644
   with_items: "{{ metrics_server_templates }}"
   register: metrics_server_manifests
   when:

--- a/roles/kubernetes-apps/persistent_volumes/aws-ebs-csi/tasks/main.yml
+++ b/roles/kubernetes-apps/persistent_volumes/aws-ebs-csi/tasks/main.yml
@@ -3,6 +3,7 @@
   template:
     src: "aws-ebs-csi-storage-class.yml.j2"
     dest: "{{ kube_config_dir }}/aws-ebs-csi-storage-class.yml"
+    mode: 0644
   register: manifests
   when:
     - inventory_hostname == groups['kube_control_plane'][0]

--- a/roles/kubernetes-apps/persistent_volumes/azuredisk-csi/tasks/main.yml
+++ b/roles/kubernetes-apps/persistent_volumes/azuredisk-csi/tasks/main.yml
@@ -3,6 +3,7 @@
   template:
     src: "azure-csi-storage-class.yml.j2"
     dest: "{{ kube_config_dir }}/azure-csi-storage-class.yml"
+    mode: 0644
   register: manifests
   when:
     - inventory_hostname == groups['kube_control_plane'][0]

--- a/roles/kubernetes-apps/persistent_volumes/cinder-csi/tasks/main.yml
+++ b/roles/kubernetes-apps/persistent_volumes/cinder-csi/tasks/main.yml
@@ -3,6 +3,7 @@
   template:
     src: "cinder-csi-storage-class.yml.j2"
     dest: "{{ kube_config_dir }}/cinder-csi-storage-class.yml"
+    mode: 0644
   register: manifests
   when:
     - inventory_hostname == groups['kube_control_plane'][0]

--- a/roles/kubernetes-apps/persistent_volumes/gcp-pd-csi/tasks/main.yml
+++ b/roles/kubernetes-apps/persistent_volumes/gcp-pd-csi/tasks/main.yml
@@ -3,6 +3,7 @@
   template:
     src: "gcp-pd-csi-storage-class.yml.j2"
     dest: "{{ kube_config_dir }}/gcp-pd-csi-storage-class.yml"
+    mode: 0644
   register: manifests
   when:
     - inventory_hostname == groups['kube_control_plane'][0]

--- a/roles/kubernetes-apps/persistent_volumes/openstack/tasks/main.yml
+++ b/roles/kubernetes-apps/persistent_volumes/openstack/tasks/main.yml
@@ -3,6 +3,7 @@
   template:
     src: "openstack-storage-class.yml.j2"
     dest: "{{ kube_config_dir }}/openstack-storage-class.yml"
+    mode: 0644
   register: manifests
   when:
     - inventory_hostname == groups['kube_control_plane'][0]

--- a/roles/kubernetes-apps/policy_controller/calico/tasks/main.yml
+++ b/roles/kubernetes-apps/policy_controller/calico/tasks/main.yml
@@ -12,6 +12,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 0644
   with_items:
     - {name: calico-kube-controllers, file: calico-kube-controllers.yml, type: deployment}
     - {name: calico-kube-controllers, file: calico-kube-sa.yml, type: sa}

--- a/roles/kubernetes-apps/registry/tasks/main.yml
+++ b/roles/kubernetes-apps/registry/tasks/main.yml
@@ -65,6 +65,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/addons/registry/{{ item.file }}"
+    mode: 0644
   with_items: "{{ registry_templates }}"
   register: registry_manifests
   when: inventory_hostname == groups['kube_control_plane'][0]
@@ -84,6 +85,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/addons/registry/{{ item.file }}"
+    mode: 0644
   with_items:
     - { name: registry-pvc, file: registry-pvc.yml, type: pvc }
   register: registry_manifests

--- a/roles/kubernetes-apps/snapshots/cinder-csi/tasks/main.yml
+++ b/roles/kubernetes-apps/snapshots/cinder-csi/tasks/main.yml
@@ -3,6 +3,7 @@
   template:
     src: "cinder-csi-snapshot-class.yml.j2"
     dest: "{{ kube_config_dir }}/cinder-csi-snapshot-class.yml"
+    mode: 0644
   register: manifests
   when:
     - inventory_hostname == groups['kube_control_plane'][0]

--- a/roles/kubernetes-apps/snapshots/snapshot-controller/tasks/main.yml
+++ b/roles/kubernetes-apps/snapshots/snapshot-controller/tasks/main.yml
@@ -3,6 +3,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 0644
   with_items:
     - {name: rbac-snapshot-controller, file: rbac-snapshot-controller.yml}
     - {name: snapshot-controller, file: snapshot-controller.yml}

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -20,6 +20,7 @@
   template:
     src: "cni-calico.conflist.j2"
     dest: "/etc/cni/net.d/calico.conflist.template"
+    mode: 0644
     owner: root
   register: calico_conflist
   notify: reset_calico_cni
@@ -126,6 +127,7 @@
       assemble:
         src: "{{ local_release_dir }}/calico-{{ calico_version }}-kdd-crds"
         dest: "{{ kube_config_dir }}/kdd-crds.yml"
+        mode: 0644
         delimiter: "---\n"
         regexp: ".*\\.yaml"
         remote_src: true
@@ -330,6 +332,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 0644
   with_items:
     - {name: calico-config, file: calico-config.yml, type: cm}
     - {name: calico-node, file: calico-node.yml, type: ds}
@@ -346,6 +349,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 0644
   with_items:
     - {name: calico, file: calico-typha.yml, type: typha}
   register: calico_node_typha_manifest

--- a/roles/network_plugin/calico/tasks/typha_certs.yml
+++ b/roles/network_plugin/calico/tasks/typha_certs.yml
@@ -9,6 +9,7 @@
   file:
     path: /etc/calico/certs
     state: directory
+    mode: 0755
   when: typha_server_secret.rc != 0
 
 - name: Calico | Copy ssl script for typha certs

--- a/roles/network_plugin/canal/tasks/main.yml
+++ b/roles/network_plugin/canal/tasks/main.yml
@@ -3,6 +3,7 @@
   template:
     src: "cni-canal.conflist.j2"
     dest: "/etc/cni/net.d/canal.conflist.template"
+    mode: 0644
     owner: kube
   register: canal_conflist
   notify: reset_canal_cni
@@ -50,6 +51,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 0644
   with_items:
     - {name: canal-config, file: canal-config.yaml, type: cm}
     - {name: canal-node, file: canal-node.yaml, type: ds}
@@ -74,3 +76,4 @@
   file:
     path: "{{ canal_policy_dir }}"
     state: directory
+    mode: 0755

--- a/roles/network_plugin/cilium/tasks/install.yml
+++ b/roles/network_plugin/cilium/tasks/install.yml
@@ -18,6 +18,7 @@
   file:
     src: "{{ etcd_cert_dir }}/{{ item.s }}"
     dest: "{{ cilium_cert_dir }}/{{ item.d }}"
+    mode: 0644
     state: hard
     force: yes
   loop:
@@ -40,6 +41,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 0644
   loop:
     - {name: cilium, file: cilium-config.yml, type: cm}
     - {name: cilium, file: cilium-crb.yml, type: clusterrolebinding}
@@ -57,6 +59,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/addons/hubble/{{ item.file }}"
+    mode: 0644
   loop:
     - {name: hubble, file: hubble-config.yml, type: cm}
     - {name: hubble, file: hubble-crb.yml, type: clusterrolebinding}
@@ -76,4 +79,5 @@
   template:
     src: 000-cilium-portmap.conflist.j2
     dest: /etc/cni/net.d/000-cilium-portmap.conflist
+    mode: 0644
   when: cilium_enable_portmap

--- a/roles/network_plugin/flannel/tasks/main.yml
+++ b/roles/network_plugin/flannel/tasks/main.yml
@@ -15,6 +15,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 0644
   with_items:
     - {name: flannel, file: cni-flannel-rbac.yml, type: sa}
     - {name: kube-flannel, file: cni-flannel.yml, type: ds}

--- a/roles/network_plugin/kube-ovn/tasks/main.yml
+++ b/roles/network_plugin/kube-ovn/tasks/main.yml
@@ -9,6 +9,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 0644
   with_items:
     - {name: kube-ovn-crd, file: cni-kube-ovn-crd.yml}
     - {name: ovn, file: cni-ovn.yml}

--- a/roles/network_plugin/kube-router/tasks/main.yml
+++ b/roles/network_plugin/kube-router/tasks/main.yml
@@ -15,6 +15,7 @@
   template:
     src: kubeconfig.yml.j2
     dest: /var/lib/kube-router/kubeconfig
+    mode: 0644
     owner: kube
   notify:
     - reset_kube_router
@@ -42,6 +43,7 @@
   template:
     src: cni-conf.json.j2
     dest: /etc/cni/net.d/10-kuberouter.conflist
+    mode: 0644
     owner: kube
   notify:
     - reset_kube_router
@@ -55,5 +57,6 @@
   template:
     src: kube-router.yml.j2
     dest: "{{ kube_config_dir }}/kube-router.yml"
+    mode: 0644
   delegate_to: "{{ groups['kube_control_plane'] | first }}"
   run_once: true

--- a/roles/network_plugin/macvlan/tasks/main.yml
+++ b/roles/network_plugin/macvlan/tasks/main.yml
@@ -23,6 +23,7 @@
   template:
     src: debian-network-macvlan.cfg.j2
     dest: /etc/network/interfaces.d/60-mac0.cfg
+    mode: 0644
   notify: Macvlan | restart network
   when: ansible_os_family in ["Debian"]
 
@@ -50,6 +51,7 @@
   template:
     src: "{{ item.src }}.j2"
     dest: "/etc/sysconfig/network-scripts/{{ item.dst }}"
+    mode: 0644
   with_items:
     - {src: centos-network-macvlan.cfg, dst: ifcfg-mac0 }
     - {src: centos-routes-macvlan.cfg, dst: route-mac0 }
@@ -61,6 +63,7 @@
   template:
     src: coreos-service-nat_ouside.j2
     dest: /etc/systemd/system/enable_nat_ouside.service
+    mode: 0644
   when: ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"] and enable_nat_default_gateway
 
 - name: Macvlan | Enable service nat via gateway on Flatcar Container Linux
@@ -74,6 +77,7 @@
   template:
     src: "{{ item.src }}.j2"
     dest: "/etc/systemd/network/{{ item.dst }}"
+    mode: 0644
   with_items:
     - {src: coreos-device-macvlan.cfg, dst: macvlan.netdev }
     - {src: coreos-interface-macvlan.cfg, dst: output.network }
@@ -85,11 +89,13 @@
   template:
     src: 10-macvlan.conf.j2
     dest: /etc/cni/net.d/10-macvlan.conf
+    mode: 0644
 
 - name: Macvlan | Install loopback definition for Macvlan
   template:
     src: 99-loopback.conf.j2
     dest: /etc/cni/net.d/99-loopback.conf
+    mode: 0644
 
 - name: Enable net.ipv4.conf.all.arp_notify in sysctl
   sysctl:

--- a/roles/network_plugin/multus/tasks/main.yml
+++ b/roles/network_plugin/multus/tasks/main.yml
@@ -3,6 +3,7 @@
   copy:
     src: "{{ item.file }}"
     dest: "{{ kube_config_dir }}"
+    mode: 0644
   with_items:
     - {name: multus-crd, file: multus-crd.yml, type: customresourcedefinition}
     - {name: multus-serviceaccount, file: multus-serviceaccount.yml, type: serviceaccount}
@@ -14,6 +15,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 0644
   with_items:
     - {name: multus-daemonset, file: multus-daemonset.yml, type: daemonset}
   register: multus_manifest_2

--- a/roles/network_plugin/weave/tasks/main.yml
+++ b/roles/network_plugin/weave/tasks/main.yml
@@ -3,8 +3,10 @@
   template:
     src: weave-net.yml.j2
     dest: "{{ kube_config_dir }}/weave-net.yml"
+    mode: 0644
 
 - name: Weave | Fix nodePort for Weave
   template:
     src: 10-weave.conflist.j2
     dest: /etc/cni/net.d/10-weave.conflist
+    mode: 0644


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

When running ansible-lint directly, we can see a lot of warning message like
```
risky-file-permissions File permissions unset or incorrect
```

This fixes the warning messages.

**Special notes for your reviewer**:

We recommend to run ansible-lint locally before submitting a pull request according to CONTRIBUTING.md.
However that outputs a lot of warning at this time.
For improving  contributor experience, these warning should be fixed.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
