### PR TITLE
Argument jsonpath must be single-quoted in "See if node is schedulable" task

### DIFF
--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -30,7 +30,7 @@
 - name: See if node is schedulable
   command: >
     {{ kubectl }} get node {{ kube_override_hostname|default(inventory_hostname) }}
-    -o jsonpath={ .spec.unschedulable }
+    -o jsonpath='{ .spec.unschedulable }'
   register: kubectl_node_schedulable
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
   failed_when: false


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The "See if node is schedulable" task never fails (due to `failed_when: false`), as a consequence, unschedulable nodes are not considered as such (are cordoned again, drained and uncordoned) due to the command failure (`error: error parsing jsonpath {, unclosed action`).
This PR fixes this by adding single-quote around jsonpath argument's value

**Which issue(s) this PR fixes**:
None that I found

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
Fix missing quote in task "See if node is schedulable" 
```
