### PR TITLE
feat: add a parameter to disable host nameservers

### DIFF
--- a/inventory/sample/group_vars/all/all.yml
+++ b/inventory/sample/group_vars/all/all.yml
@@ -35,6 +35,11 @@ loadbalancer_apiserver_healthcheck_port: 8081
 
 ### OTHER OPTIONAL VARIABLES
 
+## By default, Kubespray collects nameservers on the host. It then adds the previously collected nameservers in nameserverentries.
+## If true, Kubespray does not include host nameservers in nameserverentries in dns_late stage. However, It uses the nameserver to make sure cluster installed safely in dns_early stage.
+## Use this option with caution, you may need to define your dns servers. Otherwise, the outbound queries such as www.google.com may fail.
+# disable_host_nameservers: false
+
 ## Upstream dns servers
 # upstream_dns_servers:
 #   - 8.8.8.8

--- a/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
@@ -201,7 +201,7 @@
 - name: generate nameservers for resolvconf, including cluster DNS
   set_fact:
     nameserverentries: |-
-      {{ (([nodelocaldns_ip] if enable_nodelocaldns else []) + (coredns_server|d([]) if not enable_nodelocaldns else []) + nameservers|d([]) + cloud_resolver|d([]) + configured_nameservers|d([])) | unique | join(',') }}
+      {{ (([nodelocaldns_ip] if enable_nodelocaldns else []) + (coredns_server|d([]) if not enable_nodelocaldns else []) + nameservers|d([]) + cloud_resolver|d([]) + (configured_nameservers|d([]) if not disable_host_nameservers|d()|bool else [])) | unique | join(',') }}
     supersede_nameserver:
       supersede domain-name-servers {{ ( ( [nodelocaldns_ip] if enable_nodelocaldns else []) + coredns_server|d([]) + nameservers|d([]) + cloud_resolver|d([])) | unique | join(', ') }};
   when: not dns_early or dns_late


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**: Users now can choose to include the nameserver in the host.

**Special notes for your reviewer**: With this option, users will have the option to include nameservers that are fetched in the hosts. This option will be disabled by default so it won't have any effect until `disable_host_namerservers` option is enabled. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add a parameter (`disable_host_nameservers`) to disable host nameservers 
```


Signed-off-by: eminaktas <eminaktas34@gmail.com>