### PR TITLE
Update nodes in etc hosts after cluster scale

### DIFF
--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -38,6 +38,8 @@ resolveconf_cloud_init_conf: /etc/resolveconf_cloud_init.conf
 populate_inventory_to_hosts_file: true
 # K8S Api FQDN will be written into /etc/hosts file.
 populate_loadbalancer_apiserver_to_hosts_file: true
+# etc_hosts_localhost_entries will be written into /etc/hosts file.
+populate_localhost_entries_to_hosts_file: true
 
 sysctl_file_path: "/etc/sysctl.d/99-sysctl.conf"
 

--- a/roles/kubernetes/preinstall/tasks/0090-etchosts.yml
+++ b/roles/kubernetes/preinstall/tasks/0090-etchosts.yml
@@ -1,29 +1,31 @@
 ---
-- name: Hosts | create list from inventory
-  set_fact:
-    etc_hosts_inventory_block: |-
-      {% for item in (groups['k8s_cluster'] + groups['etcd']|default([]) + groups['calico_rr']|default([]))|unique -%}
-      {% if 'access_ip' in hostvars[item] or 'ip' in hostvars[item] or 'ansible_default_ipv4' in hostvars[item] -%}
-      {{ hostvars[item]['access_ip'] | default(hostvars[item]['ip'] | default(hostvars[item]['ansible_default_ipv4']['address'])) }}
-      {%- if ('ansible_hostname' in hostvars[item] and item != hostvars[item]['ansible_hostname']) %} {{ hostvars[item]['ansible_hostname'] }}.{{ dns_domain }} {{ hostvars[item]['ansible_hostname'] }} {% else %} {{ item }}.{{ dns_domain }} {{ item }} {% endif %}
+- name: Hosts | update inventory in hosts file
+  block:
+    - name: Hosts | create list from inventory
+      set_fact:
+        etc_hosts_inventory_block: |-
+          {% for item in (groups['k8s_cluster'] + groups['etcd']|default([]) + groups['calico_rr']|default([]))|unique -%}
+          {% if 'access_ip' in hostvars[item] or 'ip' in hostvars[item] or 'ansible_default_ipv4' in hostvars[item] -%}
+          {{ hostvars[item]['access_ip'] | default(hostvars[item]['ip'] | default(hostvars[item]['ansible_default_ipv4']['address'])) }}
+          {%- if ('ansible_hostname' in hostvars[item] and item != hostvars[item]['ansible_hostname']) %} {{ hostvars[item]['ansible_hostname'] }}.{{ dns_domain }} {{ hostvars[item]['ansible_hostname'] }} {% else %} {{ item }}.{{ dns_domain }} {{ item }} {% endif %}
 
-      {% endif %}
-      {% endfor %}
-  delegate_to: localhost
-  connection: local
-  delegate_facts: yes
-  run_once: yes
+          {% endif %}
+          {% endfor %}
+      delegate_to: localhost
+      connection: local
+      delegate_facts: yes
+      run_once: yes
 
-- name: Hosts | populate inventory into hosts file
-  blockinfile:
-    path: /etc/hosts
-    block: "{{ hostvars.localhost.etc_hosts_inventory_block }}"
-    state: present
-    create: yes
-    backup: yes
-    unsafe_writes: yes
-    marker: "# Ansible inventory hosts {mark}"
-    mode: 0644
+    - name: Hosts | populate inventory into hosts file
+      blockinfile:
+        path: /etc/hosts
+        block: "{{ hostvars.localhost.etc_hosts_inventory_block }}"
+        state: present
+        create: yes
+        backup: yes
+        unsafe_writes: yes
+        marker: "# Ansible inventory hosts {mark}"
+        mode: 0644
   when: populate_inventory_to_hosts_file
 
 - name: Hosts | populate kubernetes loadbalancer address into hosts file
@@ -39,39 +41,44 @@
     - loadbalancer_apiserver is defined
     - loadbalancer_apiserver.address is defined
 
-- name: Hosts | Retrieve hosts file content
-  slurp:
-    src: /etc/hosts
-  register: etc_hosts_content
+- name: Hosts | Update localhost entries in hosts file
+  block:
+    - name: Hosts | Retrieve hosts file content
+      slurp:
+        src: /etc/hosts
+      register: etc_hosts_content
 
