### PR TITLE
do not run etcd role in scale.yml playbook when etcd installed by kub…

### DIFF
--- a/scale.yml
+++ b/scale.yml
@@ -33,7 +33,12 @@
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
-    - { role: etcd, tags: etcd, etcd_cluster_setup: false }
+    - role: etcd
+      tags: etcd
+      vars:
+        etcd_cluster_setup: false
+        etcd_events_cluster_setup: false
+      when: etcd_deployment_type != "kubeadm"
 
 - name: Download images to ansible host cache via first kube_control_plane node
   hosts: kube_control_plane[0]


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

when `etcd_deployment_type: kubeadm`
playbook scale.yml failed with this error:
```
2022-08-23 11:09:47,802 p=17209 u=root n=ansible | TASK [etcd : include_tasks] *******************************************************************************
***************************************************
2022-08-23 11:09:47,970 p=17209 u=root n=ansible | fatal: [master-1]: FAILED! => {"reason": "Could not find or access '/srv/install-cluster
/kubespray/install_kubeadm.yml' on the Ansible Controller."}```
```

on this task
```
- include_tasks: "install_{{ etcd_deployment_type }}.yml"
  when: is_etcd_master
  tags:
    - upgrade
```
