### PR TITLE
Feature/add flannel wireguard encryption backend as option

### DIFF
--- a/docs/flannel.md
+++ b/docs/flannel.md
@@ -2,7 +2,7 @@
 
 Flannel is a network fabric for containers, designed for Kubernetes
 
-Supported [backends](https://github.com/flannel-io/flannel/blob/master/Documentation/backends.md#wireguard): `vxlan`, `host-gw` and `wireguard` 
+Supported [backends](https://github.com/flannel-io/flannel/blob/master/Documentation/backends.md#wireguard): `vxlan`, `host-gw` and `wireguard`
 
 **Warning:** You may encounter this [bug](https://github.com/coreos/flannel/pull/1282) with `VXLAN` backend, while waiting on a newer Flannel version the current workaround (`ethtool --offload flannel.1 rx off tx off`) is showcase in kubespray [networking test](tests/testcases/040_check-network-adv.yml:31).
 

--- a/docs/flannel.md
+++ b/docs/flannel.md
@@ -2,6 +2,8 @@
 
 Flannel is a network fabric for containers, designed for Kubernetes
 
+Supported [backends](https://github.com/flannel-io/flannel/blob/master/Documentation/backends.md#wireguard): `vxlan`, `host-gw` and `wireguard` 
+
 **Warning:** You may encounter this [bug](https://github.com/coreos/flannel/pull/1282) with `VXLAN` backend, while waiting on a newer Flannel version the current workaround (`ethtool --offload flannel.1 rx off tx off`) is showcase in kubespray [networking test](tests/testcases/040_check-network-adv.yml:31).
 
 ## Verifying flannel install

--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-flannel.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-flannel.yml
@@ -10,8 +10,7 @@
 ## single quote and escape backslashes
 # flannel_interface_regexp: '10\\.0\\.[0-2]\\.\\d{1,3}'
 
-# You can choose what type of flannel backend to use: 'vxlan' or 'host-gw'
-# for experimental backend
+# You can choose what type of flannel backend to use: 'vxlan',  'host-gw' or 'wireguard'
 # please refer to flannel's docs : https://github.com/coreos/flannel/blob/master/README.md
 # flannel_backend_type: "vxlan"
 # flannel_vxlan_vni: 1

--- a/roles/network_plugin/flannel/tasks/main.yml
+++ b/roles/network_plugin/flannel/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+
+- name: Flannel | Stop if kernel version is too low for Flannel Wireguard encryption
+  assert:
+    that: ansible_kernel.split('-')[0] is version('5.6.0', '>=')
+  when:
+    - kube_network_plugin == 'flannel'
+    - flannel_backend_type == 'wireguard'
+    - not ignore_assert_errors
+
 - name: Flannel | Create Flannel manifests
   template:
     src: "{{ item.file }}.j2"


### PR DESCRIPTION

/kind feature

**What this PR does / why we need it**:

Add support for flannel backend `wireguard`

As described in the flannel docs:
https://github.com/flannel-io/flannel/blob/master/Documentation/backends.md#wireguard

This does not support optional configuration methods like:
- setting a psk (will be autogenerated by default)
- chang listening ports
- change mode (defaults to 'separate')
- change PersistentKeepaliveInterval (defaults to 0)

The check for Linux kernel >=5.6 was adopted from the cilium [check.yml](https://github.com/kubernetes-sigs/kubespray/blob/master/roles/network_plugin/cilium/tasks/check.yml#L23-L30)

**Which issue(s) this PR fixes**:
Fixes #9490 


