### PR TITLE
Change the "containerd_insecure_registries" setting offline.

### DIFF
--- a/docs/offline-environment.md
+++ b/docs/offline-environment.md
@@ -35,7 +35,7 @@ containerd_download_url: "{{ files_repo }}/containerd-{{ containerd_version }}-l
 runc_download_url: "{{ files_repo }}/runc.{{ image_arch }}"
 nerdctl_download_url: "{{ files_repo }}/nerdctl-{{ nerdctl_version }}-{{ ansible_system | lower }}-{{ image_arch }}.tar.gz"
 # Insecure registries for containerd
-containerd_insecure_registries:
+nerdctl_insecure_registries:
   - "{{ registry_host }}"
 
 # CentOS/Redhat/AlmaLinux/Rocky Linux


### PR DESCRIPTION
The "containerd_insecure_registries" setting is the same for nerdctl and containerd, but has a different syntax. This causes an error when building offline

 ./inventory/sample/group_vars/all/containerd.yml
./roles/kubespray-defaults/defaults/main.yaml
./roles/download/defaults/main.yml
./roles/container-engine/nerdctl/templates/nerdctl.toml.j2 
./roles/container-engine/containerd/templates/config.toml.j2 
./docs/offline-environment.md
