### PR TITLE
Clarify confirmation prompt during node upgrade

### DIFF
--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Confirm node upgrade
   pause:
     echo: yes
-    prompt: "Ready to upgrade node ?"
+    prompt: "Ready to upgrade node? (Press Enter to continue or Ctrl+C for other options)"
   when:
     - upgrade_node_confirm
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Entering any value causes the play to proceed, e.g., entering "no<Enter>". (This is simply how Ansible's pause module behaves.)

That behavior is quite unexpected and in this case happens to be dangerous.

Unfortunately there is no simpler option to abort than going through Ctrl+C, A.

An even better option (in my opinion) would be to actually check user input (using the `prompt` module rather than `pause`). Then we could implement the usual behavior, e.g., "Continue? [Y/n]" accepting Enter, "y" and "n", obviously aborting on "n".

**Which issue(s) this PR fixes**: –

**Special notes for your reviewer**: –

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
