### PR TITLE
Remove ETCD_UNSUPPORTED_ARCH since etcdmain officially supports "arm64"

### DIFF
--- a/roles/etcd/templates/etcd-events.env.j2
+++ b/roles/etcd/templates/etcd-events.env.j2
@@ -41,7 +41,3 @@ ETCD_CIPHER_SUITES={% for tls in etcd_tls_cipher_suites %}{{ tls }}{{ "," if not
 {% for key, value in etcd_extra_vars.items() %}
 {{ key }}={{ value }}
 {% endfor %}
-
-{% if host_architecture != "amd64" -%}
-ETCD_UNSUPPORTED_ARCH={{host_architecture}}
-{%- endif %}

--- a/roles/etcd/templates/etcd.env.j2
+++ b/roles/etcd/templates/etcd.env.j2
@@ -57,10 +57,6 @@ ETCD_CIPHER_SUITES={% for tls in etcd_tls_cipher_suites %}{{ tls }}{{ "," if not
 {{ key }}={{ value }}
 {% endfor %}
 
-{% if host_architecture != "amd64" -%}
-ETCD_UNSUPPORTED_ARCH={{host_architecture}}
-{%- endif %}
-
 # CLI settings
 ETCDCTL_ENDPOINTS=https://127.0.0.1:2379
 ETCDCTL_CACERT={{ etcd_cert_dir }}/ca.pem

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
@@ -67,9 +67,6 @@ etcd:
 {% for key, value in etcd_extra_vars.items() %}
       {{ key }}: "{{ value }}"
 {% endfor %}
-{% if host_architecture != "amd64" %}
-      etcd-unsupported-arch: {{host_architecture}}
-{% endif %}
     serverCertSANs:
 {% for san in etcd_cert_alt_names %}
       - {{ san }}


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:

Remove ETCD_UNSUPPORTED_ARCH since [etcdmain officially supports "arm64".](https://github.com/etcd-io/etcd/pull/12929).

The etcd env ETCD_UNSUPPORTED_ARCH, and etcd args `etcd-unsupported-arch` in arm64 is no need anymore in etcd 3.5.x
( https://github.com/etcd-io/etcd/blob/v3.5.0/server/etcdmain/etcd.go#L468 )

**Which issue(s) this PR fixes**:

When 'etcd_deployment_type: kubeadm'  the in arm64, it fails:

![企业微信截图_16566728418447](https://user-images.githubusercontent.com/1469319/176883755-35168345-dae8-482d-81ea-c71dc4373e84.png)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
remove the 'etcd-unsupported-arch' args to fix the etcd issue  in arm64
```
