### PR TITLE
Copy contrib/ to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ ENV LANG=C.UTF-8
 WORKDIR /kubespray
 COPY *yml /kubespray/
 COPY roles /kubespray/roles
+COPY contrib /kubespray/contrib
 COPY inventory /kubespray/inventory
 COPY library /kubespray/library
 COPY extra_playbooks /kubespray/extra_playbooks


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Since Kubespray v2.21.0, the commit a98ab40434470726 removes copying contrib/ accidentaly.
The contrib/ contains useful tools like offline tools etc.
This adds the contrib/ to Dockerfile again.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9704 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Copy contrib/ to Dockerfile
```
