### PR TITLE
[2.18] cert-manager: leader election namespace fixes

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s_cluster/addons.yml
@@ -134,6 +134,7 @@ cert_manager_enabled: false
 #   -----BEGIN CERTIFICATE-----
 #   [REPLACE with your CA certificate]
 #   -----END CERTIFICATE-----
+# cert_manager_leader_election_namespace: kube-system
 
 # MetalLB deployment
 metallb_enabled: false

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/defaults/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/defaults/main.yml
@@ -1,3 +1,7 @@
 ---
 cert_manager_namespace: "cert-manager"
 cert_manager_user: 1001
+
+## Change leader election namespace when deploying on GKE Autopilot that forbid the changes on kube-system namespace.
+## See https://github.com/jetstack/cert-manager/issues/3717
+cert_manager_leader_election_namespace: kube-system

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
@@ -630,7 +630,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cert-manager-cainjector:leaderelection
-  namespace: {{ cert_manager_namespace }}
+  namespace: {{ cert_manager_leader_election_namespace }}
   labels:
     app: cainjector
     app.kubernetes.io/name: cainjector
@@ -664,7 +664,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cert-manager:leaderelection
-  namespace: {{ cert_manager_namespace }}
+  namespace: {{ cert_manager_leader_election_namespace }}
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
@@ -719,7 +719,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cert-manager-cainjector:leaderelection
-  namespace: {{ cert_manager_namespace }}
+  namespace: {{ cert_manager_leader_election_namespace }}
   labels:
     app: cainjector
     app.kubernetes.io/name: cainjector
@@ -742,7 +742,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cert-manager:leaderelection
-  namespace: {{ cert_manager_namespace }}
+  namespace: {{ cert_manager_leader_election_namespace }}
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
@@ -866,7 +866,7 @@ spec:
           imagePullPolicy: {{ k8s_image_pull_policy }}
           args:
           - --v=2
-          - --leader-election-namespace=kube-system
+          - --leader-election-namespace={{ cert_manager_leader_election_namespace }}
           env:
           - name: POD_NAMESPACE
             valueFrom:
@@ -928,7 +928,7 @@ spec:
           args:
           - --v=2
           - --cluster-resource-namespace=$(POD_NAMESPACE)
-          - --leader-election-namespace=kube-system
+          - --leader-election-namespace={{ cert_manager_leader_election_namespace }}
           ports:
           - containerPort: 9402
             protocol: TCP


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This is a backport of cert-manager leader election namespace fixes to `kubespray-2.18` which I backported from these commits
* ccd3180 (#8433)
* e791089 (#8424)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cert-manager is unusable in 2.18 branch due to this bug.

**Does this PR introduce a user-facing change?**:
```release-note
Fix cert-manager unusable due to leader election namespace problem
```
