### PR TITLE
Disable 'Check that IP range is enough for the nodes' when calico is used

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -187,6 +187,7 @@
     that:
       - 2 ** (kube_network_node_prefix - kube_pods_subnet | ipaddr('prefix')) >= groups['k8s_cluster'] | length
     msg: "Not enough IPs are available for the desired node count."
+  when: kube_network_plugin != 'calico'
   run_once: yes
 
 - name: Stop if unknown dns mode


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Disable 'Check that IP range is enough for the nodes' when calico is used

**Which issue(s) this PR fixes**:

Fixes #9150

**Does this PR introduce a user-facing change?**:
```
None
```