### PR TITLE
Features/support kubeadm patches v1beta3

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -339,3 +339,9 @@ event_ttl_duration: "1h0m0s"
 auto_renew_certificates: false
 # First Monday of each month
 # auto_renew_certificates_systemd_calendar: "Mon *-*-1,2,3,4,5,6,7 03:{{ groups['kube_control_plane'].index(inventory_hostname) }}0:00"
+
+# kubeadm patches path
+kubeadm_patches:
+  enabled: true
+  source_dir: "{{ inventory_dir }}/patches"
+  dest_dir: "{{ kube_config_dir }}/patches"

--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -342,6 +342,6 @@ auto_renew_certificates: false
 
 # kubeadm patches path
 kubeadm_patches:
-  enabled: true
+  enabled: false
   source_dir: "{{ inventory_dir }}/patches"
   dest_dir: "{{ kube_config_dir }}/patches"

--- a/inventory/sample/patches/kube-controller-manager+merge.yaml
+++ b/inventory/sample/patches/kube-controller-manager+merge.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:

--- a/inventory/sample/patches/kube-controller-manager+merge.yaml
+++ b/inventory/sample/patches/kube-controller-manager+merge.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-controller-manager
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '10257'

--- a/inventory/sample/patches/kube-scheduler+merge.yaml
+++ b/inventory/sample/patches/kube-scheduler+merge.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:

--- a/inventory/sample/patches/kube-scheduler+merge.yaml
+++ b/inventory/sample/patches/kube-scheduler+merge.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-scheduler
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '10259'

--- a/roles/kubernetes/control-plane/defaults/main/main.yml
+++ b/roles/kubernetes/control-plane/defaults/main/main.yml
@@ -234,4 +234,3 @@ kubeadm_patches:
   enabled: true
   source_dir: "{{ inventory_dir }}/patches"
   dest_dir: "{{ kube_config_dir }}/patches"
-  

--- a/roles/kubernetes/control-plane/defaults/main/main.yml
+++ b/roles/kubernetes/control-plane/defaults/main/main.yml
@@ -228,3 +228,10 @@ auto_renew_certificates_systemd_calendar: "{{ 'Mon *-*-1,2,3,4,5,6,7 03:' ~
 # If we have requirement like without renewing certs upgrade the cluster,
 # we can opt out from the default behavior by setting kubeadm_upgrade_auto_cert_renewal to false
 kubeadm_upgrade_auto_cert_renewal: true
+
+# kubeadm patches path
+kubeadm_patches:
+  enabled: true
+  source_dir: "{{ inventory_dir }}/patches"
+  dest_dir: "{{ kube_config_dir }}/patches"
+  

--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -150,6 +150,21 @@
     - apiserver_sans_check.changed
     - not kube_external_ca_mode
 
+- name: kubeadm | Create directory to store kubeadm patches
+  file:
+    path: "{{ kubeadm_patches.dest_dir }}"
+    state: directory
+    mode: 0640
+  when: kubeadm_patches is defined and kubeadm_patches.enabled
+
+- name: kubeadm | Copy kubeadm patches from inventory files
+  copy:
+    src: "{{ kubeadm_patches.source_dir }}/"
+    dest: "{{ kubeadm_patches.dest_dir }}"
+    owner: "root"
+    mode: 0644
+  when: kubeadm_patches is defined and kubeadm_patches.enabled
+
 - name: kubeadm | Initialize first master
   command: >-
     timeout -k 300s 300s

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
@@ -28,6 +28,10 @@ nodeRegistration:
   kubeletExtraArgs:
     cloud-provider: external
 {% endif %}
+{% if kubeadm_patches is defined and kubeadm_patches.enabled %}
+patches:
+  directory: {{ kubeadm_patches.dest_dir }}
+{% endif %}
 ---
 apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration

--- a/roles/kubernetes/control-plane/templates/kubeadm-controlplane.v1beta3.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-controlplane.v1beta3.yaml.j2
@@ -26,3 +26,7 @@ nodeRegistration:
 {% else %}
   taints: []
 {% endif %}
+{% if kubeadm_patches is defined and kubeadm_patches.enabled %}
+patches:
+  directory: {{ kubeadm_patches.dest_dir }}
+{% endif %}

--- a/roles/kubernetes/kubeadm/defaults/main.yml
+++ b/roles/kubernetes/kubeadm/defaults/main.yml
@@ -10,3 +10,10 @@ kube_override_hostname: >-
   {%- else -%}
   {{ inventory_hostname }}
   {%- endif -%}
+
+# kubeadm patches path
+kubeadm_patches:
+  enabled: true
+  source_dir: "{{ inventory_dir }}/patches"
+  dest_dir: "{{ kube_config_dir }}/patches"
+

--- a/roles/kubernetes/kubeadm/defaults/main.yml
+++ b/roles/kubernetes/kubeadm/defaults/main.yml
@@ -16,4 +16,3 @@ kubeadm_patches:
   enabled: true
   source_dir: "{{ inventory_dir }}/patches"
   dest_dir: "{{ kube_config_dir }}/patches"
-

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -52,7 +52,7 @@
     kubeadm_token: "{{ temp_token.stdout }}"
   when: kubeadm_token is not defined
 
-- name: Set kubeadm api version to v1beta2
+- name: Set kubeadm api version to v1beta3
   set_fact:
     kubeadmConfig_api_version: v1beta3
 
@@ -63,6 +63,21 @@
     backup: yes
     mode: 0640
   when: not is_kube_master
+
+- name: kubeadm | Create directory to store kubeadm patches
+  file:
+    path: "{{ kubeadm_patches.dest_dir }}"
+    state: directory
+    mode: 0640
+  when: kubeadm_patches is defined and kubeadm_patches.enabled
+
+- name: kubeadm | Copy kubeadm patches from inventory files
+  copy:
+    src: "{{ kubeadm_patches.source_dir }}/"
+    dest: "{{ kubeadm_patches.dest_dir }}"
+    owner: "root"
+    mode: 0644
+  when: kubeadm_patches is defined and kubeadm_patches.enabled
 
 - name: Join to cluster if needed
   environment:

--- a/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1beta3.j2
+++ b/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1beta3.j2
@@ -26,3 +26,7 @@ nodeRegistration:
   - effect: NoSchedule
     key: node-role.kubernetes.io/calico-rr
 {% endif %}
+{% if kubeadm_patches is defined and kubeadm_patches.enabled %}
+patches:
+  directory: {{ kubeadm_patches.dest_dir }}
+{% endif %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:
Support kubeadm patches than mentioned in #9325 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9325 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Support patches field in kubeadm v1beta3 in both InitConfiguration and JoinConfiguration (using new variable `kubeadm_patches`)
```
