### PR TITLE
Use ansible 2.12 for testcases_prepare

### DIFF
--- a/tests/scripts/testcases_prepare.sh
+++ b/tests/scripts/testcases_prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euxo pipefail
 
-: ${ANSIBLE_MAJOR_VERSION:=2.10}
+: ${ANSIBLE_MAJOR_VERSION:=2.12}
 
 /usr/bin/python -m pip uninstall -y ansible ansible-base ansible-core
 /usr/bin/python -m pip install -r tests/requirements-${ANSIBLE_MAJOR_VERSION}.txt


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

tests/requirements.txt links to tests/requirements-2.12.txt, so Kubespray uses ansible 2.12 by default for testing.
However we forgot to update testcases_prepare.sh to use ansible 2.12.
This updates testcases_prepare to use ansible 2.12.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
