### PR TITLE
Add 'flush ip6tables' task in reset role

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -205,6 +205,20 @@
   tags:
     - iptables
 
+- name: flush ip6tables
+  iptables:
+    table: "{{ item }}"
+    flush: yes
+    ip_version: ipv6
+  with_items:
+    - filter
+    - nat
+    - mangle
+    - raw
+  when: flush_iptables|bool and enable_dual_stack_networks
+  tags:
+    - ip6tables
+
 - name: Clear IPVS virtual server table
   command: "ipvsadm -C"
   ignore_errors: true  # noqa ignore-errors


### PR DESCRIPTION
If enable_dual_stack_networks is set to true and ip6 is defined，ip6tables will be created. But when reset the kubernetes cluster, kubespray doesn't flush ip6tables.

**What type of PR is this?**
> /kind feature


**What this PR does / why we need it**:
If enable_dual_stack_networks is set to true and ip6 is defined，ip6tables will be created. But when reset the kubernetes cluster, kubespray doesn't flush ip6tables.

**Which issue(s) this PR fixes**:
Fixes #9167

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
