### PR TITLE
[Weave] Use the correct CNI version

### DIFF
--- a/roles/network_plugin/weave/templates/10-weave.conflist.j2
+++ b/roles/network_plugin/weave/templates/10-weave.conflist.j2
@@ -1,5 +1,5 @@
 {
-    "cniVersion": "0.3.0",
+    "cniVersion": "{{ cni_version }}",
     "name": "weave",
       "plugins": [
         {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The PR purpose is to use the correct CNI version in the Weave CNI configuration file. The current hardcoded version stucks all pods in the Containercreating state with this warning:
`Warning  FailedCreatePodSandBox [...]  Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create pod network sandbox [...]: error adding pod [...] to CNI network "weave": plugin type="portmap" failed (add): failed to parse config: could not parse prevResult: could not parse prevResult: result type supports [0.3.0 0.3.1 0.4.0] but unmarshalled CNIVersion is "0.1.0│ ` (Tested with Kubespray 2.19 and CRI-O 1.23)

**Does this PR introduce a user-facing change?**:

NONE