### PR TITLE
Fix inconsistent handling of admission plugin list

### DIFF
--- a/docs/hardening.md
+++ b/docs/hardening.md
@@ -41,7 +41,18 @@ kube_encrypt_secret_data: true
 kube_encryption_resources: [secrets]
 kube_encryption_algorithm: "secretbox"
 
-kube_apiserver_enable_admission_plugins: ['EventRateLimit,AlwaysPullImages,ServiceAccount,NamespaceLifecycle,NodeRestriction,LimitRanger,ResourceQuota,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,PodNodeSelector,PodSecurity']
+kube_apiserver_enable_admission_plugins:
+  - EventRateLimit
+  - AlwaysPullImages
+  - ServiceAccount
+  - NamespaceLifecycle
+  - NodeRestriction
+  - LimitRanger
+  - ResourceQuota
+  - MutatingAdmissionWebhook
+  - ValidatingAdmissionWebhook
+  - PodNodeSelector
+  - PodSecurity
 kube_apiserver_admission_control_config_file: true
 # EventRateLimit plugin configuration
 kube_apiserver_admission_event_rate_limits:

--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -106,7 +106,8 @@
   when:
     - kube_apiserver_admission_control_config_file
     - item in kube_apiserver_admission_plugins_needs_configuration
-  loop: "{{ kube_apiserver_enable_admission_plugins[0].split(',') }}"
+  # Backward compatible handling of both normal list and single item comma separated admission plugins
+  loop: "{{ kube_apiserver_enable_admission_plugins[0].split(',') + kube_apiserver_enable_admission_plugins[1:] }}"
 
 - name: kubeadm | Check if apiserver.crt contains all needed SANs
   shell: |

--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -107,7 +107,7 @@
     - kube_apiserver_admission_control_config_file
     - item in kube_apiserver_admission_plugins_needs_configuration
   # Backward compatible handling of both normal list and single item comma separated admission plugins
-  loop: "{{ kube_apiserver_enable_admission_plugins[0].split(',') + kube_apiserver_enable_admission_plugins[1:] }}"
+  loop: "{{ kube_apiserver_enable_admission_plugins }}"
 
 - name: kubeadm | Check if apiserver.crt contains all needed SANs
   shell: |

--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -106,7 +106,6 @@
   when:
     - kube_apiserver_admission_control_config_file
     - item in kube_apiserver_admission_plugins_needs_configuration
-  # Backward compatible handling of both normal list and single item comma separated admission plugins
   loop: "{{ kube_apiserver_enable_admission_plugins }}"
 
 - name: kubeadm | Check if apiserver.crt contains all needed SANs

--- a/roles/kubernetes/control-plane/templates/admission-controls.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/admission-controls.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: apiserver.config.k8s.io/v1
 kind: AdmissionConfiguration
 plugins:
-{% for plugin in kube_apiserver_enable_admission_plugins[0].split(',') %}
+{% for plugin in kube_apiserver_enable_admission_plugins %}
 {% if plugin in kube_apiserver_admission_plugins_needs_configuration %}
 - name: {{ plugin }}
   path: {{ kube_config_dir }}/{{ plugin|lower }}.yaml

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -310,4 +310,6 @@
   assert:
     that: "',' not in kube_apiserver_enable_admission_plugins[0]"
     msg: "Comma-separated list for kube_apiserver_enable_admission_plugins is now deprecated, use separate list items for each plugin."
-  when: kube_apiserver_enable_admission_plugins
+  when:
+    - kube_apiserver_enable_admission_plugins is defined
+    - kube_apiserver_enable_admission_plugins | length > 0

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -305,3 +305,9 @@
   when:
     - kube_external_ca_mode
     - not ignore_assert_errors
+
+- name: Stop if using deprecated comma separated list for admission plugins
+  assert:
+    that: "',' not in kube_apiserver_enable_admission_plugins[0]"
+    msg: "Comma-separated list for kube_apiserver_enable_admission_plugins is now deprecated, use separate list items for each plugin."
+  when: kube_apiserver_enable_admission_plugins

--- a/tests/files/packet_ubuntu20-calico-aio-hardening.yml
+++ b/tests/files/packet_ubuntu20-calico-aio-hardening.yml
@@ -36,7 +36,18 @@ kube_encrypt_secret_data: true
 kube_encryption_resources: [secrets]
 kube_encryption_algorithm: "secretbox"
 
-kube_apiserver_enable_admission_plugins: ['EventRateLimit,AlwaysPullImages,ServiceAccount,NamespaceLifecycle,NodeRestriction,LimitRanger,ResourceQuota,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,PodNodeSelector,PodSecurity']
+kube_apiserver_enable_admission_plugins:
+  - EventRateLimit
+  - AlwaysPullImages
+  - ServiceAccount
+  - NamespaceLifecycle
+  - NodeRestriction
+  - LimitRanger
+  - ResourceQuota
+  - MutatingAdmissionWebhook
+  - ValidatingAdmissionWebhook
+  - PodNodeSelector
+  - PodSecurity
 kube_apiserver_admission_control_config_file: true
 # EventRateLimit plugin configuration
 kube_apiserver_admission_event_rate_limits:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Addresses inconsistent handling of the admission plugin list format.

Most cases simply expect the list to be joinable on commas so either formats would end up the same, except for this one case in `kubeadm-setup` that's looping on each plugin.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

I made it so it's backward compatible, but it could also be a made into a breaking change if we want to remove the weird list concat.

**Does this PR introduce a user-facing change?**:

```release-note
`kube_apiserver_enable_admission_plugins` must be specified as a list of individual plugin names instead of a single item comma-separated list.
```
