### PR TITLE
Add Ubuntu 22.04 Support in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ vagrant up
 
 - **Flatcar Container Linux by Kinvolk**
 - **Debian** Bullseye, Buster, Jessie, Stretch
-- **Ubuntu** 16.04, 18.04, 20.04
+- **Ubuntu** 16.04, 18.04, 20.04, 22.04
 - **CentOS/RHEL** 7, [8](docs/centos8.md)
 - **Fedora** 34, 35
 - **Fedora CoreOS** (see [fcos Note](docs/fcos.md))


### PR DESCRIPTION
Ubuntu 22.04 is supported in kubespray, for https://github.com/kubernetes-sigs/kubespray/issues/8823.

So the readme should be updated.

**What type of PR is this?**

/kind documentation

**Which issue(s) this PR fixes**:

https://github.com/kubernetes-sigs/kubespray/issues/8823

