### PR TITLE
Check all places with `check_mode: no` for side effects

### DIFF
--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -156,11 +156,9 @@
     executable: /bin/bash
   no_log: true
   changed_when: false
-  check_mode: no
   when: (('calico_rr' in groups and inventory_hostname in groups['calico_rr']) or
         inventory_hostname in groups['k8s_cluster']) and
         sync_certs|default(false) and inventory_hostname not in groups['etcd']
-  notify: set etcd_secret_changed
 
 - name: Gen_certs | check certificate permissions
   file:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fixes the last place where running with `--check` might change files. Noticed by @tjanson in https://github.com/kubernetes-sigs/kubespray/pull/8570 

Also removes `notify` from this task as the task has `changed_when: false`
and notify is not going to fire.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Remove remaining `check_mode: no` in playbooks
```
