### PR TITLE
Drop containerd 1.4 support

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -768,10 +768,6 @@ nerdctl_archive_checksums:
 
 containerd_archive_checksums:
   arm:
-    1.4.9: 0
-    1.4.11: 0
-    1.4.12: 0
-    1.4.13: 0
     1.5.5: 0
     1.5.7: 0
     1.5.8: 0
@@ -783,10 +779,6 @@ containerd_archive_checksums:
     1.6.2: 0
     1.6.3: 0
   arm64:
-    1.4.9: 0
-    1.4.11: 0
-    1.4.12: 0
-    1.4.13: 0
     1.5.5: 0
     1.5.7: 0
     1.5.8: 0
@@ -798,10 +790,6 @@ containerd_archive_checksums:
     1.6.2: a4b24b3c38a67852daa80f03ec2bc94e31a0f4393477cd7dc1c1a7c2d3eb2a95
     1.6.3: 354e30d52ff94bd6cd7ceb8259bdf28419296b46cf5585e9492a87fdefcfe8b2
   amd64:
-    1.4.9: 346f88ad5b973960ff81b5539d4177af5941ec2e4703b479ca9a6081ff1d023b
-    1.4.11: 80c47ec5ce2cd91a15204b5f5b534892ca653e75f3fba0c451ca326bca45fb00
-    1.4.12: 26bb35ee8a2467029ca450352112ba3a0d2b8bf6b70bf040f62d91f3c501736c
-    1.4.13: bc8b3e6abe99143788de5afaaf896cb7f229733f1ebd980eec48e71cc21c0a6a
     1.5.5: 8efc527ffb772a82021800f0151374a3113ed2439922497ff08f2596a70f10f1
     1.5.7: 109fc95b86382065ea668005c376360ddcd8c4ec413e7abe220ae9f461e0e173
     1.5.8: feeda3f563edf0294e33b6c4b89bd7dbe0ee182ca61a2f9b8c3de2766bcbc99b
@@ -813,10 +801,6 @@ containerd_archive_checksums:
     1.6.2: 3d94f887de5f284b0d6ee61fa17ba413a7d60b4bb27d756a402b713a53685c6a
     1.6.3: 306b3c77f0b5e28ed10d527edf3d73f56bf0a1fb296075af4483d8516b6975ed
   ppc64le:
-    1.4.9: 0
-    1.4.11: 0
-    1.4.12: 0
-    1.4.13: 0
     1.5.5: 0
     1.5.7: 0
     1.5.8: 0


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The version 1.4 of containerd has been End of Life since March 3, 2022 as https://containerd.io/releases/#support-horizon
It is nice to drop the support from Kubespray also to follow containerd.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Drop containerd 1.4 support
```
