### PR TITLE
Add assertion for IPv4 check in verify settings

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -94,8 +94,8 @@
 
 - name: Stop if ip var does not match local ips
   assert:
-    that: ip in ansible_all_ipv4_addresses
-    msg: "'{{ ansible_all_ipv4_addresses }}' do not contain '{{ ip }}'"
+    that: (ip in ansible_all_ipv4_addresses) or (ip in ansible_all_ipv6_addresses)
+    msg: "IPv4: '{{ ansible_all_ipv4_addresses }}' and IPv6: '{{ ansible_all_ipv6_addresses }}' do not contain '{{ ip }}'"
   when:
     - not ignore_assert_errors
     - ip is defined


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Installation on IPv6 only nodes fails, because of an IPv4 assertion. 
Is needed to run kubespray for IPv6 only nodes.

**Special notes for your reviewer**:
All nodes have to IPv6 only.

**Does this PR introduce a user-facing change?**:
```release-note
Add assertion for IPv4 check in verify settings (to allow IPv6 deployments)
```
