### PR TITLE
[calico]use ipamconfig instead of calico ipam command

### DIFF
--- a/roles/kubernetes-apps/csi_driver/upcloud/tasks/main.yml
+++ b/roles/kubernetes-apps/csi_driver/upcloud/tasks/main.yml
@@ -18,6 +18,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 0644
   with_items:
     - {name: upcloud-csi-cred-secret, file: upcloud-csi-cred-secret.yml}
     - {name: upcloud-csi-setup, file: upcloud-csi-setup.yml}

--- a/roles/kubernetes-apps/persistent_volumes/upcloud-csi/tasks/main.yml
+++ b/roles/kubernetes-apps/persistent_volumes/upcloud-csi/tasks/main.yml
@@ -3,6 +3,7 @@
   template:
     src: "upcloud-csi-storage-class.yml.j2"
     dest: "{{ kube_config_dir }}/upcloud-csi-storage-class.yml"
+    mode: 0644
   register: manifests
   when:
     - inventory_hostname == groups['kube_control_plane'][0]

--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -133,8 +133,14 @@ calico_felix_log_severity_screen: Info
 # Calico container settings
 calico_allow_ip_forwarding: false
 
-# Calico IPAM strictaffinity
+# Calico IPAM strictAffinity
 calico_ipam_strictaffinity: false
+
+# Calico IPAM autoAllocateBlocks
+calcio_ipam_autoallocateblocks: true
+
+# Calico IPAM maxBlocksPerHost, default 0
+calico_ipam_maxblocksperhost: 0
 
 # Calico apiserver (only with kdd)
 calico_apiserver_enabled: false

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -491,13 +491,20 @@
     - peer_with_router|default(false)
     - inventory_hostname == groups['kube_control_plane'][0]
 
-- name: Calico | Configure ipam strictaffinity
-  command:
-    cmd: "{{ bin_dir }}/calicoctl.sh ipam configure --strictaffinity={{ calico_ipam_strictaffinity }}"
-  register: output
-  retries: 4
-  until: output.rc == 0
-  delay: "{{ retry_stagger | random + 3 }}"
+- name: Calico | Create Calico ipam manifests
+  template:
+    src: "{{ item.file }}.j2"
+    dest: "{{ kube_config_dir }}/{{ item.file }}"
+    mode: 644
+  with_items:
+    - {name: calico, file: calico-ipamconfig.yml, type: ipam}
   when:
-    - calico_ipam_strictaffinity is defined
+    - inventory_hostname in groups['kube_control_plane']
+
+- name: Calico | Create ipamconfig resources
+  kube:
+    kubectl: "{{ bin_dir }}/kubectl"
+    filename: "{{ kube_config_dir }}/calico-ipamconfig.yml"
+    state: "latest"
+  when:
     - inventory_hostname == groups['kube_control_plane'][0]

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -495,7 +495,7 @@
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
-    mode: 644
+    mode: 0644
   with_items:
     - {name: calico, file: calico-ipamconfig.yml, type: ipam}
   when:

--- a/roles/network_plugin/calico/templates/calico-ipamconfig.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-ipamconfig.yml.j2
@@ -1,0 +1,8 @@
+apiVersion: crd.projectcalico.org/v1
+kind: IPAMConfig
+metadata:
+  name: default
+spec:
+  autoAllocateBlocks: {{ calcio_ipam_autoallocateblocks }}
+  strictAffinity: {{ calico_ipam_strictaffinity }}
+  maxBlocksPerHost: {{ calico_ipam_maxblocksperhost }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
use ipamconfig instead of calico ipam command,
`calicoctl ipam` command has limitations, The MaxBlocksPerHost/AutoAllocateBlocks parameter cannot be configured directly.
```
root@node1:~/liupeng/kubespray# calicoctl.sh ipam show --show-configuration
+--------------------+-------+
|      PROPERTY      | VALUE |
+--------------------+-------+
| StrictAffinity     | false |
| AutoAllocateBlocks | true  |
| MaxBlocksPerHost   |     0 |
+--------------------+-------+
root@node1:~/liupeng/kubespray# calicoctl.sh ipam configure
Usage:
  calicoctl ipam configure --strictaffinity=<true/false> [--config=<CONFIG>] [--allow-version-mismatch]
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
A new resource has been added:

root@node1:~/liupeng/kubespray# kubectl get ipamconfigs.crd.projectcalico.org  default -oyaml
apiVersion: crd.projectcalico.org/v1
kind: IPAMConfig
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"crd.projectcalico.org/v1","kind":"IPAMConfig","metadata":{"annotations":{},"name":"default"},"spec":{"autoAllocateBlocks":true,"maxBlocksPerHost":0,"strictAffinity":false}}
    projectcalico.org/metadata: '{"creationTimestamp":null}'
  creationTimestamp: "2022-05-17T05:04:08Z"
  generation: 3
  name: default
  resourceVersion: "1740453"
  uid: 57331889-f72b-4778-a07c-264e6dabfa33
spec:
  autoAllocateBlocks: true
  maxBlocksPerHost: 0
  strictAffinity: false
```
