### PR TITLE
Move containerd_version to defaults/main.yml

### DIFF
--- a/contrib/offline/generate_list.sh
+++ b/contrib/offline/generate_list.sh
@@ -21,6 +21,7 @@ arch=${ARCH}
 image_arch=${IMAGE_ARCH}
 ansible_system=${ANSIBLE_SYSTEM}
 ansible_architecture=${ANSIBLE_ARCHITECTURE}
+host_os=${ANSIBLE_SYSTEM}
 EOF
 
 # generate all component version by $DOWNLOAD_YML

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -58,6 +58,10 @@ crun_version: 1.4
 runc_version: v1.0.3
 kata_containers_version: 2.2.3
 gvisor_version: 20210921
+containerd_version: 1.5.8
+
+# this is relevant when container_manager == 'docker'
+docker_containerd_version: 1.4.12
 
 # gcr and kubernetes image repo define
 gcr_image_repo: "gcr.io"

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -344,11 +344,7 @@ docker_plugins: []
 etcd_kubeadm_enabled: false
 
 # Containerd options - thse are relevant when container_manager == 'containerd'
-containerd_version: 1.5.8
 containerd_use_systemd_cgroup: true
-
-# Docker options - this is relevant when container_manager == 'docker'
-docker_containerd_version: 1.4.12
 
 ## An obvious use case is allowing insecure-registry access to self hosted registries.
 ## Can be ipaddress and domain_name.


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

All container image versions were defined in download/defaults/main.yml except containerd.
The inconsistency caused the offline script(generate_list.sh) could not output the URL of containerd image.
This moves the definition into a valid file.
In addition, this adds host_os to generate_list.sh for downloading krew from a valid URL.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8378

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix an issue offline script could not output URLs of both containerd and krew.
```
