### PR TITLE
feat(offline): Improve generate_list.sh using ansible (#8537)

### DIFF
--- a/contrib/offline/README.md
+++ b/contrib/offline/README.md
@@ -28,16 +28,19 @@ manage-offline-container-images.sh   register
 
 This script generates the list of downloaded files and the list of container images by `roles/download/defaults/main.yml` file.
 
-Run this script will generates three files, all downloaded files url in files.list, all container images in images.list, all component version in generate.sh.
+Run this script will execute `generate_list.yml` playbook in kubespray root directory and generate four files,
+all downloaded files url in files.list, all container images in images.list, jinja2 templates in *.template.
 
 ```shell
-bash generate_list.sh
+./generate_list.sh
 tree temp
 temp
 ├── files.list
-├── generate.sh
-└── images.list
-0 directories, 3 files
+├── files.list.template
+├── images.list
+└── images.list.template
+0 directories, 5 files
 ```
 
-In some cases you may want to update some component version, you can edit `generate.sh` file, then run `bash generate.sh | grep 'https' > files.list` to update file.list or run `bash generate.sh | grep -v 'https'> images.list` to update images.list.
+In some cases you may want to update some component version, you can declare version variables in ansible inventory file or group_vars,
+then run `./generate_list.sh -i [inventory_file]` to update file.list and images.list.

--- a/contrib/offline/generate_list.sh
+++ b/contrib/offline/generate_list.sh
@@ -5,54 +5,26 @@ CURRENT_DIR=$(cd $(dirname $0); pwd)
 TEMP_DIR="${CURRENT_DIR}/temp"
 REPO_ROOT_DIR="${CURRENT_DIR%/contrib/offline}"
 
-: ${IMAGE_ARCH:="amd64"}
-: ${ANSIBLE_SYSTEM:="linux"}
-: ${ANSIBLE_ARCHITECTURE:="x86_64"}
 : ${DOWNLOAD_YML:="roles/download/defaults/main.yml"}
-: ${KUBE_VERSION_YAML:="roles/kubespray-defaults/defaults/main.yaml"}
 
 mkdir -p ${TEMP_DIR}
 
-# ARCH used in convert {%- if image_arch != 'amd64' -%}-{{ image_arch }}{%- endif -%} to {{arch}}
-if [ "${IMAGE_ARCH}" != "amd64" ]; then ARCH="${IMAGE_ARCH}"; fi
-
-cat > ${TEMP_DIR}/generate.sh << EOF
-arch=${ARCH}
-image_arch=${IMAGE_ARCH}
-ansible_system=${ANSIBLE_SYSTEM}
-ansible_architecture=${ANSIBLE_ARCHITECTURE}
-host_os=${ANSIBLE_SYSTEM}
-EOF
-
-# generate all component version by $DOWNLOAD_YML
-grep 'kube_version:' ${REPO_ROOT_DIR}/${KUBE_VERSION_YAML} \
-| sed 's/: /=/g' >> ${TEMP_DIR}/generate.sh
-grep '_version:' ${REPO_ROOT_DIR}/${DOWNLOAD_YML} \
-| sed 's/: /=/g;s/{{/${/g;s/}}/}/g' | tr -d ' ' >> ${TEMP_DIR}/generate.sh
-sed -i 's/kube_major_version=.*/kube_major_version=${kube_version%.*}/g' ${TEMP_DIR}/generate.sh
-sed -i 's/crictl_version=.*/crictl_version=${kube_version%.*}.0/g' ${TEMP_DIR}/generate.sh
-
-# generate all download files url
+# generate all download files url template
 grep 'download_url:' ${REPO_ROOT_DIR}/${DOWNLOAD_YML} \
-| sed 's/: /=/g;s/ //g;s/{{/${/g;s/}}/}/g;s/|lower//g;s/^.*_url=/echo /g' >> ${TEMP_DIR}/generate.sh
+    | sed 's/^.*_url: //g;s/\"//g' > ${TEMP_DIR}/files.list.template
 
-# generate all images list
-grep -E '_repo:|_tag:' ${REPO_ROOT_DIR}/${DOWNLOAD_YML} \
-| sed "s#{%- if image_arch != 'amd64' -%}-{{ image_arch }}{%- endif -%}#{{arch}}#g" \
-| sed 's/: /=/g;s/{{/${/g;s/}}/}/g' | tr -d ' ' >> ${TEMP_DIR}/generate.sh
+# generate all images list template
 sed -n '/^downloads:/,/download_defaults:/p' ${REPO_ROOT_DIR}/${DOWNLOAD_YML} \
-| sed -n "s/repo: //p;s/tag: //p" | tr -d ' ' | sed 's/{{/${/g;s/}}/}/g' \
-| sed 'N;s#\n# #g' | tr ' ' ':' | sed 's/^/echo /g' >> ${TEMP_DIR}/generate.sh
+    | sed -n "s/repo: //p;s/tag: //p" | tr -d ' ' \
+    | sed 'N;s#\n# #g' | tr ' ' ':' | sed 's/\"//g' > ${TEMP_DIR}/images.list.template
 
-# special handling for https://github.com/kubernetes-sigs/kubespray/pull/7570
-sed -i 's#^coredns_image_repo=.*#coredns_image_repo=${kube_image_repo}$(if printf "%s\\n%s\\n" v1.21 ${kube_version%.*} | sort --check=quiet --version-sort; then echo -n /coredns/coredns;else echo -n /coredns; fi)#' ${TEMP_DIR}/generate.sh
-sed -i 's#^coredns_image_tag=.*#coredns_image_tag=$(if printf "%s\\n%s\\n" v1.21 ${kube_version%.*} | sort --check=quiet --version-sort; then echo -n ${coredns_version};else echo -n ${coredns_version/v/}; fi)#' ${TEMP_DIR}/generate.sh
-
-# add kube-* images to images list
+# add kube-* images to images list template
 KUBE_IMAGES="kube-apiserver kube-controller-manager kube-scheduler kube-proxy"
-echo "${KUBE_IMAGES}" | tr ' ' '\n' | xargs -L1 -I {} \
-echo 'echo ${kube_image_repo}/{}:${kube_version}' >> ${TEMP_DIR}/generate.sh
+for i in $KUBE_IMAGES; do
+    echo "{{ kube_image_repo }}/$i:{{ kube_version }}" >> ${TEMP_DIR}/images.list.template
+done
 
-# print files.list and images.list
-bash ${TEMP_DIR}/generate.sh | grep 'https' | sort > ${TEMP_DIR}/files.list
-bash ${TEMP_DIR}/generate.sh | grep -v 'https' | sort > ${TEMP_DIR}/images.list
+# run ansible to expand templates
+/bin/cp ${CURRENT_DIR}/generate_list.yml ${REPO_ROOT_DIR}
+
+(cd ${REPO_ROOT_DIR} && ansible-playbook $* generate_list.yml && /bin/rm generate_list.yml) || exit 1

--- a/contrib/offline/generate_list.yml
+++ b/contrib/offline/generate_list.yml
@@ -1,0 +1,19 @@
+---
+- hosts: localhost
+  become: no
+
+  roles:
+    # Just load default variables from roles.
+    - role: kubespray-defaults
+      when: false
+    - role: download
+      when: false
+
+  tasks:
+    # Generate files.list and images.list files from templates.
+    - template:
+        src: ./contrib/offline/temp/{{ item }}.list.template
+        dest: ./contrib/offline/temp/{{ item }}.list
+      with_items:
+        - files
+        - images


### PR DESCRIPTION
Improve generate_list.sh to generate offline file list using ansible (#8537)

Use jinja2 template and ansible to expand variables.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Current contrib/offline/generate_list.sh parses some yaml files and expands variables without using ansible.
This is a bit of tough task, and hard to maintain.

It should make use of jinja2 template and ansible to expand variables.

**Which issue(s) this PR fixes**:

Fixes #8537

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
