### PR TITLE
Run 0100-dhclient-hooks if dhcpclient is enabled

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0100-dhclient-hooks.yml
+++ b/roles/kubernetes/preinstall/tasks/0100-dhclient-hooks.yml
@@ -13,7 +13,6 @@
     marker: "# Ansible entries {mark}"
     mode: 0644
   notify: Preinstall | propagate resolvconf to k8s components
-  when: dhclientconffile is defined
 
 - name: Configure dhclient hooks for resolv.conf (non-RH)
   template:

--- a/roles/kubernetes/preinstall/tasks/0110-dhclient-hooks-undo.yml
+++ b/roles/kubernetes/preinstall/tasks/0110-dhclient-hooks-undo.yml
@@ -9,12 +9,10 @@
     state: absent
     backup: yes
     marker: "# Ansible entries {mark}"
-  when: dhclientconffile is defined
   notify: Preinstall | propagate resolvconf to k8s components
 
 - name: Remove kubespray specific dhclient hook
   file:
     path: "{{ dhclienthookfile }}"
     state: absent
-  when: dhclienthookfile is defined
   notify: Preinstall | propagate resolvconf to k8s components

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -77,6 +77,7 @@
   when:
     - dns_mode != 'none'
     - resolvconf_mode == 'host_resolvconf'
+    - dhclientconffile is defined
     - not ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
   tags:
     - bootstrap-os
@@ -86,6 +87,7 @@
   when:
     - dns_mode != 'none'
     - resolvconf_mode != 'host_resolvconf'
+    - dhclientconffile is defined
     - not ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
   tags:
     - bootstrap-os


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

If running Kubespray on static IP environments, a task was failed like:
```
  TASK [kubernetes/preinstall : Configure dhclient hooks for resolv.conf (RH-only)]
  fatal: [ak8s2]: FAILED! => {
    "changed": false, "checksum": "..",
    "msg": "Destination directory /etc/dhcp/dhclient.d does not exist"}
```

This adds a check for dhclientconffile for running 0100-dhclient-hooks to
run the task only if dhcpclient is enabled.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8654

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Run 0100-dhclient-hooks only if dhcpclient is enabled
```
