### PR TITLE
fix(kubelet): no cloud config for external cloud provider

### DIFF
--- a/roles/kubernetes/node/templates/kubelet.env.v1beta1.j2
+++ b/roles/kubernetes/node/templates/kubelet.env.v1beta1.j2
@@ -33,8 +33,10 @@ KUBELET_VOLUME_PLUGIN="--volume-plugin-dir={{ kubelet_flexvolumes_plugins_dir }}
 {% if kube_network_plugin is defined and kube_network_plugin == "cloud" %}
 KUBELET_NETWORK_PLUGIN="--hairpin-mode=promiscuous-bridge --network-plugin=kubenet"
 {% endif %}
-{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws", "gce", "external"] %}
+{% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws", "gce"] %}
 KUBELET_CLOUDPROVIDER="--cloud-provider={{ cloud_provider }} --cloud-config={{ kube_config_dir }}/cloud_config"
+{% elif cloud_provider is defined and cloud_provider in ["external"] %}
+KUBELET_CLOUDPROVIDER="--cloud-provider={{ cloud_provider }}"
 {% else %}
 KUBELET_CLOUDPROVIDER=""
 {% endif %}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When using an external cloud provider (out-tree), kubelet still defines a `cloud-config` option.
This simple PR removes this option as external cloud providers do not need a cloud config to be passed to kubelet.

PS: we still need to set `cloud-provider` since they are waiting to have only `external` as a possible value, see those links for more context:
- https://github.com/gardener/gardener-extension-provider-aws/issues/514#issuecomment-1064163827
- https://github.com/kubernetes/kubernetes/pull/90408#issuecomment-668806889
- https://github.com/kubernetes/kubernetes/pull/90408#issuecomment-670057176

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
