### PR TITLE
arm64 support of cilium

### DIFF
--- a/docs/arch.md
+++ b/docs/arch.md
@@ -12,6 +12,6 @@ The following table shows the impact of the CPU architecture on compatible featu
 | Weave               | Y     | Y     | Y             |
 | Flannel             | Y     | N     | N             |
 | Canal               | Y     | N     | N             |
-| Cilium              | Y     | N     | N             |
+| Cilium              | Y     | Y     | N             |
 | Contib              | Y     | N     | N             |
 | kube-router         | Y     | N     | N             |


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

update the documentation
when I read the markdown , it confuse me
when come to  v1.10 , cilium  is ok to support arm64  
https://cilium.io/blog/2021/05/20/cilium-110

**Which issue(s) this PR fixes**:

none


**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:

```release-note
NONE
```



