### PR TITLE
Expose calico-typha metrics port when metrics are enabled

### DIFF
--- a/roles/network_plugin/calico/templates/calico-typha.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-typha.yml.j2
@@ -14,6 +14,12 @@ spec:
       protocol: TCP
       targetPort: calico-typha
       name: calico-typha
+{% if typha_prometheusmetricsenabled %}
+    - port: {{ typha_prometheusmetricsport }}
+      protocol: TCP
+      targetPort: http-metrics
+      name: metrics
+{% endif %}
   selector:
     k8s-app: calico-typha
 
@@ -76,6 +82,11 @@ spec:
         - containerPort: 5473
           name: calico-typha
           protocol: TCP
+{% if typha_prometheusmetricsenabled %}
+        - containerPort: {{ typha_prometheusmetricsport }}
+          name: http-metrics
+          protocol: TCP
+{% endif %}
         envFrom:
         - configMapRef:
             # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
If enabled, calico-typha metrics port is not currently exposed. This PR completes the template to expose those ports when `typha_prometheusmetricsenabled` is `true`.

**Which issue(s) this PR fixes**:
Fixes #8854

**Does this PR introduce a user-facing change?**:
```release-note
[Calico] calico-typha metrics port are now exposed when metrics are enabled
```
