### PR TITLE
kube-vip shoud fail if kube_proxy_strict_arp is false in arp mod

### DIFF
--- a/docs/kube-vip.md
+++ b/docs/kube-vip.md
@@ -2,6 +2,14 @@
 
 kube-vip provides Kubernetes clusters with a virtual IP and load balancer for both the control plane (for building a highly-available cluster) and Kubernetes Services of type LoadBalancer without relying on any external hardware or software.
 
+## Prerequisites
+
+You have to configure `kube_proxy_strict_arp` when the kube_proxy_mode is `ipvs` and kube-vip ARP is enabled.
+
+```yaml
+kube_proxy_strict_arp: true
+```
+
 ## Install
 
 You have to explicitly enable the kube-vip extension:

--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -125,7 +125,7 @@ kube_apiserver_port: 6443  # (https)
 kube_proxy_mode: ipvs
 
 # configure arp_ignore and arp_announce to avoid answering ARP queries from kube-ipvs0 interface
-# must be set to true for MetalLB to work
+# must be set to true for MetalLB, kube-vip(ARP enabled) to work
 kube_proxy_strict_arp: false
 
 # A string slice of values which specify the addresses to use for NodePorts.

--- a/roles/kubernetes/control-plane/defaults/main/kube-proxy.yml
+++ b/roles/kubernetes/control-plane/defaults/main/kube-proxy.yml
@@ -77,7 +77,7 @@ kube_proxy_exclude_cidrs: []
 kube_proxy_scheduler: rr
 
 # configure arp_ignore and arp_announce to avoid answering ARP queries from kube-ipvs0 interface
-# must be set to true for MetalLB to work
+# must be set to true for MetalLB, kube-vip(ARP enabled) to work
 kube_proxy_strict_arp: false
 
 # kube_proxy_tcp_timeout is the timeout value used for idle IPVS TCP sessions.

--- a/roles/kubernetes/node/tasks/loadbalancer/kube-vip.yml
+++ b/roles/kubernetes/node/tasks/loadbalancer/kube-vip.yml
@@ -1,4 +1,11 @@
 ---
+- name: kube-vip  | Check cluster settings for kube-vip
+  fail:
+    msg: "kube-vip require kube_proxy_strict_arp = true, see https://github.com/kube-vip/kube-vip/blob/main/docs/kubernetes/arp/index.md"
+  when:
+    - kube_proxy_mode == 'ipvs' and not kube_proxy_strict_arp
+    - kube_vip_arp_enabled
+
 - name: kube-vip | Write static pod
   template:
     src: manifests/kube-vip.manifest.j2


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug


**What this PR does / why we need it**:

Like MetalLB : https://github.com/kubernetes-sigs/kubespray/pull/5180 ,
The Kube-VIP in ARP-mod should set kube_proxy_strict_arp=false, according to it's official docs: https://github.com/kube-vip/kube-vip/blob/main/docs/kubernetes/arp/index.md

**Which issue(s) this PR fixes**:

Fixes # 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
kube-vip will now fail if `kube_proxy_strict_arp` is set to `false` in arp mode
```