### PR TITLE
add list/watch nodes rules to cilium-operator clusterrole

### DIFF
--- a/roles/network_plugin/cilium/templates/cilium-operator/cr.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-operator/cr.yml.j2
@@ -51,12 +51,10 @@ rules:
 - apiGroups:
   - ""
   resources:
-{% if cilium_version | regex_replace('v') is version('1.8', '<') %}
   # to automatically read from k8s and import the node's pod CIDR to cilium's
   # etcd so all nodes know how to reach another pod running in in a different
   # node.
   - nodes
-{% endif %}
   # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Cilium operator v1.12.0 needs list/watch node roles, otherwise it will report an error:

```log
Failed to watch *v1.Node: failed to list *v1.Node: nodes is forbidden: User \"system:serviceaccount:kube-system:cilium-operator\" cannot list resource \"nodes\" in API group \"\" at the cluster scope" subsys=k8s
```

See the [official helm charts](https://github.com/cilium/cilium/blob/4bd2478db37a6859c57372dcc97ac43922d26e90/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml#L28).

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

None.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[Cilium] Add list/watch nodes rules to cilium-operator clusterrole.
```
