### PR TITLE
terraform/gcp: Do not create unused subnetworks and Upgrade to latest google provider

### DIFF
--- a/contrib/terraform/gcp/main.tf
+++ b/contrib/terraform/gcp/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.48"
+      version = "~> 4.0"
     }
   }
 }

--- a/contrib/terraform/gcp/modules/kubernetes-cluster/main.tf
+++ b/contrib/terraform/gcp/modules/kubernetes-cluster/main.tf
@@ -5,6 +5,8 @@
 
 resource "google_compute_network" "main" {
   name = "${var.prefix}-network"
+
+  auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "main" {

--- a/contrib/terraform/gcp/modules/kubernetes-cluster/main.tf
+++ b/contrib/terraform/gcp/modules/kubernetes-cluster/main.tf
@@ -22,6 +22,8 @@ resource "google_compute_firewall" "deny_all" {
 
   priority = 1000
 
+  source_ranges = ["0.0.0.0/0"]
+
   deny {
     protocol = "all"
   }
@@ -88,6 +90,8 @@ resource "google_compute_firewall" "ingress_http" {
 
   priority = 100
 
+  source_ranges = ["0.0.0.0/0"]
+
   allow {
     protocol = "tcp"
     ports    = ["80"]
@@ -99,6 +103,8 @@ resource "google_compute_firewall" "ingress_https" {
   network = google_compute_network.main.name
 
   priority = 100
+
+  source_ranges = ["0.0.0.0/0"]
 
   allow {
     protocol = "tcp"


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:

This PR has two changes:

- Do not create unused subnetworks. Caught because I reached the maximun number of subnets (395)
- Upgrade to latest google provider, caught by [renovate](https://gitlab.com/kubitus-project/kubitus-installer/-/merge_requests/605)

**Which issue(s) this PR fixes**:
Fixes #nope

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
terraform/gcp: Do not create unused subnetworks
terraform/gcp: Upgrade to latest google provider
```
