### PR TITLE
Have ingress_controller and external_provisioner in upgrade-cluster.yml

### DIFF
--- a/upgrade-cluster.yml
+++ b/upgrade-cluster.yml
@@ -153,6 +153,8 @@
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
+    - { role: kubernetes-apps/ingress_controller, tags: ingress-controller }
+    - { role: kubernetes-apps/external_provisioner, tags: external-provisioner }
     - { role: kubernetes-apps, tags: apps }
 
 - name: Apply resolv.conf changes now that cluster DNS is up


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
ingress_controller and external_provisioner are not upgraded by upgrade-cluster.yml (while other component are).

**Which issue(s) this PR fixes**:
None that I've found

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Ingress controllers and external provisioners (respectively deployed via ingress_controller and external_provisioner roles meta dependencies) are now upgraded in upgrade-cluster.yml
```
