### PR TITLE
[calico] drop 3.18.x and make 3.21.x the new default

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -93,7 +93,7 @@ github_image_repo: "ghcr.io"
 
 # TODO(mattymo): Move calico versions to roles/network_plugins/calico/defaults
 # after migration to container download
-calico_version: "v3.20.3"
+calico_version: "v3.21.2"
 calico_ctl_version: "{{ calico_version }}"
 calico_cni_version: "{{ calico_version }}"
 calico_flexvol_version: "{{ calico_version }}"
@@ -363,22 +363,18 @@ calicoctl_binary_checksums:
     v3.21.2: 0
     v3.20.3: 0
     v3.19.3: 0
-    v3.18.6: 0
   amd64:
     v3.21.2: d495edfc254e00f008ef6872422a31ef5f442a1ff96bcb724dd2df86ef75b7e3
     v3.20.3: 29bec97b1dfc135b830b0cbfd3dfe216f00e97e9e6ef08e620d81d4a09db6393
     v3.19.3: e9d91036764ec24f32025c3176efb2c2673b9936270e6165fb6583cce97bc43f
-    v3.18.6: 0306c2e82d7c77d53d3e1bc3d826c01bb670292562c1f2287b80738064710665
   arm64:
     v3.21.2: 94c1bec6b7661243f053314d901df54d2e3e5bf4eb746af09b29b07e4654f4b9
     v3.20.3: 63683f21515a20ceee8f234a9aba0e5efb342860940026d0ba6f281cc76aa1e3
     v3.19.3: ec3cfbd2dccbd614ac353be8c9abf8e336d8700fbd2b9b76da1c3c4c14a6dfe2
-    v3.18.6: 2990c2004d9b9ab6cfc913fe0ed521c12d7b5a3f3fcf4940549a8a15721e84dd
 calico_crds_archive_checksums:
   v3.21.2: 6f1342ac8b3d9ebfa9714f06aa92f4f0eea0d2b09d7e77ed73c0c9de0bb0aee8
   v3.20.3: 2a3a5cbe05c60fa2fc850252c4eecfa36dd6629191ed805eea31f9b5c740bc4c
   v3.19.3: 7066d0e6b0136920f82a75a5bd2d595e9f69bd3ab823403e920906569ec6be07
-  v3.18.6: f8eea12992c41bb4954364e9e4d332b4daf40305688973541110b6268dc0037a
 
 krew_archive_checksums:
   linux:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
This PR makes calico 3.21.x the new default and drops support for 3.18.x

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[calico] make calico 3.21.x the news default and drop 3.18.x
```
