### PR TITLE
fix a typo in the "matallb_auto_assign" variable name

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s_cluster/addons.yml
@@ -165,7 +165,7 @@ metallb_speaker_enabled: true
 # metallb_ip_range:
 #   - "10.5.0.50-10.5.0.99"
 # metallb_pool_name: "loadbalanced"
-# matallb_auto_assign: true
+# metallb_auto_assign: true
 # metallb_speaker_nodeselector:
 #   kubernetes.io/os: "linux"
 # metallb_controller_nodeselector:

--- a/roles/kubernetes-apps/metallb/defaults/main.yml
+++ b/roles/kubernetes-apps/metallb/defaults/main.yml
@@ -19,4 +19,4 @@ metallb_speaker_tolerations:
     operator: Exists
 metallb_controller_tolerations: []
 metallb_pool_name: "loadbalanced"
-matallb_auto_assign: true
+metallb_auto_assign: true

--- a/roles/kubernetes-apps/metallb/tasks/main.yml
+++ b/roles/kubernetes-apps/metallb/tasks/main.yml
@@ -18,6 +18,12 @@
     - metallb_protocol == 'bgp' and metallb_speaker_enabled
     - metallb_peers is not defined or not metallb_peers
 
+- name: Kubernetes Apps | Check that the deprecated 'matallb_auto_assign' variable is not used anymore
+  fail:
+    msg: "'matallb_auto_assign' configuration variable is deprecated, please use 'metallb_auto_assign' instead"
+  when:
+    - matallb_auto_assign is defined
+
 - name: Kubernetes Apps | Check AppArmor status
   command: which apparmor_parser
   register: apparmor_status

--- a/roles/kubernetes-apps/metallb/templates/metallb-config.yml.j2
+++ b/roles/kubernetes-apps/metallb/templates/metallb-config.yml.j2
@@ -31,7 +31,7 @@ data:
 {% for ip_range in metallb_ip_range %}
       - {{ ip_range }}
 {% endfor %}
-{% if matallb_auto_assign == false %}
+{% if metallb_auto_assign == false %}
       auto-assign: false
 {% endif %}
 {% if metallb_additional_address_pools is defined %}{% for pool in metallb_additional_address_pools %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind api-change


**What this PR does / why we need it**:
Fixes a typo in the variable setting the auto-assign param of metallb:
`matallb_auto_assign` => ` metallb_auto_assign` 


**Special notes for your reviewer**:

This is a breaking change for existing inventories using the `matallb_auto_assign` variable name. Should kubespray support both names and deprecate the previous one?

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[Metallb] Renamed `matallb_auto_assign` variable to `metallb_auto_assign` (action required: users disabling 'auto-assign' in metallb must update the variable name)
```
