### PR TITLE
DNM: Delete unnecessary subnet on tf-elastx_cleanup

### DIFF
--- a/scripts/openstack-cleanup/main.py
+++ b/scripts/openstack-cleanup/main.py
@@ -41,6 +41,13 @@ def main():
     map_if_old(conn.network.delete_security_group,
                conn.network.security_groups())
 
+    for r in conn.network.routers():
+        try:
+            conn.network.remove_interface_from_router(r, subnet_id='2f79d96d-53c3-4553-9191-df6cd0a30884')
+        except Exception as ex:
+            print('Failed to delete subnet from router as %s', ex)
+            continue
+
     print('Ports...')
     map_if_old(conn.network.delete_port,
                conn.network.ports())


### PR DESCRIPTION

**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

This is a workaround pull request to cleanup unnecessary subnet on elastx cloud.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8211

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
