### PR TITLE
Add variable for the vsphere-csi namespace

### DIFF
--- a/docs/vsphere-csi.md
+++ b/docs/vsphere-csi.md
@@ -37,6 +37,7 @@ You need to source the vSphere credentials you use to deploy your machines that 
 | vsphere_csi_aggressive_node_drain           | FALSE    | boolean |                            | false                     | Enable aggressive node drain strategy                                                                               |
 | vsphere_csi_aggressive_node_unreachable_timeout            | FALSE     | int  | 300   |                           | Timeout till node will be drained when it in an unreachable state                                                           |
 | vsphere_csi_aggressive_node_not_ready_timeout              | FALSE     | int  | 300   |                           | Timeout till node will be drained when it in not-ready state                                                                |
+| vsphere_csi_namespace                       | TRUE     | string  |                            | "vmware-system-csi"       | vSphere CSI namespace to use
 
 ## Usage example
 

--- a/roles/kubernetes-apps/csi_driver/vsphere/defaults/main.yml
+++ b/roles/kubernetes-apps/csi_driver/vsphere/defaults/main.yml
@@ -14,6 +14,8 @@ vsphere_csi_node_driver_registrar_image_tag: "v2.5.0"
 vsphere_csi_driver_image_tag: "v2.5.1"
 vsphere_csi_resizer_tag: "v1.4.0"
 
+vsphere_csi_namespace: "vmware-system-csi"
+
 vsphere_csi_controller_replicas: 1
 
 csi_endpoint: '{% if external_vsphere_version >= "7.0u1" %}/csi{% else %}/var/lib/csi/sockets/pluginproxy{% endif %}'

--- a/roles/kubernetes-apps/csi_driver/vsphere/tasks/main.yml
+++ b/roles/kubernetes-apps/csi_driver/vsphere/tasks/main.yml
@@ -16,6 +16,7 @@
     dest: "{{ kube_config_dir }}/{{ item }}"
     mode: 0644
   with_items:
+    - vsphere-csi-namespace.yml
     - vsphere-csi-driver.yml
     - vsphere-csi-controller-rbac.yml
     - vsphere-csi-node-rbac.yml
@@ -27,7 +28,7 @@
   when: inventory_hostname == groups['kube_control_plane'][0]
 
 - name: vSphere CSI Driver | Generate a CSI secret manifest
-  command: "{{ kubectl }} create secret generic vsphere-config-secret --from-file=csi-vsphere.conf={{ kube_config_dir }}/vsphere-csi-cloud-config -n kube-system --dry-run --save-config -o yaml"
+  command: "{{ kubectl }} create secret generic vsphere-config-secret --from-file=csi-vsphere.conf={{ kube_config_dir }}/vsphere-csi-cloud-config -n {{ vsphere_csi_namespace }} --dry-run --save-config -o yaml"
   register: vsphere_csi_secret_manifest
   when: inventory_hostname == groups['kube_control_plane'][0]
   no_log: "{{ not (unsafe_show_logs|bool) }}"

--- a/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-controller-config.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-controller-config.yml.j2
@@ -21,4 +21,4 @@ data:
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com
-  namespace: kube-system
+  namespace: "{{ vsphere_csi_namespace }}"

--- a/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-controller-deployment.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-controller-deployment.yml.j2
@@ -2,7 +2,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: vsphere-csi-controller
-  namespace: kube-system
+  namespace: "{{ vsphere_csi_namespace }}"
 spec:
   replicas: {{ vsphere_csi_controller_replicas }}
   strategy:
@@ -90,8 +90,8 @@ spec:
           image: {{ gcr_image_repo }}/cloud-provider-vsphere/csi/release/driver:{{ vsphere_csi_controller }}
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
-            - "--fss-namespace=kube-system"
-            - "--supervisor-fss-namespace=kube-system"
+            - "--fss-namespace={{ vsphere_csi_namespace }}"
+            - "--supervisor-fss-namespace={{ vsphere_csi_namespace }}"
             - "--use-gocsi=false"
           imagePullPolicy: {{ k8s_image_pull_policy }}
           env:
@@ -150,8 +150,8 @@ spec:
           args:
             - "--leader-election"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
-            - "--fss-namespace=kube-system"
-            - "--supervisor-fss-namespace=kube-system"
+            - "--fss-namespace={{ vsphere_csi_namespace }}"
+            - "--supervisor-fss-namespace={{ vsphere_csi_namespace }}"
           imagePullPolicy: {{ k8s_image_pull_policy }}
           ports:
             - containerPort: 2113

--- a/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-controller-rbac.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-controller-rbac.yml.j2
@@ -2,7 +2,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: vsphere-csi-controller
-  namespace: kube-system
+  namespace: "{{ vsphere_csi_namespace }}"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -79,7 +79,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: vsphere-csi-controller
-    namespace: kube-system
+    namespace: "{{ vsphere_csi_namespace }}"
 roleRef:
   kind: ClusterRole
   name: vsphere-csi-controller-role

--- a/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-controller-service.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-controller-service.yml.j2
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: vsphere-csi-controller
-  namespace: kube-system
+  namespace: "{{ vsphere_csi_namespace }}"
   labels:
     app: vsphere-csi-controller
 spec:

--- a/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-namespace.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-namespace.yml.j2
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "{{ vsphere_csi_namespace }}"

--- a/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-node-rbac.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-node-rbac.yml.j2
@@ -3,7 +3,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: vsphere-csi-node
-  namespace: kube-system
+  namespace: "{{ vsphere_csi_namespace }}"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -24,7 +24,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: vsphere-csi-node
-    namespace: kube-system
+    namespace: "{{ vsphere_csi_namespace }}"
 roleRef:
   kind: ClusterRole
   name: vsphere-csi-node-cluster-role
@@ -34,7 +34,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: vsphere-csi-node-role
-  namespace: kube-system
+  namespace: "{{ vsphere_csi_namespace }}"
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
@@ -44,11 +44,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: vsphere-csi-node-binding
-  namespace: kube-system
+  namespace: "{{ vsphere_csi_namespace }}"
 subjects:
   - kind: ServiceAccount
     name: vsphere-csi-node
-    namespace: kube-system
+    namespace: "{{ vsphere_csi_namespace }}"
 roleRef:
   kind: Role
   name: vsphere-csi-node-role

--- a/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-node.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-node.yml.j2
@@ -2,7 +2,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: vsphere-csi-node
-  namespace: kube-system
+  namespace: "{{ vsphere_csi_namespace }}"
 spec:
   selector:
     matchLabels:
@@ -57,8 +57,8 @@ spec:
         imagePullPolicy: {{ k8s_image_pull_policy }}
         args:
           - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
-          - "--fss-namespace=kube-system"
-          - "--supervisor-fss-namespace=kube-system"
+          - "--fss-namespace={{ vsphere_csi_namespace }}"
+          - "--supervisor-fss-namespace={{ vsphere_csi_namespace }}"
           - "--use-gocsi=false"
         imagePullPolicy: "Always"
         env:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

I've added a new variable for the vsphere-csi-namespace and all vsphere-csi manifest will be deploy on this namespace instead of "kube-system" namespace.
vsphere csi uses its own namespace that is "vmware-system-csi", but in the current version of kubespray in the deploying vsphere csi, the namespace is set to the kube-system, but it will be an issue for csi, because it wants to find "vmware-system-csi" namespace but it doesn't exist. the value should be fixed but I've added a variable with "vmware-system-csi" default value for flexibility.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add variable to tweak the vsphere-csi namespace (`vsphere_csi_namespace`)
```
