### PR TITLE
[2.18] Update quay.io/kubespray/vagrant for fixing molecule_tests

### DIFF
--- a/.gitlab-ci/vagrant.yml
+++ b/.gitlab-ci/vagrant.yml
@@ -4,7 +4,7 @@ molecule_tests:
   tags: [c3.small.x86]
   only: [/^pr-.*$/]
   except: ['triggers']
-  image: quay.io/kubespray/vagrant:$KUBESPRAY_VERSION
+  image: quay.io/kubespray/vagrant:v2.18.0
   services: []
   stage: deploy-part1
   before_script:
@@ -33,7 +33,7 @@ molecule_tests:
   tags: [c3.small.x86]
   only: [/^pr-.*$/]
   except: ['triggers']
-  image: quay.io/kubespray/vagrant:$KUBESPRAY_VERSION
+  image: quay.io/kubespray/vagrant:v2.18.0
   services: []
   before_script:
     - apt-get update && apt-get install -y python3-pip


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

quay.io/kubespray/vagrant image is used for molecule_tests.
The tag was v2.17.1 on release-2.18 branch but the image contains vagrant-2.2.15 which has a bug related to a virtual machine creation.
That caused kubespray CI failures.
This updates the image to use a newer vagrant.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8603

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
