### PR TITLE
Cluster support for ovn-central.

### DIFF
--- a/roles/network_plugin/kube-ovn/defaults/main.yml
+++ b/roles/network_plugin/kube-ovn/defaults/main.yml
@@ -28,8 +28,13 @@ kube_ovn_dpdk_node_memory_request: 2Gi
 kube_ovn_dpdk_node_cpu_limit: 1000m
 kube_ovn_dpdk_node_memory_limit: 2Gi
 
-kube_ovn_central_replics: 1
-kube_ovn_controller_replics: 1
+kube_ovn_central_hosts: "{{ groups['kube_control_plane'] }}"
+kube_ovn_central_replics: "{{ kube_ovn_central_hosts | length }}"
+kube_ovn_controller_replics: "{{ kube_ovn_central_hosts | length }}"
+kube_ovn_central_ips: |-
+  {% for item in kube_ovn_central_hosts -%}
+    {{ hostvars[item]['ip'] | default(fallback_ips[item]) }}{% if not loop.last %},{% endif %}
+  {%- endfor %}
 
 # geneve or vlan
 kube_ovn_network_type: geneve

--- a/roles/network_plugin/kube-ovn/tasks/main.yml
+++ b/roles/network_plugin/kube-ovn/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Kube-OVN | Label ovn-db node
-  command: >-
-    {{ kubectl }} label --overwrite node {{ groups['kube_control_plane'] | first }} kube-ovn/role=master
+  command: "{{ kubectl }} label --overwrite node {{ item }} kube-ovn/role=master"
+  loop: "{{ kube_ovn_central_hosts }}"
   when:
     - inventory_hostname == groups['kube_control_plane'][0]
 

--- a/roles/network_plugin/kube-ovn/templates/cni-ovn.yml.j2
+++ b/roles/network_plugin/kube-ovn/templates/cni-ovn.yml.j2
@@ -249,6 +249,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: NODE_IPS
+              value: "{{ kube_ovn_central_ips }}"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -386,6 +388,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: OVN_DB_IPS
+              value: "{{ kube_ovn_central_ips }}"
           volumeMounts:
             - mountPath: /var/run/netns
               name: host-ns


### PR DESCRIPTION
Without minimal cluster configuration, even on a one node control plane, the health check of the ovn-cental container always fails as it queries the cluster/status.

/kind bug

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
|kube-ovn] Cluster support for ovn-central
```