### PR TITLE
Add the option to enable default Pod Security Configuration

### DIFF
--- a/docs/hardening.md
+++ b/docs/hardening.md
@@ -89,6 +89,11 @@ kubelet_seccomp_default: true
 # additional configurations
 kube_owner: root
 kube_cert_group: root
+
+# create a default Pod Security Configuration and deny running of insecure pods
+# kube_system namespace is exempted by default
+kube_pod_security_use_default: true
+kube_pod_security_default_enforce: restricted
 ```
 
 Let's take a deep look to the resultant **kubernetes** configuration:

--- a/roles/kubernetes/control-plane/defaults/main/main.yml
+++ b/roles/kubernetes/control-plane/defaults/main/main.yml
@@ -104,6 +104,19 @@ kube_apiserver_admission_control_config_file: false
 #   cache_size: <cache_size_value>
 kube_apiserver_admission_event_rate_limits: {}
 
+kube_pod_security_use_default: false
+kube_pod_security_default_enforce: baseline
+kube_pod_security_default_enforce_version: latest
+kube_pod_security_default_audit: restricted
+kube_pod_security_default_audit_version: latest
+kube_pod_security_default_warn: restricted
+kube_pod_security_default_warn_version: latest
+kube_pod_security_exemptions_usernames: []
+kube_pod_security_exemptions_runtime_class_names: []
+kube_pod_security_exemptions_namespaces:
+  - kube-system
+
+
 # 1.10+ list of disabled admission plugins
 kube_apiserver_disable_admission_plugins: []
 

--- a/roles/kubernetes/control-plane/defaults/main/main.yml
+++ b/roles/kubernetes/control-plane/defaults/main/main.yml
@@ -116,7 +116,6 @@ kube_pod_security_exemptions_runtime_class_names: []
 kube_pod_security_exemptions_namespaces:
   - kube-system
 
-
 # 1.10+ list of disabled admission plugins
 kube_apiserver_disable_admission_plugins: []
 

--- a/roles/kubernetes/control-plane/templates/podsecurity.v1beta2.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/podsecurity.v1beta2.yaml.j2
@@ -1,0 +1,15 @@
+{% if kube_pod_security_use_default %}
+apiVersion: pod-security.admission.config.k8s.io/v1beta1
+kind: PodSecurityConfiguration
+defaults:
+  enforce: "{{ kube_pod_security_default_enforce }}"
+  enforce-version: "{{ kube_pod_security_default_enforce_version }}"
+  audit: "{{ kube_pod_security_default_audit }}"
+  audit-version: "{{ kube_pod_security_default_audit_version }}"
+  warn: "{{ kube_pod_security_default_warn }}"
+  warn-version: "{{ kube_pod_security_default_warn_version }}"
+exemptions:
+  usernames: {{ kube_pod_security_exemptions_usernames|to_json }}
+  runtimeClasses: {{ kube_pod_security_exemptions_runtime_class_names|to_json }}
+  namespaces: {{ kube_pod_security_exemptions_namespaces|to_json }}
+{% endif %}

--- a/roles/kubernetes/control-plane/templates/podsecurity.v1beta2.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/podsecurity.v1beta2.yaml.j2
@@ -1,4 +1,3 @@
-{% if kube_pod_security_use_default %}
 apiVersion: pod-security.admission.config.k8s.io/v1beta1
 kind: PodSecurityConfiguration
 defaults:
@@ -12,4 +11,3 @@ exemptions:
   usernames: {{ kube_pod_security_exemptions_usernames|to_json }}
   runtimeClasses: {{ kube_pod_security_exemptions_runtime_class_names|to_json }}
   namespaces: {{ kube_pod_security_exemptions_namespaces|to_json }}
-{% endif %}

--- a/roles/kubernetes/control-plane/templates/podsecurity.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/podsecurity.yaml.j2
@@ -1,3 +1,4 @@
+{% if kube_pod_security_use_default %}
 apiVersion: pod-security.admission.config.k8s.io/v1beta1
 kind: PodSecurityConfiguration
 defaults:
@@ -11,3 +12,6 @@ exemptions:
   usernames: {{ kube_pod_security_exemptions_usernames|to_json }}
   runtimeClasses: {{ kube_pod_security_exemptions_runtime_class_names|to_json }}
   namespaces: {{ kube_pod_security_exemptions_namespaces|to_json }}
+{% else %}
+# This file is intentinally left empty as kube_pod_security_use_default={{ kube_pod_security_use_default }}
+{% endif %}

--- a/roles/kubernetes/control-plane/vars/main.yaml
+++ b/roles/kubernetes/control-plane/vars/main.yaml
@@ -1,3 +1,3 @@
 ---
 # list of admission plugins that needs to be configured
-kube_apiserver_admission_plugins_needs_configuration: [EventRateLimit, PodSecurity]
+kube_apiserver_admission_plugins_needs_configuration: "{{ ['EventRateLimit', kube_pod_security_use_default|ternary('PodSecurity', None)]|select('string') }}"

--- a/roles/kubernetes/control-plane/vars/main.yaml
+++ b/roles/kubernetes/control-plane/vars/main.yaml
@@ -1,3 +1,3 @@
 ---
 # list of admission plugins that needs to be configured
-kube_apiserver_admission_plugins_needs_configuration: [EventRateLimit]
+kube_apiserver_admission_plugins_needs_configuration: [EventRateLimit, PodSecurity]

--- a/roles/kubernetes/control-plane/vars/main.yaml
+++ b/roles/kubernetes/control-plane/vars/main.yaml
@@ -1,3 +1,3 @@
 ---
 # list of admission plugins that needs to be configured
-kube_apiserver_admission_plugins_needs_configuration: "{{ ['EventRateLimit', kube_pod_security_use_default|ternary('PodSecurity', None)]|select('string') }}"
+kube_apiserver_admission_plugins_needs_configuration: [EventRateLimit, PodSecurity]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?** 
/kind feature

**What this PR does / why we need it**:
By default only Pods in annotated namespaces are checked for following Pod Security Standards. This change adds the option to reverse the behavior, where Pods in all namespaces not exmpted are checked.

**Special notes for your reviewer**:
This is my first PR to kubespray and this looks like a quick and easy win to me, but I might be mistaken. Thanks for any feedback.

I'm not sure if any other namespaces should be on the default exempt list.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add the option to enable default Pod Security Configuration
```