### PR TITLE
Support OVN Interconnect

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-kube-ovn.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-kube-ovn.yml
@@ -55,3 +55,9 @@ kube_ovn_enable_ssl: false
 
 ## dpdk
 kube_ovn_dpdk_enabled: false
+
+## enable interconnection to an existing IC database server.
+kube_ovn_ic_enable: false
+kube_ovn_ic_autoroute: true
+kube_ovn_ic_dbhost: "127.0.0.1"
+kube_ovn_ic_zone: "kubernetes"

--- a/roles/network_plugin/kube-ovn/defaults/main.yml
+++ b/roles/network_plugin/kube-ovn/defaults/main.yml
@@ -36,6 +36,11 @@ kube_ovn_central_ips: |-
     {{ hostvars[item]['ip'] | default(fallback_ips[item]) }}{% if not loop.last %},{% endif %}
   {%- endfor %}
 
+kube_ovn_ic_enable: false
+kube_ovn_ic_autoroute: true
+kube_ovn_ic_dbhost: "127.0.0.1"
+kube_ovn_ic_zone: "kubernetes"
+
 # geneve or vlan
 kube_ovn_network_type: geneve
 

--- a/roles/network_plugin/kube-ovn/templates/cni-kube-ovn.yml.j2
+++ b/roles/network_plugin/kube-ovn/templates/cni-kube-ovn.yml.j2
@@ -608,3 +608,19 @@ spec:
   ports:
     - port: 10665
       name: metrics
+{% if kube_ovn_ic_enable %}
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ovn-ic-config
+  namespace: kube-system
+data:
+  enable-ic: "{{ kube_ovn_ic_enable | lower }}"
+  az-name: "{{ kube_ovn_ic_zone }}"
+  ic-db-host: "{{ kube_ovn_ic_dbhost }}"
+  ic-nb-port: "6645"
+  ic-sb-port: "6646"
+  gw-nodes: "{{ kube_ovn_central_hosts|join(',') }}"
+  auto-route: "{{ kube_ovn_ic_autoroute | lower }}"
+{% endif %}


### PR DESCRIPTION
Add support for Inter Connection.

Mostly taken from: https://raw.githubusercontent.com/kubeovn/kube-ovn/master/yamls/ovn-ic.yaml.j2

/kind feature

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[kube-ovn] Support OVN Interconnect (using new variables kube_ovn_ic_xxxx)
```
