### PR TITLE
[etcd] add 3.5.5 hashes, make it default for k8s 1.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Note: Upstart/SysV init based OS types are not supported.
 
 - Core
   - [kubernetes](https://github.com/kubernetes/kubernetes) v1.25.3
-  - [etcd](https://github.com/etcd-io/etcd) v3.5.4
+  - [etcd](https://github.com/etcd-io/etcd) v3.5.5
   - [docker](https://www.docker.com/) v20.10 (see note)
   - [containerd](https://containerd.io/) v1.6.8
   - [cri-o](http://cri-o.io/) v1.24 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -132,7 +132,7 @@ skopeo_version: v1.10.0
 kube_major_version: "{{ kube_version | regex_replace('^v([0-9])+\\.([0-9]+)\\.[0-9]+', 'v\\1.\\2') }}"
 
 etcd_supported_versions:
-  v1.25: "v3.5.4"
+  v1.25: "v3.5.5"
   v1.24: "v3.5.4"
   v1.23: "v3.5.3"
 etcd_version: "{{ etcd_supported_versions[kube_major_version] }}"
@@ -546,15 +546,19 @@ etcd_binary_checksums:
   arm:
     v3.5.3: 0
     v3.5.4: 0
+    v3.5.5: 0
   arm64:
     v3.5.3: 8b00f2f51568303799368ee4a3c9b9ff8a3dd9f8b7772c4f6589e46bc62f7115
     v3.5.4: 8e9c2c28ed6b35f36fd94300541da10e1385f335d677afd8efccdcba026f1fa7
+    v3.5.5: a8d177ae8ecfd1ef025c35ac8c444041d14e67028c1a7b4eda3a69a8dee5f9c3
   amd64:
     v3.5.3: e13e119ff9b28234561738cd261c2a031eb1c8688079dcf96d8035b3ad19ca58
     v3.5.4: b1091166153df1ee0bb29b47fb1943ef0ddf0cd5d07a8fe69827580a08134def
+    v3.5.5: 7910a2fdb1863c80b885d06f6729043bff0540f2006bf6af34674df2636cb906
   ppc64le:
     v3.5.3: f14154897ca5ad4698383b4c197001340fbe467525f6fab3b89ee8116246480f
     v3.5.4: 2f0389caed87c2504ffc5a07592ca2a688dee45d599073e5f977d9ce75b5f941
+    v3.5.5: 08422dffd5749f0a5f18bd820241d751e539a666af94251c3715cba8f4702c42
 
 cni_binary_checksums:
   arm:


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds etcd 3.5.5 and makes it the default for kubernetes 1.25
The release changelog is here https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.5.md 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[etcd] Default version to 3.5.5 for k8s 1.25.x
```