### PR TITLE
Move flannel to kubespray/quay for CI

### DIFF
--- a/tests/common/_docker_hub_registry_mirror.yml
+++ b/tests/common/_docker_hub_registry_mirror.yml
@@ -26,6 +26,8 @@ netcheck_server_image_repo: "{{ quay_image_repo }}/kubespray/k8s-netchecker-serv
 
 nginx_image_repo: "{{ quay_image_repo }}/kubespray/nginx"
 
+flannel_image_repo: "{{ quay_image_repo}}/kubespray/flannel"
+
 # Kubespray settings for tests
 deploy_netchecker: true
 dns_min_replicas: 1


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Mirror Flannel image to CI to mitigate dockerhub throttling

**Which issue(s) this PR fixes**:
Fixes future CI errors ;)

**Special notes for your reviewer**:
cf #8740 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
