### PR TITLE
Add CI Test for kubeadm etcd deployment

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -284,6 +284,11 @@ packet_almalinux8-calico-remove-node:
     REMOVE_NODE_CHECK: "true"
     REMOVE_NODE_NAME: "instance-3"
 
+packet_ubuntu20-calico-etcd-kubeadm:
+  stage: deploy-part3
+  extends: .packet_pr
+  when: on_success
+
 packet_debian11-calico-upgrade-once:
   stage: deploy-part3
   extends: .packet_periodic

--- a/tests/files/packet_ubuntu20-calico-etcd-kubeadm.yml
+++ b/tests/files/packet_ubuntu20-calico-etcd-kubeadm.yml
@@ -1,18 +1,11 @@
 ---
 # Instance settings
 cloud_image: ubuntu-2004
-mode: ha
+mode: default
 
 # use the kubeadm etcd setting to test the upgrade
 etcd_deployment_type: kubeadm
 
-upgrade_cluster_setup: true
-
 # Currently ipvs not available on KVM: https://packages.ubuntu.com/search?suite=focal&arch=amd64&mode=exactfilename&searchon=contents&keywords=ip_vs_sh.ko
 kube_proxy_mode: iptables
 enable_nodelocaldns: False
-
-# Pin disabling ipip mode to ensure proper upgrade
-ipip: false
-calico_vxlan_mode: Always
-calico_network_backend: bird


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

There lack of CI "etcd_deployment_type: kubeadm".

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/kubespray/issues/9006

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:

```release-note
```

