### PR TITLE
Updated containerd migration to work when etcd_kubeadm_enabled is set

### DIFF
--- a/docs/upgrades/migrate_docker2containerd.md
+++ b/docs/upgrades/migrate_docker2containerd.md
@@ -65,6 +65,13 @@ apt-get install pigz
 
 ### 5) Run `cluster.yml` playbook with `--limit`
 
+> NOTE: If your cluster is previously setup using `etcd_kubeadm_enabled: true` then you will need to update the static manifest `/etc/kubernetes/manifests/etcd.yaml` on all etcd nodes with the new version before this step.
+>
+> ```diff
+> -     image: quay.io/coreos/etcd:v3.4.13
+> +     image: quay.io/coreos/etcd:v3.5.0
+> ```
+
 ```commandline
 ansible-playbook cluster.yml -i inventory/sample/hosts.ini cluster.yml --limit=NODENAME
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
/kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

The containerd migration documentation didn't really work with a cluster that had `etcd_kubeadm_enabled` set to `true`.
This PR tries to fix that.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
