### PR TITLE
[CI] tune VM resources to prevent qemu-kvm being oom'ed

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -133,15 +133,15 @@ packet_debian11-docker:
   extends: .packet_pr
   when: on_success
 
-packet_centos7-calico-ha-once-localhost:
-  stage: deploy-part2
+packet_almalinux8-calico-ha-once-localhost:
+  stage: unit-tests
   extends: .packet_pr
   when: on_success
   variables:
     # This will instruct Docker not to start over TLS.
     DOCKER_TLS_CERTDIR: ""
   services:
-    - docker:19.03.9-dind
+    - docker:20.10.15-dind
 
 packet_almalinux8-kube-ovn:
   stage: deploy-part2

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -44,7 +44,7 @@ ubuntu20 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 |---| --- | --- | --- | --- | --- | --- | --- | --- |
 almalinux8 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 amazon |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
-centos7 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: |
+centos7 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: |
 debian10 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian11 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian9 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |

--- a/tests/cloud_playbooks/roles/packet-ci/templates/vm.yml.j2
+++ b/tests/cloud_playbooks/roles/packet-ci/templates/vm.yml.j2
@@ -7,7 +7,7 @@ metadata:
   labels:
     kubevirt.io/os: {{ cloud_image }}
 spec:
-  runStrategy: Always
+  running: true
   template:
     metadata:
       labels:

--- a/tests/cloud_playbooks/roles/packet-ci/templates/vm.yml.j2
+++ b/tests/cloud_playbooks/roles/packet-ci/templates/vm.yml.j2
@@ -7,7 +7,7 @@ metadata:
   labels:
     kubevirt.io/os: {{ cloud_image }}
 spec:
-  running: true
+  runStrategy: Always
   template:
     metadata:
       labels:
@@ -32,13 +32,12 @@ spec:
             cores: {{ vm_cpu_cores }}
             sockets: {{ vm_cpu_sockets }}
             threads: {{ vm_cpu_threads }}
+        memory:
+          guest: {{ vm_memory }}
         resources:
           requests:
             memory: {{ vm_memory * memory_allocation_ratio }}
             cpu: {{ vm_cpu_cores * cpu_allocation_ratio }}
-          limits:
-            memory: {{ vm_memory }}
-            cpu: {{ vm_cpu_cores }}
       networks:
       - name: default
         pod: {}

--- a/tests/files/packet_almalinux8-calico-ha-once-localhost.yml
+++ b/tests/files/packet_almalinux8-calico-ha-once-localhost.yml
@@ -1,6 +1,6 @@
 ---
 # Instance settings
-cloud_image: centos-7
+cloud_image: almalinux-8
 mode: ha
 
 # Kubespray settings


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:
This PR attempts to tune the CI vm resources used by the VMs to prevent the CI jobs failing due to OOM'ed qemu-kvm processes.

**Which issue(s) this PR fixes**:

On the worker node it looks like qemu-kvm processes are oom'ed leading kubevirt to replace the VMs and the CI jobs to fail.

