### PR TITLE
Fixes for calico etcd mode (2.19 backport)

### DIFF
--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -582,6 +582,7 @@
     - {name: calico, file: calico-ipamconfig.yml, type: ipam}
   when:
     - inventory_hostname in groups['kube_control_plane']
+    - calico_datastore == "kdd"
 
 - name: Calico | Create ipamconfig resources
   kube:
@@ -590,3 +591,4 @@
     state: "latest"
   when:
     - inventory_hostname == groups['kube_control_plane'][0]
+    - calico_datastore == "kdd"


### PR DESCRIPTION
release-2.19 backport of #9228

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

It seems that PR #8839 broke `calico_datastore: etcd` when it removed ipamconfig support for etcd mode.

This PR fixes some failing tasks when `calico_datastore == etcd`, but it does not restore ipamconfig support for calico in etcd mode. If someone wants to restore ipamconfig support for `calico_datastore: etcd` please submit a follow up PR for that.

**Which issue(s) this PR fixes**:
Fixes #8917

**Does this PR introduce a user-facing change?**:
```release-note
Fix failing tasks when calico_datastore is set to etcd
```