### PR TITLE
add support for `service-account-lookup` parameter

### DIFF
--- a/docs/vars.md
+++ b/docs/vars.md
@@ -146,6 +146,8 @@ kube_apiserver_admission_event_rate_limits:
   ...
 ```
 
+* *kube_apiserver_service_account_lookup* - Enable validation service account before validating token. Default `true`.
+
 Note, if cloud providers have any use of the ``10.233.0.0/16``, like instances'
 private addresses, make sure to pick another values for ``kube_service_addresses``
 and ``kube_pods_subnet``, for example from the ``172.18.0.0/16``.

--- a/roles/kubernetes/control-plane/defaults/main/main.yml
+++ b/roles/kubernetes/control-plane/defaults/main/main.yml
@@ -18,6 +18,11 @@ kube_apiserver_node_port_range: "30000-32767"
 # ETCD backend for k8s data
 kube_apiserver_storage_backend: etcd3
 
+# CIS 1.2.26
+# Validate that the service account token
+# in the request is actually present in etcd.
+kube_apiserver_service_account_lookup: true
+
 kube_etcd_cacert_file: ca.pem
 kube_etcd_cert_file: node-{{ inventory_hostname }}.pem
 kube_etcd_key_file: node-{{ inventory_hostname }}-key.pem

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta2.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta2.yaml.j2
@@ -146,6 +146,9 @@ apiServer:
 {% if kube_token_auth|default(true) %}
     token-auth-file: {{ kube_token_dir }}/known_tokens.csv
 {% endif %}
+{% if kube_apiserver_service_account_lookup %}
+    service-account-lookup: "{{ kube_apiserver_service_account_lookup }}"
+{% endif %}
 {% if kube_oidc_auth|default(false) and kube_oidc_url is defined and kube_oidc_client_id is defined %}
     oidc-issuer-url: "{{ kube_oidc_url }}"
     oidc-client-id: "{{ kube_oidc_client_id }}"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
This PR covers the parameter `service-account-lookup` for CIS Benchmark.
It allows the user to make a complete hardening configuration through IaC.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8729

P.S.
This PR is also related to this issue: https://github.com/kubernetes-sigs/kubespray/issues/8773