### PR TITLE
WIP: Replace packet_debian9-macvlan with debian11

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -205,9 +205,9 @@ packet_almalinux8-calico-ha-ebpf:
   when: manual
 
 packet_debian11-macvlan:
-  stage: deploy-part2
+  stage: unit-tests
   extends: .packet_pr
-  when: manual
+  when: on_success
 
 packet_centos7-calico-ha:
   stage: deploy-part2

--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -204,7 +204,7 @@ packet_almalinux8-calico-ha-ebpf:
   extends: .packet_pr
   when: manual
 
-packet_debian9-macvlan:
+packet_debian11-macvlan:
   stage: deploy-part2
   extends: .packet_pr
   when: manual

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -10,8 +10,7 @@ almalinux8 |  :white_check_mark: | :x: | :x: | :x: | :white_check_mark: | :x: | 
 amazon |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 centos7 |  :white_check_mark: | :white_check_mark: | :x: | :white_check_mark: | :x: | :white_check_mark: | :x: | :white_check_mark: |
 debian10 |  :white_check_mark: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
-debian11 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
-debian9 |  :x: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: |
+debian11 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: |
 fedora35 |  :white_check_mark: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x: |
 fedora36 |  :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x: | :x: |
 opensuse |  :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
@@ -31,7 +30,6 @@ amazon |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 centos7 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian10 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian11 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
-debian9 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 fedora35 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 fedora36 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 opensuse |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
@@ -51,7 +49,6 @@ amazon |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 centos7 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian10 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian11 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
-debian9 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 fedora35 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 fedora36 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: |
 opensuse |  :x: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: |

--- a/roles/network_plugin/macvlan/tasks/main.yml
+++ b/roles/network_plugin/macvlan/tasks/main.yml
@@ -108,3 +108,18 @@
     sysctl_file: "{{ sysctl_file_path }}"
     state: present
     reload: yes
+
+- name: Containerd | restart containerd
+  systemd:
+    name: containerd
+    state: restarted
+    enabled: yes
+    daemon-reload: yes
+    masked: no
+
+- name: Containerd | wait for containerd
+  command: "{{ containerd_bin_dir }}/ctr images ls -q"
+  register: containerd_ready
+  retries: 8
+  delay: 4
+  until: containerd_ready.rc == 0

--- a/tests/files/packet_debian11-macvlan.yml
+++ b/tests/files/packet_debian11-macvlan.yml
@@ -1,9 +1,10 @@
 ---
 # Instance settings
-cloud_image: debian-9
+cloud_image: debian-11
 mode: default
 
 # Kubespray settings
+container_manager: containerd
 kube_network_plugin: macvlan
 enable_nodelocaldns: false
 kube_proxy_masquerade_all: true

--- a/tests/testcases/020_check-pods-running.yml
+++ b/tests/testcases/020_check-pods-running.yml
@@ -44,6 +44,18 @@
     register: get_pods
     no_log: true
 
-  - debug:  # noqa unnamed-task
-      msg: "{{ get_pods.stdout.split('\n') }}"
-    failed_when: not run_pods_log is success
+  - name: Show debugging information when some pods are not ready
+    when: not run_pods_log is success
+    block:
+    - debug:  # noqa unnamed-task
+        msg: "{{ get_pods.stdout.split('\n') }}"
+
+    - name: Get a not-running pod name
+      command: "{{ bin_dir }}/kubectl get pods --all-namespaces --field-selector=status.phase!=Running --output=jsonpath='{.items[0].metadata.namespace} {.items[0].metadata.name}'"
+      register: problematic_pod
+      no_log: true
+      failed_when: false
+
+    - name: Describe the problematic pod
+      command: "{{ bin_dir }}/kubectl describe pod -n {{ problematic_pod.stdout }}"
+      failed_when: true


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

packet_debian9-macvlan is unstable job.
In addition, debian9 is going to EOL soon as [1]
So this replaces packet_debian9-macvlan with debian11 to avoid wasting our time for the job anymore.
    
[1]: https://wiki.debian.org/DebianReleases#Production_Releases

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8916

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Drop debian9 support from Kubespray because of the EOL
```
