### PR TITLE
terraform/gcp: Allow to use preemptible VM instances

### DIFF
--- a/contrib/terraform/gcp/README.md
+++ b/contrib/terraform/gcp/README.md
@@ -80,8 +80,12 @@ ansible-playbook -i contrib/terraform/gcs/inventory.ini cluster.yml -b -v
 * `prefix`: Prefix to use for all resources, required to be unique for all clusters in the same project *(Defaults to `default`)*
 * `master_sa_email`: Service account email to use for the master nodes *(Defaults to `""`, auto generate one)*
 * `master_sa_scopes`: Service account email to use for the master nodes *(Defaults to `["https://www.googleapis.com/auth/cloud-platform"]`)*
+* `master_preemptible`: Enable [preemptible](https://cloud.google.com/compute/docs/instances/preemptible)
+  for the master nodes *(Defaults to `false`)*
 * `worker_sa_email`: Service account email to use for the worker nodes *(Defaults to `""`, auto generate one)*
 * `worker_sa_scopes`: Service account email to use for the worker nodes *(Defaults to `["https://www.googleapis.com/auth/cloud-platform"]`)*
+* `worker_preemptible`: Enable [preemptible](https://cloud.google.com/compute/docs/instances/preemptible)
+  for the worker nodes *(Defaults to `false`)*
 
 An example variables file can be found `tfvars.json`
 

--- a/contrib/terraform/gcp/main.tf
+++ b/contrib/terraform/gcp/main.tf
@@ -21,10 +21,12 @@ module "kubernetes" {
   machines    = var.machines
   ssh_pub_key = var.ssh_pub_key
 
-  master_sa_email  = var.master_sa_email
-  master_sa_scopes = var.master_sa_scopes
-  worker_sa_email  = var.worker_sa_email
-  worker_sa_scopes = var.worker_sa_scopes
+  master_sa_email    = var.master_sa_email
+  master_sa_scopes   = var.master_sa_scopes
+  master_preemptible = var.master_preemptible
+  worker_sa_email    = var.worker_sa_email
+  worker_sa_scopes   = var.worker_sa_scopes
+  worker_preemptible = var.worker_preemptible
 
   ssh_whitelist        = var.ssh_whitelist
   api_server_whitelist = var.api_server_whitelist

--- a/contrib/terraform/gcp/modules/kubernetes-cluster/main.tf
+++ b/contrib/terraform/gcp/modules/kubernetes-cluster/main.tf
@@ -231,6 +231,11 @@ resource "google_compute_instance" "master" {
   lifecycle {
     ignore_changes = [attached_disk]
   }
+
+  scheduling {
+    preemptible = var.master_preemptible
+    automatic_restart = !var.master_preemptible
+  }
 }
 
 resource "google_compute_forwarding_rule" "master_lb" {
@@ -327,6 +332,11 @@ resource "google_compute_instance" "worker" {
   # Since we use google_compute_attached_disk we need to ignore this
   lifecycle {
     ignore_changes = [attached_disk]
+  }
+
+  scheduling {
+    preemptible = var.worker_preemptible
+    automatic_restart = !var.worker_preemptible
   }
 }
 

--- a/contrib/terraform/gcp/modules/kubernetes-cluster/variables.tf
+++ b/contrib/terraform/gcp/modules/kubernetes-cluster/variables.tf
@@ -27,12 +27,20 @@ variable "master_sa_scopes" {
   type = list(string)
 }
 
+variable "master_preemptible" {
+  type = bool
+}
+
 variable "worker_sa_email" {
   type = string
 }
 
 variable "worker_sa_scopes" {
   type = list(string)
+}
+
+variable "worker_preemptible" {
+  type = bool
 }
 
 variable "ssh_pub_key" {}

--- a/contrib/terraform/gcp/variables.tf
+++ b/contrib/terraform/gcp/variables.tf
@@ -44,6 +44,11 @@ variable "master_sa_scopes" {
   default = ["https://www.googleapis.com/auth/cloud-platform"]
 }
 
+variable "master_preemptible" {
+  type    = bool
+  default = false
+}
+
 variable "worker_sa_email" {
   type    = string
   default = ""
@@ -52,6 +57,11 @@ variable "worker_sa_email" {
 variable "worker_sa_scopes" {
   type    = list(string)
   default = ["https://www.googleapis.com/auth/cloud-platform"]
+}
+
+variable "worker_preemptible" {
+  type    = bool
+  default = false
 }
 
 variable ssh_pub_key {


### PR DESCRIPTION
**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:

I run kubespray in CI, and want to reduce cost...

**Which issue(s) this PR fixes**:

Fixes #none

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
terraform/gcp: Allow to use preemptible VM instances (using two new variable `master_preemptible` and `worker_preemptible`)
```
