### PR TITLE
fix disk controller type in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -171,7 +171,7 @@ Vagrant.configure("2") do |config|
           # always make /dev/sd{a/b/c} so that CI can ensure that
           # virtualbox and libvirt will have the same devices to use for OSDs
           (1..$kube_node_instances_with_disks_number).each do |d|
-            lv.storage :file, :device => "hd#{driverletters[d]}", :path => "disk-#{i}-#{d}-#{DISK_UUID}.disk", :size => $kube_node_instances_with_disks_size, :bus => "ide"
+            lv.storage :file, :device => "hd#{driverletters[d]}", :path => "disk-#{i}-#{d}-#{DISK_UUID}.disk", :size => $kube_node_instances_with_disks_size, :bus => "scsi"
           end
         end
       end


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

fix a bug that prevented nodes with more than 3 disks from booting by Vagrant using libvirt as provisioner.

**Which issue(s) this PR fixes**:

Fixes #8655

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Change libvirt default disk controller from IDE to SCSI
```