### PR TITLE
[WIP] fix deploy Cilium with eBPF-based Masquerading failed

### DIFF
--- a/roles/network_plugin/cilium/templates/cilium/ds.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/ds.yml.j2
@@ -187,6 +187,9 @@ spec:
           name: cilium-config-path
           readOnly: true
           # Needed to be able to load kernel modules
+        - name: ip-masq-agent
+          mountPath: /etc/config
+          readOnly: true
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
@@ -365,6 +368,13 @@ spec:
       - configMap:
           name: cilium-config
         name: cilium-config-path
+      - name: ip-masq-agent
+        configMap:
+          name: ip-masq-agent
+          optional: true
+          items:
+          - key: config
+            path: ip-masq-agent
 {% if cilium_encryption_enabled and cilium_encryption_type == "ipsec" %}
       - name: cilium-ipsec-secrets
         secret:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Which issue(s) this PR fixes**:
Fixes #8889 .

**Special notes for your reviewer**:

The ConfigMap `ip-masq-agent` is optional, but must be declared in cilium-agent DaemonSet. See <https://docs.cilium.io/en/v1.8/concepts/networking/masquerading/#ebpf-based>.
We could let user defined their own `ip-masq-agent` in future.

**Does this PR introduce a user-facing change?**:
```release-note
fix deploy Cilium with eBPF-based Masquerading failed
```
