### PR TITLE
[kubernetes] make 1.23.7 the new default in sample ansible inventory

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -17,7 +17,7 @@ kube_token_dir: "{{ kube_config_dir }}/tokens"
 kube_api_anonymous_auth: true
 
 ## Change this to use another Kubernetes version, e.g. a current beta release
-kube_version: v1.23.6
+kube_version: v1.23.7
 
 # Where the binaries will be downloaded.
 # Note: ensure that you've enough disk space (about 1G)


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Update Kubernetes version in sample ansible inventory to match the new default.

https://github.com/kubernetes-sigs/kubespray/blob/78aacee21b03f24a535411820d1ecc68892cb89d/roles/kubespray-defaults/defaults/main.yaml#L18

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```