### PR TITLE
Reset role: Remove kube-ovn log directories

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -289,6 +289,9 @@
     - "{{ etcd_events_data_dir }}"
     - "{{ etcd_config_dir }}"
     - /var/log/calico
+    - /var/log/openvswitch
+    - /var/log/ovn
+    - /var/log/kube-ovn
     - /etc/cni
     - /etc/nerdctl
     - "{{ nginx_config_dir }}"


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

Cleans up log directories added by kube-ovn.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[kube-ovn] Remove kube-ovn log directories when reseting
```