### PR TITLE
Fix: The Hubble certificate is faulty because the cluster name is har…

### DIFF
--- a/roles/network_plugin/cilium/templates/hubble/cronjob.yml.j2
+++ b/roles/network_plugin/cilium/templates/hubble/cronjob.yml.j2
@@ -37,7 +37,7 @@ spec:
                 - "--hubble-ca-config-map-create=true"
                 - "--hubble-ca-config-map-name=hubble-ca-cert"
                 - "--hubble-server-cert-generate=true"
-                - "--hubble-server-cert-common-name=*.default.hubble-grpc.cilium.io"
+                - "--hubble-server-cert-common-name=*.{{ cilium_cluster_name }}.hubble-grpc.cilium.io"
                 - "--hubble-server-cert-validity-duration=94608000s"
                 - "--hubble-server-cert-secret-name=hubble-server-certs"
                 - "--hubble-relay-client-cert-generate=true"

--- a/roles/network_plugin/cilium/templates/hubble/job.yml.j2
+++ b/roles/network_plugin/cilium/templates/hubble/job.yml.j2
@@ -33,7 +33,7 @@ spec:
             - "--hubble-ca-config-map-create=true"
             - "--hubble-ca-config-map-name=hubble-ca-cert"
             - "--hubble-server-cert-generate=true"
-            - "--hubble-server-cert-common-name=*.default.hubble-grpc.cilium.io"
+            - "--hubble-server-cert-common-name=*.{{ cilium_cluster_name }}.hubble-grpc.cilium.io"
             - "--hubble-server-cert-validity-duration=94608000s"
             - "--hubble-server-cert-secret-name=hubble-server-certs"
             - "--hubble-relay-client-cert-generate=true"


### PR DESCRIPTION
…d coded

Signed-off-by: dcwbq <biqiang.wu@daocloud.io>

**What type of PR is this?**
> /kind bug


**What this PR does / why we need it**:
When CILIum is used and the cluster name is set, the Hubble certificate will be created incorrectly

kubespray  config:
```
    kube_network_plugin: cilium
    cilium_enable_hubble: true
    cilium_hubble_install: true
    cilium_hubble_tls_generate: true
    cilium_cluster_name: cilium-test
```

Fix: The Hubble certificate is faulty because the cluster name is hard coded

**Which issue(s) this PR fixes**:
Fixes: https://github.com/cilium/cilium/issues/21454

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

```release-note

```
