### PR TITLE
Fix ensure ping package error in fedora CoreOS & Flatcar

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -116,7 +116,6 @@
     - not is_fedora_coreos
     - not ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
 
-
 - name: Stop if access_ip is not pingable
   command: ping -c1 {{ access_ip }}
   when:

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -113,6 +113,9 @@
     - access_ip is defined
     - not ignore_assert_errors
     - ping_access_ip
+    - not is_fedora_coreos
+    - not ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
+
 
 - name: Stop if access_ip is not pingable
   command: ping -c1 {{ access_ip }}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Skip the CoreOS and Flatcar (they can not install ping with ansible package)

**Which issue(s) this PR fixes**:

Fixes:  https://kubernetes.slack.com/archives/C2V9WJSJD/p1665254198064559

**Special notes for your reviewer**:

Shoud it patch to the kubespray v1.20.1 .

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix ensure ping package error in Fedora CoreOS & Flatcar 
```
