### PR TITLE
Cleanup v1.23.x missing references/conditions/hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Note: Upstart/SysV init based OS types are not supported.
 
 ## Requirements
 
-- **Minimum required version of Kubernetes is v1.23**
+- **Minimum required version of Kubernetes is v1.24**
 - **Ansible v2.11+, Jinja 2.11+ and python-netaddr is installed on the machine that will run Ansible commands**
 - The target servers must have **access to the Internet** in order to pull docker images. Otherwise, additional configuration is required (See [Offline Environment](docs/offline-environment.md))
 - The target servers are configured to allow **IPv4 forwarding**.

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -136,21 +136,18 @@ etcd_supported_versions:
   v1.26: "v3.5.6"
   v1.25: "v3.5.6"
   v1.24: "v3.5.6"
-  v1.23: "v3.5.6"
 etcd_version: "{{ etcd_supported_versions[kube_major_version] }}"
 
 crictl_supported_versions:
   v1.26: "v1.26.0"
   v1.25: "v1.25.0"
   v1.24: "v1.24.0"
-  v1.23: "v1.23.0"
 crictl_version: "{{ crictl_supported_versions[kube_major_version] }}"
 
 crio_supported_versions:
   v1.26: v1.26.0
   v1.25: v1.25.1
   v1.24: v1.24.3
-  v1.23: v1.23.2
 crio_version: "{{ crio_supported_versions[kube_major_version] }}"
 
 # Download URLs
@@ -183,44 +180,36 @@ crictl_checksums:
     v1.26.0: 88891ee29eab097ab1ed88d55094e7bf464f3347bc9f056140e45efeddd15b33
     v1.25.0: c4efe3649af5542f2b07cdfc0be62e9e13c7bb846a9b59d57e190c764f28dae4
     v1.24.0: 1ab8a88d6ce1e9cff1c76fc454d2d41cf0c89e98c6db15a41804a3a5874cbf89
-    v1.23.0: c20f7a118183d1e6da24c3709471ea0b4dee51cb709f958e0d90f3acb4eb59ae
   arm64:
     v1.26.0: b632ca705a98edc8ad7806f4279feaff956ac83aa109bba8a85ed81e6b900599
     v1.25.0: 651c939eca010bbf48cc3932516b194028af0893025f9e366127f5b50ad5c4f4
     v1.24.0: b6fe172738dfa68ca4c71ade53574e859bf61a3e34d21b305587b1ad4ab28d24
-    v1.23.0: 91094253e77094435027998a99b9b6a67b0baad3327975365f7715a1a3bd9595
   amd64:
     v1.26.0: cda5e2143bf19f6b548110ffba0fe3565e03e8743fadd625fee3d62fc4134eed
     v1.25.0: 86ab210c007f521ac4cdcbcf0ae3fb2e10923e65f16de83e0e1db191a07f0235
     v1.24.0: 3df4a4306e0554aea4fdc26ecef9eea29a58c8460bebfaca3405799787609880
-    v1.23.0: b754f83c80acdc75f93aba191ff269da6be45d0fc2d3f4079704e7d1424f1ca8
   ppc64le:
     v1.26.0: 5538c88b8ccde419e6158ab9c06dfcca1fa0abecf33d0a75b2d22ceddd283f0d
     v1.25.0: 1b77d1f198c67b2015104eee6fe7690465b8efa4675ea6b4b958c63d60a487e7
     v1.24.0: 586c263678c6d8d543976607ea1732115e622d44993e2bcbed29832370d3a754
-    v1.23.0: 53db9e605a3042ea77bbf42a01a4e248dea8839bcab544c491745874f73aeee7
 
 crio_archive_checksums:
   arm:
     v1.26.0: 0
     v1.25.1: 0
     v1.24.3: 0
-    v1.23.2: 0
   arm64:
     v1.26.0: 0
     v1.25.1: add26675dc993b292024d007fd69980d8d1e75c675851d0cb687fe1dfd1f3008
     v1.24.3: d8040602e03c90e4482b4ce97b63c2cf1301cd2afb0aa722342f40f3537a1a1f
-    v1.23.2: a866ccc3a062ac29906a619b9045a5e23b11fa9249f8802f8be0849491d01fbd
   amd64:
     v1.26.0: 0
     v1.25.1: 49f98a38805740c40266a5bf3badc28e4ca725ccf923327c75c00fccc241f562
     v1.24.3: 43f6e3a7ad6ae8cf05ed0f1e493578c28abf6a798aedb8ee9643ff7c25a68ca3
-    v1.23.2: 5c766dbf366a80f8b5dbc7a06d566f43e7cb0675186c50062df01f3b3cb5e526
   ppc64le:
     v1.26.0: 0
     v1.25.1: 0
     v1.24.3: 0
-    v1.23.2: 0
 
 # Checksum
 # Kubernetes versions above Kubespray's current target version are untested and should be used with caution.
@@ -1003,7 +992,6 @@ snapshot_controller_supported_versions:
   v1.26: "v4.2.1"
   v1.25: "v4.2.1"
   v1.24: "v4.2.1"
-  v1.23: "v4.2.1"
 snapshot_controller_image_repo: "{{ kube_image_repo }}/sig-storage/snapshot-controller"
 snapshot_controller_image_tag: "{{ snapshot_controller_supported_versions[kube_major_version] }}"
 

--- a/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
@@ -261,19 +261,3 @@
   set_fact:
     kubelet_flexvolumes_plugins_dir: /var/lib/kubelet/volumeplugins
   when: not usr.stat.writeable
-
-- block:
-    - name: Ensure IPv6DualStack featureGate is set when enable_dual_stack_networks is true
-      set_fact:
-        kube_feature_gates: "{{ kube_feature_gates + [ 'IPv6DualStack=true' ] }}"
-      when:
-        - not 'IPv6DualStack=true' in kube_feature_gates
-
-    - name: Ensure IPv6DualStack kubeadm featureGate is set when enable_dual_stack_networks is true
-      set_fact:
-        kubeadm_feature_gates: "{{ kubeadm_feature_gates + [ 'IPv6DualStack=true' ] }}"
-      when:
-        - not 'IPv6DualStack=true' in kubeadm_feature_gates
-  when:
-    - enable_dual_stack_networks
-    - kube_version is version('v1.24.0', '<')


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Cleanup forgotten 1.23.x references (my bad 😆)

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Highway to 1.26.x

**Does this PR introduce a user-facing change?**:
```release-note
Cleanup v1.23.x references/conditions/hashes
```
