### PR TITLE
vSphere-csi: add nodeAffinity to daemonset

### DIFF
--- a/roles/kubernetes-apps/csi_driver/vsphere/defaults/main.yml
+++ b/roles/kubernetes-apps/csi_driver/vsphere/defaults/main.yml
@@ -24,6 +24,8 @@ vsphere_csi_aggressive_node_drain: False
 vsphere_csi_aggressive_node_unreachable_timeout: 300
 vsphere_csi_aggressive_node_not_ready_timeout: 300
 
+vsphere_csi_node_affinity: {}
+
 # If this is true, debug information will be displayed but
 # may contain some private data, so it is recommended to set it to false
 # in the production environment.

--- a/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-node.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-node.yml.j2
@@ -19,6 +19,10 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+{% if vsphere_csi_node_affinity %}
+      affinity:
+        {{ vsphere_csi_node_affinity | to_nice_yaml | indent(width=8) }}
+{% endif %}
       serviceAccountName: vsphere-csi-node
       hostNetwork: true
       dnsPolicy: "ClusterFirstWithHostNet"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR adds affinity spec to vSphere CSI daemonset template (with empty dict value by default)
We need this to control node assignment for the vSphere CSI driver in a mixed environment (not only VMware VMs in one k8s cluster). Running pods of this daemonset (from 2.4.0 version at least) on not VMware nodes will cause crashes of these pods
**Which issue(s) this PR fixes**:
**Special notes for your reviewer**:
**Does this PR introduce a user-facing change?**:
```release-note
vSphere-csi: add nodeAffinity to daemonset
```
