### PR TITLE
terraform/gcp: Add ingress_whitelist

### DIFF
--- a/contrib/terraform/gcp/README.md
+++ b/contrib/terraform/gcp/README.md
@@ -74,6 +74,7 @@ ansible-playbook -i contrib/terraform/gcs/inventory.ini cluster.yml -b -v
 * `ssh_whitelist`: List of IP ranges (CIDR) that will be allowed to ssh to the nodes
 * `api_server_whitelist`: List of IP ranges (CIDR) that will be allowed to connect to the API server
 * `nodeport_whitelist`: List of IP ranges (CIDR) that will be allowed to connect to the kubernetes nodes on port 30000-32767 (kubernetes nodeports)
+* `ingress_whitelist`: List of IP ranges (CIDR) that will be allowed to connect to ingress on ports 80 and 443
 
 ### Optional
 

--- a/contrib/terraform/gcp/main.tf
+++ b/contrib/terraform/gcp/main.tf
@@ -33,4 +33,5 @@ module "kubernetes" {
   ssh_whitelist        = var.ssh_whitelist
   api_server_whitelist = var.api_server_whitelist
   nodeport_whitelist   = var.nodeport_whitelist
+  ingress_whitelist    = var.ingress_whitelist
 }

--- a/contrib/terraform/gcp/modules/kubernetes-cluster/output.tf
+++ b/contrib/terraform/gcp/modules/kubernetes-cluster/output.tf
@@ -19,9 +19,9 @@ output "worker_ip_addresses" {
 }
 
 output "ingress_controller_lb_ip_address" {
-  value = google_compute_address.worker_lb.address
+  value = length(var.ingress_whitelist) > 0 ? google_compute_address.worker_lb.0.address : ""
 }
 
 output "control_plane_lb_ip_address" {
-  value = google_compute_forwarding_rule.master_lb.ip_address
+  value = length(var.api_server_whitelist) > 0 ? google_compute_forwarding_rule.master_lb.0.ip_address : ""
 }

--- a/contrib/terraform/gcp/modules/kubernetes-cluster/variables.tf
+++ b/contrib/terraform/gcp/modules/kubernetes-cluster/variables.tf
@@ -65,6 +65,11 @@ variable "nodeport_whitelist" {
   type = list(string)
 }
 
+variable "ingress_whitelist" {
+  type = list(string)
+  default = ["0.0.0.0/0"]
+}
+
 variable "private_network_cidr" {
   default = "10.0.10.0/24"
 }

--- a/contrib/terraform/gcp/tfvars.json
+++ b/contrib/terraform/gcp/tfvars.json
@@ -16,6 +16,9 @@
   "nodeport_whitelist": [
     "1.2.3.4/32"
   ],
+  "ingress_whitelist": [
+    "0.0.0.0/0"
+  ],
 
   "machines": {
     "master-0": {

--- a/contrib/terraform/gcp/variables.tf
+++ b/contrib/terraform/gcp/variables.tf
@@ -90,3 +90,8 @@ variable api_server_whitelist {
 variable nodeport_whitelist {
   type = list(string)
 }
+
+variable "ingress_whitelist" {
+  type = list(string)
+  default = ["0.0.0.0/0"]
+}


### PR DESCRIPTION
Ingress resources access can be restricted.

Also, do not create unneeded resources (target pools are charged and should
only be created when needed).