### PR TITLE
feat: make kubernetes owner parametrized

### DIFF
--- a/docs/hardening.md
+++ b/docs/hardening.md
@@ -84,6 +84,10 @@ kubelet_rotate_certificates: true
 kubelet_streaming_connection_idle_timeout: "5m"
 kubelet_make_iptables_util_chains: true
 kubelet_feature_gates: ["RotateKubeletServerCertificate=true"]
+
+# additional configurations
+kube_owner: root
+kube_cert_group: root
 ```
 
 Let's take a deep look to the resultant **kubernetes** configuration:

--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -25,6 +25,9 @@ local_release_dir: "/tmp/releases"
 # Random shifts for retrying failed ops like pushing/downloading
 retry_stagger: 5
 
+# This is the user that owns tha cluster installation.
+kube_owner: kube
+
 # This is the group that the cert creation scripts chgrp the
 # cert files to. Not really changeable...
 kube_cert_group: kube-cert

--- a/roles/adduser/defaults/main.yml
+++ b/roles/adduser/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+kube_owner: kube
 kube_cert_group: kube-cert
 etcd_data_dir: "/var/lib/etcd"
 

--- a/roles/adduser/tasks/main.yml
+++ b/roles/adduser/tasks/main.yml
@@ -13,3 +13,4 @@
     shell: "{{ user.shell|default(omit) }}"
     name: "{{ user.name }}"
     system: "{{ user.system|default(omit) }}"
+  when: kube_owner != "root"

--- a/roles/container-engine/cri-dockerd/molecule/default/prepare.yml
+++ b/roles/container-engine/cri-dockerd/molecule/default/prepare.yml
@@ -35,7 +35,7 @@
       file:
         path: /etc/cni/net.d
         state: directory
-        owner: kube
+        owner: "{{ kube_owner }}"
         mode: 0755
     - name: Setup CNI
       copy:

--- a/roles/container-engine/kata-containers/molecule/default/prepare.yml
+++ b/roles/container-engine/kata-containers/molecule/default/prepare.yml
@@ -36,7 +36,7 @@
       file:
         path: /etc/cni/net.d
         state: directory
-        owner: kube
+        owner: "{{ kube_owner }}"
         mode: 0755
     - name: Setup CNI
       copy:

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -1802,5 +1802,5 @@ download_defaults:
   version: None
   url: None
   unarchive: false
-  owner: kube
+  owner: "{{ kube_owner }}"
   mode: None

--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+# Set etcd user
+etcd_owner: etcd
+
 # Set to false to only do certificate management
 etcd_cluster_setup: true
 etcd_events_cluster_setup: false

--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -4,7 +4,7 @@
     path: "{{ etcd_cert_dir }}"
     group: "{{ etcd_cert_group }}"
     state: directory
-    owner: kube
+    owner: "{{ etcd_owner }}"
     mode: "{{ etcd_cert_dir_mode }}"
     recurse: yes
 
@@ -81,7 +81,7 @@
     dest: "{{ item.item }}"
     content: "{{ item.content | b64decode }}"
     group: "{{ etcd_cert_group }}"
-    owner: kube
+    owner: "{{ etcd_owner }}"
     mode: 0640
   with_items: "{{ etcd_master_certs.results }}"
   when:
@@ -111,7 +111,7 @@
     dest: "{{ item.item }}"
     content: "{{ item.content | b64decode }}"
     group: "{{ etcd_cert_group }}"
-    owner: kube
+    owner: "{{ etcd_owner }}"
     mode: 0640
   with_items: "{{ etcd_master_node_certs.results }}"
   when:
@@ -165,6 +165,6 @@
     path: "{{ etcd_cert_dir }}"
     group: "{{ etcd_cert_group }}"
     state: directory
-    owner: kube
+    owner: "{{ etcd_owner }}"
     mode: "{{ etcd_cert_dir_mode }}"
     recurse: yes

--- a/roles/kubernetes/control-plane/defaults/main/etcd.yml
+++ b/roles/kubernetes/control-plane/defaults/main/etcd.yml
@@ -1,4 +1,7 @@
 ---
+# Set etcd user/group
+etcd_owner: etcd
+
 # Note: This does not set up DNS entries. It simply adds the following DNS
 # entries to the certificate
 etcd_cert_alt_names:

--- a/roles/kubernetes/control-plane/tasks/kubeadm-etcd.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-etcd.yml
@@ -16,3 +16,10 @@
   import_role:
     name: etcdctl
   when: etcd_deployment_type == "kubeadm"
+
+- name: Set ownership for etcd data directory
+  file:
+    path: "{{ etcd_data_dir }}"
+    owner: "{{ etcd_owner }}"
+    group: "{{ etcd_owner }}"
+    mode: 0700

--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -22,6 +22,7 @@ common_required_pkgs:
 # GCE docker repository
 disable_ipv6_dns: false
 
+kube_owner: kube
 kube_cert_group: kube-cert
 kube_config_dir: /etc/kubernetes
 kube_cert_dir: "{{ kube_config_dir }}/ssl"

--- a/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
+++ b/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
@@ -3,7 +3,7 @@
   file:
     path: "{{ item }}"
     state: directory
-    owner: kube
+    owner: "{{ kube_owner }}"
     mode: 0755
   when: inventory_hostname in groups['k8s_cluster']
   become: true
@@ -71,7 +71,7 @@
   file:
     path: "{{ item }}"
     state: directory
-    owner: kube
+    owner: "{{ kube_owner }}"
     mode: 0755
   with_items:
     - "/etc/cni/net.d"

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -153,6 +153,9 @@ kube_cert_compat_dir: "/etc/kubernetes/pki"
 # This is where all of the bearer tokens will be stored
 kube_token_dir: "{{ kube_config_dir }}/tokens"
 
+# This is the user that owns tha cluster installation.
+kube_owner: kube
+
 # This is the group that the cert creation scripts chgrp the
 # cert files to. Not really changeable...
 kube_cert_group: kube-cert

--- a/roles/network_plugin/canal/tasks/main.yml
+++ b/roles/network_plugin/canal/tasks/main.yml
@@ -4,7 +4,7 @@
     src: "cni-canal.conflist.j2"
     dest: "/etc/cni/net.d/canal.conflist.template"
     mode: 0644
-    owner: kube
+    owner: "{{ kube_owner }}"
   register: canal_conflist
   notify: reset_canal_cni
 

--- a/roles/network_plugin/cni/tasks/main.yml
+++ b/roles/network_plugin/cni/tasks/main.yml
@@ -4,7 +4,7 @@
     path: /opt/cni/bin
     state: directory
     mode: 0755
-    owner: kube
+    owner: "{{ kube_owner }}"
     recurse: true
 
 - name: CNI | Copy cni plugins

--- a/roles/network_plugin/kube-router/tasks/main.yml
+++ b/roles/network_plugin/kube-router/tasks/main.yml
@@ -7,7 +7,7 @@
   file:
     path: /var/lib/kube-router
     state: directory
-    owner: kube
+    owner: "{{ kube_owner }}"
     recurse: true
     mode: 0755
 
@@ -16,7 +16,7 @@
     src: kubeconfig.yml.j2
     dest: /var/lib/kube-router/kubeconfig
     mode: 0644
-    owner: kube
+    owner: "{{ kube_owner }}"
   notify:
     - reset_kube_router
 
@@ -44,7 +44,7 @@
     src: cni-conf.json.j2
     dest: /etc/cni/net.d/10-kuberouter.conflist
     mode: 0644
-    owner: kube
+    owner: "{{ kube_owner }}"
   notify:
     - reset_kube_router
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

The following PR provide a new variable called `kube_owner`. It allows the user to set the kubernetes installation owner (default: `kube`).
This enable compliance with [CIS 1.1.19](https://www.tenable.com/audits/items/CIS_Kubernetes_v1.20_v1.0.0_Level_1_Master.audit:7c2372fabcc905e8ce10aed4ef02c853), setting the variable `kube_owner: root`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8948

**Special notes for your reviewer**:

This PR follows the job done in the previous months (#8773).

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Make kubernetes owner parametrized (using `kube_owner`/`kube_cert_group`/`etcd_owner` variables)
```
