### PR TITLE
fix kube token dir permissions

### DIFF
--- a/roles/kubernetes/tokens/tasks/main.yml
+++ b/roles/kubernetes/tokens/tasks/main.yml
@@ -10,7 +10,7 @@
   file:
     path: "{{ kube_token_dir }}"
     state: directory
-    mode: o-rwx
+    mode: 0644
     group: "{{ kube_cert_group }}"
 
 - import_tasks: gen_tokens.yml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
when `kube_token_auth: true` fixes permission error:
```
failed: [k1-cp1] (item=['system:kubectl', 'k1-cp3']) => {"ansible_loop_var": "item", "changed": false, "cmd": "/usr/local/bin/kubernetes-scripts/kube-gen-token.sh system:kubectl-k1-cp3", "item": ["system:kubectl", "k1-cp3"], "msg": "[Errno 2] No such file or directory: b'/usr/local/bin/kubernetes-scripts/kube-gen-token.sh'", "rc": 2, "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9589

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
