### PR TITLE
change the default of calico_network_backend to bird

### DIFF
--- a/docs/calico.md
+++ b/docs/calico.md
@@ -50,7 +50,7 @@ calico_datastore: kdd
 
 ### Optional : Define network backend
 
-In some cases you may want to define Calico network backend. Allowed values are `bird`, `vxlan` or `none`. `vxlan` is the default value.
+In some cases you may want to define Calico network backend. Allowed values are `bird`, `vxlan` or `none`. `bird` is the default value.
 
 To re-define you need to edit the inventory and add a group variable `calico_network_backend`
 

--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -27,7 +27,7 @@ calico_vxlan_mode_ipv6: Never
 calico_pool_blocksize_ipv6: 122
 
 # Calico network backend can be 'bird', 'vxlan' and 'none'
-calico_network_backend: vxlan
+calico_network_backend: bird
 
 calico_cert_dir: /etc/calico/certs
 


### PR DESCRIPTION
Signed-off-by: weizhou.lan@daocloud.io <weizhou.lan@daocloud.io>



**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix communication issue when enable ipv6 vxlan of calico CNI

**Which issue(s) this PR fixes**:
According to my test, when set calico_network_backend to be vxlan , enable ipv6 vxlan and dual-stack IP family, although ipv4 vxlan works fine, but each node does not take effect the IPv6 block route for pods of other nodes, so  it fails to communicate the IPv6 address of pod on other nodes. 

if calico_network_backend  set to be bird, seems every tunnel case works fine, including ipip and vxlan for IPv4 and IPv6. So this default value is good for common use


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
fails to communicate IPv6 address of pod  when enable calico ipv6 vxlan  
```
