### PR TITLE
:seedling: Enable cri-dockerd service

### DIFF
--- a/roles/container-engine/cri-dockerd/handlers/main.yml
+++ b/roles/container-engine/cri-dockerd/handlers/main.yml
@@ -1,10 +1,11 @@
 ---
-- name: restart cri-dockerd
+- name: restart and enable cri-dockerd
   command: /bin/true
   notify:
     - cri-dockerd | reload systemd
     - cri-dockerd | reload cri-dockerd.socket
     - cri-dockerd | reload cri-dockerd.service
+    - cri-dockerd | enable cri-dockerd service
 
 - name: cri-dockerd | reload systemd
   systemd:
@@ -21,3 +22,8 @@
   service:
     name: cri-dockerd.service
     state: restarted
+
+- name: cri-dockerd | enable cri-dockerd service
+  service:
+    name: cri-dockerd.service
+    enabled: yes


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
In case the usage of `docker` as CRI (Container Runtime Interface), there are situations where the kubelet stop working properly and there is nothing helpful after going through its log using `journalctl -xfu kubelet.service` command. The problem is initiated where one of the nodes of the cluster is rebooted unintentionally. Since the `cri-dockerd` service is not enabled, the node will stop working (because of the issue occurred with kubelet that not running any longer) and it would be out of service. In order to resolve this problem it is necessary to enable the `cri-dockerd` service at boot time. In this merge request I have added the mentioned functionality to Kubespray. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9140 #8850 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
None
```
