### PR TITLE
Move back vsphere csi to kube-system ns

### DIFF
--- a/docs/vsphere-csi.md
+++ b/docs/vsphere-csi.md
@@ -37,7 +37,7 @@ You need to source the vSphere credentials you use to deploy your machines that 
 | vsphere_csi_aggressive_node_drain           | FALSE    | boolean |                            | false                     | Enable aggressive node drain strategy                                                                               |
 | vsphere_csi_aggressive_node_unreachable_timeout            | FALSE     | int  | 300   |                           | Timeout till node will be drained when it in an unreachable state                                                           |
 | vsphere_csi_aggressive_node_not_ready_timeout              | FALSE     | int  | 300   |                           | Timeout till node will be drained when it in not-ready state                                                                |
-| vsphere_csi_namespace                       | TRUE     | string  |                            | "vmware-system-csi"       | vSphere CSI namespace to use
+| vsphere_csi_namespace                       | TRUE     | string  |                            | "kube-system"       | vSphere CSI namespace to use; kube-system for backward compatibility, should be change to vmware-system-csi on the long run |
 
 ## Usage example
 

--- a/roles/kubernetes-apps/csi_driver/vsphere/defaults/main.yml
+++ b/roles/kubernetes-apps/csi_driver/vsphere/defaults/main.yml
@@ -14,7 +14,8 @@ vsphere_csi_node_driver_registrar_image_tag: "v2.5.0"
 vsphere_csi_driver_image_tag: "v2.5.1"
 vsphere_csi_resizer_tag: "v1.4.0"
 
-vsphere_csi_namespace: "vmware-system-csi"
+# Set to kube-system for backward compatibility, should be change to vmware-system-csi on the long run
+vsphere_csi_namespace: "kube-system"
 
 vsphere_csi_controller_replicas: 1
 


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
As stated by @fungusakafungus, the vsphere_csi_namespace should still be kube-system for now, users should be warn that this may change in the future

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
See https://github.com/kubernetes-sigs/kubespray/pull/9278 for the initial change

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
