### PR TITLE
Add retry to avoid 'unknown' state for calicoctl

### DIFF
--- a/roles/network_plugin/calico/tasks/check.yml
+++ b/roles/network_plugin/calico/tasks/check.yml
@@ -51,6 +51,9 @@
   async: 10
   poll: 3
   run_once: True
+  until: calico_version_on_server.stdout != 'unknown'
+  retries: 5
+  delay: "{{ retry_stagger | random + 3 }}"
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
   changed_when: false
   failed_when: false
@@ -62,6 +65,7 @@
     msg: >
       Your version of calico is not fresh enough for upgrade.
       Minimum version is {{ calico_min_version_required }} supported by the previous kubespray release.
+      But current version is {{ calico_version_on_server.stdout }}.
   when:
     - 'calico_version_on_server.stdout is defined'
     - calico_version_on_server.stdout


### PR DESCRIPTION
Signed-off-by: tu1h <lihai.tu@daocloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

In some scenarios, the K8s cluster is successfully deployed and calico is successfully applied, but some following steps fail. Generally, the deployment operation needs to be retried. However, calico may not be ready when the retry is performed, resulting in role `preinstall` verify that the version of the calico cluster is `unknown`(show in the figure below). So that the Calico version checking would be failed.

<img width="1419" alt="企业微信截图_4e591e99-6e5f-4d8b-b2b8-82b77051f838" src="https://user-images.githubusercontent.com/92532497/210322280-5f8b7c2e-64e1-44a1-a0fb-d32acb3268d4.png">

![Picture1](https://user-images.githubusercontent.com/92532497/210319548-9f76b70a-21b5-4b3a-9a41-b8353668d301.png)

So, to avoid this situation as much as possible, add retries and standard output judgment.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[Calico] Add retry to avoid 'unknown' state for calicoctl
```
