### PR TITLE
Update check calico version command

### DIFF
--- a/roles/network_plugin/calico/tasks/check.yml
+++ b/roles/network_plugin/calico/tasks/check.yml
@@ -43,35 +43,33 @@
   run_once: True
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
 
-- name: Get current calico cluster version
-  shell: "set -o pipefail && {{ bin_dir }}/calicoctl.sh version  | grep 'Cluster Version:' | awk '{ print $3}'"
-  args:
-    executable: /bin/bash
-  register: calico_version_on_server
-  async: 10
-  poll: 3
+- name: Check if calico exists
+  stat:
+    path: "{{ bin_dir }}/calicoctl.sh"
+  register: calico_exists
   run_once: True
-  until: calico_version_on_server.stdout != 'unknown'
-  retries: 5
-  delay: "{{ retry_stagger | random + 3 }}"
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
-  changed_when: false
-  failed_when: false
 
 - name: Check that current calico version is enough for upgrade
-  assert:
-    that:
-      - calico_version_on_server.stdout is version(calico_min_version_required, '>=')
-    msg: >
-      Your version of calico is not fresh enough for upgrade.
-      Minimum version is {{ calico_min_version_required }} supported by the previous kubespray release.
-      But current version is {{ calico_version_on_server.stdout }}.
-  when:
-    - 'calico_version_on_server.stdout is defined'
-    - calico_version_on_server.stdout
-    - inventory_hostname == groups['kube_control_plane'][0]
+  block:
+    - name: Get current calico version
+      shell: "set -o pipefail && {{ bin_dir }}/calicoctl.sh version | grep 'Client Version:' | awk '{ print $3}'"
+      args:
+        executable: /bin/bash
+      register: calico_version_on_server
+      changed_when: false
+
+    - name: Assert that current calico version is enough for upgrade
+      assert:
+        that:
+          - calico_version_on_server.stdout is version(calico_min_version_required, '>=')
+        msg: >
+          Your version of calico is not fresh enough for upgrade.
+          Minimum version is {{ calico_min_version_required }} supported by the previous kubespray release.
+          But current version is {{ calico_version_on_server.stdout }}.
   run_once: True
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  when: calico_exists.stat.exists
 
 - name: "Check that cluster_id is set if calico_rr enabled"
   assert:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The `Get current calico cluster version` has not ever been working.

And the task fail is ignore, by 'fail_when: false'

```txt
TASK [network_plugin/calico : Get current calico cluster version] ********************************************************************************
ok: [node1]
```

It's `Client` instead of `Cluster`

```shell
$ /usr/local/bin/calicoctl.sh version
Client Version:    v3.24.5
Git commit:        f1a1611ac
Unable to detect installed Calico version
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
No issue

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
