### PR TITLE
fix(defaults): wrong cri_socket path for containerd

### DIFF
--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -290,7 +290,7 @@ cri_socket: >-
   {%- if container_manager == 'crio' -%}
   unix:///var/run/crio/crio.sock
   {%- elif container_manager == 'containerd' -%}
-  unix:////var/run/containerd/containerd.sock
+  unix:///var/run/containerd/containerd.sock
   {%- elif container_manager == 'docker' -%}
   unix:///var/run/cri-dockerd.sock
   {%- endif -%}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes the wrong default values of cri_socket that was setting 4 `/` instead of 3 `/` 
We need this PR because kubelet is throwing errors with the default configuration as described below:
```
Oct 17 13:58:56 kube-test-sandbox-node-002 kubelet[2401900]: I1017 13:58:56.831825 2401900 remote_runtime.go:71] "Connecting to runtime service" endpoint="unix:////var/run/containerd/containerd.sock"
Oct 17 13:58:56 kube-test-sandbox-node-002 kubelet[2401900]: I1017 13:58:56.831876 2401900 clientconn.go:252] "[core] parsed scheme: \"\"\n"
Oct 17 13:58:56 kube-test-sandbox-node-002 kubelet[2401900]: I1017 13:58:56.831890 2401900 clientconn.go:258] "[core] scheme \"\" not registered, fallback to default scheme\n"
```
It also puts misleading annotations on nodes:
```
kubeadm.alpha.kubernetes.io/cri-socket: unix:////var/run/containerd/containerd.sock
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix wrong cri_socket path for containerd
```
