### PR TITLE
[2.18] Update containerd_insecure_registries to match containerd_registries

### DIFF
--- a/inventory/sample/group_vars/all/containerd.yml
+++ b/inventory/sample/group_vars/all/containerd.yml
@@ -33,10 +33,11 @@
 ## An obvious use case is allowing insecure-registry access to self hosted registries.
 ## Can be ipaddress and domain_name.
 ## example define mirror.registry.io or 172.19.16.11:5000
+## set "name": "url". insecure url must be started http://
 ## Port number is also needed if the default HTTPS port is not used.
 # containerd_insecure_registries:
-#   - mirror.registry.io
-#   - 172.19.16.11:5000
+#   "localhost": "http://127.0.0.1"
+#   "172.19.16.11:5000": "http://172.19.16.11:5000"
 
 # containerd_registries:
 #   "docker.io": "https://registry-1.docker.io"

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -54,12 +54,14 @@ oom_score = {{ containerd_oom_score }}
         [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ registry }}"]
           endpoint = ["{{ ([ addr ] | flatten ) | join('","') }}"]
 {% endfor %}
-{% for addr in containerd_insecure_registries %}
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ addr }}"]
+{% if containerd_insecure_registries is defined and containerd_insecure_registries|length>0 %}
+{% for registry, addr in containerd_insecure_registries.items() %}
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ registry }}"]
           endpoint = ["{{ ([ addr ] | flatten ) | join('","') }}"]
-        [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ addr }}".tls]
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ registry }}".tls]
           insecure_skip_verify = true
 {% endfor %}
+{% endif %}
 {% for registry in containerd_registry_auth if registry['registry'] is defined %}
 {% if (registry['username'] is defined and registry['password'] is defined) or registry['auth'] is defined %}
       [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ registry['registry'] }}".auth]


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Backport #8340 to 2.18-release
Cherry-pick dda557ed23a533e6dc3a1ab6d329e66b7d7ab687

**Which issue(s) this PR fixes**:

Fixes #8340

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
[containerd] make containerd_insecure_registries into a dict similar to containerd_registries [⚠️ ADD NOTE `containerd_insecure_registries` needs to be updated or won't work anymore]
```
