### PR TITLE
Fix CI broken by drop spport for ansible 2.9 and 2.10

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -31,23 +31,6 @@ packet_ubuntu20-calico-aio:
   variables:
     RESET_CHECK: "true"
 
-# Exericse ansible variants during the nightly jobs
-packet_ubuntu20-calico-aio-ansible-2_9:
-  stage: deploy-part1
-  extends: .packet_periodic
-  when: on_success
-  variables:
-    ANSIBLE_MAJOR_VERSION: "2.9"
-    RESET_CHECK: "true"
-
-packet_ubuntu20-calico-aio-ansible-2_10:
-  stage: deploy-part1
-  extends: .packet_periodic
-  when: on_success
-  variables:
-    ANSIBLE_MAJOR_VERSION: "2.10"
-    RESET_CHECK: "true"
-
 packet_ubuntu20-calico-aio-ansible-2_11:
   stage: deploy-part1
   extends: .packet_periodic

--- a/tests/files/packet_ubuntu20-calico-aio-ansible-2_10.yml
+++ b/tests/files/packet_ubuntu20-calico-aio-ansible-2_10.yml
@@ -1,1 +1,0 @@
-packet_ubuntu20-calico-aio.yml

--- a/tests/files/packet_ubuntu20-calico-aio-ansible-2_9.yml
+++ b/tests/files/packet_ubuntu20-calico-aio-ansible-2_9.yml
@@ -1,1 +1,0 @@
-packet_ubuntu20-calico-aio.yml


### PR DESCRIPTION
With https://github.com/kubernetes-sigs/kubespray/pull/8925 the ansible 2.9 and 2.10 support has been droped.

But there some test in gitlab. So the CI Broken.

![image](https://user-images.githubusercontent.com/1469319/172983855-cc68a68a-1480-4d45-98b1-926cf0f17649.png)

The PR is to fix it.