### PR TITLE
terraform/gcp: Allow to change extra disk types

### DIFF
--- a/contrib/terraform/gcp/README.md
+++ b/contrib/terraform/gcp/README.md
@@ -78,14 +78,18 @@ ansible-playbook -i contrib/terraform/gcs/inventory.ini cluster.yml -b -v
 ### Optional
 
 * `prefix`: Prefix to use for all resources, required to be unique for all clusters in the same project *(Defaults to `default`)*
-* `master_sa_email`: Service account email to use for the master nodes *(Defaults to `""`, auto generate one)*
-* `master_sa_scopes`: Service account email to use for the master nodes *(Defaults to `["https://www.googleapis.com/auth/cloud-platform"]`)*
+* `master_sa_email`: Service account email to use for the control plane nodes *(Defaults to `""`, auto generate one)*
+* `master_sa_scopes`: Service account email to use for the control plane nodes *(Defaults to `["https://www.googleapis.com/auth/cloud-platform"]`)*
 * `master_preemptible`: Enable [preemptible](https://cloud.google.com/compute/docs/instances/preemptible)
-  for the master nodes *(Defaults to `false`)*
+  for the control plane nodes *(Defaults to `false`)*
+* `master_additional_disk_type`: [Disk type](https://cloud.google.com/compute/docs/disks/#disk-types)
+  for extra disks added on the control plane nodes *(Defaults to `"pd-ssd"`)*
 * `worker_sa_email`: Service account email to use for the worker nodes *(Defaults to `""`, auto generate one)*
 * `worker_sa_scopes`: Service account email to use for the worker nodes *(Defaults to `["https://www.googleapis.com/auth/cloud-platform"]`)*
 * `worker_preemptible`: Enable [preemptible](https://cloud.google.com/compute/docs/instances/preemptible)
   for the worker nodes *(Defaults to `false`)*
+* `worker_additional_disk_type`: [Disk type](https://cloud.google.com/compute/docs/disks/#disk-types)
+  for extra disks added on the worker nodes *(Defaults to `"pd-ssd"`)*
 
 An example variables file can be found `tfvars.json`
 

--- a/contrib/terraform/gcp/main.tf
+++ b/contrib/terraform/gcp/main.tf
@@ -24,9 +24,11 @@ module "kubernetes" {
   master_sa_email    = var.master_sa_email
   master_sa_scopes   = var.master_sa_scopes
   master_preemptible = var.master_preemptible
+  master_additional_disk_type = var.master_additional_disk_type
   worker_sa_email    = var.worker_sa_email
   worker_sa_scopes   = var.worker_sa_scopes
   worker_preemptible = var.worker_preemptible
+  worker_additional_disk_type = var.worker_additional_disk_type
 
   ssh_whitelist        = var.ssh_whitelist
   api_server_whitelist = var.api_server_whitelist

--- a/contrib/terraform/gcp/modules/kubernetes-cluster/main.tf
+++ b/contrib/terraform/gcp/modules/kubernetes-cluster/main.tf
@@ -181,7 +181,7 @@ resource "google_compute_disk" "master" {
    }
 
   name = "${var.prefix}-${each.key}"
-  type = "pd-ssd"
+  type = var.master_additional_disk_type
   zone = each.value.machine.zone
   size = each.value.disk_size
 
@@ -271,7 +271,7 @@ resource "google_compute_disk" "worker" {
    }
 
   name = "${var.prefix}-${each.key}"
-  type = "pd-ssd"
+  type = var.worker_additional_disk_type
   zone = each.value.machine.zone
   size = each.value.disk_size
 

--- a/contrib/terraform/gcp/modules/kubernetes-cluster/variables.tf
+++ b/contrib/terraform/gcp/modules/kubernetes-cluster/variables.tf
@@ -31,6 +31,10 @@ variable "master_preemptible" {
   type = bool
 }
 
+variable "master_additional_disk_type" {
+  type = string
+}
+
 variable "worker_sa_email" {
   type = string
 }
@@ -41,6 +45,10 @@ variable "worker_sa_scopes" {
 
 variable "worker_preemptible" {
   type = bool
+}
+
+variable "worker_additional_disk_type" {
+  type = string
 }
 
 variable "ssh_pub_key" {}

--- a/contrib/terraform/gcp/variables.tf
+++ b/contrib/terraform/gcp/variables.tf
@@ -49,6 +49,11 @@ variable "master_preemptible" {
   default = false
 }
 
+variable "master_additional_disk_type" {
+  type = string
+  default = "pd-ssd"
+}
+
 variable "worker_sa_email" {
   type    = string
   default = ""
@@ -62,6 +67,11 @@ variable "worker_sa_scopes" {
 variable "worker_preemptible" {
   type    = bool
   default = false
+}
+
+variable "worker_additional_disk_type" {
+  type = string
+  default = "pd-ssd"
 }
 
 variable ssh_pub_key {


### PR DESCRIPTION

**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:

I need to use pd-standard to reduce cost.

See [kubitus-project/kubitus-installer!646](https://gitlab.com/kubitus-project/kubitus-installer/-/merge_requests/646)

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
terraform/gcp: Allow to change extra disk types
```
