### PR TITLE
Add missing defaults for external_vsphere_* variables in the csi_driver/vsphere role

### DIFF
--- a/roles/kubernetes-apps/csi_driver/vsphere/defaults/main.yml
+++ b/roles/kubernetes-apps/csi_driver/vsphere/defaults/main.yml
@@ -35,3 +35,6 @@ unsafe_show_logs: false
 # https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/docs/book/features/volume_snapshot.md#how-to-enable-volume-snapshot--restore-feature-in-vsphere-csi-
 # according to the above link , we can controler the block-volume-snapshot parameter
 vsphere_csi_block_volume_snapshot: false
+
+external_vsphere_user: "{{ lookup('env','VSPHERE_USER') }}"
+external_vsphere_password: "{{ lookup('env','VSPHERE_PASSWORD') }}"


### PR DESCRIPTION
roles/csi_driver/vsphere

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR adds missing environment lookup for vSphere login credentials in the csi_driver/vsphere role. 

This should be already a feature as mentioned in this line: https://github.com/kubernetes-sigs/kubespray/blob/6b43d6aff2e74ebfc803a4f9e062f21303165c4b/inventory/sample/group_vars/all/vsphere.yml#L5
but currently, it only works with the external_cloud_controller/vsphere role.
https://github.com/kubernetes-sigs/kubespray/blob/master/roles/kubernetes-apps/external_cloud_controller/vsphere/defaults/main.yml#L13

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
