### PR TITLE
[etcd] Add support for setting the request size limit

### DIFF
--- a/inventory/sample/group_vars/etcd.yml
+++ b/inventory/sample/group_vars/etcd.yml
@@ -16,6 +16,11 @@
 # 8G is a suggested maximum size for normal environments and etcd warns at startup if the configured value exceeds it.
 # etcd_quota_backend_bytes: "2147483648"
 
+# Maximum client request size in bytes the server will accept.
+# etcd is designed to handle small key value pairs typical for metadata.
+# Larger requests will work, but may increase the latency of other requests
+# etcd_max_request_bytes: "1572864"
+
 ### ETCD: disable peer client cert authentication.
 # This affects ETCD_PEER_CLIENT_CERT_AUTH variable
 # etcd_peer_client_auth: true

--- a/inventory/sample/group_vars/etcd.yml
+++ b/inventory/sample/group_vars/etcd.yml
@@ -7,11 +7,13 @@
 
 ## Etcd is restricted by default to 512M on systems under 4GB RAM, 512MB is not enough for much more than testing.
 ## Set this if your etcd nodes have less than 4GB but you want more RAM for etcd. Set to 0 for unrestricted RAM.
+## This value is only relevant when deploying etcd with `etcd_deployment_type: docker`
 # etcd_memory_limit: "512M"
 
 ## Etcd has a default of 2G for its space quota. If you put a value in etcd_memory_limit which is less than
 ## etcd_quota_backend_bytes, you may encounter out of memory terminations of the etcd cluster. Please check
 ## etcd documentation for more information.
+# 8G is a suggested maximum size for normal environments and etcd warns at startup if the configured value exceeds it.
 # etcd_quota_backend_bytes: "2147483648"
 
 ### ETCD: disable peer client cert authentication.

--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -46,8 +46,11 @@ etcd_extra_vars: {}
 
 # Limits
 # Limit memory only if <4GB memory on host. 0=unlimited
+# This value is only relevant when deploying etcd with `etcd_deployment_type: docker`
 etcd_memory_limit: "{% if ansible_memtotal_mb < 4096 %}512M{% else %}0{% endif %}"
 
+# The default storage size limit is 2G.
+# 8G is a suggested maximum size for normal environments and etcd warns at startup if the configured value exceeds it.
 # etcd_quota_backend_bytes: "2147483648"
 
 # Uncomment to set CPU share for etcd

--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -53,6 +53,11 @@ etcd_memory_limit: "{% if ansible_memtotal_mb < 4096 %}512M{% else %}0{% endif %
 # 8G is a suggested maximum size for normal environments and etcd warns at startup if the configured value exceeds it.
 # etcd_quota_backend_bytes: "2147483648"
 
+# Maximum client request size in bytes the server will accept.
+# etcd is designed to handle small key value pairs typical for metadata.
+# Larger requests will work, but may increase the latency of other requests
+# etcd_max_request_bytes: "1572864"
+
 # Uncomment to set CPU share for etcd
 # etcd_cpu_limit: 300m
 

--- a/roles/etcd/templates/etcd-events.env.j2
+++ b/roles/etcd/templates/etcd-events.env.j2
@@ -19,6 +19,9 @@ ETCD_SNAPSHOT_COUNT={{ etcd_snapshot_count }}
 {% if etcd_quota_backend_bytes is defined %}
 ETCD_QUOTA_BACKEND_BYTES={{ etcd_quota_backend_bytes }}
 {% endif %}
+{% if etcd_max_request_bytes is defined %}
+ETCD_MAX_REQUEST_BYTES={{ etcd_max_request_bytes }}
+{% endif %}
 
 # TLS settings
 ETCD_TRUSTED_CA_FILE={{ etcd_cert_dir }}/ca.pem

--- a/roles/etcd/templates/etcd.env.j2
+++ b/roles/etcd/templates/etcd.env.j2
@@ -23,6 +23,9 @@ ETCD_SNAPSHOT_COUNT={{ etcd_snapshot_count }}
 {% if etcd_quota_backend_bytes is defined %}
 ETCD_QUOTA_BACKEND_BYTES={{ etcd_quota_backend_bytes }}
 {% endif %}
+{% if etcd_max_request_bytes is defined %}
+ETCD_MAX_REQUEST_BYTES={{ etcd_max_request_bytes }}
+{% endif %}
 {% if etcd_log_package_levels is defined %}
 ETCD_LOG_PACKAGE_LEVELS={{ etcd_log_package_levels }}
 {% endif %}

--- a/roles/kubernetes/control-plane/defaults/main/etcd.yml
+++ b/roles/kubernetes/control-plane/defaults/main/etcd.yml
@@ -23,5 +23,6 @@ etcd_metrics: "basic"
 etcd_extra_vars: {}
 
 # etcd_quota_backend_bytes: "2147483648"
+# etcd_max_request_bytes: "1572864"
 
 etcd_compaction_retention: "8"

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta2.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta2.yaml.j2
@@ -58,6 +58,9 @@ etcd:
 {% if etcd_quota_backend_bytes is defined %}
       quota-backend-bytes: "{{ etcd_quota_backend_bytes }}"
 {% endif %}
+{% if etcd_max_request_bytes is defined %}
+      max-request-bytes: "{{ etcd_max_request_bytes }}"
+{% endif %}
 {% if etcd_log_package_levels is defined %}
       log-package-levels: "{{ etcd_log_package_levels }}"
 {% endif %}
@@ -450,4 +453,3 @@ featureGates:
   {{ feature|replace("=", ": ") }}
 {%   endfor %}
 {% endif %}
-


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
etcd [supports](https://etcd.io/docs/v3.5/dev-guide/limit/) setting the request size limit. We should support it too.

**Which issue(s) this PR fixes**:
Fixes #8848

**Special notes for your reviewer**:
I also added a few comments for the `etcd_memory_limit` and `etcd_quota_backend_bytes` variables and did not want to create a new PR since these variables are related to the subject of this PR.


**Does this PR introduce a user-facing change?**:
```release-note
Add etcd_max_request_bytes option to set the request size limit of etcd
```
