### PR TITLE
Fix broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,13 +119,13 @@ vagrant up
 - **Flatcar Container Linux by Kinvolk**
 - **Debian** Bullseye, Buster, Jessie, Stretch
 - **Ubuntu** 16.04, 18.04, 20.04, 22.04
-- **CentOS/RHEL** 7, [8](docs/centos8.md)
+- **CentOS/RHEL** 7, [8](docs/centos.md#centos-8)
 - **Fedora** 34, 35
 - **Fedora CoreOS** (see [fcos Note](docs/fcos.md))
 - **openSUSE** Leap 15.x/Tumbleweed
-- **Oracle Linux** 7, [8](docs/centos8.md)
-- **Alma Linux** [8](docs/centos8.md)
-- **Rocky Linux** [8](docs/centos8.md)
+- **Oracle Linux** 7, [8](docs/centos.md#centos-8)
+- **Alma Linux** [8](docs/centos.md#centos-8)
+- **Rocky Linux** [8](docs/centos.md#centos-8)
 - **Amazon Linux 2** (experimental: see [amazon linux notes](docs/amazonlinux.md))
 
 Note: Upstart/SysV init based OS types are not supported.


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
From the https://github.com/kubernetes-sigs/kubespray/pull/8827, the centos.md has been renamed. So the link in readme is broken.
The PR is to fix the broken link in readme

Which issue(s) this PR fixes:
None

Special notes for your reviewer:
None


