### PR TITLE
Add ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK flag to etcd config

### DIFF
--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -100,3 +100,7 @@ etcd_retries: 4
 #   - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
 #   - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
 #   - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+
+# ETCD 3.5.x issue
+# https://groups.google.com/a/kubernetes.io/g/dev/c/B7gJs88XtQc/m/rSgNOzV2BwAJ?utm_medium=email&utm_source=footer
+etcd_experimental_initial_corrupt_check: true

--- a/roles/etcd/templates/etcd.env.j2
+++ b/roles/etcd/templates/etcd.env.j2
@@ -63,3 +63,7 @@ ETCDCTL_ENDPOINTS=https://127.0.0.1:2379
 ETCDCTL_CACERT={{ etcd_cert_dir }}/ca.pem
 ETCDCTL_KEY={{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem
 ETCDCTL_CERT={{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem
+
+# ETCD 3.5.x issue
+# https://groups.google.com/a/kubernetes.io/g/dev/c/B7gJs88XtQc/m/rSgNOzV2BwAJ?utm_medium=email&utm_source=footer
+ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK={{ etcd_experimental_initial_corrupt_check }}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
etcd 3.5.x has an issue, which can disturb production
https://groups.google.com/a/kubernetes.io/g/dev/c/B7gJs88XtQc/m/rSgNOzV2BwAJ?utm_medium=email&utm_source=footer

**Which issue(s) this PR fixes**:
https://github.com/etcd-io/etcd/issues/13766#issuecomment-1078897588

**Special notes for your reviewer**:
This is a recommendation by sig-cluser-lifecycle team
https://kubernetes.slack.com/archives/C13J86Z63/p1648574650285699

**Does this PR introduce a user-facing change?**:
```release-note
Add ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK flag to etcd config (default to true)
```
