### PR TITLE
fix(coredns): make sure to keep coredns repository namespace

### DIFF
--- a/roles/download/templates/kubeadm-images.yaml.j2
+++ b/roles/download/templates/kubeadm-images.yaml.j2
@@ -21,5 +21,5 @@ etcd:
 {% endif %}
 dns:
   type: CoreDNS
-  imageRepository: {{ coredns_image_repo | regex_replace('/coredns.*$','') }}
+  imageRepository: {{ coredns_image_repo | regex_replace('/coredns(?!/coredns).*$','') }}
   imageTag: {{ coredns_image_tag }}

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta2.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta2.yaml.j2
@@ -84,7 +84,7 @@ etcd:
 {% endif %}
 dns:
   type: CoreDNS
-  imageRepository: {{ coredns_image_repo | regex_replace('/coredns.*$','') }}
+  imageRepository: {{ coredns_image_repo | regex_replace('/coredns(?!/coredns).*$','') }}
   imageTag: {{ coredns_image_tag }}
 networking:
   dnsDomain: {{ dns_domain }}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR updates the `coredns_image_repo` usage by kubeadm config files. It updates the replace regex used in those config files to ensure that the repository namespace is kept if it exists, while keeping a backward compatibility when repository is not namespaced.

See the issue this PR fixes for further details on why we need it.

**Which issue(s) this PR fixes**:

Fixes #8182

**Special notes for your reviewer**:

This issue was _partially_ addressed by PR #8183 but for some reason it wasn’t merged. Furthermore, the code involved appears to have changed since then, that’s why I’m creating a new pull request.

**Does this PR introduce a user-facing change?**:

```release-note
Fix imageRepository path for CoreDNS
```
