### PR TITLE
Ability to define options for DNS upstream servers

### DIFF
--- a/docs/dns-stack.md
+++ b/docs/dns-stack.md
@@ -40,6 +40,12 @@ is not set, a default resolver is chosen (depending on cloud provider or 8.8.8.8
 DNS servers to be added *after* the cluster DNS. Used by all ``resolvconf_mode`` modes. These serve as backup
 DNS servers in early cluster deployment when no cluster DNS is available yet.
 
+### dns_upstream_forward_extra_opts
+
+Whether or not upstream DNS servers come from `upstream_dns_servers` variable or /etc/resolv.conf, related forward block in coredns (and nodelocaldns) configuration can take options (see <https://coredns.io/plugins/forward/> for details).
+These are configurable in inventory in as a dictionary in the `dns_upstream_forward_extra_opts` variable.
+By default, no other option than the ones hardcoded (see `roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2` and `roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2`).
+
 ### coredns_external_zones
 
 Array of optional external zones to coredns forward queries to. It's  injected into

--- a/docs/vars.md
+++ b/docs/vars.md
@@ -167,6 +167,7 @@ variables to match your requirements.
 * *nameservers* - Array of DNS servers configured for use by hosts
 * *searchdomains* - Array of up to 4 search domains
 * *dns_etchosts* - Content of hosts file for coredns and nodelocaldns
+* *dns_upstream_forward_extra_opts* - Options to add in the forward section of coredns/nodelocaldns related to upstream DNS servers
 
 For more information, see [DNS
 Stack](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/dns-stack.md).

--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -197,6 +197,9 @@ enable_coredns_k8s_external: false
 coredns_k8s_external_zone: k8s_external.local
 # Enable endpoint_pod_names option for kubernetes plugin
 enable_coredns_k8s_endpoint_pod_names: false
+# Set forward options for upstream DNS servers in coredns (and nodelocaldns) config
+# dns_upstream_forward_extra_opts:
+#   policy: sequential
 
 # Can be docker_dns, host_resolvconf or none
 resolvconf_mode: host_resolvconf

--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -14,6 +14,10 @@ coredns_deployment_nodeselector: "kubernetes.io/os: linux"
 coredns_default_zone_cache_block: |
   cache 30
 
+# dns_upstream_forward_extra_opts apply to coredns forward section as well as nodelocaldns upstream target forward section
+# dns_upstream_forward_extra_opts:
+#   policy: sequential
+
 # nodelocaldns
 nodelocaldns_cpu_requests: 100m
 nodelocaldns_memory_limit: 200Mi

--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -46,17 +46,15 @@ data:
 {% endif %}
         }
         prometheus :9153
-{% if upstream_dns_servers is defined and upstream_dns_servers|length > 0 %}
-        forward . {{ upstream_dns_servers|join(' ') }} {
+        forward . {{ upstream_dns_servers|join(' ') if upstream_dns_servers is defined and upstream_dns_servers|length > 0 else '/etc/resolv.conf' }} {
           prefer_udp
           max_concurrent 1000
-        }
-{% else %}
-        forward . /etc/resolv.conf {
-          prefer_udp
-          max_concurrent 1000
-        }
+{% if dns_upstream_forward_extra_opts is defined %}
+{% for optname, optvalue in dns_upstream_forward_extra_opts.items() %}
+          {{ optname }} {{ optvalue }}
+{% endfor %}
 {% endif %}
+        }
 {% if enable_coredns_k8s_external %}
         k8s_external {{ coredns_k8s_external_zone }}
 {% endif %}

--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2
@@ -80,7 +80,12 @@ data:
         reload
         loop
         bind {{ nodelocaldns_ip }}
-        forward . {{ upstreamForwardTarget }}
+        forward . {{ upstreamForwardTarget }}{% if dns_upstream_forward_extra_opts is defined %} {
+{% for optname, optvalue in dns_upstream_forward_extra_opts.items() %}
+          {{ optname }} {{ optvalue }}
+{% endfor %}
+        }{% endif %}
+
         prometheus {% if nodelocaldns_bind_metrics_host_ip %}{$MY_HOST_IP}{% endif %}:{{ nodelocaldns_prometheus_port }}
 {% if dns_etchosts | default(None) %}
         hosts /etc/coredns/hosts {
@@ -157,7 +162,12 @@ data:
         reload
         loop
         bind {{ nodelocaldns_ip }}
-        forward . {{ upstreamForwardTarget }}
+        forward . {{ upstreamForwardTarget }}{% if dns_upstream_forward_extra_opts is defined %} {
+{% for optname, optvalue in dns_upstream_forward_extra_opts.items() %}
+          {{ optname }} {{ optvalue }}
+{% endfor %}
+        }{% endif %}
+
         prometheus {% if nodelocaldns_bind_metrics_host_ip %}{$MY_HOST_IP}{% endif %}:{{ nodelocaldns_secondary_prometheus_port }}
 {% if dns_etchosts | default(None) %}
         hosts /etc/coredns/hosts {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This allows one to define options in forward sections of coredns and nodelocaldns config related to upstream servers (either via `upstream_dns_servers` or /etc/hosts).
The example added in defaults/main.yml is related to the policy option. The default value for this option in coredns is "random" (meaning all upstream servers are used randomly) which, when using /etc/hosts as forwarder, differs from the behaviour on servers with the very same /etc/hosts. That can lead to unexpected behaviour when the first nameserver is supposed to be the main and others are fallback servers.
BTW the default behaviour (no option defined) is kept.

**Which issue(s) this PR fixes**:
None that I know of

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add the ability to define options for DNS upstream servers (using new variable `dns_upstream_forward_extra_opts`)
```
