### PR TITLE
[cert-manager] Upgrade to v1.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Note: Upstart/SysV init based OS types are not supported.
 - Application
   - [cephfs-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.0-k8s1.11
   - [rbd-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.1-k8s1.11
-  - [cert-manager](https://github.com/jetstack/cert-manager) v1.8.0
+  - [cert-manager](https://github.com/jetstack/cert-manager) v1.8.1
   - [coredns](https://github.com/coredns/coredns) v1.8.6
   - [ingress-nginx](https://github.com/kubernetes/ingress-nginx) v1.2.1
 

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -1025,7 +1025,7 @@ ingress_nginx_controller_image_repo: "{{ kube_image_repo }}/ingress-nginx/contro
 ingress_nginx_controller_image_tag: "v1.2.1"
 alb_ingress_image_repo: "{{ docker_image_repo }}/amazon/aws-alb-ingress-controller"
 alb_ingress_image_tag: "v1.1.9"
-cert_manager_version: "v1.8.0"
+cert_manager_version: "v1.8.1"
 cert_manager_controller_image_repo: "{{ quay_image_repo }}/jetstack/cert-manager-controller"
 cert_manager_controller_image_tag: "{{ cert_manager_version }}"
 cert_manager_cainjector_image_repo: "{{ quay_image_repo }}/jetstack/cert-manager-cainjector"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Upgrade to [cert-manager v1.8.1](https://github.com/cert-manager/cert-manager/releases/tag/v1.8.1)

**Special notes for your reviewer**:
Diff checked between v1.8.0 and v1.8.1 manifest confirmed only version number changes. https://gist.github.com/rtsp/c673a80853118c4c01482cebce09b340

**Does this PR introduce a user-facing change?**:
```release-note
[cert-manager] Upgrade to v1.8.1
```
