### PR TITLE
[sysctl] set fs.may_detach_mounts=1 even when CRIs don't set it themselves

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
+++ b/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
@@ -87,6 +87,24 @@
     reload: yes
   when: enable_dual_stack_networks | bool
 
+- name: Check if we need to set fs.may_detach_mounts
+  stat:
+    path: /proc/sys/fs/may_detach_mounts
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
+  register: fs_may_detach_mounts
+  ignore_errors: true  # noqa ignore-errors
+
+- name: Set fs.may_detach_mounts if needed
+  sysctl:
+    sysctl_file: "{{ sysctl_file_path }}"
+    name: fs.may_detach_mounts
+    value: 1
+    state: present
+    reload: yes
+  when: fs_may_detach_mounts.stat.exists | d(false)
+
 - name: Ensure kube-bench parameters are set
   sysctl:
     sysctl_file: "{{ sysctl_file_path }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
`fs.may_detach_mounts` sysctl was introduced in the linux kernel (https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=8ed936b5671bfb33d89bc60bdcc7cf0470ba52fe) to facilitate the removal of mounts on unlinked files and directories. This behavior is expected by CRIs which cannot always control the order of layer removals causing race conditions that can result in "file busy" errors when trying to tare down pods. Since not all CRIs set this setting themselves and the impact of not setting it can be failure to terminate pods we should handle it in kubespray.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8622

**Special notes for your reviewer**:
We should backport this to `release-2.18` before tagging 2.18.1 since it affects the default deployment with containerd.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[sysctl] set fs.may_detach_mounts=1 to address pods stuck in Terminating state
```
