### PR TITLE
CRI-O: fix unqualified-search registries

### DIFF
--- a/docs/cri-o.md
+++ b/docs/cri-o.md
@@ -38,6 +38,7 @@ crio_registries:
     insecure: false
     blocked: false
     location: registry-1.docker.io
+    unqualified: false
     mirrors:
       - location: 192.168.100.100:5000
         insecure: true

--- a/roles/container-engine/cri-o/templates/unqualified.conf.j2
+++ b/roles/container-engine/cri-o/templates/unqualified.conf.j2
@@ -7,4 +7,4 @@
 {%- endif %}
 {%- endfor %}
 
-unqualified-search-registries = {{ _unqualified_registries | to_yaml }}
+unqualified-search-registries = {{ _unqualified_registries | string }}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
If we set `unqualified: true` in `crio_registries:` e.g for `docker.io` playbook will fail and journalctl will show:

```
level=fatal msg="validating runtime config: invalid registries: loading drop-in registries configuration \"/etc/containers/registries.conf.d/01-unqualified.conf\": Near line 4 (last key parsed 'unqualified-search-registries'): expected value but found \"docker\" instead"
```
With this change entries in `/etc/containers/registries.conf.d/01-unqualified.conf` are quoted. E.g `unqualified-search-registries = ['docker.io']`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8495 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
CRI-O: fix unqualified-search registries
```