### PR TITLE
Remove mutual exclusivity in calico: NAT and router mode

### DIFF
--- a/docs/calico.md
+++ b/docs/calico.md
@@ -80,12 +80,6 @@ you'll need to edit the inventory and add a hostvar `local_as` by node.
 node1 ansible_ssh_host=95.54.0.12 local_as=xxxxxx
 ```
 
-In another cases you may want to utilize `peer_with_router` with NAT.
-Then the following variables need to be set:
-
-* `nat_outgoing` to enable NAT (default value: true).
-* `peer_with_router_nat_outgoing` to forcefully enable NAT (default value: false).
-
 ### Optional : Defining BGP peers
 
 Peers can be defined using the `peers` variable (see docs/calico_peer_example examples).

--- a/docs/calico.md
+++ b/docs/calico.md
@@ -80,6 +80,11 @@ you'll need to edit the inventory and add a hostvar `local_as` by node.
 node1 ansible_ssh_host=95.54.0.12 local_as=xxxxxx
 ```
 
+In another cases you may want to utilize `peer_with_router` with NAT.
+Then the following variables need to be set:
+* `nat_outgoing` to enable NAT (default value: true).
+* `peer_with_router_nat_outgoing` to forcefully enable NAT (default value: false).
+
 ### Optional : Defining BGP peers
 
 Peers can be defined using the `peers` variable (see docs/calico_peer_example examples).

--- a/docs/calico.md
+++ b/docs/calico.md
@@ -72,9 +72,14 @@ calico_pool_cidr_ipv6: fd85:ee78:d8a6:8607::1:0000/112
 
 In some cases you may want to route the pods subnet and so NAT is not needed on the nodes.
 For instance if you have a cluster spread on different locations and you want your pods to talk each other no matter where they are located.
