### PR TITLE
Add Fedora37 support and remove Fedora35

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -68,9 +68,8 @@ packet_centos7-flannel-addons-ha:
 
 packet_almalinux8-crio:
   extends: .packet_pr
-  stage: deploy-part2
+  stage: unit-tests
   when: on_success
-  allow_failure: true
 
 packet_ubuntu20-crio:
   extends: .packet_pr

--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -133,6 +133,8 @@
       value: '"overlay"'
     - option: graphroot
       value: '"/var/lib/containers/storage"'
+    - option: runroot
+      value: '"/var/run/containers/storage"'
 
 # metacopy=on is available since 4.19 and was backported to RHEL 4.18 kernel
 - name: Cri-o | set metacopy mount options correctly


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add Fedora 37 image (pushed to quay) with CI
Remove Fedora 35 support (eol)

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:
none

All jobs are green here:
(soon)

**Does this PR introduce a user-facing change?**:
```release-note
Drop support for Fedora35, Add suport for Fedora37
```