### PR TITLE
Drop crun_bin_dir unused var

### DIFF
--- a/roles/container-engine/crun/defaults/main.yml
+++ b/roles/container-engine/crun/defaults/main.yml
@@ -1,3 +1,0 @@
----
-
-crun_bin_dir: /usr/bin/

--- a/roles/container-engine/crun/tasks/main.yml
+++ b/roles/container-engine/crun/tasks/main.yml
@@ -7,6 +7,6 @@
 - name: Copy crun binary from download dir
   copy:
     src: "{{ local_release_dir }}/crun"
-    dest: "{{ crun_bin_dir }}/crun"
+    dest: "{{ bin_dir }}/crun"
     mode: 0755
     remote_src: true


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This change fixes the CRI-O configuration for `crun` runtime class

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
```yaml
crun_enabled: true
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
