### PR TITLE
upgrade kubevip to v0.5.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [kube-router](https://github.com/cloudnativelabs/kube-router) v1.5.1
   - [multus](https://github.com/intel/multus-cni) v3.8
   - [weave](https://github.com/weaveworks/weave) v2.8.1
-  - [kube-vip](https://github.com/kube-vip/kube-vip) v0.5.8
+  - [kube-vip](https://github.com/kube-vip/kube-vip) v0.5.11
 - Application
   - [cert-manager](https://github.com/jetstack/cert-manager) v1.11.0
   - [coredns](https://github.com/coredns/coredns) v1.9.3

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -991,7 +991,7 @@ multus_image_repo: "{{ github_image_repo }}/k8snetworkplumbingwg/multus-cni"
 multus_image_tag: "{{ multus_version }}"
 
 kube_vip_image_repo: "{{ github_image_repo }}/kube-vip/kube-vip"
-kube_vip_image_tag: v0.5.8
+kube_vip_image_tag: v0.5.11
 nginx_image_repo: "{{ docker_image_repo }}/library/nginx"
 nginx_image_tag: 1.23.2-alpine
 haproxy_image_repo: "{{ docker_image_repo }}/library/haproxy"

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -68,7 +68,7 @@ eviction_hard_control_plane: {}
 kubelet_status_update_frequency: 10s
 
 # kube-vip
-kube_vip_version: v0.5.8
+kube_vip_version: v0.5.11
 
 kube_vip_arp_enabled: false
 kube_vip_interface:

--- a/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
@@ -1,4 +1,4 @@
-# Inspired by https://github.com/kube-vip/kube-vip/blob/v0.5.8/pkg/kubevip/config_generator.go#L13
+# Inspired by https://github.com/kube-vip/kube-vip/blob/v0.5.11/pkg/kubevip/config_generator.go#L13
 apiVersion: v1
 kind: Pod
 metadata:


### PR DESCRIPTION
**What type of PR is this?**

 /kind feature

**What this PR does / why we need it**:

upgrade kube-vip to v0.5.11

**Does this PR introduce a user-facing change?**:

```release-note
Upgrade kube-vip to v0.5.11
```
