### PR TITLE
Change Default kube_proxy_mode to Iptables

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -122,7 +122,7 @@ kube_apiserver_port: 6443  # (https)
 
 # Kube-proxy proxyMode configuration.
 # Can be ipvs, iptables
-kube_proxy_mode: ipvs
+kube_proxy_mode: iptables
 
 # configure arp_ignore and arp_announce to avoid answering ARP queries from kube-ipvs0 interface
 # must be set to true for MetalLB to work

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -21,7 +21,7 @@ kube_version: v1.24.2
 kube_version_min_required: v1.22.0
 
 ## Kube Proxy mode One of ['iptables','ipvs']
-kube_proxy_mode: ipvs
+kube_proxy_mode: iptables
 
 ## List of kubeadm init phases that should be skipped during control plane setup
 ## By default 'addon/coredns' is skipped


### PR DESCRIPTION
In most kubernetes distributions, the kube_proxy_mode is iptables. So iptables is more common for the default production case.

1. Kubernetes Default Config

https://kubernetes.io/docs/reference/config-api/kube-proxy-config.v1alpha1/#kubeproxy-config-k8s-io-v1alpha1-ProxyMode

1. KubeAdm
https://github.com/kubernetes/kubernetes/blob/master/pkg/proxy/apis/config/types.go#L199

3. OpenShift
https://docs.openshift.com/container-platform/4.10/networking/openshift_sdn/configuring-kube-proxy.html

5. AWS EKS
https://github.com/aws/eks-distro/blob/main/docs/contents/users/install/kubeadm.md


And there are some relate issue about the kube-proxy ipvs mod, so I think the iptables mod is more suitable for KubeSpray.

* https://github.com/kubernetes/kubernetes/issues/81775
* https://github.com/kubernetes/kubernetes/issues/70747
* https://github.com/kubernetes/kubernetes/commit/f39060c6047b8dce5af197a97d5f18422d93c9d1
* https://github.com/torvalds/linux/commit/d752c364571743d696c2a54a449ce77550c35ac5

Another way is to leave the "proxy mode blank", so the kubeadm would choose the default ome(currently is iptables).
And by the way if user want to switch Iptables to IPVS, the kube-proxy should cleanup the rule before.


Thanks for review.
