### PR TITLE
Modified the default value of cilium IPAM and added the support for r…

### DIFF
--- a/docs/cilium.md
+++ b/docs/cilium.md
@@ -1,5 +1,48 @@
 # Cilium
 
+## IP Address Management (IPAM)
+
+IP Address Management (IPAM) is responsible for the allocation and management of IP addresses used by network endpoints (container and others) managed by Cilium. The default mode is "Cluster Scope".
+
+You can set the following parameters:
+
+```yml
+cilium_ipam_mode: cluster-pool
+```
+
+### Set the cluster Pod CIDRs
+
+Cluster Pod CIDRs use the kube_pods_subnet value by default.
+If your node network is in the same range you will lose connectivity to other nodes
+
+You can set the following parameters:
+
+```yml
+cilium_pool_cidr: 10.233.64.0/18
+```
+
+When cilium_enable_ipv6 is used, you need to set the IPV6 value:
+
+```yml
+cilium_pool_cidr_ipv6: fd85:ee78:d8a6:8607::1:0000/112
+```
+
+### Set the Pod CIDR size of a node
+
+When cilium IPAM uses the "Cluster Scope" mode, it will pre-allocate a segment of IP to each node,
+schedule the Pod to this node, and then allocate IP from here. cilium_pool_mask_size Specifies
+the size allocated from cluster Pod CIDR to node.ipam.podCIDRs
+
+```yml
+cilium_pool_mask_size: "26"
+```
+
+cilium_pool_mask_size Specifies the size allocated to node.ipam.podCIDRs from cluster Pod IPV6 CIDR
+
+```yml
+cilium_pool_mask_size_ipv6: "120"
+```
+
 ## Kube-proxy replacement with Cilium
 
 Cilium can run without kube-proxy by setting `cilium_kube_proxy_replacement`

--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -145,9 +145,25 @@ cilium_hubble_install: false
 ### Enable auto generate certs if cilium_hubble_install: true
 cilium_hubble_tls_generate: false
 
-# IP address management mode for v1.9+.
-# https://docs.cilium.io/en/v1.9/concepts/networking/ipam/
-cilium_ipam_mode: kubernetes
+# The default IP address management mode is "Cluster Scope".
+# https://docs.cilium.io/en/stable/concepts/networking/ipam/
+cilium_ipam_mode: cluster-pool
+
+# Cluster Pod CIDRs use the kube_pods_subnet value by default.
+# If your node network is in the same range you will lose connectivity to other nodes
+cilium_pool_cidr: "{{ kube_pods_subnet | 10.233.64.0/18 }}"
+
+# When cilium_enable_ipv6 is used, you need to set the IPV6 value
+cilium_pool_cidr_ipv6: "{{ kube_pods_subnet_ipv6 | fd85:ee78:d8a6:8607::1:0000/112 }}"
+
+# When cilium IPAM uses the "Cluster Scope" mode, it will pre-allocate a segment of IP to each node,
+# schedule the Pod to this node, and then allocate IP from here. cilium_pool_mask_size Specifies
+# the size allocated from cluster Pod CIDR to node.ipam.podCIDRs
+cilium_pool_mask_size: "26"
+
+# cilium_pool_mask_size Specifies the size allocated to node.ipam.podCIDRs from cluster Pod IPV6 CIDR
+cilium_pool_mask_size_ipv6: "120"
+
 
 # Extra arguments for the Cilium agent
 cilium_agent_custom_args: []

--- a/roles/network_plugin/cilium/templates/cilium/config.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/config.yml.j2
@@ -196,6 +196,14 @@ data:
 
   # IPAM settings
   ipam: "{{ cilium_ipam_mode }}"
+{% if cilium_ipam_mode == "cluster-pool" %}
+  cluster-pool-ipv4-cidr: {% cilium_pool_cidr | default(kube_pods_subnet) %}
+  cluster-pool-ipv4-mask-size: {% cilium_pool_mask_size %}
+{% if cilium_enable_ipv6 %}
+  cluster-pool-ipv6-cidr: {% cilium_pool_cidr_ipv6 | default(kube_pods_subnet_ipv6) %}
+  cluster-pool-ipv6-mask-size: {% cilium_pool_mask_size_ipv6 %}
+{% endif %}
+{% endif %}
 
   agent-health-port: "{{ cilium_agent_health_port }}"
 


### PR DESCRIPTION
Signed-off-by: dcwbq <biqiang.wu@daocloud.io>

**What type of PR is this?**
 /kind feature

**What this PR does / why we need it**:
cilium IPAM uses "Cluster Scope" mode by default. Also add the parameters required for this mode

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cilium Default value in "Cluster Scope" mode
```
  cluster-pool-ipv4-cidr: 10.0.0.0/8
  cluster-pool-ipv4-mask-size: "26"
  cluster-pool-ipv6-cidr: fd00::/104
  cluster-pool-ipv6-mask-size: "120"
```
But I think the cluster Pod CIDR is too big, and "kube_pods_subnet" is more reasonable.

**Does this PR introduce a user-facing change?**:
cilium IPAM default mode changed from "Kubernetes" to "Cluster Scope"

```release-note
cilium IPAM uses "Cluster Scope" mode by default. Also add the parameters required for this mode
```
