### PR TITLE
Fix print_hostnames of inventory.py

### DIFF
--- a/contrib/inventory_builder/inventory.py
+++ b/contrib/inventory_builder/inventory.py
@@ -83,11 +83,15 @@ class KubesprayInventory(object):
         self.config_file = config_file
         self.yaml_config = {}
         loadPreviousConfig = False
+        printHostnames = False
         # See whether there are any commands to process
         if changed_hosts and changed_hosts[0] in AVAILABLE_COMMANDS:
             if changed_hosts[0] == "add":
                 loadPreviousConfig = True
                 changed_hosts = changed_hosts[1:]
+            elif changed_hosts[0] == "print_hostnames":
+                loadPreviousConfig = True
+                printHostnames = True
             else:
                 self.parse_command(changed_hosts[0], changed_hosts[1:])
                 sys.exit(0)
@@ -104,6 +108,10 @@ class KubesprayInventory(object):
                 # I am assuming we are catching "cannot open file" exceptions
                 print(e)
                 sys.exit(1)
+
+        if printHostnames:
+            self.print_hostnames()
+            sys.exit(0)
 
         self.ensure_required_groups(ROLES)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When trying to run print_hostnames of inventory.py, it outputs the following error:

```
 $ CONFIG_FILE=./test-hosts.yaml python3 ./inventory.py print_hostnames
 Traceback (most recent call last):
   File "./inventory.py", line 472, in <module>
     sys.exit(main())
   File "./inventory.py", line 467, in main
     KubesprayInventory(argv, CONFIG_FILE)
   File "./inventory.py", line 92, in __init__
     self.parse_command(changed_hosts[0], changed_hosts[1:])
   File "./inventory.py", line 415, in parse_command
     self.print_hostnames()
   File "./inventory.py", line 455, in print_hostnames
     print(' '.join(self.yaml_config['all']['hosts'].keys()))
 KeyError: 'all'
```

because it is missed to load a hosts config file before printing hostnames.
This fixes the issue.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8507

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix print_hostnames of inventory.py
```
