### PR TITLE
feat(Dockerfile): openssh-client support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY library ./library
 COPY extra_playbooks ./extra_playbooks
 
 RUN apt update && apt install -y --no-install-recommends \
-    curl python3 python3-pip sshpass vim rsync \
+    curl python3 python3-pip sshpass vim rsync openssh-client \
     && rm -rf /var/lib/apt/lists/* /var/log/* \
     && pip install --no-cache-dir \
     ansible==5.7.1 \


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

openssh-client was present before this [MR](https://github.com/kubernetes-sigs/kubespray/pull/9810).
This simple commit adds it back as it let us manage ssh connections that require a private/public key instead of a password with sshpass.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
