### PR TITLE
fix raspbian: apparmor_parser is there, yet apparmor not started

### DIFF
--- a/roles/kubernetes-apps/ansible/tasks/netchecker.yml
+++ b/roles/kubernetes-apps/ansible/tasks/netchecker.yml
@@ -1,6 +1,6 @@
 ---
 - name: Kubernetes Apps | Check AppArmor status
-  command: which apparmor_parser
+  command: grep Y /sys/module/apparmor/parameters/enabled
   register: apparmor_status
   when:
     - inventory_hostname == groups['kube_control_plane'][0]

--- a/roles/kubernetes-apps/metallb/tasks/main.yml
+++ b/roles/kubernetes-apps/metallb/tasks/main.yml
@@ -25,7 +25,7 @@
     - matallb_auto_assign is defined
 
 - name: Kubernetes Apps | Check AppArmor status
-  command: which apparmor_parser
+  command: grep Y /sys/module/apparmor/parameters/enabled
   register: apparmor_status
   when:
     - podsecuritypolicy_enabled

--- a/roles/kubernetes/control-plane/tasks/psp-install.yml
+++ b/roles/kubernetes/control-plane/tasks/psp-install.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check AppArmor status
-  command: which apparmor_parser
+  command: grep Y /sys/module/apparmor/parameters/enabled
   register: apparmor_status
   failed_when: false
   changed_when: apparmor_status.rc != 0

--- a/roles/network_plugin/flannel/tasks/main.yml
+++ b/roles/network_plugin/flannel/tasks/main.yml
@@ -8,6 +8,21 @@
     - flannel_backend_type == 'wireguard'
     - not ignore_assert_errors
 
+- name: Flannel | Check AppArmor status
+  command: grep Y /sys/module/apparmor/parameters/enabled
+  register: apparmor_status
+  when:
+    - podsecuritypolicy_enabled
+    - inventory_hostname == groups['kube_control_plane'][0]
+  failed_when: false
+
+- name: Flannel | Set apparmor_enabled
+  set_fact:
+    apparmor_enabled: "{{ apparmor_status.rc == 0 }}"
+  when:
+    - podsecuritypolicy_enabled
+    - inventory_hostname == groups['kube_control_plane'][0]
+
 - name: Flannel | Create Flannel manifests
   template:
     src: "{{ item.file }}.j2"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Upgrading a raspbian cluster from kubernetes 1.21 to 1.22 / kubespray 2.17.1 to 2.18.2
I'm left with lots of pods with "Blocked" status, complaining about apparmor not being started.

Apparmor support detection does not check apparmor is actually started.
Deploying Kubernetes to raspbian / RPI, kubespray would install PSP preventing workloads from starting.

**Which issue(s) this PR fixes**:

Didn't report that issue ... fixed it, finished upgrading my cluster, and here we are.

**Special notes for your reviewer**:

N/A

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```