### PR TITLE
Build pipeline image even on schedules and master

### DIFF
--- a/.gitlab-ci/build.yml
+++ b/.gitlab-ci/build.yml
@@ -14,4 +14,3 @@ pipeline image:
     # DOCKER_HOST is overwritten if we set it as a GitLab variable
     - DOCKER_HOST=tcp://docker:2375; docker build --network host --file pipeline.Dockerfile --tag $PIPELINE_IMAGE .
     - docker push $PIPELINE_IMAGE
-  except: ['triggers', 'master']


### PR DESCRIPTION

/kind bug

**What this PR does / why we need it**:

It fixes fails on scheduled pipelines and master branch pipelines, as the pipeline image is needed for both of these

Fixes #9606

See comment: https://github.com/kubernetes-sigs/kubespray/pull/9606#issuecomment-1375249720

**Special notes for your reviewer**:

@yankay This should problems with the pipeline failing on the master branch

**Does this PR introduce a user-facing change?**:
NONE

```release-note
Build and push pipeline image on schedules and master branch
```
