### PR TITLE
Fix the issue of the miss the etcd user when etcd_deployment_type: kubeadm

### DIFF
--- a/roles/kubernetes/control-plane/meta/main.yml
+++ b/roles/kubernetes/control-plane/meta/main.yml
@@ -4,3 +4,8 @@ dependencies:
     when: kube_token_auth
     tags:
       - k8s-secrets
+  - role: adduser
+    user: "{{ addusers.etcd }}"
+    when:
+      - etcd_deployment_type == "kubeadm"
+      - not (ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk", "ClearLinux"] or is_fedora_coreos)

--- a/roles/kubernetes/control-plane/tasks/kubeadm-etcd.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-etcd.yml
@@ -23,3 +23,4 @@
     owner: "{{ etcd_owner }}"
     group: "{{ etcd_owner }}"
     mode: 0700
+  when: etcd_deployment_type == "kubeadm"


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:

Fix the issue of the miss the etcd user when etcd_deployment_type: kubeadm.

**Which issue(s) this PR fixes**:
Fixes #9006

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:

```release-note
fix the bug of failed to look up user etcd when add user 
```

PS: the bug is imported by the PR https://github.com/kubernetes-sigs/kubespray/pull/8952, only effect the main branch. It may do not need release-note.

