### PR TITLE
Add support for the updated (startup|liveness|readiness)Probe.Port numbers in Cilium

### DIFF
--- a/roles/network_plugin/cilium/templates/cilium/ds.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/ds.yml.j2
@@ -96,7 +96,11 @@ spec:
           httpGet:
             host: '127.0.0.1'
             path: /healthz
+{% if cilium_version | regex_replace('v') is version('1.11.6', '>=') %}
+            port: 9879
+{% else %}
             port: 9876
+{% endif %}
             scheme: HTTP
             httpHeaders:
             - name: "brief"
@@ -108,7 +112,11 @@ spec:
           httpGet:
             host: '127.0.0.1'
             path: /healthz
+{% if cilium_version | regex_replace('v') is version('1.11.6', '>=') %}
+            port: 9879
+{% else %}
             port: 9876
+{% endif %}
             scheme: HTTP
             httpHeaders:
             - name: "brief"
@@ -121,7 +129,11 @@ spec:
           httpGet:
             host: 127.0.0.1
             path: /healthz
+{% if cilium_version | regex_replace('v') is version('1.11.6', '>=') %}
+            port: 9879
+{% else %}
             port: 9876
+{% endif %}
             scheme: HTTP
             httpHeaders:
             - name: "brief"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
In Cilium version `1.11.6` and above, they have changed the port number used for the (startup|liveness|readiness)Probes. This PR supports the change in port number for the newer versions, and makes sure that the older versions will be deployed using their port number.

Details on why the port changed can be found here: https://github.com/cilium/cilium/pull/19830 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9030

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
