### PR TITLE
Fix container engine still installed on dedicated etcd node even if `etcd_deployment_type: host`

### DIFF
--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -258,7 +258,7 @@ kubelet_shutdown_grace_period: 60s
 kubelet_shutdown_grace_period_critical_pods: 20s
 
 # Whether to deploy the container engine
-deploy_container_engine: inventory_hostname in groups['k8s_cluster'] or etcd_deployment_type != 'host'
+deploy_container_engine: "{{ inventory_hostname in groups['k8s_cluster'] or etcd_deployment_type != 'host' }}"
 
 # Container for runtime
 container_manager: containerd


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Missing a bracket `{{ ... }}` in #7532 cause the `deploy_container_engine` to parse as a string instead of conditional logic.

**Which issue(s) this PR fixes**:
Fixes #8381 #7987

**Special notes for your reviewer**:
- This fix should also backport to `release-2.18`
- Look like there's no CI test for dedicated `etcd`?

**Does this PR introduce a user-facing change?**:
```release-note
Fix container engine still installed on dedicated etcd node even if `etcd_deployment_type: host`
```
