### PR TITLE
fix calico rbac issue

### DIFF
--- a/roles/network_plugin/calico/templates/calico-cr.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-cr.yml.j2
@@ -144,6 +144,7 @@ rules:
       - ipamconfigs
     verbs:
       - get
+      - create
   # Block affinities must also be watchable by confd for route aggregation.
   - apiGroups: ["crd.projectcalico.org"]
     resources:


### PR DESCRIPTION
/kind bug
when i install kubernetes with calico cni, and specific calico version in `inventory/mycluster/group_vas/k8s-cluster.yml`,  and specifiy calico version with `calico_version: v3.24.5`.
the calico pods will fail, logs as below
```
tunnel-ip-allocator/ipam.go 1847: Error creating IPAM config error=connection is unauthorized:
ipamconfigs.crd.projectcalico.org is forbidden: User "system:serviceaccount:kube-system:calico-node" cannot create resource "ipamconfigs" in API group "crd.projectcalico.org" at the cluster scope
```

so i just modify the rbac, and grant the permission as this pr, and install again, it works


for latest calico release tag please check here: https://github.com/projectcalico/calico/blob/v3.25.0/charts/calico/templates/calico-node-rbac.yaml#L160

it still need create permission