### PR TITLE
Skip removing worker nodes if kube_control_plane is not set

### DIFF
--- a/roles/remove-node/post-remove/tasks/main.yml
+++ b/roles/remove-node/post-remove/tasks/main.yml
@@ -2,8 +2,10 @@
 - name: remove-node | Delete node
   command: "{{ kubectl }} delete node {{ kube_override_hostname|default(inventory_hostname) }}"
   delegate_to: "{{ groups['kube_control_plane']|first }}"
-  # ignore servers that are not nodes
-  when: inventory_hostname in groups['k8s_cluster'] and kube_override_hostname|default(inventory_hostname) in nodes.stdout_lines
+  when:
+    - groups['kube_control_plane'] | length > 0
+    # ignore servers that are not nodes
+    - inventory_hostname in groups['k8s_cluster'] and kube_override_hostname|default(inventory_hostname) in nodes.stdout_lines
   retries: "{{ delete_node_retries }}"
   # Sometimes the api-server can have a short window of indisponibility when we delete a master node
   delay: "{{ delete_node_delay_seconds }}"

--- a/roles/remove-node/pre-remove/tasks/main.yml
+++ b/roles/remove-node/pre-remove/tasks/main.yml
@@ -3,6 +3,8 @@
   command: >-
     {{ kubectl }} get nodes -o go-template={% raw %}'{{ range .items }}{{ .metadata.name }}{{ "\n" }}{{ end }}'{% endraw %}
   register: nodes
+  when:
+    - groups['kube_control_plane'] | length > 0
   delegate_to: "{{ groups['kube_control_plane']|first }}"
   changed_when: false
   run_once: true
@@ -15,8 +17,10 @@
       --grace-period {{ drain_grace_period }}
       --timeout {{ drain_timeout }}
       --delete-emptydir-data {{ kube_override_hostname|default(inventory_hostname) }}
-  # ignore servers that are not nodes
-  when: kube_override_hostname|default(inventory_hostname) in nodes.stdout_lines
+  when:
+    - groups['kube_control_plane'] | length > 0
+    # ignore servers that are not nodes
+    - kube_override_hostname|default(inventory_hostname) in nodes.stdout_lines
   register: result
   failed_when: result.rc != 0 and not allow_ungraceful_removal
   delegate_to: "{{ groups['kube_control_plane']|first }}"
@@ -34,5 +38,6 @@
   retries: 3
   delay: "{{ drain_grace_period }}"
   when:
+    - groups['kube_control_plane'] | length > 0
     - not allow_ungraceful_removal
     - kube_override_hostname|default(inventory_hostname) in nodes.stdout_lines

--- a/roles/remove-node/remove-etcd-node/tasks/main.yml
+++ b/roles/remove-node/remove-etcd-node/tasks/main.yml
@@ -5,6 +5,7 @@
     -o jsonpath='{range .status.addresses[?(@.type=="InternalIP")]}{@.address}{"\n"}{end}'
   register: remove_node_ip
   when:
+    - groups['kube_control_plane'] | length > 0
     - inventory_hostname in groups['etcd']
     - ip is not defined
     - access_ip is not defined


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
If I try to delete a worker node when no `kube_control_plane` nodes are given, it tries to access to the first control plane node (`kube_control_plane[0]` or `kube_control_plane | first`) without verifying the number of `kube_control_plane` nodes, and an error occurs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Deleting worker nodes is now skipped if there is no `kube_control_plane` node.
```
