### PR TITLE
Fix kubeadm san error when fqdn is emptry

### DIFF
--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -43,7 +43,7 @@
     sans_address: "{{ groups['kube_control_plane'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | list | select('defined') | list }}"
     sans_override: "{{ [kube_override_hostname] if kube_override_hostname else [] }}"
     sans_hostname: "{{ groups['kube_control_plane'] | map('extract', hostvars, ['ansible_hostname']) | list | select('defined') | list }}"
-    sans_fqdn: "{{ groups['kube_control_plane'] | map('extract', hostvars, ['ansible_fqdn']) | list | select('defined') | list }}"
+    sans_fqdn: "{{ groups['kube_control_plane'] | map('extract', hostvars, ['ansible_fqdn']) | list | select('defined') | list | select('!='','') | list}}"
     sans_kube_vip_address: "{{ [kube_vip_address] if kube_vip_address is defined and kube_vip_address else [] }}"
   tags: facts
 


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug


**What this PR does / why we need it**:

When the /etc/host is setted as:

![企业微信截图_98171e83-752d-40ab-a768-6b57491e9d56](https://user-images.githubusercontent.com/1469319/201272652-fda442c8-19ae-4bf9-936f-d03ba777ffd7.png)

The kubeadm cannot run correctly:

![image](https://user-images.githubusercontent.com/1469319/201272578-97d43b1d-cfa8-4a67-a316-ee17c03055af.png)


Because of there are empty strings in the san.


![企业微信截图_172fabff-8f1d-425c-871d-069cd31989f2](https://user-images.githubusercontent.com/1469319/201272556-ee998ae6-1fe3-4a6d-ab7e-863e8bf1fc4f.png)

So the kubesrapy can filter the empty string in the san list.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
