### PR TITLE
cleanup: replace node-role.kubernetes.io/master

### DIFF
--- a/roles/network_plugin/calico/templates/calico-apiserver.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-apiserver.yml.j2
@@ -1,4 +1,4 @@
-# Policy to ensure the API server isn't cut off. Can be modified, but ensure 
+# Policy to ensure the API server isn't cut off. Can be modified, but ensure
 # that the main API server is always able to reach the Calico API server.
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
@@ -94,6 +94,8 @@ spec:
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
       volumes:
       - name: calico-apiserver-certs
         secret:
@@ -104,8 +106,8 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: calico-apiserver 
-  namespace: calico-apiserver 
+  name: calico-apiserver
+  namespace: calico-apiserver
 
 ---
 

--- a/roles/network_plugin/canal/templates/canal-calico-kube-controllers.yml.j2
+++ b/roles/network_plugin/canal/templates/canal-calico-kube-controllers.yml.j2
@@ -31,6 +31,8 @@ spec:
           operator: Exists
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       serviceAccountName: calico-kube-controllers
       priorityClassName: system-cluster-critical
       # The controllers must run in the host network namespace so that


### PR DESCRIPTION
/kind cleanup

`node-role.kubernetes.io/master` has been deprecated,  and replaced by [node-role.kubernetes.io/control-plane](https://kubernetes.io/docs/reference/labels-annotations-taints/#node-role-kubernetes-io-control-plane-taint)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[Calico] Replace node-role.kubernetes.io/master with control-plane
```