### PR TITLE
[2.18] Use proxy_env for argocd app.

### DIFF
--- a/roles/kubernetes-apps/argocd/tasks/main.yml
+++ b/roles/kubernetes-apps/argocd/tasks/main.yml
@@ -5,6 +5,7 @@
     url: "https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64"
     dest: "{{ bin_dir }}/yq"
     mode: '0755'
+  environment: "{{ proxy_env }}"
 
 - name: Kubernetes Apps | Set ArgoCD template list
   set_fact:
@@ -26,6 +27,7 @@
   with_items: "{{ argocd_templates | selectattr('url', 'defined') | list }}"
   loop_control:
     label: "{{ item.file }}"
+  environment: "{{ proxy_env }}"
   when:
     - "inventory_hostname == groups['kube_control_plane'][0]"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes issue where get_url for agocd doesn't use proxy settings.
