### PR TITLE
Delete kube_version v1.20- related code

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -943,7 +943,7 @@ haproxy_image_tag: 2.4.9
 # bundle with kubeadm; if not 'basic' upgrade can sometimes fail
 
 coredns_version: "{{ 'v1.8.6' if (kube_version is version('v1.23.0','>=')) else 'v1.8.0' }}"
-coredns_image_is_namespaced: "{{ (kube_version is version('v1.21.0','>=')) or (coredns_version is version('v1.7.1','>=')) }}"
+coredns_image_is_namespaced: "{{ (coredns_version is version('v1.7.1','>=')) }}"
 
 coredns_image_repo: "{{ kube_image_repo }}{{'/coredns/coredns' if (coredns_image_is_namespaced | bool) else '/coredns' }}"
 coredns_image_tag: "{{ coredns_version if (coredns_image_is_namespaced | bool) else (coredns_version | regex_replace('^v', '')) }}"

--- a/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
@@ -109,10 +109,8 @@ tlsCipherSuites:
 {% if kubelet_event_record_qps %}
 eventRecordQPS: {{ kubelet_event_record_qps }}
 {% endif %}
-{% if kube_version is version('v1.21.0', '>=') %}
 shutdownGracePeriod: {{ kubelet_shutdown_grace_period }}
 shutdownGracePeriodCriticalPods: {{ kubelet_shutdown_grace_period_critical_pods }}
-{% endif %}
 {% if not kubelet_fail_swap_on|default(true) %}
 memorySwap:
   swapBehavior: {{ kubelet_swap_behavior|default("LimitedSwap") }}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Current Kubespray supports the Kubernetes version 1.21 or upper with `kube_version_min_required: v1.21.0`

Then kube_version v1.20- related code is not used at all.
This deletes those code for cleanup.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
