### PR TITLE
Ignore deleting worker nodes that are not in cluster

### DIFF
--- a/roles/remove-node/post-remove/tasks/main.yml
+++ b/roles/remove-node/post-remove/tasks/main.yml
@@ -2,7 +2,8 @@
 - name: remove-node | Delete node
   command: "{{ kubectl }} delete node {{ kube_override_hostname|default(inventory_hostname) }}"
   delegate_to: "{{ groups['kube_control_plane']|first }}"
-  when: inventory_hostname in groups['k8s_cluster']
+  # ignore servers that are not nodes
+  when: inventory_hostname in groups['k8s_cluster'] and inventory_hostname in nodes.stdout_lines
   retries: "{{ delete_node_retries }}"
   # Sometimes the api-server can have a short window of indisponibility when we delete a master node
   delay: "{{ delete_node_delay_seconds }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

There is a bug that `remove-node.yml` tries to remove the worker nodes that are actually not in the cluster and emits an error.

In fact, there have been several mechanisms to exclude 'ghost' nodes from deleting such as:
- `nodes` variable in https://github.com/kubernetes-sigs/kubespray/blob/master/roles/remove-node/pre-remove/tasks/main.yml#L18

However, this implementation was not applied in the `post-remove` process, and this caused the process to eventually crash.
- https://github.com/kubernetes-sigs/kubespray/blob/master/roles/remove-node/post-remove/tasks/main.yml

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
No more errors are emitted when attempting to delete worker nodes that do not exist.
```
