### PR TITLE
fix containerd config toml for insecure registries

### DIFF
--- a/pipeline.Dockerfile
+++ b/pipeline.Dockerfile
@@ -45,3 +45,7 @@ RUN wget https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAG
  dpkg -i vagrant_${VAGRANT_VERSION}_x86_64.deb && \
  rm vagrant_${VAGRANT_VERSION}_x86_64.deb && \
  vagrant plugin install vagrant-libvirt
+
+# Install Kubernetes collections
+RUN pip3 install kubernetes \
+    && ansible-galaxy collection install kubernetes.core

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -57,8 +57,8 @@ oom_score = {{ containerd_oom_score }}
         [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ registry }}"]
           endpoint = ["{{ ([ addr ] | flatten ) | join('","') }}"]
 {% endfor %}
-{% for addr in containerd_insecure_registries.values() | flatten | unique %}
-        [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ addr }}".tls]
+{% for registry in containerd_insecure_registries.keys() %}
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ registry }}".tls]
           insecure_skip_verify = true
 {% endfor %}
 {% endif %}

--- a/tests/cloud_playbooks/roles/packet-ci/tasks/create-vms.yml
+++ b/tests/cloud_playbooks/roles/packet-ci/tasks/create-vms.yml
@@ -11,20 +11,19 @@
     mode: 0755
 
 - name: Template vm files for CI job
-  template:
-    src: "vm.yml.j2"
-    dest: "/tmp/{{ test_name }}/instance-{{ vm_id }}.yml"
-    mode: 0644
+  set_fact:
+    vms_files: "{{ vms_files }} + [{{ lookup('ansible.builtin.template', 'vm.yml.j2') | from_yaml }}]"
+  vars:
+    vms_files: []
   loop: "{{ range(1, vm_count|int + 1, 1) | list }}"
   loop_control:
     index_var: vm_id
 
 - name: Start vms for CI job
-  command: "kubectl apply -f /tmp/{{ test_name }}/instance-{{ vm_id }}.yml"
+  kubernetes.core.k8s:
+    definition: "{{ item }}"
   changed_when: false
-  loop: "{{ range(1, vm_count|int + 1, 1) | list }}"
-  loop_control:
-    index_var: vm_id
+  loop: "{{ vms_files }}"
 
 - name: Wait for vms to have ipaddress assigned
   shell: "set -o pipefail && kubectl get vmis -n {{ test_name }} instance-{{ vm_id }} -o json | jq '.status.interfaces[].ipAddress' | tr -d '\"'"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

here is the config about insecure registries for containerd.

    containerd_insecure_registries:
      "192.168.x.x:8080":
        - "http://192.168.x.x:8080"
the rendered /etc/containerd/config.toml contains:

        [plugins."io.containerd.grpc.v1.cri".registry.configs."http://192.168.x.x:8080".tls]
          insecure_skip_verify = true
but it needs to be:

        [plugins."io.containerd.grpc.v1.cri".registry.configs."192.168.x.x:8080".tls]
          insecure_skip_verify = true

because insecure_registries template has registry address instead of registry name

```
diff --git a/roles/container-engine/containerd/templates/config.toml.j2 b/roles/container-engine/containerd/templates/config.toml.j2
index c1bda12b..096dea40 100644
--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -57,8 +57,8 @@ oom_score = {{ containerd_oom_score }}
         [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ registry }}"]
           endpoint = ["{{ ([ addr ] | flatten ) | join('","') }}"]
 {% endfor %}
-{% for addr in containerd_insecure_registries.values() | flatten | unique %}
-        [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ addr }}".tls]
+{% for registry in containerd_insecure_registries.keys() %}
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ registry }}".tls]
           insecure_skip_verify = true
 {% endfor %}
 {% endif %}
```

**What type of PR is this?**
/kind bug
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Fixes /etc/containerd/config.toml generation for insecure registries.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9371 #9207 #9653

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
