### PR TITLE
Update nodelocaldns to 1.22.18

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -938,7 +938,7 @@ coredns_image_is_namespaced: "{{ (coredns_version is version('v1.7.1','>=')) }}"
 coredns_image_repo: "{{ kube_image_repo }}{{'/coredns/coredns' if (coredns_image_is_namespaced | bool) else '/coredns' }}"
 coredns_image_tag: "{{ coredns_version if (coredns_image_is_namespaced | bool) else (coredns_version | regex_replace('^v', '')) }}"
 
-nodelocaldns_version: "1.21.1"
+nodelocaldns_version: "1.22.18"
 nodelocaldns_image_repo: "{{ kube_image_repo }}/dns/k8s-dns-node-cache"
 nodelocaldns_image_tag: "{{ nodelocaldns_version }}"
 


### PR DESCRIPTION

**What type of PR is this?**
> /kind bug

(marking as bug, beacuse of CVEs)

**What this PR does / why we need it**:

Cf. https://github.com/kubernetes/kubernetes/pull/115717/commits/ceb37c3a5c95b218985064b34ef96b5053a9dbe1

```release-note
Update nodelocaldns to 1.22.18
```
