### PR TITLE
Update Calico VXLAN offload docs because Calico changed the default value.

### DIFF
--- a/docs/calico.md
+++ b/docs/calico.md
@@ -207,10 +207,10 @@ calico_healthhost: "0.0.0.0"
 
 ### Optional : Configure VXLAN hardware Offload
 
-Because of the Issue [projectcalico/calico#4727](https://github.com/projectcalico/calico/issues/4727), The VXLAN Offload is disable by default. It can be configured like this:
+The VXLAN Offload is disable by default. It can be configured like this to enabled it:
 
 ```yml
-calico_feature_detect_override: "ChecksumOffloadBroken=true" # The vxlan offload will enabled with kernel version is > 5.7 (It may cause problem on buggy NIC driver)
+calico_feature_detect_override: "ChecksumOffloadBroken=false" # The vxlan offload will enabled (It may cause problem on buggy NIC driver)
 ```
 
 ### Optional : Configure Calico Node probe timeouts

--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -160,6 +160,5 @@ calico_ipam_maxblocksperhost: 0
 # Calico apiserver (only with kdd)
 calico_apiserver_enabled: false
 
-# Calico feature detect override, set "ChecksumOffloadBroken=true" to
-# solve the https://github.com/projectcalico/calico/issues/3145
+# Calico feature detect override
 calico_feature_detect_override: ""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind documentation

**What this PR does / why we need it**:

Update Calico VXLAN offload docs because Calico changed the default value.
The Calico VXLAN Offload Issue has been fixed at the calico 3.25 & 3.24.5 by https://github.com/projectcalico/calico/pull/6842 , So the kubespray should change the docs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update Calico VXLAN offload docs because Calico changed the default value.
```
