### PR TITLE
Drop remaining part for supporting ansible 2.9 and 2.10

### DIFF
--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -15,9 +15,6 @@ virtualenv  --python=$(which python3) $VENVDIR
 source $VENVDIR/bin/activate
 cd $KUBESPRAYDIR
 pip install -U -r requirements-$ANSIBLE_VERSION.txt
-test -f requirements-$ANSIBLE_VERSION.yml && \
-  ansible-galaxy role install -r requirements-$ANSIBLE_VERSION.yml && \
-  ansible-galaxy collection -r requirements-$ANSIBLE_VERSION.yml
 ```
 
 ### Ansible Python Compatibility

--- a/tests/scripts/testcases_prepare.sh
+++ b/tests/scripts/testcases_prepare.sh
@@ -9,10 +9,3 @@ mkdir -p /.ssh
 mkdir -p cluster-dump
 mkdir -p $HOME/.ssh
 ansible-playbook --version
-
-# in some cases we may need to bring in collections or roles from ansible-galaxy
-# to compensate for missing functionality in older ansible versions
-if [ -f requirements-${ANSIBLE_MAJOR_VERSION}.yml ] ; then
-  ansible-galaxy role install -r requirements-${ANSIBLE_MAJOR_VERSION}.yml
-  ansible-galaxy collection install -r requirements-${ANSIBLE_MAJOR_VERSION}.yml
-fi


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

requirements-$ANSIBLE_VERSION.yml doesn't exist in Kubespray repo.
That was for supporting ansible 2.10-, and now Kubespray supports 2.11+.
So this drops the part to avoid confusion.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9803 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
