### PR TITLE
[cri-o] - remove dpkg-hold on crio packages before uninstall them

### DIFF
--- a/roles/container-engine/cri-o/tasks/cleanup.yaml
+++ b/roles/container-engine/cri-o/tasks/cleanup.yaml
@@ -9,6 +9,7 @@
   apt_key:
     url: "https://{{ crio_download_base }}/{{ crio_kubic_debian_repo_name }}/Release.key"
     state: absent
+  environment: "{{ proxy_env }}"
   when: crio_kubic_debian_repo_name is defined
 
 - name: Remove legacy CRI-O kubic apt repo

--- a/roles/container-engine/cri-o/tasks/cleanup.yaml
+++ b/roles/container-engine/cri-o/tasks/cleanup.yaml
@@ -109,6 +109,19 @@
     - 1.23
     - 1.24
 
+# Remove old apt hold on packages before uninstall them
+- name: Remove dpkg hold
+  dpkg_selections:
+    name: "{{ item }}"
+    selection: install
+  when:
+    - ansible_pkg_mgr == 'apt'
+    - not is_ostree
+  with_items:
+    - cri-o
+    - cri-o-runc
+    - oci-systemd-hook
+
 - name: cri-o | remove installed packages
   package:
     name: "{{ item }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
before the change introduced here: https://github.com/kubernetes-sigs/kubespray/pull/9374 there was an apt-mark hold on the following packages:
- cri-o
- cri-o-runc
- oci-systemd-hook

which prevent to uninstall them. (https://github.com/kubernetes-sigs/kubespray/pull/9374/files#diff-ea892a747581fef8d9bfccf1d4c7cf9cb3afee7de424f77d79cda5b034eed126L120)

This PR remove the apt-mark hold on the packages before uninstall them

**Which issue(s) this PR fixes**:
Fixes #9771 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[cri-o] Remove dpkg-hold on crio packages before uninstall them 
```
