### PR TITLE
cert-manager: Fix incorrect leader election namespace lead to insufficient permission

### DIFF
--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
@@ -630,7 +630,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cert-manager-cainjector:leaderelection
-  namespace: {{ cert_manager_namespace }}
+  namespace: {{ cert_manager_leader_election_namespace }}
   labels:
     app: cainjector
     app.kubernetes.io/name: cainjector
@@ -664,7 +664,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cert-manager:leaderelection
-  namespace: {{ cert_manager_namespace }}
+  namespace: {{ cert_manager_leader_election_namespace }}
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
@@ -719,7 +719,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cert-manager-cainjector:leaderelection
-  namespace: {{ cert_manager_namespace }}
+  namespace: {{ cert_manager_leader_election_namespace }}
   labels:
     app: cainjector
     app.kubernetes.io/name: cainjector
@@ -742,7 +742,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cert-manager:leaderelection
-  namespace: {{ cert_manager_namespace }}
+  namespace: {{ cert_manager_leader_election_namespace }}
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

My last PR #8424 fix the GKE Autopilot problem but not the original problem reported in #8393 (at least it didn't break anything).

https://github.com/kubernetes-sigs/kubespray/blob/cee481f63d50d18ce33d727e59fdc1ac4fbeb343/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2#L629-L633

Referring to [official cert-manager manifest](https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml). The leader election namespace is `kube-system`, not `cert-manager`. so the metadata.namespace here (and other 3 places) should be the `cert_manager_leader_election_namespace` (which I introduced in #8424) instead of `cert_manager_namespace`.

This PR change namespace configurations in `cert-manager.yml.j2` to match the upstream cert-manager manifests which use kube-system by default and allow overriding with `cert_manager_leader_election_namespace` variable.


**Which issue(s) this PR fixes**:

Fixes #8393


**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
```release-note
Fix incorrect leader election namespace with cert-manager leading to insufficient permission
```
