### PR TITLE
Downgrade version of coredns to 1.8.6 for compatibility with 1.23-1.24

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -1000,7 +1000,7 @@ haproxy_image_tag: 2.6.6-alpine
 # Coredns version should be supported by corefile-migration (or at least work with)
 # bundle with kubeadm; if not 'basic' upgrade can sometimes fail
 
-coredns_version: "v1.9.3"
+coredns_version: "{{ 'v1.9.3' if (kube_version is version('v1.25.0','>=')) else 'v1.8.6' }}"
 coredns_image_is_namespaced: "{{ (coredns_version is version('v1.7.1','>=')) }}"
 
 coredns_image_repo: "{{ kube_image_repo }}{{'/coredns/coredns' if (coredns_image_is_namespaced | bool) else '/coredns' }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Kubespray 2.21 doesn't take into account the compatibility of Kubernetes with a version of CoreDNS. Kubernetes versions prior to 1.25 support CoreDNS 1.8.6, not 1.9.3. When you try to update the cluster inside 1.24.x branch with the Kubespray 2.21, you will get an error like:
```
start version '1.9.3' not supported
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
You can check compatibility versions here: [1.23](https://github.com/kubernetes/kubernetes/blob/release-1.23/build/dependencies.yaml#L42), [1.24](https://github.com/kubernetes/kubernetes/blob/release-1.24/build/dependencies.yaml#L42), [1.25](https://github.com/kubernetes/kubernetes/blob/release-1.25/build/dependencies.yaml#L42).

**Does this PR introduce a user-facing change?**:
```release-note
Downgrade the version of CoreDNS to 1.8.6 for compatibility with Kubernetes versions older than 1.25.
```
