### PR TITLE
let containerd_default_runtime be undefined by default

### DIFF
--- a/docs/vars.md
+++ b/docs/vars.md
@@ -176,7 +176,7 @@ Stack](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/dns-stack.m
 * *docker_options* - Commonly used to set
   ``--insecure-registry=myregistry.mydomain:5000``
 * *docker_plugins* - This list can be used to define [Docker plugins](https://docs.docker.com/engine/extend/) to install.
-* *containerd_default_runtime* - Sets the default Containerd runtime used by the Kubernetes CRI plugin.
+* *containerd_default_runtime* - If defined, changes the default Containerd runtime used by the Kubernetes CRI plugin.
 * *containerd_additional_runtimes* - Sets the additional Containerd runtimes used by the Kubernetes CRI plugin.
   [Default config](https://github.com/kubernetes-sigs/kubespray/blob/master/roles/container-engine/containerd/defaults/main.yml) can be overriden in inventory vars.
 * *http_proxy/https_proxy/no_proxy/no_proxy_exclude_workers/additional_no_proxy* - Proxy variables for deploying behind a

--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -4,7 +4,7 @@ containerd_state_dir: "/run/containerd"
 containerd_systemd_dir: "/etc/systemd/system/containerd.service.d"
 containerd_oom_score: 0
 
-containerd_default_runtime: "runc"
+# containerd_default_runtime: "runc"
 # containerd_snapshotter: "native"
 
 containerd_runc_runtime:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
See https://github.com/kubernetes-sigs/kubespray/issues/9025
**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/kubespray/issues/9025
**Special notes for your reviewer**:
The default filter is used so the only effect of this change will be to allow users to configure the variable in their inventory better. This is a better design pattern which is already used by other variables such as `containerd_snapshotter`.
**Does this PR introduce a user-facing change?**:
No