### PR TITLE
Remove the set_fact action which raise error in the CI

### DIFF
--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -92,14 +92,6 @@
   tags:
     - facts
 
-- name: Set os_family fact for UOS Linux
-  set_fact:
-    ansible_os_family: "RedHat"
-    ansible_distribution_major_version: "8"
-  when: ansible_distribution == "UnionTech"
-  tags:
-    - facts
-
 - name: Install ceph-commmon package
   package:
     name:


### PR DESCRIPTION

**What type of PR is this?**

> /kind bug


**What this PR does / why we need it**:
Remove the set_fact action which raise error in the CI.
And i am trying to change the ansible_os_family to RedHat for UOS Linux in the ansible program code

**Which issue(s) this PR fixes**:

Fixes #9449 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
