### PR TITLE
Enable Kubespray deployment on vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -75,6 +75,7 @@ $local_path_provisioner_claim_root ||= "/opt/local-path-provisioner/"
 $libvirt_nested ||= false
 # boolean or string (e.g. "-vvv")
 $ansible_verbosity ||= false
+$ansible_tags ||= ENV['VAGRANT_ANSIBLE_TAGS'] || ""
 
 $playbook ||= "cluster.yml"
 
@@ -256,7 +257,9 @@ Vagrant.configure("2") do |config|
           ansible.host_key_checking = false
           ansible.raw_arguments = ["--forks=#{$num_instances}", "--flush-cache", "-e ansible_become_pass=vagrant"]
           ansible.host_vars = host_vars
-          ansible.tags = ['facts']
+          if $ansible_tags != ""
+            ansible.tags = [$ansible_tags]
+          end
           ansible.groups = {
             "etcd" => ["#{$instance_name_prefix}-[1:#{$etcd_instances}]"],
             "kube_control_plane" => ["#{$instance_name_prefix}-[1:#{$kube_master_instances}]"],

--- a/test-infra/vagrant-docker/Dockerfile
+++ b/test-infra/vagrant-docker/Dockerfile
@@ -5,6 +5,7 @@ FROM quay.io/kubespray/kubespray:${KUBESPRAY_VERSION}
 
 ENV VAGRANT_VERSION=2.2.19
 ENV VAGRANT_DEFAULT_PROVIDER=libvirt
+ENV VAGRANT_ANSIBLE_TAGS=facts
 
 RUN apt-get update && apt-get install -y wget libvirt-dev openssh-client rsync git
 


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Current ansible.tags 'facts' is for skipping actual Kubespray deployment at vagrant CI
because the deployment takes much time.
However the static 'facts' skips the deployment for normal usage of vagrant also.
That causes confusions.

This adds VAGRANT_ANSIBLE_TAGS to skip the deployment for vagrant CI.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8682

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Enable Kubespray deployment on vagrant
```
