### PR TITLE
Fix the condition of drain on pre-remove task

### DIFF
--- a/roles/container-engine/validate-container-engine/tasks/main.yml
+++ b/roles/container-engine/validate-container-engine/tasks/main.yml
@@ -63,6 +63,8 @@
         apply:
           tags:
             - pre-remove
+      when:
+        - kubelet_systemd_unit_exists
     - name: Stop kubelet
       service:
         name: kubelet
@@ -89,6 +91,8 @@
         apply:
           tags:
             - pre-remove
+      when:
+        - kubelet_systemd_unit_exists
     - name: Stop kubelet
       service:
         name: kubelet
@@ -114,6 +118,8 @@
         apply:
           tags:
             - pre-remove
+      when:
+        - kubelet_systemd_unit_exists
     - name: Stop kubelet
       service:
         name: kubelet


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When running cluster.yml for new machines what containerd is already install but Kubernetes cluster were not installed before,
the task "remove-node | List nodes" is failed like
```
  "changed": false,
  "cmd": [
    "/usr/local/bin/kubectl", "--kubeconfig",
    "/etc/kubernetes/admin.conf", "get", "nodes", "-o",
    "go-template={{ range .items }}{{ .metadata.name }}
    {{ "\n" }}{{ end }}"
   ],
   ..
   "stderr": "error: stat /etc/kubernetes/admin.conf: no such file or directory",
```
That was due to lack to check the existing Kubernetes cluster exists or not before running "kubectl drain" command.
This adds the check to avoid the issue.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8627

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix the condition of drain on pre-remove task
```
