### PR TITLE
[etcd] ensure etcd is properly upgraded when managed by kubeadm

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -263,6 +263,13 @@ packet_centos7-docker-weave-upgrade-ha:
   variables:
     UPGRADE_TEST: basic
 
+packet_ubuntu20-calico-etcd-kubeadm-upgrade-ha:
+  stage: deploy-part3
+  extends: .packet_periodic
+  when: on_success
+  variables:
+    UPGRADE_TEST: basic
+
 # Calico HA Wireguard
 packet_ubuntu20-calico-ha-wireguard:
   stage: deploy-part2

--- a/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
@@ -18,7 +18,7 @@
     --config={{ kube_config_dir }}/kubeadm-config.yaml
     --ignore-preflight-errors=all
     --allow-experimental-upgrades
-    --etcd-upgrade={{ etcd_deployment_type == "kubeadm" | bool | lower }}
+    --etcd-upgrade={{ (etcd_deployment_type == "kubeadm") | bool | lower }}
     --force
   register: kubeadm_upgrade
   # Retry is because upload config sometimes fails
@@ -39,7 +39,7 @@
     --config={{ kube_config_dir }}/kubeadm-config.yaml
     --ignore-preflight-errors=all
     --allow-experimental-upgrades
-    --etcd-upgrade={{ etcd_deployment_type == "kubeadm" | bool | lower }}
+    --etcd-upgrade={{ (etcd_deployment_type == "kubeadm") | bool | lower }}
     --force
   register: kubeadm_upgrade
   when: inventory_hostname != first_kube_control_plane

--- a/tests/files/packet_ubuntu20-calico-etcd-kubeadm-upgrade-ha.yml
+++ b/tests/files/packet_ubuntu20-calico-etcd-kubeadm-upgrade-ha.yml
@@ -1,0 +1,13 @@
+---
+# Instance settings
+cloud_image: ubuntu-2004
+mode: ha
+
+# use the legacy setting to test the upgrade
+etcd_kubeadm_enabled: true
+
+upgrade_cluster_setup: true
+
+# Currently ipvs not available on KVM: https://packages.ubuntu.com/search?suite=focal&arch=amd64&mode=exactfilename&searchon=contents&keywords=ip_vs_sh.ko
+kube_proxy_mode: iptables
+enable_nodelocaldns: False


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
This PR addresses an issue with ansible templating that results in the etcd cluster failing to be upgraded when `etcd_deployment_type == "kubeadm"`.

```
etcd_deployment_type == "kubeadm" | bool | lower
```

The line above always results in `False` since ansible evaluates conversion operator `|` before the comparison operator `==`.

This PR also adds a CI job to the periodic (nightly) run to test the upgrade with etcd managed by kubeadm so we can catch this kind of breakage in the future.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8721 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```
