### PR TITLE
add containerd config_path

### DIFF
--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -111,6 +111,29 @@
     mode: 0640
   notify: restart containerd
 
+- name: containerd ｜ Create registry directories
+  file:
+    path: "{{ containerd_cfg_dir }}/certs.d/{{ item.key }}"
+    state: directory
+    mode: 0755
+    recurse: true
+  with_items: "{{ containerd_insecure_registries }}"
+  when: containerd_insecure_registries is defined
+
+- name: containerd ｜ Write hosts.toml file
+  blockinfile:
+    path: "{{ containerd_cfg_dir }}/certs.d/{{ item.key }}/hosts.toml"
+    owner: "root"
+    mode: 0640
+    create: true
+    block: |
+      server = "{{ item.value }}"
+      [host."{{ item.value }}"]
+        capabilities = ["pull", "resolve", "push"]
+        skip_verify = true
+  with_items: "{{ containerd_insecure_registries }}"
+  when: containerd_insecure_registries is defined
+
 # you can sometimes end up in a state where everything is installed
 # but containerd was not started / enabled
 - name: containerd | Flush handlers

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -47,6 +47,9 @@ oom_score = {{ containerd_oom_score }}
           runtime_type = "io.containerd.runsc.v1"
 {% endif %}
     [plugins."io.containerd.grpc.v1.cri".registry]
+{% if containerd_insecure_registries is defined and containerd_insecure_registries|length>0 %}
+      config_path = "{{ containerd_cfg_dir }}/certs.d"
+{% endif %}
       [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
 {% for registry, addr in containerd_registries.items() %}
         [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ registry }}"]


### PR DESCRIPTION
Signed-off-by: rongfu.leng <rongfu.leng@daocloud.io>

**What type of PR is this?**
> /kind feature


**What this PR does / why we need it**:
   Because [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ addr }}".tls] config whell DEPRECATE.

**Which issue(s) this PR fixes**:
Fixes # https://github.com/kubernetes-sigs/kubespray/issues/9559

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
In containerd config.toml.j2 file add config_path var.
```
