### PR TITLE
Block failures of ansible-lint at the CI

### DIFF
--- a/.gitlab-ci/lint.yml
+++ b/.gitlab-ci/lint.yml
@@ -23,9 +23,8 @@ ansible-lint:
   extends: .job
   stage: unit-tests
   tags: [light]
-  # lint every yml/yaml file that looks like it contains Ansible plays
-  script: |-
-    grep -Rl '^- hosts: \|^  hosts: ' --include \*.yml --include \*.yaml . | xargs -P 4 -n 25 ansible-lint -v
+  script:
+    - ansible-lint -v
   except: ['triggers', 'master']
 
 syntax-check:

--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -178,6 +178,7 @@
   template:
     src: unqualified.conf.j2
     dest: "/etc/containers/registries.conf.d/01-unqualified.conf"
+    mode: 0644
   notify: restart crio
 
 - name: Write cri-o proxy drop-in

--- a/roles/kubernetes-apps/argocd/tasks/main.yml
+++ b/roles/kubernetes-apps/argocd/tasks/main.yml
@@ -14,7 +14,7 @@
       - name: install
         file: argocd-install.yml
         namespace: "{{ argocd_namespace }}"
-        url: "https://raw.githubusercontent.com/argoproj/argo-cd/{{argocd_version}}/manifests/install.yaml"
+        url: "https://raw.githubusercontent.com/argoproj/argo-cd/{{ argocd_version }}/manifests/install.yaml"
   when:
     - "inventory_hostname == groups['kube_control_plane'][0]"
 
@@ -33,7 +33,7 @@
 - name: Kubernetes Apps | Set ArgoCD namespace for remote manifests
   become: yes
   command: |
-    {{ bin_dir }}/yq eval-all -i '.metadata.namespace="{{argocd_namespace}}"' {{ kube_config_dir }}/{{ item.file }}
+    {{ bin_dir }}/yq eval-all -i '.metadata.namespace="{{ argocd_namespace }}"' {{ kube_config_dir }}/{{ item.file }}
   with_items: "{{ argocd_templates | selectattr('url', 'defined') | list }}"
   loop_control:
     label: "{{ item.file }}"
@@ -67,10 +67,10 @@
 - name: Kubernetes Apps | Set ArgoCD custom admin password
   become: yes
   shell: |
-    {{ bin_dir }}/kubectl --kubeconfig /etc/kubernetes/admin.conf -n {{argocd_namespace}} patch secret argocd-secret -p \
+    {{ bin_dir }}/kubectl --kubeconfig /etc/kubernetes/admin.conf -n {{ argocd_namespace }} patch secret argocd-secret -p \
       '{
         "stringData": {
-          "admin.password": "{{argocd_admin_password|password_hash('bcrypt')}}",
+          "admin.password": "{{ argocd_admin_password | password_hash('bcrypt') }}",
           "admin.passwordMtime": "'$(date +%FT%T%Z)'"
         }
       }'

--- a/roles/kubernetes-apps/container_runtimes/gvisor/tasks/main.yaml
+++ b/roles/kubernetes-apps/container_runtimes/gvisor/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: gVisor | Create addon dir
   file:
-    path: "{{ kube_config_dir}}/addons/gvisor"
+    path: "{{ kube_config_dir }}/addons/gvisor"
     owner: root
     group: root
     mode: 0755
@@ -15,7 +15,7 @@
 - name: gVisort | Create manifests
   template:
     src: "{{ item.file }}.j2"
-    dest: "{{ kube_config_dir}}/addons/gvisor/{{ item.file }}"
+    dest: "{{ kube_config_dir }}/addons/gvisor/{{ item.file }}"
     mode: 0644
   with_items: "{{ gvisor_templates }}"
   register: gvisor_manifests
@@ -25,7 +25,7 @@
 - name: gVisor | Apply manifests
   kube:
     name: "{{ item.item.name }}"
