### PR TITLE
Update ansible-lint to 5.4.0 (#8607)

### DIFF
--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -78,6 +78,7 @@
         --ignore-preflight-errors=DirAvailable--etc-kubernetes-manifests
         --skip-phases={{ kubeadm_join_phases_skip | join(',') }}
       register: kubeadm_join
+      changed_when: kubeadm_join is success
 
   rescue:
 
@@ -89,6 +90,7 @@
         --ignore-preflight-errors=all
         --skip-phases={{ kubeadm_join_phases_skip | join(',') }}
       register: kubeadm_join
+      changed_when: kubeadm_join is success
 
   always:
 

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -148,6 +148,7 @@
     - name: reset | force remove all cri pods (rescue)
       shell: "ip netns list | cut -d' ' -f 1 | xargs -n1 ip netns delete && {{ bin_dir }}/crictl rmp -a -f"
       ignore_errors: true  # noqa ignore-errors
+      changed_when: true
 
 - name: reset | stop etcd services
   service:

--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -50,6 +50,7 @@
     - name: Cordon node
       command: "{{ kubectl }} cordon {{ kube_override_hostname|default(inventory_hostname) }}"
       delegate_to: "{{ groups['kube_control_plane'][0] }}"
+      changed_when: true
 
     - name: Check kubectl version
       command: "{{ kubectl }} version --client --short"
@@ -110,6 +111,7 @@
           until: drain_fallback_result.rc == 0
           retries: "{{ drain_fallback_retries }}"
           delay: "{{ drain_fallback_retry_delay_seconds }}"
+          changed_when: drain_fallback_result.rc == 0
       when:
         - drain_nodes
         - drain_fallback_enabled

--- a/tests/requirements-2.10.txt
+++ b/tests/requirements-2.10.txt
@@ -4,7 +4,7 @@ apache-libcloud==2.2.1
 tox==3.11.1
 dopy==0.3.7
 cryptography==2.8
-ansible-lint==5.0.11
+ansible-lint==5.4.0
 openshift==0.8.8
 molecule==3.0.6
 molecule-vagrant==0.3

--- a/tests/requirements-2.11.txt
+++ b/tests/requirements-2.11.txt
@@ -4,7 +4,7 @@ apache-libcloud==2.2.1
 tox==3.11.1
 dopy==0.3.7
 cryptography==2.8
-ansible-lint==5.0.11
+ansible-lint==5.4.0
 openshift==0.8.8
 molecule==3.0.6
 molecule-vagrant==0.3

--- a/tests/requirements-2.9.txt
+++ b/tests/requirements-2.9.txt
@@ -4,7 +4,7 @@ apache-libcloud==2.2.1
 tox==3.11.1
 dopy==0.3.7
 cryptography==2.8
-ansible-lint==5.0.11 ; python_version >= '3.0'
+ansible-lint==5.4.0 ; python_version >= '3.0'
 ansible-lint==4.2.0 ; python_version < '3.0'
 openshift==0.8.8
 molecule==3.0.6 ; python_version >= '3.0'


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

It seems that the Rich version 11.0.0 has a breaking change.
So need to update ansible-lint to 5.3.2 or later.

**Which issue(s) this PR fixes**:

Fixes #8607

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
