### PR TITLE
[#9067] archive offline-files and NO_HTTP_SERVER to skip nginx running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@
 **/vagrant_ansible_inventory
 *.iml
 temp
-offline-files
+contrib/offline/offline-files
+contrib/offline/offline-files.tar.gz
 .idea
 .vscode
 .tox

--- a/contrib/offline/manage-offline-files.sh
+++ b/contrib/offline/manage-offline-files.sh
@@ -1,18 +1,26 @@
 #!/bin/bash
 
-CURRENT_DIR=$(cd $(dirname $0); pwd)
-OFFLINE_FILES_DIR="${CURRENT_DIR}/offline-files"
+CURRENT_DIR=$( dirname "$(readlink -f "$0")" )
+OFFLINE_FILES_DIR_NAME="offline-files"
+OFFLINE_FILES_DIR="${CURRENT_DIR}/${OFFLINE_FILES_DIR_NAME}"
+OFFLINE_FILES_ARCHIVE="${CURRENT_DIR}/offline-files.tar.gz"
 FILES_LIST=${FILES_LIST:-"${CURRENT_DIR}/temp/files.list"}
 NGINX_PORT=8080
 
 # download files
-if [ ! -f ${FILES_LIST} ]; then
-    echo "${FILES_LIST} should exist."
+if [ ! -f "${FILES_LIST}" ]; then
+    echo "${FILES_LIST} should exist, run ./generate_list.sh first."
     exit 1
 fi
-rm -rf ${OFFLINE_FILES_DIR}
-mkdir  ${OFFLINE_FILES_DIR}
-wget -x -P ${OFFLINE_FILES_DIR} -i ${FILES_LIST}
+
+rm -rf "${OFFLINE_FILES_DIR}"
+rm "${OFFLINE_FILES_ARCHIVE}"
+mkdir  "${OFFLINE_FILES_DIR}"
+
+wget -x -P "${OFFLINE_FILES_DIR}" -i "${FILES_LIST}"
+tar -czvf "${OFFLINE_FILES_ARCHIVE}"  "${OFFLINE_FILES_DIR_NAME}"
+
+[ -n "$NO_HTTP_SERVER" ] && echo "skip to run nginx" && exit 0
 
 # run nginx container server
 if command -v nerdctl 1>/dev/null 2>&1; then
@@ -25,11 +33,12 @@ else
     echo "No supported container runtime found"
     exit 1
 fi
+
 sudo "${runtime}" container inspect nginx >/dev/null 2>&1
 if [ $? -ne 0 ]; then
     sudo "${runtime}" run \
         --restart=always -d -p ${NGINX_PORT}:80 \
-        --volume ${OFFLINE_FILES_DIR}:/usr/share/nginx/html/download \
+        --volume "${OFFLINE_FILES_DIR}:/usr/share/nginx/html/download" \
         --volume "$(pwd)"/nginx.conf:/etc/nginx/nginx.conf \
         --name nginx nginx:alpine
 fi


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Archive offline-files and env NO_HTTP_SERVER to skip Nginx container running.

**Which issue(s) this PR fixes**:

Fixes #9067 

**Special notes for your reviewer**:
Quotes file/path -related variable to [prevent globbing and word-splitting](https://github.com/koalaman/shellcheck/wiki/SC2086).

**Does this PR introduce a user-facing change?**:

```release-note
[offline] Archive offline-files and env NO_HTTP_SERVER to skip Nginx container running.
```
