### PR TITLE
local volume provisioner should not run on control plane nodes by def…

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s_cluster/addons.yml
@@ -52,6 +52,9 @@ local_volume_provisioner_enabled: false
 #       - "2"
 #     volume_mode: Filesystem
 #     fs_type: ext4
+# local_volume_provisioner_tolerations:
+#   - effect: NoSchedule
+#     operator: Exists
 
 # CSI Volume Snapshot Controller deployment, set this to true if your CSI is able to manage snapshots
 # currently, setting cinder_csi_enabled=true would automatically enable the snapshot controller

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/defaults/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/defaults/main.yml
@@ -5,6 +5,7 @@ local_volume_provisioner_nodelabels: []
 #   - kubernetes.io/hostname
 #   - topology.kubernetes.io/region
 #   - topology.kubernetes.io/zone
+local_volume_provisioner_tolerations: []
 # Levarages Ansibles string to Python datatype casting. Otherwise the dict_key isn't substituted
 # see https://github.com/ansible/ansible/issues/17324
 local_volume_provisioner_use_node_name_only: false

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-ds.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-ds.yml.j2
@@ -20,9 +20,10 @@ spec:
     spec:
       priorityClassName: {% if local_volume_provisioner_namespace == 'kube-system' %}system-node-critical{% else %}k8s-cluster-critical{% endif %}{{''}}
       serviceAccountName: local-volume-provisioner
+{% if local_volume_provisioner_tolerations %}
       tolerations:
-        - effect: NoSchedule
-          operator: Exists
+        {{ local_volume_provisioner_tolerations | to_nice_yaml(indent=2) | indent(width=8) }}
+{% endif %}
       containers:
         - name: provisioner
           image: {{ local_volume_provisioner_image_repo }}:{{ local_volume_provisioner_image_tag }}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

it is very uncommon to run local volumes on control plane nodes.
But we should allow to configure tolerations for special cases.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
local volume provisioner tolerations removed by default.
```
