### PR TITLE
Fix condition on kata_containers_version/kube_version check when kata_containers_enabled is false

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -248,7 +248,7 @@
           You can set `etcd_deployment_type` to `kubeadm` instead of setting `etcd_kubeadm_enabled` to `true`."
       changed_when: true
 
-    - name: Stop if `etcd_kubeadm_enabled` is defined and `etcd_deployment_type` is not `kubadm` or `host`
+    - name: Stop if `etcd_kubeadm_enabled` is defined and `etcd_deployment_type` is not `kubeadm` or `host`
       assert:
         that: etcd_deployment_type == 'kubeadm'
         msg: >
@@ -274,7 +274,9 @@
   assert:
     that: kube_version is version('v1.22.0', '>')
     msg: "Kata containers version 2.3.0 is compatible with Kubernetes 1.22.0+"
-  when: kata_containers_version is version ('2.3.0', '>=')
+  when:
+    - kata_containers_enabled
+    - kata_containers_version is version ('2.3.0', '>=')
 
 - name: Stop if gvisor_enabled is enabled when container_manager is not containerd
   assert:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The check on the compatibility between `kata_containers_version` and `kube_version` was performed even if  kata containers weren't enabled.
This PR adds a condition to the check task on `kata_containers_enabled`.

On the way, a small typo has been fixed.

**Which issue(s) this PR fixes**:
None that I know of

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
No
