### PR TITLE
Remove cri_dockerd_enabled configuration

### DIFF
--- a/tests/files/packet_ubuntu22-aio-docker.yml
+++ b/tests/files/packet_ubuntu22-aio-docker.yml
@@ -15,4 +15,3 @@ enable_nodelocaldns: False
 container_manager: docker
 etcd_deployment_type: docker
 resolvconf_mode: docker_dns
-cri_dockerd_enabled: true


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Since the commit fad296616c6a1c739703fb13b79899d0b2644e48 cri_dockerd_enabled has not been used.
But the packet_ubuntu22-aio-docker.yml still contains the configuration and causes confusions.
This removes the configuration for cleanup.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
