### PR TITLE
Remove versions from setting-up-your-first-cluster

### DIFF
--- a/docs/setting-up-your-first-cluster.md
+++ b/docs/setting-up-your-first-cluster.md
@@ -14,8 +14,8 @@ hands-on guide to get started with Kubespray.
 
 ## Cluster Details
 
-* [kubespray](https://github.com/kubernetes-sigs/kubespray) v2.17.x
-* [kubernetes](https://github.com/kubernetes/kubernetes) v1.17.9
+* [kubespray](https://github.com/kubernetes-sigs/kubespray)
+* [kubernetes](https://github.com/kubernetes/kubernetes)
 
 ## Prerequisites
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind documentation

**What this PR does / why we need it**:

We are maintaining version info on the README.md, and it is not necessary to maintain that on setting-up-your-first-cluster.md

**Special notes for your reviewer**:

Please see the discussion on https://github.com/kubernetes-sigs/kubespray/pull/8995

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
