### PR TITLE
upgrade containerd_version to 1.6.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [kubernetes](https://github.com/kubernetes/kubernetes) v1.25.4
   - [etcd](https://github.com/etcd-io/etcd) v3.5.5
   - [docker](https://www.docker.com/) v20.10 (see note)
-  - [containerd](https://containerd.io/) v1.6.9
+  - [containerd](https://containerd.io/) v1.6.10
   - [cri-o](http://cri-o.io/) v1.24 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)
 - Network Plugin
   - [cni-plugins](https://github.com/containernetworking/plugins) v1.1.1

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -79,7 +79,7 @@ runc_version: v1.1.4
 kata_containers_version: 2.4.1
 youki_version: 0.0.1
 gvisor_version: 20210921
-containerd_version: 1.6.9
+containerd_version: 1.6.10
 cri_dockerd_version: 0.2.2
 
 # this is relevant when container_manager == 'docker'
@@ -839,6 +839,7 @@ containerd_archive_checksums:
     1.6.7: 0
     1.6.8: 0
     1.6.9: 0
+    1.6.10: 0
   arm64:
     1.5.5: 0
     1.5.7: 0
@@ -858,6 +859,7 @@ containerd_archive_checksums:
     1.6.7: 4167bf688a0ed08b76b3ac264b90aad7d9dd1424ad9c3911e9416b45e37b0be5
     1.6.8: b114e36ecce78cef9d611416c01b784a420928c82766d6df7dc02b10d9da94cd
     1.6.9: 140197aee930a8bd8a69ff8e0161e56305751be66e899dccd833c27d139f4f47
+    1.6.10: 6d655e80a843f480e1c1cead18479185251581ff2d4a2e2e5eb88ad5b5e3d937
   amd64:
     1.5.5: 8efc527ffb772a82021800f0151374a3113ed2439922497ff08f2596a70f10f1
     1.5.7: 109fc95b86382065ea668005c376360ddcd8c4ec413e7abe220ae9f461e0e173
@@ -877,6 +879,7 @@ containerd_archive_checksums:
     1.6.7: 52e817b712d521b193773529ff33626f47507973040c02474a2db95a37da1c37
     1.6.8: 3a1322c18ee5ff4b9bd5af6b7b30c923a3eab8af1df05554f530ef8e2b24ac5e
     1.6.9: 9ee2644bfb95b23123f96b564df2035ec94a46f64060ae12322e09a8ec3c2b53
+    1.6.10: dd1f4730daf728822aea3ba35a440e14b1dfa8f1db97288a59a8666676a13637
   ppc64le:
     1.5.5: 0
     1.5.7: 0
@@ -896,6 +899,7 @@ containerd_archive_checksums:
     1.6.7: 0db5cb6d5dd4f3b7369c6945d2ec29a9c10b106643948e3224e53885f56863a9
     1.6.8: f18769721f614828f6b778030c72dc6969ce2108f2363ddc85f6c7a147df0fb8
     1.6.9: fe0046437cfe971ef0b3101ee69fcef5cf52e8868de708d35f8b82f998044f6e
+    1.6.10: 704b1affd306b807fe6b4701d778129283635c576ecedc6d0a9da5370a07d56a
 
 skopeo_binary_checksums:
   arm:


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

containerd 1.6.10 released now.
https://github.com/containerd/containerd/releases/tag/v1.6.10