### PR TITLE
[2.18] Fix container engine still installed on dedicated etcd

### DIFF
--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -254,7 +254,7 @@ kubelet_shutdown_grace_period: 60s
 kubelet_shutdown_grace_period_critical_pods: 20s
 
 # Whether to deploy the container engine
-deploy_container_engine: inventory_hostname in groups['k8s_cluster'] or etcd_deployment_type != 'host'
+deploy_container_engine: "{{ inventory_hostname in groups['k8s_cluster'] or etcd_deployment_type != 'host' }}"
 
 # Container for runtime
 container_manager: containerd


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Backport of #8386 to `release-2.18` branch

**Which issue(s) this PR fixes**:
Fixes #7987
Fixes #8381

**Special notes for your reviewer**:
- Open discussion. I'm not sure if we should backport this PR or just wait for 2.18.1 release.

**Does this PR introduce a user-facing change?**:
```release-note
Fix container engine still installed on dedicated etcd node even if `etcd_deployment_type: host`
```
