### PR TITLE
Suggest calico_iptables_backend: "NFT" In Centos8

### DIFF
--- a/docs/centos.md
+++ b/docs/centos.md
@@ -9,7 +9,7 @@ Kubespray supports multiple ansible versions but only the default (5.x) gets wid
 
 CentOS 8 / Oracle Linux 8 / AlmaLinux 8 / Rocky Linux 8 ship only with iptables-nft (ie without iptables-legacy similar to RHEL8)
 The only tested configuration for now is using Calico CNI
-You need to add `calico_iptables_backend: "NFT"` or `calico_iptables_backend: "Auto"` to your configuration.
+You need to add `calico_iptables_backend: "NFT"` to your configuration.
 
 If you have containers that are using iptables in the host network namespace (`hostNetwork=true`),
 you need to ensure they are using iptables-nft.


### PR DESCRIPTION
What type of PR is this?
/kind documentation

What this PR does / why we need it:
The `calico_iptables_backend=Auto` is not stable. The problem is very often in Centos 8 , Oracle Linux 8 and RHEL 8.
So should we suggest user to use `calico_iptables_backend: "NFT"` instead of the "auto" mode, only suggest user to use the `calico_iptables_backend: "NFT"`.

Which issue(s) this PR fixes:
Fixes #

Special notes for your reviewer:
NONE

Does this PR introduce a user-facing change?:
NONE

Reasons:
1. RHEL/Centos 8 ships a hacked version of iptables 1.8 that only supports nft mode from the (https://github.com/kubernetes-sigs/iptables-wrappers"),  
2. We failed on Calico in Centos8 many time. The "auto" mode is not stable after the cluster runned for days.
3. The docs of RHEL in kubespray :  https://github.com/kubernetes-sigs/kubespray/blob/master/docs/rhel.md is NFT mode
4. a blog article about the issue: https://mihail-milev.medium.com/no-pod-to-pod-communication-on-centos-8-kubernetes-with-calico-56d694d2a6f4

Issues Relate to the PR:

* https://github.com/projectcalico/calico/issues/3709
* https://github.com/projectcalico/calico/issues/2322 
* https://github.com/kubernetes-sigs/kubespray/issues/7268

