### PR TITLE
9035: Make Cilium rolling-restart delay/timeout configurable

### DIFF
--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -236,3 +236,7 @@ cilium_enable_bpf_clock_probe: true
 
 # -- Whether to enable CNP status updates.
 cilium_disable_cnp_status_updates: true
+
+# Configure how long to wait for the Cilium DaemonSet to be ready again
+cilium_rolling_restart_wait_retries_count: 30
+cilium_rolling_restart_wait_retries_delay_seconds: 10

--- a/roles/network_plugin/cilium/tasks/apply.yml
+++ b/roles/network_plugin/cilium/tasks/apply.yml
@@ -14,8 +14,8 @@
   command: "{{ kubectl }} -n kube-system get pods -l k8s-app=cilium -o jsonpath='{.items[?(@.status.containerStatuses[0].ready==false)].metadata.name}'"  # noqa 601
   register: pods_not_ready
   until: pods_not_ready.stdout.find("cilium")==-1
-  retries: 30
-  delay: 10
+  retries: "{{ cilium_rolling_restart_wait_retries_count | int }}"
+  delay: "{{ cilium_rolling_restart_wait_retries_delay_seconds | int }}"
   failed_when: false
   when: inventory_hostname == groups['kube_control_plane'][0]
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Allows overriding the Cilium DaemonSet rolling-restart timeouts on Kubespray's side to accomodate larger clusters.

**Which issue(s) this PR fixes**:

Fixes #9035

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[cilium] Make rolling-restart readiness wait delay and count configurable via `cilium_rolling_restart_wait_retries_{count, delay_seconds}`
```
