### PR TITLE
Revert documentation regression

### DIFF
--- a/docs/large-deployments.md
+++ b/docs/large-deployments.md
@@ -11,7 +11,7 @@ For a large scaled deployments, consider the following configuration changes:
 * Override the ``download_run_once: true`` and/or ``download_localhost: true``.
   See download modes for details.
 
-* Adjust the `retry_stagger` global var as appropriate. It should provide same
+* Adjust the `retry_stagger` global var as appropriate. It should provide sane
   load on a delegate (the first K8s control plane node) then retrying failed
   push or download operations.
 

--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -2,7 +2,7 @@
 # Kubernetes configuration dirs and system namespace.
 # Those are where all the additional config stuff goes
 # the kubernetes normally puts in /srv/kubernetes.
-# This puts them in a same location and namespace.
+# This puts them in a sane location and namespace.
 # Editing those values will almost surely break something.
 kube_config_dir: /etc/kubernetes
 kube_script_dir: "{{ bin_dir }}/kubernetes-scripts"

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -132,7 +132,7 @@ enable_coredns_k8s_endpoint_pod_names: false
 # Kubernetes configuration dirs and system namespace.
 # Those are where all the additional config stuff goes
 # the kubernetes normally puts in /srv/kubernetes.
-# This puts them in a same location and namespace.
+# This puts them in a sane location and namespace.
 # Editing those values will almost surely break something.
 kube_config_dir: /etc/kubernetes
 kube_script_dir: "{{ bin_dir }}/kubernetes-scripts"


### PR DESCRIPTION
**What this PR does / why we need it**:

Reverts kubernetes-sigs/kubespray#7805. As noted by @piquer in https://github.com/kubernetes-sigs/kubespray/pull/7805#issuecomment-960673511 the change was a mistake; the previous version is correct in both content and grammar.

/kind documentation

**Which issue(s) this PR fixes**: #7805 (revert)

**Special notes for your reviewer**: –

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```