### PR TITLE
Several fixes for docker reset tasks

### DIFF
--- a/roles/container-engine/docker/tasks/reset.yml
+++ b/roles/container-engine/docker/tasks/reset.yml
@@ -40,6 +40,7 @@
     - docker
     - docker.socket
     - containerd
+  when: docker_packages_list|length>0
 
 - name: Docker | Remove dpkg hold
   dpkg_selections:
@@ -98,6 +99,7 @@
     - /etc/systemd/system/containerd.service.d
     - /var/lib/docker
     - /etc/docker
+  ignore_errors: true  # noqa ignore-errors
 
 - name: Docker | systemctl daemon-reload  # noqa 503
   systemd:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Fixes several issues with the docker reset task:

- (**edit**: not a bug, the used ansible version is not supported anymore)  ` docker_packages_list` and `containerd_package` var types (i.e generators) did not work with later `with_item` calls, at least with my version of ansible (2.9.27). Added ` | list` to avoid this.
- ` Stop all running container` task would run even if corresponding packages were already uninstalled, I added a `when` condition
- ` Remove docker configuration files` task fails when some of the listed directories are mounts. I added `ignore_errors` there, since this was already done for [this similar task in the reset role](https://github.com/kubernetes-sigs/kubespray/blob/master/roles/reset/tasks/main.yml#L320)

**Which issue(s) this PR fixes**:
Fixes #8765 with the solution that was suggested in the discussion 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
