### PR TITLE
Fix the invalid kube vip manifest

### DIFF
--- a/docs/kata-containers.md
+++ b/docs/kata-containers.md
@@ -8,7 +8,7 @@ _Qemu_ is the only hypervisor supported by Kubespray.
 
 ## Installation
 
-To use Kata Containers, set the following variables:
+To enable Kata Containers, set the following variables:
 
 **k8s-cluster.yml**:
 
@@ -21,6 +21,31 @@ kata_containers_enabled: true
 
 ```yaml
 etcd_deployment_type: host
+```
+
+## Usage
+
+By default, runc is used for pods.
+Kubespray generates the runtimeClass kata-qemu, and it is necessary to specify it as
+the runtimeClassName of a pod spec to use Kata Containers:
+
+```shell
+$ kubectl get runtimeclass
+NAME        HANDLER     AGE
+kata-qemu   kata-qemu   3m34s
+$
+$ cat nginx.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mypod
+spec:
+  runtimeClassName: kata-qemu
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+$
+$ kubectl apply -f nginx.yaml
 ```
 
 ## Configuration

--- a/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
@@ -14,31 +14,31 @@ spec:
       value: {{ kube_vip_arp_enabled | string | to_json }}
     - name: port
       value: "6443"
-    {% if kube_vip_interface %}
+{% if kube_vip_interface %}
     - name: vip_interface
-      value: "{{ kube_vip_interface | string | to_json }}"
-    {% endif %}
-    {% if kube_vip_services_interface %}
+      value: {{ kube_vip_interface | string | to_json }}
+{% endif %}
+{% if kube_vip_services_interface %}
     - name: vip_servicesinterface
       value: {{ kube_vip_services_interface | string | to_json }}
-    {% endif %}
-    {% if kube_vip_cidr %}
+{% endif %}
+{% if kube_vip_cidr %}
     - name: vip_cidr
       value: {{ kube_vip_cidr | string | to_json }}
-    {% endif %}
-    {% if kube_vip_controlplane_enabled %}
+{% endif %}
+{% if kube_vip_controlplane_enabled %}
     - name: cp_enable
       value: "true"
     - name: cp_namespace
       value: kube-system
     - name: vip_ddns
       value: {{ kube_vip_ddns_enabled | string | to_json }}
-    {% endif %}
-    {% if kube_vip_services_enabled %}
+{% endif %}
+{% if kube_vip_services_enabled %}
     - name: svc_enable
       value: "true"
-    {% endif %}
-    {% if kube_vip_leader_election_enabled %}
+{% endif %}
+{% if kube_vip_leader_election_enabled %}
     - name: vip_leaderelection
       value: "true"
     - name: vip_leaseduration
@@ -47,8 +47,8 @@ spec:
       value: "3"
     - name: vip_retryperiod
       value: "1"
-    {% endif %}
-    {% if kube_vip_bgp_enabled %}
+{% endif %}
+{% if kube_vip_bgp_enabled %}
     - name: bgp_enable
       value: "true"
     - name: bgp_routerid
@@ -61,11 +61,11 @@ spec:
       value: {{ kube_vip_bgp_peerpass | to_json }}
     - name: bgp_peeras
       value: {{ kube_vip_bgp_peeras | to_json }}
-    {% if kube_vip_bgppeers %}
+{% if kube_vip_bgppeers %}
     - name: bgp_peers
       value: {{ kube_vip_bgp_peeras | join(',')  | to_json }}
-    {% endif %}
-    {% endif %}
+{% endif %}
+{% endif %}
     - name: address
       value: {{ kube_vip_address | to_json }}
     image: {{ kube_vip_image_repo }}:{{ kube_vip_image_tag }}


### PR DESCRIPTION

**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:

the   kube-vip.yml generated is wrong, and cannot start by kubelet.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes-sigs/kubespray/issues/8829

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

![企业微信截图_16526835027912](https://user-images.githubusercontent.com/1469319/168534420-f2dbb7d7-b0a2-430d-9b00-efd1e169808f.png)

```release-note
Fix an issue the kube-vip manifest with extra space.
```

