### PR TITLE
Avoid MetalLB speaker image download when MetalLB speaker is disabled

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s_cluster/addons.yml
@@ -161,7 +161,7 @@ cert_manager_enabled: false
 
 # MetalLB deployment
 metallb_enabled: false
-metallb_speaker_enabled: true
+metallb_speaker_enabled: "{{ metallb_enabled }}"
 # metallb_ip_range:
 #   - "10.5.0.50-10.5.0.99"
 # metallb_pool_name: "loadbalanced"

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -1647,7 +1647,7 @@ downloads:
     - kube_control_plane
 
   metallb_speaker:
-    enabled: "{{ metallb_enabled }}"
+    enabled: "{{ metallb_speaker_enabled }}"
     container: true
     repo: "{{ metallb_speaker_image_repo }}"
     tag: "{{ metallb_version }}"

--- a/roles/kubernetes-apps/metallb/defaults/main.yml
+++ b/roles/kubernetes-apps/metallb/defaults/main.yml
@@ -5,6 +5,7 @@ metallb_protocol: "layer2"
 metallb_port: "7472"
 metallb_memberlist_port: "7946"
 metallb_peers: []
+metallb_speaker_enabled: true
 metallb_speaker_nodeselector:
   kubernetes.io/os: "linux"
 metallb_controller_nodeselector:

--- a/roles/kubernetes-apps/metallb/defaults/main.yml
+++ b/roles/kubernetes-apps/metallb/defaults/main.yml
@@ -5,7 +5,6 @@ metallb_protocol: "layer2"
 metallb_port: "7472"
 metallb_memberlist_port: "7946"
 metallb_peers: []
-metallb_speaker_enabled: true
 metallb_speaker_nodeselector:
   kubernetes.io/os: "linux"
 metallb_controller_nodeselector:

--- a/roles/kubernetes-apps/metallb/defaults/main.yml
+++ b/roles/kubernetes-apps/metallb/defaults/main.yml
@@ -5,7 +5,7 @@ metallb_protocol: "layer2"
 metallb_port: "7472"
 metallb_memberlist_port: "7946"
 metallb_peers: []
-metallb_speaker_enabled: true
+metallb_speaker_enabled: "{{ metallb_enabled }}"
 metallb_speaker_nodeselector:
   kubernetes.io/os: "linux"
 metallb_controller_nodeselector:

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -409,6 +409,7 @@ ingress_alb_enabled: false
 cert_manager_enabled: false
 expand_persistent_volumes: false
 metallb_enabled: false
+metallb_speaker_enabled: true
 argocd_enabled: false
 
 ## When OpenStack is used, Cinder version can be explicitly specified if autodetection fails (Fixed in 1.9: https://github.com/kubernetes/kubernetes/issues/50461)

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -409,7 +409,7 @@ ingress_alb_enabled: false
 cert_manager_enabled: false
 expand_persistent_volumes: false
 metallb_enabled: false
-metallb_speaker_enabled: true
+metallb_speaker_enabled: "{{ metallb_enabled }}"
 argocd_enabled: false
 
 ## When OpenStack is used, Cinder version can be explicitly specified if autodetection fails (Fixed in 1.9: https://github.com/kubernetes/kubernetes/issues/50461)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Both MetalLB controller and MetalLB speaker are downloaded when `metallb_enabled: true` since https://github.com/kubernetes-sigs/kubespray/pull/8715.

Since MetalLB speaker can be disabled, its image should be only downloaded when `metallb_speaker_enabled: true`