### PR TITLE
fix(crio): First runc then crictl

### DIFF
--- a/roles/container-engine/cri-o/meta/main.yml
+++ b/roles/container-engine/cri-o/meta/main.yml
@@ -1,5 +1,5 @@
 ---
 dependencies:
-  - role: container-engine/crictl
   - role: container-engine/runc
+  - role: container-engine/crictl
   - role: container-engine/skopeo


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
/etc/crictl.yaml was removed by uninstalling runc and crio using the package manager. Because crictl installation/configuration was run before runc it never restored this file.

**Which issue(s) this PR fixes**:
Fixes #9772

**Special notes for your reviewer**:
This bug broke our upgrade.

**Does this PR introduce a user-facing change?**:
```release-note
[cri-o] Fix order -> first runc then crictl
```
