### PR TITLE
Fix kubernetes-app/argocd: download related things with the download role

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -150,6 +150,8 @@ crio_supported_versions:
   v1.24: v1.24.3
 crio_version: "{{ crio_supported_versions[kube_major_version] }}"
 
+yq_version: "v4.30.6"
+
 # Download URLs
 kubelet_download_url: "https://storage.googleapis.com/kubernetes-release/release/{{ kube_version }}/bin/linux/{{ image_arch }}/kubelet"
 kubectl_download_url: "https://storage.googleapis.com/kubernetes-release/release/{{ kube_version }}/bin/linux/{{ image_arch }}/kubectl"
@@ -174,6 +176,7 @@ krew_download_url: "https://github.com/kubernetes-sigs/krew/releases/download/{{
 containerd_download_url: "https://github.com/containerd/containerd/releases/download/v{{ containerd_version }}/containerd-{{ containerd_version }}-linux-{{ image_arch }}.tar.gz"
 cri_dockerd_download_url: "https://github.com/Mirantis/cri-dockerd/releases/download/v{{ cri_dockerd_version }}/cri-dockerd-{{ cri_dockerd_version }}.{{ image_arch }}.tgz"
 skopeo_download_url: "https://github.com/lework/skopeo-binary/releases/download/{{ skopeo_version }}/skopeo-linux-{{ image_arch }}"
+yq_download_url: "https://github.com/mikefarah/yq/releases/download/{{ yq_version }}/yq_linux_{{ image_arch }}"
 
 crictl_checksums:
   arm:
@@ -837,11 +840,17 @@ skopeo_binary_checksums:
   ppc64l3:
     v1.10.0: 0
 
+yq_checksums:
+  amd64:
+    v4.27.5: 9a54846e81720ae22814941905cd3b056ebdffb76bf09acffa30f5e90b22d615
+    v4.30.6: 2aabdd748d301fc2286ea9f73eb20477b4ce173fbf072e0102fff1fcbed05985
+
 etcd_binary_checksum: "{{ etcd_binary_checksums[image_arch][etcd_version] }}"
 cni_binary_checksum: "{{ cni_binary_checksums[image_arch][cni_version] }}"
 kubelet_binary_checksum: "{{ kubelet_checksums[image_arch][kube_version] }}"
 kubectl_binary_checksum: "{{ kubectl_checksums[image_arch][kube_version] }}"
 kubeadm_binary_checksum: "{{ kubeadm_checksums[image_arch][kubeadm_version] }}"
+yq_binary_checksum: "{{ yq_checksums[image_arch][yq_version] }}"
 calicoctl_binary_checksum: "{{ calicoctl_binary_checksums[image_arch][calico_ctl_version] }}"
 calico_crds_archive_checksum: "{{ calico_crds_archive_checksums[calico_version] }}"
 ciliumcli_binary_checksum: "{{ ciliumcli_binary_checksums[image_arch][cilium_cli_version] }}"
@@ -1803,6 +1812,19 @@ downloads:
     repo: "{{ metallb_controller_image_repo }}"
     tag: "{{ metallb_version }}"
     sha256: "{{ metallb_controller_digest_checksum|default(None) }}"
+    groups:
+    - kube_control_plane
+
+  yq:
+    enabled: "{{ argocd_enabled }}"
+    file: true
+    version: "{{ yq_version }}"
+    dest: "{{ local_release_dir }}/yq"
+    sha256: "{{ yq_binary_checksum|default(None) }}"
+    url: "{{ yq_download_url }}"
+    unarchive: false
+    owner: "root"
+    mode: "0755"
     groups:
     - kube_control_plane
 

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -841,9 +841,12 @@ skopeo_binary_checksums:
     v1.10.0: 0
 
 yq_checksums:
+  arm64:
+    v4.30.6: 40ee3000d5b65703caffb0263a7d5e75164f10afd2c9a3c879b6016f0300ac25
+    v4.27.5: ea360a0ecdff30c8625ccd0b97f8714b8308a429fd839cf8ccc481f311e217c6
   amd64:
