### PR TITLE
make kube cluster deployed with kubespray restartable

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s_cluster/addons.yml
@@ -4,7 +4,7 @@
 # dashboard_enabled: false
 
 # Helm deployment
-helm_enabled: false
+helm_enabled: true
 
 # Registry deployment
 registry_enabled: false
@@ -133,7 +133,7 @@ ingress_alb_enabled: false
 # alb_ingress_aws_debug: "false"
 
 # Cert manager deployment
-cert_manager_enabled: false
+cert_manager_enabled: true
 # cert_manager_namespace: "cert-manager"
 # cert_manager_tolerations:
 #   - key: node-role.kubernetes.io/master

--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -162,6 +162,7 @@ cluster_name: cluster.local
 ndots: 2
 # Can be coredns, coredns_dual, manual or none
 dns_mode: coredns
+dns_min_replicas: 1
 # Set manual server if using a custom cluster DNS server
 # manual_dns_server: 10.x.x.x
 # Enable nodelocal dns cache

--- a/roles/bootstrap-os/tasks/bootstrap-debian.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-debian.yml
@@ -74,3 +74,34 @@
     state: present
     use: apt
   become: true
+
+# Workaround for https://github.com/kubernetes-sigs/kubespray/issues/8850
+- name: check if cgroupv2 are enabled
+  stat:
+    path: "/sys/fs/cgroup/cgroup.controllers"
+
+# Workaround for https://github.com/kubernetes-sigs/kubespray/issues/8850
+- name: Disable Systemd Resolved
+  become: true
+  block:
+    - name: Set default as DNS operational mode
+      ini_file:
+        path: "/etc/NetworkManager/NetworkManager.conf"
+        section: main
+        option: dns
+        value: default
+        no_extra_spaces: yes
+    - name: Disable systemd-resolved
+      systemd:
+        name: systemd-resolved
+        state: stopped
+        enabled: no
+    - name: Remove resolv.conf
+      file:
+        path: "/etc/resolv.conf"
+        state: absent
+    - name: Restart and enable NetworkManager
+      systemd:
+        name: NetworkManager
+        state: restarted
+        enabled: yes

--- a/roles/container-engine/cri-dockerd/handlers/main.yml
+++ b/roles/container-engine/cri-dockerd/handlers/main.yml
@@ -20,4 +20,5 @@
 - name: cri-dockerd | reload cri-dockerd.service
   service:
     name: cri-dockerd.service
+    enabled: yes
     state: restarted

--- a/roles/kubernetes/node/vars/ubuntu-18.yml
+++ b/roles/kubernetes/node/vars/ubuntu-18.yml
@@ -1,2 +1,2 @@
 ---
-kube_resolv_conf: "/run/systemd/resolve/resolv.conf"
+kube_resolv_conf: "/etc/resolv.conf"

--- a/roles/kubernetes/node/vars/ubuntu-20.yml
+++ b/roles/kubernetes/node/vars/ubuntu-20.yml
@@ -1,2 +1,2 @@
 ---
-kube_resolv_conf: "/run/systemd/resolve/resolv.conf"
+kube_resolv_conf: "/etc/resolv.conf"

--- a/roles/kubernetes/node/vars/ubuntu-22.yml
+++ b/roles/kubernetes/node/vars/ubuntu-22.yml
@@ -1,2 +1,2 @@
 ---
-kube_resolv_conf: "/run/systemd/resolve/resolv.conf"
+kube_resolv_conf: "/etc/resolv.conf"


### PR DESCRIPTION
Kubernetes cluster installed with Kubespary may not be able to restart.

https://github.com/kubernetes-sigs/kubespray/issues/9140

Contributions to solve this issue. Tested with Ubuntu20.04