### PR TITLE
rename ansible groups to use _ instead of

### DIFF
--- a/contrib/terraform/hetzner/templates/inventory.tpl
+++ b/contrib/terraform/hetzner/templates/inventory.tpl
@@ -2,18 +2,18 @@
 ${connection_strings_master}
 ${connection_strings_worker}
 
-[kube-master]
+[kube_control_plane]
 ${list_master}
 
 [etcd]
 ${list_master}
 
-[kube-node]
+[kube_node]
 ${list_worker}
 
-[k8s-cluster:children]
+[k8s_cluster:children]
 kube-master
 kube-node
 
-[k8s-cluster:vars]
+[k8s_cluster:vars]
 network_id=${network_id}


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug
> /kind cleanup

**What this PR does / why we need it**:

Without renaming, `scale.yml` might fail when generating node certificates as `group[k8s_cluster]` only contains the hosts specified in `--limit`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE