### PR TITLE
Fix docker option in centos arm64

### DIFF
--- a/roles/container-engine/docker/templates/docker-options.conf.j2
+++ b/roles/container-engine/docker/templates/docker-options.conf.j2
@@ -4,11 +4,7 @@ Environment="DOCKER_OPTS={{ docker_options|default('') }} --iptables={{ docker_i
 {% for i in docker_insecure_registries %}--insecure-registry={{ i }} {% endfor %} \
 {% for i in docker_registry_mirrors %}--registry-mirror={{ i }} {% endfor %} \
 --data-root={{ docker_daemon_graph }} \
-{% if ansible_os_family not in ["openSUSE Leap", "openSUSE Tumbleweed", "Suse"] %}{{ docker_log_opts }}{% endif %} \
-{% if ansible_architecture == "aarch64" and ansible_os_family == "RedHat" %} \
---add-runtime docker-runc=/usr/libexec/docker/docker-runc-current --default-runtime=docker-runc \
---userland-proxy-path=/usr/libexec/docker/docker-proxy-current --signature-verification=false \
-{% endif %}"
+{% if ansible_os_family not in ["openSUSE Leap", "openSUSE Tumbleweed", "Suse"] %}{{ docker_log_opts }}{% endif %}"
 
 {% if docker_mount_flags is defined and docker_mount_flags != "" %}
 MountFlags={{ docker_mount_flags }}


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:

The Docker Option is not work in centos arm64 platform. Because of it use error cgroupdriver.

The code is added in  https://github.com/kubernetes-sigs/kubespray/pull/2168 in 2018. The cgroup driver is cgroupfs in x86 , and systemd in arm64. 

And the default docker_cgroup_driver has been to systemd now. It's the same between arm64 and x86 now. So we should remove these code.

I have tested the change in ARM64 machine.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/kubespray/issues/9013

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note

Fix the Centos/RHEL docker installation issue in  ARM64 

```
