### PR TITLE
Add Check resolv.conf is empty to avoid CoreDNS crash

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
@@ -75,6 +75,16 @@
 
   when: resolvconf_stat.stat.exists is defined and resolvconf_stat.stat.exists
 
+- name: Stop if /etc/resolv.conf not configured nameservers
+  assert:
+    that: configured_nameservers|length>0
+    fail_msg: "nameserver should not empty in /etc/resolv.conf"
+  when:
+    - not ignore_assert_errors
+    - configured_nameservers is defined
+    - not (upstream_dns_servers is defined and upstream_dns_servers|length > 0)
+    - not (disable_host_nameservers | default(false))
+
 - name: NetworkManager | Check if host has NetworkManager
   # noqa 303 Should we use service_facts for this?
   command: systemctl is-active --quiet NetworkManager.service


### PR DESCRIPTION
**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:

If the /etc/resolv.conf is empty. The kubernetes coredns is in CrashLoopBackOff status with "no nameservers found" error.

The same issue is at:

- https://serverfault.com/questions/1081685/kubernetes-coredns-is-in-crashloopbackoff-status-with-no-nameservers-found-err
- https://discuss.kubernetes.io/t/coredns-is-in-crashloopbackoff-state-with-no-nameservers-found-error-log/17863

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kubespray/issues/9497 (workaround)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add Check resolv.conf is empty to avoid CoreDNS crash
```
