### PR TITLE
[2.21] Backport "fix with item to with dict"

### DIFF
--- a/docs/containerd.md
+++ b/docs/containerd.md
@@ -100,6 +100,15 @@ containerd_runc_runtime:
   ...
 ```
 
+Config insecure-registry access to self hosted registries.
+
+```yaml
+containerd_insecure_registries:
+  "test.registry.io": "http://test.registry.io"
+  "172.19.16.11:5000": "http://172.19.16.11:5000"
+  "repo:5000": "http://repo:5000"
+```
+
 [containerd]: https://containerd.io/
 [RuntimeClass]: https://kubernetes.io/docs/concepts/containers/runtime-class/
 [runtime classes in containerd]: https://github.com/containerd/containerd/blob/main/docs/cri/config.md#runtime-classes

--- a/docs/offline-environment.md
+++ b/docs/offline-environment.md
@@ -7,7 +7,8 @@ following artifacts in advance from another environment where has access to the 
 * Some static files (zips and binaries)
 * OS packages (rpm/deb files)
 * Container images used by Kubespray. Exhaustive list depends on your setup
-* [Optional] Python packages used by Kubespray (only required if your OS doesn't provide all python packages/versions listed in `requirements.txt`)
+* [Optional] Python packages used by Kubespray (only required if your OS doesn't provide all python packages/versions
+  listed in `requirements.txt`)
 * [Optional] Helm chart files (only required if `helm_enabled=true`)
 
 Then you need to setup the following services on your offline environment:
@@ -23,7 +24,8 @@ In addition, you can find some tools for offline deployment under [contrib/offli
 
 ## Configure Inventory
 
-Once all artifacts are accessible from your internal network, **adjust** the following variables in [your inventory](/inventory/sample/group_vars/all/offline.yml) to match your environment:
+Once all artifacts are accessible from your internal network, **adjust** the following variables
+in [your inventory](/inventory/sample/group_vars/all/offline.yml) to match your environment:
 
 ```yaml
 # Registry overrides
@@ -49,7 +51,7 @@ runc_download_url: "{{ files_repo }}/runc.{{ image_arch }}"
 nerdctl_download_url: "{{ files_repo }}/nerdctl-{{ nerdctl_version }}-{{ ansible_system | lower }}-{{ image_arch }}.tar.gz"
 # Insecure registries for containerd
 containerd_insecure_registries:
-  - "{{ registry_host }}"
+    "{{ registry_addr }}"："{{ registry_host }}"
 
 # CentOS/Redhat/AlmaLinux/Rocky Linux
 ## Docker / Containerd
@@ -86,20 +88,31 @@ containerd_ubuntu_repo_repokey: 'YOURREPOKEY'
 For the OS specific settings, just define the one matching your OS.
 If you use the settings like the one above, you'll need to define in your inventory the following variables:
 
