### PR TITLE
Add enableServicesElection env variable.

### DIFF
--- a/docs/kube-vip.md
+++ b/docs/kube-vip.md
@@ -39,6 +39,12 @@ kube_vip_services_enabled: false
 [additional manual steps](https://kube-vip.io/docs/usage/cloud-provider/)
 are needed.
 
+If using [local traffic policy](https://kube-vip.io/docs/usage/kubernetes-services/#external-traffic-policy-kube-vip-v050):
+
+```yaml
+kube_vip_enableServicesElection: true
+```
+
 If using [ARP mode](https://kube-vip.io/docs/installation/static/#arp) :
 
 ```yaml

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -80,6 +80,7 @@ kube_vip_bgp_peerpass:
 kube_vip_bgp_peeras: 65000
 kube_vip_bgppeers:
 kube_vip_address:
+kube_vip_enableServicesElection: false
 
 # Requests for load balancer app
 loadbalancer_apiserver_memory_requests: 32M

--- a/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
@@ -68,6 +68,10 @@ spec:
 {% endif %}
     - name: address
       value: {{ kube_vip_address | to_json }}
+{% if kube_vip_enableServicesElection %}
+    - name: enableServicesElection
+      value: "true"
+{% endif %}
     image: {{ kube_vip_image_repo }}:{{ kube_vip_image_tag }}
     imagePullPolicy: {{ k8s_image_pull_policy }}
     name: kube-vip


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Kube-vip manifest is missing enableServicesElection variable. You need this option when you use LoadBalancer with external traffic policy local. See: https://kube-vip.io/docs/usage/kubernetes-services/#external-traffic-policy-kube-vip-v050
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add variable in kube-vip pod (`enableServicesElection`) to be able use local traffic policy in LB service.
