### PR TITLE
Replace nodelocaldns label 

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-daemonset.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-daemonset.yml.j2
@@ -9,11 +9,11 @@ metadata:
 spec:
   selector:
     matchLabels:
-      k8s-app: nodelocaldns
+      k8s-app: node-local-dns
   template:
     metadata:
       labels:
-        k8s-app: nodelocaldns
+        k8s-app: node-local-dns
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '{{ nodelocaldns_prometheus_port }}'

--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-second-daemonset.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-second-daemonset.yml.j2
@@ -9,11 +9,11 @@ metadata:
 spec:
   selector:
     matchLabels:
-      k8s-app: nodelocaldns-second
+      k8s-app: node-local-dns-second
   template:
     metadata:
       labels:
-        k8s-app: nodelocaldns-second
+        k8s-app: node-local-dns-second
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '{{ nodelocaldns_secondary_prometheus_port }}'


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Replace label `k8s-app: nodelocaldns` in DaemonSet template by `k8s-app: node-local-dns`. Label in template should match upstream DaemonSet definition as other projects/deployments can rely on it. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9717

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Replace nodelocaldns label to `k8s-app: node-local-dns`
```
