### PR TITLE
Restart etcd if the etcd version changes

### DIFF
--- a/roles/etcd/tasks/install_docker.yml
+++ b/roles/etcd/tasks/install_docker.yml
@@ -2,6 +2,30 @@
 - import_tasks: install_etcdctl_docker.yml
   when: etcd_cluster_setup
 
+- name: Get currently-deployed etcd version
+  shell: "{{ docker_bin_dir }}/docker ps --filter='name={{ etcd_member_name }}' --format='{{ '{{ .Image }}' }}'"
+  register: etcd_current_docker_image
+  when: etcd_cluster_setup
+
+- name: Get currently-deployed etcd-events version
+  shell: "{{ docker_bin_dir }}/docker ps --filter='name={{ etcd_member_name }}-events' --format='{{ '{{ .Image }}' }}'"
+  register: etcd_events_current_docker_image
+  when: etcd_events_cluster_setup
+
+- name: Restart etcd if necessary
+  command: /bin/true
+  notify: restart etcd
+  when:
+    - etcd_cluster_setup
+    - etcd_image_tag not in etcd_current_docker_image.stdout|default('')
+
+- name: Restart etcd-events if necessary
+  command: /bin/true
+  notify: restart etcd-events
+  when:
+    - etcd_events_cluster_setup
+    - etcd_image_tag not in etcd_events_current_docker_image.stdout|default('')
+
 - name: Install etcd launch script
   template:
     src: etcd.j2

--- a/roles/etcd/tasks/install_host.yml
+++ b/roles/etcd/tasks/install_host.yml
@@ -1,4 +1,25 @@
 ---
+- name: Get currently-deployed etcd version
+  command: "{{ bin_dir }}/etcd --version"
+  register: etcd_current_host_version
+  # There's a chance this play could run before etcd is installed at all
+  ignore_errors: true
+  when: etcd_cluster_setup
+
+- name: Restart etcd if necessary
+  command: /bin/true
+  notify: restart etcd
+  when:
+    - etcd_cluster_setup
+    - etcd_version.lstrip('v') not in etcd_current_host_version.stdout|default('')
+
+- name: Restart etcd-events if necessary
+  command: /bin/true
+  notify: restart etcd-events
+  when:
+    - etcd_events_cluster_setup
+    - etcd_version.lstrip('v') not in etcd_current_host_version.stdout|default('')
+
 - name: install | Download etcd and etcdctl
   include_tasks: "../../download/tasks/download_file.yml"
   vars:

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -46,17 +46,13 @@
   when: is_etcd_master
 
 - name: Restart etcd if certs changed
-  service:
-    name: etcd
-    state: restarted
-    enabled: yes
+  command: /bin/true
+  notify: restart etcd
   when: is_etcd_master and etcd_cluster_setup and etcd_secret_changed|default(false)
 
 - name: Restart etcd-events if certs changed
-  service:
-    name: etcd-events
-    state: restarted
-    enabled: yes
+  command: /bin/true
+  notify: restart etcd
   when: is_etcd_master and etcd_events_cluster_setup and etcd_secret_changed|default(false)
 
 # After etcd cluster is assembled, make sure that


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently, if someone runs upgrade-cluster.yml and the etcd version happened to have changed, the new etcd version doesn't get rolled out because no restart is triggered. That might cause issues where the etcd version change may happen unexpectedly after a reboot, or may not be applied to all nodes at once.

This PR determines if the current etcd version is different from the soon-to-be-installed etcd version, and if so, runs `notifiy: restart etcd` so that a restart is triggered at the end.


**Which issue(s) this PR fixes**:
Fixes #8551

**Special notes for your reviewer**:

Also removed the explicit restart of etcd if the certs changed (in main.yml). Using `notify` avoids multiple restarts. 

**Does this PR introduce a user-facing change?**:

```release-note
Fixed a bug where updated versions of etcd weren't being applied. Check your etcd instances to make sure their versions are what you expect. If not, restarting all etcd members should apply the update.
```
