### PR TITLE
[ansible] make ansible 5.x the new default version

### DIFF
--- a/.gitlab-ci/lint.yml
+++ b/.gitlab-ci/lint.yml
@@ -52,7 +52,7 @@ tox-inventory-builder:
     - ./tests/scripts/rebase.sh
     - apt-get update && apt-get install -y python3-pip
     - update-alternatives --install /usr/bin/python python /usr/bin/python3 10
-    - python -m pip uninstall -y ansible
+    - python -m pip uninstall -y ansible ansible-base ansible-core
     - python -m pip install -r tests/requirements.txt
   script:
     - pip3 install tox

--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -31,29 +31,29 @@ packet_ubuntu20-calico-aio:
   variables:
     RESET_CHECK: "true"
 
-# Exericse ansible variants
+# Exericse ansible variants during the nightly jobs
 packet_ubuntu20-calico-aio-ansible-2_9:
   stage: deploy-part1
-  extends: .packet_pr
+  extends: .packet_periodic
   when: on_success
   variables:
     ANSIBLE_MAJOR_VERSION: "2.9"
     RESET_CHECK: "true"
 
+packet_ubuntu20-calico-aio-ansible-2_10:
+  stage: deploy-part1
+  extends: .packet_periodic
+  when: on_success
+  variables:
+    ANSIBLE_MAJOR_VERSION: "2.10"
+    RESET_CHECK: "true"
+
 packet_ubuntu20-calico-aio-ansible-2_11:
   stage: deploy-part1
-  extends: .packet_pr
+  extends: .packet_periodic
   when: on_success
   variables:
     ANSIBLE_MAJOR_VERSION: "2.11"
-    RESET_CHECK: "true"
-
-packet_ubuntu20-calico-aio-ansible-2_12:
-  stage: deploy-part1
-  extends: .packet_pr
-  when: on_success
-  variables:
-    ANSIBLE_MAJOR_VERSION: "2.12"
     RESET_CHECK: "true"
 
 # ### PR JOBS PART2

--- a/.gitlab-ci/vagrant.yml
+++ b/.gitlab-ci/vagrant.yml
@@ -11,7 +11,7 @@ molecule_tests:
     - tests/scripts/rebase.sh
     - apt-get update && apt-get install -y python3-pip
     - update-alternatives --install /usr/bin/python python /usr/bin/python3 10
-    - python -m pip uninstall -y ansible
+    - python -m pip uninstall -y ansible ansible-base ansible-core
     - python -m pip install -r tests/requirements.txt
     - ./tests/scripts/vagrant_clean.sh
   script:
@@ -38,7 +38,7 @@ molecule_tests:
   before_script:
     - apt-get update && apt-get install -y python3-pip
     - update-alternatives --install /usr/bin/python python /usr/bin/python3 10
-    - python -m pip uninstall -y ansible
+    - python -m pip uninstall -y ansible ansible-base ansible-core
     - python -m pip install -r tests/requirements.txt
     - ./tests/scripts/vagrant_clean.sh
   script:

--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -267,7 +267,7 @@ that explains in detail the need and the evolution plan.
 You first need to uninstall your old ansible (pre 2.10) version and install the new one.
 
 ```ShellSession
-pip uninstall ansible
+pip uninstall ansible ansible-base ansible-core
 cd kubespray/
 pip install -U .
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requirements-2.10.txt
+requirements-2.12.txt

--- a/tests/files/packet_ubuntu20-calico-aio-ansible-2_12.yml
+++ b/tests/files/packet_ubuntu20-calico-aio-ansible-2_12.yml
@@ -1,1 +1,0 @@
-packet_ubuntu20-calico-aio.yml

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,1 +1,1 @@
-requirements-2.10.txt
+requirements-2.12.txt


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Following the suggestion from @floryut  in https://github.com/kubernetes-sigs/kubespray/pull/8512#pullrequestreview-922674738 I submit this change to make ansible 5.5 our new default ansible version and move the other supported versions to a nightly job to decrease the number of redundant checks we test for each PR.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[ansible] make ansible 5.x the new default version
[CI] move supported ansible versions jobs to nightly
```
