### PR TITLE
Add kube-vip check to check_readme_versions.sh

### DIFF
--- a/tests/scripts/check_readme_versions.sh
+++ b/tests/scripts/check_readme_versions.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-TARGET_COMPONENTS="containerd calico cilium flannel kube-ovn kube-router weave cert-manager krew helm metallb registry cephfs-provisioner rbd-provisioner aws-ebs-csi-plugin azure-csi-plugin cinder-csi-plugin gcp-pd-csi-plugin local-path-provisioner local-volume-provisioner"
+TARGET_COMPONENTS="containerd calico cilium flannel kube-ovn kube-router weave cert-manager krew helm metallb registry cephfs-provisioner rbd-provisioner aws-ebs-csi-plugin azure-csi-plugin cinder-csi-plugin gcp-pd-csi-plugin local-path-provisioner local-volume-provisioner kube-vip"
 
 # cd to the root directory of kubespray
 cd $(dirname $0)/../../
@@ -18,6 +18,9 @@ fi
 for component in $(echo ${TARGET_COMPONENTS}); do
 	echo checking ${component}..
 	version_from_default=$(grep "^$(echo ${component} | sed s/"-"/"_"/g)_version:" ./roles/download/defaults/main.yml | awk '{print $2}' | sed s/\"//g | sed s/^v//)
+	if [ "${version_from_default}" = "" ]; then
+		version_from_default=$(grep "^$(echo ${component} | sed s/"-"/"_"/g)_version:" ./roles/kubernetes/node/defaults/main.yml | awk '{print $2}' | sed s/\"//g | sed s/^v//)
+	fi
 	version_from_readme=$(grep "\[${component}\]" ./README.md | grep "https" | awk '{print $3}' | sed s/^v//)
 	if [ "${version_from_default}" != "${version_from_readme}" ]; then
 		echo "The version of ${component} is different between main.yml(${version_from_default}) and README.md(${version_from_readme})."


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

To check the kube-vip version between readme.md and the default value on the role, this updates check_readme_versions.sh

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
