### PR TITLE
Add switch cilium_enable_bandwidth_manager

### DIFF
--- a/docs/cilium.md
+++ b/docs/cilium.md
@@ -121,6 +121,23 @@ cilium_encryption_type: "wireguard"
 
 Kubespray currently supports Linux distributions with Wireguard Kernel mode on Linux 5.6 and newer.
 
+## Bandwidth Manager
+
+Cilium’s bandwidth manager supports the kubernetes.io/egress-bandwidth Pod annotation.
+
+Bandwidth enforcement currently does not work in combination with L7 Cilium Network Policies.
+In case they select the Pod at egress, then the bandwidth enforcement will be disabled for those Pods.
+
+Bandwidth Manager requires a v5.1.x or more recent Linux kernel.
+
+For further information, make sure to check the official [Cilium documentation.](https://docs.cilium.io/en/v1.12/gettingstarted/bandwidth-manager/)
+
+To use this function, set the following parameters
+
+```yml
+cilium_enable_bandwidth_manager: true
+```
+
 ## Install Cilium Hubble
 
 k8s-net-cilium.yml:

--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -103,6 +103,13 @@ cilium_ipsec_node_encryption: false
 # This option is only effective when `cilium_encryption_type` is set to `wireguard`.
 cilium_wireguard_userspace_fallback: false
 
+# Enable Bandwidth Manager
+# Cilium’s bandwidth manager supports the kubernetes.io/egress-bandwidth Pod annotation.
+# Bandwidth enforcement currently does not work in combination with L7 Cilium Network Policies.
+# In case they select the Pod at egress, then the bandwidth enforcement will be disabled for those Pods.
+# Bandwidth Manager requires a v5.1.x or more recent Linux kernel.
+cilium_enable_bandwidth_manager: false
+
 # IP Masquerade Agent
 # https://docs.cilium.io/en/stable/concepts/networking/masquerading/
 # By default, all packets from a pod destined to an IP address outside of the cilium_native_routing_cidr range are masqueraded

--- a/roles/network_plugin/cilium/templates/cilium/config.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/config.yml.j2
@@ -117,6 +117,15 @@ data:
   #   - geneve
   tunnel: "{{ cilium_tunnel_mode }}"
 
+  # Enable Bandwidth Manager
+  # Cilium’s bandwidth manager supports the kubernetes.io/egress-bandwidth Pod annotation.
+  # Bandwidth enforcement currently does not work in combination with L7 Cilium Network Policies.
+  # In case they select the Pod at egress, then the bandwidth enforcement will be disabled for those Pods.
+  # Bandwidth Manager requires a v5.1.x or more recent Linux kernel.
+{% if cilium_enable_bandwidth_manager %}
+  enable-bandwidth-manager: "true"
+{% endif %}
+
   # Name of the cluster. Only relevant when building a mesh of clusters.
   cluster-name: "{{ cilium_cluster_name }}"
 


### PR DESCRIPTION
Signed-off-by: dcwbq <biqiang.wu@daocloud.io>

**What type of PR is this?**
 /kind feature

**What this PR does / why we need it**:
Bandwidth Manager is officially supported in cilium v1.12

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

```release-note
Add switch cilium_enable_bandwidth_manager
```
