### PR TITLE
calico: vxlan is the default for calico_network_backend

### DIFF
--- a/docs/calico.md
+++ b/docs/calico.md
@@ -50,7 +50,7 @@ calico_datastore: kdd
 
 ### Optional : Define network backend
 
-In some cases you may want to define Calico network backend. Allowed values are `bird`, `vxlan` or `none`. Bird is a default value.
+In some cases you may want to define Calico network backend. Allowed values are `bird`, `vxlan` or `none`. `vxlan` is the default value.
 
 To re-define you need to edit the inventory and add a group variable `calico_network_backend`
 


### PR DESCRIPTION
Since https://github.com/kubernetes-sigs/kubespray/pull/8434:

https://github.com/kubernetes-sigs/kubespray/blob/a4f26dc8f3ca34cba93f577d88a2978c622b52f0/roles/network_plugin/calico/defaults/main.yml#L17-L18

> /kind documentation