### PR TITLE
Update containerd version to 1.6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [kubernetes](https://github.com/kubernetes/kubernetes) v1.23.6
   - [etcd](https://github.com/etcd-io/etcd) v3.5.3
   - [docker](https://www.docker.com/) v20.10 (see note)
-  - [containerd](https://containerd.io/) v1.6.2
+  - [containerd](https://containerd.io/) v1.6.3
   - [cri-o](http://cri-o.io/) v1.22 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)
 - Network Plugin
   - [cni-plugins](https://github.com/containernetworking/plugins) v1.0.1

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -74,7 +74,7 @@ runc_version: v1.1.1
 kata_containers_version: 2.2.3
 youki_version: 0.0.1
 gvisor_version: 20210921
-containerd_version: 1.6.2
+containerd_version: 1.6.3
 cri_dockerd_version: v0.2.0
 
 # this is relevant when container_manager == 'docker'
@@ -781,6 +781,7 @@ containerd_archive_checksums:
     1.6.0: 0
     1.6.1: 0
     1.6.2: 0
+    1.6.3: 0
   arm64:
     1.4.9: 0
     1.4.11: 0
@@ -795,6 +796,7 @@ containerd_archive_checksums:
     1.6.0: 6eff3e16d44c89e1e8480a9ca078f79bab82af602818455cc162be344f64686a
     1.6.1: fbeec71f2d37e0e4ceaaac2bdf081295add940a7a5c7a6bcc125e5bbae067791
     1.6.2: a4b24b3c38a67852daa80f03ec2bc94e31a0f4393477cd7dc1c1a7c2d3eb2a95
+    1.6.3: 354e30d52ff94bd6cd7ceb8259bdf28419296b46cf5585e9492a87fdefcfe8b2
   amd64:
     1.4.9: 346f88ad5b973960ff81b5539d4177af5941ec2e4703b479ca9a6081ff1d023b
     1.4.11: 80c47ec5ce2cd91a15204b5f5b534892ca653e75f3fba0c451ca326bca45fb00
@@ -809,6 +811,7 @@ containerd_archive_checksums:
     1.6.0: f77725e4f757523bf1472ec3b9e02b09303a5d99529173be0f11a6d39f5676e9
     1.6.1: c1df0a12af2be019ca2d6c157f94e8ce7430484ab29948c9805882df40ec458b
     1.6.2: 3d94f887de5f284b0d6ee61fa17ba413a7d60b4bb27d756a402b713a53685c6a
+    1.6.3: 306b3c77f0b5e28ed10d527edf3d73f56bf0a1fb296075af4483d8516b6975ed
   ppc64le:
     1.4.9: 0
     1.4.11: 0
@@ -823,6 +826,7 @@ containerd_archive_checksums:
     1.6.0: 0
     1.6.1: 0
     1.6.2: 0
+    1.6.3: 0
 
 etcd_binary_checksum: "{{ etcd_binary_checksums[image_arch][etcd_version] }}"
 cni_binary_checksum: "{{ cni_binary_checksums[image_arch][cni_version] }}"


### PR DESCRIPTION

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

containerd version 1.6.3 has been released as [1]
This adds the checksums and makes Kubespray use it.

[1]: https://github.com/containerd/containerd/releases/tag/v1.6.3

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update containerd version to 1.6.3
```
