### PR TITLE
add max_concurrent in coredns to fix memory leak issue

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -44,10 +44,12 @@ data:
 {% if upstream_dns_servers is defined and upstream_dns_servers|length > 0 %}
         forward . {{ upstream_dns_servers|join(' ') }} {
           prefer_udp
+          max_concurrent 1000
         }
 {% else %}
         forward . /etc/resolv.conf {
           prefer_udp
+          max_concurrent 1000
         }
 {% endif %}
 {% if enable_coredns_k8s_external %}


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:

Without the max_concurrent , slow upstream connection can cause the number of concurrent connections to grow unbound and exhaust memory.

Like the kubeadm (ref to https://github.com/kubernetes/kubernetes/pull/92651 ) , The KubeSpray can set the max_concurrent=1000  to solve the problem.



**Which issue(s) this PR fixes**:

Fixes

- https://github.com/kubernetes-sigs/kubespray/issues/9306
- https://github.com/kubernetes-sigs/kubespray/issues/9083
- https://github.com/coredns/coredns/issues/3635
- https://github.com/coredns/coredns/issues/4544

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix memory leak issue by adding `max_concurrent=1000` in the CoreDNS config.
```
