### PR TITLE
Single quotes are missing in jsonpath argument of kubectl get node

### DIFF
--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -19,7 +19,7 @@
 - name: See if node is in ready state
   command: >
     {{ kubectl }} get node {{ kube_override_hostname|default(inventory_hostname) }}
-    -o jsonpath={ range .status.conditions[?(@.type == "Ready")].status }{ @ }{ end }
+    -o jsonpath='{ range .status.conditions[?(@.type == "Ready")].status }{ @ }{ end }'
   register: kubectl_node_ready
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
   failed_when: false


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Jsonpath expression contains spaces, thus requires quoting.
Otherwise the following error occurs...
```
error: error parsing jsonpath {, unclosed action
```
... and the node is not considered ready hence not drained

**Which issue(s) this PR fixes**:
None that I've found

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
No
