### PR TITLE
DNM: Check hubble test

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -196,9 +196,9 @@ packet_ubuntu16-docker-weave-sep:
   when: manual
 
 packet_ubuntu18-cilium-sep:
-  stage: deploy-special
+  stage: unit-tests
   extends: .packet_pr
-  when: manual
+  when: on_success
 
 packet_ubuntu18-flannel-ha:
   stage: deploy-part2

--- a/tests/files/packet_ubuntu18-cilium-sep.yml
+++ b/tests/files/packet_ubuntu18-cilium-sep.yml
@@ -5,5 +5,7 @@ mode: separate
 
 # Kubespray settings
 kube_network_plugin: cilium
+cilium_enable_hubble: true
+cilium_hubble_install: true
 enable_network_policy: true
 auto_renew_certificates: true


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This enables hubble deployment on packet_ubuntu18-cilium-sep to verify that works always.

Ref: #9567 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
