### PR TITLE
[containerd] Upgrade containerd to 1.6.0 and re-enable arm64 architecture with default options

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [kubernetes](https://github.com/kubernetes/kubernetes) v1.23.3
   - [etcd](https://github.com/etcd-io/etcd) v3.5.1
   - [docker](https://www.docker.com/) v20.10 (see note)
-  - [containerd](https://containerd.io/) v1.5.9
+  - [containerd](https://containerd.io/) v1.6.0
   - [cri-o](http://cri-o.io/) v1.22 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)
 - Network Plugin
   - [cni-plugins](https://github.com/containernetworking/plugins) v1.0.1

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -112,7 +112,7 @@ kube_ovn_version: "v1.8.1"
 kube_router_version: "v1.4.0"
 multus_version: "v3.8"
 helm_version: "v3.8.0"
-nerdctl_version: "0.16.1"
+nerdctl_version: "0.17.0"
 krew_version: "v0.4.2"
 
 # Get kubernetes major version (i.e. 1.17.4 => 1.17)
@@ -632,13 +632,13 @@ gvisor_containerd_shim_binary_checksums:
 
 nerdctl_archive_checksums:
   arm:
-    0.16.1: f47330c88201e23cb4f43f9ca3d5b467fa88e50a8d306ee757db0b07321e2ee8
+    0.17.0: 6fc702457e2013cc66b90300b19f860908b6ed124a24c0c5eb2c3ade47d4d9bf
   arm64:
-    0.16.1: b400f27afda9bb215484249f07d642684551eb234d6a430c248b9a3aca38d3f5
+    0.17.0: cddd33f915c617e7ed32f79bc5a18eb2821cddf4de082e3e47764871abe21f90
   amd64:
-    0.16.1: 543d58c057a5a59c67ca523016c1dac57f9a09d1d9e9c98bd092b9df82ec5246
+    0.17.0: 4c08a6ce657ff851dd7a7b1d21c64f1c1950e35de03fa7f1853eab47fa2b2d53
   ppc64le:
-    0.16.1: f0a3a23c650c637cdf7f5b1a02fbcfe22e39db5627f79b63cc4137226ce79c3a
+    0.17.0: b9113bb537861ecd400e12649045c4587c3bd229ac6ccf36af69c79da5563840
 
 containerd_archive_checksums:
   arm:

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -649,6 +649,7 @@ containerd_archive_checksums:
     1.5.7: 0
     1.5.8: 0
     1.5.9: 0
+    1.6.0: 0
   arm64:
     1.4.9: 0
     1.4.11: 0
@@ -657,6 +658,7 @@ containerd_archive_checksums:
     1.5.7: 0
     1.5.8: 0
     1.5.9: 0
+    1.6.0: 6eff3e16d44c89e1e8480a9ca078f79bab82af602818455cc162be344f64686a
   amd64:
     1.4.9: 346f88ad5b973960ff81b5539d4177af5941ec2e4703b479ca9a6081ff1d023b
     1.4.11: 80c47ec5ce2cd91a15204b5f5b534892ca653e75f3fba0c451ca326bca45fb00
@@ -665,6 +667,7 @@ containerd_archive_checksums:
     1.5.7: 109fc95b86382065ea668005c376360ddcd8c4ec413e7abe220ae9f461e0e173
     1.5.8: feeda3f563edf0294e33b6c4b89bd7dbe0ee182ca61a2f9b8c3de2766bcbc99b
     1.5.9: a457793a1643657588baf46d3ffbf44fae0139b65076064e237ddf29cd838ba4
+    1.6.0: f77725e4f757523bf1472ec3b9e02b09303a5d99529173be0f11a6d39f5676e9
   ppc64le:
     1.4.9: 0
     1.4.11: 0
@@ -673,6 +676,7 @@ containerd_archive_checksums:
     1.5.7: 0
     1.5.8: 0
     1.5.9: 0
+    1.6.0: 0
 
 etcd_binary_checksum: "{{ etcd_binary_checksums[image_arch][etcd_version] }}"
 flannel_cni_binary_checksum: "{{ flannel_cni_binary_checksums[image_arch][flannel_cni_version] }}"

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -70,7 +70,7 @@ nerdctl_extra_flags: '{%- if containerd_insecure_registries is defined and conta
 # Versions
 kubeadm_version: "{{ kube_version }}"
 crun_version: 1.4
-runc_version: v1.0.3
+runc_version: v1.1.0
 kata_containers_version: 2.2.3
 youki_version: 0.0.1
 gvisor_version: 20210921

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -74,7 +74,7 @@ runc_version: v1.0.3
 kata_containers_version: 2.2.3
 youki_version: 0.0.1
 gvisor_version: 20210921
-containerd_version: 1.5.9
+containerd_version: 1.6.0
 
 # this is relevant when container_manager == 'docker'
 docker_containerd_version: 1.4.12

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -101,6 +101,7 @@
     - crictl.stat.exists
     - container_manager in ["crio", "containerd"]
     - deploy_container_engine
+  ignore_errors: true  # noqa ignore-errors
 
 - name: reset | stop and disable crio service
   service:
@@ -146,6 +147,7 @@
   rescue:
     - name: reset | force remove all cri pods (rescue)
       shell: "ip netns list | cut -d' ' -f 1 | xargs -n1 ip netns delete && {{ bin_dir }}/crictl rmp -a -f"
+      ignore_errors: true  # noqa ignore-errors
 
 - name: reset | stop etcd services
   service:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
This PR upgrades containerd to 1.6.0 and related dependencies needed to run on arm64 out of the box with default options.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8536

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[containerd] Upgrade containerd to 1.6.0 and re-enable arm architecture with default options
[runc] make 1.1.0 the default
[nerdctl] upgrade to 0.17.0
```
