### PR TITLE
Update securityContext of netchecker

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/netchecker-server-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-server-deployment.yml.j2
@@ -32,8 +32,14 @@ spec:
               cpu: {{ netchecker_server_cpu_requests }}
               memory: {{ netchecker_server_memory_requests }}
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ['ALL']
             runAsUser: {{ netchecker_server_user | default('0') }}
             runAsGroup: {{ netchecker_server_group | default('0') }}
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - containerPort: 8081
           args:
@@ -63,8 +69,14 @@ spec:
               cpu: {{ netchecker_etcd_cpu_requests }}
               memory: {{ netchecker_etcd_memory_requests }}
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ['ALL']
             runAsUser: {{ netchecker_server_user | default('0') }}
             runAsGroup: {{ netchecker_server_group | default('0') }}
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
       tolerations:
         - effect: NoSchedule
           operator: Exists


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

To run netchecker with necessary privilege, this updates the securityContext.

This comes from https://github.com/kubernetes-sigs/kubespray/pull/9359

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
