### PR TITLE
Upgrade ruamel.yaml.clib to work with Python 3.11

### DIFF
--- a/requirements-2.11.txt
+++ b/requirements-2.11.txt
@@ -6,5 +6,5 @@ netaddr==0.7.19
 pbr==5.4.4
 jmespath==0.9.5
 ruamel.yaml==0.16.10
-ruamel.yaml.clib==0.2.6
+ruamel.yaml.clib==0.2.7
 MarkupSafe==1.1.1

--- a/requirements-2.12.txt
+++ b/requirements-2.12.txt
@@ -6,5 +6,5 @@ netaddr==0.7.19
 pbr==5.4.4
 jmespath==0.9.5
 ruamel.yaml==0.16.10
-ruamel.yaml.clib==0.2.6
+ruamel.yaml.clib==0.2.7
 MarkupSafe==1.1.1


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This commit upgrades `ruamel.yaml.clib` to work with <s>the upcoming</s> Python 3.11.

Cf. https://sourceforge.net/p/ruamel-yaml-clib/tickets/9/

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

`ruamel.yaml.clib==0.2.7` fixes the Python 3.11 issue and works with previous Python versions.

**Does this PR introduce a user-facing change?**:
```release-note
Support Python 3.11 -  `ruamel.yaml.clib` need to be updated to 0.2.7
```
