### PR TITLE
[2.19] Fix: set fallback value of kubelet ip6 (#8858) (#8926)

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -3,7 +3,7 @@
 kube_apiserver_insecure_bind_address: 127.0.0.1
 
 # advertised host IP for kubelet. This affects network plugin config. Take caution
-kubelet_address: "{{ ip | default(fallback_ips[inventory_hostname]) }}{{ ',' + ip6 if enable_dual_stack_networks and ip6 is defined }}"
+kubelet_address: "{{ ip | default(fallback_ips[inventory_hostname]) }}{{ (',' + ip6) if enable_dual_stack_networks and ip6 is defined else '' }}"
 
 # bind address for kubelet. Set to 0.0.0.0 to listen on all interfaces
 kubelet_bind_address: "{{ ip | default('0.0.0.0') }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This is a cherry-pick of #8926

**Which issue(s) this PR fixes**:
Fixes #8858 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```
Set fallback value of kubelet ip6
```