### PR TITLE
Change dns upstream condition for nodelocaldns

### DIFF
--- a/roles/kubernetes-apps/ansible/tasks/nodelocaldns.yml
+++ b/roles/kubernetes-apps/ansible/tasks/nodelocaldns.yml
@@ -33,7 +33,7 @@
       {{ primaryClusterIP }}
       {%- endif -%}
     upstreamForwardTarget: >-
-      {%- if resolvconf_mode == 'host_resolvconf' and upstream_dns_servers is defined and upstream_dns_servers|length > 0 -%}
+      {%- if upstream_dns_servers is defined and upstream_dns_servers|length > 0 -%}
       {{ upstream_dns_servers|join(' ') }}
       {%- else -%}
       /etc/resolv.conf
@@ -61,7 +61,7 @@
       {{ primaryClusterIP }}
       {%- endif -%}
     upstreamForwardTarget: >-
-      {%- if resolvconf_mode == 'host_resolvconf' and upstream_dns_servers is defined and upstream_dns_servers|length > 0 -%}
+      {%- if upstream_dns_servers is defined and upstream_dns_servers|length > 0 -%}
       {{ upstream_dns_servers|join(' ') }}
       {%- else -%}
       /etc/resolv.conf


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

When `upstream_dns_servers` are defined, NodelocalDNS should use them. Now `resolv.conf` is used instead depending on `resolvconf_mode` .

**Special notes for your reviewer**:

Similar problem, but related with CoreDNS was fixed in https://github.com/kubernetes-sigs/kubespray/pull/8263

Thanx!

**Does this PR introduce a user-facing change?**:
```release-note
Change dns upstream condition for nodelocaldns when using `host_resolvconf`
```
