### PR TITLE
Fixed concatenate str & int in auto_renew_certificates_systemd_calendar var

### DIFF
--- a/roles/kubernetes/control-plane/defaults/main/main.yml
+++ b/roles/kubernetes/control-plane/defaults/main/main.yml
@@ -210,7 +210,8 @@ event_ttl_duration: "1h0m0s"
 ## Automatically renew K8S control plane certificates on first Monday of each month
 auto_renew_certificates: false
 # First Monday of each month
-auto_renew_certificates_systemd_calendar: "Mon *-*-1,2,3,4,5,6,7 03:{{ groups['kube_control_plane'].index(inventory_hostname) }}0:00"
+auto_renew_certificates_systemd_calendar: "{{ 'Mon *-*-1,2,3,4,5,6,7 03:' ~
+  groups['kube_control_plane'].index(inventory_hostname) ~ '0:00' }}"
 # kubeadm renews all the certificates during control plane upgrade.
 # If we have requirement like without renewing certs upgrade the cluster,
 # we can opt out from the default behavior by setting kubeadm_upgrade_auto_cert_renewal to false


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix bug with concatenation of string and int

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
This is a port of #8819 not merged due to CLA unable to be signed

**Does this PR introduce a user-facing change?**:
```release-note
Fixed concatenate str & int in `auto_renew_certificates_systemd_calendar`
```
