### PR TITLE
Specify quick mode for sonobuoy

### DIFF
--- a/tests/testcases/100_check-k8s-conformance.yml
+++ b/tests/testcases/100_check-k8s-conformance.yml
@@ -5,7 +5,7 @@
     sonobuoy_arch: amd64
     sonobuoy_parallel: 30
     sonobuoy_path: /usr/local/bin/sonobuoy
-    sonobuoy_mode: certified-conformance
+    sonobuoy_mode: Quick
 
   tasks:
   - name: Run sonobuoy


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The sonobuoy mode has been changed recently from Quick to certified-conformance.
The Quick mode took 30 minutes or less for the CI job tf-elastx_ubuntu18-calico, but the certified-conformance mode takes 2 hours today.
For smooth Kubespray development, this updates the mode again to Quick mode.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9496 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
