### PR TITLE
Remove immutable flag from /var/lib/kubelet subdirs

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -253,6 +253,13 @@
     - enable_nodelocaldns|default(false)|bool
     - nodelocaldns_device.stat.exists
 
+- name: reset | Remove immutable flag from /var/lib/kubelet subdirs
+  file:
+    path: /var/lib/kubelet
+    state: directory
+    attributes: "-i"
+    recurse: true
+
 - name: reset | delete some files and directories
   file:
     path: "{{ item }}"

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -253,12 +253,24 @@
     - enable_nodelocaldns|default(false)|bool
     - nodelocaldns_device.stat.exists
 
-- name: reset | Remove immutable flag from /var/lib/kubelet subdirs
+- name: reset | find files/dirs with immutable flag in /var/lib/kubelet
+  command: lsattr -laR /var/lib/kubelet
+  become: true
+  register: var_lib_kubelet_files_dirs_w_attrs
+  changed_when: false
+  no_log: true
+
+- name: reset | remove immutable flag from files/dirs in /var/lib/kubelet
   file:
-    path: /var/lib/kubelet
-    state: directory
+    path: "{{ filedir_path }}"
+    state: touch
     attributes: "-i"
-    recurse: true
+  loop: "{{ var_lib_kubelet_files_dirs_w_attrs.stdout_lines|select('search', 'Immutable')|list }}"
+  loop_control:
+    loop_var: file_dir_line
+    label: "{{ filedir_path }}"
+  vars:
+    filedir_path: "{{ file_dir_line.split(' ')[0] }}"
 
 - name: reset | delete some files and directories
   file:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Before removing /var/lib/kubelet, make sure immutable flag (`chattr -i`) is removed from /var/lib/kubelet's tree.
As a matter of fact, file module does not change attributes before removing the directory (hence the separate task before).

We need it because some CSI drivers set immutable flag on mount directories (at least some leftovers of those CSI driver have been found) in /var/lib/kubelet, and shutil.rmtree (which is used in file module when state is "absent") simply does not remove most of /var/lib/kubelet if only one dir is immutable in, for example, /var/lib/kubelets/pods. That causes node join to fail afterwards.

**Which issue(s) this PR fixes**:
None that I know of

**Special notes for your reviewer**:
I initially planned to remove immutable flag from all the list of files/dirs in "reset | delete some files and directories" task but that would have meant creating them if missing, I hope you find this way better.


**Does this PR introduce a user-facing change?**:
NONE