### PR TITLE
fix: correctly mount ssl ca directories

### DIFF
--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin.yml.j2
@@ -133,6 +133,13 @@ spec:
             - name: ca-certs
               mountPath: /etc/ssl/certs
               readOnly: true
+{% if ssl_ca_dirs|length %}
+{% for dir in ssl_ca_dirs %}
+            - name: {{ dir | regex_replace('^/(.*)$', '\\1' ) | regex_replace('/', '-') }}
+              mountPath: {{ dir }}
+              readOnly: true
+{% endfor %}
+{% endif %}
 {% if cinder_cacert is defined and cinder_cacert != "" %}
             - name: cinder-cacert
               mountPath: {{ kube_config_dir }}/cinder-cacert.pem
@@ -148,6 +155,14 @@ spec:
           hostPath:
             path: /etc/ssl/certs
             type: DirectoryOrCreate
+{% if ssl_ca_dirs|length %}
+{% for dir in ssl_ca_dirs %}
+        - name: {{ dir | regex_replace('^/(.*)$', '\\1' ) | regex_replace('/', '-') }}
+          hostPath:
+            path: {{ dir }}
+            type: DirectoryOrCreate
+{% endfor %}
+{% endif %}
 {% if cinder_cacert is defined and cinder_cacert != "" %}
         - name: cinder-cacert
           hostPath:

--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-nodeplugin.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-nodeplugin.yml.j2
@@ -89,6 +89,13 @@ spec:
             - name: ca-certs
               mountPath: /etc/ssl/certs
               readOnly: true
+{% if ssl_ca_dirs|length %}
+{% for dir in ssl_ca_dirs %}
+            - name: {{ dir | regex_replace('^/(.*)$', '\\1' ) | regex_replace('/', '-') }}
+              mountPath: {{ dir }}
+              readOnly: true
+{% endfor %}
+{% endif %}
 {% if cinder_cacert is defined and cinder_cacert != "" %}
             - name: cinder-cacert
               mountPath: {{ kube_config_dir }}/cinder-cacert.pem
@@ -118,6 +125,14 @@ spec:
           hostPath:
             path: /etc/ssl/certs
             type: DirectoryOrCreate
+{% if ssl_ca_dirs|length %}
+{% for dir in ssl_ca_dirs %}
+        - name: {{ dir | regex_replace('^/(.*)$', '\\1' ) | regex_replace('/', '-') }}
+          hostPath:
+            path: {{ dir }}
+            type: DirectoryOrCreate
+{% endfor %}
+{% endif %}
 {% if cinder_cacert is defined and cinder_cacert != "" %}
         - name: cinder-cacert
           hostPath:

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-controller-manager-ds.yml.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-controller-manager-ds.yml.j2
@@ -57,6 +57,13 @@ spec:
             - mountPath: /etc/ssl/certs
               name: ca-certs
               readOnly: true
+{% if ssl_ca_dirs|length %}
+{% for dir in ssl_ca_dirs %}
+            - name: {{ dir | regex_replace('^/(.*)$', '\\1' ) | regex_replace('/', '-') }}
+              mountPath: {{ dir }}
+              readOnly: true
+{% endfor %}
+{% endif %}
             - mountPath: /etc/config/cloud.conf
               name: cloud-config-volume
               readOnly: true
@@ -78,19 +85,27 @@ spec:
       hostNetwork: true
       volumes:
 {% if kubelet_flexvolumes_plugins_dir is defined %}
-      - hostPath:
+      - name: flexvolume-dir
+        hostPath:
           path: "{{ kubelet_flexvolumes_plugins_dir }}"
           type: DirectoryOrCreate
-        name: flexvolume-dir
 {% endif %}
-      - hostPath:
+      - name: k8s-certs
+        hostPath:
           path: /etc/kubernetes/pki
           type: DirectoryOrCreate
-        name: k8s-certs
-      - hostPath:
+      - name: ca-certs
+        hostPath:
           path: /etc/ssl/certs
           type: DirectoryOrCreate
-        name: ca-certs
+{% if ssl_ca_dirs|length %}
+{% for dir in ssl_ca_dirs %}
+      - name: {{ dir | regex_replace('^/(.*)$', '\\1' ) | regex_replace('/', '-') }}
+        hostPath:
+          path: {{ dir }}
+          type: DirectoryOrCreate
+{% endfor %}
+{% endif %}
       - name: cloud-config-volume
         secret:
           secretName: external-openstack-cloud-config


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:

`/etc/ssl/certs` is mounted for a lot of pods but symlinks inside them are pointing to nowhere, leaving us with mainly this error: `x509: certificate signed by unknown authority`

A previous attempt was made but was not correctly solving the problem:
- https://github.com/kubernetes-sigs/kubespray/pull/9363

So here is a simple fix to mount missing certificate folders.
I have removed it from `kube-apiserver` as this has been fixed in upstream 5 years ago:
- https://github.com/kubernetes/kubernetes/pull/59122

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