-- name: Hosts | Extract existing entries for localhost from hosts file
-  set_fact:
-    etc_hosts_localhosts_dict: >-
-      {%- set splitted = (item | regex_replace('[ \t]+', ' ')|regex_replace('#.*$')|trim).split( ' ') -%}
-      {{ etc_hosts_localhosts_dict|default({}) | combine({splitted[0]: splitted[1::] }) }}
-  with_items: "{{ (etc_hosts_content['content'] | b64decode).splitlines() }}"
-  when:
-    - etc_hosts_content.content is defined
-    - (item is match('^::1 .*') or item is match('^127.0.0.1 .*'))
+    - name: Hosts | Extract existing entries for localhost from hosts file
+      set_fact:
+        etc_hosts_localhosts_dict: >-
+          {%- set splitted = (item | regex_replace('[ \t]+', ' ')|regex_replace('#.*$')|trim).split( ' ') -%}
+          {{ etc_hosts_localhosts_dict|default({}) | combine({splitted[0]: splitted[1::] }) }}
+      with_items: "{{ (etc_hosts_content['content'] | b64decode).splitlines() }}"
+      when:
+        - etc_hosts_content.content is defined
+        - (item is match('^::1 .*') or item is match('^127.0.0.1 .*'))
 
-- name: Hosts | Update target hosts file entries dict with required entries
-  set_fact:
-    etc_hosts_localhosts_dict_target: >-
-      {%- set target_entries = (etc_hosts_localhosts_dict|default({})).get(item.key, []) | difference(item.value.get('unexpected' ,[])) -%}
-      {{ etc_hosts_localhosts_dict_target|default({}) | combine({item.key: (target_entries + item.value.expected)|unique}) }}
-  loop: "{{ etc_hosts_localhost_entries|dict2items }}"
+    - name: Hosts | Update target hosts file entries dict with required entries
+      set_fact:
+        etc_hosts_localhosts_dict_target: >-
+          {%- set target_entries = (etc_hosts_localhosts_dict|default({})).get(item.key, []) | difference(item.value.get('unexpected' ,[])) -%}
+          {{ etc_hosts_localhosts_dict_target|default({}) | combine({item.key: (target_entries + item.value.expected)|unique}) }}
+      loop: "{{ etc_hosts_localhost_entries|dict2items }}"
 
-- name: Hosts | Update (if necessary) hosts file
-  lineinfile:
-    dest: /etc/hosts
-    line: "{{ item.key }} {{ item.value|join(' ') }}"
-    regexp: "^{{ item.key }}.*$"
-    state: present
-    backup: yes
-    unsafe_writes: yes
-  loop: "{{ etc_hosts_localhosts_dict_target|default({})|dict2items }}"
+    - name: Hosts | Update (if necessary) hosts file
+      lineinfile:
+        dest: /etc/hosts
+        line: "{{ item.key }} {{ item.value|join(' ') }}"
+        regexp: "^{{ item.key }}.*$"
+        state: present
+        backup: yes
+        unsafe_writes: yes
+      loop: "{{ etc_hosts_localhosts_dict_target|default({})|dict2items }}"
+  when: populate_localhost_entries_to_hosts_file
 
 # gather facts to update ansible_fqdn
 - name: Update facts
   setup:
     gather_subset: min
+  when:
+    - not dns_late

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -74,8 +74,6 @@
     - bootstrap-os
 
 - import_tasks: 0090-etchosts.yml
-  when:
-    - not dns_late
   tags:
     - bootstrap-os
     - etchosts


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Add new nodes into /etc/hosts of current nodes after cluster scale with scale.yml.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9817

**Special notes for your reviewer**:

Combine `Hosts | create list from inventory` and `Hosts | populate inventory into hosts file` into one block with one condition, so if `populate_inventory_to_hosts_file` is false, there is no need to run `Hosts | create list from inventory`.

Combine the localhost entries tasks into one block and add a variable `populate_localhost_entries_to_hosts_file` as a condition.

It will save some time, Respect #9279.

The ssl certificate has been generated in dns_early stage.
The `setup` task is a time-consuming task, so there is no need to update `ansible_fqdn` in dns_late stage.



**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
