### PR TITLE
[2.20] Fix: install calico-kube-controller on kdd (#9358)

### DIFF
--- a/roles/kubernetes-apps/policy_controller/meta/main.yml
+++ b/roles/kubernetes-apps/policy_controller/meta/main.yml
@@ -2,15 +2,7 @@
 dependencies:
   - role: policy_controller/calico
     when:
-      - kube_network_plugin == 'calico'
+      - kube_network_plugin in ['calico', 'canal']
       - enable_network_policy
-      - calico_datastore != "kdd"
-    tags:
-      - policy-controller
-
-  - role: policy_controller/calico
-    when:
-      - kube_network_plugin == 'canal'
-      - calico_datastore != "kdd"
     tags:
       - policy-controller


### PR DESCRIPTION
Backport https://github.com/kubernetes-sigs/kubespray/pull/9358 to 2.20

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9300

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
