### PR TITLE
Assign cgroups from systemd units for kubelet and container engine

### DIFF
--- a/roles/container-engine/containerd/templates/containerd.service.j2
+++ b/roles/container-engine/containerd/templates/containerd.service.j2
@@ -16,6 +16,9 @@
 Description=containerd container runtime
 Documentation=https://containerd.io
 After=network.target local-fs.target
+{% if container_runtime_slice %}
+Slice={{ container_runtime_slice }}
+{% endif %}
 
 [Service]
 ExecStartPre=-/sbin/modprobe overlay

--- a/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
@@ -32,7 +32,6 @@ address: {{ kubelet_bind_address }}
 readOnlyPort: {{ kube_read_only_port }}
 healthzPort: {{ kubelet_healthz_port }}
 healthzBindAddress: {{ kubelet_healthz_bind_address }}
-kubeletCgroups: {{ kubelet_kubelet_cgroups }}
 clusterDomain: {{ dns_domain }}
 {% if kubelet_protect_kernel_defaults|bool %}
 protectKernelDefaults: true

--- a/roles/kubernetes/node/templates/kubelet.env.v1beta1.j2
+++ b/roles/kubernetes/node/templates/kubelet.env.v1beta1.j2
@@ -14,7 +14,6 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {# end kubeadm specific settings #}
 --container-runtime=remote \
 --container-runtime-endpoint={{ cri_socket }} \
---runtime-cgroups={{ kubelet_runtime_cgroups }} \
 {% endset %}
 
 {# Kubelet node taints for gpu #}

--- a/roles/kubernetes/node/templates/kubelet.service.j2
+++ b/roles/kubernetes/node/templates/kubelet.service.j2
@@ -7,6 +7,9 @@ Wants=docker.socket
 {% else %}
 Wants={{ container_manager }}.service
 {% endif %}
+{% if kubelet_slice %}
+Slice={{ kubelet_slice }}
+{% endif %}
 
 [Service]
 EnvironmentFile=-{{ kube_config_dir }}/kubelet.env

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -248,6 +248,11 @@ kube_override_hostname: >-
 # kubelet_config_dir:
 default_kubelet_config_dir: "{{ kube_config_dir }}/dynamic_kubelet_dir"
 
+# Node components cgroup slices to use
+
+kubelet_slice: "kubernetes.slice"
+container_runtime_slice: "{{ kubelet_slice }}"
+
 # Aggregator
 kube_api_aggregator_routing: false
 


### PR DESCRIPTION
- Set kubelet and container cgroups from their systemd services
- Default both container runtime and kubelet to "kubernetes.slice" cgroup

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does **: 

Instead of using the kubelet --runtime-cgroups and the config entry in
kubelet-config.yaml `kubeletCgroups`, use `Slice` in respectively the container
engine unit and the kubelet unit for their systemd services.

**Why we need it**:

- As I understand it, kubeletCgroups make the kubelet set its own cgroup when
starting. On some cases, this appear to confuse `journalctl -u kubelet` which
becomes unable to retrieve the kubelet logs (although they are present, they are
not tagged correctly with the unit).
(I encountered this case on RHEL8, using kubespray 2.15.1 with default
 kube_version)
- `--runtime-cgroups` does not seem to do anything: on my clusters, containerd
runs in `system.slice/containerd.service` even though the --runtime-cgroups
for kubelet is `/systemd/system.slice`. There does not seem to be any adverse
effects either.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to #7340

**Special notes for your reviewer**:

This is a prototype and need refinement, in particular, docs should be written
and other container engine should be edited if necessary.
I'm looking for feedback on the general idea to set cgroups from the systemd
unit instead of using kubelet options / arguments, since I might not be aware of
some subtleties making the current approach necessary

The second commit defaulting to kubernetes.slice is optional but I thing
grouping kubelet and the container engine in the same cgroup slice is a good
thing (see commit message).

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubelet and container runtime will now run in the systemd slice
`kubernetes.slice`, each in their respective service unit.
action required: if you relied on the kubelet or container engine cgroups, you
will need to add approriate `kubelet_slice` and/or `container_runtime_slice` in
your inventory.
```
