### PR TITLE
DNM: Output all details of pods when failing

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -270,7 +270,7 @@ packet_ubuntu20-calico-ha-wireguard:
   when: manual
 
 packet_debian10-calico-upgrade:
-  stage: deploy-part3
+  stage: unit-tests
   extends: .packet_pr
   when: on_success
   variables:

--- a/tests/testcases/020_check-pods-running.yml
+++ b/tests/testcases/020_check-pods-running.yml
@@ -39,7 +39,7 @@
     no_log: true
 
   - name: Check kubectl output
-    command: "{{ bin_dir }}/kubectl get pods --all-namespaces -owide"
+    command: "{{ bin_dir }}/kubectl describe pods --all-namespaces"
     changed_when: false
     register: get_pods
     no_log: true


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

This is only for debugging upgrading job failures.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
