### PR TITLE
[2.18] Fix image_command_tool var ignored since PR #8601

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -49,7 +49,7 @@ download_delegate: "{% if download_localhost %}localhost{% else %}{{ groups['kub
 docker_image_pull_command: "{{ docker_bin_dir }}/docker pull"
 docker_image_info_command: "{{ docker_bin_dir }}/docker images -q | xargs -i {{ '{{' }} docker_bin_dir }}/docker inspect -f {% raw %}'{{ '{{' }} if .RepoTags }}{{ '{{' }} join .RepoTags \",\" }}{{ '{{' }} end }}{{ '{{' }} if .RepoDigests }},{{ '{{' }} join .RepoDigests \",\" }}{{ '{{' }} end }}' {% endraw %} {} | tr '\n' ','"
 nerdctl_image_info_command: "{{ bin_dir }}/nerdctl -n k8s.io images --format '{% raw %}{{ '{{' }} .Repository {{ '}}' }}:{{ '{{' }} .Tag {{ '}}' }}{% endraw %}' 2>/dev/null | grep -v ^:$ | tr '\n' ','"
-nerdctl_image_pull_command: "{{ bin_dir }}/nerdctl -n k8s.io pull --quiet"
+nerdctl_image_pull_command: "{{ bin_dir }}/nerdctl -n k8s.io pull --quiet{{ nerdctl_extra_flags  }}"
 crictl_image_info_command: "{{ bin_dir }}/crictl images --verbose | awk -F ': ' '/RepoTags|RepoDigests/ {print $2}' | tr '\n' ','"
 crictl_image_pull_command: "{{ bin_dir }}/crictl pull"
 

--- a/roles/download/tasks/prep_download.yml
+++ b/roles/download/tasks/prep_download.yml
@@ -5,44 +5,6 @@
   tags:
     - facts
 
-# The docker image_info_command might seems weird but we are using raw/endraw and `{{ `{{` }}` to manage the double jinja2 processing
-# done here and when `image_info_command` is used (first the raw/endraw allow to store the command, then the second processing replace `{{`
-- name: prep_download | Set image pull/info command for docker
-  set_fact:
-    image_pull_command: "{{ docker_bin_dir }}/docker pull"
-    image_info_command: "{{ docker_bin_dir }}/docker images -q | xargs -i {{ '{{' }} docker_bin_dir }}/docker inspect -f {% raw %}'{{ '{{' }} if .RepoTags }}{{ '{{' }} join .RepoTags \",\" }}{{ '{{' }} end }}{{ '{{' }} if .RepoDigests }},{{ '{{' }} join .RepoDigests \",\" }}{{ '{{' }} end }}' {% endraw %} {} | tr '\n' ','"
-  when: container_manager == 'docker'
-
-- name: prep_download | Set image pull/info command for containerd
-  set_fact:
-    image_info_command: "{{ bin_dir }}/nerdctl -n k8s.io images --format '{% raw %}{{ '{{' }} .Repository {{ '}}' }}:{{ '{{' }} .Tag {{ '}}' }}{% endraw %}' 2>/dev/null | grep -v ^:$ | tr '\n' ','"
-    image_pull_command: "{{ bin_dir }}/nerdctl -n k8s.io pull --quiet{{ nerdctl_extra_flags }}"
-  when: container_manager == 'containerd'
-
-- name: prep_download | Set image pull/info command for crio
-  set_fact:
-    image_info_command: "{{ bin_dir }}/crictl images --verbose | awk -F ': ' '/RepoTags|RepoDigests/ {print $2}' | tr '\n' ','"
-    image_pull_command: "{{ bin_dir }}/crictl pull"
-  when: container_manager == 'crio'
-
-- name: prep_download | Set image pull/info command for docker on localhost
-  set_fact:
-    image_pull_command_on_localhost: "{{ docker_bin_dir }}/docker pull"
-    image_info_command_on_localhost: "{{ docker_bin_dir }}/docker images"
-  when: container_manager_on_localhost == 'docker'
-
-- name: prep_download | Set image pull/info command for containerd on localhost
-  set_fact:
-    image_info_command_on_localhost: "{{ bin_dir }}/nerdctl -n k8s.io images --format '{% raw %}{{ '{{' }} .Repository {{ '}}' }}:{{ '{{' }} .Tag {{ '}}' }}{% endraw %}' 2>/dev/null | grep -v ^:$ | tr '\n' ','"
-    image_pull_command_on_localhost: "{{ bin_dir }}/nerdctl -n k8s.io pull --quiet{{ nerdctl_extra_flags }}"
-  when: container_manager_on_localhost == 'containerd'
-
-- name: prep_download | Set image pull/info command for crio on localhost
-  set_fact:
-    image_info_command_on_localhost: "{{ bin_dir }}/crictl images --verbose | awk -F ': ' '/RepoTags|RepoDigests/ {print $2}' | tr '\n' ','"
-    image_pull_command_on_localhost: "{{ bin_dir }}/crictl pull"
-  when: container_manager_on_localhost == 'crio'
-
 - name: prep_download | On localhost, check if passwordless root is possible
   command: "true"
   delegate_to: localhost


### PR DESCRIPTION


**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:

Fixes a regression from https://github.com/kubernetes-sigs/kubespray/pull/8601#issuecomment-1088852134.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix image_command_tool var ignored since PR #8601
```
