### PR TITLE
Support customize the additional sysctl variables

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
+++ b/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
@@ -127,3 +127,12 @@
     state: present
     params: 'numdummies=0'
   when: enable_nodelocaldns
+
+- name: Set additional sysctl variables
+  sysctl:
+    sysctl_file: "{{ sysctl_file_path }}"
+    name: "{{ item.name }}"
+    value: "{{ item.value }}"
+    state: present
+    reload: yes
+  with_items: "{{ additional_sysctl }}"

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -487,6 +487,12 @@ kubelet_rotate_server_certificates: false
 # If set to true, kubelet errors if any of kernel tunables is different than kubelet defaults
 kubelet_protect_kernel_defaults: true
 
+# Set additional sysctl variables to modify Linux kernel variables, for example:
+# additional_sysctl:
+#  - { name: kernel.pid_max, value: 131072 }
+#
+additional_sysctl: []
+
 ## List of key=value pairs that describe feature gates for
 ## the k8s cluster.
 kube_feature_gates: []


### PR DESCRIPTION
**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:

Kernel parameters (sysctl) are important for the Kubernetes tunning (especially in the production environment). So If the kubespray can provide the feature to customize the nodes' sysctl variable, it's very useful. For example, the kernel.pid_max in centos7 is too small for Kubernetes, the OS often hangs because of it.


**Which issue(s) this PR fixes**:

Fixes:

- https://github.com/kubernetes-sigs/kubespray/pull/8801
- https://github.com/kubernetes-sigs/kubespray/issues/8825

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Support customize the additional sysctl variables using `additional_sysctl`
```

