### PR TITLE
When using cilium CNI, install Cilium CLI

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -117,6 +117,7 @@ weave_version: 2.8.1
 pod_infra_version: "3.7"
 
 cilium_version: "v1.12.1"
+cilium_cli_version: "v0.12.5"
 cilium_enable_hubble: false
 
 kube_ovn_version: "v1.9.7"
@@ -158,6 +159,7 @@ cni_download_url: "https://github.com/containernetworking/plugins/releases/downl
 calicoctl_download_url: "https://github.com/projectcalico/calico/releases/download/{{ calico_ctl_version }}/calicoctl-linux-{{ image_arch }}"
 calicoctl_alternate_download_url: "https://github.com/projectcalico/calicoctl/releases/download/{{ calico_ctl_version }}/calicoctl-linux-{{ image_arch }}"
 calico_crds_download_url: "https://github.com/projectcalico/calico/archive/{{ calico_version }}.tar.gz"
+ciliumcli_download_url: "https://github.com/cilium/cilium-cli/releases/download/{{ cilium_cli_version }}/cilium-linux-{{ image_arch }}.tar.gz"
 crictl_download_url: "https://github.com/kubernetes-sigs/cri-tools/releases/download/{{ crictl_version }}/crictl-{{ crictl_version }}-{{ ansible_system | lower }}-{{ image_arch }}.tar.gz"
 crio_download_url: "https://storage.googleapis.com/cri-o/artifacts/cri-o.{{ image_arch }}.{{ crio_version }}.tar.gz"
 helm_download_url: "https://get.helm.sh/helm-{{ helm_version }}-linux-{{ image_arch }}.tar.gz"
@@ -592,6 +594,20 @@ calicoctl_binary_checksums:
     v3.22.4: f8672ac27ab72c1b05b0f9ae5694881ef8e061bfbcf551f964e7f0a37090a243
     v3.21.6: f7aad0409de2838ba691708943a2aeeef6fb9c02a0475293106e179dc48a4632
 
+ciliumcli_binary_checksums:
+  arm:
+    v0.12.4: 8e0596d321c97a55449942c2ebd8bb0102dc6a9381919287e383b679cee8f524
+    v0.12.5: 1c9a8cf8df62eb814d6c90f6ad6a1c074f991fde5b5573059d27729f12619496
+  amd64:
+    v0.12.4: 6b4f899fa09b6558a89a32ace3be4dedca08b7f4b76f04931ed1ffb2de8965e2
+    v0.12.5: 6b2c9031e4264482b18873ad337394442b8787d6ac26e16e865d36f320c650f0
+  arm64:
+    v0.12.4: e037f34fded56e4199e9e7ff1ce623d2516be7116a6490e02377f786acec5bda
+    v0.12.5: b779d4b04b23fcae30cc158ce9d29e2cad0c98bd88582c0a2c8d457c71d5c4b3
+  ppc64le:
+    v0.12.4: 0
+    v0.12.5: 0
+
 calico_crds_archive_checksums:
   v3.23.3: d25f5c9a3adeba63219f3c8425a8475ebfbca485376a78193ec1e4c74e7a6115
   v3.22.4: e72e7b8b26256950c1ce0042ac85fa83700154dae9723c8d007de88343f6a7e5
@@ -858,6 +874,7 @@ kubectl_binary_checksum: "{{ kubectl_checksums[image_arch][kube_version] }}"
 kubeadm_binary_checksum: "{{ kubeadm_checksums[image_arch][kubeadm_version] }}"
 calicoctl_binary_checksum: "{{ calicoctl_binary_checksums[image_arch][calico_ctl_version] }}"
 calico_crds_archive_checksum: "{{ calico_crds_archive_checksums[calico_version] }}"
+ciliumcli_binary_checksum: "{{ ciliumcli_binary_checksums[image_arch][cilium_cli_version] }}"
 crictl_binary_checksum: "{{ crictl_checksums[image_arch][crictl_version] }}"
 crio_archive_checksum: "{{ crio_archive_checksums[image_arch][crio_version] }}"
 cri_dockerd_archive_checksum: "{{ cri_dockerd_archive_checksums[image_arch][cri_dockerd_version] }}"
@@ -1368,6 +1385,19 @@ downloads:
     repo: "{{ cilium_hubble_envoy_image_repo }}"
     tag: "{{ cilium_hubble_envoy_image_tag }}"
     sha256: "{{ cilium_hubble_envoy_digest_checksum|default(None) }}"
+    groups:
+    - k8s_cluster
+
+  ciliumcli:
+    enabled: "{{ kube_network_plugin == 'cilium' or cilium_deploy_additionally | default(false) | bool }}"
+    file: true
+    version: "{{ cilium_cli_version }}"
+    dest: "{{ local_release_dir }}/cilium"
+    sha256: "{{ ciliumcli_binary_checksum }}"
+    url: "{{ ciliumcli_download_url }}"
+    unarchive: true
+    owner: "root"
+    mode: "0755"
     groups:
     - k8s_cluster
 

--- a/roles/network_plugin/cilium/tasks/install.yml
+++ b/roles/network_plugin/cilium/tasks/install.yml
@@ -88,3 +88,10 @@
     dest: /etc/cni/net.d/000-cilium-portmap.conflist
     mode: 0644
   when: cilium_enable_portmap
+
+- name: Cilium | Copy Ciliumcli binary from download dir
+  copy:
+    src: "{{ local_release_dir }}/cilium"
+    dest: "{{ bin_dir }}/cilium"
+    mode: 0755
+    remote_src: yes


### PR DESCRIPTION
Signed-off-by: dcwbq <biqiang.wu@daocloud.io>

**What type of PR is this?**
 /kind feature

**What this PR does / why we need it**:
ciliumcli provides rich functions. You must use this tool when you start clustermesh. When using cilium CNI, it is necessary to install it by default

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Just like calicoctl, it is installed by default

**Does this PR introduce a user-facing change?**:
None

```release-note
When using cilium CNI, install Cilium CLI
```
