### PR TITLE
Fix pathes of offline tool on the doc

### DIFF
--- a/docs/offline-environment.md
+++ b/docs/offline-environment.md
@@ -18,8 +18,8 @@ Then you need to setup the following services on your offline environment:
 * [Optional] an internal PyPi server for python packages used by Kubespray
 * [Optional] an internal Helm registry for Helm chart files
 
-You can get artifact lists with [generate_list.sh](contrib/offline/generate_list.sh) script.
-In addition, you can find some tools for offline deployment under [contrib/offline](contrib/offline/README.md).
+You can get artifact lists with [generate_list.sh](/contrib/offline/generate_list.sh) script.
+In addition, you can find some tools for offline deployment under [contrib/offline](/contrib/offline/README.md).
 
 ## Configure Inventory
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

If clicking the links, we faced NotFound page at the time. This fixes the issue by specifying full pathes instead.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
