### PR TITLE
Fix: 'ansible_os_family' is undefined when removing a node

### DIFF
--- a/remove-node.yml
+++ b/remove-node.yml
@@ -25,7 +25,7 @@
   import_playbook: facts.yml
 
 - hosts: "{{ node | default('kube_node') }}"
-  gather_facts: no
+  gather_facts: yes
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults, when: reset_nodes|default(True)|bool }

--- a/roles/kubespray-defaults/tasks/no_proxy.yml
+++ b/roles/kubespray-defaults/tasks/no_proxy.yml
@@ -13,10 +13,6 @@
       {%- endif -%}
       {%- for item in (groups[cluster_or_master] + groups['etcd']|default([]) + groups['calico_rr']|default([]))|unique -%}
       {{ hostvars[item]['access_ip'] | default(hostvars[item]['ip'] | default(fallback_ips[item])) }},
-      {%-   if item != hostvars[item].get('ansible_hostname', '') -%}
-      {{ hostvars[item]['ansible_hostname'] }},
-      {{ hostvars[item]['ansible_hostname'] }}.{{ dns_domain }},
-      {%-   endif -%}
       {{ item }},{{ item }}.{{ dns_domain }},
       {%- endfor -%}
       {%- if additional_no_proxy is defined -%}


### PR DESCRIPTION
The conditional check 'ansible_os_family not in ["Flatcar Container Linux by Kinvolk"]' failed. The error was: error while evaluating conditional (ansible_os_family not in ["Flatcar Container Linux by Kinvolk"]): 'ansible_os_family' is undefined

We'd better merge this to release 2.17 2.18, and so on.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

The conditional check 'ansible_os_family not in ["Flatcar Container Linux by Kinvolk"]' failed. The error was: error while evaluating conditional (ansible_os_family not in ["Flatcar Container Linux by Kinvolk"]): 'ansible_os_family' is undefined

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
