### PR TITLE
Fix validate-container-engine role in vagrant CI jobs

### DIFF
--- a/roles/container-engine/validate-container-engine/tasks/main.yml
+++ b/roles/container-engine/validate-container-engine/tasks/main.yml
@@ -6,18 +6,26 @@
     get_checksum: no
     get_mime: no
   register: ostree
+  tags:
+    - facts
 
 - name: validate-container-engine | set is_ostree
   set_fact:
     is_ostree: "{{ ostree.stat.exists }}"
+  tags:
+    - facts
 
 - name: Ensure kubelet systemd unit exists
   stat:
     path: "/etc/systemd/system/kubelet.service"
   register: kubelet_systemd_unit_exists
+  tags:
+    - facts
 
 - name: Populate service facts
   service_facts:
+  tags:
+    - facts
 
 - name: Check if containerd is installed
   find:
@@ -31,6 +39,8 @@
       - /etc/systemd
       - /run/systemd
   register: containerd_installed
+  tags:
+    - facts
 
 - name: Check if docker is installed
   find:
@@ -44,6 +54,8 @@
       - /etc/systemd
       - /run/systemd
   register: docker_installed
+  tags:
+    - facts
 
 - name: Check if crio is installed
   find:
@@ -57,6 +69,8 @@
       - /etc/systemd
       - /run/systemd
   register: crio_installed
+  tags:
+    - facts
 
 - name: Uninstall containerd
   block:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:
This PR addresses an issue with kubespray running in vagrant resulting in errors like the one below.
The issue was reported by @oboudry and seems to have been introduced in https://github.com/kubernetes-sigs/kubespray/pull/8662

```
TASK [container-engine/containerd-common : containerd-common | gather os specific variables] *** fatal: [kub-1]: FAILED! => {"msg": "The conditional check 'not (is_ostree or (ansible_distribution == \"Flatcar Container Linux by Kinvolk\") or (ansible_distribution == \"Flatcar\"))' failed. The error was: error while evaluating conditional (not (is_ostree or (ansible_distribution == \"Flatcar Container Linux by Kinvolk\") or (ansible_distribution == \"Flatcar\"))): 'is_ostree' is undefined\n\nThe error appears to be in '/home/olivier/Documents/kubespray/roles/container-engine/containerd-common/tasks/main.yml': line 14, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: containerd-common | gather os specific variables\n ^ here\n"}
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8673

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