-The following variables need to be set:
-`peer_with_router` to enable the peering with the datacenter's border router (default value: false).
-you'll need to edit the inventory and add a hostvar `local_as` by node.
+The following variables need to be set as follow:
+
+```yml
+peer_with_router: true  # enable the peering with the datacenter's border router (default value: false).
+nat_outgoing: false  # (optional) NAT outgoing (default value: true).
+```
+
+And you'll need to edit the inventory and add a hostvar `local_as` by node.
 
 ```ShellSession
 node1 ansible_ssh_host=95.54.0.12 local_as=xxxxxx

--- a/docs/calico.md
+++ b/docs/calico.md
@@ -82,6 +82,7 @@ node1 ansible_ssh_host=95.54.0.12 local_as=xxxxxx
 
 In another cases you may want to utilize `peer_with_router` with NAT.
 Then the following variables need to be set:
+
 * `nat_outgoing` to enable NAT (default value: true).
 * `peer_with_router_nat_outgoing` to forcefully enable NAT (default value: false).
 

--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-calico.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-calico.yml
@@ -9,9 +9,6 @@ calico_cni_name: k8s-pod-network
 ## The subnets of each nodes will be distributed by the datacenter router
 # peer_with_router: false
 
-# Enables Internet connectivity from containers while using peer_with_router
-# peer_with_router_nat_outgoing: false
-
 # Enables Internet connectivity from containers
 # nat_outgoing: true
 

--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-calico.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-calico.yml
@@ -9,6 +9,9 @@ calico_cni_name: k8s-pod-network
 ## The subnets of each nodes will be distributed by the datacenter router
 # peer_with_router: false
 
+# Enables Internet connectivity from containers while using peer_with_router
+# peer_with_router_nat_outgoing: false
+
 # Enables Internet connectivity from containers
 # nat_outgoing: true
 

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -227,7 +227,7 @@
               "cidr": "{{ calico_pool_cidr | default(kube_pods_subnet) }}",
               "ipipMode": "{{ calico_ipip_mode }}",
               "vxlanMode": "{{ calico_vxlan_mode }}",
-              "natOutgoing": {{ nat_outgoing|default(false) or not peer_with_router|default(false) }}
+              "natOutgoing": {{ nat_outgoing|default(false) }}
             }
           }
 
@@ -266,7 +266,7 @@
               "cidr": "{{ calico_pool_cidr_ipv6 | default(kube_pods_subnet_ipv6) }}",
               "ipipMode": "{{ calico_ipip_mode_ipv6 }}",
               "vxlanMode": "{{ calico_vxlan_mode_ipv6 }}",
-              "natOutgoing": {{ nat_outgoing_ipv6|default(false) or not peer_with_router_ipv6|default(false) }}
+              "natOutgoing": {{ nat_outgoing_ipv6|default(false) }}
             }
           }
 

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -227,7 +227,7 @@
               "cidr": "{{ calico_pool_cidr | default(kube_pods_subnet) }}",
               "ipipMode": "{{ calico_ipip_mode }}",
               "vxlanMode": "{{ calico_vxlan_mode }}",
-              "natOutgoing": {{ nat_outgoing|default(false) and not peer_with_router|default(false) }}
+              "natOutgoing": {{ nat_outgoing|default(false) and ((not peer_with_router|default(false)) or (peer_with_router_nat_outgoing|default(false))) }}
             }
           }
 
@@ -266,7 +266,7 @@
               "cidr": "{{ calico_pool_cidr_ipv6 | default(kube_pods_subnet_ipv6) }}",
               "ipipMode": "{{ calico_ipip_mode_ipv6 }}",
               "vxlanMode": "{{ calico_vxlan_mode_ipv6 }}",
-              "natOutgoing": {{ nat_outgoing_ipv6|default(false) and not peer_with_router_ipv6|default(false) }}
+              "natOutgoing": {{ nat_outgoing_ipv6|default(false) and ((not peer_with_router_ipv6|default(false)) or (peer_with_router_ipv6_nat_outgoing|default(false))) }}
             }
           }
 

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -227,7 +227,7 @@
               "cidr": "{{ calico_pool_cidr | default(kube_pods_subnet) }}",
               "ipipMode": "{{ calico_ipip_mode }}",
               "vxlanMode": "{{ calico_vxlan_mode }}",
-              "natOutgoing": {{ nat_outgoing|default(false) and ((not peer_with_router|default(false)) or (peer_with_router_nat_outgoing|default(false))) }}
+              "natOutgoing": {{ nat_outgoing|default(false) or not peer_with_router|default(false) }}
             }
           }
 
@@ -266,7 +266,7 @@
               "cidr": "{{ calico_pool_cidr_ipv6 | default(kube_pods_subnet_ipv6) }}",
               "ipipMode": "{{ calico_ipip_mode_ipv6 }}",
               "vxlanMode": "{{ calico_vxlan_mode_ipv6 }}",
-              "natOutgoing": {{ nat_outgoing_ipv6|default(false) and ((not peer_with_router_ipv6|default(false)) or (peer_with_router_ipv6_nat_outgoing|default(false))) }}
+              "natOutgoing": {{ nat_outgoing_ipv6|default(false) or not peer_with_router_ipv6|default(false) }}
             }
           }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

In special cases it's needed to enable `peer_with_router` with NAT in calico, such as in labs.
But these have been implemented as mutually exclusive, so there is no way to enable both of them.

<del>
So, I offer a optional feature that forcefully enables NAT mode even when `peer_with_router` is enabled:
* `peer_with_router_nat_outgoing` to forcefully enable NAT when `peer_with_router` is enabled (default value: false).
</del>

So, I think it's better to release the mutual exclusivity between `nat_outgoing` and `peer_with_router`.
If someone wants to use `peer_with_router` without the NAT, he/she should disable the `nat_outgoing` **manually**.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[Calico] The NAT (`nat_outgoing`) would not be disabled automatically when enabling `peer_with_router`.
```
