### PR TITLE
Add a way to deploy CNI plugins alongside another CNI

### DIFF
--- a/roles/network_plugin/meta/main.yml
+++ b/roles/network_plugin/meta/main.yml
@@ -1,5 +1,10 @@
 ---
 dependencies:
+  - role: network_plugin/cni
+    when: kube_network_plugin in ['cni', 'cloud'] or cni_plugins_deploy_additionally | default(false) | bool
+    tags:
+      - cni
+
   - role: network_plugin/cilium
     when: kube_network_plugin == 'cilium' or cilium_deploy_additionally | default(false) | bool
     tags:
@@ -24,11 +29,6 @@ dependencies:
     when: kube_network_plugin == 'canal'
     tags:
       - canal
-
-  - role: network_plugin/cni
-    when: kube_network_plugin in ['cni', 'cloud']
-    tags:
-      - cni
 
   - role: network_plugin/macvlan
     when: kube_network_plugin == 'macvlan'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:

The user wants to use bridge ( or others) CNI in the Kubernetes Cluster where Calico is the default CNI.
There needs a way to enable it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kubespray/issues/9366

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add cni_plugins_deploy_additionally to deploy CNI plugins alongside another CNI
```
