### PR TITLE
Fix kube_ovn_hw_offload value

### DIFF
--- a/roles/network_plugin/kube-ovn/templates/cni-ovn.yml.j2
+++ b/roles/network_plugin/kube-ovn/templates/cni-ovn.yml.j2
@@ -369,7 +369,7 @@ spec:
                   fieldPath: status.podIP
 {% if not kube_ovn_dpdk_enabled %}
             - name: HW_OFFLOAD
-              value: "{{ kube_ovn_hw_offload }}"
+              value: "{{ kube_ovn_hw_offload | string | lower }}"
             - name: TUNNEL_TYPE
               value: "{{ kube_ovn_tunnel_type }}"
 {% endif %}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix kubeovn value comparison 

**Which issue(s) this PR fixes**:
Fixes #9198

**Special notes for your reviewer**:
https://github.com/kubeovn/kube-ovn/blob/70f1b141ca7f5c58e64a46c9dd8f89a0e1d82df8/dist/images/start-ovs.sh#L60

**Does this PR introduce a user-facing change?**:
```release-note
Fix kubeovn value check for `HW_OFFLOAD`
```
