### PR TITLE
Enable check mode in DNS Cleanup tasks

### DIFF
--- a/roles/kubernetes-apps/ansible/tasks/cleanup_dns.yml
+++ b/roles/kubernetes-apps/ansible/tasks/cleanup_dns.yml
@@ -3,6 +3,7 @@
   command: "{{ kubectl }} get deploy -n kube-system coredns -o jsonpath='{ .spec.template.metadata.annotations.createdby }'"
   register: createdby_annotation_deploy
   changed_when: false
+  check_mode: false
   ignore_errors: true  # noqa ignore-errors
   when:
     - dns_mode in ['coredns', 'coredns_dual']
@@ -12,6 +13,7 @@
   command: "{{ kubectl }} get svc -n kube-system coredns -o jsonpath='{ .metadata.annotations.createdby }'"
   register: createdby_annotation_svc
   changed_when: false
+  check_mode: false
   ignore_errors: true  # noqa ignore-errors
   when:
     - dns_mode in ['coredns', 'coredns_dual']


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
As noticed in PR #9311 tests, in check mode, "Delete kubeadm CoreDNS" and "Delete kubeadm Kube-DNS service" tasks fail because registered variables from previous ("kubectl get" using command module) tasks are skipped.
This PR only adds `check_mode: false` to the related tasks so that cleanup works in check mode.

**Which issue(s) this PR fixes**:
None that I know of

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
