### PR TITLE
Fix CRI socket reference within cri-dockerd service

### DIFF
--- a/roles/container-engine/cri-dockerd/templates/cri-dockerd.service.j2
+++ b/roles/container-engine/cri-dockerd/templates/cri-dockerd.service.j2
@@ -7,7 +7,7 @@ Requires=cri-dockerd.socket
 
 [Service]
 Type=notify
-ExecStart={{ bin_dir }}/cri-dockerd --container-runtime-endpoint {{ cri_socket }} --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin --network-plugin=cni --pod-cidr={{ kube_pods_subnet }} --pod-infra-container-image={{ pod_infra_image_repo }}:{{ pod_infra_version }} {% if enable_dual_stack_networks %}--ipv6-dual-stack=True{% endif %}
+ExecStart={{ bin_dir }}/cri-dockerd --container-runtime-endpoint unix://{{ cri_socket }} --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin --network-plugin=cni --pod-cidr={{ kube_pods_subnet }} --pod-infra-container-image={{ pod_infra_image_repo }}:{{ pod_infra_version }} {% if enable_dual_stack_networks %}--ipv6-dual-stack=True{% endif %}
 
 ExecReload=/bin/kill -s HUP $MAINPID
 TimeoutSec=0


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When installing using `docker` as the container manager `container_manager: docker` the installation fails when restarting `cri-dockerd` service: 

```bash
RUNNING HANDLER [container-engine/cri-dockerd : cri-dockerd | reload cri-dockerd.service] *************************************************************************************************************************
» Tuesday 30 August 2022  08:17:39 +0000 (0:00:00.980)       0:08:51.755 ****** 
fatal: [kube-control-plane-gx03l4zz]: FAILED! => changed=false 
  msg: |-
    Unable to start service cri-dockerd.service: Job for cri-dockerd.service failed because the control process exited with error code.
    See "systemctl status cri-dockerd.service" and "journalctl -xe" for details.
fatal: [kube-node-dz6jn4z3]: FAILED! => changed=false 
  msg: |-
    Unable to start service cri-dockerd.service: Job for cri-dockerd.service failed because the control process exited with error code.
    See "systemctl status cri-dockerd.service" and "journalctl -xe" for details.
fatal: [kube-node-ey04m560]: FAILED! => changed=false 
  msg: |-
    Unable to start service cri-dockerd.service: Job for cri-dockerd.service failed because the control process exited with error code.
    See "systemctl status cri-dockerd.service" and "journalctl -xe" for details.
fatal: [kube-node-g04l37v7]: FAILED! => changed=false 
  msg: |-
    Unable to start service cri-dockerd.service: Job for cri-dockerd.service failed because the control process exited with error code.
    See "systemctl status cri-dockerd.service" and "journalctl -xe" for details.
fatal: [kube-node-e14m3jwx]: FAILED! => changed=false 
  msg: |-
    Unable to start service cri-dockerd.service: Job for cri-dockerd.service failed because the control process exited with error code.
    See "systemctl status cri-dockerd.service" and "journalctl -xe" for details.
```

If we take a look at `cri-dockerd` logs, we see the following error:

