### PR TITLE
cloud-provider-openstack: upgrade 1.22.0 to 1.23.4

### DIFF
--- a/roles/kubernetes-apps/external_cloud_controller/openstack/defaults/main.yml
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/defaults/main.yml
@@ -21,4 +21,4 @@ external_openstack_cacert: "{{ lookup('env','OS_CACERT') }}"
 ##    arg1: "value1"
 ##    arg2: "value2"
 external_openstack_cloud_controller_extra_args: {}
-external_openstack_cloud_controller_image_tag: "v1.22.0"
+external_openstack_cloud_controller_image_tag: "v1.23.4"

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
@@ -65,6 +65,12 @@ use-octavia=true
 {% if external_openstack_enable_ingress_hostname is defined %}
 enable-ingress-hostname={{ external_openstack_enable_ingress_hostname | bool }}
 {% endif %}
+{% if external_openstack_ingress_hostname_suffix is defined %}
+ingress-hostname-suffix={{ external_openstack_ingress_hostname_suffix | string | lower }}
+{% endif %}
+{% if external_openstack_max_shared_lb is defined %}
+max-shared-lb={{ external_openstack_max_shared_lb }}
+{% endif %}
 
 [Networking]
 ipv6-support-disabled={{ external_openstack_network_ipv6_disabled | string | lower }}

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -440,6 +440,8 @@ openstack_cacert: "{{ lookup('env','OS_CACERT') }}"
 
 # Default values for the external OpenStack Cloud Controller
 external_openstack_enable_ingress_hostname: false
+external_openstack_ingress_hostname_suffix: "nip.io"
+external_openstack_max_shared_lb: 2
 external_openstack_lbaas_create_monitor: false
 external_openstack_lbaas_monitor_delay: "1m"
 external_openstack_lbaas_monitor_timeout: "30s"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR switches the default version of the external cloud provider for openstack to `v.1.23.4`, which also brings these two major features:
- share OS loadbalancers between multiple k8s LB services (added a default value for this)
- specify a different ingress hostname suffix rather than `nip.io` (added new value for this)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[Openstack] Upgrade 1.22.0 to 1.23.4
As stated in [cloud-provider-openstack:1.23.0](https://github.com/kubernetes/cloud-provider-openstack/releases/tag/v1.23.0): `load balancers don't relate to a dedicated Service anymore, any scripts relying on that relationship previously need to change to use the load balancer tags instead`.
```