-    kubectl: "{{ bin_dir}}/kubectl"
+    kubectl: "{{ bin_dir }}/kubectl"
     resource: "{{ item.item.type }}"
     filename: "{{ kube_config_dir }}/addons/gvisor/{{ item.item.file }}"
     state: "latest"

--- a/roles/kubernetes-apps/external_provisioner/rbd_provisioner/tasks/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/rbd_provisioner/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: RBD Provisioner | Remove legacy namespace
   command: >
     {{ kubectl }} delete namespace {{ rbd_provisioner_namespace }}
-  ignore_errors: true  # noqa ignore-errrors
+  ignore_errors: true  # noqa ignore-errors
   when:
     - inventory_hostname == groups['kube_control_plane'][0]
   tags:
@@ -21,7 +21,7 @@
 - name: RBD Provisioner | Remove legacy storageclass
   command: >
     {{ kubectl }} delete storageclass {{ rbd_provisioner_storage_class }}
-  ignore_errors: true  # noqa ignore-errrors
+  ignore_errors: true  # noqa ignore-errors
   when:
     - inventory_hostname == groups['kube_control_plane'][0]
   tags:

--- a/roles/kubernetes-apps/registry/tasks/main.yml
+++ b/roles/kubernetes-apps/registry/tasks/main.yml
@@ -8,21 +8,21 @@
   fail:
     msg: "registry_service_cluster_ip support only compatible with ClusterIP."
   when:
-    - registry_service_cluster_ip is defined and registry_service_cluster_ip != ""
+    - registry_service_cluster_ip is defined and registry_service_cluster_ip|length > 0
     - registry_service_type != "ClusterIP"
 
 - name: Registry | Stop if registry_service_loadbalancer_ip is defined when registry_service_type is not 'LoadBalancer'
   fail:
     msg: "registry_service_loadbalancer_ip support only compatible with LoadBalancer."
   when:
-    - registry_service_loadbalancer_ip is defined and registry_service_loadbalancer_ip != ""
+    - registry_service_loadbalancer_ip is defined and registry_service_loadbalancer_ip|length > 0
     - registry_service_type != "LoadBalancer"
 
 - name: Registry | Stop if registry_service_nodeport is defined when registry_service_type is not 'NodePort'
   fail:
     msg: "registry_service_nodeport support only compatible with NodePort."
   when:
-    - registry_service_nodeport is defined and registry_service_nodeport != ""
+    - registry_service_nodeport is defined and registry_service_nodeport|length > 0
     - registry_service_type != "NodePort"
 
 - name: Registry | Create addon dir
@@ -59,7 +59,7 @@
     registry_templates: "{{ registry_templates + [item] }}"
   with_items:
     - [{ name: registry-ing, file: registry-ing.yml, type: ing }]
-  when: ingress_nginx_enabled == true or ingress_alb_enabled == true
+  when: ingress_nginx_enabled or ingress_alb_enabled
 
 - name: Registry | Create manifests
   template:

--- a/roles/network_plugin/calico/tasks/reset.yml
+++ b/roles/network_plugin/calico/tasks/reset.yml
@@ -12,5 +12,7 @@
   when: dummy0.stat.exists
 
 - name: reset | get and remove remaining routes set by bird
-  shell: ip route show proto bird | xargs -i bash -c "ip route del {} proto bird "
+  shell: set -o pipefail && ip route show proto bird | xargs -i bash -c "ip route del {} proto bird "
+  args:
+    executable: /bin/bash
   changed_when: false

--- a/roles/network_plugin/ovn4nfv/tasks/main.yml
+++ b/roles/network_plugin/ovn4nfv/tasks/main.yml
@@ -9,6 +9,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 0644
   with_items:
     - {name: ovn-daemonset, file: ovn-daemonset.yml}
     - {name: ovn4nfv-k8s-plugin, file: ovn4nfv-k8s-plugin.yml}


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This fixes the following types of failures:
- empty-string-compare
- literal-compare
- risky-file-permissions
- risky-shell-pipe
- var-spacing

In addition, this changes .gitlab-ci/lint.yml to block the same issue by using the same method at Kubespray CI.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8400

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
