### PR TITLE
Fix kubectl call before installing it when setting `first_kube_control_plane`/`joined_control_planes`

### DIFF
--- a/roles/kubernetes/control-plane/tasks/main.yml
+++ b/roles/kubernetes/control-plane/tasks/main.yml
@@ -3,9 +3,6 @@
   tags:
     - k8s-pre-upgrade
 
-- name: Define nodes already joined to existing cluster and first_kube_control_plane
-  import_tasks: define-first-kube-control.yml
-
 - name: Create webhook token auth config
   template:
     src: webhook-token-auth-config.yaml.j2
@@ -63,6 +60,9 @@
   set_fact:
     kube_apiserver_enable_admission_plugins: "{{ kube_apiserver_enable_admission_plugins | difference(['SecurityContextDeny']) | union(['PodSecurityPolicy']) | unique }}"
   when: podsecuritypolicy_enabled
+
+- name: Define nodes already joined to existing cluster and first_kube_control_plane
+  import_tasks: define-first-kube-control.yml
 
 - name: Include kubeadm setup
   import_tasks: kubeadm-setup.yml


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
kubectl is called before being installed thus variable are never set

**Which issue(s) this PR fixes**:
```
TASK [kubernetes/control-plane : Check which kube-control nodes are already members of the cluster] ***
task path: /builds/kargo-ci/kubernetes-sigs-kubespray/roles/kubernetes/control-plane/tasks/define-first-kube-control.yml:3
Tuesday 11 January 2022  19:02:15 +0000 (0:00:00.076)       0:18:05.206 ******* 
fatal: [instance-1]: FAILED! => {"changed": false, "cmd": "/usr/local/bin/kubectl get nodes --selector=node-role.kubernetes.io/control-plane -o json", "msg": "[Errno 2] No such file or directory: b'/usr/local/bin/kubectl': b'/usr/local/bin/kubectl'", "rc": 2}
...ignoring
```

**Special notes for your reviewer**:
n/a

**Does this PR introduce a user-facing change?**:
```release-note
Fix kubectl call before installing it when setting `first_kube_control_plane`/`joined_control_planes`
```
