### PR TITLE
tests: Update ara 1.5.7 to 1.6.1

### DIFF
--- a/tests/requirements-2.11.txt
+++ b/tests/requirements-2.11.txt
@@ -8,4 +8,4 @@ molecule==3.0.6
 molecule-vagrant==0.3
 testinfra==5.2.2
 python-vagrant==0.5.15
-ara[server]==1.5.7
+ara[server]==1.6.1

--- a/tests/requirements-2.12.txt
+++ b/tests/requirements-2.12.txt
@@ -8,4 +8,4 @@ molecule==3.0.6
 molecule-vagrant==0.3
 testinfra==5.2.2
 python-vagrant==0.5.15
-ara[server]==1.5.7
+ara[server]==1.6.1


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

ara 1.5.7 was released Aug 2, 2021 and 1.6.1 came out on Dec 13, 2022.

There's been a good amount of new features, improvements and fixes since 1.5.7 and the changelogs for each version are available in the docs: https://ara.readthedocs.io/en/latest/changelog-release-notes.html

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

This is a follow up to the initial implementation via https://github.com/kubernetes-sigs/kubespray/pull/8545

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[CI] Updated version of ara included in CI job logs collection from 1.5.7 to 1.6.1
```
