### PR TITLE
Update load balancers Versions and use the alpine base image

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -853,9 +853,9 @@ multus_image_tag: "{{ multus_version }}"
 kube_vip_image_repo: "{{ github_image_repo }}/kube-vip/kube-vip"
 kube_vip_image_tag: v0.4.2
 nginx_image_repo: "{{ docker_image_repo }}/library/nginx"
-nginx_image_tag: 1.21.4
+nginx_image_tag: 1.23.0-alpine
 haproxy_image_repo: "{{ docker_image_repo }}/library/haproxy"
-haproxy_image_tag: 2.4.9
+haproxy_image_tag: 2.6.1-alpine
 
 # Coredns version should be supported by corefile-migration (or at least work with)
 # bundle with kubeadm; if not 'basic' upgrade can sometimes fail


### PR DESCRIPTION
Update load balancers Versions and use the alpine base image.

The nginx image 1.21.4 has so many CVEs. like : https://snyk.io/test/docker/nginx%3A1.21.4 .
So should we upgrade it to the newer version , and use the smaller base image ?


**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Upgrade the nginx-proxy and haproxy image version , and use the alpine base image
```
