### PR TITLE
supplement the omit cni-version in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [containerd](https://containerd.io/) v1.6.15
   - [cri-o](http://cri-o.io/) v1.24 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)
 - Network Plugin
-  - [cni-plugins](https://github.com/containernetworking/plugins) v1.1.1
+  - [cni-plugins](https://github.com/containernetworking/plugins) v1.2.0
   - [calico](https://github.com/projectcalico/calico) v3.24.5
   - [canal](https://github.com/projectcalico/canal) (given calico/flannel versions)
   - [cilium](https://github.com/cilium/cilium) v1.12.1


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
As [bump cni-plugins version to v1.2.0](https://github.com/kubernetes-sigs/kubespray/pull/9671) is merged by.
But missed bumping this up in the readme.

```release-note

```
