### PR TITLE
[calico] add v3.23.3 and make it default

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [cri-o](http://cri-o.io/) v1.22 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)
 - Network Plugin
   - [cni-plugins](https://github.com/containernetworking/plugins) v1.1.1
-  - [calico](https://github.com/projectcalico/calico) v3.23.2
+  - [calico](https://github.com/projectcalico/calico) v3.23.3
   - [canal](https://github.com/projectcalico/canal) (given calico/flannel versions)
   - [cilium](https://github.com/cilium/cilium) v1.11.6
   - [flannel](https://github.com/flannel-io/flannel) v0.18.1

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -95,7 +95,7 @@ github_image_repo: "ghcr.io"
 
 # TODO(mattymo): Move calico versions to roles/network_plugins/calico/defaults
 # after migration to container download
-calico_version: "v3.23.2"
+calico_version: "v3.23.3"
 calico_ctl_version: "{{ calico_version }}"
 calico_cni_version: "{{ calico_version }}"
 calico_flexvol_version: "{{ calico_version }}"
@@ -549,24 +549,24 @@ cni_binary_checksums:
 
 calicoctl_binary_checksums:
   arm:
-    v3.23.2: 0
+    v3.23.3: 0
     v3.22.3: 0
     v3.21.5: 0
   amd64:
-    v3.23.2: 3784200cdfc0106c9987df2048d219bb91147f0cc3fa365b36279ac82ea37c7a
+    v3.23.3: d9c04ab15bad9d8037192abd2aa4733a01b0b64a461c7b788118a0d6747c1737
     v3.22.3: a9e5f6bad4ad8c543f6bdcd21d3665cdd23edc780860d8e52a87881a7b3e203c
     v3.21.5: 98407b1c608fec0896004767c72cd4b6cf939976d67d3eca121f1f02137c92a7
   arm64:
-    v3.23.2: 232b992e6767c68c8c832cc7027a0d9aacb29901a9b5e8871e25baedbbb9c64c
+    v3.23.2: 741b222f9bb10b7b5e268e5362796061c8862d4f785bb6b9c4f623ea143f4682
     v3.22.3: 3a3e70828c020efd911181102d21cb4390b7b68669898bd40c0c69b64d11bb63
     v3.21.5: cc73e2b8f5b695b6ab06e7856cd516c1e9ec3e903abb510ef465ca6b530e18e6
   ppc64le:
-    v3.23.2: d9ded02381a0fc1311561d0cc9eed9ea827462f3b823593d6ac8bd0591d2020f
+    v3.23.2: f83efcd8d3d7c96dfe8e596dc9739eb5d9616626a6afba29b0af97e5c222575a
     v3.22.3: 7c2fe391f2a18eccff65c64bf93133dc5c58c7322cbd31ea207bbfef5b563947
     v3.21.5: 1ebb615b18f9c3fe2d41281d1bc9e3909048b56d2bc76c18431cbeb7a653d24d
 
 calico_crds_archive_checksums:
-  v3.23.2: 37c429650723c5f12ffc20dd390ead1e10d2b8a955a199666d155115a49b4dcc
+  v3.23.3: d25f5c9a3adeba63219f3c8425a8475ebfbca485376a78193ec1e4c74e7a6115
   v3.22.3: 55ece01da00f82c62619b82b6bfd6442a021acc6fd915a753735e6ebceabaa21
   v3.21.5: ffbbaa2bc32b01bf160828d2cfd4504d83c69cb1f74c0028349181ed61bad635
 


### PR DESCRIPTION
 **What type of PR is this?**
 
 /kind feature
 
 **What this PR does / why we need it**: 

This PR adds calico version v3.23.3 and make it default

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[calico] upgrade default calico version to v3.23.3
```

