### PR TITLE
[containerd] add hashes for 1.6.17 , 1.6.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [kubernetes](https://github.com/kubernetes/kubernetes) v1.26.1
   - [etcd](https://github.com/etcd-io/etcd) v3.5.6
   - [docker](https://www.docker.com/) v20.10 (see note)
-  - [containerd](https://containerd.io/) v1.6.16
+  - [containerd](https://containerd.io/) v1.6.18
   - [cri-o](http://cri-o.io/) v1.24 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)
 - Network Plugin
   - [cni-plugins](https://github.com/containernetworking/plugins) v1.2.0

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -79,7 +79,7 @@ runc_version: v1.1.4
 kata_containers_version: 2.4.1
 youki_version: 0.0.1
 gvisor_version: 20210921
-containerd_version: 1.6.16
+containerd_version: 1.6.18
 cri_dockerd_version: 0.3.0
 
 # this is relevant when container_manager == 'docker'
@@ -726,6 +726,8 @@ containerd_archive_checksums:
     1.5.14: 0
     1.5.15: 0
     1.5.16: 0
+    1.5.17: 0
+    1.5.18: 0
     1.6.0: 0
     1.6.1: 0
     1.6.2: 0
@@ -743,6 +745,8 @@ containerd_archive_checksums:
     1.6.14: 0
     1.6.15: 0
     1.6.16: 0
+    1.6.17: 0
+    1.6.18: 0
   arm64:
     1.5.5: 0
     1.5.7: 0
@@ -755,6 +759,8 @@ containerd_archive_checksums:
     1.5.14: 0
     1.5.15: 0
     1.5.16: 0
+    1.5.17: 0
+    1.5.18: 0
     1.6.0: 6eff3e16d44c89e1e8480a9ca078f79bab82af602818455cc162be344f64686a
     1.6.1: fbeec71f2d37e0e4ceaaac2bdf081295add940a7a5c7a6bcc125e5bbae067791
     1.6.2: a4b24b3c38a67852daa80f03ec2bc94e31a0f4393477cd7dc1c1a7c2d3eb2a95
@@ -772,6 +778,8 @@ containerd_archive_checksums:
     1.6.14: 3ccb61218e60cbba0e1bbe1e5e2bf809ac1ead8eafbbff36c3195d3edd0e4809
     1.6.15: d63e4d27c51e33cd10f8b5621c559f09ece8a65fec66d80551b36cac9e61a07d
     1.6.16: c2bf51fde02ec9cf8b9c18721bc4f53bd1f19fb2bb3251f41ece61af7347e082
+    1.6.17: 7e110faa738bff2f5f0ffd54c4ec2c17c05fd2af6de4877c839794ca3dadd61c
+    1.6.18: 56b83a0bc955edc5ebaa3bd0f788e654b63395be00fcb1bd03ff4bdfe4b5e1e7
   amd64:
     1.5.5: 8efc527ffb772a82021800f0151374a3113ed2439922497ff08f2596a70f10f1
     1.5.7: 109fc95b86382065ea668005c376360ddcd8c4ec413e7abe220ae9f461e0e173
@@ -784,6 +792,8 @@ containerd_archive_checksums:
     1.5.14: 8513ead11aca164b7e70bcea0429b4e51dad836b6383b806322e128821aaebbd
     1.5.15: 0d09043be08dcf6bf136aa78bfd719e836cf9f9679afa4db0b6e4d478e396528
     1.5.16: f5326865c2b86aba794f590fd2ca479f817fa1f88c084d97a45816aec9d0ce32
+    1.5.17: b676f56f43bf02782179320b5070fb210cbc1784a9b0875086bc15c3bcc546f3
+    1.5.18: d132525d375bbafd3aee8e9aa5517203cef2bbf77197db7522c8730cc526b3db
     1.6.0: f77725e4f757523bf1472ec3b9e02b09303a5d99529173be0f11a6d39f5676e9
     1.6.1: c1df0a12af2be019ca2d6c157f94e8ce7430484ab29948c9805882df40ec458b
     1.6.2: 3d94f887de5f284b0d6ee61fa17ba413a7d60b4bb27d756a402b713a53685c6a
@@ -801,6 +811,8 @@ containerd_archive_checksums:
     1.6.14: 7da626d46c4edcae1eefe6d48dc6521db3e594a402715afcddc6ac9e67e1bfcd
     1.6.15: 191bb4f6e4afc237efc5c85b5866b6fdfed731bde12cceaa6017a9c7f8aeda02
     1.6.16: 2415b431a900275c14942f87f751e1e13d513c1c2f062322b5ca5a9a2190f22a
+    1.6.17: 5f0584d000769d0cf08fc0e25135614ef5bf52971a6069175c78437699f3b8d4
+    1.6.18: c4e516376a2392520a87abea94baf2045cc3a67e9e0c90c75fb6ed038170561e
   ppc64le:
     1.5.5: 0
     1.5.7: 0
@@ -813,6 +825,8 @@ containerd_archive_checksums:
     1.5.14: 0
     1.5.15: 0
     1.5.16: 0
+    1.5.17: 0
+    1.5.18: 0
     1.6.0: 0
     1.6.1: 0
     1.6.2: 0
@@ -830,6 +844,8 @@ containerd_archive_checksums:
     1.6.14: 73025da0666079fc3bbd48cf185da320955d323c7dc42d8a4ade0e7926d62bb0
     1.6.15: 502f3e4c8ea2018aaa285fe4f704bfd560fdf93193bb829dd9302d013bc38370
     1.6.16: 9cfd5dade6a1c2671f5c76496395afe0aa0ce902c13672b306d8d09fdbb99492
+    1.6.17: 2f689ff36ba41c3c86ce926f55b0101118a40dd7b741946386062fddaa287db0
+    1.6.18: b7083473061a61200d04f500ad4a96813d1b09f71b2d427019076836c2a49836
 skopeo_binary_checksums:
   arm:
     v1.10.0: 0


### PR DESCRIPTION
**What type of PR is this?**

/kind container-managers

**What this PR does / why we need it**:

The 1.5.18, 1.6.18 addresses the following issues:
https://github.com/advisories/GHSA-259w-8hf6-59c2 
https://github.com/advisories/GHSA-hmfx-3pcx-653p
Add hashes for containerd versions 1.5.17, 1.5.18, 1.6.17 , 1.6.18
Make containerd 1.6.18 default

**Does this PR introduce a user-facing change?**:
<!--
NONE
-->
```release-note
[containerd] Add hashes for containerd versions 1.5.17, 1.5.18, 1.6.17 , 1.6.18
```