### PR TITLE
Fix uniontech os installation failure

### DIFF
--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -77,5 +77,26 @@ containerd_limit_mem_lock: "infinity"
 # If enabled it will use config_path and disable use mirrors config
 containerd_use_config_path: false
 
+# OS distributions that already support containerd
+containerd_supported_distributions:
+  - "CentOS"
+  - "OracleLinux"
+  - "RedHat"
+  - "Ubuntu"
+  - "Debian"
+  - "Fedora"
+  - "AlmaLinux"
+  - "Rocky"
+  - "Amazon"
+  - "Flatcar"
+  - "Flatcar Container Linux by Kinvolk"
+  - "Suse"
+  - "openSUSE Leap"
+  - "openSUSE Tumbleweed"
+  - "Kylin Linux Advanced Server"
+  - "UnionTech"
+  - "UniontechOS"
+  - "openEuler"
+
 # If enabled it will allow kubespray to attempt setup even if the distribution is not supported. For unsupported distributions this can lead to unexpected failures in some cases.
 allow_unsupported_distribution_setup: false

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -3,7 +3,7 @@
   fail:
     msg: "{{ ansible_distribution }} is not supported by containerd."
   when:
-    - not (allow_unsupported_distribution_setup | default(false)) and (ansible_distribution not in ["CentOS", "OracleLinux", "RedHat", "Ubuntu", "Debian", "Fedora", "AlmaLinux", "Rocky", "Amazon", "Flatcar", "Flatcar Container Linux by Kinvolk", "Suse", "openSUSE Leap", "openSUSE Tumbleweed", "Kylin Linux Advanced Server", "UnionTech", "openEuler"])
+    - not (allow_unsupported_distribution_setup | default(false)) and (ansible_distribution not in containerd_supported_distributions)
 
 - name: containerd | Remove any package manager controlled containerd package
   package:

--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -107,3 +107,32 @@ ntp_force_sync_immediately: false
 
 # Set the timezone for your server.  eg: "Etc/UTC","Etc/GMT-8". If not set, the timezone will not change.
 ntp_timezone: ""
+
+# Currently known os distributions
+supported_os_distributions:
+  - 'RedHat'
+  - 'CentOS'
+  - 'Fedora'
+  - 'Ubuntu'
+  - 'Debian'
+  - 'Flatcar'
+  - 'Flatcar Container Linux by Kinvolk'
+  - 'Suse'
+  - 'openSUSE Leap'
+  - 'openSUSE Tumbleweed'
+  - 'ClearLinux'
+  - 'OracleLinux'
+  - 'AlmaLinux'
+  - 'Rocky'
+  - 'Amazon'
+  - 'Kylin Linux Advanced Server'
+  - 'UnionTech'
+  - 'UniontechOS'
+  - 'openEuler'
+
+# Extending some distributions into the redhat os family
+redhat_os_family_extensions:
+  - "Kylin Linux Advanced Server"
+  - "openEuler"
+  - "UnionTech"
+  - "UniontechOS"

--- a/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-verify-settings.yml
@@ -22,9 +22,9 @@
     that: ansible_service_mgr == "systemd"
   when: not ignore_assert_errors
 
-- name: Stop if unknown OS
+- name: Stop if the os does not support
   assert:
-    that: ansible_distribution in ['RedHat', 'CentOS', 'Fedora', 'Ubuntu', 'Debian', 'Flatcar', 'Flatcar Container Linux by Kinvolk', 'Suse', 'openSUSE Leap', 'openSUSE Tumbleweed', 'ClearLinux', 'OracleLinux', 'AlmaLinux', 'Rocky', 'Amazon', 'Kylin Linux Advanced Server', 'UnionTech', 'openEuler']
+    that: ansible_distribution in supported_os_distributions
     msg: "{{ ansible_distribution }} is not a known OS"
   when: not ignore_assert_errors
 

--- a/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-set_facts.yml
@@ -10,7 +10,7 @@
   set_fact:
     ansible_os_family: "RedHat"
     ansible_distribution_major_version: "8"
-  when: ansible_distribution in ["Kylin Linux Advanced Server", "openEuler"]
+  when: ansible_distribution in redhat_os_family_extensions
   tags:
     - facts
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
When os is UnionTech, the variables `ntp_package` and `dhclienthookfile` will have incorrect values and cause the cluster installation to fail.
![image](https://user-images.githubusercontent.com/10629406/223448983-ddbf7e06-77f6-47df-80a9-81763d42f420.png)
![image](https://user-images.githubusercontent.com/10629406/223449029-bbbe5ef4-5ddf-45d7-8330-235d5598c4cf.png)
this PR fixes the above problem.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
