### PR TITLE
 Backport various fixes for 2.18

### DIFF
--- a/docs/containerd.md
+++ b/docs/containerd.md
@@ -28,4 +28,13 @@ containerd_registries:
     - "https://registry-1.docker.io"
 ```
 
+`containerd_registries` is ignored for pulling images when `image_command_tool=nerdctl`
+(the default for `container_manager=containerd`). Use `crictl` instead, it supports
+`containerd_registries` but lacks proper multi-arch support (see
+[#8375](https://github.com/kubernetes-sigs/kubespray/issues/8375)):
+
+```yaml
+image_command_tool: crictl
+```
+
 [containerd]: https://containerd.io/

--- a/docs/vars.md
+++ b/docs/vars.md
@@ -52,7 +52,11 @@ Kubernetes needs some parameters in order to get deployed. These are the
 following default cluster parameters:
 
 * *cluster_name* - Name of cluster (default is cluster.local)
-* *container_manager* - Container Runtime to install in the nodes (default is docker)
+* *container_manager* - Container Runtime to install in the nodes (default is containerd)
+* *image_command_tool* - Tool used to pull images (default depends on `container_manager`
+  and is `nerdctl` for `containerd`, `crictl` for `crio`, `docker` for `docker`)
+* *image_command_tool_on_localhost* - Tool used to pull images on localhost
+  (default is equal to `image_command_tool`)
 * *dns_domain* - Name of cluster DNS domain (default is cluster.local)
 * *kube_network_plugin* - Plugin to use for container networking
 * *kube_service_addresses* - Subnet for cluster IPs (default is

--- a/inventory/sample/group_vars/all/offline.yml
+++ b/inventory/sample/group_vars/all/offline.yml
@@ -55,6 +55,7 @@
 # [Optional] runc,containerd: only if you set container_runtime: containerd
 # runc_download_url: "{{ files_repo }}/{{ runc_version }}/runc.{{ image_arch }}"
 # containerd_download_url: "{{ files_repo }}/containerd/v{{ containerd_version }}/containerd-{{ containerd_version }}-linux-{{ image_arch }}.tar.gz"
+# nerdctl_download_url: "{{ files_repo }}/nerdctl/v{{ nerdctl_version }}/nerdctl-{{ nerdctl_version }}-{{ ansible_system | lower }}-{{ image_arch }}.tar.gz"
 
 ## CentOS/Redhat/AlmaLinux
 ### For EL7, base and extras repo must be available, for EL8, baseos and appstream

--- a/requirements-2.10.txt
+++ b/requirements-2.10.txt
@@ -6,5 +6,5 @@ netaddr==0.7.19
 pbr==5.4.4
 jmespath==0.9.5
 ruamel.yaml==0.16.10
-ruamel.yaml.clib==0.2.4
+ruamel.yaml.clib==0.2.6
 MarkupSafe==1.1.1

--- a/requirements-2.11.txt
+++ b/requirements-2.11.txt
@@ -6,5 +6,5 @@ netaddr==0.7.19
 pbr==5.4.4
 jmespath==0.9.5
 ruamel.yaml==0.16.10
-ruamel.yaml.clib==0.2.4
+ruamel.yaml.clib==0.2.6
 MarkupSafe==1.1.1

--- a/requirements-2.9.txt
+++ b/requirements-2.9.txt
@@ -4,6 +4,6 @@ netaddr==0.7.19
 pbr==5.4.4
 jmespath==0.9.5
 ruamel.yaml==0.16.10
-ruamel.yaml.clib==0.2.4 ; python_version >= '3.5'
+ruamel.yaml.clib==0.2.6 ; python_version >= '3.5'
 ruamel.yaml.clib==0.2.2 ; python_version < '3.5'
 MarkupSafe==1.1.1

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -45,6 +45,22 @@ download_validate_certs: true
 # Use the first kube_control_plane if download_localhost is not set
 download_delegate: "{% if download_localhost %}localhost{% else %}{{ groups['kube_control_plane'][0] }}{% endif %}"
 
+# The docker_image_info_command might seems weird but we are using raw/endraw and `{{ `{{` }}` to manage the double jinja2 processing
+docker_image_pull_command: "{{ docker_bin_dir }}/docker pull"
+docker_image_info_command: "{{ docker_bin_dir }}/docker images -q | xargs -i {{ '{{' }} docker_bin_dir }}/docker inspect -f {% raw %}'{{ '{{' }} if .RepoTags }}{{ '{{' }} join .RepoTags \",\" }}{{ '{{' }} end }}{{ '{{' }} if .RepoDigests }},{{ '{{' }} join .RepoDigests \",\" }}{{ '{{' }} end }}' {% endraw %} {} | tr '\n' ','"
+nerdctl_image_info_command: "{{ bin_dir }}/nerdctl -n k8s.io images --format '{% raw %}{{ '{{' }} .Repository {{ '}}' }}:{{ '{{' }} .Tag {{ '}}' }}{% endraw %}' 2>/dev/null | grep -v ^:$ | tr '\n' ','"
+nerdctl_image_pull_command: "{{ bin_dir }}/nerdctl -n k8s.io pull --quiet"
+crictl_image_info_command: "{{ bin_dir }}/crictl images --verbose | awk -F ': ' '/RepoTags|RepoDigests/ {print $2}' | tr '\n' ','"
+crictl_image_pull_command: "{{ bin_dir }}/crictl pull"
+
+image_command_tool: "{%- if container_manager == 'containerd' -%}nerdctl{%- elif container_manager == 'crio' -%}crictl{%- else -%}{{ container_manager }}{%- endif -%}"
+image_command_tool_on_localhost: "{{ image_command_tool }}"
+
+image_pull_command: "{{ lookup('vars', image_command_tool + '_image_pull_command') }}"
+image_info_command: "{{ lookup('vars', image_command_tool + '_image_info_command') }}"
+image_pull_command_on_localhost: "{{ lookup('vars', image_command_tool_on_localhost + '_image_pull_command') }}"
+image_info_command_on_localhost: "{{ lookup('vars', image_command_tool_on_localhost + '_image_info_command') }}"
+
 # Arch of Docker images and needed packages
 image_arch: "{{host_architecture | default('amd64')}}"
 

--- a/roles/download/tasks/prep_download.yml
+++ b/roles/download/tasks/prep_download.yml
@@ -5,44 +5,6 @@
   tags:
     - facts
 
-# The docker image_info_command might seems weird but we are using raw/endraw and `{{ `{{` }}` to manage the double jinja2 processing
-# done here and when `image_info_command` is used (first the raw/endraw allow to store the command, then the second processing replace `{{`
-- name: prep_download | Set image pull/info command for docker
-  set_fact:
-    image_pull_command: "{{ docker_bin_dir }}/docker pull"
-    image_info_command: "{{ docker_bin_dir }}/docker images -q | xargs -i {{ '{{' }} docker_bin_dir }}/docker inspect -f {% raw %}'{{ '{{' }} if .RepoTags }}{{ '{{' }} join .RepoTags \",\" }}{{ '{{' }} end }}{{ '{{' }} if .RepoDigests }},{{ '{{' }} join .RepoDigests \",\" }}{{ '{{' }} end }}' {% endraw %} {} | tr '\n' ','"
-  when: container_manager == 'docker'
-
-- name: prep_download | Set image pull/info command for containerd
-  set_fact:
-    image_info_command: "{{ bin_dir }}/nerdctl -n k8s.io images --format '{% raw %}{{ '{{' }} .Repository {{ '}}' }}:{{ '{{' }} .Tag {{ '}}' }}{% endraw %}' 2>/dev/null | grep -v ^:$ | tr '\n' ','"
-    image_pull_command: "{{ bin_dir }}/nerdctl -n k8s.io pull --quiet"
-  when: container_manager == 'containerd'
-
-- name: prep_download | Set image pull/info command for crio
-  set_fact:
-    image_info_command: "{{ bin_dir }}/crictl images --verbose | awk -F ': ' '/RepoTags|RepoDigests/ {print $2}' | tr '\n' ','"
-    image_pull_command: "{{ bin_dir }}/crictl pull"
-  when: container_manager == 'crio'
-
-- name: prep_download | Set image pull/info command for docker on localhost
-  set_fact:
-    image_pull_command_on_localhost: "{{ docker_bin_dir }}/docker pull"
-    image_info_command_on_localhost: "{{ docker_bin_dir }}/docker images"
-  when: container_manager_on_localhost == 'docker'
-
-- name: prep_download | Set image pull/info command for containerd on localhost
-  set_fact:
-    image_info_command_on_localhost: "{{ bin_dir }}/nerdctl -n k8s.io images --format '{% raw %}{{ '{{' }} .Repository {{ '}}' }}:{{ '{{' }} .Tag {{ '}}' }}{% endraw %}' 2>/dev/null | grep -v ^:$ | tr '\n' ','"
-    image_pull_command_on_localhost: "{{ bin_dir }}/nerdctl -n k8s.io pull --quiet"
-  when: container_manager_on_localhost == 'containerd'
-
-- name: prep_download | Set image pull/info command for crio on localhost
-  set_fact:
-    image_info_command_on_localhost: "{{ bin_dir }}/crictl images --verbose | awk -F ': ' '/RepoTags|RepoDigests/ {print $2}' | tr '\n' ','"
-    image_pull_command_on_localhost: "{{ bin_dir }}/crictl pull"
-  when: container_manager_on_localhost == 'crio'
-
 - name: prep_download | On localhost, check if passwordless root is possible
   command: "true"
   delegate_to: localhost


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:

This is a collection of backports for 2.18:

- #8372
- #8373
- #8380 (adapted because nerdctl_extra_flags is not in the release-2.18 branch (#8339))
- #8409

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
