### PR TITLE
Add PSS labels to metallb namespace

### DIFF
--- a/roles/kubernetes-apps/metallb/templates/metallb.yml.j2
+++ b/roles/kubernetes-apps/metallb/templates/metallb.yml.j2
@@ -4,6 +4,9 @@ metadata:
   name: metallb-system
   labels:
     app: metallb
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Allows metallb to work independent of configured default PSS level.

**Which issue(s) this PR fixes**:

Fixes #9712.

**Special notes for your reviewer**:

An upgrade to a newer version of metallb is out of scope.

**Does this PR introduce a user-facing change?**:

```release-note
Add PSS labels to metallb namespace
```
