### PR TITLE
set apparmor_enabled in netchecker task

### DIFF
--- a/roles/kubernetes-apps/ansible/tasks/netchecker.yml
+++ b/roles/kubernetes-apps/ansible/tasks/netchecker.yml
@@ -1,4 +1,17 @@
 ---
+- name: Kubernetes Apps | Check AppArmor status
+  command: which apparmor_parser
+  register: apparmor_status
+  when:
+    - inventory_hostname == groups['kube_control_plane'][0]
+  failed_when: false
+
+- name: Kubernetes Apps | Set apparmor_enabled
+  set_fact:
+    apparmor_enabled: "{{ apparmor_status.rc == 0 }}"
+  when:
+    - inventory_hostname == groups['kube_control_plane'][0]
+
 - name: Kubernetes Apps | Netchecker Templates list
   set_fact:
     netchecker_templates:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes a bug where the `roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-psp.yml.j2` template would fail because the `apparmor_enabled` variable is not defined.

It seems that the `Set apparmor_enabled` step is already defined twice, in [metalLB ](https://github.com/kubernetes-sigs/kubespray/blob/master/roles/kubernetes-apps/metallb/tasks/main.yml#L29) and [psp-install](https://github.com/kubernetes-sigs/kubespray/blob/master/roles/kubernetes/control-plane/tasks/psp-install.yml#L8) tasks, but those do not necessarily run before the netchecker psp is templated.

This problem was detected when running the `upgrade-cluster.yml` playbook

This PR simply duplicates the 2 tasks needed to define `apparmor_enable` variable.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
