### PR TITLE
[containerd] add hashes for 1.6.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [kubernetes](https://github.com/kubernetes/kubernetes) v1.26.1
   - [etcd](https://github.com/etcd-io/etcd) v3.5.6
   - [docker](https://www.docker.com/) v20.10 (see note)
-  - [containerd](https://containerd.io/) v1.6.18
+  - [containerd](https://containerd.io/) v1.6.19
   - [cri-o](http://cri-o.io/) v1.24 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)
 - Network Plugin
   - [cni-plugins](https://github.com/containernetworking/plugins) v1.2.0

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -79,7 +79,7 @@ runc_version: v1.1.4
 kata_containers_version: 2.4.1
 youki_version: 0.0.1
 gvisor_version: 20210921
-containerd_version: 1.6.18
+containerd_version: 1.6.19
 cri_dockerd_version: 0.3.0
 
 # this is relevant when container_manager == 'docker'
@@ -747,6 +747,7 @@ containerd_archive_checksums:
     1.6.16: 0
     1.6.17: 0
     1.6.18: 0
+    1.6.19: 0
   arm64:
     1.5.5: 0
     1.5.7: 0
@@ -780,6 +781,7 @@ containerd_archive_checksums:
     1.6.16: c2bf51fde02ec9cf8b9c18721bc4f53bd1f19fb2bb3251f41ece61af7347e082
     1.6.17: 7e110faa738bff2f5f0ffd54c4ec2c17c05fd2af6de4877c839794ca3dadd61c
     1.6.18: 56b83a0bc955edc5ebaa3bd0f788e654b63395be00fcb1bd03ff4bdfe4b5e1e7
+    1.6.19: 25a0dd6cce4e1058824d6dc277fc01dc45da92539ccb39bb6c8a481c24d2476e
   amd64:
     1.5.5: 8efc527ffb772a82021800f0151374a3113ed2439922497ff08f2596a70f10f1
     1.5.7: 109fc95b86382065ea668005c376360ddcd8c4ec413e7abe220ae9f461e0e173
@@ -813,6 +815,7 @@ containerd_archive_checksums:
     1.6.16: 2415b431a900275c14942f87f751e1e13d513c1c2f062322b5ca5a9a2190f22a
     1.6.17: 5f0584d000769d0cf08fc0e25135614ef5bf52971a6069175c78437699f3b8d4
     1.6.18: c4e516376a2392520a87abea94baf2045cc3a67e9e0c90c75fb6ed038170561e
+    1.6.19: 3262454d9b3581f4d4da0948f77dde1be51cfc42347a1548bc9ab6870b055815
   ppc64le:
     1.5.5: 0
     1.5.7: 0
@@ -846,6 +849,7 @@ containerd_archive_checksums:
     1.6.16: 9cfd5dade6a1c2671f5c76496395afe0aa0ce902c13672b306d8d09fdbb99492
     1.6.17: 2f689ff36ba41c3c86ce926f55b0101118a40dd7b741946386062fddaa287db0
     1.6.18: b7083473061a61200d04f500ad4a96813d1b09f71b2d427019076836c2a49836
+    1.6.19: 18cf11b6dfc980aca8792a2cd3ea7afed6379c2988ca6fe9e53a19a0bece5a2d
 skopeo_binary_checksums:
   arm:
     v1.10.0: 0


### PR DESCRIPTION
**What type of PR is this?**

/kind container-managers

**What this PR does / why we need it**:

Add hashes for containerd versions 1.6.19
Make containerd 1.6.19 default

**Does this PR introduce a user-facing change?**:
<!--
NONE
-->
```release-note
[containerd] Add hashes for containerd version 1.6.19
```