### PR TITLE
Fix etcd_events not getting upgraded in upgrade-cluster.yml

### DIFF
--- a/upgrade-cluster.yml
+++ b/upgrade-cluster.yml
@@ -69,7 +69,7 @@
       tags: etcd
       vars:
         etcd_cluster_setup: true
-        etcd_events_cluster_setup: false
+        etcd_events_cluster_setup: "{{ etcd_events_cluster_enabled }}"
       when: not etcd_kubeadm_enabled | default(false)
 
 - hosts: k8s_cluster


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

When running upgrade-cluster.yml, this PR makes it so that updates to etcd-events actually get applied (if enabled), just like regular etcd. This matches the behavior of cluster.yml, which does properly apply etcd-events updates: https://github.com/kubernetes-sigs/kubespray/blob/063fc525b1412bda310a1088ea52d2d61fe952bb/cluster.yml#L46-L48

Since the code I edited explicitly sets `etcd_cluster_setup: true` already, that indicates that we should be applying etcd updates at this phase, which ought to include etcd-events as well (if enabled).

This has been a bug [for a long time](https://github.com/kubernetes-sigs/kubespray/pull/4818/files#diff-95a28f9763d6e8dc3a93ce30d9c6fa77b2303cfa1c16f5339e6678f707b8b6a0R63) but only recently became visible when the 2.18 upgrade changed the port number of etcd-events (#8232 ). Since that update does get applied to kube-apiserver but doesn't get applied to etcd-events itself, it causes upgrades to 2.18 to fail. May want to cherry-pick into 2.18, if possible.

**Which issue(s) this PR fixes**:

Fixes #8549 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Fixed a bug where upgrade-cluster.yaml would not apply updates to etcd-events
```
