### PR TITLE
Add IPv6 listen directive to haproxy proxy if enable_dual_stack_networks

### DIFF
--- a/roles/kubernetes/node/templates/loadbalancer/haproxy.cfg.j2
+++ b/roles/kubernetes/node/templates/loadbalancer/haproxy.cfg.j2
@@ -21,13 +21,19 @@ defaults
 
 {% if loadbalancer_apiserver_healthcheck_port is defined -%}
 frontend healthz
-  bind *:{{ loadbalancer_apiserver_healthcheck_port }}
+  bind 0.0.0.0:{{ loadbalancer_apiserver_healthcheck_port }}
+  {% if enable_dual_stack_networks -%}
+  bind :::{{ loadbalancer_apiserver_healthcheck_port }}
+  {% endif -%}
   mode http
   monitor-uri /healthz
 {% endif %}
 
 frontend kube_api_frontend
   bind 127.0.0.1:{{ loadbalancer_apiserver_port|default(kube_apiserver_port) }}
+  {% if enable_dual_stack_networks -%}
+  bind [::1]:{{ loadbalancer_apiserver_port|default(kube_apiserver_port) }};
+  {% endif -%}
   mode tcp
   option tcplog
   default_backend kube_api_backend

--- a/roles/kubernetes/node/templates/loadbalancer/nginx.conf.j2
+++ b/roles/kubernetes/node/templates/loadbalancer/nginx.conf.j2
@@ -21,7 +21,7 @@ stream {
   server {
     listen        127.0.0.1:{{ loadbalancer_apiserver_port|default(kube_apiserver_port) }};
     {% if enable_dual_stack_networks -%}
-    listen        [::]:{{ loadbalancer_apiserver_port|default(kube_apiserver_port) }};
+    listen        [::1]:{{ loadbalancer_apiserver_port|default(kube_apiserver_port) }};
     {% endif -%}
     proxy_pass    kube_apiserver;
     proxy_timeout 10m;


### PR DESCRIPTION
**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:

- Like https://github.com/kubernetes-sigs/kubespray/pull/8596, add the same feature to the haproxy.
- Fix a bug of ipv6 in nginx.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add IPv6 listen directive to haproxy if enable_dual_stack_networks
```