-* `registry_host`: Container image registry. If you _don't_ use the same repository path for the container images that the ones defined in [Download's role defaults](https://github.com/kubernetes-sigs/kubespray/blob/master/roles/download/defaults/main.yml), you need to override the `*_image_repo` for these container images. If you want to make your life easier, use the same repository path, you won't have to override anything else.
-* `files_repo`: HTTP webserver or reverse proxy that is able to serve the files listed above. Path is not important, you can store them anywhere as long as it's accessible by kubespray. It's recommended to use `*_version` in the path so that you don't need to modify this setting everytime kubespray upgrades one of these components.
-* `yum_repo`/`debian_repo`/`ubuntu_repo`: OS package repository depending of your OS, should point to your internal repository. Adjust the path accordingly.
+* `registry_host`: Container image registry. If you _don't_ use the same repository path for the container images that
+  the ones defined
+  in [Download's role defaults](https://github.com/kubernetes-sigs/kubespray/blob/master/roles/download/defaults/main.yml)
+  , you need to override the `*_image_repo` for these container images. If you want to make your life easier, use the
+  same repository path, you won't have to override anything else.
+* `registry_addr`: Container image registry, but only have [domain or ip]:[port].
+* `files_repo`: HTTP webserver or reverse proxy that is able to serve the files listed above. Path is not important, you
+  can store them anywhere as long as it's accessible by kubespray. It's recommended to use `*_version` in the path so
+  that you don't need to modify this setting everytime kubespray upgrades one of these components.
+* `yum_repo`/`debian_repo`/`ubuntu_repo`: OS package repository depending of your OS, should point to your internal
+  repository. Adjust the path accordingly.
 
 ## Install Kubespray Python Packages
 
 ### Recommended way: Kubespray Container Image
 
-The easiest way is to use [kubespray container image](https://quay.io/kubespray/kubespray) as all the required packages are baked in the image.
+The easiest way is to use [kubespray container image](https://quay.io/kubespray/kubespray) as all the required packages
+are baked in the image.
 Just copy the container image in your private container image registry and you are all set!
 
 ### Manual installation
 
-Look at the `requirements.txt` file and check if your OS provides all packages out-of-the-box (Using the OS package manager). For those missing, you need to either use a proxy that has Internet access (typically from a DMZ) or setup a PyPi server in your network that will host these packages.
+Look at the `requirements.txt` file and check if your OS provides all packages out-of-the-box (Using the OS package
+manager). For those missing, you need to either use a proxy that has Internet access (typically from a DMZ) or setup a
+PyPi server in your network that will host these packages.
 
 If you're using a HTTP(S) proxy to download your python packages:
 
@@ -119,13 +132,15 @@ pip install -i https://pypiserver/pypi package_you_miss
 
 ## Run Kubespray as usual
 
-Once all artifacts are in place and your inventory properly set up, you can run kubespray with the regular `cluster.yaml` command:
+Once all artifacts are in place and your inventory properly set up, you can run kubespray with the
+regular `cluster.yaml` command:
 
 ```bash
 ansible-playbook -i inventory/my_airgap_cluster/hosts.yaml -b cluster.yml
 ```
 
-If you use [Kubespray Container Image](#recommended-way:-kubespray-container-image), you can mount your inventory inside the container:
+If you use [Kubespray Container Image](#recommended-way:-kubespray-container-image), you can mount your inventory inside
+the container:
 
 ```bash
 docker run --rm -it -v path_to_inventory/my_airgap_cluster:inventory/my_airgap_cluster myprivateregisry.com/kubespray/kubespray:v2.14.0 ansible-playbook -i inventory/my_airgap_cluster/hosts.yaml -b cluster.yml

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -117,13 +117,12 @@
     state: directory
     mode: 0755
     recurse: true
-  with_items: "{{ containerd_insecure_registries }}"
+  with_dict: "{{ containerd_insecure_registries }}"
   when: containerd_insecure_registries is defined
 
 - name: containerd ｜ Write hosts.toml file
   blockinfile:
     path: "{{ containerd_cfg_dir }}/certs.d/{{ item.key }}/hosts.toml"
-    owner: "root"
     mode: 0640
     create: true
     block: |
@@ -131,7 +130,7 @@
       [host."{{ item.value }}"]
         capabilities = ["pull", "resolve", "push"]
         skip_verify = true
-  with_items: "{{ containerd_insecure_registries }}"
+  with_dict: "{{ containerd_insecure_registries }}"
   when: containerd_insecure_registries is defined
 
 # you can sometimes end up in a state where everything is installed

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -358,9 +358,9 @@ containerd_use_systemd_cgroup: true
 ## example define mirror.registry.io or 172.19.16.11:5000
 ## Port number is also needed if the default HTTPS port is not used.
 # containerd_insecure_registries:
-#   - mirror.registry.io
-#   - 172.19.16.11:5000
-containerd_insecure_registries: []
+#   "mirror.registry.io":"http://mirror.registry.io"
+#   "172.19.16.11:5000":"http://172.19.16.11:5000"
+containerd_insecure_registries: {}
 
 # Containerd conf default dir
 containerd_storage_dir: "/var/lib/containerd"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Backport: fixes containerd config_path.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Backport https://github.com/kubernetes-sigs/kubespray/pull/9729 to 2.21 release

**Does this PR introduce a user-facing change?**:
```release-note
Fix `containerd_insecure_registries` => move `with_item` to `with_dict`
```
