### PR TITLE
Update calico.md to metion the `ChecksumOffloadBroken=true`

### DIFF
--- a/docs/calico.md
+++ b/docs/calico.md
@@ -214,6 +214,14 @@ calico_node_livenessprobe_timeout: 10
 calico_node_readinessprobe_timeout: 10
 ```
 
+### Optional : Configure VXLAN hardware Offload
+
+Because of the Issue [projectcalico/calico#4727](https://github.com/projectcalico/calico/issues/4727), The VXLAN Offload is disable by default. It can be configured like this:
+
+```yml
+calico_feature_detect_override: "" # The vxlan offload will enabled with kernel version is > 5.7 (It may cause problem on buggy NIC driver)
+```
+
 ## Config encapsulation for cross server traffic
 
 Calico supports two types of encapsulation: [VXLAN and IP in IP](https://docs.projectcalico.org/v3.11/networking/vxlan-ipip). VXLAN is the more mature implementation and enabled by default, please check your environment if you need *IP in IP* encapsulation.


### PR DESCRIPTION
**What type of PR is this?**

> /kind documentation

**What this PR does / why we need it**:

When installed in the Rocky9, there are some bugs with calico and kernel. The network is broken. The kubespray's default configuration needs to provision a healthy cluster.

So I want to recommend to the metion it the calico.md.

The solution is also used by:

Rancher: https://github.com/rancher/rke2-charts/blob/main-source/packages/rke2-calico/generated-changes/patch/values.yaml.patch#L55
Azure: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/templates/addons/calico/patches/calico-node.yaml

So, I suggest setting the default value to the ChecksumOffloadBroken=true, to disable the VXLAN offload by default, so the calico can be worked in most cases.


**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes-sigs/kubespray/issues/8992

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Disalbe the Calico VXLAN hardware Offload by default with setting `ChecksumOffloadBroken=true`, to work around the issue: https://github.com/projectcalico/calico/issues/4727
```
