### PR TITLE
cert-manager: Allow to change leader election namespace for GKE Autopilot support

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s_cluster/addons.yml
@@ -152,6 +152,7 @@ cert_manager_enabled: false
 #   -----BEGIN CERTIFICATE-----
 #   [REPLACE with your CA certificate]
 #   -----END CERTIFICATE-----
+# cert_manager_leader_election_namespace: kube-system
 
 # MetalLB deployment
 metallb_enabled: false

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/defaults/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/defaults/main.yml
@@ -4,3 +4,7 @@ cert_manager_user: 1001
 cert_manager_tolerations: []
 cert_manager_affinity: {}
 cert_manager_nodeselector: {}
+
+## Change leader election namespace when deploying on GKE Autopilot that forbid the changes on kube-system namespace.
+## See https://github.com/jetstack/cert-manager/issues/3717
+cert_manager_leader_election_namespace: kube-system

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
@@ -866,7 +866,7 @@ spec:
           imagePullPolicy: {{ k8s_image_pull_policy }}
           args:
           - --v=2
-          - --leader-election-namespace=kube-system
+          - --leader-election-namespace={{ cert_manager_leader_election_namespace }}
           env:
           - name: POD_NAMESPACE
             valueFrom:
@@ -940,7 +940,7 @@ spec:
           args:
           - --v=2
           - --cluster-resource-namespace=$(POD_NAMESPACE)
-          - --leader-election-namespace=kube-system
+          - --leader-election-namespace={{ cert_manager_leader_election_namespace }}
           ports:
           - containerPort: 9402
             protocol: TCP


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

- cert-manager manifest force to set leader election namespace to kube-system (See jetstack/cert-manager#4102).
- GKE Autopilot forbid user to touch the kube-system namespace (See jetstack/cert-manager#3717).
- This PR allow user to override the leader election namespace to allow installation on GKE Autopilot or another system that forbid the change to kube-system.


**Which issue(s) this PR fixes**:

Fixes #8393 


**Special notes for your reviewer**:

Tested on my cluster


**Does this PR introduce a user-facing change?**:
```release-note
cert-manager: Allow to change leader election namespace for GKE Autopilot support
```
