### PR TITLE
Revert "[cert-manager] Fix missing RBAC rules for ClusterRole cert-manager-cainjector"

### DIFF
--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
@@ -93,12 +93,6 @@ rules:
   - apiGroups: ["auditregistration.k8s.io"]
     resources: ["auditsinks"]
     verbs: ["get", "list", "watch", "update"]
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["create", "get", "update"]
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["create", "get", "update"]
 ---
 # Source: cert-manager/templates/rbac.yaml
 # Issuer controller role
@@ -667,7 +661,7 @@ rules:
 ---
 # Source: cert-manager/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: cert-manager:leaderelection
   namespace: {{ cert_manager_leader_election_namespace }}
@@ -745,7 +739,7 @@ subjects:
 # grant cert-manager permission to manage the leaderelection configmap in the
 # leader election namespace
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: cert-manager:leaderelection
   namespace: {{ cert_manager_leader_election_namespace }}
@@ -757,7 +751,7 @@ metadata:
     app.kubernetes.io/version: "{{ cert_manager_version }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: cert-manager:leaderelection
 subjects:
   - apiGroup: ""


### PR DESCRIPTION
This reverts commit 392815d97c470f42273fb3aec0a2105248f9d066.

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:
Revert #8444

Details in https://github.com/kubernetes-sigs/kubespray/pull/8444#issuecomment-1023598810

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
