### PR TITLE
Add tz to kubespray image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Use imutable image tags rather than mutable tags (like ubuntu:20.04)
 FROM ubuntu:focal-20220316
 
+ARG TZ=Etc/UTC
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 RUN apt update -y \
     && apt install -y \
     libssl-dev python3-dev sshpass apt-transport-https jq moreutils \


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix docker image hand on tzdata if no tz is set

**Which issue(s) this PR fixes**:
Fixes non interactive docker image build

**Special notes for your reviewer**:
n/a

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
