### PR TITLE
[containerd] upgrade to 1.6.8 , add hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [kubernetes](https://github.com/kubernetes/kubernetes) v1.24.3
   - [etcd](https://github.com/etcd-io/etcd) v3.5.4
   - [docker](https://www.docker.com/) v20.10 (see note)
-  - [containerd](https://containerd.io/) v1.6.6
+  - [containerd](https://containerd.io/) v1.6.8
   - [cri-o](http://cri-o.io/) v1.24 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)
 - Network Plugin
   - [cni-plugins](https://github.com/containernetworking/plugins) v1.1.1

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -74,7 +74,7 @@ runc_version: v1.1.3
 kata_containers_version: 2.4.1
 youki_version: 0.0.1
 gvisor_version: 20210921
-containerd_version: 1.6.6
+containerd_version: 1.6.8
 cri_dockerd_version: 0.2.2
 
 # this is relevant when container_manager == 'docker'
@@ -753,6 +753,8 @@ containerd_archive_checksums:
     1.6.4: 0
     1.6.5: 0
     1.6.6: 0
+    1.6.7: 0
+    1.6.8: 0
   arm64:
     1.5.5: 0
     1.5.7: 0
@@ -769,6 +771,8 @@ containerd_archive_checksums:
     1.6.4: 0205bd1907154388dc85b1afeeb550cbb44c470ef4a290cb1daf91501c85cae6
     1.6.5: 2833e2f0e8f3cb5044566d64121fdd92bbdfe523e9fe912259e936af280da62a
     1.6.6: 807bf333df331d713708ead66919189d7b142a0cc21ec32debbc988f9069d5eb
+    1.6.7: 4167bf688a0ed08b76b3ac264b90aad7d9dd1424ad9c3911e9416b45e37b0be5
+    1.6.8: b114e36ecce78cef9d611416c01b784a420928c82766d6df7dc02b10d9da94cd
   amd64:
     1.5.5: 8efc527ffb772a82021800f0151374a3113ed2439922497ff08f2596a70f10f1
     1.5.7: 109fc95b86382065ea668005c376360ddcd8c4ec413e7abe220ae9f461e0e173
@@ -785,6 +789,8 @@ containerd_archive_checksums:
     1.6.4: f23c8ac914d748f85df94d3e82d11ca89ca9fe19a220ce61b99a05b070044de0
     1.6.5: cf02a2da998bfcf61727c65ede6f53e89052a68190563a1799a7298b0cea86b4
     1.6.6: 0212869675742081d70600a1afc6cea4388435cc52bf5dc21f4efdcb9a92d2ef
+    1.6.7: 52e817b712d521b193773529ff33626f47507973040c02474a2db95a37da1c37
+    1.6.8: 3a1322c18ee5ff4b9bd5af6b7b30c923a3eab8af1df05554f530ef8e2b24ac5e
   ppc64le:
     1.5.5: 0
     1.5.7: 0
@@ -801,6 +807,8 @@ containerd_archive_checksums:
     1.6.4: 0
     1.6.5: 0
     1.6.6: 0
+    1.6.7: 0db5cb6d5dd4f3b7369c6945d2ec29a9c10b106643948e3224e53885f56863a9
+    1.6.8: f18769721f614828f6b778030c72dc6969ce2108f2363ddc85f6c7a147df0fb8
 
 etcd_binary_checksum: "{{ etcd_binary_checksums[image_arch][etcd_version] }}"
 cni_binary_checksum: "{{ cni_binary_checksums[image_arch][cni_version] }}"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add hashes for containerd versions 1.6.7 , 1.6.8 and make version 1.6.8 default. containerd now supports pc64le starting with version 1.6.7.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Make containerd 1.6.8 default
containerd supports pc64le starting from version 1.6.7
```
