### PR TITLE
Adding metrics server to use host network

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s_cluster/addons.yml
@@ -18,6 +18,7 @@ metrics_server_enabled: false
 # metrics_server_kubelet_insecure_tls: true
 # metrics_server_metric_resolution: 15s
 # metrics_server_kubelet_preferred_address_types: "InternalIP,ExternalIP,Hostname"
+# metrics_server_host_network: false
 
 # Rancher Local Path Provisioner
 local_path_provisioner_enabled: false

--- a/roles/kubernetes-apps/metrics_server/defaults/main.yml
+++ b/roles/kubernetes-apps/metrics_server/defaults/main.yml
@@ -7,3 +7,4 @@ metrics_server_limits_cpu: 100m
 metrics_server_limits_memory: 200Mi
 metrics_server_requests_cpu: 100m
 metrics_server_requests_memory: 200Mi
+metrics_server_host_network: false

--- a/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
@@ -27,7 +27,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: metrics-server
-      hostNetwork: true
+      hostNetwork: {{ metrics_server_host_network | default(false) }}
       containers:
       - name: metrics-server
         image: {{ metrics_server_image_repo }}:{{ metrics_server_image_tag }}

--- a/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
@@ -27,6 +27,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: metrics-server
+      hostNetwork: true
       containers:
       - name: metrics-server
         image: {{ metrics_server_image_repo }}:{{ metrics_server_image_tag }}


### PR DESCRIPTION

**What type of PR is this?**
I've identified that the kube-app for metrics-server is not providing metrics for the server where it is being deployed.
For instance, if the metrics-server pod is running on `vm-stage-k8s-master-3`, then when getting node metrics with `kubectl top nodes`, there are no metrics for `vm-stage-k8s-master-3`.
```
# kubectl top nodes
NAME                    CPU(cores)   CPU%        MEMORY(bytes)   MEMORY%     
server-stage-002   181m         1%          2682Mi          2%          
server-stage-001   249m         0%          3908Mi          3%          
vm-stage-k8s-master-1   410m         26%         3007Mi          102%        
vm-stage-k8s-master-2   434m         28%         2761Mi          93%         
vm-stage-k8s-master-3   <unknown>    <unknown>   <unknown>       <unknown>  
 ```
 
 After reviewing it here https://github.com/kubernetes-sigs/metrics-server/issues/1111, I consider that the deployment template should be changed to add the `spec.template.spec.hostNetwork: true`

/kind bug


**What this PR does / why we need it**:
Allows to show node metrics for all nodes
 