### PR TITLE
fix(*): remove the etcd events cluster member node when the cluster node was deleted

### DIFF
--- a/roles/recover_control_plane/etcd/tasks/main.yml
+++ b/roles/recover_control_plane/etcd/tasks/main.yml
@@ -91,3 +91,38 @@
     - not healthy
     - has_quorum
     - hostvars[item[0]]['etcd_member_name'] == item[1].replace(' ','').split(',')[2]
+
+- name: Get etcd events cluster members
+  command: "{{ bin_dir }}/etcdctl member list"
+  register: member_list
+  changed_when: false
+  check_mode: no
+  environment:
+    ETCDCTL_API: 3
+    ETCDCTL_ENDPOINTS: "{{ etcd_events_access_addresses }}"
+    ETCDCTL_CERT: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
+    ETCDCTL_KEY: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
+    ETCDCTL_CACERT: "{{ etcd_cert_dir }}/ca.pem"
+  when:
+    - groups['broken_etcd']
+    - not healthy
+    - has_quorum
+    - etcd_events_cluster_enabled
+
+- name: Remove broken cluster events members
+  command: "{{ bin_dir }}/etcdctl member remove {{ item[1].replace(' ','').split(',')[0] }}"
+  environment:
+    ETCDCTL_API: 3
+    ETCDCTL_ENDPOINTS: "{{ etcd_events_access_addresses }}"
+    ETCDCTL_CERT: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
+    ETCDCTL_KEY: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
+    ETCDCTL_CACERT: "{{ etcd_cert_dir }}/ca.pem"
+  with_nested:
+    - "{{ groups['broken_etcd'] }}"
+    - "{{ member_list.stdout_lines }}"
+  when:
+    - groups['broken_etcd']
+    - not healthy
+    - has_quorum
+    - hostvars[item[0]]['etcd_member_name'] == item[1].replace(' ','').split(',')[2]
+    - etcd_events_cluster_enabled

--- a/roles/remove-node/remove-etcd-node/tasks/main.yml
+++ b/roles/remove-node/remove-etcd-node/tasks/main.yml
@@ -62,3 +62,45 @@
   when:
     - inventory_hostname in groups['etcd']
     - etcd_member_id.stdout | length > 0
+
+- name: Lookup etcd events member id
+  shell: "{{ bin_dir }}/etcdctl member list | grep {{ node_ip }} | cut -d, -f1"
+  register: etcd_member_id
+  ignore_errors: true  # noqa ignore-errors
+  changed_when: false
+  check_mode: no
+  tags:
+    - facts
+  environment:
+    ETCDCTL_API: 3
+    ETCDCTL_CERT: "{{ kube_cert_dir + '/etcd/server.crt' if etcd_kubeadm_enabled else etcd_cert_dir + '/admin-' + groups['etcd']|first + '.pem' }}"
+    ETCDCTL_KEY: "{{ kube_cert_dir + '/etcd/server.key' if etcd_kubeadm_enabled else etcd_cert_dir + '/admin-' + groups['etcd']|first + '-key.pem' }}"
+    ETCDCTL_CACERT: "{{ kube_cert_dir + '/etcd/ca.crt' if etcd_kubeadm_enabled else etcd_cert_dir + '/ca.pem' }}"
+    ETCDCTL_ENDPOINTS: "https://{{ hostvars[groups['etcd']|first]['etcd_access_address'] |
+                                   default(hostvars[groups['etcd']|first]['ip']) |
+                                   default(hostvars[groups['etcd']|first]['fallback_ips'][groups['etcd']|first]) }}:2381"
+  delegate_to: "{{ groups['etcd']|first }}"
+  when:
+    - inventory_hostname in groups['etcd']
+    - etcd_events_cluster_enabled
+
+- name: Remove etcd events member from cluster
+  command: "{{ bin_dir }}/etcdctl member remove {{ etcd_member_id.stdout }}"
+  register: etcd_member_in_cluster
+  changed_when: false
+  check_mode: no
+  tags:
+    - facts
+  environment:
+    ETCDCTL_API: 3
+    ETCDCTL_CERT: "{{ kube_cert_dir + '/etcd/server.crt' if etcd_kubeadm_enabled else etcd_cert_dir + '/admin-' + groups['etcd']|first + '.pem' }}"
+    ETCDCTL_KEY: "{{ kube_cert_dir + '/etcd/server.key' if etcd_kubeadm_enabled else etcd_cert_dir + '/admin-' + groups['etcd']|first + '-key.pem' }}"
+    ETCDCTL_CACERT: "{{ kube_cert_dir + '/etcd/ca.crt' if etcd_kubeadm_enabled else etcd_cert_dir + '/ca.pem' }}"
+    ETCDCTL_ENDPOINTS: "https://{{ hostvars[groups['etcd']|first]['etcd_access_address'] |
+                                   default(hostvars[groups['etcd']|first]['ip']) |
+                                   default(hostvars[groups['etcd']|first]['fallback_ips'][groups['etcd']|first]) }}:2381"
+  delegate_to: "{{ groups['etcd']|first }}"
+  when:
+    - inventory_hostname in groups['etcd']
+    - etcd_events_cluster_enabled
+    - etcd_member_id.stdout | length > 0


### PR DESCRIPTION
Fixed the problem that etcd events cluster didn't remove the member node when the cluster node was deleted

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
remove the etcd events cluster member node when the cluster node was deleted
```
