### PR TITLE
Add offline note for kube-* images

### DIFF
--- a/contrib/offline/generate_list.sh
+++ b/contrib/offline/generate_list.sh
@@ -19,6 +19,9 @@ sed -n '/^downloads:/,/download_defaults:/p' ${REPO_ROOT_DIR}/${DOWNLOAD_YML} \
     | sed 'N;s#\n# #g' | tr ' ' ':' | sed 's/\"//g' > ${TEMP_DIR}/images.list.template
 
 # add kube-* images to images list template
+# Those container images are downloaded by kubeadm, then roles/download/defaults/main.yml
+# doesn't contain those images. That is reason why here needs to put those images into the
+# list separately.
 KUBE_IMAGES="kube-apiserver kube-controller-manager kube-scheduler kube-proxy"
 for i in $KUBE_IMAGES; do
     echo "{{ kube_image_repo }}/$i:{{ kube_version }}" >> ${TEMP_DIR}/images.list.template


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

We had a question[1] why kube-* images need to be handled separately when getting container image list for offline deployment.
This adds the note to explain it for long-term maintenance.

[1]: https://github.com/kubernetes-sigs/kubespray/pull/8715#issuecomment-1099167099

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
