### PR TITLE
[2.17] Add missing configuration for extra tolerations

### DIFF
--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -22,6 +22,7 @@ nodelocaldns_ds_nodeselector: "kubernetes.io/os: linux"
 dns_autoscaler_cpu_requests: 20m
 dns_autoscaler_memory_requests: 10Mi
 dns_autoscaler_deployment_nodeselector: "kubernetes.io/os: linux"
+# dns_autoscaler_extra_tolerations: [{effect: NoSchedule, operator: "Exists"}]
 
 # Netchecker
 deploy_netchecker: false

--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -68,3 +68,6 @@ dashboard_master_toleration: true
 # Override dashboard default settings
 dashboard_token_ttl: 900
 dashboard_skip_login: false
+
+# Policy Controllers
+# policy_controller_extra_tolerations: [{effect: NoSchedule, operator: "Exists"}]

--- a/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
@@ -34,7 +34,7 @@ spec:
           effect: NoSchedule
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-{% if dns_extra_tolerations | default(None) %}
+{% if dns_extra_tolerations is defined %}
         {{ dns_extra_tolerations | list | to_nice_yaml(indent=2) | indent(8) }}
 {% endif %}
       affinity:

--- a/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
@@ -45,6 +45,9 @@ spec:
           key: node-role.kubernetes.io/master
         - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane
+{% if dns_autoscaler_extra_tolerations is defined %}
+        {{ dns_autoscaler_extra_tolerations | list | to_nice_yaml(indent=2) | indent(8) }}
+{% endif %}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-controllers.yml.j2
+++ b/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-controllers.yml.j2
@@ -28,6 +28,9 @@ spec:
           effect: NoSchedule
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+{% if policy_controller_extra_tolerations is defined %}
+        {{ policy_controller_extra_tolerations | list | to_nice_yaml(indent=2) | indent(8) }}
+{% endif %}
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Similarly to what is currently done for CoreDNS deployment, this PR adds configuration items to add extra tolerations for calico kube controllers and DNS autoscaler.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Backporting #8908 to 2.17

**Does this PR introduce a user-facing change?**:
```release-note
Add missing configuration for extra tolerations
```