### PR TITLE
[Need Discuss] Fix containerd config_path error when `containerd_registries` is configed

### DIFF
--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -120,16 +120,32 @@
   with_dict: "{{ containerd_insecure_registries }}"
   when: containerd_insecure_registries is defined
 
-- name: containerd ｜ Write hosts.toml file
+- name: containerd ｜ Write registries hosts.toml file
+  blockinfile:
+    path: "{{ containerd_cfg_dir }}/certs.d/{{ item.key }}/hosts.toml"
+    mode: 0640
+    create: true
+    block: |
+      server = "https://{{ item.key }}"
+      {% for addr in [ item.value ] | flatten  %}
+      [host."{{ addr }}"]
+        capabilities = ["pull", "resolve", "push"]
+      {% endfor %}
+  with_dict: "{{ containerd_registries }}"
+  when: containerd_registries is defined
+
+- name: containerd ｜ Write insecure registries hosts.toml file
   blockinfile:
     path: "{{ containerd_cfg_dir }}/certs.d/{{ item.key }}/hosts.toml"
     mode: 0640
     create: true
     block: |
       server = "{{ item.value }}"
-      [host."{{ item.value }}"]
+      {% for addr in [ item.value ] | flatten  %}
+      [host."{{ addr }}"]
         capabilities = ["pull", "resolve", "push"]
         skip_verify = true
+      {% endfor %}
   with_dict: "{{ containerd_insecure_registries }}"
   when: containerd_insecure_registries is defined
 

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -51,10 +51,6 @@ oom_score = {{ containerd_oom_score }}
       config_path = "{{ containerd_cfg_dir }}/certs.d"
 {% endif %}
       [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-{% for registry, addr in containerd_registries.items() %}
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ registry }}"]
-          endpoint = ["{{ ([ addr ] | flatten ) | join('","') }}"]
-{% endfor %}
 {% for registry in containerd_registry_auth if registry['registry'] is defined %}
 {% if (registry['username'] is defined and registry['password'] is defined) or registry['auth'] is defined %}
       [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ registry['registry'] }}".auth]

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -55,16 +55,6 @@ oom_score = {{ containerd_oom_score }}
         [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ registry }}"]
           endpoint = ["{{ ([ addr ] | flatten ) | join('","') }}"]
 {% endfor %}
-{% if containerd_insecure_registries is defined and containerd_insecure_registries|length>0 %}
-{% for registry, addr in containerd_insecure_registries.items() %}
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ registry }}"]
-          endpoint = ["{{ ([ addr ] | flatten ) | join('","') }}"]
-{% endfor %}
-{% for addr in containerd_insecure_registries.values() | flatten | unique %}
-        [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ addr }}".tls]
-          insecure_skip_verify = true
-{% endfor %}
-{% endif %}
 {% for registry in containerd_registry_auth if registry['registry'] is defined %}
 {% if (registry['username'] is defined and registry['password'] is defined) or registry['auth'] is defined %}
       [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ registry['registry'] }}".auth]

--- a/tests/files/packet_ubuntu22-calico-aio.yml
+++ b/tests/files/packet_ubuntu22-calico-aio.yml
@@ -15,4 +15,4 @@ containerd_insecure_registries:
   "172.19.16.11:5000": "http://172.19.16.11:5000"
 
 containerd_registries:
-  "docker.io": "https://docker.io"
+  "docker.io": "https://mirror.gcr.io"

--- a/tests/files/packet_ubuntu22-calico-aio.yml
+++ b/tests/files/packet_ubuntu22-calico-aio.yml
@@ -10,3 +10,9 @@ auto_renew_certificates: true
 # Currently ipvs not available on KVM: https://packages.ubuntu.com/search?suite=focal&arch=amd64&mode=exactfilename&searchon=contents&keywords=ip_vs_sh.ko
 kube_proxy_mode: iptables
 enable_nodelocaldns: False
+
+containerd_insecure_registries:
+  "172.19.16.11:5000": "http://172.19.16.11:5000"
+
+containerd_registries:
+  "docker.io": "https://docker.io"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:

After the https://github.com/kubernetes-sigs/kubespray/pull/9566
There is a warning log when start the containerd:

```
containerd[58616]: time="2023-01-31T21:05:15.041655133Z" level=warning 
  msg="failed to load plugin io.containerd.grpc.v1.cri" 
  error="invalid plugin config: `mirrors` cannot be set when `config_path` is provided"
```

When the `containerd_insecure_registries ` or `containerd_registries` are configured, the kubeadm can not install the Kubernetes. And kubelet can not start the Pod.

So the PR is try to fix the bug, following the https://github.com/containerd/containerd/blob/main/docs/hosts.md.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kubespray/issues/9741

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
