### PR TITLE
fix removing `docker-ce.repo` failed

### DIFF
--- a/roles/container-engine/docker/tasks/reset.yml
+++ b/roles/container-engine/docker/tasks/reset.yml
@@ -78,7 +78,7 @@
   when: ansible_distribution == "Fedora" and not is_ostree
 
 - name: Docker | Remove docker repository on RedHat/CentOS/Oracle/AlmaLinux Linux
-  template:
+  file:
     name: "{{ yum_repo_dir }}/docker-ce.repo"
     state: absent
   when:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fix following error when running `ansible-playbook` (core 2.12.5):
```txt
TASK [container-engine/docker : Docker | Remove docker repository on RedHat/CentOS/Oracle/AlmaLinux Linux] ***
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: NoneType: None
fatal: [node1]: FAILED! => {"changed": false, "msg": "'state' cannot be specified on a template"}
```

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix removing `docker-ce.repo` failed
```
