### PR TITLE
Add 'avoid-buggy-ips' support of MetalLB

### DIFF
--- a/docs/metallb.md
+++ b/docs/metallb.md
@@ -19,6 +19,7 @@ You have to explicitly enable the MetalLB extension and set an IP address range 
 ```yaml
 metallb_enabled: true
 metallb_speaker_enabled: true
+metallb_avoid_buggy_ips: true
 metallb_ip_range:
   - 10.5.0.0/16
 ```
@@ -73,12 +74,13 @@ In this scenarion you should disable the MetalLB speaker and configure the `cali
 
 ```yaml
 metallb_speaker_enabled: false
+metallb_avoid_buggy_ips: true
 metallb_ip_range:
   - 10.5.0.0/16
 calico_advertise_service_loadbalancer_ips: "{{ metallb_ip_range }}"
 ```
 
-If you have additional loadbalancer IP pool in `metallb_additional_address_pools`, ensure to add them to the list.
+If you have additional loadbalancer IP pool in `metallb_additional_address_pools` , ensure to add them to the list.
 
 ```yaml
 metallb_speaker_enabled: false
@@ -90,11 +92,13 @@ metallb_additional_address_pools:
       - 10.6.0.0/16
     protocol: "bgp"
     auto_assign: false
+    avoid_buggy_ips: true
   kube_service_pool_2:
     ip_range:
       - 10.10.0.0/16
     protocol: "bgp"
     auto_assign: false
+    avoid_buggy_ips: true
 calico_advertise_service_loadbalancer_ips:
   - 10.5.0.0/16
   - 10.6.0.0/16

--- a/inventory/sample/group_vars/k8s_cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s_cluster/addons.yml
@@ -166,6 +166,7 @@ metallb_speaker_enabled: true
 #   - "10.5.0.50-10.5.0.99"
 # metallb_pool_name: "loadbalanced"
 # metallb_auto_assign: true
+# metallb_avoid_buggy_ips: false
 # metallb_speaker_nodeselector:
 #   kubernetes.io/os: "linux"
 # metallb_controller_nodeselector:
@@ -198,6 +199,7 @@ metallb_speaker_enabled: true
 #       - "10.5.1.50-10.5.1.99"
 #     protocol: "layer2"
 #     auto_assign: false
+#     avoid_buggy_ips: false
 # metallb_protocol: "bgp"
 # metallb_peers:
 #   - peer_address: 192.0.2.1
@@ -206,7 +208,6 @@ metallb_speaker_enabled: true
 #   - peer_address: 192.0.2.2
 #     peer_asn: 64513
 #     my_asn: 4200000000
-
 
 argocd_enabled: false
 # argocd_version: v2.4.7

--- a/roles/kubernetes-apps/metallb/defaults/main.yml
+++ b/roles/kubernetes-apps/metallb/defaults/main.yml
@@ -20,3 +20,4 @@ metallb_speaker_tolerations:
 metallb_controller_tolerations: []
 metallb_pool_name: "loadbalanced"
 metallb_auto_assign: true
+metallb_avoid_buggy_ips: false

--- a/roles/kubernetes-apps/metallb/templates/metallb-config.yml.j2
+++ b/roles/kubernetes-apps/metallb/templates/metallb-config.yml.j2
@@ -34,6 +34,9 @@ data:
 {% if metallb_auto_assign == false %}
       auto-assign: false
 {% endif %}
+{% if metallb_avoid_buggy_ips == true %}
+      avoid-buggy-ips: true
+{% endif %}
 {% if metallb_additional_address_pools is defined %}{% for pool in metallb_additional_address_pools %}
     - name: {{ pool }}
       protocol: {{ metallb_additional_address_pools[pool].protocol }}
@@ -41,6 +44,11 @@ data:
 {% for ip_range in metallb_additional_address_pools[pool].ip_range %}
       - {{ ip_range }}
 {% endfor %}
+{% if metallb_additional_address_pools[pool].auto_assign is defined %}
       auto-assign: {{ metallb_additional_address_pools[pool].auto_assign }}
+{% endif %}
+{% if metallb_additional_address_pools[pool].avoid_buggy_ips is defined %}
+      avoid-buggy-ips: {{ metallb_additional_address_pools[pool].avoid_buggy_ips }}
+{% endif %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

`avoid-buggy-ips` is a kind of feature of MetalLB, and it has a function to prevent load-balancing of IPs that are practically unavailable such as:
* `192.168.0.0`, `192.168.0.255` in 192.168.0.0/24

This feature is disabled in MetalLB by default, but there is no manual in Kubespray.
So when I try to use MetalLB with CIDR IP subnets, these useless IPs are necessarily assigned.

Therefore, I thought that this function should be controllable in Kubespray as well, and I implemented it as follows:
* `metallb_avoid_buggy_ips` for default IP address pool
* `avoid_buggy_ips` for additional IP address pools defined in `metallb_additional_address_pools`

## Examples

```yaml
metallb_enabled: true
metallb_ip_range:
  - 10.5.0.0/16
metallb_avoid_buggy_ips: true  # new feature
metallb_additional_address_pools:
  kube_service_pool_1:
    ip_range:
      - 10.6.0.0/16
    protocol: "bgp"
    auto_assign: false
    avoid_buggy_ips: true  # new feature
  kube_service_pool_2:
    ip_range:
      - 10.10.0.0/16
    protocol: "bgp"
    auto_assign: false
    avoid_buggy_ips: true  # new feature
```

Separately, I added this to the `docs/metallb.md` documentation as examples to indicate that it can be used.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4158 (MetalLB configuration via Inventory)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
* Added 'avoid-buggy-ips' support of MetalLB
    * `metallb_avoid_buggy_ips` for default IP address pool
    * `avoid_buggy_ips` for additional IP address pools defined in `metallb_additional_address_pools`
* As the newly added feature uses the default value of MetalLB as same, there is no side effect for users who do not change it's value.
```
