### PR TITLE
Update sonobuoy version

### DIFF
--- a/tests/testcases/100_check-k8s-conformance.yml
+++ b/tests/testcases/100_check-k8s-conformance.yml
@@ -1,12 +1,11 @@
 ---
 - hosts: kube_control_plane[0]
   vars:
-    sonobuoy_version: 0.20.0
+    sonobuoy_version: 0.56.11
     sonobuoy_arch: amd64
     sonobuoy_parallel: 30
     sonobuoy_path: /usr/local/bin/sonobuoy
-    sonobuoy_skip: 'Alpha|Disruptive|Feature|Flaky|Slow|Serial'
-    sonobuoy_mode: Quick
+    sonobuoy_mode: certified-conformance
 
   tasks:
   - name: Run sonobuoy
@@ -26,7 +25,7 @@
         copy: no
 
     - name: Run sonobuoy
-      command: "{{ sonobuoy_path }} run --mode {{ sonobuoy_mode }} --e2e-parallel {{ sonobuoy_parallel }} --e2e-skip {{ sonobuoy_skip }} --wait"
+      command: "{{ sonobuoy_path }} run --mode {{ sonobuoy_mode }} --e2e-parallel {{ sonobuoy_parallel }} --wait"
       when: sonobuoy_enabled | default(false)
 
     - name: Run sonobuoy retrieve
@@ -34,4 +33,4 @@
       register: sonobuoy_retrieve
 
     - name: Run inspect results
-      command: "{{ sonobuoy_path }} e2e {{ sonobuoy_retrieve.stdout }}"
+      command: "{{ sonobuoy_path }} results {{ sonobuoy_retrieve.stdout }} --plugin e2e --mode report"


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

The latest version of sonobuoy is v0.56.11.
This updates the version to the latest.
In addition, this makes it use certified-conformance mode for sonobuoy according to https://github.com/cncf/k8s-conformance/blob/master/instructions.md

Fixes: #9484

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
