### PR TITLE
Terraform vsphere cleanup

### DIFF
--- a/contrib/terraform/vsphere/variables.tf
+++ b/contrib/terraform/vsphere/variables.tf
@@ -23,7 +23,9 @@ variable "vsphere_datastore" {}
 
 variable "vsphere_user" {}
 
-variable "vsphere_password" {}
+variable "vsphere_password" {
+  sensitive = true
+}
 
 variable "vsphere_server" {}
 

--- a/contrib/terraform/vsphere/versions.tf
+++ b/contrib/terraform/vsphere/versions.tf
@@ -4,12 +4,6 @@ terraform {
       source  = "hashicorp/vsphere"
       version = ">= 1.24.3"
     }
-    null = {
-      source = "hashicorp/null"
-    }
-    template = {
-      source = "hashicorp/template"
-    }
   }
   required_version = ">= 0.13"
 }


### PR DESCRIPTION


**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:

Removing unneeded terraform dependencies helps for air-gapped installation.

Marking vsphere_password as sensitive improves security (tiny).