### PR TITLE
[cert-manager] update cert-manager to v1.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [weave](https://github.com/weaveworks/weave) v2.8.1
   - [kube-vip](https://github.com/kube-vip/kube-vip) v0.5.5
 - Application
-  - [cert-manager](https://github.com/jetstack/cert-manager) v1.10.1
+  - [cert-manager](https://github.com/jetstack/cert-manager) v1.11.0
   - [coredns](https://github.com/coredns/coredns) v1.9.3
   - [ingress-nginx](https://github.com/kubernetes/ingress-nginx) v1.5.1
   - [krew](https://github.com/kubernetes-sigs/krew) v0.4.3

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -1095,7 +1095,7 @@ ingress_nginx_kube_webhook_certgen_imae_repo: "{{ kube_image_repo }}/ingress-ngi
 ingress_nginx_kube_webhook_certgen_imae_tag: "v1.3.0"
 alb_ingress_image_repo: "{{ docker_image_repo }}/amazon/aws-alb-ingress-controller"
 alb_ingress_image_tag: "v1.1.9"
-cert_manager_version: "v1.10.1"
+cert_manager_version: "v1.11.0"
 cert_manager_controller_image_repo: "{{ quay_image_repo }}/jetstack/cert-manager-controller"
 cert_manager_controller_image_tag: "{{ cert_manager_version }}"
 cert_manager_cainjector_image_repo: "{{ quay_image_repo }}/jetstack/cert-manager-cainjector"

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.crds.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.crds.yml.j2
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Source: cert-manager/templates/crds.yaml
+# Source: cert-manager/deploy/crds/crd-clusterissuers.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -75,6 +75,10 @@ spec:
                     - privateKeySecretRef
                     - server
                   properties:
+                    caBundle:
+                      description: Base64-encoded bundle of PEM CAs which can be used to validate the certificate chain presented by the ACME server. Mutually exclusive with SkipTLSVerify; prefer using CABundle to prevent various kinds of security vulnerabilities. If CABundle and SkipTLSVerify are unset, the system certificate bundle inside the container is used to validate the TLS connection.
+                      type: string
+                      format: byte
                     disableAccountKeyGeneration:
                       description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
                       type: boolean
@@ -133,7 +137,7 @@ spec:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
                     skipTLSVerify:
-                      description: Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have their TLS certificate validated (i.e. insecure connections will be allowed). Only enable this option in development environments. The cert-manager system installed roots will be used to verify connections to the ACME server if this is false. Defaults to false.
+                      description: 'INSECURE: Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have the TLS certificate chain validated. Mutually exclusive with CABundle; prefer using CABundle to prevent various kinds of security vulnerabilities. Only enable this option in development environments. If CABundle and SkipTLSVerify are unset, the system certificate bundle inside the container is used to validate the TLS connection. Defaults to false.'
                       type: boolean
                     solvers:
                       description: 'Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/'
@@ -351,7 +355,7 @@ spec:
                                   - nameserver
                                 properties:
                                   nameserver:
-                                    description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
+                                    description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
                                     type: string
                                   tsigAlgorithm:
                                     description: 'The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
@@ -443,7 +447,7 @@ spec:
                                     additionalProperties:
                                       type: string
                                   parentRefs:
-                                    description: 'When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways'
+                                    description: 'When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways'
                                     type: array
                                     items:
                                       description: "ParentReference identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid."
@@ -452,13 +456,13 @@ spec:
                                         - name
                                       properties:
                                         group:
-                                          description: "Group is the group of the referent. \n Support: Core"
+                                          description: "Group is the group of the referent. When unspecified, \"gateway.networking.k8s.io\" is inferred. To set the core API group (such as for a \"Service\" kind referent), Group must be explicitly set to \"\" (empty string). \n Support: Core"
                                           type: string
                                           default: gateway.networking.k8s.io
                                           maxLength: 253
                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                         kind:
-                                          description: "Kind is kind of the referent. \n Support: Core (Gateway) \n Support: Custom (Other Resources)"
+                                          description: "Kind is kind of the referent. \n Support: Core (Gateway) \n Support: Implementation-specific (Other Resources)"
                                           type: string
                                           default: Gateway
                                           maxLength: 63
@@ -470,7 +474,7 @@ spec:
                                           maxLength: 253
                                           minLength: 1
                                         namespace:
-                                          description: "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core"
+                                          description: "Namespace is the namespace of the referent. When unspecified, this refers to the local namespace of the Route. \n Note that there are specific rules for ParentRefs which cross namespace boundaries. Cross-namespace references are only valid if they are explicitly allowed by something in the namespace they are referring to. For example: Gateway has the AllowedRoutes field, and ReferenceGrant provides a generic way to enable any other kind of cross-namespace reference. \n Support: Core"
                                           type: string
                                           maxLength: 63
                                           minLength: 1
@@ -1172,11 +1176,11 @@ spec:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                     caBundle:
-                      description: PEM-encoded CA bundle (base64-encoded) used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection. Mutually exclusive with CABundleSecretRef. If neither CABundle nor CABundleSecretRef are defined, the cert-manager controller system root certificates are used to validate the TLS connection.
+                      description: Base64-encoded bundle of PEM CAs which will be used to validate the certificate chain presented by Vault. Only used if using HTTPS to connect to Vault and ignored for HTTP connections. Mutually exclusive with CABundleSecretRef. If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in the cert-manager controller container is used to validate the TLS connection.
                       type: string
                       format: byte
                     caBundleSecretRef:
-                      description: CABundleSecretRef is a reference to a Secret which contains the CABundle which will be used when connecting to Vault when using HTTPS. Mutually exclusive with CABundle. If neither CABundleSecretRef nor CABundle are defined, the cert-manager controller system root certificates are used to validate the TLS connection. If no key for the Secret is specified, cert-manager will default to 'ca.crt'.
+                      description: Reference to a Secret containing a bundle of PEM-encoded CAs to use when verifying the certificate chain presented by Vault when using HTTPS. Mutually exclusive with CABundle. If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in the cert-manager controller container is used to validate the TLS connection. If no key for the Secret is specified, cert-manager will default to 'ca.crt'.
                       type: object
                       required:
                         - name
@@ -1231,7 +1235,7 @@ spec:
                         - url
                       properties:
                         caBundle:
-                          description: CABundle is a PEM encoded TLS certificate to use to verify connections to the TPP instance. If specified, system roots will not be used and the issuing CA for the TPP instance must be verifiable using the provided root. If not specified, the connection will be verified using the cert-manager system root certificates.
+                          description: Base64-encoded bundle of PEM CAs which will be used to validate the certificate chain presented by the TPP server. Only used if using HTTPS; ignored for HTTP. If undefined, the certificate bundle in the cert-manager controller container is used to validate the chain.
                           type: string
                           format: byte
                         credentialsRef:
@@ -1303,7 +1307,7 @@ spec:
       served: true
       storage: true
 ---
-# Source: cert-manager/templates/crds.yaml
+# Source: cert-manager/deploy/crds/crd-challenges.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -1607,7 +1611,7 @@ spec:
                             - nameserver
                           properties:
                             nameserver:
-                              description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
+                              description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
                               type: string
                             tsigAlgorithm:
                               description: 'The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
@@ -1699,7 +1703,7 @@ spec:
                               additionalProperties:
                                 type: string
                             parentRefs:
-                              description: 'When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways'
+                              description: 'When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways'
                               type: array
                               items:
                                 description: "ParentReference identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid."
@@ -1708,13 +1712,13 @@ spec:
                                   - name
                                 properties:
                                   group:
-                                    description: "Group is the group of the referent. \n Support: Core"
+                                    description: "Group is the group of the referent. When unspecified, \"gateway.networking.k8s.io\" is inferred. To set the core API group (such as for a \"Service\" kind referent), Group must be explicitly set to \"\" (empty string). \n Support: Core"
                                     type: string
                                     default: gateway.networking.k8s.io
                                     maxLength: 253
                                     pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                   kind:
-                                    description: "Kind is kind of the referent. \n Support: Core (Gateway) \n Support: Custom (Other Resources)"
+                                    description: "Kind is kind of the referent. \n Support: Core (Gateway) \n Support: Implementation-specific (Other Resources)"
                                     type: string
                                     default: Gateway
                                     maxLength: 63
@@ -1726,7 +1730,7 @@ spec:
                                     maxLength: 253
                                     minLength: 1
                                   namespace:
-                                    description: "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core"
+                                    description: "Namespace is the namespace of the referent. When unspecified, this refers to the local namespace of the Route. \n Note that there are specific rules for ParentRefs which cross namespace boundaries. Cross-namespace references are only valid if they are explicitly allowed by something in the namespace they are referring to. For example: Gateway has the AllowedRoutes field, and ReferenceGrant provides a generic way to enable any other kind of cross-namespace reference. \n Support: Core"
                                     type: string
                                     maxLength: 63
                                     minLength: 1
@@ -2367,7 +2371,7 @@ spec:
       subresources:
         status: {}
 ---
-# Source: cert-manager/templates/crds.yaml
+# Source: cert-manager/deploy/crds/crd-certificaterequests.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -2567,7 +2571,7 @@ spec:
       served: true
       storage: true
 ---
-# Source: cert-manager/templates/crds.yaml
+# Source: cert-manager/deploy/crds/crd-issuers.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -2630,6 +2634,10 @@ spec:
                     - privateKeySecretRef
                     - server
                   properties:
+                    caBundle:
+                      description: Base64-encoded bundle of PEM CAs which can be used to validate the certificate chain presented by the ACME server. Mutually exclusive with SkipTLSVerify; prefer using CABundle to prevent various kinds of security vulnerabilities. If CABundle and SkipTLSVerify are unset, the system certificate bundle inside the container is used to validate the TLS connection.
+                      type: string
+                      format: byte
                     disableAccountKeyGeneration:
                       description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
                       type: boolean
@@ -2688,7 +2696,7 @@ spec:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
                     skipTLSVerify:
-                      description: Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have their TLS certificate validated (i.e. insecure connections will be allowed). Only enable this option in development environments. The cert-manager system installed roots will be used to verify connections to the ACME server if this is false. Defaults to false.
+                      description: 'INSECURE: Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have the TLS certificate chain validated. Mutually exclusive with CABundle; prefer using CABundle to prevent various kinds of security vulnerabilities. Only enable this option in development environments. If CABundle and SkipTLSVerify are unset, the system certificate bundle inside the container is used to validate the TLS connection. Defaults to false.'
                       type: boolean
                     solvers:
                       description: 'Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/'
@@ -2906,7 +2914,7 @@ spec:
                                   - nameserver
                                 properties:
                                   nameserver:
-                                    description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
+                                    description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
                                     type: string
                                   tsigAlgorithm:
                                     description: 'The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
@@ -2998,7 +3006,7 @@ spec:
                                     additionalProperties:
                                       type: string
                                   parentRefs:
-                                    description: 'When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways'
+                                    description: 'When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways'
                                     type: array
                                     items:
                                       description: "ParentReference identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid."
@@ -3007,13 +3015,13 @@ spec:
                                         - name
                                       properties:
                                         group:
-                                          description: "Group is the group of the referent. \n Support: Core"
+                                          description: "Group is the group of the referent. When unspecified, \"gateway.networking.k8s.io\" is inferred. To set the core API group (such as for a \"Service\" kind referent), Group must be explicitly set to \"\" (empty string). \n Support: Core"
                                           type: string
                                           default: gateway.networking.k8s.io
                                           maxLength: 253
                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                         kind:
-                                          description: "Kind is kind of the referent. \n Support: Core (Gateway) \n Support: Custom (Other Resources)"
+                                          description: "Kind is kind of the referent. \n Support: Core (Gateway) \n Support: Implementation-specific (Other Resources)"
                                           type: string
                                           default: Gateway
                                           maxLength: 63
@@ -3025,7 +3033,7 @@ spec:
                                           maxLength: 253
                                           minLength: 1
                                         namespace:
-                                          description: "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core"
+                                          description: "Namespace is the namespace of the referent. When unspecified, this refers to the local namespace of the Route. \n Note that there are specific rules for ParentRefs which cross namespace boundaries. Cross-namespace references are only valid if they are explicitly allowed by something in the namespace they are referring to. For example: Gateway has the AllowedRoutes field, and ReferenceGrant provides a generic way to enable any other kind of cross-namespace reference. \n Support: Core"
                                           type: string
                                           maxLength: 63
                                           minLength: 1
@@ -3727,11 +3735,11 @@ spec:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                     caBundle:
-                      description: PEM-encoded CA bundle (base64-encoded) used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection. Mutually exclusive with CABundleSecretRef. If neither CABundle nor CABundleSecretRef are defined, the cert-manager controller system root certificates are used to validate the TLS connection.
+                      description: Base64-encoded bundle of PEM CAs which will be used to validate the certificate chain presented by Vault. Only used if using HTTPS to connect to Vault and ignored for HTTP connections. Mutually exclusive with CABundleSecretRef. If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in the cert-manager controller container is used to validate the TLS connection.
                       type: string
                       format: byte
                     caBundleSecretRef:
-                      description: CABundleSecretRef is a reference to a Secret which contains the CABundle which will be used when connecting to Vault when using HTTPS. Mutually exclusive with CABundle. If neither CABundleSecretRef nor CABundle are defined, the cert-manager controller system root certificates are used to validate the TLS connection. If no key for the Secret is specified, cert-manager will default to 'ca.crt'.
+                      description: Reference to a Secret containing a bundle of PEM-encoded CAs to use when verifying the certificate chain presented by Vault when using HTTPS. Mutually exclusive with CABundle. If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in the cert-manager controller container is used to validate the TLS connection. If no key for the Secret is specified, cert-manager will default to 'ca.crt'.
                       type: object
                       required:
                         - name
@@ -3786,7 +3794,7 @@ spec:
                         - url
                       properties:
                         caBundle:
-                          description: CABundle is a PEM encoded TLS certificate to use to verify connections to the TPP instance. If specified, system roots will not be used and the issuing CA for the TPP instance must be verifiable using the provided root. If not specified, the connection will be verified using the cert-manager system root certificates.
+                          description: Base64-encoded bundle of PEM CAs which will be used to validate the certificate chain presented by the TPP server. Only used if using HTTPS; ignored for HTTP. If undefined, the certificate bundle in the cert-manager controller container is used to validate the chain.
                           type: string
                           format: byte
                         credentialsRef:
@@ -3858,7 +3866,7 @@ spec:
       served: true
       storage: true
 ---
-# Source: cert-manager/templates/crds.yaml
+# Source: cert-manager/deploy/crds/crd-certificates.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -3996,7 +4004,7 @@ spec:
                         - passwordSecretRef
                       properties:
                         create:
-                          description: Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.jks` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority
+                          description: Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will be updated immediately. A file named `truststore.jks` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority
                           type: boolean
                         passwordSecretRef:
                           description: PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the JKS keystore.
@@ -4018,7 +4026,7 @@ spec:
                         - passwordSecretRef
                       properties:
                         create:
-                          description: Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.p12` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority
+                          description: Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will be updated immediately. A file named `truststore.p12` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority
                           type: boolean
                         passwordSecretRef:
                           description: PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the PKCS12 keystore.
@@ -4231,7 +4239,7 @@ spec:
       served: true
       storage: true
 ---
-# Source: cert-manager/templates/crds.yaml
+# Source: cert-manager/deploy/crds/crd-orders.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
@@ -18,7 +18,7 @@ kind: Namespace
 metadata:
   name: {{ cert_manager_namespace }}
 ---
-# Source: cert-manager/templates/cainjector-serviceaccount.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/cainjector-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: true
@@ -32,7 +32,7 @@ metadata:
     app.kubernetes.io/component: "cainjector"
     app.kubernetes.io/version: "{{ cert_manager_version }}"
 ---
-# Source: cert-manager/templates/serviceaccount.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: true
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/component: "controller"
     app.kubernetes.io/version: "{{ cert_manager_version }}"
 ---
-# Source: cert-manager/templates/webhook-serviceaccount.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/webhook-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: true
@@ -60,7 +60,7 @@ metadata:
     app.kubernetes.io/component: "webhook"
     app.kubernetes.io/version: "{{ cert_manager_version }}"
 ---
-# Source: cert-manager/templates/webhook-config.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/webhook-config.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -73,7 +73,7 @@ metadata:
     app.kubernetes.io/component: "webhook"
 data:
 ---
-# Source: cert-manager/templates/cainjector-rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/cainjector-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -104,7 +104,7 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "watch", "update"]
 ---
-# Source: cert-manager/templates/rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/rbac.yaml
 # Issuer controller role
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -130,7 +130,7 @@ rules:
     resources: ["events"]
     verbs: ["create", "patch"]
 ---
-# Source: cert-manager/templates/rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/rbac.yaml
 # ClusterIssuer controller role
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -156,7 +156,7 @@ rules:
     resources: ["events"]
     verbs: ["create", "patch"]
 ---
-# Source: cert-manager/templates/rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/rbac.yaml
 # Certificates controller role
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -191,7 +191,7 @@ rules:
     resources: ["events"]
     verbs: ["create", "patch"]
 ---
-# Source: cert-manager/templates/rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/rbac.yaml
 # Orders controller role
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -229,7 +229,7 @@ rules:
     resources: ["events"]
     verbs: ["create", "patch"]
 ---
-# Source: cert-manager/templates/rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/rbac.yaml
 # Challenges controller role
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -289,7 +289,7 @@ rules:
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
 ---
-# Source: cert-manager/templates/rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/rbac.yaml
 # ingress-shim controller role
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -327,7 +327,7 @@ rules:
     resources: ["events"]
     verbs: ["create", "patch"]
 ---
-# Source: cert-manager/templates/rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -349,7 +349,7 @@ rules:
     resources: ["challenges", "orders"]
     verbs: ["get", "list", "watch"]
 ---
-# Source: cert-manager/templates/rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -373,7 +373,7 @@ rules:
     resources: ["challenges", "orders"]
     verbs: ["create", "delete", "deletecollection", "patch", "update"]
 ---
-# Source: cert-manager/templates/rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/rbac.yaml
 # Permission to approve CertificateRequests referencing cert-manager.io Issuers and ClusterIssuers
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -391,7 +391,7 @@ rules:
     verbs: ["approve"]
     resourceNames: ["issuers.cert-manager.io/*", "clusterissuers.cert-manager.io/*"]
 ---
-# Source: cert-manager/templates/rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/rbac.yaml
 # Permission to:
 # - Update and sign CertificatSigningeRequests referencing cert-manager.io Issuers and ClusterIssuers
 # - Perform SubjectAccessReviews to test whether users are able to reference Namespaced Issuers
@@ -420,7 +420,7 @@ rules:
     resources: ["subjectaccessreviews"]
     verbs: ["create"]
 ---
-# Source: cert-manager/templates/webhook-rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/webhook-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -436,7 +436,7 @@ rules:
   resources: ["subjectaccessreviews"]
   verbs: ["create"]
 ---
-# Source: cert-manager/templates/cainjector-rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/cainjector-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -456,7 +456,7 @@ subjects:
     namespace: {{ cert_manager_namespace }}
     kind: ServiceAccount
 ---
-# Source: cert-manager/templates/rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -476,7 +476,7 @@ subjects:
     namespace: {{ cert_manager_namespace }}
     kind: ServiceAccount
 ---
-# Source: cert-manager/templates/rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates//rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -496,7 +496,7 @@ subjects:
     namespace: {{ cert_manager_namespace }}
     kind: ServiceAccount
 ---
-# Source: cert-manager/templates/rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -516,7 +516,7 @@ subjects:
     namespace: {{ cert_manager_namespace }}
     kind: ServiceAccount
 ---
-# Source: cert-manager/templates/rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -536,7 +536,7 @@ subjects:
     namespace: {{ cert_manager_namespace }}
     kind: ServiceAccount
 ---
-# Source: cert-manager/templates/rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -556,7 +556,7 @@ subjects:
     namespace: {{ cert_manager_namespace }}
     kind: ServiceAccount
 ---
-# Source: cert-manager/templates/rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -576,7 +576,7 @@ subjects:
     namespace: {{ cert_manager_namespace }}
     kind: ServiceAccount
 ---
-# Source: cert-manager/templates/rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -596,7 +596,7 @@ subjects:
     namespace: {{ cert_manager_namespace }}
     kind: ServiceAccount
 ---
-# Source: cert-manager/templates/rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -616,7 +616,7 @@ subjects:
     namespace: {{ cert_manager_namespace }}
     kind: ServiceAccount
 ---
-# Source: cert-manager/templates/webhook-rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/webhook-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -637,7 +637,7 @@ subjects:
   name: cert-manager-webhook
   namespace: {{ cert_manager_namespace }}
 ---
-# Source: cert-manager/templates/cainjector-rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/cainjector-rbac.yaml
 # leader election rules
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -664,7 +664,7 @@ rules:
     resources: ["leases"]
     verbs: ["create"]
 ---
-# Source: cert-manager/templates/rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -685,7 +685,7 @@ rules:
     resources: ["leases"]
     verbs: ["create"]
 ---
-# Source: cert-manager/templates/webhook-rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/webhook-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -708,7 +708,7 @@ rules:
   resources: ["secrets"]
   verbs: ["create"]
 ---
-# Source: cert-manager/templates/cainjector-rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/cainjector-rbac.yaml
 # grant cert-manager permission to manage the leaderelection configmap in the
 # leader election namespace
 apiVersion: rbac.authorization.k8s.io/v1
@@ -731,7 +731,7 @@ subjects:
     name: cert-manager-cainjector
     namespace: {{ cert_manager_namespace }}
 ---
-# Source: cert-manager/templates/rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/rbac.yaml
 # grant cert-manager permission to manage the leaderelection configmap in the
 # leader election namespace
 apiVersion: rbac.authorization.k8s.io/v1
@@ -755,7 +755,7 @@ subjects:
     name: cert-manager
     namespace: {{ cert_manager_namespace }}
 ---
-# Source: cert-manager/templates/webhook-rbac.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/webhook-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -777,7 +777,7 @@ subjects:
   name: cert-manager-webhook
   namespace: {{ cert_manager_namespace }}
 ---
-# Source: cert-manager/templates/service.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -801,7 +801,7 @@ spec:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
 ---
-# Source: cert-manager/templates/webhook-service.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/webhook-service.yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -825,7 +825,7 @@ spec:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
 ---
-# Source: cert-manager/templates/cainjector-deployment.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -902,7 +902,7 @@ metadata:
   namespace: {{ cert_manager_namespace }}
 ---
 {% endif %}
-# Source: cert-manager/templates/deployment.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -988,7 +988,7 @@ spec:
         name: ca-internal-truststore
 {% endif %}
 ---
-# Source: cert-manager/templates/webhook-deployment.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/webhook-deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1086,7 +1086,7 @@ spec:
         {{ cert_manager_affinity | to_nice_yaml | indent(width=8) }}
 {% endif %}
 ---
-# Source: cert-manager/templates/webhook-mutating-webhook.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -1127,7 +1127,7 @@ webhooks:
         namespace: {{ cert_manager_namespace }}
         path: /mutate
 ---
-# Source: cert-manager/templates/webhook-validating-webhook.yaml
+# Source: cert-manager/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Upgrade cert-manager to [v1.11.0](https://github.com/cert-manager/cert-manager/releases/tag/v1.11.0)

**Does this PR introduce a user-facing change?**:
<!--
[cert-manager] Upgrade to v1.11.0
-->
```release-note
Make cert-manager v1.11.0 default
```