### PR TITLE
Ensure the ping package

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -100,6 +100,20 @@
     - not ignore_assert_errors
     - ip is defined
 
+- name: Ensure ping package
+  package:
+    name: >-
+          {%- if ansible_os_family in ['RedHat', 'Suse'] -%}
+          iputils
+          {%- else -%}
+          iputils-ping
+          {%- endif -%}
+    state: present
+  when:
+    - access_ip is defined
+    - not ignore_assert_errors
+    - ping_access_ip
+
 - name: Stop if access_ip is not pingable
   command: ping -c1 {{ access_ip }}
   when:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

On the ubuntu server 22.04 (min install), there need to install the ping package.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes  https://github.com/kubernetes-sigs/kubespray/issues/9283

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Ensure ping package is installed on the system
```
