### PR TITLE
Allow overriding CoreDNS default zone cache block

### DIFF
--- a/docs/dns-stack.md
+++ b/docs/dns-stack.md
@@ -86,6 +86,28 @@ dns_etchosts: |
 
 Whether reverse DNS lookups are enabled in the coredns config. Defaults to `true`.
 
+### CoreDNS default zone cache plugin
+
+If you wish to configure the caching behaviour of CoreDNS on the default zone, you can do so using the `coredns_default_zone_cache_block` string block.
+
+An example value (more information on the [plugin's documentation](https://coredns.io/plugins/cache/)) to:
+
+* raise the max cache TTL to 3600 seconds
+* raise the max amount of success responses to cache to 3000
+* disable caching of denial responses altogether
+* enable pre-fetching of lookups with at least 10 lookups per minute before they expire
+
+Would be as follows:
+
+```yaml
+coredns_default_zone_cache_block: |
+  cache 3600 {
+    success 3000
+    denial 0
+    prefetch 10 1m
+  }
+```
+
 ## DNS modes supported by Kubespray
 
 You can modify how Kubespray sets up DNS for your cluster with the variables ``dns_mode`` and ``resolvconf_mode``.

--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -11,6 +11,8 @@ enable_coredns_reverse_dns_lookups: true
 coredns_ordinal_suffix: ""
 # dns_extra_tolerations: [{effect: NoSchedule, operator: "Exists"}]
 coredns_deployment_nodeselector: "kubernetes.io/os: linux"
+coredns_default_zone_cache_block: |
+  cache 30
 
 # nodelocaldns
 nodelocaldns_cpu_requests: 100m

--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -53,7 +53,7 @@ data:
 {% if enable_coredns_k8s_external %}
         k8s_external {{ coredns_k8s_external_zone }}
 {% endif %}
-        cache 30
+        {{ coredns_default_zone_cache_block | indent(width=8, first=False) }}
         loop
         reload
         loadbalance


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Allows overriding the CoreDNS `cache` plugin configuration for the default zone

**Which issue(s) this PR fixes**:
#8487 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[coredns] Allow overriding the default CoreDNS zone's `cache` plugin configuration via the `coredns_cluster_zone_cache_block` variable
```
