### PR TITLE
[metrics_server]: Enabled HA mode by adding 'metrics_server_replicas'…

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s_cluster/addons.yml
@@ -19,6 +19,7 @@ metrics_server_enabled: false
 # metrics_server_metric_resolution: 15s
 # metrics_server_kubelet_preferred_address_types: "InternalIP,ExternalIP,Hostname"
 # metrics_server_host_network: false
+# metrics_server_replicas: 1
 
 # Rancher Local Path Provisioner
 local_path_provisioner_enabled: false

--- a/roles/kubernetes-apps/metrics_server/defaults/main.yml
+++ b/roles/kubernetes-apps/metrics_server/defaults/main.yml
@@ -8,3 +8,4 @@ metrics_server_limits_memory: 200Mi
 metrics_server_requests_cpu: 100m
 metrics_server_requests_memory: 200Mi
 metrics_server_host_network: false
+metrics_server_replicas: 1

--- a/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
@@ -103,3 +103,5 @@ spec:
                   values:
                   - metrics-server
               topologyKey: kubernetes.io/hostname
+              namespaces:
+              - kube-system

--- a/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
@@ -9,6 +9,7 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
     version: {{ metrics_server_version }}
 spec:
+  replicas: {{ metrics_server_replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/name: metrics-server
@@ -91,12 +92,14 @@ spec:
           effect: NoSchedule
 {% endif %}
       affinity:
-        nodeAffinity:
+        podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
-            preference:
-              matchExpressions:
-              - key: node-role.kubernetes.io/control-plane
-                operator: In
-                values:
-                - ""
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - metrics-server
+              topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
Signed-off-by: Ugur Can Ozturk [ugurozturk918@gmail.com](mailto:ugurozturk918@gmail.com)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
We were looking for a parameter to deploy `metrics_server` in HA mode with KubeSpray and discovered the [issue](https://github.com/kubernetes-sigs/kubespray/issues/9197); wanted to contribute with this PR.

The small feature provides usage of metrics_server in HA mode by manipulating the number of replicas, also nodeAffinity rule which prioritizes running replicas on control_planes was removed, and instead of it, the podAntiAffinity rule was added.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kubespray/issues/9197

**Special notes for your reviewer**:
Tested by installing a new cluster.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Add variable in metrics_server deployment (`metrics_server_replicas`) to enable HA mode
```