```
May 05 00:02:21 ci-k8s-node-1 kernel: worker invoked oom-killer: gfp_mask=0x101cca(GFP_HIGHUSER_MOVABLE|__GFP_WRITE), order=0, oom_score_adj=965
May 05 00:02:21 ci-k8s-node-1 kernel: CPU: 11 PID: 758598 Comm: worker Tainted: P           O      5.13.0-40-generic #45~20.04.1-Ubuntu
May 05 00:02:21 ci-k8s-node-1 kernel: Hardware name: Dell Inc. PowerEdge R6515/04F3CJ, BIOS 2.2.4 04/12/2021
May 05 00:02:21 ci-k8s-node-1 kernel: Call Trace:
May 05 00:02:21 ci-k8s-node-1 kernel:  <TASK>
May 05 00:02:21 ci-k8s-node-1 kernel:  dump_stack+0x7d/0x9c
May 05 00:02:21 ci-k8s-node-1 kernel:  dump_header+0x4f/0x1f6
May 05 00:02:21 ci-k8s-node-1 kernel:  oom_kill_process.cold+0xb/0x10
May 05 00:02:21 ci-k8s-node-1 kernel:  out_of_memory+0x1cf/0x520
May 05 00:02:21 ci-k8s-node-1 kernel:  mem_cgroup_out_of_memory+0xe4/0x100
May 05 00:02:21 ci-k8s-node-1 kernel:  try_charge+0x708/0x760
May 05 00:02:21 ci-k8s-node-1 kernel:  __mem_cgroup_charge+0x3e/0xb0
May 05 00:02:21 ci-k8s-node-1 kernel:  mem_cgroup_charge+0x32/0x90
May 05 00:02:21 ci-k8s-node-1 kernel:  __add_to_page_cache_locked+0x30b/0x360
May 05 00:02:21 ci-k8s-node-1 kernel:  ? scan_shadow_nodes+0x30/0x30
May 05 00:02:21 ci-k8s-node-1 kernel:  add_to_page_cache_lru+0x4d/0xd0
May 05 00:02:21 ci-k8s-node-1 kernel:  pagecache_get_page+0x257/0x4d0
May 05 00:02:21 ci-k8s-node-1 kernel:  grab_cache_page_write_begin+0x21/0x40
May 05 00:02:21 ci-k8s-node-1 kernel:  ext4_da_write_begin+0x111/0x460
May 05 00:02:21 ci-k8s-node-1 kernel:  generic_perform_write+0xc2/0x1c0
May 05 00:02:21 ci-k8s-node-1 kernel:  ext4_buffered_write_iter+0x98/0x150
May 05 00:02:21 ci-k8s-node-1 kernel:  ext4_file_write_iter+0x53/0x220
May 05 00:02:21 ci-k8s-node-1 kernel:  ? common_file_perm+0x72/0x170
May 05 00:02:21 ci-k8s-node-1 kernel:  do_iter_readv_writev+0x152/0x1b0
May 05 00:02:21 ci-k8s-node-1 kernel:  do_iter_write+0x88/0x1c0
May 05 00:02:21 ci-k8s-node-1 kernel:  vfs_writev+0x83/0x140
May 05 00:02:21 ci-k8s-node-1 kernel:  ? __x64_sys_futex+0x7b/0x1b0
May 05 00:02:21 ci-k8s-node-1 kernel:  ? __fget_light+0xce/0xf0
May 05 00:02:21 ci-k8s-node-1 kernel:  do_pwritev+0x93/0xd0
May 05 00:02:21 ci-k8s-node-1 kernel:  __x64_sys_pwritev+0x21/0x30
May 05 00:02:21 ci-k8s-node-1 kernel:  do_syscall_64+0x61/0xb0
May 05 00:02:21 ci-k8s-node-1 kernel:  ? do_syscall_64+0x6e/0xb0
May 05 00:02:21 ci-k8s-node-1 kernel:  ? do_syscall_64+0x6e/0xb0
May 05 00:02:21 ci-k8s-node-1 kernel:  ? do_syscall_64+0x6e/0xb0
May 05 00:02:21 ci-k8s-node-1 kernel:  ? syscall_exit_to_user_mode+0x27/0x50
May 05 00:02:21 ci-k8s-node-1 kernel:  entry_SYSCALL_64_after_hwframe+0x44/0xae
May 05 00:02:21 ci-k8s-node-1 kernel: RIP: 0033:0x7fdf5d1418b2
May 05 00:02:21 ci-k8s-node-1 kernel: Code: 89 d4 55 48 89 f5 53 89 fb 48 83 ec 18 e8 36 d8 ef ff 45 31 c0 4d 89 ea 44 89 e2 41 89 c1 48 89 ee 89 df b8 28 01 00 00 0f 05 <48> 3d 00 f0 ff ff 77 3a 44 89 cf 4>
May 05 00:02:21 ci-k8s-node-1 kernel: RSP: 002b:00007fddf77fd650 EFLAGS: 00000246 ORIG_RAX: 0000000000000128
May 05 00:02:21 ci-k8s-node-1 kernel: RAX: ffffffffffffffda RBX: 000000000000000f RCX: 00007fdf5d1418b2
May 05 00:02:21 ci-k8s-node-1 kernel: RDX: 000000000000012e RSI: 000055dda44db4c0 RDI: 000000000000000f
May 05 00:02:21 ci-k8s-node-1 kernel: RBP: 000055dda44db4c0 R08: 0000000000000000 R09: 0000000000000000
May 05 00:02:21 ci-k8s-node-1 kernel: R10: 00000000ba2f0000 R11: 0000000000000246 R12: 000000000000012e
May 05 00:02:21 ci-k8s-node-1 kernel: R13: 00000000ba2f0000 R14: 000055dda49891d0 R15: 00007fddf77fd800
May 05 00:02:21 ci-k8s-node-1 kernel:  </TASK>
May 05 00:02:21 ci-k8s-node-1 kernel: memory: usage 2299904kB, limit 2299904kB, failcnt 172195
May 05 00:02:21 ci-k8s-node-1 kernel: memory+swap: usage 2299904kB, limit 9007199254740988kB, failcnt 0
May 05 00:02:21 ci-k8s-node-1 kernel: kmem: usage 35600kB, limit 9007199254740988kB, failcnt 0
May 05 00:02:21 ci-k8s-node-1 kernel: Memory cgroup stats for /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podd9d8c55e_2a2e_4a0a_86ee_d6c66dd3ad05.slice/cri-containerd-7cb82238ccb573763892aeb>
May 05 00:02:21 ci-k8s-node-1 kernel: anon 2228797440
                                      file 89849856
                                      kernel_stack 2703360
                                      pagetables 8167424
                                      percpu 1728
                                      sock 0
                                      shmem 0
                                      file_mapped 36864
                                      file_dirty 89849856
                                      file_writeback 0
                                      swapcached 0
                                      anon_thp 2134900736
                                      file_thp 0
                                      shmem_thp 0
                                      inactive_anon 2142564352
                                      active_anon 86233088
                                      inactive_file 45187072
                                      active_file 44535808
                                      unevictable 0
                                      slab_reclaimable 11582560
                                      slab_unreclaimable 12993664
                                      slab 24576224
                                      workingset_refault_anon 0
                                      workingset_refault_file 55723
                                      workingset_activate_anon 0
                                      workingset_activate_file 1272
                                      workingset_restore_anon 0
                                      workingset_restore_file 0
                                      workingset_nodereclaim 0
                                      pgfault 64162
                                      pgmajfault 104
                                      pgrefill 659519
                                      pgscan 1611778
                                      pgsteal 993648
                                      pgactivate 718188
                                      pgdeactivate 659385
                                      pglazyfree 0
                                      pglazyfreed 0
                                      thp_fault_alloc 1027
                                      thp_collapse_alloc 0
May 05 00:02:21 ci-k8s-node-1 kernel: Tasks state (memory values in pages):
May 05 00:02:21 ci-k8s-node-1 kernel: [  pid  ]   uid  tgid total_vm      rss pgtables_bytes swapents oom_score_adj name
May 05 00:02:21 ci-k8s-node-1 kernel: [ 721493]     0 721493   702750    11695   712704        0           965 virt-launcher
May 05 00:02:21 ci-k8s-node-1 kernel: [ 721648]     0 721648  1035411    14938   909312        0           965 virt-launcher
May 05 00:02:21 ci-k8s-node-1 kernel: [ 721820]     0 721820   368403     5161   487424        0           965 libvirtd
May 05 00:02:21 ci-k8s-node-1 kernel: [ 721831]     0 721831    34457     3239   299008        0           965 virtlogd
May 05 00:02:21 ci-k8s-node-1 kernel: [ 722557]   107 722557  1953560   536918  5828608        0           965 qemu-kvm
May 05 00:02:21 ci-k8s-node-1 kernel: oom-kill:constraint=CONSTRAINT_MEMCG,nodemask=(null),cpuset=cri-containerd-7cb82238ccb573763892aebcf104cf890e5d653d726ca2a322bd4bb184b34adf.scope,mems_allowed=0,oom_mem>
May 05 00:02:21 ci-k8s-node-1 kernel: Memory cgroup out of memory: Killed process 722557 (qemu-kvm) total-vm:7814240kB, anon-rss:2130528kB, file-rss:17144kB, shmem-rss:0kB, UID:107 pgtables:5692kB oom_score>
May 05 00:02:21 ci-k8s-node-1 kernel: oom_reaper: reaped process 722557 (qemu-kvm), now anon-rss:0kB, file-rss:36kB, shmem-rss:0kB
May 05 00:02:22 ci-k8s-node-1 kernel: k6t-eth0: port 2(tap0) entered disabled state
```

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
