### PR TITLE
[2.19] Ensure ostree variable has been defined

### DIFF
--- a/roles/container-engine/runc/tasks/main.yml
+++ b/roles/container-engine/runc/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: runc | check if fedora coreos
+  stat:
+    path: /run/ostree-booted
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
+  register: ostree
+
 - name: runc | set is_ostree
   set_fact:
     is_ostree: "{{ ostree.stat.exists }}"


### PR DESCRIPTION
The ostree variable is not defined previously raising an error when the runtime tries to read it.

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Backport of https://github.com/kubernetes-sigs/kubespray/pull/9321

**Special notes for your reviewer**:
This backport is also needed for 2.18 and 2.17, but let's not change more than one previous release.