### PR TITLE
Add ignore_assert_error to ubuntu20 etcd ha job

### DIFF
--- a/tests/files/packet_ubuntu20-calico-etcd-kubeadm-upgrade-ha.yml
+++ b/tests/files/packet_ubuntu20-calico-etcd-kubeadm-upgrade-ha.yml
@@ -16,3 +16,9 @@ enable_nodelocaldns: False
 ipip: false
 calico_vxlan_mode: Always
 calico_network_backend: bird
+
+# Needed to bypass deprecation check
+ignore_assert_errors: true
+### FIXME FLORYUT Needed for upgrade job, will be removed when releasing kubespray 2.20
+calico_pool_blocksize: 24
+### /FIXME


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Job https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/2744024607 is failing for a few weeks I guess (even months ? 😆 )

**Which issue(s) this PR fixes**:
periodic job

**Special notes for your reviewer**:
Job in success in the last test => https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/2747961702 (before putting back the job as a nightly one)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
