### PR TITLE
[2.18] Fix quotation of nerdctl_extra_flags (#8668)

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -65,7 +65,7 @@ image_info_command_on_localhost: "{{ lookup('vars', image_command_tool_on_localh
 image_arch: "{{host_architecture | default('amd64')}}"
 
 # Nerdctl insecure flag set
-nerdctl_extra_flags: '{%- if containerd_insecure_registries is defined and containerd_insecure_registries|length>0 -%}\" --insecure-registry"{%- else -%}{%- endif -%}'
+nerdctl_extra_flags: '{%- if containerd_insecure_registries is defined and containerd_insecure_registries|length>0 -%}\" --insecure-registry\"{%- else -%}{%- endif -%}'
 
 # Versions
 kubeadm_version: "{{ kube_version }}"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This is a cherry-pick of https://github.com/kubernetes-sigs/kubespray/pull/8668

Due to missing quotation of nerdctl_extra_flags, ansible-playbook was failed:
```
  Using module file /usr/local/lib/python3.6/dist-packages/ansible/modules/command.py
  Pipelining is enabled.
    [..]
    File "/usr/lib/python3.8/shlex.py", line 191, in read_token
      raise ValueError("No closing quotation")
```
This fixes the issue.

T-Eberle investigated the issue and found the solution.
Thank you T-Eberle!

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8529

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix quotation of nerdctl_extra_flags
```
