### PR TITLE
Update pause image version to v3.8

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -114,7 +114,7 @@ flannel_version: "v0.20.1"
 flannel_cni_version: "v1.2.0"
 cni_version: "v1.1.1"
 weave_version: 2.8.1
-pod_infra_version: "3.7"
+pod_infra_version: "3.8"
 
 cilium_version: "v1.12.1"
 cilium_cli_version: "v0.12.5"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Update pause image version to v3.8 see: https://github.com/kubernetes/kubernetes/blob/v1.25.5/cmd/kubeadm/app/constants/constants.go#L423-L424

**Which issue(s) this PR fixes**:

Fixes #9667

**Does this PR introduce a user-facing change?**:
```
NONE
```