### PR TITLE
Allow setting the DirectRouting option on flannel VXLAN

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-flannel.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-flannel.yml
@@ -16,3 +16,4 @@
 # flannel_backend_type: "vxlan"
 # flannel_vxlan_vni: 1
 # flannel_vxlan_port: 8472
+# flannel_vxlan_direct_routing: false

--- a/roles/network_plugin/flannel/defaults/main.yml
+++ b/roles/network_plugin/flannel/defaults/main.yml
@@ -19,6 +19,7 @@
 flannel_backend_type: "vxlan"
 flannel_vxlan_vni: 1
 flannel_vxlan_port: 8472
+flannel_vxlan_direct_routing: false
 
 # Limits for apps
 flannel_memory_limit: 500M

--- a/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
+++ b/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
@@ -34,7 +34,8 @@ data:
       "Backend": {
         "Type": "{{ flannel_backend_type }}"{% if flannel_backend_type == "vxlan" %},
         "VNI": {{ flannel_vxlan_vni }},
-        "Port": {{ flannel_vxlan_port }}
+        "Port": {{ flannel_vxlan_port }},
+        "DirectRouting": {{ flannel_vxlan_direct_routing | to_json }}
 {% endif %}
       }
     }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds the possibility to set the `DirectRouting` option on the flannel VXLAN backend.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

It is disabled by default on flannel, by defaulting to `false` here as well we are fully backward compatible with the previous behavior.

**Does this PR introduce a user-facing change?**:

```release-note

```
