### PR TITLE
Prevent removing etcd member when running in check mode

### DIFF
--- a/roles/remove-node/remove-etcd-node/tasks/main.yml
+++ b/roles/remove-node/remove-etcd-node/tasks/main.yml
@@ -45,11 +45,6 @@
 
 - name: Remove etcd member from cluster
   command: "{{ bin_dir }}/etcdctl member remove {{ etcd_member_id.stdout }}"
-  register: etcd_member_in_cluster
-  changed_when: false
-  check_mode: no
-  tags:
-    - facts
   environment:
     ETCDCTL_API: 3
     ETCDCTL_CERT: "{{ kube_cert_dir + '/etcd/server.crt' if etcd_kubeadm_enabled else etcd_cert_dir + '/admin-' + groups['etcd']|first + '.pem' }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes removing etcd node when running with `--check`. Before, running remove-node playbook on an etcd node with `--check` will happily remove the node. That's the opposite of how `--check` is supposed to work. This seems to be a copy-paste issue(introduced in https://github.com/kubernetes-sigs/kubespray/pull/5009/files#diff-84b588aaf686ff2f99d525c4269b48f766a3bc074f4cb34bd381918a43fb2ab1R23-R54), so I'm also removing other irrelevant lines.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
check_mode docs: https://docs.ansible.com/ansible/latest/user_guide/playbooks_checkmode.html#enforcing-or-preventing-check-mode-on-tasks

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Prevent removing etcd member when running in check mode
```
