### PR TITLE
reword confusing etcd download url comment

### DIFF
--- a/inventory/sample/group_vars/all/offline.yml
+++ b/inventory/sample/group_vars/all/offline.yml
@@ -28,7 +28,7 @@
 ## cri-tools
 # crictl_download_url: "{{ files_repo }}/github.com/kubernetes-sigs/cri-tools/releases/download/{{ crictl_version }}/crictl-{{ crictl_version }}-{{ ansible_system | lower }}-{{ image_arch }}.tar.gz"
 
-## [Optional] etcd: only if you **DON'T** use etcd_deployment=host
+## [Optional] etcd: only if you use etcd_deployment=host
 # etcd_download_url: "{{ files_repo }}/github.com/etcd-io/etcd/releases/download/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-{{ image_arch }}.tar.gz"
 
 # [Optional] Calico: If using Calico network plugin
@@ -40,7 +40,7 @@
 # [Optional] Cilium: If using Cilium network plugin
 # ciliumcli_download_url: "{{ files_repo }}/github.com/cilium/cilium-cli/releases/download/{{ cilium_cli_version }}/cilium-linux-{{ image_arch }}.tar.gz"
 
-# [Optional] Flannel: If using Falnnel network plugin
+# [Optional] Flannel: If using Flannel network plugin
 # flannel_cni_download_url: "{{ files_repo }}/kubernetes/flannel/{{ flannel_cni_version }}/flannel-{{ image_arch }}"
 
 # [Optional] helm: only if you set helm_enabled: true


### PR DESCRIPTION
It is quite confusing that there's an all-caps, bolded comment that seems to imply that `etcd_download_url` is relevant only when not using host-based deployment. The opposite is true: of course the artifact download URL is relevant and required for host-based etcd.

Perhaps the entire comment can be read in a different way, and should perhaps be reworded entirely, cf. https://github.com/kubernetes-sigs/kubespray/blob/374438a3d631e98b34db4433d972fb4a221c0505/docs/offline-environment.md?plain=1#L38

Removing the "**DON'T**" matches the way the other comments in this file are written and matches my personal interpretation.

/kind cleanup
/kind documentation

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
