### PR TITLE
[containerd] add 1.6.4 which is needed for kubernetes 1.24.0 and make it the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [kubernetes](https://github.com/kubernetes/kubernetes) v1.23.6
   - [etcd](https://github.com/etcd-io/etcd) v3.5.3
   - [docker](https://www.docker.com/) v20.10 (see note)
-  - [containerd](https://containerd.io/) v1.6.3
+  - [containerd](https://containerd.io/) v1.6.4
   - [cri-o](http://cri-o.io/) v1.22 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)
 - Network Plugin
   - [cni-plugins](https://github.com/containernetworking/plugins) v1.0.1

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -74,7 +74,7 @@ runc_version: v1.1.1
 kata_containers_version: 2.2.3
 youki_version: 0.0.1
 gvisor_version: 20210921
-containerd_version: 1.6.3
+containerd_version: 1.6.4
 cri_dockerd_version: v0.2.0
 
 # this is relevant when container_manager == 'docker'
@@ -795,6 +795,7 @@ containerd_archive_checksums:
     1.6.1: 0
     1.6.2: 0
     1.6.3: 0
+    1.6.4: 0
   arm64:
     1.5.5: 0
     1.5.7: 0
@@ -806,6 +807,7 @@ containerd_archive_checksums:
     1.6.1: fbeec71f2d37e0e4ceaaac2bdf081295add940a7a5c7a6bcc125e5bbae067791
     1.6.2: a4b24b3c38a67852daa80f03ec2bc94e31a0f4393477cd7dc1c1a7c2d3eb2a95
     1.6.3: 354e30d52ff94bd6cd7ceb8259bdf28419296b46cf5585e9492a87fdefcfe8b2
+    1.6.4: 0205bd1907154388dc85b1afeeb550cbb44c470ef4a290cb1daf91501c85cae6
   amd64:
     1.5.5: 8efc527ffb772a82021800f0151374a3113ed2439922497ff08f2596a70f10f1
     1.5.7: 109fc95b86382065ea668005c376360ddcd8c4ec413e7abe220ae9f461e0e173
@@ -817,6 +819,7 @@ containerd_archive_checksums:
     1.6.1: c1df0a12af2be019ca2d6c157f94e8ce7430484ab29948c9805882df40ec458b
     1.6.2: 3d94f887de5f284b0d6ee61fa17ba413a7d60b4bb27d756a402b713a53685c6a
     1.6.3: 306b3c77f0b5e28ed10d527edf3d73f56bf0a1fb296075af4483d8516b6975ed
+    1.6.4: f23c8ac914d748f85df94d3e82d11ca89ca9fe19a220ce61b99a05b070044de0
   ppc64le:
     1.5.5: 0
     1.5.7: 0
@@ -828,6 +831,7 @@ containerd_archive_checksums:
     1.6.1: 0
     1.6.2: 0
     1.6.3: 0
+    1.6.4: 0
 
 etcd_binary_checksum: "{{ etcd_binary_checksums[image_arch][etcd_version] }}"
 cni_binary_checksum: "{{ cni_binary_checksums[image_arch][cni_version] }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
According to the kubernetes 1.24.0 release blog (https://kubernetes.io/blog/2022/05/03/kubernetes-1-24-release-announcement/) containerd 1.6.4 is needed for this new version of kubernetes. The blog mentions some workarounds for earlier versions of containerd but it does not make sense to hold back on a new release.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[containerd] add 1.6.4 which is needed for kubernetes 1.24.0 and make it the default
```