-    v4.27.5: 9a54846e81720ae22814941905cd3b056ebdffb76bf09acffa30f5e90b22d615
     v4.30.6: 2aabdd748d301fc2286ea9f73eb20477b4ce173fbf072e0102fff1fcbed05985
+    v4.27.5: 9a54846e81720ae22814941905cd3b056ebdffb76bf09acffa30f5e90b22d615
 
 etcd_binary_checksum: "{{ etcd_binary_checksums[image_arch][etcd_version] }}"
 cni_binary_checksum: "{{ cni_binary_checksums[image_arch][cni_version] }}"

--- a/roles/kubernetes-apps/argocd/tasks/main.yml
+++ b/roles/kubernetes-apps/argocd/tasks/main.yml
@@ -27,11 +27,33 @@
     - "inventory_hostname == groups['kube_control_plane'][0]"
 
 - name: Kubernetes Apps | Download ArgoCD remote manifests
-  become: yes
-  get_url:
-    url: "{{ item.url }}"
+  include_tasks: "../../../download/tasks/download_file.yml"
+  vars:
+    download_argocd:
+      enabled: "{{ argocd_enabled }}"
+      file: true
+      dest: "{{ local_release_dir }}/{{ item.file }}"
+      url: "{{ item.url }}"
+      unarchive: false
+      owner: "root"
+      mode: 0644
+      sha256: ""
+    download: "{{ download_defaults | combine(download_argocd) }}"
+  with_items: "{{ argocd_templates | selectattr('url', 'defined') | list }}"
+  loop_control:
+    label: "{{ item.file }}"
+  when:
+    - "inventory_hostname == groups['kube_control_plane'][0]"
+
+- name: Kubernetes Apps | Copy ArgoCD remote manifests from download dir
+  synchronize:
+    src: "{{ local_release_dir }}/{{ item.file }}"
     dest: "{{ kube_config_dir }}/{{ item.file }}"
-    mode: 0644
+    compress: no
+    perms: yes
+    owner: no
+    group: no
+  delegate_to: "{{ inventory_hostname }}"
   with_items: "{{ argocd_templates | selectattr('url', 'defined') | list }}"
   loop_control:
     label: "{{ item.file }}"

--- a/roles/kubernetes-apps/argocd/tasks/main.yml
+++ b/roles/kubernetes-apps/argocd/tasks/main.yml
@@ -55,8 +55,6 @@
     group: no
   delegate_to: "{{ inventory_hostname }}"
   with_items: "{{ argocd_templates | selectattr('url', 'defined') | list }}"
-  loop_control:
-    label: "{{ item.file }}"
   when:
     - "inventory_hostname == groups['kube_control_plane'][0]"
 

--- a/roles/kubernetes-apps/argocd/tasks/main.yml
+++ b/roles/kubernetes-apps/argocd/tasks/main.yml
@@ -1,10 +1,18 @@
 ---
-- name: Kubernetes Apps | Install yq
-  become: yes
-  get_url:
-    url: "https://github.com/mikefarah/yq/releases/download/v4.30.6/yq_linux_{{ host_architecture }}"
+- name: Kubernetes Apps | Download yq
+  include_tasks: "../../../download/tasks/download_file.yml"
+  vars:
+    download: "{{ download_defaults | combine(downloads.yq) }}"
+
+- name: Kubernetes Apps | Copy yq binary from download dir
+  synchronize:
+    src: "{{ local_release_dir }}/yq"
     dest: "{{ bin_dir }}/yq"
-    mode: '0755'
+    compress: no
+    perms: yes
+    owner: no
+    group: no
+  delegate_to: "{{ inventory_hostname }}"
 
 - name: Kubernetes Apps | Set ArgoCD template list
   set_fact:


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

This PR fix in the kubernetes-apps/argocd role: 
  - the install of yq  cli
  - the install of the argocd-install manifest.yml
It  use `download_file` task instead of `get_url`
Without this patch, yq cli  and argocd can 't be installed behind corporate http_proxy using `proxy_env`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
