### PR TITLE
Add arm64 Flatcar OS's pypy bootstrapping support

### DIFF
--- a/roles/bootstrap-os/files/bootstrap.sh
+++ b/roles/bootstrap-os/files/bootstrap.sh
@@ -2,23 +2,39 @@
 set -e
 
 BINDIR="/opt/bin"
-PYPY_VERSION=7.3.2
-PYPI_URL="https://downloads.python.org/pypy/pypy3.6-v${PYPY_VERSION}-linux64.tar.bz2"
-PYPI_HASH=d7a91f179076aaa28115ffc0a81e46c6a787785b2bc995c926fe3b02f0e9ad83
+if [[ -e $BINDIR/.bootstrapped ]]; then
+  exit 0
+fi
+
+ARCH=$(uname -m)
+case $ARCH in
+  "x86_64")
+    PYPY_ARCH=linux64
+    PYPI_HASH=46818cb3d74b96b34787548343d266e2562b531ddbaf330383ba930ff1930ed5
+    ;;
+  "aarch64")
+    PYPY_ARCH=aarch64
+    PYPI_HASH=2e1ae193d98bc51439642a7618d521ea019f45b8fb226940f7e334c548d2b4b9
+    ;;
+  *)
+    echo "Unsupported Architecture: ${ARCH}"
+    exit 1
+esac
+
+PYTHON_VERSION=3.9
+PYPY_VERSION=7.3.9
+PYPY_FILENAME="pypy${PYTHON_VERSION}-v${PYPY_VERSION}-${PYPY_ARCH}"
+PYPI_URL="https://downloads.python.org/pypy/${PYPY_FILENAME}.tar.bz2"
 
 mkdir -p $BINDIR
 
 cd $BINDIR
 
-if [[ -e $BINDIR/.bootstrapped ]]; then
-  exit 0
-fi
-
 TAR_FILE=pyp.tar.bz2
 wget -O "${TAR_FILE}" "${PYPI_URL}"
 echo "${PYPI_HASH} ${TAR_FILE}" | sha256sum -c -
 tar -xjf "${TAR_FILE}" && rm "${TAR_FILE}"
-mv -n "pypy3.6-v${PYPY_VERSION}-linux64" pypy3
+mv -n "${PYPY_FILENAME}" pypy3
 
 ln -s ./pypy3/bin/pypy3 python
 $BINDIR/python --version


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
* Add arm64 Flatcar OS's pypy bootstrapping support
    - Upgrade pypy's python version from `3.6` to `3.9`
    - Upgrade pypys version from `7.3.2` to `7.3.9`
    - Note: the latest update date is `9 Oct 2020`

**Special notes for your reviewer**:
This PR enables the pypy bootstrapping into `Flatcar + arm64` out of the box, just like the `Flatcar + amd64` ones.

**However**, when using arm64 Flatcar, there are some bugs about missing shared libraries such as `ncurses` and `libffi` from **official** arm64 pypy prebuilt binaries. Then I found that upgrading the pypy version to `7.3.9` can resolve it. But the latest official pypy version for python `3.6` is `7.3.3` which cannot help it.

So I think my commit is essential for `Flatcar + arm64` users, but do not guarantee complete reliability for `Flatcar` at this time.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add arm64 Flatcar OS's pypy bootstrapping support (⚠️ ADD NOTE upgrading the bootstrap pypy may cause some unexpected behaviors for `Flatcar` use-cases)
```
