### PR TITLE
add retry for patch kube proxy

### DIFF
--- a/roles/win_nodes/kubernetes_patch/tasks/main.yml
+++ b/roles/win_nodes/kubernetes_patch/tasks/main.yml
@@ -27,6 +27,9 @@
         patch ds kube-proxy --namespace=kube-system --type=strategic -p
         '{"spec":{"template":{"spec":{"nodeSelector":{"{{ kube_proxy_nodeselector }}":"linux"} }}}}'
       register: patch_kube_proxy_state
+      retries: 60
+      delay: 5
+      until: patch_kube_proxy_state is succeeded
       when: current_kube_proxy_state.stdout | trim | lower != "linux"
 
     - debug:  # noqa unnamed-task


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug

**What this PR does / why we need it**:
when deploying kube-proxy, i found it failed that the log output says 
```
TASK [win_nodes/kubernetes_patch : Ensure that user manifests directory exists] ***
ok: [controller-node-1]
Monday 31 October 2022  05:37:02 +0000 (0:00:05.273)       0:23:25.860 ********

TASK [win_nodes/kubernetes_patch : Check current nodeselector for kube-proxy daemonset] ***
ok: [controller-node-1]
Monday 31 October 2022  05:37:10 +0000 (0:00:08.043)       0:23:33.904 ********

TASK [win_nodes/kubernetes_patch : Apply nodeselector patch for kube-proxy daemonset] ***
fatal: [controller-node-1]: FAILED! => {"changed": true, "cmd": ["/usr/local/bin/kubectl", "--kubeconfig", "/etc/kubernetes/admin.conf", "patch", "ds", "kube-proxy", "--namespace=kube-system", "--type=strategic", "-p", "{\"spec\":{\"template\":{\"spec\":{\"nodeSelector\":{\"kubernetes.io/os\":\"linux\"} }}}}"], "delta": "0:00:00.091852", "end": "2022-10-31 01:41:59.397634", "msg": "non-zero return code", "rc": 1, "start": "2022-10-31 01:41:59.305782", "stderr": "The connection to the server 127.0.0.1:6443 was refused - did you specify the right host or port?", "stderr_lines": ["The connection to the server 127.0.0.1:6443 was refused - did you specify the right host or port?"], "stdout": "", "stdout_lines": []}

NO MORE HOSTS LEFT *************************************************************
```
 so add retries to make it more stable
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
