### PR TITLE
feat(coredns): Forward extra domains to coredns kubernetes plugin

### DIFF
--- a/docs/dns-stack.md
+++ b/docs/dns-stack.md
@@ -60,6 +60,10 @@ By default, no other option than the ones hardcoded (see `roles/kubernetes-apps/
 
 Custom options to be added to the kubernetes coredns plugin.
 
+### coredns_kubernetes_extra_domains
+
+Extra domains to be forwarded to the kubernetes coredns plugin.
+
 ### coredns_external_zones
 
 Array of optional external zones to coredns forward queries to. It's  injected into

--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -211,6 +211,8 @@ enable_coredns_k8s_endpoint_pod_names: false
 # Apply extra options to coredns kubernetes plugin
 # coredns_kubernetes_extra_opts:
 #   - 'fallthrough example.local'
+# Forward extra domains to the coredns kubernetes plugin
+# coredns_kubernetes_extra_domains: ''
 
 # Can be docker_dns, host_resolvconf or none
 resolvconf_mode: host_resolvconf

--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -36,7 +36,7 @@ data:
             lameduck 5s
         }
         ready
-        kubernetes {{ dns_domain }} {% if enable_coredns_reverse_dns_lookups %}in-addr.arpa ip6.arpa {% endif %}{
+        kubernetes {{ dns_domain }} {% if coredns_kubernetes_extra_domains is defined %}{{ coredns_kubernetes_extra_domains }} {% endif %}{% if enable_coredns_reverse_dns_lookups %}in-addr.arpa ip6.arpa {% endif %}{
           pods insecure
 {% if enable_coredns_k8s_endpoint_pod_names %}
           endpoint_pod_names


### PR DESCRIPTION


What type of PR is this?
/kind feature

What this PR does / why we need it:
For our environment we would like to have a more granular method to specify the domains passed to the coredns kubernetes plugin. This pull-request adds an extra optional variable that will help users who want to fine-tune the configuration for a specific environment.

Does this PR introduce a user-facing change?:
Add the possibility to specify extra domains for the coredns kubernets plugin.
