### PR TITLE
Drop calico v3.21 support

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -157,7 +157,6 @@ kubeadm_download_url: "https://storage.googleapis.com/kubernetes-release/release
 etcd_download_url: "https://github.com/etcd-io/etcd/releases/download/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-{{ image_arch }}.tar.gz"
 cni_download_url: "https://github.com/containernetworking/plugins/releases/download/{{ cni_version }}/cni-plugins-linux-{{ image_arch }}-{{ cni_version }}.tgz"
 calicoctl_download_url: "https://github.com/projectcalico/calico/releases/download/{{ calico_ctl_version }}/calicoctl-linux-{{ image_arch }}"
-calicoctl_alternate_download_url: "https://github.com/projectcalico/calicoctl/releases/download/{{ calico_ctl_version }}/calicoctl-linux-{{ image_arch }}"
 calico_crds_download_url: "https://github.com/projectcalico/calico/archive/{{ calico_version }}.tar.gz"
 ciliumcli_download_url: "https://github.com/cilium/cilium-cli/releases/download/{{ cilium_cli_version }}/cilium-linux-{{ image_arch }}.tar.gz"
 crictl_download_url: "https://github.com/kubernetes-sigs/cri-tools/releases/download/{{ crictl_version }}/crictl-{{ crictl_version }}-{{ ansible_system | lower }}-{{ image_arch }}.tar.gz"
@@ -647,7 +646,6 @@ ciliumcli_binary_checksums:
 calico_crds_archive_checksums:
   v3.23.3: d25f5c9a3adeba63219f3c8425a8475ebfbca485376a78193ec1e4c74e7a6115
   v3.22.4: e72e7b8b26256950c1ce0042ac85fa83700154dae9723c8d007de88343f6a7e5
-  v3.21.6: db4fa80b79b39853f0b1a04d875c110b637dd8754bf7b4cec06ae510fb8a2acd
 
 krew_archive_checksums:
   linux:
@@ -1480,7 +1478,6 @@ downloads:
     sha256: "{{ calicoctl_binary_checksum }}"
     url: "{{ calicoctl_download_url }}"
     mirrors:
-    - "{{ calicoctl_alternate_download_url }}"
     - "{{ calicoctl_download_url }}"
     unarchive: false
     owner: "root"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

At the upstream calico development, the v3.21 branch is not updated over 2 monthes.
In addition, unnecessary error message is output at Kubespray deployment due to different URLs for calico v3.21 or v3.22+.
This drops the v3.21 support to solve the issue.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9514

**Special notes for your reviewer**:

https://github.com/kubernetes-sigs/kubespray/issues/9473 is for adding newer version support of calico.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Drop calico v3.21 support
```