### PR TITLE
[systemd-resolved] Fix DNS configuration according to docs/dns-stack.…

### DIFF
--- a/reset.yml
+++ b/reset.yml
@@ -32,4 +32,5 @@
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults}
+    - { role: kubernetes/preinstall, when: "dns_mode != 'none' and resolvconf_mode == 'host_resolvconf'", tags: resolvconf, dns_early: true }
     - { role: reset, tags: reset }

--- a/roles/kubernetes/preinstall/templates/resolved.conf.j2
+++ b/roles/kubernetes/preinstall/templates/resolved.conf.j2
@@ -1,6 +1,10 @@
 [Resolve]
+{% if dns_early is sameas true and dns_late is sameas false %}
+#DNS=
+{% else %}
 DNS={{ ([nodelocaldns_ip] if enable_nodelocaldns else coredns_server )| list | join(' ') }}
-FallbackDNS={{ ( nameservers|d([]) + cloud_resolver|d([])) | unique | join(' ') }}
+{% endif %}
+FallbackDNS={{ ( upstream_dns_servers|d([]) + nameservers|d([]) + cloud_resolver|d([])) | unique | join(' ') }}
 Domains={{ ([ 'default.svc.' + dns_domain, 'svc.' + dns_domain ] + searchdomains|default([])) | join(' ') }}
 #LLMNR=no
 #MulticastDNS=no


### PR DESCRIPTION
…md and during reset of cluster (#8560)

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
see #8560 

**Which issue(s) this PR fixes**:
Fixes #8560

**Does this PR introduce a user-facing change?**:
```release-note
[systemd-resolved] Fix DNS early and late stages (`dns_early`|`dns_late`) of cluster deployment
[systemd-resolved] Add `upstream_dns_servers` to `FallbackDNS`
[cluster-reset] Revert DNS configuration to early stage (for instance: only defined upstream nameservers)
```
