### PR TITLE
node: fix default kubelet/runtime cgroups when kube_reserved is false

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -272,7 +272,7 @@ podsecuritypolicy_enabled: false
 # kubelet_kubelet_cgroups_cgroupfs: "/system.slice/kubelet.service"
 
 # Optionally reserve this space for kube daemons.
-# kube_reserved: true
+# kube_reserved: false
 ## Uncomment to override default values
 ## The following two items need to be set when kube_reserved is true
 # kube_reserved_cgroups_for_service_slice: kube.slice

--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -264,8 +264,8 @@ podsecuritypolicy_enabled: false
 # kubelet_enforce_node_allocatable: pods
 
 ## Set runtime and kubelet cgroups when using systemd as cgroup driver (default)
-# kubelet_runtime_cgroups: "{{ kube_reserved_cgroups }}/{{ container_manager }}.service"
-# kubelet_kubelet_cgroups: "{{ kube_reserved_cgroups }}/kubelet.service"
+# kubelet_runtime_cgroups: "/{{ kube_service_cgroups }}/{{ container_manager }}.service"
+# kubelet_kubelet_cgroups: "/{{ kube_service_cgroups }}/kubelet.service"
 
 ## Set runtime and kubelet cgroups when using cgroupfs as cgroup driver
 # kubelet_runtime_cgroups_cgroupfs: "/system.slice/{{ container_manager }}.service"

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -12,8 +12,9 @@ kube_resolv_conf: "/etc/resolv.conf"
 kubelet_enforce_node_allocatable: "\"\""
 
 # Set runtime and kubelet cgroups when using systemd as cgroup driver (default)
-kubelet_runtime_cgroups: "{{ kube_reserved_cgroups }}/{{ container_manager }}.service"
-kubelet_kubelet_cgroups: "{{ kube_reserved_cgroups }}/kubelet.service"
+kube_service_cgroups: "{% if kube_reserved %}{{ kube_reserved_cgroups_for_service_slice }}{% else %}system.slice{% endif %}"
+kubelet_runtime_cgroups: "/{{ kube_service_cgroups }}/{{ container_manager }}.service"
+kubelet_kubelet_cgroups: "/{{ kube_service_cgroups }}/kubelet.service"
 
 # Set runtime and kubelet cgroups when using cgroupfs as cgroup driver
 kubelet_runtime_cgroups_cgroupfs: "/system.slice/{{ container_manager }}.service"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Commit https://github.com/kubernetes-sigs/kubespray/commit/1c4db6132d9a2bf79e8d72c09cbdb12f3fef572a (PR https://github.com/kubernetes-sigs/kubespray/pull/9209) introduced a notion of kube_reserved. This introduced a breaking change defaulting to use kube.slice for the container_manager and the kubelet as if kube_reserved was always enabled whereas it is disabled by default.

This commit fixes this by bringing back system.slice whenever kube_reserved is disabled.

**Which issue(s) this PR fixes**:
Fixes #9769

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixing default cgroups for kubelet and container_manager
```
