### PR TITLE
fix(external-openstack): Do not override /etc/ssl/certs

### DIFF
--- a/docs/cinder-csi.md
+++ b/docs/cinder-csi.md
@@ -93,6 +93,8 @@ kubectl exec -it nginx -- df -h | grep /var/lib/www/html
 It is not necessary to enable OpenStack as a cloud provider for Cinder CSI Driver to work.
 Though, you can run both the in-tree openstack cloud provider and the Cinder CSI Driver at the same time. The storage class provisioners associated to each one of them are differently named.
 
+When using the in-tree OpenStack cloud provider with an external CA certificate, Cinder will not use the external CA certificate set by base64 encoding the cacert file and storing it in the variable `openstack_cacert`, it will use the `OS_CACERT = <path_to_external_cacert>` in your openrc.
+
 ## Cinder v2 support
 
 For the moment, only Cinder v3 is supported by the CSI Driver.

--- a/docs/openstack.md
+++ b/docs/openstack.md
@@ -109,6 +109,7 @@ The new cloud provider is configured to have Octavia by default in Kubespray.
   ```
 
 - Run `source path/to/your/openstack-rc` to read your OpenStack credentials like `OS_AUTH_URL`, `OS_USERNAME`, `OS_PASSWORD`, etc. Those variables are used for accessing OpenStack from the external cloud provider.
+- If you are using an external OpenStack CA certificate, you will need to set `OS_CACERT = <path_to_external_cacert>` in your openrc.
 - Run the `cluster.yml` playbook
 
 ## Additional step needed when using calico or kube-router

--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin.yml.j2
@@ -130,9 +130,6 @@ spec:
             - name: secret-cinderplugin
               mountPath: /etc/config
               readOnly: true
-            - name: ca-certs
-              mountPath: /etc/ssl/certs
-              readOnly: true
 {% if cinder_cacert is defined and cinder_cacert != "" %}
             - name: cinder-cacert
               mountPath: {{ kube_config_dir }}/cinder-cacert.pem
@@ -144,10 +141,6 @@ spec:
         - name: secret-cinderplugin
           secret:
             secretName: cloud-config
-        - name: ca-certs
-          hostPath:
-            path: /etc/ssl/certs
-            type: DirectoryOrCreate
 {% if cinder_cacert is defined and cinder_cacert != "" %}
         - name: cinder-cacert
           hostPath:

--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-nodeplugin.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-nodeplugin.yml.j2
@@ -89,9 +89,6 @@ spec:
             - name: secret-cinderplugin
               mountPath: /etc/config
               readOnly: true
-            - name: ca-certs
-              mountPath: /etc/ssl/certs
-              readOnly: true
 {% if cinder_cacert is defined and cinder_cacert != "" %}
             - name: cinder-cacert
               mountPath: {{ kube_config_dir }}/cinder-cacert.pem
@@ -121,10 +118,6 @@ spec:
         - name: secret-cinderplugin
           secret:
             secretName: cloud-config
-        - name: ca-certs
-          hostPath:
-            path: /etc/ssl/certs
-            type: DirectoryOrCreate
 {% if cinder_cacert is defined and cinder_cacert != "" %}
         - name: cinder-cacert
           hostPath:

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-controller-manager-ds.yml.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-controller-manager-ds.yml.j2
@@ -54,9 +54,6 @@ spec:
             - mountPath: /etc/kubernetes/pki
               name: k8s-certs
               readOnly: true
-            - mountPath: /etc/ssl/certs
-              name: ca-certs
-              readOnly: true
             - mountPath: /etc/config/cloud.conf
               name: cloud-config-volume
               readOnly: true
@@ -87,10 +84,6 @@ spec:
           path: /etc/kubernetes/pki
           type: DirectoryOrCreate
         name: k8s-certs
-      - hostPath:
-          path: /etc/ssl/certs
-          type: DirectoryOrCreate
-        name: ca-certs
       - name: cloud-config-volume
         secret:
           secretName: external-openstack-cloud-config


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

For now, /etc/ssl/certs on the host is mounted on /etc/ssl/certs on the container. This overrides the default /etc/ssl/certs of the container. Because the files in /etc/ssl/certs on the host are often symlinks, when it is mounted on the container those symlinks are broken and the container can not verify SSL certificates anymore (for example `x509: certificate signed by unknown authority` when cinder-csi-plugin tries to connect to the auth-url in cloud.conf).

This PR removes the mount and makes the containers use their default ca-certificates. Custom certificates can still be specified using the `OS_CACERT` environment variable (e.g. in openrc.sh).

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[action required] If you are using an external CA for OpenStack and relied on a custom host /etc/ssl/certs, you now need to set `OS_CACERT = <path_to_external_cacert>` in your openrc because `csi_driver` and `external-openstack-cloud-controller-manager` now use their built-in ca-certificates if not instructed otherwise.
```
