### PR TITLE
Fix Hetzner CCM cluster-cidr

### DIFF
--- a/roles/kubernetes-apps/external_cloud_controller/hcloud/templates/external-hcloud-cloud-controller-manager-ds-with-networks.yml.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/hcloud/templates/external-hcloud-cloud-controller-manager-ds-with-networks.yml.j2
@@ -43,7 +43,7 @@ spec:
             - "--leader-elect=false"
             - "--allow-untagged-cloud"
             - "--allocate-node-cidrs=true"
-            - "--cluster-cidr=10.244.0.0/16"
+            - "--cluster-cidr={{ kube_pods_subnet }}"
 {% if external_hcloud_cloud.controller_extra_args is defined %}
 
           args:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Cluster CIDR was hard-coded and this caused connectivity issues if podCIDR != 10.244.0.0/16

**Which issue(s) this PR fixes**:

This would set CCM's cluster-cidr argument to `kube_pods_subnet`

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Fix Hetzner CCM cluster-cidr (wrongly set to a static value)
```
