### PR TITLE
Minor changes on Kube VIP configuration parameters

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -77,7 +77,7 @@ kube_vip_bgp_routerid:
 kube_vip_local_as: 65000
 kube_vip_bgp_peeraddress:
 kube_vip_bgp_peerpass:
-kube_vip_bgp_peeras:
+kube_vip_bgp_peeras: 65000
 kube_vip_bgppeers:
 kube_vip_address:
 

--- a/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
@@ -13,7 +13,7 @@ spec:
     - name: vip_arp
       value: {{ kube_vip_arp_enabled | string | to_json }}
     - name: port
-      value: "6443"
+      value: {{ kube_apiserver_port | string | to_json }}
 {% if kube_vip_interface %}
     - name: vip_interface
       value: {{ kube_vip_interface | string | to_json }}
@@ -60,10 +60,10 @@ spec:
     - name: bgp_peerpass
       value: {{ kube_vip_bgp_peerpass | to_json }}
     - name: bgp_peeras
-      value: {{ kube_vip_bgp_peeras | to_json }}
+      value: {{ kube_vip_bgp_peeras | string | to_json }}
 {% if kube_vip_bgppeers %}
     - name: bgp_peers
-      value: {{ kube_vip_bgp_peeras | join(',')  | to_json }}
+      value: {{ kube_vip_bgppeers | join(',')  | to_json }}
 {% endif %}
 {% endif %}
     - name: address


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
There were 2 issues with the Kube-vip definitions when used within Kubespray:
 - When moving the API controller to a separate port (lets say 443 instead of 6443), usage of Kube Vip for an HA address wasn't possible as the API port for Kube Vip was statically assigned at 6443
 - When using Kube-VIP with BGP, setting a custom BGP PeerAs-does not work as it is applied as numeric value in the resulting yaml. Converting to string was necessary and is applied, and as a regression also a default value needed to be set

**Which issue(s) this PR fixes**:
Fixes #9391 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[kube-vip] Minor changes on Kube VIP configuration parameters (and fix wrong properties)
```