### PR TITLE
Remove aufs-tools from Ubuntu requirement

### DIFF
--- a/roles/kubernetes/preinstall/vars/ubuntu.yml
+++ b/roles/kubernetes/preinstall/vars/ubuntu.yml
@@ -1,7 +1,6 @@
 ---
 required_pkgs:
   - python3-apt
-  - aufs-tools
   - apt-transport-https
   - software-properties-common
   - conntrack


### PR DESCRIPTION

**What type of PR is this?**

/kind bug
/kind cleanup

**What this PR does / why we need it**:

aufs-tools was required for docker.io package originally, but Kubespray installs docker-ce package instead today.
In addition, Ubuntu 20.04 doesn't provide aufs-tools as [1].
Then this removes aufs-tools from Ubuntu requirement.

[1]: https://bugs.launchpad.net/ubuntu/+source/aufs-tools/+bug/1947004

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8741

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Remove aufs-tools from Ubuntu requirement for Ubuntu 20.04 suport
```
