### PR TITLE
fix(kubernetes): Also apply kubeadm patches during upgrade

### DIFF
--- a/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
@@ -19,6 +19,7 @@
     --ignore-preflight-errors=all
     --allow-experimental-upgrades
     --etcd-upgrade={{ (etcd_deployment_type == "kubeadm") | bool | lower }}
+    {% if kubeadm_patches is defined and kubeadm_patches.enabled %}--patches={{ kubeadm_patches.dest_dir }}{% endif %}
     --force
   register: kubeadm_upgrade
   # Retry is because upload config sometimes fails
@@ -40,6 +41,7 @@
     --ignore-preflight-errors=all
     --allow-experimental-upgrades
     --etcd-upgrade={{ (etcd_deployment_type == "kubeadm") | bool | lower }}
+    {% if kubeadm_patches is defined and kubeadm_patches.enabled %}--patches={{ kubeadm_patches.dest_dir }}{% endif %}
     --force
   register: kubeadm_upgrade
   when: inventory_hostname != first_kube_control_plane


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Kubespray offers support for kubeadm patches but these patches where not applied during an upgrade. According https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/control-plane-flags/ the --patches flag is necessary when using kubeadm upgrade.

**Which issue(s) this PR fixes**:
Fixes 9773

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Apply kubeadm patches during upgrade as recommended by k8s 
```
