### PR TITLE
Remove include task in play, deprecated in favor of import_playbook

### DIFF
--- a/recover-control-plane.yml
+++ b/recover-control-plane.yml
@@ -24,7 +24,7 @@
     - { role: kubespray-defaults}
     - { role: recover_control_plane/control-plane }
 
-- include: cluster.yml
+- import_playbook: cluster.yml
 
 - hosts: kube_control_plane
   environment: "{{ proxy_disable_env }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Remove `include` keyword in playbook recover_cp as it should only be deprecated but is in fact removed and create an error

**Which issue(s) this PR fixes**:
Fixes #9478

**Special notes for your reviewer**:
Reference the ansible issue (regarding the deprecation/removal): https://github.com/ansible/ansible/issues/76686

**Does this PR introduce a user-facing change?**:
```release-note
Change `include` to `import_playbook` in recover_control_plane playbook, to support ansible 2.12+
```
