### PR TITLE
Skip gathering facts when reset_nodes is false

### DIFF
--- a/remove-node.yml
+++ b/remove-node.yml
@@ -30,6 +30,7 @@
 
 - name: Gather facts
   import_playbook: facts.yml
+  when: reset_nodes|default(True)|bool
 
 - hosts: "{{ node | default('kube_node') }}"
   gather_facts: no


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The doc[1] explains we need to specify
```
  "-e reset_nodes=false -e allow_ungraceful_removal=true"
```
to delete offline node. However the task "Gather facts" tried to gather facts of offline node also and the task was failed.
This adds a condition to skip gathering facts when reset_nodes is false on remove-node.yml.

This change comes from @acainelli's comment, thank you @acainelli!

[1]: https://github.com/kubernetes-sigs/kubespray/blob/master/docs/nodes.md#3-remove-an-old-node-with-remove-nodeyml

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8806

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix remove-node.yaml playbook fails when host is unreachable
```
