### PR TITLE
[containerd] add hashes for 1.5.x

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -864,6 +864,9 @@ containerd_archive_checksums:
     1.5.11: 0
     1.5.12: 0
     1.5.13: 0
+    1.5.14: 0
+    1.5.15: 0
+    1.5.16: 0
     1.6.0: 0
     1.6.1: 0
     1.6.2: 0
@@ -889,6 +892,9 @@ containerd_archive_checksums:
     1.5.11: 0
     1.5.12: 0
     1.5.13: 0
+    1.5.14: 0
+    1.5.15: 0
+    1.5.16: 0
     1.6.0: 6eff3e16d44c89e1e8480a9ca078f79bab82af602818455cc162be344f64686a
     1.6.1: fbeec71f2d37e0e4ceaaac2bdf081295add940a7a5c7a6bcc125e5bbae067791
     1.6.2: a4b24b3c38a67852daa80f03ec2bc94e31a0f4393477cd7dc1c1a7c2d3eb2a95
@@ -914,6 +920,9 @@ containerd_archive_checksums:
     1.5.11: f2a2476ca44a24067488cd6d0b064b2128e01f6f53e5f29c5acfaf1520927ee2
     1.5.12: 301833f6377e9471a2cf1a1088ba98826db7e8fe9d3ffdc9f570b0638bcd3a1f
     1.5.13: 7b5b34f30a144985e849bdeb0921cfd3fe65f9508b5707fd237fd2c308d9abae
+    1.5.14: 8513ead11aca164b7e70bcea0429b4e51dad836b6383b806322e128821aaebbd
+    1.5.15: 0d09043be08dcf6bf136aa78bfd719e836cf9f9679afa4db0b6e4d478e396528
+    1.5.16: f5326865c2b86aba794f590fd2ca479f817fa1f88c084d97a45816aec9d0ce32
     1.6.0: f77725e4f757523bf1472ec3b9e02b09303a5d99529173be0f11a6d39f5676e9
     1.6.1: c1df0a12af2be019ca2d6c157f94e8ce7430484ab29948c9805882df40ec458b
     1.6.2: 3d94f887de5f284b0d6ee61fa17ba413a7d60b4bb27d756a402b713a53685c6a
@@ -939,6 +948,9 @@ containerd_archive_checksums:
     1.5.11: 0
     1.5.12: 0
     1.5.13: 0
+    1.5.14: 0
+    1.5.15: 0
+    1.5.16: 0
     1.6.0: 0
     1.6.1: 0
     1.6.2: 0


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add hashes for containerd versions 1.5.14 , 1.5.15 , 1.5.16

**Does this PR introduce a user-facing change?**:
<!--
NONE
-->
```release-note
[containers] Add hashes for containerd versions 1.5.14 , 1.5.15 , 1.5.16
```
