### PR TITLE
Fix CentOS Extras repo url for Oracle Linux 7 aarch64

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-centos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-centos.yml
@@ -79,7 +79,7 @@
     - { option: "name", value: "CentOS-{{ ansible_distribution_major_version }} - Extras" }
     - { option: "enabled", value: "1" }
     - { option: "gpgcheck", value: "0" }
-    - { option: "baseurl", value: "http://mirror.centos.org/centos/{{ ansible_distribution_major_version }}/extras/$basearch/{% if ansible_distribution_major_version|int > 7 %}os/{% endif %}" }
+    - { option: "baseurl", value: "http://mirror.centos.org/{{ 'altarch' if (ansible_distribution_major_version | int) <= 7 and ansible_architecture == 'aarch64' else 'centos' }}/{{ ansible_distribution_major_version }}/extras/$basearch/{% if ansible_distribution_major_version|int > 7 %}os/{% endif %}" }
   when:
     - use_oracle_public_repo|default(true)
     - '''ID="ol"'' in os_release.stdout_lines'


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
HTTP Error 404 occurred while deploying nodes on Oracle Linux 7 aarch64

```
ansible-playbook -i inventory/mycluster/hosts.yaml  --become --become-user=root cluster.yml
...
TASK [kubernetes/preinstall : Install packages requirements] ***********************************************************************
fatal: [node1]: FAILED! => {"attempts": 4, "changed": false, "msg": "Failure talking to yum: failure: repodata/repomd.xml from extras: [Errno 256] No more mirrors to try.\nhttp://mirror.centos.org/centos/7/extras/aarch64/repodata/repomd.xml: [Errno 14] HTTP Error 404 - Not Found"}
...
```
Correct repo url is http://mirror.centos.org/altarch/7/extras/aarch64/



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
