### PR TITLE
replace bash for loop when checking API server SANs

### DIFF
--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -108,22 +108,23 @@
     - item in kube_apiserver_admission_plugins_needs_configuration
   loop: "{{ kube_apiserver_enable_admission_plugins }}"
 
-- name: kubeadm | Check if apiserver.crt contains all needed SANs
-  shell: |
-    set -o pipefail
-    for IP in {{ apiserver_ips | join(' ') }}; do
-      openssl x509 -noout -in "{{ kube_cert_dir }}/apiserver.crt" -checkip $IP | grep -q 'does match certificate' || echo 'NEED-RENEW'
-    done
-    for HOST in {{ apiserver_hosts | join(' ') }}; do
-      openssl x509 -noout -in "{{ kube_cert_dir }}/apiserver.crt" -checkhost $HOST | grep -q 'does match certificate' || echo 'NEED-RENEW'
-    done
+- name: kubeadm | Check apiserver.crt SANs
+  block:
+    - name: kubeadm | Check apiserver.crt SAN IPs
+      command:
+        cmd: "openssl x509 -noout -in {{ kube_cert_dir }}/apiserver.crt -checkip {{ item }}"
+      loop: "{{ apiserver_ips }}"
+      register: apiserver_sans_ip_check
+      changed_when: apiserver_sans_ip_check.stdout is not search('does match certificate')
+    - name: kubeadm | Check apiserver.crt SAN hosts
+      command:
+        cmd: "openssl x509 -noout -in {{ kube_cert_dir }}/apiserver.crt -checkhost {{ item }}"
+      loop: "{{ apiserver_hosts }}"
+      register: apiserver_sans_host_check
+      changed_when: apiserver_sans_host_check.stdout is not search('does match certificate')
   vars:
     apiserver_ips: "{{ apiserver_sans|map('ipaddr')|reject('equalto', False)|list }}"
     apiserver_hosts: "{{ apiserver_sans|difference(apiserver_ips) }}"
-  args:
-    executable: /bin/bash
-  register: apiserver_sans_check
-  changed_when: "'NEED-RENEW' in apiserver_sans_check.stdout"
   when:
     - kubeadm_already_run.stat.exists
     - not kube_external_ca_mode
@@ -137,7 +138,7 @@
     - apiserver.key
   when:
     - kubeadm_already_run.stat.exists
-    - apiserver_sans_check.changed
+    - apiserver_sans_ip_check.changed or apiserver_sans_host_check.changed
     - not kube_external_ca_mode
 
 - name: kubeadm | regenerate apiserver cert 2/2
@@ -147,7 +148,7 @@
     --config={{ kube_config_dir }}/kubeadm-config.yaml
   when:
     - kubeadm_already_run.stat.exists
-    - apiserver_sans_check.changed
+    - apiserver_sans_ip_check.changed or apiserver_sans_host_check.changed
     - not kube_external_ca_mode
 
 - name: kubeadm | Create directory to store kubeadm patches


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This is an updated rebased version of https://github.com/kubernetes-sigs/kubespray/pull/8050, see discussion and motivation there. 

**Special notes for your reviewer**:
It may take about one second longer to run by default (maybe several seconds if there are a lot of SANs?) but even for a small cluster Kubespray takes ~ 30 minutes to run so the effect is only ~ 0.1% - 1%, so the impact would not be significant or even perceptible. 

**Does this PR introduce a user-facing change?**:
```release-note
Replace bash for loop when checking API server SANs
```