### PR TITLE
Adds support for multiple architectures to yq

### DIFF
--- a/roles/kubernetes-apps/argocd/tasks/main.yml
+++ b/roles/kubernetes-apps/argocd/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Kubernetes Apps | Install yq
   become: yes
   get_url:
-    url: "https://github.com/mikefarah/yq/releases/download/v4.25.3/yq_linux_amd64"
+    url: "https://github.com/mikefarah/yq/releases/download/v4.25.3/yq_linux_{{ host_architecture }}"
     dest: "{{ bin_dir }}/yq"
     mode: '0755'
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Installing argocd fails on kubernetes nodes having non amd64 architecture. yq is hardcoded to download only amd64 compiled binaries.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
