### PR TITLE
Add epoch to docker-ce and docker-ce-cli packages to ensure docker up…

### DIFF
--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -21,6 +21,7 @@
         - "{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version|lower|replace('/', '_') }}.yml"
         - "{{ ansible_distribution|lower }}-{{ host_architecture }}.yml"
         - "{{ ansible_distribution|lower }}.yml"
+        - "{{ ansible_os_family|lower }}-{{ ansible_distribution_major_version|lower|replace('/', '_') }}.yml"
         - "{{ ansible_os_family|lower }}-{{ host_architecture }}.yml"
         - "{{ ansible_os_family|lower }}.yml"
         - defaults.yml

--- a/roles/container-engine/docker/vars/redhat-7.yml
+++ b/roles/container-engine/docker/vars/redhat-7.yml
@@ -1,0 +1,39 @@
+---
+# containerd versions are only relevant for docker
+containerd_versioned_pkg:
+  'latest': "{{ containerd_package }}"
+  '1.3.7': "{{ containerd_package }}-1.3.7-3.1.el7"
+  '1.3.9': "{{ containerd_package }}-1.3.9-3.1.el7"
+  '1.4.3': "{{ containerd_package }}-1.4.3-3.2.el7"
+  '1.4.4': "{{ containerd_package }}-1.4.4-3.1.el7"
+  '1.4.6': "{{ containerd_package }}-1.4.6-3.1.el7"
+  '1.4.9': "{{ containerd_package }}-1.4.9-3.1.el7"
+  '1.4.12': "{{ containerd_package }}-1.4.12-3.1.el7"
+  'stable': "{{ containerd_package }}-1.4.12-3.1.el7"
+  'edge': "{{ containerd_package }}-1.4.12-3.1.el7"
+
+# https://docs.docker.com/engine/installation/linux/centos/#install-from-a-package
+# https://download.docker.com/linux/centos/<centos_version>>/x86_64/stable/Packages/
+# or do 'yum --showduplicates list docker-engine'
+docker_versioned_pkg:
+  'latest': docker-ce
+  '18.09': docker-ce-18.09.9-3.el7
+  '19.03': docker-ce-19.03.15-3.el7
+  '20.10': docker-ce-20.10.11-3.el7
+  'stable': docker-ce-20.10.11-3.el7
+  'edge': docker-ce-20.10.11-3.el7
+
+docker_cli_versioned_pkg:
+  'latest': docker-ce-cli
+  '18.09': docker-ce-cli-18.09.9-3.el7
+  '19.03': docker-ce-cli-19.03.15-3.el7
+  '20.10': docker-ce-cli-20.10.11-3.el7
+  'stable': docker-ce-cli-20.10.11-3.el7
+  'edge': docker-ce-cli-20.10.11-3.el7
+
+docker_package_info:
+  enablerepo: "docker-ce"
+  pkgs:
+    - "{{ containerd_versioned_pkg[docker_containerd_version | string] }}"
+    - "{{ docker_cli_versioned_pkg[docker_cli_version | string] }}"
+    - "{{ docker_versioned_pkg[docker_version | string] }}"

--- a/roles/container-engine/docker/vars/redhat.yml
+++ b/roles/container-engine/docker/vars/redhat.yml
@@ -17,19 +17,19 @@ containerd_versioned_pkg:
 # or do 'yum --showduplicates list docker-engine'
 docker_versioned_pkg:
   'latest': docker-ce
-  '18.09': docker-ce-18.09.9-3.el7
-  '19.03': docker-ce-19.03.15-3.el{{ ansible_distribution_major_version }}
-  '20.10': docker-ce-20.10.11-3.el{{ ansible_distribution_major_version }}
-  'stable': docker-ce-20.10.11-3.el{{ ansible_distribution_major_version }}
-  'edge': docker-ce-20.10.11-3.el{{ ansible_distribution_major_version }}
+  '18.09': docker-ce-3:18.09.9-3.el7
+  '19.03': docker-ce-3:19.03.15-3.el{{ ansible_distribution_major_version }}
+  '20.10': docker-ce-3:20.10.11-3.el{{ ansible_distribution_major_version }}
+  'stable': docker-ce-3:20.10.11-3.el{{ ansible_distribution_major_version }}
+  'edge': docker-ce-3:20.10.11-3.el{{ ansible_distribution_major_version }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
-  '18.09': docker-ce-cli-18.09.9-3.el7
-  '19.03': docker-ce-cli-19.03.15-3.el{{ ansible_distribution_major_version }}
-  '20.10': docker-ce-cli-20.10.11-3.el{{ ansible_distribution_major_version }}
-  'stable': docker-ce-cli-20.10.11-3.el{{ ansible_distribution_major_version }}
-  'edge': docker-ce-cli-20.10.11-3.el{{ ansible_distribution_major_version }}
+  '18.09': docker-ce-cli-1:18.09.9-3.el7
+  '19.03': docker-ce-cli-1:19.03.15-3.el{{ ansible_distribution_major_version }}
+  '20.10': docker-ce-cli-1:20.10.11-3.el{{ ansible_distribution_major_version }}
+  'stable': docker-ce-cli-1:20.10.11-3.el{{ ansible_distribution_major_version }}
+  'edge': docker-ce-cli-1:20.10.11-3.el{{ ansible_distribution_major_version }}
 
 docker_package_info:
   enablerepo: "docker-ce"


### PR DESCRIPTION
…grade

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

We need to ensure `epoch` is set within both `docker-ce` and `docker-ce-cli` packages names. If we don't set it, Ansible will set `epoch` value to `0`.

As current `epoch` values for  both `docker-ce` and `docker-ce-cli` are greater than `0`, `docker` won't be upgraded ever.

**Special notes for your reviewer**:

If you hace any doubt about the PR or the issue feel free to discuss it :smile: 

```release-note
[Docker] Add epoch to docker-ce and docker-ce-cli packages to ensure docker upgrade
```