### PR TITLE
feat(cinder-csi): Allow deletionPolicy to be configurable

### DIFF
--- a/roles/kubernetes-apps/snapshots/cinder-csi/defaults/main.yml
+++ b/roles/kubernetes-apps/snapshots/cinder-csi/defaults/main.yml
@@ -3,3 +3,4 @@ snapshot_classes:
   - name: cinder-csi-snapshot
     is_default: false
     force_create: true
+    deletionPolicy: Delete

--- a/roles/kubernetes-apps/snapshots/cinder-csi/templates/cinder-csi-snapshot-class.yml.j2
+++ b/roles/kubernetes-apps/snapshots/cinder-csi/templates/cinder-csi-snapshot-class.yml.j2
@@ -7,7 +7,7 @@ metadata:
   annotations:
     storageclass.kubernetes.io/is-default-class: "{{ class.is_default | default(false) | ternary("true","false") }}"
 driver: cinder.csi.openstack.org
-deletionPolicy: Delete
+deletionPolicy: "{{ class.deletionPolicy | default("Delete") }}"
 parameters:
   force-create: "{{ class.force_create }}"
 {% endfor %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:

This allows the VolumeSnapshotClass' deletionPolicy of cinder-csi to be configurable.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
cinder-csi: Allow VolumeSnapshotClass' deletionPolicy to be configurable
```
