### PR TITLE
improve validation conditions for MetalLB BGP Peers

### DIFF
--- a/roles/kubernetes-apps/metallb/tasks/main.yml
+++ b/roles/kubernetes-apps/metallb/tasks/main.yml
@@ -13,9 +13,10 @@
 
 - name: Kubernetes Apps | Check BGP peers for MetalLB
   fail:
-    msg: "metallb_peers is mandatory when metallb_protocol is bgp"
+    msg: "metallb_peers is mandatory when metallb_protocol is bgp and metallb_speaker_enabled"
   when:
-    - metallb_protocol == 'bgp' and metallb_peers is not defined
+    - metallb_protocol == 'bgp' and metallb_speaker_enabled
+    - metallb_peers is not defined or not metallb_peers
 
 - name: Kubernetes Apps | Check AppArmor status
   command: which apparmor_parser


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

When I replace MetalLB speaker by calico Service LoadBalancer IP advertisement, `metallb_peers` is NOT mandatory. ([docs / MetalLB / BGP Mode](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/metallb.md#bgp-mode))
And when `metallb_peers` is mandatory(`metallb_protocol` is bgp && `metallb_speaker_enabled` is true), it is also better to make sure the `metallb_peers` is not empty(`{}`). 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
