### PR TITLE
[cert-manager] Upgrade to v1.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [weave](https://github.com/weaveworks/weave) v2.8.1
   - [kube-vip](https://github.com/kube-vip/kube-vip) v0.5.5
 - Application
-  - [cert-manager](https://github.com/jetstack/cert-manager) v1.9.1
+  - [cert-manager](https://github.com/jetstack/cert-manager) v1.9.2
   - [coredns](https://github.com/coredns/coredns) v1.9.3
   - [ingress-nginx](https://github.com/kubernetes/ingress-nginx) v1.4.0
   - [krew](https://github.com/kubernetes-sigs/krew) v0.4.3

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -1046,7 +1046,7 @@ ingress_nginx_kube_webhook_certgen_imae_repo: "{{ kube_image_repo }}/ingress-ngi
 ingress_nginx_kube_webhook_certgen_imae_tag: "v1.3.0"
 alb_ingress_image_repo: "{{ docker_image_repo }}/amazon/aws-alb-ingress-controller"
 alb_ingress_image_tag: "v1.1.9"
-cert_manager_version: "v1.9.1"
+cert_manager_version: "v1.9.2"
 cert_manager_controller_image_repo: "{{ quay_image_repo }}/jetstack/cert-manager-controller"
 cert_manager_controller_image_tag: "{{ cert_manager_version }}"
 cert_manager_cainjector_image_repo: "{{ quay_image_repo }}/jetstack/cert-manager-cainjector"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Upgrade `cert-manager` to [v1.9.2](https://github.com/cert-manager/cert-manager/releases/tag/v1.9.2)

**Does this PR introduce a user-facing change?**:
```release-note
[cert-manager] Upgrade to v1.9.2
```