### PR TITLE
Creates a pipeline image and eliminates "pipeline bloat" from the Kubespray image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 ---
 stages:
+  - build
   - unit-tests
   - deploy-part1
   - moderator
@@ -35,6 +36,7 @@ variables:
   RECOVER_CONTROL_PLANE_TEST_GROUPS: "etcd[2:],kube_control_plane[1:]"
   TERRAFORM_VERSION: 1.0.8
   ANSIBLE_MAJOR_VERSION: "2.11"
+  PIPELINE_IMAGE: "$CI_REGISTRY_IMAGE/pipeline:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
 
 before_script:
   - ./tests/scripts/rebase.sh
@@ -46,7 +48,7 @@ before_script:
 .job: &job
   tags:
     - packet
-  image: quay.io/kubespray/kubespray:$KUBESPRAY_VERSION
+  image: $PIPELINE_IMAGE
   artifacts:
     when: always
     paths:
@@ -76,6 +78,7 @@ ci-authorized:
   only: []
 
 include:
+  - .gitlab-ci/build.yml
   - .gitlab-ci/lint.yml
   - .gitlab-ci/shellcheck.yml
   - .gitlab-ci/terraform.yml

--- a/.gitlab-ci/build.yml
+++ b/.gitlab-ci/build.yml
@@ -1,0 +1,17 @@
+---
+pipeline image:
+  stage: build
+  image: docker:20.10.22-cli
+  variables:
+    DOCKER_TLS_CERTDIR: ""
+  services:
+    - name: docker:20.10.22-dind
+      # See https://gitlab.com/gitlab-org/gitlab-runner/-/issues/27300 for why this is required
+      command: ["--tls=false"]
+  before_script:
+    - echo $CI_REGISTRY_PASSWORD | docker login -u $CI_REGISTRY_USER --password-stdin $CI_REGISTRY
+  script:
+    # DOCKER_HOST is overwritten if we set it as a GitLab variable
+    - DOCKER_HOST=tcp://docker:2375; docker build --network host --file pipeline.Dockerfile --tag $PIPELINE_IMAGE .
+    - docker push $PIPELINE_IMAGE
+  except: ['triggers', 'master']

--- a/.gitlab-ci/molecule.yml
+++ b/.gitlab-ci/molecule.yml
@@ -4,7 +4,7 @@
   tags: [c3.small.x86]
   only: [/^pr-.*$/]
   except: ['triggers']
-  image: quay.io/kubespray/vagrant:$KUBESPRAY_VERSION
+  image: $PIPELINE_IMAGE
   services: []
   stage: deploy-part1
   before_script:

--- a/.gitlab-ci/vagrant.yml
+++ b/.gitlab-ci/vagrant.yml
@@ -10,7 +10,7 @@
   tags: [c3.small.x86]
   only: [/^pr-.*$/]
   except: ['triggers']
-  image: quay.io/kubespray/vagrant:$KUBESPRAY_VERSION
+  image: $PIPELINE_IMAGE
   services: []
   before_script:
     - apt-get update && apt-get install -y python3-pip

--- a/pipeline.Dockerfile
+++ b/pipeline.Dockerfile
@@ -1,0 +1,47 @@
+# Use imutable image tags rather than mutable tags (like ubuntu:20.04)
+FROM ubuntu:focal-20220531
+
+ARG ARCH=amd64
+ARG TZ=Etc/UTC
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+ENV VAGRANT_VERSION=2.2.19
+ENV VAGRANT_DEFAULT_PROVIDER=libvirt
+ENV VAGRANT_ANSIBLE_TAGS=facts
+
+RUN apt update -y \
+    && apt install -y \
+    libssl-dev python3-dev sshpass apt-transport-https jq moreutils wget libvirt-dev openssh-client rsync git \
+    ca-certificates curl gnupg2 software-properties-common python3-pip unzip \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
+    && add-apt-repository \
+    "deb [arch=$ARCH] https://download.docker.com/linux/ubuntu \
+    $(lsb_release -cs) \
+    stable" \
+    && apt update -y && apt-get install --no-install-recommends -y docker-ce \
+    && rm -rf /var/lib/apt/lists/*
+
+# Some tools like yamllint need this
+# Pip needs this as well at the moment to install ansible
+# (and potentially other packages)
+# See: https://github.com/pypa/pip/issues/10219
+ENV LANG=C.UTF-8
+
+WORKDIR /kubespray
+COPY . .
+RUN /usr/bin/python3 -m pip install --no-cache-dir pip -U \
+    && /usr/bin/python3 -m pip install --no-cache-dir -r tests/requirements.txt \
+    && python3 -m pip install --no-cache-dir -r requirements.txt \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+
+RUN KUBE_VERSION=$(sed -n 's/^kube_version: //p' roles/kubespray-defaults/defaults/main.yaml) \
+    && curl -LO https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/$ARCH/kubectl \
+    && chmod a+x kubectl \
+    && mv kubectl /usr/local/bin/kubectl
+
+# Install Vagrant
+RUN wget https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_x86_64.deb && \
+ dpkg -i vagrant_${VAGRANT_VERSION}_x86_64.deb && \
+ rm vagrant_${VAGRANT_VERSION}_x86_64.deb && \
+ vagrant plugin install vagrant-libvirt


### PR DESCRIPTION

/kind cleanup

**What this PR does / why we need it**:

Downstream users of Kubespray should not have all of the bloat from pipeline requirements in the released Docker image

**Which issue(s) this PR fixes**:
Fixes #9411

**Does this PR introduce a user-facing change?**:
None

```release-note
- Creates a separate image for pipeline tests
- Reduces the size of the released image
```
