### PR TITLE
Fixes for calico_datastore: etcd

### DIFF
--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -451,6 +451,7 @@
     - {name: calico, file: calico-ipamconfig.yml, type: ipam}
   when:
     - inventory_hostname in groups['kube_control_plane']
+    - calico_datastore == "kdd"
 
 - name: Calico | Create ipamconfig resources
   kube:
@@ -459,6 +460,7 @@
     state: "latest"
   when:
     - inventory_hostname == groups['kube_control_plane'][0]
+    - calico_datastore == "kdd"
 
 - include_tasks: peer_with_calico_rr.yml
   when:

--- a/roles/network_plugin/calico/templates/calico-cr.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-cr.yml.j2
@@ -157,6 +157,7 @@ rules:
       - daemonsets
     verbs:
       - get
+{% endif %}
   # Used for creating service account tokens to be used by the CNI plugin
   - apiGroups: [""]
     resources:
@@ -165,4 +166,3 @@ rules:
       - calico-node
     verbs:
       - create
-{% endif %}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

It seems that PR #8839 broke `calico_datastore: etcd` when it removed ipamconfig support for etcd mode.

This PR fixes some failing tasks when `calico_datastore == etcd`, but it does not restore ipamconfig support for calico in etcd mode. If someone wants to restore ipamconfig support for `calico_datastore: etcd` please submit a follow up PR for that.

**Which issue(s) this PR fixes**:
Fixes #8917
