### PR TITLE
[feat] Upgrade metrics server to v0.6.1

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -1012,7 +1012,7 @@ dnsautoscaler_image_tag: "{{ dnsautoscaler_version }}"
 
 registry_image_repo: "{{ docker_image_repo }}/library/registry"
 registry_image_tag: "2.7.1"
-metrics_server_version: "v0.5.2"
+metrics_server_version: "v0.6.1"
 metrics_server_image_repo: "{{ kube_image_repo }}/metrics-server/metrics-server"
 metrics_server_image_tag: "{{ metrics_server_version }}"
 local_volume_provisioner_image_repo: "{{ kube_image_repo }}/sig-storage/local-volume-provisioner"

--- a/roles/kubernetes-apps/metrics_server/templates/resource-reader.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/resource-reader.yaml.j2
@@ -10,9 +10,7 @@ rules:
     resources:
       - pods
       - nodes
-      - nodes/stats
-      - namespaces
-      - configmaps
+      - nodes/metrics
     verbs:
       - get
       - list


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Upgrade metrics server to v0.6.1

* Metrics Server now requires access to nodes/metrics RBAC resource instead of nodes/stats. See: https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.6.0
* Also Minimize rbac permissions.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Check https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.6.1
```