### PR TITLE
[2.18] nerdctl insecure registry config

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -64,6 +64,9 @@ image_info_command_on_localhost: "{{ lookup('vars', image_command_tool_on_localh
 # Arch of Docker images and needed packages
 image_arch: "{{host_architecture | default('amd64')}}"
 
+# Nerdctl insecure flag set
+nerdctl_extra_flags: '{%- if containerd_insecure_registries is defined and containerd_insecure_registries|length>0 -%}\" --insecure-registry"{%- else -%}{%- endif -%}'
+
 # Versions
 kubeadm_version: "{{ kube_version }}"
 etcd_version: v3.5.0

--- a/roles/download/tasks/prep_download.yml
+++ b/roles/download/tasks/prep_download.yml
@@ -5,6 +5,44 @@
   tags:
     - facts
 
+# The docker image_info_command might seems weird but we are using raw/endraw and `{{ `{{` }}` to manage the double jinja2 processing
+# done here and when `image_info_command` is used (first the raw/endraw allow to store the command, then the second processing replace `{{`
+- name: prep_download | Set image pull/info command for docker
+  set_fact:
+    image_pull_command: "{{ docker_bin_dir }}/docker pull"
+    image_info_command: "{{ docker_bin_dir }}/docker images -q | xargs -i {{ '{{' }} docker_bin_dir }}/docker inspect -f {% raw %}'{{ '{{' }} if .RepoTags }}{{ '{{' }} join .RepoTags \",\" }}{{ '{{' }} end }}{{ '{{' }} if .RepoDigests }},{{ '{{' }} join .RepoDigests \",\" }}{{ '{{' }} end }}' {% endraw %} {} | tr '\n' ','"
+  when: container_manager == 'docker'
+
+- name: prep_download | Set image pull/info command for containerd
+  set_fact:
+    image_info_command: "{{ bin_dir }}/nerdctl -n k8s.io images --format '{% raw %}{{ '{{' }} .Repository {{ '}}' }}:{{ '{{' }} .Tag {{ '}}' }}{% endraw %}' 2>/dev/null | grep -v ^:$ | tr '\n' ','"
+    image_pull_command: "{{ bin_dir }}/nerdctl -n k8s.io pull --quiet{{ nerdctl_extra_flags }}"
+  when: container_manager == 'containerd'
+
+- name: prep_download | Set image pull/info command for crio
+  set_fact:
+    image_info_command: "{{ bin_dir }}/crictl images --verbose | awk -F ': ' '/RepoTags|RepoDigests/ {print $2}' | tr '\n' ','"
+    image_pull_command: "{{ bin_dir }}/crictl pull"
+  when: container_manager == 'crio'
+
+- name: prep_download | Set image pull/info command for docker on localhost
+  set_fact:
+    image_pull_command_on_localhost: "{{ docker_bin_dir }}/docker pull"
+    image_info_command_on_localhost: "{{ docker_bin_dir }}/docker images"
+  when: container_manager_on_localhost == 'docker'
+
+- name: prep_download | Set image pull/info command for containerd on localhost
+  set_fact:
+    image_info_command_on_localhost: "{{ bin_dir }}/nerdctl -n k8s.io images --format '{% raw %}{{ '{{' }} .Repository {{ '}}' }}:{{ '{{' }} .Tag {{ '}}' }}{% endraw %}' 2>/dev/null | grep -v ^:$ | tr '\n' ','"
+    image_pull_command_on_localhost: "{{ bin_dir }}/nerdctl -n k8s.io pull --quiet{{ nerdctl_extra_flags }}"
+  when: container_manager_on_localhost == 'containerd'
+
+- name: prep_download | Set image pull/info command for crio on localhost
+  set_fact:
+    image_info_command_on_localhost: "{{ bin_dir }}/crictl images --verbose | awk -F ': ' '/RepoTags|RepoDigests/ {print $2}' | tr '\n' ','"
+    image_pull_command_on_localhost: "{{ bin_dir }}/crictl pull"
+  when: container_manager_on_localhost == 'crio'
+
 - name: prep_download | On localhost, check if passwordless root is possible
   command: "true"
   delegate_to: localhost


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Backport #8339 to 2.18-release
Cherry-pick 24f1402a142bfd72c5c0a624fdeef0b30c43c490

**Which issue(s) this PR fixes**:

Fixes #8339 on 2.18-release

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
[containerd] nerdctl insecure registry support
```
