### PR TITLE
Fix kubelet_kubelet_cgroups_cgroupfs

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -20,7 +20,7 @@ kubelet_kubelet_cgroups: "/systemd/system.slice"
 
 # Set runtime and kubelet cgroups when using cgroupfs as cgroup driver
 kubelet_runtime_cgroups_cgroupfs: "/system.slice/containerd.service"
-kubelet_kubelet_cgroups_cgroupfs: "/system.slice/kubelet.slice"
+kubelet_kubelet_cgroups_cgroupfs: "/system.slice/kubelet.service"
 
 ### fail with swap on (default true)
 kubelet_fail_swap_on: true


### PR DESCRIPTION
If kubelet is run with systemd (as it always is when using kubespray),
it starts in systemd's /system.slice/kubelet.service cgroup.

This commit prevents a creation and usage of a second unrelated cgroup.

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This fixes a slight error introduced in https://github.com/kubernetes-sigs/kubespray/pull/8123

As I have observed, kubelet starts in `/system.slice/kubelet.service` and then moves itself to `kubeletCgroups` value:
```
# pgrep kubelet
34006

# tail /sys/fs/cgroup/memory/system.slice/kubelet*/{cgroup.procs,memory.usage_in_bytes}
==> /sys/fs/cgroup/memory/system.slice/kubelet.service/cgroup.procs <==

==> /sys/fs/cgroup/memory/system.slice/kubelet.slice/cgroup.procs <==
34006

==> /sys/fs/cgroup/memory/system.slice/kubelet.service/memory.usage_in_bytes <==
59301888

==> /sys/fs/cgroup/memory/system.slice/kubelet.slice/memory.usage_in_bytes <==
150597632
```

This results in cAdvisor kubelet metrics showing both of these cgroups.

Alternatively, we could let kubelet figure out the right cgroup for itself(by setting `kubeletCgroups` to "" or leaving it out of config), it seems to do that by looking at `name=systemd:` entry in `/proc/<own pid>/cgroups`([code for v1.21](https://github.com/kubernetes/kubernetes/blob/v1.21.9/pkg/kubelet/cm/container_manager_linux.go#L951)), which would produce the same result for me at least.

The defaulting doesn't work for `kubelet_runtime_cgroups_cgroupfs` on the previous line, as kubernetes currently only has special handling for docker runtime: https://github.com/kubernetes/kubernetes/blob/v1.23.0/pkg/kubelet/cm/helpers_linux.go#L343

**Which issue(s) this PR fixes**:
https://github.com/kubernetes-sigs/kubespray/pull/8123

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix kubelet_kubelet_cgroups_cgroupfs pointing incorrectly to slice
```
