### PR TITLE
Fix nginx-proxy(& haproxy) binds on all interfaces

### DIFF
--- a/roles/kubernetes/node/templates/loadbalancer/haproxy.cfg.j2
+++ b/roles/kubernetes/node/templates/loadbalancer/haproxy.cfg.j2
@@ -21,13 +21,19 @@ defaults
 
 {% if loadbalancer_apiserver_healthcheck_port is defined -%}
 frontend healthz
-  bind *:{{ loadbalancer_apiserver_healthcheck_port }}
+  bind 127.0.0.1:{{ loadbalancer_apiserver_healthcheck_port }}
+  {% if enable_dual_stack_networks -%}
+  bind [::1]:{{ loadbalancer_apiserver_healthcheck_port }}
+  {% endif -%}
   mode http
   monitor-uri /healthz
 {% endif %}
 
 frontend kube_api_frontend
   bind 127.0.0.1:{{ loadbalancer_apiserver_port|default(kube_apiserver_port) }}
+  {% if enable_dual_stack_networks -%}
+  bind [::1]:{{ loadbalancer_apiserver_port|default(kube_apiserver_port) }}
+  {% endif -%}
   mode tcp
   option tcplog
   default_backend kube_api_backend

--- a/roles/kubernetes/node/templates/loadbalancer/nginx.conf.j2
+++ b/roles/kubernetes/node/templates/loadbalancer/nginx.conf.j2
@@ -21,7 +21,7 @@ stream {
   server {
     listen        127.0.0.1:{{ loadbalancer_apiserver_port|default(kube_apiserver_port) }};
     {% if enable_dual_stack_networks -%}
-    listen        [::]:{{ loadbalancer_apiserver_port|default(kube_apiserver_port) }};
+    listen        [::1]:{{ loadbalancer_apiserver_port|default(kube_apiserver_port) }};
     {% endif -%}
     proxy_pass    kube_apiserver;
     proxy_timeout 10m;
@@ -43,9 +43,9 @@ http {
 
   {% if loadbalancer_apiserver_healthcheck_port is defined -%}
   server {
-    listen {{ loadbalancer_apiserver_healthcheck_port }};
+    listen 127.0.0.1:{{ loadbalancer_apiserver_healthcheck_port }};
     {% if enable_dual_stack_networks -%}
-    listen [::]:{{ loadbalancer_apiserver_healthcheck_port }};
+    listen [::1]:{{ loadbalancer_apiserver_healthcheck_port }};
     {% endif -%}
     location /healthz {
       access_log off;

--- a/roles/kubernetes/node/templates/manifests/haproxy.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/haproxy.manifest.j2
@@ -25,10 +25,12 @@ spec:
     {% if loadbalancer_apiserver_healthcheck_port is defined -%}
     livenessProbe:
       httpGet:
+        host: 127.0.0.1
         path: /healthz
         port: {{ loadbalancer_apiserver_healthcheck_port }}
     readinessProbe:
       httpGet:
+        host: 127.0.0.1
         path: /healthz
         port: {{ loadbalancer_apiserver_healthcheck_port }}
     {% endif -%}

--- a/roles/kubernetes/node/templates/manifests/nginx-proxy.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/nginx-proxy.manifest.j2
@@ -25,10 +25,12 @@ spec:
     {% if loadbalancer_apiserver_healthcheck_port is defined -%}
     livenessProbe:
       httpGet:
+        host: 127.0.0.1
         path: /healthz
         port: {{ loadbalancer_apiserver_healthcheck_port }}
     readinessProbe:
       httpGet:
+        host: 127.0.0.1
         path: /healthz
         port: {{ loadbalancer_apiserver_healthcheck_port }}
     {% endif -%}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind bug


**What this PR does / why we need it**:

Static pod nginx-proxy binds on 0.0.0.0 and [it is not configurable](https://github.com/kubernetes-sigs/kubespray/blob/master/roles/kubernetes/node/templates/loadbalancer/nginx.conf.j2#L46). 

It binds to 127.0.0.1 could be better.

![image](https://user-images.githubusercontent.com/1469319/196842903-2d7cc854-24bd-432f-afb3-92159ff2b38c.png)

This can be an issue since it exposes the port on all interfaces and it cannot be used by something else.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes  https://github.com/kubernetes-sigs/kubespray/issues/9135

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Bind loadbalancer_apiserver_healthcheck interface to 127.0.0.1 .
```

