### PR TITLE
Ensure all Kubelet required kernel values are configured when enablin…

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
+++ b/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
@@ -113,9 +113,12 @@
     state: present
     reload: yes
   with_items:
-    - { name: vm.overcommit_memory, value: 1 }
+    - { name: kernel.keys.root_maxbytes, value: 25000000 }
+    - { name: kernel.keys.root_maxkeys, value: 1000000 }
     - { name: kernel.panic, value: 10 }
     - { name: kernel.panic_on_oops, value: 1 }
+    - { name: vm.overcommit_memory, value: 1 }
+    - { name: vm.panic_on_oom, value: 0 }
   when: kubelet_protect_kernel_defaults|bool
 
 - name: Check dummy module


### PR DESCRIPTION
…g protectKernelDefaults

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

We need to ensure required kernel defaults configuration for Kubelet when enabling `protectKernelDefaults`. If we take a look at the [code-base](https://github.com/kubernetes/kubernetes/blob/v1.23.5/staging/src/k8s.io/component-helpers/node/util/sysctl/sysctl.go#L26-L65) these kernel values are hardcoded, so I think we should set them all in order to avoid kernel values misconfigurations.

If `protectKernelDefaults` is disabled, these values won't be configured as Kubelet will configure them during its startup.

**Special notes for your reviewer**:

If you hace any doubt about the PR or the issue feel free to discuss it :smile: 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
