### PR TITLE
follow containerd1.16.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [kubernetes](https://github.com/kubernetes/kubernetes) v1.25.4
   - [etcd](https://github.com/etcd-io/etcd) v3.5.6
   - [docker](https://www.docker.com/) v20.10 (see note)
-  - [containerd](https://containerd.io/) v1.6.11
+  - [containerd](https://containerd.io/) v1.6.12
   - [cri-o](http://cri-o.io/) v1.24 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)
 - Network Plugin
   - [cni-plugins](https://github.com/containernetworking/plugins) v1.1.1

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -79,7 +79,7 @@ runc_version: v1.1.4
 kata_containers_version: 2.4.1
 youki_version: 0.0.1
 gvisor_version: 20210921
-containerd_version: 1.6.11
+containerd_version: 1.6.12
 cri_dockerd_version: 0.2.2
 
 # this is relevant when container_manager == 'docker'
@@ -833,6 +833,7 @@ containerd_archive_checksums:
     1.6.9: 0
     1.6.10: 0
     1.6.11: 0
+    1.6.12: 0
   arm64:
     1.5.5: 0
     1.5.7: 0
@@ -854,6 +855,7 @@ containerd_archive_checksums:
     1.6.9: 140197aee930a8bd8a69ff8e0161e56305751be66e899dccd833c27d139f4f47
     1.6.10: 6d655e80a843f480e1c1cead18479185251581ff2d4a2e2e5eb88ad5b5e3d937
     1.6.11: 1b34d8ff067da482af021dac325dc4e993d7356c0bd9dc8e5a3bb8271c1532de
+    1.6.12: 0a0133336596b2d1dcafe3587eb91ab302afc28f273614e0e02300694b5457a0
   amd64:
     1.5.5: 8efc527ffb772a82021800f0151374a3113ed2439922497ff08f2596a70f10f1
     1.5.7: 109fc95b86382065ea668005c376360ddcd8c4ec413e7abe220ae9f461e0e173
@@ -875,6 +877,7 @@ containerd_archive_checksums:
     1.6.9: 9ee2644bfb95b23123f96b564df2035ec94a46f64060ae12322e09a8ec3c2b53
     1.6.10: dd1f4730daf728822aea3ba35a440e14b1dfa8f1db97288a59a8666676a13637
     1.6.11: 21870d7022c52f5f74336d440deffb208ba747b332a88e6369e2aecb69382e48
+    1.6.12: a56c39795fd0d0ee356b4099a4dfa34689779f61afc858ef84c765c63e983a7d
   ppc64le:
     1.5.5: 0
     1.5.7: 0
@@ -896,7 +899,7 @@ containerd_archive_checksums:
     1.6.9: fe0046437cfe971ef0b3101ee69fcef5cf52e8868de708d35f8b82f998044f6e
     1.6.10: 704b1affd306b807fe6b4701d778129283635c576ecedc6d0a9da5370a07d56a
     1.6.11: e600a5714ffb29937b3710f9ae81bb7aa15b7b6661192f5e8d0b9b58ac6d5e66
-
+    1.6.12: 088e4d1fe1787fc4a173de24a58da01880d1ead5a13f1ab55e1ade972d3907d4
 skopeo_binary_checksums:
   arm:
     v1.10.0: 0


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

Quick release containerd [v1.6.12](https://github.com/containerd/containerd/releases/tag/v1.6.12).
a fix for CVE-2022-23471.
