### PR TITLE
Update CoreDNS version to v1.9.3 

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [kube-vip](https://github.com/kube-vip/kube-vip) v0.5.5
 - Application
   - [cert-manager](https://github.com/jetstack/cert-manager) v1.9.1
-  - [coredns](https://github.com/coredns/coredns) v1.8.6
+  - [coredns](https://github.com/coredns/coredns) v1.9.3
   - [ingress-nginx](https://github.com/kubernetes/ingress-nginx) v1.4.0
   - [krew](https://github.com/kubernetes-sigs/krew) v0.4.3
   - [argocd](https://argoproj.github.io/) v2.4.16

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -1008,7 +1008,7 @@ haproxy_image_tag: 2.6.1-alpine
 # Coredns version should be supported by corefile-migration (or at least work with)
 # bundle with kubeadm; if not 'basic' upgrade can sometimes fail
 
-coredns_version: "v1.8.6"
+coredns_version: "v1.9.3"
 coredns_image_is_namespaced: "{{ (coredns_version is version('v1.7.1','>=')) }}"
 
 coredns_image_repo: "{{ kube_image_repo }}{{'/coredns/coredns' if (coredns_image_is_namespaced | bool) else '/coredns' }}"


### PR DESCRIPTION
**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:

The Kube 1.25 use the CoreDNS 1.9.3
https://github.com/kubernetes/kubernetes/pull/110488


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update CoreDNS version to v1.9.3 
```
