### PR TITLE
Fix Fedora CI following ipset version in kube-proxy for k8s 1.23

### DIFF
--- a/tests/files/packet_fedora34-calico-selinux.yml
+++ b/tests/files/packet_fedora34-calico-selinux.yml
@@ -5,6 +5,10 @@ mode: default
 
 # Kubespray settings
 auto_renew_certificates: true
+# Switching to iptable due to https://github.com/projectcalico/calico/issues/5011
+# Kubernetes v1.23.0 kube-proxy does use v.7.x now. Calico v3.20.x/v3.21.x Pods show the following error
+# Bad return code from 'ipset list'. error=exit status 1 family="inet" stderr="ipset v7.1: Kernel and userspace incompatible: settype hash:ip,port with revision 6 not supported by userspace.
+kube_proxy_mode: iptables
 
 # Test with SELinux in enforcing mode
 preinstall_selinux_state: enforcing

--- a/tests/files/packet_fedora35-docker-calico.yml
+++ b/tests/files/packet_fedora35-docker-calico.yml
@@ -5,6 +5,10 @@ mode: default
 
 # Kubespray settings
 auto_renew_certificates: true
+# Switching to iptable due to https://github.com/projectcalico/calico/issues/5011
+# Kubernetes v1.23.0 kube-proxy does use v.7.x now. Calico v3.20.x/v3.21.x Pods show the following error
+# Bad return code from 'ipset list'. error=exit status 1 family="inet" stderr="ipset v7.1: Kernel and userspace incompatible: settype hash:ip,port with revision 6 not supported by userspace.
+kube_proxy_mode: iptables
 
 # Docker specific settings:
 container_manager: docker


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Incompatible ipset protocol version (7) included in kube-proxy since k8s 1.23, is causing issue with fedora kernel.
https://github.com/projectcalico/calico/issues/5011
`Bad return code from 'ipset list'. error=exit status 1 family="inet" stderr="ipset v7.1: Kernel and userspace incompatible: settype hash:ip,port with revision 6 not supported by userspace.`


**Which issue(s) this PR fixes**:
Fixes 
https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/1956025018
https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/1957228282

**Special notes for your reviewer**:
Switching to iptables instead of ipvs in the meantime..
=> https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/1959178378
=> https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/1959178373

**Does this PR introduce a user-facing change?**:
```release-note
[⚠️ ADD NOTE: For now Calico and K8S 1.23 might broke under some OS, careful !]
```
