### PR TITLE
Update docker version to 20.10.20

### DIFF
--- a/roles/container-engine/docker/vars/debian.yml
+++ b/roles/container-engine/docker/vars/debian.yml
@@ -18,17 +18,17 @@ docker_versioned_pkg:
   'latest': docker-ce
   '18.09': docker-ce=5:18.09.9~3-0~debian-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce=5:19.03.15~3-0~debian-{{ ansible_distribution_release|lower }}
-  '20.10': docker-ce=5:20.10.17~3-0~debian-{{ ansible_distribution_release|lower }}
-  'stable': docker-ce=5:20.10.17~3-0~debian-{{ ansible_distribution_release|lower }}
-  'edge': docker-ce=5:20.10.17~3-0~debian-{{ ansible_distribution_release|lower }}
+  '20.10': docker-ce=5:20.10.20~3-0~debian-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce=5:20.10.20~3-0~debian-{{ ansible_distribution_release|lower }}
+  'edge': docker-ce=5:20.10.20~3-0~debian-{{ ansible_distribution_release|lower }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
   '18.09': docker-ce-cli=5:18.09.9~3-0~debian-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce-cli=5:19.03.15~3-0~debian-{{ ansible_distribution_release|lower }}
-  '20.10': docker-ce-cli=5:20.10.17~3-0~debian-{{ ansible_distribution_release|lower }}
-  'stable': docker-ce-cli=5:20.10.17~3-0~debian-{{ ansible_distribution_release|lower }}
-  'edge': docker-ce-cli=5:20.10.17~3-0~debian-{{ ansible_distribution_release|lower }}
+  '20.10': docker-ce-cli=5:20.10.20~3-0~debian-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce-cli=5:20.10.20~3-0~debian-{{ ansible_distribution_release|lower }}
+  'edge': docker-ce-cli=5:20.10.20~3-0~debian-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkgs:

--- a/roles/container-engine/docker/vars/fedora.yml
+++ b/roles/container-engine/docker/vars/fedora.yml
@@ -18,16 +18,16 @@ containerd_versioned_pkg:
 docker_versioned_pkg:
   'latest': docker-ce
   '19.03': docker-ce-19.03.15-3.fc{{ ansible_distribution_major_version }}
-  '20.10': docker-ce-20.10.17-3.fc{{ ansible_distribution_major_version }}
-  'stable': docker-ce-20.10.17-3.fc{{ ansible_distribution_major_version }}
-  'edge': docker-ce-20.10.17-3.fc{{ ansible_distribution_major_version }}
+  '20.10': docker-ce-20.10.20-3.fc{{ ansible_distribution_major_version }}
+  'stable': docker-ce-20.10.20-3.fc{{ ansible_distribution_major_version }}
+  'edge': docker-ce-20.10.20-3.fc{{ ansible_distribution_major_version }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
   '19.03': docker-ce-cli-19.03.15-3.fc{{ ansible_distribution_major_version }}
-  '20.10': docker-ce-cli-20.10.17-3.fc{{ ansible_distribution_major_version }}
-  'stable': docker-ce-cli-20.10.17-3.fc{{ ansible_distribution_major_version }}
-  'edge': docker-ce-cli-20.10.17-3.fc{{ ansible_distribution_major_version }}
+  '20.10': docker-ce-cli-20.10.20-3.fc{{ ansible_distribution_major_version }}
+  'stable': docker-ce-cli-20.10.20-3.fc{{ ansible_distribution_major_version }}
+  'edge': docker-ce-cli-20.10.20-3.fc{{ ansible_distribution_major_version }}
 
 docker_package_info:
   enablerepo: "docker-ce"

--- a/roles/container-engine/docker/vars/redhat-7.yml
+++ b/roles/container-engine/docker/vars/redhat-7.yml
@@ -20,17 +20,17 @@ docker_versioned_pkg:
   'latest': docker-ce
   '18.09': docker-ce-18.09.9-3.el7
   '19.03': docker-ce-19.03.15-3.el7
-  '20.10': docker-ce-20.10.17-3.el7
-  'stable': docker-ce-20.10.17-3.el7
-  'edge': docker-ce-20.10.17-3.el7
+  '20.10': docker-ce-20.10.20-3.el7
+  'stable': docker-ce-20.10.20-3.el7
+  'edge': docker-ce-20.10.20-3.el7
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
   '18.09': docker-ce-cli-18.09.9-3.el7
   '19.03': docker-ce-cli-19.03.15-3.el7
-  '20.10': docker-ce-cli-20.10.17-3.el7
-  'stable': docker-ce-cli-20.10.17-3.el7
-  'edge': docker-ce-cli-20.10.17-3.el7
+  '20.10': docker-ce-cli-20.10.20-3.el7
+  'stable': docker-ce-cli-20.10.20-3.el7
+  'edge': docker-ce-cli-20.10.20-3.el7
 
 docker_package_info:
   enablerepo: "docker-ce"

--- a/roles/container-engine/docker/vars/redhat.yml
+++ b/roles/container-engine/docker/vars/redhat.yml
@@ -20,17 +20,17 @@ docker_versioned_pkg:
   'latest': docker-ce
   '18.09': docker-ce-3:18.09.9-3.el7
   '19.03': docker-ce-3:19.03.15-3.el{{ ansible_distribution_major_version }}
-  '20.10': docker-ce-3:20.10.17-3.el{{ ansible_distribution_major_version }}
-  'stable': docker-ce-3:20.10.17-3.el{{ ansible_distribution_major_version }}
-  'edge': docker-ce-3:20.10.17-3.el{{ ansible_distribution_major_version }}
+  '20.10': docker-ce-3:20.10.20-3.el{{ ansible_distribution_major_version }}
+  'stable': docker-ce-3:20.10.20-3.el{{ ansible_distribution_major_version }}
+  'edge': docker-ce-3:20.10.20-3.el{{ ansible_distribution_major_version }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
   '18.09': docker-ce-cli-1:18.09.9-3.el7
   '19.03': docker-ce-cli-1:19.03.15-3.el{{ ansible_distribution_major_version }}
-  '20.10': docker-ce-cli-1:20.10.17-3.el{{ ansible_distribution_major_version }}
-  'stable': docker-ce-cli-1:20.10.17-3.el{{ ansible_distribution_major_version }}
-  'edge': docker-ce-cli-1:20.10.17-3.el{{ ansible_distribution_major_version }}
+  '20.10': docker-ce-cli-1:20.10.20-3.el{{ ansible_distribution_major_version }}
+  'stable': docker-ce-cli-1:20.10.20-3.el{{ ansible_distribution_major_version }}
+  'edge': docker-ce-cli-1:20.10.20-3.el{{ ansible_distribution_major_version }}
 
 docker_package_info:
   enablerepo: "docker-ce"

--- a/roles/container-engine/docker/vars/ubuntu.yml
+++ b/roles/container-engine/docker/vars/ubuntu.yml
@@ -18,17 +18,17 @@ docker_versioned_pkg:
   'latest': docker-ce
   '18.09': docker-ce=5:18.09.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce=5:19.03.15~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  '20.10': docker-ce=5:20.10.17~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'stable': docker-ce=5:20.10.17~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'edge': docker-ce=5:20.10.17~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '20.10': docker-ce=5:20.10.20~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce=5:20.10.20~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'edge': docker-ce=5:20.10.20~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
   '18.09': docker-ce-cli=5:18.09.9~3-0~ubuntu-{{ ansible_distribution_release|lower }}
   '19.03': docker-ce-cli=5:19.03.15~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  '20.10': docker-ce-cli=5:20.10.17~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'stable': docker-ce-cli=5:20.10.17~3-0~ubuntu-{{ ansible_distribution_release|lower }}
-  'edge': docker-ce-cli=5:20.10.17~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '20.10': docker-ce-cli=5:20.10.20~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'stable': docker-ce-cli=5:20.10.20~3-0~ubuntu-{{ ansible_distribution_release|lower }}
+  'edge': docker-ce-cli=5:20.10.20~3-0~ubuntu-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkgs:


### PR DESCRIPTION
**What type of PR is this?**
/kind container-managers

**What this PR does / why we need it**:
Update docker to 20.10.20 to mitigate CVE 
ref: https://github.com/moby/moby/releases/tag/v20.10.20

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
[Docker] Update docker package to 20.10.20 (partial fix for CVE-2022-39253)
```
