### PR TITLE
Move old etcd backup removal after etcd restart

### DIFF
--- a/roles/etcd/handlers/backup.yml
+++ b/roles/etcd/handlers/backup.yml
@@ -8,7 +8,6 @@
     - Stat etcd v2 data directory
     - Backup etcd v2 data
     - Backup etcd v3 data
-    - Remove old etcd backups
   when: etcd_cluster_is_healthy.rc == 0
 
 - name: Refresh Time Fact
@@ -61,9 +60,3 @@
   register: etcd_backup_v3_command
   until: etcd_backup_v3_command.rc == 0
   delay: "{{ retry_stagger | random + 3 }}"
-
-- name: Remove old etcd backups
-  shell:
-    chdir: "{{ etcd_backup_prefix }}"
-    cmd: "find . -name 'etcd-*' -type d | sort -n | head -n -{{ etcd_backup_retention_count }} | xargs rm -rf"
-  when: etcd_backup_retention_count >= 0

--- a/roles/etcd/handlers/backup_cleanup.yml
+++ b/roles/etcd/handlers/backup_cleanup.yml
@@ -1,0 +1,11 @@
+---
+- name: Cleanup etcd backups
+  command: /bin/true
+  notify:
+    - Remove old etcd backups
+
+- name: Remove old etcd backups
+  shell:
+    chdir: "{{ etcd_backup_prefix }}"
+    cmd: "find . -name 'etcd-*' -type d | sort -n | head -n -{{ etcd_backup_retention_count }} | xargs rm -rf"
+  when: etcd_backup_retention_count >= 0

--- a/roles/etcd/handlers/main.yml
+++ b/roles/etcd/handlers/main.yml
@@ -6,6 +6,7 @@
     - etcd | reload systemd
     - reload etcd
     - wait for etcd up
+    - Cleanup etcd backups
 
 - name: restart etcd-events
   command: /bin/true
@@ -42,6 +43,8 @@
   until: result.status is defined and result.status == 200
   retries: 60
   delay: 1
+
+- import_tasks: backup_cleanup.yml
 
 - name: wait for etcd-events up
   uri:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
So far, when `etcd_backup_retention_count: 0`, the backup/snapshot is done but is removed right away (as well as older backups).
This PR moves the removal of old etcd backups after "reload etcd" (and especially "wait for etcd up") handler tasks.
This way, if etcd fails to restart (and `any_errors_fatal: true`), the backup is kept.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Move old etcd backup removal after etcd restart, to prevent removing backup if etcd fail
```
