### PR TITLE
Fixes VM creation bug in Ubuntu 20 Calico AIO test

### DIFF
--- a/pipeline.Dockerfile
+++ b/pipeline.Dockerfile
@@ -45,3 +45,7 @@ RUN wget https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAG
  dpkg -i vagrant_${VAGRANT_VERSION}_x86_64.deb && \
  rm vagrant_${VAGRANT_VERSION}_x86_64.deb && \
  vagrant plugin install vagrant-libvirt
+
+# Install Kubernetes collections
+RUN pip3 install kubernetes \
+    && ansible-galaxy collection install kubernetes.core

--- a/tests/cloud_playbooks/roles/packet-ci/tasks/create-vms.yml
+++ b/tests/cloud_playbooks/roles/packet-ci/tasks/create-vms.yml
@@ -11,20 +11,19 @@
     mode: 0755
 
 - name: Template vm files for CI job
-  template:
-    src: "vm.yml.j2"
-    dest: "/tmp/{{ test_name }}/instance-{{ vm_id }}.yml"
-    mode: 0644
+  set_fact:
+    vms_files: "{{ vms_files }} + [{{ lookup('ansible.builtin.template', 'vm.yml.j2') | from_yaml }}]"
+  vars:
+    vms_files: []
   loop: "{{ range(1, vm_count|int + 1, 1) | list }}"
   loop_control:
     index_var: vm_id
 
 - name: Start vms for CI job
-  command: "kubectl apply -f /tmp/{{ test_name }}/instance-{{ vm_id }}.yml"
+  kubernetes.core.k8s:
+    definition: "{{ item }}"
   changed_when: false
-  loop: "{{ range(1, vm_count|int + 1, 1) | list }}"
-  loop_control:
-    index_var: vm_id
+  loop: "{{ vms_files }}"
 
 - name: Wait for vms to have ipaddress assigned
   shell: "set -o pipefail && kubectl get vmis -n {{ test_name }} instance-{{ vm_id }} -o json | jq '.status.interfaces[].ipAddress' | tr -d '\"'"


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

packet_ubuntu20-calico-aio is failing

**Which issue(s) this PR fixes**:

Fixes #9660

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

NONE

```release-note
Adds template file as Ansible fact for creating VMs for testing and then applies the fact as stdin to `kubectl apply` to workaround this bug
```
