### PR TITLE
Skip retry operation with containerd when etcd installed on host VM

### DIFF
--- a/reset.yml
+++ b/reset.yml
@@ -29,6 +29,9 @@
         msg: "Reset confirmation failed"
       when: reset_confirmation != "yes"
 
+    - name: Gather information about installed services
+      service_facts:
+
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults}

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -65,6 +65,7 @@
   when:
     - crictl.stat.exists
     - container_manager in ["crio", "containerd"]
+    - ansible_facts.services['containerd.service'] is defined or ansible_facts.services['cri-o.service'] is defined
   ignore_errors: true  # noqa ignore-errors
 
 - name: reset | force remove all cri containers
@@ -80,6 +81,7 @@
     - crictl.stat.exists
     - container_manager in ["crio", "containerd"]
     - deploy_container_engine
+    - ansible_facts.services['containerd.service'] is defined or ansible_facts.services['cri-o.service'] is defined
   ignore_errors: true  # noqa ignore-errors
 
 - name: reset | stop and disable crio service
@@ -109,6 +111,7 @@
   when:
     - crictl.stat.exists
     - container_manager == "containerd"
+    - ansible_facts.services['containerd.service'] is defined or ansible_facts.services['cri-o.service'] is defined
   ignore_errors: true  # noqa ignore-errors
 
 - block:
@@ -122,6 +125,7 @@
       when:
         - crictl.stat.exists
         - container_manager == "containerd"
+        - ansible_facts.services['containerd.service'] is defined or ansible_facts.services['cri-o.service'] is defined
 
   rescue:
     - name: reset | force remove all cri pods (rescue)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> 
/kind bug
When etcd installed on host VM and we use containerd in K8S, Kubespray always retry crictl for 5 time, it's took additional time when you delete your cluster .
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature  
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
