### PR TITLE
Fix a bug in removing kubelet data dir

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -257,14 +257,23 @@
     - enable_nodelocaldns|default(false)|bool
     - nodelocaldns_device.stat.exists
 
-- name: reset | find files/dirs with immutable flag in /var/lib/kubelet
+- name: reset | Check whether /var/lib/kubelet directory exists
+  stat:
+    path: /var/lib/kubelet
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
+  register: var_lib_kubelet_directory
+
+- name: reset | Find files/dirs with immutable flag in /var/lib/kubelet
   command: lsattr -laR /var/lib/kubelet
   become: true
   register: var_lib_kubelet_files_dirs_w_attrs
   changed_when: false
   no_log: true
+  when: var_lib_kubelet_directory.stat.exists
 
-- name: reset | remove immutable flag from files/dirs in /var/lib/kubelet
+- name: reset | Remove immutable flag from files/dirs in /var/lib/kubelet
   file:
     path: "{{ filedir_path }}"
     state: touch
@@ -275,6 +284,7 @@
     label: "{{ filedir_path }}"
   vars:
     filedir_path: "{{ file_dir_line.split(' ')[0] }}"
+  when: var_lib_kubelet_directory.stat.exists
 
 - name: reset | delete some files and directories
   file:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind bug

**What this PR does / why we need it**:

When the reset playbook is executed more than once, the playbook fails because it tries to retrieve the information of `/var/lib/kubelet`, a directory that has already been deleted.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
