### PR TITLE
Apply calico bgp peer definition task to all nodes

### DIFF
--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -569,9 +569,10 @@
   delay: "{{ retry_stagger | random + 3 }}"
   with_items:
     - "{{ peers|selectattr('scope','undefined')|list|default([]) | union(peers|selectattr('scope','defined')|selectattr('scope','equalto', 'node')|list|default([])) }}"
+  delegate_to: "{{ groups['kube_control_plane'][0] }}"
   when:
     - peer_with_router|default(false)
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname in groups['k8s_cluster']
 
 - name: Calico | Create Calico ipam manifests
   template:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This partly reverts PR #8833 , which limited the `Configure peering with router(s) at node scope` task to a single node.
We actually need to keep applying this task to all nodes, since each k8s node should be able to define its own bgp peering configuration.
The fact that `inventory_hostname` is used in the BGPPeer definition seems to suggest that this task was never intended to be limited to a single arbitrary node.

**Which issue(s) this PR fixes**:

Kubespray currently fails to configure calico on a multiple node cluster with router peering, only the peering configuration of the first control plane node is defined.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
