### PR TITLE
[etcd] make etcd 3.5.5 default for k8s 1.23 , 1.24

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -134,8 +134,8 @@ kube_major_version: "{{ kube_version | regex_replace('^v([0-9])+\\.([0-9]+)\\.[0
 
 etcd_supported_versions:
   v1.25: "v3.5.5"
-  v1.24: "v3.5.4"
-  v1.23: "v3.5.3"
+  v1.24: "v3.5.5"
+  v1.23: "v3.5.5"
 etcd_version: "{{ etcd_supported_versions[kube_major_version] }}"
 
 crictl_supported_versions:


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

etcd 3.5.5 is default for the k8s v1.23. 14 , 1.24.8 releases. See the cherry-picks in https://github.com/kubernetes/kubernetes/pull/112489
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[etcd] Default version to 3.5.5 for k8s 1.25.x , 1.24 , 1.23
```