### PR TITLE
Make vagrant-ubuntu20-flannel voting

### DIFF
--- a/.gitlab-ci/vagrant.yml
+++ b/.gitlab-ci/vagrant.yml
@@ -43,6 +43,7 @@ vagrant_ubuntu20-flannel:
   stage: deploy-part2
   extends: .vagrant
   when: on_success
+  allow_failure: false
 
 vagrant_ubuntu16-kube-router-sep:
   stage: deploy-part2


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

We made all vagrant jobs non-voting because those jobs were not stable. However the setting allowed a pull request which broke vagrant jobs completely merged into the master branch.
To avoid such situation, this makes one of vagrant jobs voting. Let's see the stability of the job.

Ref: https://github.com/kubernetes-sigs/kubespray/issues/9449

**Special notes for your reviewer**:

This needs to be merged after https://github.com/kubernetes-sigs/kubespray/pull/9453

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[CI] Make vagrant-ubuntu20-flannel voting (by removing allow failure)
```
