### PR TITLE
Fix a pre-upgrade node drain rescue task failure when `kube_override_hostname` is set

### DIFF
--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -119,11 +119,11 @@
 
   rescue:
     - name: Set node back to schedulable
-      command: "{{ kubectl }} uncordon {{ inventory_hostname }}"
+      command: "{{ kubectl }} uncordon {{ kube_override_hostname|default(inventory_hostname) }}"
       when: upgrade_node_uncordon_after_drain_failure
     - name: Fail after rescue
       fail:
-        msg: "Failed to drain node {{ inventory_hostname }}"
+        msg: "Failed to drain node {{ kube_override_hostname|default(inventory_hostname) }}"
       when: upgrade_node_fail_if_drain_fails
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
   when:


### PR DESCRIPTION
This fixes a task failure in the rescue block that uncordons nodes after an unsuccessful drain. The issue occurs when `kube_override_hostname` is set and does not match `inventory_hostname`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix a pre-upgrade node drain rescue task failure when `kube_override_hostname` is set
```
