### PR TITLE
Update calico.md to metion the ChecksumOffloadBroken=true

### DIFF
--- a/docs/calico.md
+++ b/docs/calico.md
@@ -205,6 +205,14 @@ To re-define health host please set the following variable in your inventory:
 calico_healthhost: "0.0.0.0"
 ```
 
+### Optional : Configure VXLAN hardware Offload
+
+Because of the Issue [projectcalico/calico#4727](https://github.com/projectcalico/calico/issues/4727), The VXLAN Offload is disable by default. It can be configured like this:
+
+```yml
+calico_feature_detect_override: "ChecksumOffloadBroken=true" # The vxlan offload will enabled with kernel version is > 5.7 (It may cause problem on buggy NIC driver)
+```
+
 ### Optional : Configure Calico Node probe timeouts
 
 Under certain conditions a deployer may need to tune the Calico liveness and readiness probes timeout settings. These can be configured like this:


### PR DESCRIPTION
**What type of PR is this?**

> /kind documentation

**What this PR does / why we need it**:

When installed in the Rocky9, there are some bugs with calico and kernel. The network is broken. The kubespray's default configuration needs to provision a healthy cluster.
 
So the kubespray needs to metion it the calico.md . Thanks to the @oomichi @floryut @cristicalin 's advise at the https://github.com/kubernetes-sigs/kubespray/pull/9261

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes-sigs/kubespray/issues/8992

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
