### PR TITLE
Stop network_plugin/cni dependency when include_role comes from reset role

### DIFF
--- a/roles/network_plugin/cilium/meta/main.yml
+++ b/roles/network_plugin/cilium/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - role: network_plugin/cni
+    when: not from_reset | default(true)

--- a/roles/network_plugin/flannel/meta/main.yml
+++ b/roles/network_plugin/flannel/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - role: network_plugin/cni
+    when: not from_reset | default(true)

--- a/roles/network_plugin/kube-router/meta/main.yml
+++ b/roles/network_plugin/kube-router/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - role: network_plugin/cni
+    when: not from_reset | default(true)

--- a/roles/network_plugin/macvlan/meta/main.yml
+++ b/roles/network_plugin/macvlan/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - role: network_plugin/cni
+    when: not from_reset | default(true)

--- a/roles/network_plugin/multus/meta/main.yml
+++ b/roles/network_plugin/multus/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - role: network_plugin/cni
+    when: not from_reset | default(true)

--- a/roles/network_plugin/weave/meta/main.yml
+++ b/roles/network_plugin/weave/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - role: network_plugin/cni
+    when: not from_reset | default(true)

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -381,6 +381,8 @@
   include_role:
     name: "network_plugin/{{ kube_network_plugin }}"
     tasks_from: reset
+  vars:
+    from_reset: true
   when:
     - kube_network_plugin in ['flannel', 'cilium', 'kube-router', 'calico']
   tags:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
When removing a node there is no need to execute the `network_plugin/cni` dependency and doing so causes an error

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9549 

**Special notes for your reviewer**:
Running remove-node.yml does an `include_role:` on `network_plugin/<your-network-plugin>` with a `tasks_from: reset`. All of the potential roles that can be loaded include a dependency for `network_plugin/cni` which will fail because the download role is not included in this playbook (nor should it be).  

This PR skips the dependency when the `include_role` comes from `remove-node.yml`

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
