### PR TITLE
speed up by removing defaults dependency on downloads

### DIFF
--- a/roles/kubespray-defaults/meta/main.yml
+++ b/roles/kubespray-defaults/meta/main.yml
@@ -1,6 +1,0 @@
----
-dependencies:
-  - role: download
-    skip_downloads: true
-    tags:
-      - facts


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
At one point in the past it may have been that this dependency of defaults on downloads was needed to set a fact, but not anymore.  The dependency is invoked with `skip_downloads: true`, so none of the tasks in https://github.com/kubernetes-sigs/kubespray/blob/master/roles/download/tasks/main.yml will be executed - but they all still get dynamically imported and processed so Ansible wastes a lot of time churning through them.

**Which issue(s) this PR fixes**:
[Fixes #](https://github.com/kubernetes-sigs/kubespray/issues/9279)

**Special notes for your reviewer**:
See timing measurements posted below.

**Does this PR introduce a user-facing change?**:
No
