### PR TITLE
Disable DNSStubListener for Flatcar Linux

### DIFF
--- a/roles/kubernetes/preinstall/templates/resolved.conf.j2
+++ b/roles/kubernetes/preinstall/templates/resolved.conf.j2
@@ -10,7 +10,7 @@ Domains={{ ([ 'default.svc.' + dns_domain, 'svc.' + dns_domain ] + searchdomains
 #MulticastDNS=no
 DNSSEC=no
 Cache=no-negative
-{% if ansible_os_family in ["Flatcar Container Linux by Kinvolk"] %}
+{% if ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"] %}
 DNSStubListener=no
 {% else %}
 #DNSStubListener=yes

--- a/roles/kubernetes/preinstall/templates/resolved.conf.j2
+++ b/roles/kubernetes/preinstall/templates/resolved.conf.j2
@@ -10,4 +10,8 @@ Domains={{ ([ 'default.svc.' + dns_domain, 'svc.' + dns_domain ] + searchdomains
 #MulticastDNS=no
 DNSSEC=no
 Cache=no-negative
+{% if ansible_os_family in ["Flatcar Container Linux by Kinvolk"] %}
+DNSStubListener=no
+{% else %}
 #DNSStubListener=yes
+{% endif %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

There is a conflict between the host DNSStubListener and the CoreDNS deployed on Kubernetes in Flatcar Linux.

> 0.0.0.0:53: bind: address already in use

We can solve it by turning off the host `DNSStubListener`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Disabled DNSStubListener for Flatcar Linux
```
