### PR TITLE
Fix: install calico-kube-controller on kdd

### DIFF
--- a/roles/kubernetes-apps/policy_controller/meta/main.yml
+++ b/roles/kubernetes-apps/policy_controller/meta/main.yml
@@ -4,13 +4,11 @@ dependencies:
     when:
       - kube_network_plugin == 'calico'
       - enable_network_policy
-      - calico_datastore != "kdd" or calico_policy_version is version('v3.6.0', '>=')
     tags:
       - policy-controller
 
   - role: policy_controller/calico
     when:
       - kube_network_plugin == 'canal'
-      - calico_datastore != "kdd" or calico_policy_version is version('v3.6.0', '>=')
     tags:
       - policy-controller

--- a/roles/kubernetes-apps/policy_controller/meta/main.yml
+++ b/roles/kubernetes-apps/policy_controller/meta/main.yml
@@ -4,13 +4,13 @@ dependencies:
     when:
       - kube_network_plugin == 'calico'
       - enable_network_policy
-      - calico_datastore != "kdd"
+      - calico_datastore != "kdd" or calico_policy_version is version('v3.6.0', '>=')
     tags:
       - policy-controller
 
   - role: policy_controller/calico
     when:
       - kube_network_plugin == 'canal'
-      - calico_datastore != "kdd"
+      - calico_datastore != "kdd" or calico_policy_version is version('v3.6.0', '>=')
     tags:
       - policy-controller

--- a/roles/kubernetes-apps/policy_controller/meta/main.yml
+++ b/roles/kubernetes-apps/policy_controller/meta/main.yml
@@ -2,13 +2,7 @@
 dependencies:
   - role: policy_controller/calico
     when:
-      - kube_network_plugin == 'calico'
+      - kube_network_plugin in ['calico', 'canal']
       - enable_network_policy
-    tags:
-      - policy-controller
-
-  - role: policy_controller/calico
-    when:
-      - kube_network_plugin == 'canal'
     tags:
       - policy-controller


### PR DESCRIPTION
**What type of PR is this?**

This partially reverts https://github.com/kubernetes-sigs/kubespray/commit/2de5c4821cbbea903c4add7f98111590024b526c#diff-c94700ab11e60a92e9706fb87b3a61796ff8b2a7a36e18fd465e173203d6574dL14 - which makes kubespray not installing policy controller when using calico with kubernetes data store. 

/kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #9300 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
