### PR TITLE
Terraform gcp extra ingress firewall

### DIFF
--- a/contrib/terraform/gcp/README.md
+++ b/contrib/terraform/gcp/README.md
@@ -75,6 +75,11 @@ ansible-playbook -i contrib/terraform/gcs/inventory.ini cluster.yml -b -v
 * `api_server_whitelist`: List of IP ranges (CIDR) that will be allowed to connect to the API server
 * `nodeport_whitelist`: List of IP ranges (CIDR) that will be allowed to connect to the kubernetes nodes on port 30000-32767 (kubernetes nodeports)
 * `ingress_whitelist`: List of IP ranges (CIDR) that will be allowed to connect to ingress on ports 80 and 443
+* `extra_ingress_firewalls`: Additional ingress firewall rules. Key will be used as the name of the rule
+  * `source_ranges`: List of IP ranges (CIDR). Example: `["8.8.8.8"]`
+  * `protocol`: Protocol. Example `"tcp"`
+  * `ports`: List of ports, as string. Example `["53"]`
+  * `target_tags`: List of target tag (either the machine name or `control-plane` or `worker`). Example: `["control-plane", "worker-0"]`
 
 ### Optional
 

--- a/contrib/terraform/gcp/main.tf
+++ b/contrib/terraform/gcp/main.tf
@@ -34,4 +34,6 @@ module "kubernetes" {
   api_server_whitelist = var.api_server_whitelist
   nodeport_whitelist   = var.nodeport_whitelist
   ingress_whitelist    = var.ingress_whitelist
+
+  extra_ingress_firewalls = var.extra_ingress_firewalls
 }

--- a/contrib/terraform/gcp/modules/kubernetes-cluster/variables.tf
+++ b/contrib/terraform/gcp/modules/kubernetes-cluster/variables.tf
@@ -14,7 +14,7 @@ variable "machines" {
     }))
     boot_disk = object({
       image_name = string
-      size = number
+      size       = number
     })
   }))
 }
@@ -72,4 +72,15 @@ variable "ingress_whitelist" {
 
 variable "private_network_cidr" {
   default = "10.0.10.0/24"
+}
+
+variable "extra_ingress_firewalls" {
+  type = map(object({
+    source_ranges = set(string)
+    protocol      = string
+    ports         = list(string)
+    target_tags   = set(string)
+  }))
+
+  default = {}
 }

--- a/contrib/terraform/gcp/variables.tf
+++ b/contrib/terraform/gcp/variables.tf
@@ -95,3 +95,14 @@ variable "ingress_whitelist" {
   type = list(string)
   default = ["0.0.0.0/0"]
 }
+
+variable "extra_ingress_firewalls" {
+  type = map(object({
+    source_ranges = set(string)
+    protocol      = string
+    ports         = list(string)
+    target_tags   = set(string)
+  }))
+
+  default = {}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This PR allows to create extra ingress firewall rules for the terraform GCP.

It also includes various cleaning in contrib/terraform/vsphere (I can move those to another PR if needed).

**Does this PR introduce a user-facing change?**:
```release-note
terraform gcp can now have extra ingress firewall rules
```
