### PR TITLE
Add Support for Rewrite Plugin to CoreDNS/NodelocalDNS

### DIFF
--- a/docs/dns-stack.md
+++ b/docs/dns-stack.md
@@ -62,6 +62,13 @@ coredns_external_zones:
   nameservers:
   - 192.168.0.53
   cache: 0
+- zones:
+  - mydomain.tld
+  nameservers:
+  - 10.233.0.3
+  cache: 5
+  rewrite:
+  - name stop website.tld website.namespace.svc.cluster.local
 ```
 
 or as INI

--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -185,6 +185,13 @@ nodelocaldns_secondary_skew_seconds: 5
 #   nameservers:
 #   - 192.168.0.53
 #   cache: 0
+# - zones:
+#   - mydomain.tld
+#   nameservers:
+#   - 10.233.0.3
+#   cache: 5
+#   rewrite:
+#   - name website.tld website.namespace.svc.cluster.local
 # Enable k8s_external plugin for CoreDNS
 enable_coredns_k8s_external: false
 coredns_k8s_external_zone: k8s_external.local

--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -13,6 +13,11 @@ data:
     {{ block['zones'] | join(' ') }} {
         log
         errors
+{% if block['rewrite'] is defined and block['rewrite']|length > 0 %}
+{% for rewrite_match in block['rewrite'] %}
+        rewrite {{ rewrite_match }}
+{% endfor %}
+{% endif %}
         forward . {{ block['nameservers'] | join(' ') }}
         loadbalance
         cache {{ block['cache'] | default(5) }}

--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2
@@ -14,6 +14,11 @@ data:
         errors
         cache {{ block['cache'] | default(30) }}
         reload
+{% if block['rewrite'] is defined and block['rewrite']|length > 0 %}
+{% for rewrite_match in block['rewrite'] %}
+        rewrite {{ rewrite_match }}
+{% endfor %}
+{% endif %}
         loop
         bind {{ nodelocaldns_ip }}
         forward . {{ block['nameservers'] | join(' ') }}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds support for the usage of CoreDNS plugin rewrite: https://coredns.io/plugins/rewrite/
This allows to rewrite for example external domains to internal kubernetes service names before passing the query to upstream dns

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I did not found an variable for the CoreDNS Cluster IP, therefore i added the standard `10.233.0.3` hardcoded in the examples.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
