### PR TITLE
add image garbage collection

### DIFF
--- a/docs/vars.md
+++ b/docs/vars.md
@@ -205,6 +205,15 @@ Stack](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/dns-stack.m
 
 * *kubelet_streaming_connection_idle_timeout* - Set the maximum time a streaming connection can be idle before the connection is automatically closed.
 
+* *kubelet_image_gc_high_threshold* - Set the percent of disk usage after which image garbage collection is always run.
+  The percent is calculated by dividing this field value by 100, so this field must be between 0 and 100, inclusive.
+  When specified, the value must be greater than imageGCLowThresholdPercent. Default: 85
+
+* *kubelet_image_gc_low_threshold* - Set the percent of disk usage before which image garbage collection is never run.
+  Lowest disk usage to garbage collect to.
+  The percent is calculated by dividing this field value by 100, so the field value must be between 0 and 100, inclusive.
+  When specified, the value must be less than imageGCHighThresholdPercent. Default: 80
+
 * *kubelet_make_iptables_util_chains* - If `true`, causes the kubelet ensures a set of `iptables` rules are present on host.
 
 * *kubelet_systemd_hardening* - If `true`, provides kubelet systemd service with security features for isolation.

--- a/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
@@ -147,6 +147,12 @@ memorySwap:
 {% if kubelet_streaming_connection_idle_timeout is defined %}
 streamingConnectionIdleTimeout: {{ kubelet_streaming_connection_idle_timeout }}
 {% endif %}
+{% if kubelet_image_gc_high_threshold is defined %}
+imageGCHighThresholdPercent: {{ kubelet_image_gc_high_threshold }}
+{% endif %}
+{% if kubelet_image_gc_low_threshold is defined %}
+imageGCLowThresholdPercent: {{ kubelet_image_gc_low_threshold }}
+{% endif %}
 {% if kubelet_make_iptables_util_chains is defined %}
 makeIPTablesUtilChains: {{ kubelet_make_iptables_util_chains | bool }}
 {% endif %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Customize the imageGCHighThresholdPercent and imageGCLowThresholdPercent values in the kubelet config
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9815

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Allow to configure image garbage collection (using `kubelet_image_gc_high_threshold` and `kubelet_image_gc_low_threshold`)
```
