### PR TITLE
fix(apps): cinder: wrong rbac for csi-snapshotter-role

### DIFF
--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin-rbac.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin-rbac.yml.j2
@@ -113,7 +113,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
-    verbs: ["create", "get", "list", "watch", "update", "delete"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
     verbs: ["update"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes the wrong ClusterRole `csi-snapshotter-role` that is missing a `patch` verb for the resource `volumesnapshotcontents`.
When the `csi-snapshotter` sidecar of `csi-cinder-controllerplugin` tries to create a cinder volume snapshot, it must update the VolumeSnapshot `status` field.
But because we are lacking the `patch` verb, it cannot mark the VolumeSnapshot as ready and calls to the storage provider are not made:
```
I1223 15:29:31.503252       1 event.go:285] Event(v1.ObjectReference{Kind:"VolumeSnapshotContent", Namespace:"", Name:"snapcontent-25e83337-61da-422c-b6b7-fc2a1bcb33ec", UID:"ece6b929-cfd7-4aa4-808d-7101df6e064f", APIVersion:"snapshot.storage.k8s.io/v1", ResourceVersion:"751175", FieldPath:""}): type: 'Warning' reason: 'SnapshotCreationFailed' Failed to create snapshot: failed to add VolumeSnapshotBeingCreated annotation on the content snapcontent-25e83337-61da-422c-b6b7-fc2a1bcb33ec: "snapshot controller failed to update snapcontent-25e83337-61da-422c-b6b7-fc2a1bcb33ec on API server: volumesnapshotcontents.snapshot.storage.k8s.io \"snapcontent-25e83337-61da-422c-b6b7-fc2a1bcb33ec\" is forbidden: User \"system:serviceaccount:kube-system:csi-cinder-controller-sa\" cannot patch resource \"volumesnapshotcontents\" in API group \"snapshot.storage.k8s.io\" at the cluster scope"
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix wrong rbac of the ClusterRole `csi-snapshotter-role`
```
