### PR TITLE
hardening: Add `SeccompDefault` admission plugin for kubelet

### DIFF
--- a/docs/hardening.md
+++ b/docs/hardening.md
@@ -83,7 +83,8 @@ kubelet_event_record_qps: 1
 kubelet_rotate_certificates: true
 kubelet_streaming_connection_idle_timeout: "5m"
 kubelet_make_iptables_util_chains: true
-kubelet_feature_gates: ["RotateKubeletServerCertificate=true"]
+kubelet_feature_gates: ["RotateKubeletServerCertificate=true","SeccompDefault=true"]
+kubelet_seccomp_default: true
 
 # additional configurations
 kube_owner: root

--- a/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
@@ -118,7 +118,7 @@ resolvConf: "{{ kube_resolv_conf }}"
 {% endif %}
 {% if kubelet_feature_gates or kube_feature_gates %}
 featureGates:
-{{% for feature in kubelet_feature_gates | default(kube_feature_gates, true) | join(',') %}}
+{% for feature in (kubelet_feature_gates | default(kube_feature_gates, true)) %}
   {{ feature|replace("=", ": ") }}
 {% endfor %}
 {% endif %}
@@ -145,4 +145,7 @@ streamingConnectionIdleTimeout: {{ kubelet_streaming_connection_idle_timeout }}
 {% endif %}
 {% if kubelet_make_iptables_util_chains is defined %}
 makeIPTablesUtilChains: {{ kubelet_make_iptables_util_chains | bool }}
+{% endif %}
+{% if kubelet_seccomp_default is defined %}
+seccompDefault: {{ kubelet_seccomp_default | bool }}
 {% endif %}

--- a/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
@@ -116,9 +116,9 @@ resolvConf: "{{ kube_resolv_conf }}"
 {% if inventory_hostname in groups['kube_node'] and kubelet_node_config_extra_args %}
 {{ kubelet_node_config_extra_args | to_nice_yaml(indent=2) }}
 {% endif %}
-{% if kube_feature_gates %}
+{% if kubelet_feature_gates or kube_feature_gates %}
 featureGates:
-{% for feature in kube_feature_gates %}
+{{% for feature in kubelet_feature_gates | default(kube_feature_gates, true) | join(',') %}}
   {{ feature|replace("=", ": ") }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Add **kubelet** configuration to set default `seccomp` profile on pods.
This can improve security of the cluster, by providing documentation and examples about it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9073 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add `SeccompDefault` admission plugin for kubelet (using new variable `kubelet_seccomp_default`)
```

