### PR TITLE
[2.21] Fix cilium's hubble ui configuration (#9735)

### DIFF
--- a/roles/network_plugin/cilium/templates/hubble/config.yml.j2
+++ b/roles/network_plugin/cilium/templates/hubble/config.yml.j2
@@ -19,69 +19,48 @@ data:
     disable-server-tls: {% if cilium_hubble_tls_generate %}false{% else %}true{% endif %}
     disable-client-tls: {% if cilium_hubble_tls_generate %}false{% else %}true{% endif %}
 ---
-# Source: cilium/templates/hubble-ui-configmap.yaml
+# Source: cilium/templates/hubble-ui/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: hubble-ui-envoy
+  name: hubble-ui-nginx
   namespace: kube-system
 data:
-  envoy.yaml: |
-    static_resources:
-      listeners:
-        - name: listener_hubble_ui
-          address:
-            socket_address:
-              address: 0.0.0.0
-              port_value: 8081
-          filter_chains:
-            - filters:
-                - name: envoy.filters.network.http_connection_manager
-                  config:
-                    codec_type: auto
-                    stat_prefix: ingress_http
-                    route_config:
-                      name: local_route
-                      virtual_hosts:
-                        - name: local_service
-                          domains: ['*']
-                          routes:
-                            - match:
-                                prefix: '/api/'
-                              route:
-                                cluster: backend
-                                max_grpc_timeout: 0s
-                                prefix_rewrite: '/'
-                            - match:
-                                prefix: '/'
-                              route:
-                                cluster: frontend
-                          cors:
-                            allow_origin_string_match:
-                              - prefix: '*'
-                            allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                            allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
-                            max_age: '1728000'
-                            expose_headers: grpc-status,grpc-message
-                    http_filters:
-                      - name: envoy.filters.http.grpc_web
-                      - name: envoy.filters.http.cors
-                      - name: envoy.filters.http.router
-      clusters:
-        - name: frontend
-          connect_timeout: 0.25s
-          type: strict_dns
-          lb_policy: round_robin
-          hosts:
-            - socket_address:
-                address: 127.0.0.1
-                port_value: 8080
-        - name: backend
-          connect_timeout: 0.25s
-          type: logical_dns
-          lb_policy: round_robin
-          http2_protocol_options: {}
-          hosts:
-            - socket_address:
-                address: 127.0.0.1
-                port_value: 8090
+  nginx.conf: |
+    server {
+        listen       8081;
+    {% if cilium_enable_ipv6 %}
+        listen       [::]:8081;
+    {% endif %}
+        server_name  localhost;
+        root /app;
+        index index.html;
+        client_max_body_size 1G;
+
+        location / {
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+
+            # CORS
+            add_header Access-Control-Allow-Methods "GET, POST, PUT, HEAD, DELETE, OPTIONS";
+            add_header Access-Control-Allow-Origin *;
+            add_header Access-Control-Max-Age 1728000;
+            add_header Access-Control-Expose-Headers content-length,grpc-status,grpc-message;
+            add_header Access-Control-Allow-Headers range,keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout;
+            if ($request_method = OPTIONS) {
+                return 204;
+            }
+            # /CORS
+
+            location /api {
+                proxy_http_version 1.1;
+                proxy_pass_request_headers on;
+                proxy_hide_header Access-Control-Allow-Origin;
+                proxy_pass http://127.0.0.1:8090;
+            }
+
+            location / {
+                try_files $uri $uri/ /index.html;
+            }
+        }
+    }

--- a/roles/network_plugin/cilium/templates/hubble/deploy.yml.j2
+++ b/roles/network_plugin/cilium/templates/hubble/deploy.yml.j2
@@ -90,7 +90,7 @@ spec:
                   path: hubble-server-ca.crt
         name: tls
 ---
-# Source: cilium/templates/hubble-ui-deployment.yaml
+# Source: cilium/templates/hubble-ui/deployment.yaml
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -118,8 +118,14 @@ spec:
           image: "{{ cilium_hubble_ui_image_repo }}:{{ cilium_hubble_ui_image_tag }}"
           imagePullPolicy: {{ k8s_image_pull_policy }}
           ports:
-            - containerPort: 8080
+            - containerPort: 8081
               name: http
+          volumeMounts:
+            - name: hubble-ui-nginx-conf
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: nginx.conf
+            - name: tmp-dir
+              mountPath: /tmp
           resources:
             {}
         - name: backend
@@ -135,27 +141,10 @@ spec:
               name: grpc
           resources:
             {}
-        - name: proxy
-          image: "{{ cilium_hubble_envoy_image_repo }}:{{ cilium_hubble_envoy_image_tag }}"
-          imagePullPolicy: {{ k8s_image_pull_policy }}
-          ports:
-            - containerPort: 8081
-              name: http
-          resources:
-            {}
-          command: ["envoy"]
-          args:
-            [
-              "-c",
-              "/etc/envoy.yaml",
-              "-l",
-              "info"
-            ]
-          volumeMounts:
-            - name: hubble-ui-envoy-yaml
-              mountPath: /etc/envoy.yaml
-              subPath: envoy.yaml
       volumes:
-        - name: hubble-ui-envoy-yaml
-          configMap:
-            name: hubble-ui-envoy
+        - configMap:
+            defaultMode: 420
+            name: hubble-ui-nginx
+          name: hubble-ui-nginx-conf
+        - emptyDir: {}
+          name: tmp-dir


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This fixes the CrashLoopBackoff error that appears because envoy configuration has changed a lot and upstream removed the envoy proxy to use nginx only instead.
Those changes are based on upstream cilium helm.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9567
Fixes #9857

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix cilium's hubble ui configuration
```
