### PR TITLE
[registry] Switch registry to use registry.k8s.io

### DIFF
--- a/contrib/offline/manage-offline-container-images.sh
+++ b/contrib/offline/manage-offline-container-images.sh
@@ -15,7 +15,7 @@ function create_container_image_tar() {
 	IMAGES=$(kubectl describe pods --all-namespaces | grep " Image:" | awk '{print $2}' | sort | uniq)
 	# NOTE: etcd and pause cannot be seen as pods.
 	# The pause image is used for --pod-infra-container-image option of kubelet.
-	EXT_IMAGES=$(kubectl cluster-info dump | egrep "quay.io/coreos/etcd:|k8s.gcr.io/pause:" | sed s@\"@@g)
+	EXT_IMAGES=$(kubectl cluster-info dump | egrep "quay.io/coreos/etcd:|registry.k8s.io/pause:" | sed s@\"@@g)
 	IMAGES="${IMAGES} ${EXT_IMAGES}"
 
 	rm -f  ${IMAGE_TAR_FILE}
@@ -46,12 +46,12 @@ function create_container_image_tar() {
 
 		# NOTE: Here removes the following repo parts from each image
 		# so that these parts will be replaced with Kubespray.
-		# - kube_image_repo: "k8s.gcr.io"
+		# - kube_image_repo: "registry.k8s.io"
 		# - gcr_image_repo: "gcr.io"
 		# - docker_image_repo: "docker.io"
 		# - quay_image_repo: "quay.io"
 		FIRST_PART=$(echo ${image} | awk -F"/" '{print $1}')
-		if [ "${FIRST_PART}" = "k8s.gcr.io" ] ||
+		if [ "${FIRST_PART}" = "registry.k8s.io" ] ||
 		   [ "${FIRST_PART}" = "gcr.io" ] ||
 		   [ "${FIRST_PART}" = "docker.io" ] ||
 		   [ "${FIRST_PART}" = "quay.io" ] ||

--- a/inventory/sample/group_vars/all/vsphere.yml
+++ b/inventory/sample/group_vars/all/vsphere.yml
@@ -15,15 +15,15 @@
 # external_vsphere_cloud_controller_image_tag: "latest"
 ## gcr.io/cloud-provider-vsphere/csi/release/syncer
 # vsphere_syncer_image_tag: "v2.4.0"
-## k8s.gcr.io/sig-storage/csi-attacher
+## registry.k8s.io/sig-storage/csi-attacher
 # vsphere_csi_attacher_image_tag: "v3.3.0"
 ## gcr.io/cloud-provider-vsphere/csi/release/driver
 # vsphere_csi_controller: "v2.4.0"
-## k8s.gcr.io/sig-storage/livenessprobe
+## registry.k8s.io/sig-storage/livenessprobe
 # vsphere_csi_liveness_probe_image_tag: "v2.4.0"
-## k8s.gcr.io/sig-storage/csi-provisioner
+## registry.k8s.io/sig-storage/csi-provisioner
 # vsphere_csi_provisioner_image_tag: "v3.0.0"
-## k8s.gcr.io/sig-storage/csi-resizer
+## registry.k8s.io/sig-storage/csi-resizer
 ## makes sense only for vSphere version >=7.0
 # vsphere_csi_resizer_tag: "v1.3.0"
 

--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -294,7 +294,7 @@ persistent_volumes_enabled: false
 # nvidia_driver_install_centos_container: atzedevries/nvidia-centos-driver-installer:2
 # nvidia_driver_install_ubuntu_container: gcr.io/google-containers/ubuntu-nvidia-driver-installer@sha256:7df76a0f0a17294e86f691c81de6bbb7c04a1b4b3d4ea4e7e2cccdc42e1f6d63
 ## NVIDIA GPU device plugin image.
-# nvidia_gpu_device_plugin_container: "k8s.gcr.io/nvidia-gpu-device-plugin@sha256:0842734032018be107fa2490c98156992911e3e1f2a21e059ff0105b07dd8e9e"
+# nvidia_gpu_device_plugin_container: "registry.k8s.io/nvidia-gpu-device-plugin@sha256:0842734032018be107fa2490c98156992911e3e1f2a21e059ff0105b07dd8e9e"
 
 ## Support tls min version, Possible values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
 # tls_min_version: ""

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -82,7 +82,7 @@ docker_containerd_version: 1.4.12
 
 # gcr and kubernetes image repo define
 gcr_image_repo: "gcr.io"
-kube_image_repo: "k8s.gcr.io"
+kube_image_repo: "registry.k8s.io"
 
 # docker image repo define
 docker_image_repo: "docker.io"

--- a/roles/kubernetes-apps/container_engine_accelerator/nvidia_gpu/defaults/main.yml
+++ b/roles/kubernetes-apps/container_engine_accelerator/nvidia_gpu/defaults/main.yml
@@ -7,8 +7,8 @@ nvidia_gpu_flavor: tesla
 nvidia_url_end: "{{ nvidia_driver_version }}/NVIDIA-Linux-x86_64-{{ nvidia_driver_version }}.run"
 nvidia_driver_install_container: false
 nvidia_driver_install_centos_container: atzedevries/nvidia-centos-driver-installer:2
-nvidia_driver_install_ubuntu_container: k8s.gcr.io/ubuntu-nvidia-driver-installer@sha256:7df76a0f0a17294e86f691c81de6bbb7c04a1b4b3d4ea4e7e2cccdc42e1f6d63
+nvidia_driver_install_ubuntu_container: registry.k8s.io/ubuntu-nvidia-driver-installer@sha256:7df76a0f0a17294e86f691c81de6bbb7c04a1b4b3d4ea4e7e2cccdc42e1f6d63
 nvidia_driver_install_supported: false
-nvidia_gpu_device_plugin_container: "k8s.gcr.io/nvidia-gpu-device-plugin@sha256:0842734032018be107fa2490c98156992911e3e1f2a21e059ff0105b07dd8e9e"
+nvidia_gpu_device_plugin_container: "registry.k8s.io/nvidia-gpu-device-plugin@sha256:0842734032018be107fa2490c98156992911e3e1f2a21e059ff0105b07dd8e9e"
 nvidia_gpu_nodes: []
 nvidia_gpu_device_plugin_memory: 30Mi

--- a/roles/kubernetes-apps/csi_driver/upcloud/templates/upcloud-csi-controller.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/upcloud/templates/upcloud-csi-controller.yml.j2
@@ -19,7 +19,7 @@ spec:
       serviceAccount: csi-upcloud-controller-sa
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:{{ upcloud_csi_provisioner_image_tag }}
+          image: registry.k8s.io/sig-storage/csi-provisioner:{{ upcloud_csi_provisioner_image_tag }}
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -32,7 +32,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:{{ upcloud_csi_attacher_image_tag }}
+          image: registry.k8s.io/sig-storage/csi-attacher:{{ upcloud_csi_attacher_image_tag }}
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -45,7 +45,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:{{ upcloud_csi_resizer_image_tag }}
+          image: registry.k8s.io/sig-storage/csi-resizer:{{ upcloud_csi_resizer_image_tag }}
           args:
             - "--v=5"
             - "--timeout=45s"

--- a/roles/kubernetes-apps/csi_driver/upcloud/templates/upcloud-csi-node.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/upcloud/templates/upcloud-csi-node.yml.j2
@@ -18,7 +18,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:{{ upcloud_csi_node_image_tag }}
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:{{ upcloud_csi_node_image_tag }}
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/tests/testcases/030_check-network.yml
+++ b/tests/testcases/030_check-network.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: kube_control_plane[0]
   vars:
-    test_image_repo: k8s.gcr.io/busybox
+    test_image_repo: registry.k8s.io/busybox
     test_image_tag: latest
 
   tasks:


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Switch registry to use registry.k8s.io see: https://groups.google.com/a/kubernetes.io/g/dev/c/DYZYNQ_A6_c

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```