### PR TITLE
add Feature synchronized time checking

### DIFF
--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -61,3 +61,6 @@ pkg_install_retries: 4
 
 # Check if access_ip responds to ping. Set false if your firewall blocks ICMP.
 ping_access_ip: true
+
+# Check time synchronization. The number is the max allowed time between servers in ms.
+max_allowed_time_sync_diff: 60000

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -314,3 +314,19 @@
   when:
     - kube_external_ca_mode
     - not ignore_assert_errors
+
+- name: Get current state of time synchronization
+  shell: "echo $(($(date +%s%N)/1000000))"
+  args:
+    executable: /bin/bash
+  changed_when: false
+  register: cur_time_ms_string
+
+- name: Stop if time is not synchronized
+  assert:
+    that: ((hostvars[item]['cur_time_ms_string'].stdout|int - cur_time_ms_string.stdout|int) | abs) < max_allowed_time_sync_diff
+    msg: "Do not allow more than {{ max_allowed_time_sync_diff }} ms diff between servers. {{ ((hostvars[item]['cur_time_ms_string'].stdout|int - cur_time_ms_string.stdout|int) | abs) }}ms is different between the two servers."
+  when:
+    - not ignore_assert_errors
+    - inventory_hostname == groups['kube_control_plane'][0]
+  with_items: "{{ play_hosts }}"


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
Verify synchronized time

Kubespray should stop any further actions for a node if it does not have synchronized time. Proceeding most likely creates strange errors with certificates that are not yet valid or similar.

If the time is different between two servers, it will stop the preinstall. It's very useful for etcd and bare-metal environment.

Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes-sigs/kubespray/issues/6767 https://github.com/kubernetes-sigs/kubespray/pull/6489 https://github.com/kubernetes-sigs/kubespray/pull/6787

The Feature Snapshoot:

![企业微信截图_16525382353241](https://user-images.githubusercontent.com/1469319/168429844-7ab9e28f-9a1d-4fe8-bef4-202c3fade5a2.png)

Refer to https://github.com/kubernetes-sigs/kubespray/pull/7851