### PR TITLE
[CI] Fix CI with kubespay 2.18.1 image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ stages:
   - deploy-special
 
 variables:
-  KUBESPRAY_VERSION: v2.18.0
+  KUBESPRAY_VERSION: v2.18.1
   FAILFASTCI_NAMESPACE: 'kargo-ci'
   GITLAB_REPOSITORY: 'kargo-ci/kubernetes-sigs-kubespray'
   ANSIBLE_FORCE_COLOR: "true"

--- a/tests/requirements-2.10.txt
+++ b/tests/requirements-2.10.txt
@@ -5,7 +5,7 @@ tox==3.11.1
 dopy==0.3.7
 cryptography==2.8
 ansible-lint==5.4.0
-openshift==0.8.8
+openshift==0.13.1
 molecule==3.0.6
 molecule-vagrant==0.3
 testinfra==5.2.2

--- a/tests/requirements-2.11.txt
+++ b/tests/requirements-2.11.txt
@@ -5,7 +5,7 @@ tox==3.11.1
 dopy==0.3.7
 cryptography==2.8
 ansible-lint==5.4.0
-openshift==0.8.8
+openshift==0.13.1
 molecule==3.0.6
 molecule-vagrant==0.3
 testinfra==5.2.2

--- a/tests/requirements-2.9.txt
+++ b/tests/requirements-2.9.txt
@@ -6,7 +6,7 @@ dopy==0.3.7
 cryptography==2.8
 ansible-lint==5.4.0 ; python_version >= '3.0'
 ansible-lint==4.2.0 ; python_version < '3.0'
-openshift==0.8.8
+openshift==0.13.1
 molecule==3.0.6 ; python_version >= '3.0'
 molecule==3.0.2 ; python_version < '3.0'
 molecule-vagrant==0.3


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
We need to use kubespray 2.18.1 in CI so we can upgrade ansible and test it in CI. This fix should unbreak the use of ubuntu 20.04 based image in CI.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
