### PR TITLE
Fix kube-vip doc links

### DIFF
--- a/docs/kube-vip.md
+++ b/docs/kube-vip.md
@@ -11,7 +11,7 @@ kube_vip_enabled: true
 ```
 
 You also need to enable
-[kube-vip as HA, Load Balancer, or both](https://kube-vip.chipzoller.dev/docs/installation/static/#kube-vip-as-ha-load-balancer-or-both):
+[kube-vip as HA, Load Balancer, or both](https://kube-vip.io/docs/installation/static/#kube-vip-as-ha-load-balancer-or-both):
 
 ```yaml
 # HA for control-plane, requires a VIP
@@ -28,16 +28,16 @@ kube_vip_services_enabled: false
 ```
 
 > Note: When using `kube-vip` as LoadBalancer for services,
-[additionnal manual steps](https://kube-vip.chipzoller.dev/docs/usage/cloud-provider/)
+[additionnal manual steps](https://kube-vip.io/docs/usage/cloud-provider/)
 are needed.
 
-If using [ARP mode](https://kube-vip.chipzoller.dev/docs/installation/static/#arp) :
+If using [ARP mode](https://kube-vip.io/docs/installation/static/#arp) :
 
 ```yaml
 kube_vip_arp_enabled: true
 ```
 
-If using [BGP mode](https://kube-vip.chipzoller.dev/docs/installation/static/#bgp) :
+If using [BGP mode](https://kube-vip.io/docs/installation/static/#bgp) :
 
 ```yaml
 kube_vip_bgp_enabled: true

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -53,7 +53,7 @@ eviction_hard_control_plane: {}
 kubelet_status_update_frequency: 10s
 
 # kube-vip
-kube_vip_version: v0.4.2
+kube_vip_image_tag: v0.4.2
 
 kube_vip_arp_enabled: false
 kube_vip_interface:


### PR DESCRIPTION
The docs are now hosted at https://kube-vip.io

**What type of PR is this?**
/kind documentation


**What this PR does / why we need it**:



**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No

```release-note
NONE

```
