### PR TITLE
feat(contrib/terraform): support custom ssh port

### DIFF
--- a/contrib/terraform/terraform.py
+++ b/contrib/terraform/terraform.py
@@ -318,7 +318,9 @@ def openstack_host(resource, module_name):
 
     # attrs specific to Ansible
     if 'metadata.ssh_user' in raw_attrs:
-        attrs['ansible_ssh_user'] = raw_attrs['metadata.ssh_user']
+        attrs['ansible_user'] = raw_attrs['metadata.ssh_user']
+    if 'metadata.ssh_port' in raw_attrs:
+        attrs['ansible_port'] = raw_attrs['metadata.ssh_port']
 
     if 'volume.#' in list(raw_attrs.keys()) and int(raw_attrs['volume.#']) > 0:
         device_index = 1


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

For security measures, its best to change the default ssh port to something uncommon.
This simple PR adds the possibility to specify a custom ssh port.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
