### PR TITLE
[feat] Add custom options to coredns kubernets plugin

### DIFF
--- a/docs/dns-stack.md
+++ b/docs/dns-stack.md
@@ -56,6 +56,10 @@ Whether or not upstream DNS servers come from `upstream_dns_servers` variable or
 These are configurable in inventory in as a dictionary in the `dns_upstream_forward_extra_opts` variable.
 By default, no other option than the ones hardcoded (see `roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2` and `roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2`).
 
+### coredns_kubernetes_extra_opts
+
+Custom options to be added to the kubernetes coredns plugin.
+
 ### coredns_external_zones
 
 Array of optional external zones to coredns forward queries to. It's  injected into

--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -208,6 +208,9 @@ enable_coredns_k8s_endpoint_pod_names: false
 # Set forward options for upstream DNS servers in coredns (and nodelocaldns) config
 # dns_upstream_forward_extra_opts:
 #   policy: sequential
+# Apply extra options to coredns kubernetes plugin
+# coredns_kubernetes_extra_opts:
+#   - 'fallthrough example.local'
 
 # Can be docker_dns, host_resolvconf or none
 resolvconf_mode: host_resolvconf

--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -18,6 +18,10 @@ coredns_default_zone_cache_block: |
 # dns_upstream_forward_extra_opts:
 #   policy: sequential
 
+# Apply extra options to coredns kubernetes plugin
+# coredns_kubernetes_extra_opts:
+#   - 'fallthrough example.local'
+
 # nodelocaldns
 nodelocaldns_cpu_requests: 100m
 nodelocaldns_memory_limit: 200Mi

--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -44,6 +44,11 @@ data:
 {% if enable_coredns_reverse_dns_lookups %}
           fallthrough in-addr.arpa ip6.arpa
 {% endif %}
+{% if coredns_kubernetes_extra_opts is defined %}
+{% for opt in coredns_kubernetes_extra_opts %}
+          {{ opt }}
+{% endfor %}
+{% endif %}
         }
         prometheus :9153
         forward . {{ upstream_dns_servers|join(' ') if upstream_dns_servers is defined and upstream_dns_servers|length > 0 else '/etc/resolv.conf' }} {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it:**
Add the possibility of specifying extra options to the kubernetes cordns plugin. e.g. fallthrough

Does this PR introduce a user-facing change?:

```release-note
Add custom options to coredns kubernets plugin (`coredns_kubernetes_extra_opts `)
```