### PR TITLE
get wrong server name of coredns

### DIFF
--- a/roles/kubernetes-apps/ansible/tasks/cleanup_dns.yml
+++ b/roles/kubernetes-apps/ansible/tasks/cleanup_dns.yml
@@ -9,7 +9,7 @@
     - inventory_hostname == groups['kube_control_plane'][0]
 
 - name: Kubernetes Apps | Register coredns service annotation `createdby`
-  command: "{{ kubectl }} get svc -n kube-system kube-dns -o jsonpath='{ .metadata.annotations.createdby }'"
+  command: "{{ kubectl }} get svc -n kube-system coredns -o jsonpath='{ .metadata.annotations.createdby }'"
   register: createdby_annotation_svc
   changed_when: false
   ignore_errors: true  # noqa ignore-errors


### PR DESCRIPTION
Signed-off-by: weizhou.lan@daocloud.io <weizhou.lan@daocloud.io>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

when clean up dns , it seems to use wrong service name

```
TASK [kubernetes-apps/ansible : Kubernetes Apps | Register coredns service annotation `createdby`] ************************************************************************************************************
task path: /home/kubespray/roles/kubernetes-apps/ansible/tasks/cleanup_dns.yml:11
fatal: [master1]: FAILED! => {
    "changed": false,
    "cmd": [
        "/usr/local/bin/kubectl",
        "--kubeconfig",
        "/etc/kubernetes/admin.conf",
        "get",
        "svc",
        "-n",
        "kube-system",
        "kube-dns",
        "-o",
        "jsonpath={ .metadata.annotations.createdby }"
    ],
    "delta": "0:00:00.105217",
    "end": "2022-05-11 14:46:12.546543",
    "invocation": {
        "module_args": {
            "_raw_params": "/usr/local/bin/kubectl --kubeconfig /etc/kubernetes/admin.conf get svc -n kube-system kube-dns -o jsonpath='{ .metadata.annotations.createdby }'",
            "_uses_shell": false,
            "argv": null,
            "chdir": null,
            "creates": null,
            "executable": null,
            "removes": null,
            "stdin": null,
            "stdin_add_newline": true,
            "strip_empty_ends": true,
            "warn": false
        }
    },
    "msg": "non-zero return code",
    "rc": 1,
    "start": "2022-05-11 14:46:12.441326",
    "stderr": "Error from server (NotFound): services \"kube-dns\" not found",
    "stderr_lines": [
        "Error from server (NotFound): services \"kube-dns\" not found"
    ],
    "stdout": "",
    "stdout_lines": []
}
```

**Which issue(s) this PR fixes**:

none

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
use correct service name for coredns when cleanup
```
