### PR TITLE
[#9070] offline, generate_list.sh can specify k8s version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 temp
 contrib/offline/offline-files
 contrib/offline/offline-files.tar.gz
+contrib/offline/.use-kube-version
 .idea
 .vscode
 .tox

--- a/contrib/offline/generate_list.sh
+++ b/contrib/offline/generate_list.sh
@@ -14,9 +14,9 @@ grep 'download_url:' ${REPO_ROOT_DIR}/${DOWNLOAD_YML} \
     | sed 's/^.*_url: //g;s/\"//g' > ${TEMP_DIR}/files.list.template
 
 # generate all images list template
-sed -n '/^downloads:/,/download_defaults:/p' ${REPO_ROOT_DIR}/${DOWNLOAD_YML} \
+sed -n '/^downloads:/,/download_defaults:/p' "${REPO_ROOT_DIR}/${DOWNLOAD_YML}" \
     | sed -n "s/repo: //p;s/tag: //p" | tr -d ' ' \
-    | sed 'N;s#\n# #g' | tr ' ' ':' | sed 's/\"//g' > ${TEMP_DIR}/images.list.template
+    | sed 'N;s#\n# #g' | tr ' ' ':' | sed 's/\"//g' > "${TEMP_DIR}/images.list.template"
 
 # add kube-* images to images list template
 # Those container images are downloaded by kubeadm, then roles/download/defaults/main.yml
@@ -24,10 +24,16 @@ sed -n '/^downloads:/,/download_defaults:/p' ${REPO_ROOT_DIR}/${DOWNLOAD_YML} \
 # list separately.
 KUBE_IMAGES="kube-apiserver kube-controller-manager kube-scheduler kube-proxy"
 for i in $KUBE_IMAGES; do
-    echo "{{ kube_image_repo }}/$i:{{ kube_version }}" >> ${TEMP_DIR}/images.list.template
+    echo "{{ kube_image_repo }}/$i:{{ kube_version }}" >> "${TEMP_DIR}/images.list.template"
 done
 
-# run ansible to expand templates
-/bin/cp ${CURRENT_DIR}/generate_list.yml ${REPO_ROOT_DIR}
+version_file="${CURRENT_DIR}/.use-kube-version"
+rm "$version_file" 2>/dev/null || true
+echo -n "${USE_KUBE_VERSION}" > "${version_file}"
 
-(cd ${REPO_ROOT_DIR} && ansible-playbook $* generate_list.yml && /bin/rm generate_list.yml) || exit 1
+# run ansible to expand templates
+/bin/cp "${CURRENT_DIR}/generate_list.yml" "${REPO_ROOT_DIR}"
+
+(cd "${REPO_ROOT_DIR}" && ansible-playbook $* generate_list.yml && /bin/rm generate_list.yml) || exit 1
+
+rm "$version_file"

--- a/contrib/offline/generate_list.yml
+++ b/contrib/offline/generate_list.yml
@@ -10,6 +10,21 @@
       when: false
 
   tasks:
+    - name: version_specified?
+      set_fact:
+        default_kube_version: "{{ kube_version }}"
+        specified_version: "{{lookup('ansible.builtin.file', './contrib/offline/.use-kube-version') }}"
+      failed_when: false
+    - name: up_version
+      set_fact:
+        kube_version: "{{ specified_version }}"
+      when: specified_version | length > 2
+    - name: kube_version_info
+      ansible.builtin.debug:
+        msg:
+          - "default kube version: {{ default_kube_version }}"
+          - "current kube version: {{ kube_version }}"
+          - "The minimum version working: {{ kube_version_min_required }}"
     # Generate files.list and images.list files from templates.
     - template:
         src: ./contrib/offline/temp/{{ item }}.list.template

--- a/contrib/offline/generate_list.yml
+++ b/contrib/offline/generate_list.yml
@@ -11,12 +11,22 @@
 
   tasks:
     - name: version_specified?
-      set_fact:
+      ansible.builtin.set_fact:
         default_kube_version: "{{ kube_version }}"
         specified_version: "{{lookup('ansible.builtin.file', './contrib/offline/.use-kube-version') }}"
-      failed_when: false
+    - name: "Check_k8s_specified_version"
+      ansible.builtin.assert:
+        fail_msg: "USE_KUBE_VERSION must be between {{ kube_version_min_required }} and {{ default_kube_version }} inclusive"
+        quiet: yes
+        that:
+          - specified_version is version(kube_version_min_required , ">=")
+          - specified_version is version(default_kube_version, "<=")
+      when: specified_version | length > 2
+      changed_when: false
+      tags:
+        - check
     - name: up_version
-      set_fact:
+      ansible.builtin.set_fact:
         kube_version: "{{ specified_version }}"
       when: specified_version | length > 2
     - name: kube_version_info
@@ -26,7 +36,8 @@
           - "current kube version: {{ kube_version }}"
           - "The minimum version working: {{ kube_version_min_required }}"
     # Generate files.list and images.list files from templates.
-    - template:
+    - name: generate files.list and images.list files
+      ansible.builtin.template:
         src: ./contrib/offline/temp/{{ item }}.list.template
         dest: ./contrib/offline/temp/{{ item }}.list
       with_items:


### PR DESCRIPTION
**What type of PR is this?**
 /kind feature


**What this PR does / why we need it**:
Add USE_KUBE_VERSION to generate files for a specified version instead of the default  recent version (which maybe too new for some production deployment to try/use).

```shell
$ env USE_KUBE_VERSION=v1.22.11 ./generate_list.sh
```

**Which issue(s) this PR fixes**:
Fixes #9070 

**Special notes for your reviewer**:
* Since environment variable exported in generate_list.sh is not available in ansible-playbook, a temp file is used for sharing version info. If no version specified and do not generate temp file, the ansible lookup file would fail. Always writing to the temp file would simplify the code.
* print default kube version, current kube version and minimum kube version working

**Does this PR introduce a user-facing change?**:
It's backward-compatible.

```release-note
offline, generate_list.sh can specify any supported k8s version.
```
