### PR TITLE
Calico: Fix Wireguard support for CentOS Stream 9/RHEL 9 Beta

### DIFF
--- a/roles/network_plugin/calico/tasks/repos.yml
+++ b/roles/network_plugin/calico/tasks/repos.yml
@@ -18,3 +18,4 @@
       when:
         - ansible_os_family in ['RedHat']
         - ansible_distribution not in ['Fedora']
+        - ansible_facts['distribution_major_version'] | int < 9

--- a/roles/network_plugin/calico/vars/centos-9.yml
+++ b/roles/network_plugin/calico/vars/centos-9.yml
@@ -1,0 +1,3 @@
+---
+calico_wireguard_packages:
+  - wireguard-tools

--- a/roles/network_plugin/calico/vars/redhat-9.yml
+++ b/roles/network_plugin/calico/vars/redhat-9.yml
@@ -1,0 +1,3 @@
+---
+calico_wireguard_packages:
+  - wireguard-tools


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
WireGuard is available from the default repos in RHEL 9 beta and CentOS Stream 9 so installation of a third party repo and `wireguard-dkms` package isn't needed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Not sure if PRs for EL9 are being accepted yet but in my testing everything was working fine except WireGuard installation thus this PR
 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[Calico] Fix Wireguard support for CentOS Stream 9/RHEL 9 Beta
```
