### PR TITLE
[Terraform AWS] Add tag to AWS VPC subnets for automatic subnet discovery

### DIFF
--- a/contrib/terraform/aws/modules/vpc/main.tf
+++ b/contrib/terraform/aws/modules/vpc/main.tf
@@ -31,7 +31,8 @@ resource "aws_subnet" "cluster-vpc-subnets-public" {
 
   tags = merge(var.default_tags, tomap({
     Name = "kubernetes-${var.aws_cluster_name}-${element(var.aws_avail_zones, count.index)}-public"
-    "kubernetes.io/cluster/${var.aws_cluster_name}" = "member"
+    "kubernetes.io/cluster/${var.aws_cluster_name}" = "shared"
+    "kubernetes.io/role/elb" = "1"
   }))
 }
 
@@ -49,6 +50,8 @@ resource "aws_subnet" "cluster-vpc-subnets-private" {
 
   tags = merge(var.default_tags, tomap({
     Name = "kubernetes-${var.aws_cluster_name}-${element(var.aws_avail_zones, count.index)}-private"
+    "kubernetes.io/cluster/${var.aws_cluster_name}" = "shared"
+    "kubernetes.io/role/internal-elb" = "1"
   }))
 }
 


### PR DESCRIPTION
Add tag to AWS VPC subnets for automatic subnet discovery by load balancers or ingress controllers

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
To identify a cluster's subnets, the Kubernetes Cloud Controller Manager (cloud-controller-manager) and AWS Load Balancer Controller (aws-load-balancer-controller) query that cluster's subnets by using the following tag as a filter:
```
kubernetes.io/cluster/cluster-name
```
The Cloud Controller Manager and AWS Load Balancer Controller both require subnets to have either of the following tags:
```
kubernetes.io/role/elb
```
-or-
```
kubernetes.io/role/internal-elb
```
Please refer to official Amazon document for more information: [eks-vpc-subnet-discovery](https://aws.amazon.com/premiumsupport/knowledge-center/eks-vpc-subnet-discovery/)

**Which issue(s) this PR fixes**:
Fixes #8704

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[Terraform AWS] Add tag to AWS VPC subnets for automatic subnet discovery
```
