### PR TITLE
git ignore .terraform.lock.hcl anywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ contrib/offline/offline-files.tar.gz
 *.tfstate.backup
 .terraform/
 contrib/terraform/aws/credentials.tfvars
+.terraform.lock.hcl
 /ssh-bastion.conf
 **/*.sw[pon]
 *~


### PR DESCRIPTION

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Running terraform produces a lock file `.terraform.lock.hcl`, which should be ignored by git to prevent spurious complaints
```
$ git status
HEAD detached at b0ba4234
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	contrib/terraform/openstack/.terraform.lock.hcl
```
and help keep the git state clean.

**Special notes for your reviewer**:

https://www.terraform.io/language/files/dependency-lock#lock-file-location

**Does this PR introduce a user-facing change?**:
No
