### PR TITLE
adding 0 checksum for kata_containers_version on arm(64)

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -407,6 +407,7 @@ kata_containers_binary_checksums:
     2.0.4: 0
     2.1.1: 0
     2.2.2: 0
+    2.2.3: 0
     2.3.0: 0
   amd64:
     2.0.4: 022a60c2d92a5ab9a5eb83d5a95154a2d06fdc2206b2a473d902ccc86766371a
@@ -418,6 +419,7 @@ kata_containers_binary_checksums:
     2.0.4: 0
     2.1.1: 0
     2.2.2: 0
+    2.2.3: 0
     2.3.0: 0
 
 gvisor_runsc_binary_checksums:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

In Kubespray v2.18.0 the kata version 2.2.3 was set as default (line 59 in roles/download/defaults/main.yml) the checksum was added for amd64 version but no placeholder was defined for arm64 and arm.

This causes the playbook to fail on cluster upgrade with the following error message.

```
('groups', ['kube_control_plane']))))): {{ kata_containers_binary_checksums[image_arch][kata_containers_version] }}: 'dict object' has no attribute '2.2.3'\n\nThe error appears to be in '/kubespray/roles/download/tasks/download_file. yml': line 3, column 5, but may be elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n- block:\n - name: download_file | Starting download of file\n ^ here\n"}
```

In this PR the missing placeholders are added.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fixes missing checksum for kata-containers 2.2.3 on arm architectures
```
