### PR TITLE
cni-plugins: upgrade to 1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [containerd](https://containerd.io/) v1.6.4
   - [cri-o](http://cri-o.io/) v1.22 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)
 - Network Plugin
-  - [cni-plugins](https://github.com/containernetworking/plugins) v1.0.1
+  - [cni-plugins](https://github.com/containernetworking/plugins) v1.1.1
   - [calico](https://github.com/projectcalico/calico) v3.21.4
   - [canal](https://github.com/projectcalico/canal) (given calico/flannel versions)
   - [cilium](https://github.com/cilium/cilium) v1.11.1

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -107,7 +107,7 @@ calico_apiserver_enabled: false
 
 flannel_version: "v0.17.0"
 flannel_cni_version: "v1.0.1"
-cni_version: "v1.0.1"
+cni_version: "v1.1.1"
 weave_version: 2.8.1
 pod_infra_version: "3.3"
 cilium_version: "v1.11.3"
@@ -587,12 +587,16 @@ etcd_binary_checksums:
 cni_binary_checksums:
   arm:
     v1.0.1: d35e3e9fd71687fc7e165f7dc7b1e35654b8012995bbfd937946b0681926d62d
+    v1.1.1: 84f97baf80f9670a8cd0308dedcc8405d2bbc65166d670b48795e0d1262b4248
   arm64:
     v1.0.1: 2d4528c45bdd0a8875f849a75082bc4eafe95cb61f9bcc10a6db38a031f67226
+    v1.1.1: 16484966a46b4692028ba32d16afd994e079dc2cc63fbc2191d7bfaf5e11f3dd
   amd64:
     v1.0.1: 5238fbb2767cbf6aae736ad97a7aa29167525dcd405196dfbc064672a730d3cf
+    v1.1.1: b275772da4026d2161bf8a8b41ed4786754c8a93ebfb6564006d5da7f23831e5
   ppc64le:
     v1.0.1: f078e33067e6daaef3a3a5010d6440f2464b7973dec3ca0b5d5be22fdcb1fd96
+    v1.1.1: 1551259fbfe861d942846bee028d5a85f492393e04bcd6609ac8aaa7a3d71431
 
 calicoctl_binary_checksums:
   arm:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
This PR upgrades cni-plugins to 1.1.1. There are a lot of new changes/improvements. And it has been quite a while since the release was [published](https://github.com/containernetworking/plugins/releases/tag/v1.1.1).

**Which issue(s) this PR fixes**:

Fixes #8851

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
cni-plugins: upgrade to 1.1.1
```
