### PR TITLE
add extra variable for OCCM cluster-name for separated naming

### DIFF
--- a/roles/kubernetes-apps/external_cloud_controller/openstack/defaults/main.yml
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/defaults/main.yml
@@ -21,4 +21,8 @@ external_openstack_cacert: "{{ lookup('env','OS_CACERT') }}"
 ##    arg1: "value1"
 ##    arg2: "value2"
 external_openstack_cloud_controller_extra_args: {}
+## By default the value of cluster_name variable is taken.
+## If you want to give the OCCM identifier a different value,
+## you can set the external_openstack_cloud_controller_cluster_name.
+## external_openstack_cloud_controller_cluster_name: "cluster-name"
 external_openstack_cloud_controller_image_tag: "v1.25.3"

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-controller-manager-ds.yml.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-controller-manager-ds.yml.j2
@@ -44,7 +44,11 @@ spec:
             - --v=1
             - --cloud-config=$(CLOUD_CONFIG)
             - --cloud-provider=openstack
+{% if external_openstack_cloud_controller_cluster_name is defined %}
+            - --cluster-name={{ external_openstack_cloud_controller_cluster_name }}
+{% else %}
             - --cluster-name={{ cluster_name }}
+{% endif %}
             - --use-service-account-credentials=true
             - --bind-address=127.0.0.1
 {% for key, value in external_openstack_cloud_controller_extra_args.items() %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:

At the moment there is only the possibility to configure the cluster identifier for the external openstack cloud controller via the `cluster_name` variable. However, the `cluster_name` variable is also used in other areas, e.g. domain/DNS records in the cluster.

With this PR it should be possible to configure the DNS records and the OCCM identifier separately if you want to.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
add alternative cluster-name for external openstack cloud controller manager
```
