### PR TITLE
Fix abort because calicoctl.sh is not a full path

### DIFF
--- a/roles/network_plugin/calico/tasks/check.yml
+++ b/roles/network_plugin/calico/tasks/check.yml
@@ -137,7 +137,7 @@
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
 
 - name: "Get Calico {{ calico_pool_name }} configuration"
-  command: calicoctl.sh get ipPool {{ calico_pool_name }} -o json
+  command: "{{ bin_dir }}/calicoctl.sh get ipPool {{ calico_pool_name }} -o json"
   failed_when: False
   changed_when: False
   check_mode: no


### PR DESCRIPTION
- Fixes #9214

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Abort because calicoctl.sh is not a full path

**Which issue(s) this PR fixes**:
Fixes #9214

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fix calicoctl.sh path error when getting calico configuration
```