### PR TITLE
Update kata-containers.md

### DIFF
--- a/docs/kata-containers.md
+++ b/docs/kata-containers.md
@@ -10,7 +10,7 @@ _Qemu_ is the only hypervisor supported by Kubespray.
 
 To use Kata Containers, set the following variables:
 
-**k8s_cluster.yml**:
+**k8s-cluster.yml**:
 
 ```yaml
 container_manager: containerd
@@ -61,7 +61,7 @@ kata_containers_qemu_overhead_fixed_memory: 290Mi
 
 ### Optional : Select Kata Containers version
 
-Optionally you can select the Kata Containers release version to be installed. The available releases are published in [GitHub](https://github.com/kata-containers/runtime/releases).
+Optionally you can select the Kata Containers release version to be installed. The available releases are published in [GitHub](https://github.com/kata-containers/kata-containers/releases).
 
 ```yaml
 kata_containers_version: 2.2.2


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

* kata container related options exist in k8s-cluster.yml, not k8s_cluster.yml

* https://github.com/kata-containers/runtime has been archived and https://github.com/kata-containers/kata-containers is used today.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
