### PR TITLE
fix(download): validate mirrors on localhost

### DIFF
--- a/roles/download/tasks/download_file.yml
+++ b/roles/download/tasks/download_file.yml
@@ -63,6 +63,7 @@
     delegate_to: "{{ download_delegate if download_force_cache else inventory_hostname }}"
     run_once: "{{ download_force_cache }}"
     register: uri_result
+    become: "{{ not download_localhost }}"
     until: uri_result is success
     retries: 4
     delay: "{{ retry_stagger | default(5) }}"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Like "Download Item", there is no need to ask for "become" on localhost.

```release-note
NONE
Localhost task (validate mirror) don't need to ask for `become`
```