### PR TITLE
Remove ovn.kubernetes.io/ovs_dp_type from nodeSelector

### DIFF
--- a/roles/network_plugin/kube-ovn/templates/cni-ovn.yml.j2
+++ b/roles/network_plugin/kube-ovn/templates/cni-ovn.yml.j2
@@ -463,7 +463,6 @@ spec:
 {% endif %}
       nodeSelector:
         kubernetes.io/os: "linux"
-        ovn.kubernetes.io/ovs_dp_type: "kernel"
       volumes:
         - name: host-modules
           hostPath:


### PR DESCRIPTION
Remove tag preventing openvswitch container to start.

/kind bug

Fixes: #9588


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[kube-ovn] Remove ovn.kubernetes.io/ovs_dp_type from nodeSelector
```
