### PR TITLE
split kube_feature_gates variable for different kubernetes components

### DIFF
--- a/docs/vars.md
+++ b/docs/vars.md
@@ -88,11 +88,17 @@ following default cluster parameters:
 * *cloud_provider* - Enable extra Kubelet option if operating inside GCE or
   OpenStack (default is unset)
 * *kube_feature_gates* - A list of key=value pairs that describe feature gates for
-  alpha/experimental Kubernetes features. (defaults is `[]`)
+  alpha/experimental Kubernetes features. (defaults is `[]`).
+  Additionally, you can use also the following variables to individually customize your kubernetes components installation (they works exactly like `kube_feature_gates`):
+  * *kube_apiserver_feature_gates*
+  * *kube_controller_feature_gates*
+  * *kube_scheduler_feature_gates*
+  * *kube_proxy_feature_gates*
+  * *kubelet_feature_gates*
 * *kubeadm_feature_gates* - A list of key=value pairs that describe feature gates for
   alpha/experimental Kubeadm features. (defaults is `[]`)
 * *authorization_modes* - A list of [authorization mode](
-https://kubernetes.io/docs/admin/authorization/#using-flags-for-your-authorization-module)
+  https://kubernetes.io/docs/admin/authorization/#using-flags-for-your-authorization-module)
   that the cluster should be configured for. Defaults to `['Node', 'RBAC']`
   (Node and RBAC authorizers).
   Note: `Node` and `RBAC` are enabled by default. Previously deployed clusters can be

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta2.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta2.yaml.j2
@@ -196,8 +196,8 @@ apiServer:
 {% for key in kube_kubeadm_apiserver_extra_args %}
     {{ key }}: "{{ kube_kubeadm_apiserver_extra_args[key] }}"
 {% endfor %}
-{% if kube_feature_gates %}
-    feature-gates: {{ kube_feature_gates|join(',') }}
+{% if kube_apiserver_feature_gates or kube_feature_gates %}
+    feature-gates: "{{ kube_apiserver_feature_gates | default(kube_feature_gates, true) | join(',') }}"
 {% endif %}
 {% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws", "gce"] %}
     cloud-provider: {{ cloud_provider }}
@@ -288,8 +288,8 @@ controllerManager:
     bind-address: {{ kube_controller_manager_bind_address }}
     leader-elect-lease-duration: {{ kube_controller_manager_leader_elect_lease_duration }}
     leader-elect-renew-deadline: {{ kube_controller_manager_leader_elect_renew_deadline }}
-{% if kube_feature_gates %}
-    feature-gates: {{ kube_feature_gates|join(',') }}
+{% if kube_controller_feature_gates or kube_feature_gates %}
+    feature-gates: "{{ kube_controller_feature_gates | default(kube_feature_gates, true) | join(',') }}"
 {% endif %}
 {% for key in kube_kubeadm_controller_extra_args %}
     {{ key }}: "{{ kube_kubeadm_controller_extra_args[key] }}"
@@ -334,8 +334,8 @@ scheduler:
   extraArgs:
     bind-address: {{ kube_scheduler_bind_address }}
     config: {{ kube_config_dir }}/kubescheduler-config.yaml
-{% if kube_feature_gates %}
-    feature-gates: {{ kube_feature_gates|join(',') }}
+{% if kube_scheduler_feature_gates or kube_feature_gates %}
+    feature-gates: "{{ kube_scheduler_feature_gates | default(kube_feature_gates, true) | join(',') }}"
 {% endif %}
 {% if kube_kubeadm_scheduler_extra_args|length > 0 %}
 {% for key in kube_kubeadm_scheduler_extra_args %}
@@ -404,9 +404,10 @@ nodePortAddresses: {{ kube_proxy_nodeport_addresses }}
 oomScoreAdj: {{ kube_proxy_oom_score_adj }}
 portRange: {{ kube_proxy_port_range }}
 udpIdleTimeout: {{ kube_proxy_udp_idle_timeout }}
-{% if kube_feature_gates %}
+{% if kube_proxy_feature_gates or kube_feature_gates %}
+{% set feature_gates = ( kube_proxy_feature_gates | default(kube_feature_gates, true) ) %}
 featureGates:
-{%   for feature in kube_feature_gates %}
+{%   for feature in feature_gates %}
   {{ feature|replace("=", ": ") }}
 {%   endfor %}
 {% endif %}
@@ -429,9 +430,11 @@ clusterDNS:
 {% for dns_address in kubelet_cluster_dns %}
 - {{ dns_address }}
 {% endfor %}
-{% if kube_feature_gates %}
+{% if kubelet_feature_gates or kube_feature_gates %}
+{% set feature_gates = ( kubelet_feature_gates | default(kube_feature_gates, true) ) %}
 featureGates:
-{%   for feature in kube_feature_gates %}
+{%   for feature in feature_gates %}
   {{ feature|replace("=", ": ") }}
 {%   endfor %}
 {% endif %}
+

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -489,6 +489,11 @@ kubelet_protect_kernel_defaults: true
 ## List of key=value pairs that describe feature gates for
 ## the k8s cluster.
 kube_feature_gates: []
+kube_apiserver_feature_gates: []
+kube_controller_feature_gates: []
+kube_scheduler_feature_gates: []
+kube_proxy_feature_gates: []
+kubelet_feature_gates: []
 kubeadm_feature_gates: []
 
 # Local volume provisioner storage classes


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Not all the components need the same configuration and we would configure them as best as possible.
An example could be the recently added feature for the kubelet component: KubeletInUserNamespace. This is not suitable for all the components, so we would use it just for kubelet.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8666

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Split kube_feature_gates variable for different kubernetes components (/!\ ⚠️ ADD NOTE : This add some variables that could be defined by the user. It doesn't introduce a breaking change because the previous unique variable (kube_feature_gates) still works as expected.  kube_apiserver_feature_gates/kube_controller_feature_gates/kube_scheduler_feature_gates/kube_proxy_feature_gates/kubelet_feature_gates)
```
