### PR TITLE
Add missing example offline nerdctl_download_url

### DIFF
--- a/inventory/sample/group_vars/all/offline.yml
+++ b/inventory/sample/group_vars/all/offline.yml
@@ -55,6 +55,7 @@
 # [Optional] runc,containerd: only if you set container_runtime: containerd
 # runc_download_url: "{{ files_repo }}/{{ runc_version }}/runc.{{ image_arch }}"
 # containerd_download_url: "{{ files_repo }}/containerd/v{{ containerd_version }}/containerd-{{ containerd_version }}-linux-{{ image_arch }}.tar.gz"
+# nerdctl_download_url: "{{ files_repo }}/nerdctl/v{{ nerdctl_version }}/nerdctl-{{ nerdctl_version }}-{{ ansible_system | lower }}-{{ image_arch }}.tar.gz"
 
 ## CentOS/Redhat/AlmaLinux
 ### For EL7, base and extras repo must be available, for EL8, baseos and appstream


### PR DESCRIPTION
**What this PR does / why we need it**:

Missing from https://github.com/kubernetes-sigs/kubespray/pull/8239

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
