### PR TITLE
Allow `containerd-common` to execute multiple times per play

### DIFF
--- a/roles/container-engine/containerd-common/meta/main.yml
+++ b/roles/container-engine/containerd-common/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true


### PR DESCRIPTION
The `containerd-common` role is responsible for gathering OS specific variables from the vars directory of the roles that include or import it. `containerd-common` is imported via role dependency by a total of two roles, `container-engine/docker`, and `container-engine/containerd`.

containerd-common is needed by both the docker and containerd roles as a dependency in a single play when:
- containerd is selected as the container engine
- a docker install is detected and needs to be removed
- apt is the package manager

However, by default, roles can not be invoked more than once in the same play, unless `allow_duplicates: true` is set for that role. This results in the failure of the `containerd | Remove containerd repository` task for apt repos, since only docker/vars (which executes first to remove docker) will be loaded in the play, and `containerd_repo_info.repos`, normally populated by containerd/vars, is left empty.

This change sets `allow_duplicates: true` for `containerd-common` which allows both docker and containerd to gather their vars, and fixes the currently failing containerd tasks if docker was detected and removed in the same play.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[containerd] Allow containerd-common to execute multiple times per play
```