### PR TITLE
Move woopstar to emeritus approver

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,7 +4,6 @@ aliases:
     - chadswen
     - mirwan
     - miouge1
-    - woopstar
     - luckysb
     - floryut
     - oomichi
@@ -20,3 +19,4 @@ aliases:
     - riverzhang
     - atoms
     - ant31
+    - woopstar


### PR DESCRIPTION
I suggest to move @woopstar to emeritus approver.

He had great contributions in the community, but I don't see [any commit since 2019](https://github.com/kubernetes-sigs/kubespray/commits?author=woopstar). There might be other types of contributions that I am not aware of.

Let's hold a little bit to have time for a discussion.

/hold