### PR TITLE
Add resources section to all containers releated to Vsphere CSI driver

### DIFF
--- a/roles/kubernetes-apps/csi_driver/vsphere/defaults/main.yml
+++ b/roles/kubernetes-apps/csi_driver/vsphere/defaults/main.yml
@@ -38,3 +38,17 @@ vsphere_csi_block_volume_snapshot: false
 
 external_vsphere_user: "{{ lookup('env','VSPHERE_USER') }}"
 external_vsphere_password: "{{ lookup('env','VSPHERE_PASSWORD') }}"
+
+# Controller resources
+vsphere_csi_snapshotter_resources: {}
+vsphere_csi_provisioner_resources: {}
+vsphere_syncer_resources: {}
+vsphere_csi_liveness_probe_controller_resources: {}
+vsphere_csi_resources: {}
+vsphere_csi_resizer_resources: {}
+vsphere_csi_attacher_resources: {}
+
+# DaemonSet node resources
+vsphere_csi_node_driver_registrar_resources: {}
+vsphere_csi_driver_resources: {}
+vsphere_csi_liveness_probe_ds_resources: {}

--- a/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-controller-deployment.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-controller-deployment.yml.j2
@@ -62,6 +62,10 @@ spec:
             - "--leader-election"
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
+{% if vsphere_csi_attacher_resources | length > 0 %}
+          resources:
+            {{ vsphere_csi_attacher_resources | default({}) | to_nice_yaml | trim | indent(width=12) }}
+{% endif %}
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -79,6 +83,10 @@ spec:
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
             - "--leader-election"
+{% if vsphere_csi_resizer_resources | length > 0 %}
+          resources:
+            {{ vsphere_csi_resizer_resources | default({}) | to_nice_yaml | trim | indent(width=12) }}
+{% endif %}
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -93,6 +101,10 @@ spec:
             - "--fss-namespace={{ vsphere_csi_namespace }}"
             - "--supervisor-fss-namespace={{ vsphere_csi_namespace }}"
             - "--use-gocsi=false"
+{% if vsphere_csi_resources | length > 0 %}
+          resources:
+            {{ vsphere_csi_resources | default({}) | to_nice_yaml | trim | indent(width=12) }}
+{% endif %}
           imagePullPolicy: {{ k8s_image_pull_policy }}
           env:
             - name: CSI_ENDPOINT
@@ -139,6 +151,10 @@ spec:
           args:
             - "--v=4"
             - "--csi-address=$(ADDRESS)"
+{% if vsphere_csi_liveness_probe_controller_resources | length > 0 %}
+          resources:
+            {{ vsphere_csi_liveness_probe_controller_resources | default({}) | to_nice_yaml | trim | indent(width=12) }}
+{% endif %}
           env:
             - name: ADDRESS
               value: {{ csi_endpoint }}/csi.sock
@@ -157,6 +173,10 @@ spec:
             - containerPort: 2113
               name: prometheus
               protocol: TCP
+{% if vsphere_syncer_resources | length > 0 %}
+          resources:
+            {{ vsphere_syncer_resources | default({}) | to_nice_yaml | trim | indent(width=12) }}
+{% endif %}
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES
               value: "30"
@@ -189,6 +209,10 @@ spec:
             # needed only for topology aware setup
             #- "--feature-gates=Topology=true"
             #- "--strict-topology"
+{% if vsphere_csi_provisioner_resources | length > 0 %}
+          resources:
+            {{ vsphere_csi_provisioner_resources | default({}) | to_nice_yaml | trim | indent(width=12) }}
+{% endif %}
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-node.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-node.yml.j2
@@ -39,6 +39,10 @@ spec:
         - "--v=5"
         - "--csi-address=$(ADDRESS)"
         - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+{% if vsphere_csi_node_driver_registrar_resources | length > 0 %}
+        resources:
+          {{ vsphere_csi_node_driver_registrar_resources | default({}) | to_nice_yaml | trim | indent(width=10) }}
+{% endif %}
         env:
         - name: ADDRESS
           value: /csi/csi.sock
@@ -65,6 +69,10 @@ spec:
           - "--supervisor-fss-namespace={{ vsphere_csi_namespace }}"
           - "--use-gocsi=false"
         imagePullPolicy: "Always"
+{% if vsphere_csi_driver_resources | length > 0 %}
+        resources:
+          {{ vsphere_csi_driver_resources | default({}) | to_nice_yaml | trim | indent(width=10) }}
+{% endif %}
         env:
         - name: NODE_NAME
           valueFrom:
@@ -123,6 +131,10 @@ spec:
           - "--v=4"
 {% endif %}
           - "--csi-address=/csi/csi.sock"
+{% if vsphere_csi_liveness_probe_ds_resources | length > 0 %}
+        resources:
+          {{ vsphere_csi_liveness_probe_ds_resources | default({}) | to_nice_yaml | trim | indent(width=10) }}
+{% endif %}
         volumeMounts:
         - name: plugin-dir
           mountPath: /csi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> 
/kind feature
Add resources section to the Vsphere CSI driver .
In our case, we reach a bug that liveness probe container had a memory leak
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[vSphere-csi] Add resources section to all containers releated to Vsphere CSI driver
```
