### PR TITLE
Avoid yanked ruamel.yaml.clib version

### DIFF
--- a/requirements-2.10.txt
+++ b/requirements-2.10.txt
@@ -6,5 +6,5 @@ netaddr==0.7.19
 pbr==5.4.4
 jmespath==0.9.5
 ruamel.yaml==0.16.10
-ruamel.yaml.clib==0.2.4
+ruamel.yaml.clib==0.2.6
 MarkupSafe==1.1.1

--- a/requirements-2.11.txt
+++ b/requirements-2.11.txt
@@ -6,5 +6,5 @@ netaddr==0.7.19
 pbr==5.4.4
 jmespath==0.9.5
 ruamel.yaml==0.16.10
-ruamel.yaml.clib==0.2.4
+ruamel.yaml.clib==0.2.6
 MarkupSafe==1.1.1

--- a/requirements-2.9.txt
+++ b/requirements-2.9.txt
@@ -4,6 +4,6 @@ netaddr==0.7.19
 pbr==5.4.4
 jmespath==0.9.5
 ruamel.yaml==0.16.10
-ruamel.yaml.clib==0.2.4 ; python_version >= '3.5'
+ruamel.yaml.clib==0.2.6 ; python_version >= '3.5'
 ruamel.yaml.clib==0.2.2 ; python_version < '3.5'
 MarkupSafe==1.1.1


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

```
WARNING: The candidate selected for download or install is a yanked version: 'ruamel-yaml-clib' candidate (version 0.2.4 at https://files.pythonhosted.org/packages/fc/df/b4ba0cb4b05abd43e57f7dde48e5c068f21ff6c00d6a64e4471d0943f783/ruamel.yaml.clib-0.2.4-cp39-cp39-manylinux1_x86_64.whl#sha256=2d75c965c407fdef9d1b33cd39faf47aa106d3fa2cf83960ec9ed95c4c9a55bc (from https://pypi.org/simple/ruamel-yaml-clib/))
Reason for being yanked: did not include python_requires
```

See https://pypi.org/project/ruamel.yaml.clib/#history


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