```bash
-- Unit cri-dockerd.service has finished shutting down.
ago 30 10:48:22 node01.eosdev.labs.stratio.com systemd[1]: Starting CRI Interface for Docker Application Container Engine...
-- Subject: Unit cri-dockerd.service has begun start-up
-- Defined-By: systemd
-- Support: https://access.redhat.com/support
-- 
-- Unit cri-dockerd.service has begun starting up.
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]: time="2022-08-30T10:48:22+02:00" level=info msg="Connecting to docker on the Endpoint unix:///var/run/docker.sock"
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]: time="2022-08-30T10:48:22+02:00" level=info msg="Start docker client with request timeout 0s"
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]: time="2022-08-30T10:48:22+02:00" level=info msg="Hairpin mode is set to none"
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]: time="2022-08-30T10:48:22+02:00" level=debug msg="Unable to update cni config: no networks found in /etc/cni/net.d"
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]: time="2022-08-30T10:48:22+02:00" level=debug msg="Unable to update cni config: no networks found in /etc/cni/net.d"
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]: time="2022-08-30T10:48:22+02:00" level=info msg="Loaded network plugin cni"
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]: time="2022-08-30T10:48:22+02:00" level=info msg="Docker cri networking managed by network plugin cni"
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]: time="2022-08-30T10:48:22+02:00" level=debug msg="Unable to update cni config: no networks found in /etc/cni/net.d"
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]: time="2022-08-30T10:48:22+02:00" level=info msg="Docker Info: &{ID:5HSL:ETNL:RKJ3:RUYH:HL3H:QKN6:ZL7Z:UKNC:AQDQ:EQHR:B3MK:52AA Containers:0 Con>
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]: time="2022-08-30T10:48:22+02:00" level=info msg="Setting cgroupDriver systemd"
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]: time="2022-08-30T10:48:22+02:00" level=info msg="Docker cri received runtime config &RuntimeConfig{NetworkConfig:&NetworkConfig{PodCidr:172.16.>
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]: time="2022-08-30T10:48:22+02:00" level=info msg="Starting the GRPC backend for the Docker CRI interface."
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]: time="2022-08-30T10:48:22+02:00" level=info msg="Start cri-dockerd grpc backend"
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]: panic: runtime error: index out of range [1] with length 1
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]: goroutine 1 [running]:
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]: github.com/Mirantis/cri-dockerd/backend.getListener({0x7ffc454c2e28, 0x19})
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]:         /home/rbarry/go/src/github.com/Mirantis/cri-dockerd/backend/daemon.go:58 +0xa5
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]: github.com/Mirantis/cri-dockerd/backend.(*CriDockerServer).Start(0xc0005e9020)
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]:         /home/rbarry/go/src/github.com/Mirantis/cri-dockerd/backend/daemon.go:76 +0x13b
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]: github.com/Mirantis/cri-dockerd/cmd.RunCriDockerd(0xc000364b00, 0x5?)
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]:         /home/rbarry/go/src/github.com/Mirantis/cri-dockerd/cmd/server.go:202 +0x4b8
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]: github.com/Mirantis/cri-dockerd/cmd.NewDockerCRICommand.func1(0x0?, {0xc000138010?, 0x18533ec?, 0xb?})
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]:         /home/rbarry/go/src/github.com/Mirantis/cri-dockerd/cmd/server.go:111 +0x706
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]: github.com/spf13/cobra.(*Command).execute(0xc0001f98c0, {0xc000138010, 0x8, 0x8})
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]:         /home/rbarry/go/src/github.com/Mirantis/cri-dockerd/vendor/github.com/spf13/cobra/command.go:854 +0x663
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]: github.com/spf13/cobra.(*Command).ExecuteC(0xc0001f98c0)
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]:         /home/rbarry/go/src/github.com/Mirantis/cri-dockerd/vendor/github.com/spf13/cobra/command.go:958 +0x39c
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]: github.com/spf13/cobra.(*Command).Execute(...)
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]:         /home/rbarry/go/src/github.com/Mirantis/cri-dockerd/vendor/github.com/spf13/cobra/command.go:895
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]: main.main()
ago 30 10:48:22 node01.eosdev.labs.stratio.com cri-dockerd[37238]:         /home/rbarry/go/src/github.com/Mirantis/cri-dockerd/main.go:38 +0xc5
ago 30 10:48:22 node01.eosdev.labs.stratio.com systemd[1]: cri-dockerd.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
ago 30 10:48:22 node01.eosdev.labs.stratio.com systemd[1]: cri-dockerd.service: Failed with result 'exit-code'.
```

If we take a look at the `cri-dockerd` [code](https://github.com/Mirantis/cri-dockerd/blob/v0.2.2/backend/daemon.go#L58) we see that the expect the socket with the following format:

```bash
protocol://address
```

So, the goal of this PR is to fit `cri-dockerd` requirements.

**Special notes for your reviewer**:

Let me know if you have any doubs :smile: 
