### PR TITLE
Don't use coredns_server in dhclient.conf if nodelocaldns is enabled

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
@@ -203,7 +203,7 @@
     nameserverentries: |-
       {{ (([nodelocaldns_ip] if enable_nodelocaldns else []) + (coredns_server|d([]) if not enable_nodelocaldns else []) + nameservers|d([]) + cloud_resolver|d([]) + (configured_nameservers|d([]) if not disable_host_nameservers|d()|bool else [])) | unique | join(',') }}
     supersede_nameserver:
-      supersede domain-name-servers {{ ( ( [nodelocaldns_ip] if enable_nodelocaldns else []) + coredns_server|d([]) + nameservers|d([]) + cloud_resolver|d([])) | unique | join(', ') }};
+      supersede domain-name-servers {{ ( ( [nodelocaldns_ip] if enable_nodelocaldns else []) + (coredns_server|d([]) if not enable_nodelocaldns else []) + nameservers|d([]) + cloud_resolver|d([])) | unique | join(', ') }};
   when: not dns_early or dns_late
 
 # This task should run instead of the above task when cluster/nodelocal DNS hasn't


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
This fix adds the same logic for variable `supersede_nameserver` as for variable `nameserverentries`. Without this fix, dhclient changes content of /etc/resolv.conf to something different from what was originally set.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
This fix continues the changes introduced in #9270 and #9282.

**Does this PR introduce a user-facing change?**:

```release-note
Remove coredns_server from supersede_nameserver in dhclient.conf if nodelocaldns is enabled.
```
