### PR TITLE
Stop using python 'test' internal package

### DIFF
--- a/contrib/inventory_builder/tests/test_inventory.py
+++ b/contrib/inventory_builder/tests/test_inventory.py
@@ -13,7 +13,7 @@
 # under the License.
 
 import inventory
-from test import support
+from io import StringIO
 import unittest
 from unittest import mock
 
@@ -41,7 +41,7 @@ class TestInventoryPrintHostnames(unittest.TestCase):
                       'access_ip': '10.90.0.3'}}}})
         with mock.patch('builtins.open', mock_io):
             with self.assertRaises(SystemExit) as cm:
-                with support.captured_stdout() as stdout:
+                with mock.patch('sys.stdout', new_callable=StringIO) as stdout:
                     inventory.KubesprayInventory(
                         changed_hosts=["print_hostnames"],
                         config_file="file")


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

`test` is is a internal Python package (see [doc]), and as such should not be used in Kubespray. It make tests fail in some environments.

[doc]: https://docs.python.org/3/library/test.html

Tests are working in `quay.io/kubespray/kubespray:v2.20.0` (used by CI), but are not working in some environments.

To reproduce the issue,

- create a Docker image `tox_test` with:

  ```dockerfile
  cat <<'EOF' | docker build -t tox_test -
  FROM python:3.10.6
  ENV LANG=C.UTF-8
  WORKDIR /test
  RUN pip install --no-cache-dir tox==3.11.1
  CMD ["tox"]
  EOF
  ```

- run `tox`:

  ```bash
  docker run --rm -v $(pwd)/contrib/inventory_builder:/test tox_test
  ```

On `master`, this fails with error:

```
==================================== ERRORS ====================================
___________________ ERROR collecting tests/test_inventory.py ___________________
ImportError while importing test module '/test/tests/test_inventory.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
.tox/py33/lib/python3.10/site-packages/_pytest/python.py:618: in _importtestmodule
    mod = import_path(self.path, mode=importmode, root=self.config.rootpath)
.tox/py33/lib/python3.10/site-packages/_pytest/pathlib.py:533: in import_path
    importlib.import_module(module_name)
/usr/local/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1050: in _gcd_import
    ???
<frozen importlib._bootstrap>:1027: in _find_and_load
    ???
<frozen importlib._bootstrap>:1006: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:688: in _load_unlocked
    ???
.tox/py33/lib/python3.10/site-packages/_pytest/assertion/rewrite.py:168: in exec_module
    exec(co, module.__dict__)
tests/test_inventory.py:16: in <module>
    from test import support
E   ModuleNotFoundError: No module named 'test'
=========================== short test summary info ============================
ERROR tests/test_inventory.py
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
=============================== 1 error in 0.14s ===============================
ERROR: InvocationError for command /test/.tox/py33/bin/pytest -vv (exited with code 2)
```

With this PR, it succeeds as expected.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

N/A

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
