### PR TITLE
Enable shellcheck for contrib/offline

### DIFF
--- a/.gitlab-ci/shellcheck.yml
+++ b/.gitlab-ci/shellcheck.yml
@@ -11,6 +11,6 @@ shellcheck:
     - cp shellcheck-"${SHELLCHECK_VERSION}"/shellcheck /usr/bin/
     - shellcheck --version
   script:
-    # Run shellcheck for all *.sh except contrib/
-    - find . -name '*.sh' -not -path './contrib/*' -not -path './.git/*' | xargs shellcheck --severity error
+    # Run shellcheck for all *.sh
+    - find . -name '*.sh' -not -path './.git/*' | xargs shellcheck --severity error
   except: ['triggers', 'master']

--- a/contrib/dind/run-test-distros.sh
+++ b/contrib/dind/run-test-distros.sh
@@ -17,7 +17,7 @@ pass_or_fail() {
 test_distro() {
     local distro=${1:?};shift
     local extra="${*:-}"
-    local prefix="$distro[${extra}]}"
+    local prefix="${distro[${extra}]}"
     ansible-playbook -i hosts dind-cluster.yaml -e node_distro=$distro
     pass_or_fail "$prefix: dind-nodes" || return 1
     (cd ../..
@@ -71,15 +71,15 @@ for spec in ${SPECS}; do
     echo "Loading file=${spec} ..."
     . ${spec} || continue
     : ${DISTROS:?} || continue
-    echo "DISTROS=${DISTROS[@]}"
+    echo "DISTROS:" "${DISTROS[@]}"
     echo "EXTRAS->"
     printf "  %s\n" "${EXTRAS[@]}"
     let n=1
-    for distro in ${DISTROS[@]}; do
+    for distro in "${DISTROS[@]}"; do
         for extra in "${EXTRAS[@]:-NULL}"; do
             # Magic value to let this for run once:
             [[ ${extra} == NULL ]] && unset extra
-            docker rm -f ${NODES[@]}
+            docker rm -f "${NODES[@]}"
             printf -v file_out "%s/%s-%02d.out" ${OUTPUT_DIR} ${spec} $((n++))
             {
                 info "${distro}[${extra}] START: file_out=${file_out}"


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Today we have many contributions to contrib/offline/ and some PRs contained invalid coding style for those scripts.
This enables shellcheck to make such invalid coding style easily.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
