### PR TITLE
Enable to sort kube_control_plane including the first node

### DIFF
--- a/contrib/network-storage/glusterfs/roles/kubernetes-pv/ansible/tasks/main.yaml
+++ b/contrib/network-storage/glusterfs/roles/kubernetes-pv/ansible/tasks/main.yaml
@@ -9,7 +9,7 @@
     - { file: glusterfs-kubernetes-pv.yml.j2, type: pv, dest: glusterfs-kubernetes-pv.yml}
     - { file: glusterfs-kubernetes-endpoint-svc.json.j2, type: svc, dest: glusterfs-kubernetes-endpoint-svc.json}
   register: gluster_pv
-  when: inventory_hostname == groups['kube_control_plane'][0] and groups['gfs-cluster'] is defined and hostvars[groups['gfs-cluster'][0]].gluster_disk_size_gb is defined
+  when: inventory_hostname == first_kube_control_plane and groups['gfs-cluster'] is defined and hostvars[groups['gfs-cluster'][0]].gluster_disk_size_gb is defined
 
 - name: Kubernetes Apps | Set GlusterFS endpoint and PV
   kube:
@@ -20,4 +20,4 @@
     filename: "{{ kube_config_dir }}/{{ item.item.dest }}"
     state: "{{ item.changed | ternary('latest','present') }}"
   with_items: "{{ gluster_pv.results }}"
-  when: inventory_hostname == groups['kube_control_plane'][0] and groups['gfs-cluster'] is defined
+  when: inventory_hostname == first_kube_control_plane and groups['gfs-cluster'] is defined

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -2,9 +2,9 @@
 
 Modified from [comments in #3471](https://github.com/kubernetes-sigs/kubespray/issues/3471#issuecomment-530036084)
 
-## Limitation: Removal of first kube_control_plane and etcd-master
+## Limitation: Removal of first etcd_master
 
-Currently you can't remove the first node in your kube_control_plane and etcd-master list. If you still want to remove this node you have to:
+Currently you can't remove the first node in your etcd_master list. If you still want to remove this node you have to:
 
 ### 1) Change order of current control planes
 
@@ -12,16 +12,6 @@ Modify the order of your control plane list by pushing your first entry to any o
 
 ```yaml
   children:
-    kube_control_plane:
-      hosts:
-        node-1:
-        node-2:
-        node-3:
-    kube_node:
-      hosts:
-        node-1:
-        node-2:
-        node-3:
     etcd:
       hosts:
         node-1:
@@ -33,16 +23,6 @@ change your inventory to:
 
 ```yaml
   children:
-    kube_control_plane:
-      hosts:
-        node-2:
-        node-3:
-        node-1:
-    kube_node:
-      hosts:
-        node-2:
-        node-3:
-        node-1:
     etcd:
       hosts:
         node-2:
@@ -96,45 +76,6 @@ docker ps | grep k8s_nginx-proxy_nginx-proxy | awk '{print $1}' | xargs docker r
 
 With the old node still in the inventory, run `remove-node.yml`. You need to pass `-e node=NODE_NAME` to the playbook to limit the execution to the node being removed.
 If the node you want to remove is not online, you should add `reset_nodes=false` and `allow_ungraceful_removal=true` to your extra-vars.
-
-## Replacing a first control plane node
-
-### 1) Change control plane nodes order in inventory
-
-from
-
-```ini
-[kube_control_plane]
- node-1
- node-2
- node-3
-```
-
-to
-
-```ini
-[kube_control_plane]
- node-2
- node-3
- node-1
-```
-
-### 2) Remove old first control plane node from cluster
-
-With the old node still in the inventory, run `remove-node.yml`. You need to pass `-e node=node-1` to the playbook to limit the execution to the node being removed.
-If the node you want to remove is not online, you should add `reset_nodes=false` and `allow_ungraceful_removal=true` to your extra-vars.
-
-### 3) Edit cluster-info configmap in kube-public namespace
-
-`kubectl  edit cm -n kube-public cluster-info`
-
-Change ip of old kube_control_plane node with ip of live kube_control_plane node (`server` field). Also, update `certificate-authority-data` field if you changed certs.
-
-### 4) Add new control plane node
-
-Update inventory (if needed)
-
-Run `cluster.yml` with `--limit=kube_control_plane`
 
 ## Adding an etcd node
 

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -48,7 +48,7 @@ download_always_pull: false
 download_validate_certs: true
 
 # Use the first kube_control_plane if download_localhost is not set
-download_delegate: "{% if download_localhost %}localhost{% else %}{{ groups['kube_control_plane'][0] }}{% endif %}"
+download_delegate: "{% if download_localhost %}localhost{% else %}{{ first_kube_control_plane }}{% endif %}"
 
 # The docker_image_info_command might seems weird but we are using raw/endraw and `{{ `{{` }}` to manage the double jinja2 processing
 docker_image_pull_command: "{{ docker_bin_dir }}/docker pull"

--- a/roles/kubernetes-apps/ansible/tasks/cleanup_dns.yml
+++ b/roles/kubernetes-apps/ansible/tasks/cleanup_dns.yml
@@ -7,7 +7,7 @@
   ignore_errors: true  # noqa ignore-errors
   when:
     - dns_mode in ['coredns', 'coredns_dual']
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Kubernetes Apps | Register coredns service annotation `createdby`
   command: "{{ kubectl }} get svc -n kube-system coredns -o jsonpath='{ .metadata.annotations.createdby }'"
@@ -17,7 +17,7 @@
   ignore_errors: true  # noqa ignore-errors
   when:
     - dns_mode in ['coredns', 'coredns_dual']
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Kubernetes Apps | Delete kubeadm CoreDNS
   kube:
@@ -28,7 +28,7 @@
     state: absent
   when:
     - dns_mode in ['coredns', 'coredns_dual']
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - createdby_annotation_deploy.stdout != 'kubespray'
 
 - name: Kubernetes Apps | Delete kubeadm Kube-DNS service
@@ -40,5 +40,5 @@
     state: absent
   when:
     - dns_mode in ['coredns', 'coredns_dual']
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - createdby_annotation_svc.stdout != 'kubespray'

--- a/roles/kubernetes-apps/ansible/tasks/coredns.yml
+++ b/roles/kubernetes-apps/ansible/tasks/coredns.yml
@@ -20,7 +20,7 @@
     clusterIP: "{{ skydns_server }}"
   when:
     - dns_mode in ['coredns', 'coredns_dual']
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
   tags:
     - coredns
 
@@ -39,6 +39,6 @@
     coredns_ordinal_suffix: "-secondary"
   when:
     - dns_mode == 'coredns_dual'
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
   tags:
     - coredns

--- a/roles/kubernetes-apps/ansible/tasks/dashboard.yml
+++ b/roles/kubernetes-apps/ansible/tasks/dashboard.yml
@@ -7,7 +7,7 @@
   with_items:
     - { file: dashboard.yml, type: deploy, name: kubernetes-dashboard }
   register: manifests
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: Kubernetes Apps | Start dashboard
   kube:
@@ -18,4 +18,4 @@
     filename: "{{ kube_config_dir }}/{{ item.item.file }}"
     state: "latest"
   with_items: "{{ manifests.results }}"
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane

--- a/roles/kubernetes-apps/ansible/tasks/etcd_metrics.yml
+++ b/roles/kubernetes-apps/ansible/tasks/etcd_metrics.yml
@@ -8,7 +8,7 @@
     - { file: etcd_metrics-endpoints.yml, type: endpoints, name: etcd-metrics }
     - { file: etcd_metrics-service.yml, type: service, name: etcd-metrics }
   register: manifests
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: Kubernetes Apps | Start etcd_metrics
   kube:
@@ -19,4 +19,4 @@
     filename: "{{ kube_config_dir }}/{{ item.item.file }}"
     state: "latest"
   with_items: "{{ manifests.results }}"
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane

--- a/roles/kubernetes-apps/ansible/tasks/main.yml
+++ b/roles/kubernetes-apps/ansible/tasks/main.yml
@@ -9,12 +9,12 @@
   until: result.status == 200
   retries: 20
   delay: 1
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: Kubernetes Apps | Cleanup DNS
   import_tasks: cleanup_dns.yml
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
   tags:
     - upgrade
     - coredns
@@ -24,7 +24,7 @@
   import_tasks: "coredns.yml"
   when:
     - dns_mode in ['coredns', 'coredns_dual']
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
   tags:
     - coredns
 
@@ -32,7 +32,7 @@
   import_tasks: "nodelocaldns.yml"
   when:
     - enable_nodelocaldns
-    - inventory_hostname == groups['kube_control_plane'] | first
+    - inventory_hostname == first_kube_control_plane
   tags:
     - nodelocaldns
 
@@ -51,7 +51,7 @@
     - "{{ nodelocaldns_second_manifests.results | default({}) }}"
   when:
     - dns_mode != 'none'
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - not item is skipped
   register: resource_result
   until: resource_result is succeeded

--- a/roles/kubernetes-apps/ansible/tasks/netchecker.yml
+++ b/roles/kubernetes-apps/ansible/tasks/netchecker.yml
@@ -3,14 +3,14 @@
   command: which apparmor_parser
   register: apparmor_status
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
   failed_when: false
 
 - name: Kubernetes Apps | Set apparmor_enabled
   set_fact:
     apparmor_enabled: "{{ apparmor_status.rc == 0 }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Kubernetes Apps | Netchecker Templates list
   set_fact:
@@ -42,7 +42,7 @@
   with_items: "{{ netchecker_templates }}"
   register: manifests
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Kubernetes Apps | Start Netchecker Resources
   kube:
@@ -53,4 +53,4 @@
     filename: "{{ kube_config_dir }}/{{ item.item.file }}"
     state: "latest"
   with_items: "{{ manifests.results }}"
-  when: inventory_hostname == groups['kube_control_plane'][0] and not item is skipped
+  when: inventory_hostname == first_kube_control_plane and not item is skipped

--- a/roles/kubernetes-apps/ansible/tasks/nodelocaldns.yml
+++ b/roles/kubernetes-apps/ansible/tasks/nodelocaldns.yml
@@ -10,7 +10,7 @@
     secondaryclusterIP: "{{ skydns_server_secondary }}"
   when:
     - enable_nodelocaldns
-    - inventory_hostname == groups['kube_control_plane'] | first
+    - inventory_hostname == first_kube_control_plane
   tags:
     - nodelocaldns
     - coredns
@@ -40,7 +40,7 @@
       {%- endif -%}
   when:
     - enable_nodelocaldns
-    - inventory_hostname == groups['kube_control_plane'] | first
+    - inventory_hostname == first_kube_control_plane
   tags:
     - nodelocaldns
     - coredns
@@ -69,7 +69,7 @@
   when:
     - enable_nodelocaldns
     - enable_nodelocaldns_secondary
-    - inventory_hostname == groups['kube_control_plane'] | first
+    - inventory_hostname == first_kube_control_plane
   tags:
     - nodelocaldns
     - coredns

--- a/roles/kubernetes-apps/argocd/tasks/main.yml
+++ b/roles/kubernetes-apps/argocd/tasks/main.yml
@@ -24,7 +24,7 @@
         namespace: "{{ argocd_namespace }}"
         url: "https://raw.githubusercontent.com/argoproj/argo-cd/{{ argocd_version }}/manifests/install.yaml"
   when:
-    - "inventory_hostname == groups['kube_control_plane'][0]"
+    - "inventory_hostname == first_kube_control_plane"
 
 - name: Kubernetes Apps | Download ArgoCD remote manifests
   include_tasks: "../../../download/tasks/download_file.yml"
@@ -43,7 +43,7 @@
   loop_control:
     label: "{{ item.file }}"
   when:
-    - "inventory_hostname == groups['kube_control_plane'][0]"
+    - "inventory_hostname == first_kube_control_plane"
 
 - name: Kubernetes Apps | Copy ArgoCD remote manifests from download dir
   synchronize:
@@ -66,7 +66,7 @@
   loop_control:
     label: "{{ item.file }}"
   when:
-    - "inventory_hostname == groups['kube_control_plane'][0]"
+    - "inventory_hostname == first_kube_control_plane"
 
 - name: Kubernetes Apps | Create ArgoCD manifests from templates
   become: yes
@@ -78,7 +78,7 @@
   loop_control:
     label: "{{ item.file }}"
   when:
-    - "inventory_hostname == groups['kube_control_plane'][0]"
+    - "inventory_hostname == first_kube_control_plane"
 
 - name: Kubernetes Apps | Install ArgoCD
   become: yes
@@ -89,7 +89,7 @@
     state: latest
   with_items: "{{ argocd_templates }}"
   when:
-    - "inventory_hostname == groups['kube_control_plane'][0]"
+    - "inventory_hostname == first_kube_control_plane"
 
 # https://github.com/argoproj/argo-cd/blob/master/docs/faq.md#i-forgot-the-admin-password-how-do-i-reset-it
 - name: Kubernetes Apps | Set ArgoCD custom admin password
@@ -104,4 +104,4 @@
       }'
   when:
     - argocd_admin_password is defined
-    - "inventory_hostname == groups['kube_control_plane'][0]"
+    - "inventory_hostname == first_kube_control_plane"

--- a/roles/kubernetes-apps/cloud_controller/oci/tasks/main.yml
+++ b/roles/kubernetes-apps/cloud_controller/oci/tasks/main.yml
@@ -7,7 +7,7 @@
     src: controller-manager-config.yml.j2
     dest: "{{ kube_config_dir }}/controller-manager-config.yml"
     mode: 0644
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: "OCI Cloud Controller | Slurp Configuration"
   slurp:
@@ -17,18 +17,18 @@
 - name: "OCI Cloud Controller | Encode Configuration"
   set_fact:
     controller_manager_config_base64: "{{ controller_manager_config.content }}"
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: "OCI Cloud Controller | Generate Manifests"
   template:
     src: oci-cloud-provider.yml.j2
     dest: "{{ kube_config_dir }}/oci-cloud-provider.yml"
     mode: 0644
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: "OCI Cloud Controller | Apply Manifests"
   kube:
     kubectl: "{{ bin_dir }}/kubectl"
     filename: "{{ kube_config_dir }}/oci-cloud-provider.yml"
     state: latest
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane

--- a/roles/kubernetes-apps/cluster_roles/tasks/main.yml
+++ b/roles/kubernetes-apps/cluster_roles/tasks/main.yml
@@ -9,7 +9,7 @@
   until: result.status == 200
   retries: 10
   delay: 6
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: Kubernetes Apps | Add ClusterRoleBinding to admit nodes
   template:
@@ -19,7 +19,7 @@
   register: node_crb_manifest
   when:
     - rbac_enabled
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Apply workaround to allow all nodes with cert O=system:nodes to register
   kube:
@@ -35,7 +35,7 @@
   when:
     - rbac_enabled
     - node_crb_manifest.changed
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Kubernetes Apps | Remove old webhook ClusterRole
   kube:
@@ -45,7 +45,7 @@
     state: absent
   when:
     - rbac_enabled
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
   tags: node-webhook
 
 - name: Kubernetes Apps | Remove old webhook ClusterRoleBinding
@@ -56,7 +56,7 @@
     state: absent
   when:
     - rbac_enabled
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
   tags: node-webhook
 
 - include_tasks: oci.yml

--- a/roles/kubernetes-apps/cluster_roles/tasks/oci.yml
+++ b/roles/kubernetes-apps/cluster_roles/tasks/oci.yml
@@ -7,7 +7,7 @@
   when:
   - cloud_provider is defined
   - cloud_provider == 'oci'
-  - inventory_hostname == groups['kube_control_plane'][0]
+  - inventory_hostname == first_kube_control_plane
 
 - name: Apply OCI RBAC
   kube:
@@ -16,4 +16,4 @@
   when:
   - cloud_provider is defined
   - cloud_provider == 'oci'
-  - inventory_hostname == groups['kube_control_plane'][0]
+  - inventory_hostname == first_kube_control_plane

--- a/roles/kubernetes-apps/container_engine_accelerator/nvidia_gpu/tasks/main.yml
+++ b/roles/kubernetes-apps/container_engine_accelerator/nvidia_gpu/tasks/main.yml
@@ -39,7 +39,7 @@
     - { name: k8s-device-plugin-nvidia-daemonset, file: k8s-device-plugin-nvidia-daemonset.yml, type: daemonset }
   register: container_engine_accelerator_manifests
   when:
-    - inventory_hostname == groups['kube_control_plane'][0] and nvidia_driver_install_container
+    - inventory_hostname == first_kube_control_plane and nvidia_driver_install_container
 
 - name: Container Engine Acceleration Nvidia GPU | Apply manifests for nvidia accelerators
   kube:
@@ -52,4 +52,4 @@
   with_items:
     - "{{ container_engine_accelerator_manifests.results }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0] and nvidia_driver_install_container and nvidia_driver_install_supported
+    - inventory_hostname == first_kube_control_plane and nvidia_driver_install_container and nvidia_driver_install_supported

--- a/roles/kubernetes-apps/container_runtimes/crun/tasks/main.yaml
+++ b/roles/kubernetes-apps/container_runtimes/crun/tasks/main.yaml
@@ -6,7 +6,7 @@
     dest: "{{ kube_config_dir }}/runtimeclass-crun.yml"
     mode: "0664"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: crun | Apply manifests
   kube:
@@ -16,4 +16,4 @@
     filename: "{{ kube_config_dir }}/runtimeclass-crun.yml"
     state: "latest"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane

--- a/roles/kubernetes-apps/container_runtimes/gvisor/tasks/main.yaml
+++ b/roles/kubernetes-apps/container_runtimes/gvisor/tasks/main.yaml
@@ -20,7 +20,7 @@
   with_items: "{{ gvisor_templates }}"
   register: gvisor_manifests
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: gVisor | Apply manifests
   kube:
@@ -31,4 +31,4 @@
     state: "latest"
   with_items: "{{ gvisor_manifests.results }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane

--- a/roles/kubernetes-apps/container_runtimes/kata_containers/tasks/main.yaml
+++ b/roles/kubernetes-apps/container_runtimes/kata_containers/tasks/main.yaml
@@ -21,7 +21,7 @@
   with_items: "{{ kata_containers_templates }}"
   register: kata_containers_manifests
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Kata Containers | Apply manifests
   kube:
@@ -32,4 +32,4 @@
     state: "latest"
   with_items: "{{ kata_containers_manifests.results }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane

--- a/roles/kubernetes-apps/container_runtimes/youki/tasks/main.yaml
+++ b/roles/kubernetes-apps/container_runtimes/youki/tasks/main.yaml
@@ -6,7 +6,7 @@
     dest: "{{ kube_config_dir }}/runtimeclass-youki.yml"
     mode: "0664"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: youki | Apply manifests
   kube:
@@ -16,4 +16,4 @@
     filename: "{{ kube_config_dir }}/runtimeclass-youki.yml"
     state: "latest"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane

--- a/roles/kubernetes-apps/csi_driver/aws_ebs/tasks/main.yml
+++ b/roles/kubernetes-apps/csi_driver/aws_ebs/tasks/main.yml
@@ -10,7 +10,7 @@
     - {name: aws-ebs-csi-controllerservice, file: aws-ebs-csi-controllerservice.yml}
     - {name: aws-ebs-csi-nodeservice, file: aws-ebs-csi-nodeservice.yml}
   register: aws_csi_manifests
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: AWS CSI Driver | Apply Manifests
   kube:
@@ -20,7 +20,7 @@
   with_items:
     - "{{ aws_csi_manifests.results }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - not item is skipped
   loop_control:
     label: "{{ item.item.file }}"

--- a/roles/kubernetes-apps/csi_driver/azuredisk/tasks/main.yml
+++ b/roles/kubernetes-apps/csi_driver/azuredisk/tasks/main.yml
@@ -7,13 +7,13 @@
     dest: "{{ kube_config_dir }}/azure_csi_cloud_config"
     group: "{{ kube_cert_group }}"
     mode: 0640
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: Azure CSI Driver | Get base64 cloud-config
   slurp:
     src: "{{ kube_config_dir }}/azure_csi_cloud_config"
   register: cloud_config_secret
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: Azure CSI Driver | Generate Manifests
   template:
@@ -28,7 +28,7 @@
     - {name: azure-csi-azuredisk-node-rbac, file: azure-csi-azuredisk-node-rbac.yml}
     - {name: azure-csi-azuredisk-node, file: azure-csi-azuredisk-node.yml}
   register: azure_csi_manifests
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: Azure CSI Driver | Apply Manifests
   kube:
@@ -38,7 +38,7 @@
   with_items:
     - "{{ azure_csi_manifests.results }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - not item is skipped
   loop_control:
     label: "{{ item.item.file }}"

--- a/roles/kubernetes-apps/csi_driver/cinder/tasks/main.yml
+++ b/roles/kubernetes-apps/csi_driver/cinder/tasks/main.yml
@@ -18,13 +18,13 @@
     dest: "{{ kube_config_dir }}/cinder_cloud_config"
     group: "{{ kube_cert_group }}"
     mode: 0640
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: Cinder CSI Driver | Get base64 cloud-config
   slurp:
     src: "{{ kube_config_dir }}/cinder_cloud_config"
   register: cloud_config_secret
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: Cinder CSI Driver | Generate Manifests
   template:
@@ -40,7 +40,7 @@
     - {name: cinder-csi-nodeplugin, file: cinder-csi-nodeplugin.yml}
     - {name: cinder-csi-poddisruptionbudget, file: cinder-csi-poddisruptionbudget.yml}
   register: cinder_csi_manifests
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: Cinder CSI Driver | Apply Manifests
   kube:
@@ -50,7 +50,7 @@
   with_items:
     - "{{ cinder_csi_manifests.results }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - not item is skipped
   loop_control:
     label: "{{ item.item.file }}"

--- a/roles/kubernetes-apps/csi_driver/csi_crd/tasks/main.yml
+++ b/roles/kubernetes-apps/csi_driver/csi_crd/tasks/main.yml
@@ -9,7 +9,7 @@
     - {name: volumesnapshotcontents, file: volumesnapshotcontents.yml}
     - {name: volumesnapshots, file: volumesnapshots.yml}
   register: csi_crd_manifests
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: CSI CRD | Apply Manifests
   kube:
@@ -20,7 +20,7 @@
   with_items:
     - "{{ csi_crd_manifests.results }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - not item is skipped
   loop_control:
     label: "{{ item.item.file }}"

--- a/roles/kubernetes-apps/csi_driver/gcp_pd/tasks/main.yml
+++ b/roles/kubernetes-apps/csi_driver/gcp_pd/tasks/main.yml
@@ -10,13 +10,13 @@
     dest: "{{ kube_config_dir }}/cloud-sa.json"
     group: "{{ kube_cert_group }}"
     mode: 0640
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: GCP PD CSI Driver | Get base64 cloud-sa.json
   slurp:
     src: "{{ kube_config_dir }}/cloud-sa.json"
   register: gcp_cred_secret
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: GCP PD CSI Driver | Generate Manifests
   template:
@@ -29,7 +29,7 @@
     - {name: gcp-pd-csi-controller, file: gcp-pd-csi-controller.yml}
     - {name: gcp-pd-csi-node, file: gcp-pd-csi-node.yml}
   register: gcp_pd_csi_manifests
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: GCP PD CSI Driver | Apply Manifests
   kube:
@@ -39,7 +39,7 @@
   with_items:
     - "{{ gcp_pd_csi_manifests.results }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - not item is skipped
   loop_control:
     label: "{{ item.item.file }}"

--- a/roles/kubernetes-apps/csi_driver/upcloud/tasks/main.yml
+++ b/roles/kubernetes-apps/csi_driver/upcloud/tasks/main.yml
@@ -24,7 +24,7 @@
     - {name: upcloud-csi-node, file: upcloud-csi-node.yml}
     - {name: upcloud-csi-driver, file: upcloud-csi-driver.yml}
   register: upcloud_csi_manifests
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: UpCloud CSI Driver | Apply Manifests
   kube:
@@ -34,7 +34,7 @@
   with_items:
     - "{{ upcloud_csi_manifests.results }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - not item is skipped
   loop_control:
     label: "{{ item.item.file }}"

--- a/roles/kubernetes-apps/csi_driver/vsphere/tasks/main.yml
+++ b/roles/kubernetes-apps/csi_driver/vsphere/tasks/main.yml
@@ -8,7 +8,7 @@
     mode: 0640
   with_items:
     - vsphere-csi-cloud-config
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: vSphere CSI Driver | Generate Manifests
   template:
@@ -25,19 +25,19 @@
     - vsphere-csi-controller-service.yml
     - vsphere-csi-node.yml
   register: vsphere_csi_manifests
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: vSphere CSI Driver | Generate a CSI secret manifest
   command: "{{ kubectl }} create secret generic vsphere-config-secret --from-file=csi-vsphere.conf={{ kube_config_dir }}/vsphere-csi-cloud-config -n {{ vsphere_csi_namespace }} --dry-run --save-config -o yaml"
   register: vsphere_csi_secret_manifest
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
   no_log: "{{ not (unsafe_show_logs|bool) }}"
 
 - name: vSphere CSI Driver | Apply a CSI secret manifest
   command:
     cmd: "{{ kubectl }} apply -f -"
     stdin: "{{ vsphere_csi_secret_manifest.stdout }}"
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
   no_log: "{{ not (unsafe_show_logs|bool) }}"
 
 - name: vSphere CSI Driver | Apply Manifests
@@ -48,7 +48,7 @@
   with_items:
     - "{{ vsphere_csi_manifests.results }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - not item is skipped
   loop_control:
     label: "{{ item.item }}"

--- a/roles/kubernetes-apps/external_cloud_controller/hcloud/tasks/main.yml
+++ b/roles/kubernetes-apps/external_cloud_controller/hcloud/tasks/main.yml
@@ -12,7 +12,7 @@
     - {name: "{{ 'external-hcloud-cloud-controller-manager-ds-with-networks' if external_hcloud_cloud.with_networks  else 'external-hcloud-cloud-controller-manager-ds' }}", file: "{{ 'external-hcloud-cloud-controller-manager-ds-with-networks.yml' if external_hcloud_cloud.with_networks  else  'external-hcloud-cloud-controller-manager-ds.yml' }}"}
 
   register: external_hcloud_manifests
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
   tags: external-hcloud
 
 - name: External Hcloud Cloud Controller | Apply Manifests
@@ -23,7 +23,7 @@
   with_items:
     - "{{ external_hcloud_manifests.results }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - not item is skipped
   loop_control:
     label: "{{ item.item.file }}"

--- a/roles/kubernetes-apps/external_cloud_controller/meta/main.yml
+++ b/roles/kubernetes-apps/external_cloud_controller/meta/main.yml
@@ -6,7 +6,7 @@ dependencies:
       - cloud_provider == "external"
       - external_cloud_provider is defined
       - external_cloud_provider == "openstack"
-      - inventory_hostname == groups['kube_control_plane'][0]
+      - inventory_hostname == first_kube_control_plane
     tags:
       - external-cloud-controller
       - external-openstack
@@ -16,7 +16,7 @@ dependencies:
       - cloud_provider == "external"
       - external_cloud_provider is defined
       - external_cloud_provider == "vsphere"
-      - inventory_hostname == groups['kube_control_plane'][0]
+      - inventory_hostname == first_kube_control_plane
     tags:
       - external-cloud-controller
       - external-vsphere
@@ -26,7 +26,7 @@ dependencies:
       - cloud_provider == "external"
       - external_cloud_provider is defined
       - external_cloud_provider == "hcloud"
-      - inventory_hostname == groups['kube_control_plane'][0]
+      - inventory_hostname == first_kube_control_plane
     tags:
       - external-cloud-controller
       - external-hcloud

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/tasks/main.yml
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/tasks/main.yml
@@ -7,7 +7,7 @@
     src: "{{ external_openstack_cacert }}"
   register: external_openstack_cacert_b64
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - external_openstack_cacert is defined
     - external_openstack_cacert | length > 0
   tags: external-openstack
@@ -15,7 +15,7 @@
 - name: External OpenStack Cloud Controller | Get base64 cloud-config
   set_fact:
     external_openstack_cloud_config_secret: "{{ lookup('template', 'external-openstack-cloud-config.j2') | b64encode }}"
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
   tags: external-openstack
 
 - name: External OpenStack Cloud Controller | Generate Manifests
@@ -30,7 +30,7 @@
     - {name: external-openstack-cloud-controller-manager-role-bindings, file: external-openstack-cloud-controller-manager-role-bindings.yml}
     - {name: external-openstack-cloud-controller-manager-ds, file: external-openstack-cloud-controller-manager-ds.yml}
   register: external_openstack_manifests
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
   tags: external-openstack
 
 - name: External OpenStack Cloud Controller | Apply Manifests
@@ -41,7 +41,7 @@
   with_items:
     - "{{ external_openstack_manifests.results }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - not item is skipped
   loop_control:
     label: "{{ item.item.file }}"

--- a/roles/kubernetes-apps/external_cloud_controller/vsphere/tasks/main.yml
+++ b/roles/kubernetes-apps/external_cloud_controller/vsphere/tasks/main.yml
@@ -8,7 +8,7 @@
     mode: 0640
   with_items:
     - external-vsphere-cpi-cloud-config
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: External vSphere Cloud Controller | Generate Manifests
   template:
@@ -21,18 +21,18 @@
     - external-vsphere-cloud-controller-manager-role-bindings.yml
     - external-vsphere-cloud-controller-manager-ds.yml
   register: external_vsphere_manifests
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: External vSphere Cloud Provider Interface | Create a CPI configMap manifest
   command: "{{ bin_dir }}/kubectl create configmap cloud-config --from-file=vsphere.conf={{ kube_config_dir }}/external-vsphere-cpi-cloud-config -n kube-system --dry-run --save-config -o yaml"
   register: external_vsphere_configmap_manifest
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: External vSphere Cloud Provider Interface | Apply a CPI configMap manifest
   command:
     cmd: "{{ bin_dir }}/kubectl apply -f -"
     stdin: "{{ external_vsphere_configmap_manifest.stdout }}"
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: External vSphere Cloud Controller | Apply Manifests
   kube:
@@ -42,7 +42,7 @@
   with_items:
     - "{{ external_vsphere_manifests.results }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - not item is skipped
   loop_control:
     label: "{{ item.item }}"

--- a/roles/kubernetes-apps/external_provisioner/cephfs_provisioner/tasks/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/cephfs_provisioner/tasks/main.yml
@@ -5,7 +5,7 @@
     path: "{{ kube_config_dir }}/addons/cephfs_provisioner"
     state: absent
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
   tags:
     - upgrade
 
@@ -14,7 +14,7 @@
     {{ kubectl }} delete namespace {{ cephfs_provisioner_namespace }}
   ignore_errors: true  # noqa ignore-errors
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
   tags:
     - upgrade
 
@@ -23,7 +23,7 @@
     {{ kubectl }} delete storageclass {{ cephfs_provisioner_storage_class }}
   ignore_errors: true  # noqa ignore-errors
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
   tags:
     - upgrade
 
@@ -35,7 +35,7 @@
     group: root
     mode: 0755
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: CephFS Provisioner | Templates list
   set_fact:
@@ -66,7 +66,7 @@
     mode: 0644
   with_items: "{{ cephfs_provisioner_templates }}"
   register: cephfs_provisioner_manifests
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: CephFS Provisioner | Apply manifests
   kube:
@@ -77,4 +77,4 @@
     filename: "{{ kube_config_dir }}/addons/cephfs_provisioner/{{ item.item.file }}"
     state: "latest"
   with_items: "{{ cephfs_provisioner_manifests.results }}"
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane

--- a/roles/kubernetes-apps/external_provisioner/local_path_provisioner/tasks/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/local_path_provisioner/tasks/main.yml
@@ -7,7 +7,7 @@
     group: root
     mode: 0755
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Local Path Provisioner | Create claim root dir
   file:
@@ -44,7 +44,7 @@
     mode: 0644
   with_items: "{{ local_path_provisioner_templates }}"
   register: local_path_provisioner_manifests
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: Local Path Provisioner | Apply manifests
   kube:
@@ -55,4 +55,4 @@
     filename: "{{ kube_config_dir }}/addons/local_path_provisioner/{{ item.item.file }}"
     state: "latest"
   with_items: "{{ local_path_provisioner_manifests.results }}"
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane

--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/tasks/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/tasks/main.yml
@@ -32,7 +32,7 @@
     mode: 0644
   with_items: "{{ local_volume_provisioner_templates }}"
   register: local_volume_provisioner_manifests
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: Local Volume Provisioner | Apply manifests
   kube:
@@ -43,6 +43,6 @@
     filename: "{{ kube_config_dir }}/addons/local_volume_provisioner/{{ item.item.file }}"
     state: "latest"
   with_items: "{{ local_volume_provisioner_manifests.results }}"
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
   loop_control:
     label: "{{ item.item.file }}"

--- a/roles/kubernetes-apps/external_provisioner/meta/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/meta/main.yml
@@ -3,7 +3,7 @@ dependencies:
   - role: kubernetes-apps/external_provisioner/local_volume_provisioner
     when:
       - local_volume_provisioner_enabled
-      - inventory_hostname == groups['kube_control_plane'][0]
+      - inventory_hostname == first_kube_control_plane
     tags:
       - apps
       - local-volume-provisioner

--- a/roles/kubernetes-apps/external_provisioner/rbd_provisioner/tasks/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/rbd_provisioner/tasks/main.yml
@@ -5,7 +5,7 @@
     path: "{{ kube_config_dir }}/addons/rbd_provisioner"
     state: absent
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
   tags:
     - upgrade
 
@@ -14,7 +14,7 @@
     {{ kubectl }} delete namespace {{ rbd_provisioner_namespace }}
   ignore_errors: true  # noqa ignore-errors
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
   tags:
     - upgrade
 
@@ -23,7 +23,7 @@
     {{ kubectl }} delete storageclass {{ rbd_provisioner_storage_class }}
   ignore_errors: true  # noqa ignore-errors
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
   tags:
     - upgrade
 
@@ -35,7 +35,7 @@
     group: root
     mode: 0755
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: RBD Provisioner | Templates list
   set_fact:
@@ -66,7 +66,7 @@
     mode: 0644
   with_items: "{{ rbd_provisioner_templates }}"
   register: rbd_provisioner_manifests
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: RBD Provisioner | Apply manifests
   kube:
@@ -77,4 +77,4 @@
     filename: "{{ kube_config_dir }}/addons/rbd_provisioner/{{ item.item.file }}"
     state: "latest"
   with_items: "{{ rbd_provisioner_manifests.results }}"
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane

--- a/roles/kubernetes-apps/ingress_controller/alb_ingress_controller/tasks/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/alb_ingress_controller/tasks/main.yml
@@ -21,7 +21,7 @@
     - { name: alb-ingress-deploy, file: alb-ingress-deploy.yml, type: deploy }
   register: alb_ingress_manifests
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: ALB Ingress Controller | Apply manifests
   kube:
@@ -33,4 +33,4 @@
     state: "latest"
   with_items: "{{ alb_ingress_manifests.results }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/tasks/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/tasks/main.yml
@@ -5,7 +5,7 @@
     path: "{{ kube_config_dir }}/addons/cert_manager"
     state: absent
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
   tags:
     - upgrade
 
@@ -14,7 +14,7 @@
     {{ kubectl }} delete namespace {{ cert_manager_namespace }}
   ignore_errors: true  # noqa ignore-errors
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
   tags:
     - upgrade
 
@@ -26,7 +26,7 @@
     group: root
     mode: 0755
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Cert Manager | Templates list
   set_fact:
@@ -42,7 +42,7 @@
   with_items: "{{ cert_manager_templates }}"
   register: cert_manager_manifests
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Cert Manager | Apply manifests
   kube:
@@ -53,4 +53,4 @@
     state: "latest"
   with_items: "{{ cert_manager_manifests.results }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/tasks/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/tasks/main.yml
@@ -8,7 +8,7 @@
     group: root
     mode: 0755
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: NGINX Ingress Controller | Templates list
   set_fact:
@@ -45,7 +45,7 @@
   with_items: "{{ ingress_nginx_templates }}"
   register: ingress_nginx_manifests
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: NGINX Ingress Controller | Apply manifests
   kube:
@@ -57,4 +57,4 @@
     state: "latest"
   with_items: "{{ ingress_nginx_manifests.results }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane

--- a/roles/kubernetes-apps/meta/main.yml
+++ b/roles/kubernetes-apps/meta/main.yml
@@ -2,7 +2,7 @@
 dependencies:
   - role: kubernetes-apps/ansible
     when:
-      - inventory_hostname == groups['kube_control_plane'][0]
+      - inventory_hostname == first_kube_control_plane
 
   - role: kubernetes-apps/helm
     when:
@@ -19,21 +19,21 @@ dependencies:
   - role: kubernetes-apps/registry
     when:
       - registry_enabled
-      - inventory_hostname == groups['kube_control_plane'][0]
+      - inventory_hostname == first_kube_control_plane
     tags:
       - registry
 
   - role: kubernetes-apps/metrics_server
     when:
       - metrics_server_enabled
-      - inventory_hostname == groups['kube_control_plane'][0]
+      - inventory_hostname == first_kube_control_plane
     tags:
       - metrics_server
 
   - role: kubernetes-apps/csi_driver/csi_crd
     when:
       - cinder_csi_enabled or csi_snapshot_controller_enabled
-      - inventory_hostname == groups['kube_control_plane'][0]
+      - inventory_hostname == first_kube_control_plane
     tags:
       - csi-driver
 
@@ -82,19 +82,19 @@ dependencies:
   - role: kubernetes-apps/persistent_volumes
     when:
       - persistent_volumes_enabled
-      - inventory_hostname == groups['kube_control_plane'][0]
+      - inventory_hostname == first_kube_control_plane
     tags:
       - persistent_volumes
 
   - role: kubernetes-apps/snapshots
-    when: inventory_hostname == groups['kube_control_plane'][0]
+    when: inventory_hostname == first_kube_control_plane
     tags:
       - snapshots
       - csi-driver
 
   - role: kubernetes-apps/container_runtimes
     when:
-      - inventory_hostname == groups['kube_control_plane'][0]
+      - inventory_hostname == first_kube_control_plane
     tags:
       - container-runtimes
 
@@ -107,20 +107,20 @@ dependencies:
     when:
       - cloud_provider is defined
       - cloud_provider == "oci"
-      - inventory_hostname == groups['kube_control_plane'][0]
+      - inventory_hostname == first_kube_control_plane
     tags:
       - oci
 
   - role: kubernetes-apps/metallb
     when:
       - metallb_enabled
-      - inventory_hostname == groups['kube_control_plane'][0]
+      - inventory_hostname == first_kube_control_plane
     tags:
       - metallb
 
   - role: kubernetes-apps/argocd
     when:
       - argocd_enabled
-      - inventory_hostname == groups['kube_control_plane'][0]
+      - inventory_hostname == first_kube_control_plane
     tags:
       - argocd

--- a/roles/kubernetes-apps/metallb/tasks/main.yml
+++ b/roles/kubernetes-apps/metallb/tasks/main.yml
@@ -29,7 +29,7 @@
   register: apparmor_status
   when:
     - podsecuritypolicy_enabled
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
   failed_when: false
 
 - name: Kubernetes Apps | Set apparmor_enabled
@@ -37,7 +37,7 @@
     apparmor_enabled: "{{ apparmor_status.rc == 0 }}"
   when:
     - podsecuritypolicy_enabled
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Kubernetes Apps | Lay Down MetalLB
   become: true
@@ -48,7 +48,7 @@
   with_items: ["metallb.yml", "metallb-config.yml"]
   register: "rendering"
   when:
-    - "inventory_hostname == groups['kube_control_plane'][0]"
+    - "inventory_hostname == first_kube_control_plane"
 
 - name: Kubernetes Apps | Install and configure MetalLB
   kube:
@@ -59,4 +59,4 @@
   become: true
   with_items: "{{ rendering.results }}"
   when:
-    - "inventory_hostname == groups['kube_control_plane'][0]"
+    - "inventory_hostname == first_kube_control_plane"

--- a/roles/kubernetes-apps/metrics_server/tasks/main.yml
+++ b/roles/kubernetes-apps/metrics_server/tasks/main.yml
@@ -9,7 +9,7 @@
     path: "{{ kube_config_dir }}/addons/metrics_server"
     state: absent
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
   tags:
     - upgrade
 
@@ -21,7 +21,7 @@
     group: root
     mode: 0755
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Metrics Server | Templates list
   set_fact:
@@ -43,7 +43,7 @@
   with_items: "{{ metrics_server_templates }}"
   register: metrics_server_manifests
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Metrics Server | Apply manifests
   kube:
@@ -54,4 +54,4 @@
     state: "latest"
   with_items: "{{ metrics_server_manifests.results }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane

--- a/roles/kubernetes-apps/network_plugin/canal/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/canal/tasks/main.yml
@@ -8,4 +8,4 @@
     filename: "{{ kube_config_dir }}/{{ item.item.file }}"
     state: "latest"
   with_items: "{{ canal_manifests.results }}"
-  when: inventory_hostname == groups['kube_control_plane'][0] and not item is skipped
+  when: inventory_hostname == first_kube_control_plane and not item is skipped

--- a/roles/kubernetes-apps/network_plugin/flannel/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/flannel/tasks/main.yml
@@ -8,7 +8,7 @@
     filename: "{{ kube_config_dir }}/{{ item.item.file }}"
     state: "latest"
   with_items: "{{ flannel_node_manifests.results }}"
-  when: inventory_hostname == groups['kube_control_plane'][0] and not item is skipped
+  when: inventory_hostname == first_kube_control_plane and not item is skipped
 
 - name: Flannel | Wait for flannel subnet.env file presence
   wait_for:

--- a/roles/kubernetes-apps/network_plugin/kube-ovn/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/kube-ovn/tasks/main.yml
@@ -6,4 +6,4 @@
     filename: "{{ kube_config_dir }}/{{ item.item.file }}"
     state: "latest"
   with_items: "{{ kube_ovn_node_manifests.results }}"
-  when: inventory_hostname == groups['kube_control_plane'][0] and not item is skipped
+  when: inventory_hostname == first_kube_control_plane and not item is skipped

--- a/roles/kubernetes-apps/network_plugin/kube-router/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/kube-router/tasks/main.yml
@@ -8,7 +8,7 @@
     resource: "ds"
     namespace: "kube-system"
     state: "latest"
-  delegate_to: "{{ groups['kube_control_plane'] | first }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   run_once: true
 
 - name: kube-router | Wait for kube-router pods to be ready
@@ -18,6 +18,6 @@
   retries: 30
   delay: 10
   ignore_errors: true
-  delegate_to: "{{ groups['kube_control_plane'] | first }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   run_once: true
   changed_when: false

--- a/roles/kubernetes-apps/network_plugin/multus/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/multus/tasks/main.yml
@@ -7,7 +7,7 @@
     resource: "{{ item.item.type }}"
     filename: "{{ kube_config_dir }}/{{ item.item.file }}"
     state: "latest"
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   run_once: true
   with_items: "{{ multus_manifest_1.results }} + {{ multus_nodes_list|map('extract', hostvars, 'multus_manifest_2')|list|json_query('[].results') }}"
   loop_control:

--- a/roles/kubernetes-apps/network_plugin/weave/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/weave/tasks/main.yml
@@ -8,7 +8,7 @@
     resource: "ds"
     namespace: "kube-system"
     state: "latest"
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: Weave | Wait for Weave to become available
   uri:
@@ -18,4 +18,4 @@
   retries: 180
   delay: 5
   until: "weave_status.status == 200 and 'Status: ready' in weave_status.content"
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane

--- a/roles/kubernetes-apps/persistent_volumes/aws-ebs-csi/tasks/main.yml
+++ b/roles/kubernetes-apps/persistent_volumes/aws-ebs-csi/tasks/main.yml
@@ -6,7 +6,7 @@
     mode: 0644
   register: manifests
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Kubernetes Persistent Volumes | Add AWS EBS CSI Storage Class
   kube:
@@ -16,5 +16,5 @@
     filename: "{{ kube_config_dir }}/aws-ebs-csi-storage-class.yml"
     state: "latest"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - manifests.changed

--- a/roles/kubernetes-apps/persistent_volumes/azuredisk-csi/tasks/main.yml
+++ b/roles/kubernetes-apps/persistent_volumes/azuredisk-csi/tasks/main.yml
@@ -6,7 +6,7 @@
     mode: 0644
   register: manifests
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Kubernetes Persistent Volumes | Add Azure CSI Storage Class
   kube:
@@ -16,5 +16,5 @@
     filename: "{{ kube_config_dir }}/azure-csi-storage-class.yml"
     state: "latest"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - manifests.changed

--- a/roles/kubernetes-apps/persistent_volumes/cinder-csi/tasks/main.yml
+++ b/roles/kubernetes-apps/persistent_volumes/cinder-csi/tasks/main.yml
@@ -6,7 +6,7 @@
     mode: 0644
   register: manifests
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Kubernetes Persistent Volumes | Add Cinder CSI Storage Class
   kube:
@@ -16,5 +16,5 @@
     filename: "{{ kube_config_dir }}/cinder-csi-storage-class.yml"
     state: "latest"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - manifests.changed

--- a/roles/kubernetes-apps/persistent_volumes/gcp-pd-csi/tasks/main.yml
+++ b/roles/kubernetes-apps/persistent_volumes/gcp-pd-csi/tasks/main.yml
@@ -6,7 +6,7 @@
     mode: 0644
   register: manifests
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Kubernetes Persistent Volumes | Add GCP PD CSI Storage Class
   kube:
@@ -16,5 +16,5 @@
     filename: "{{ kube_config_dir }}/gcp-pd-csi-storage-class.yml"
     state: "latest"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - manifests.changed

--- a/roles/kubernetes-apps/persistent_volumes/openstack/tasks/main.yml
+++ b/roles/kubernetes-apps/persistent_volumes/openstack/tasks/main.yml
@@ -6,7 +6,7 @@
     mode: 0644
   register: manifests
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Kubernetes Persistent Volumes | Add OpenStack Cinder Storage Class
   kube:
@@ -16,5 +16,5 @@
     filename: "{{ kube_config_dir }}/openstack-storage-class.yml"
     state: "latest"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - manifests.changed

--- a/roles/kubernetes-apps/persistent_volumes/upcloud-csi/tasks/main.yml
+++ b/roles/kubernetes-apps/persistent_volumes/upcloud-csi/tasks/main.yml
@@ -6,7 +6,7 @@
     mode: 0644
   register: manifests
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Kubernetes Persistent Volumes | Add UpCloud CSI Storage Class
   kube:
@@ -16,5 +16,5 @@
     filename: "{{ kube_config_dir }}/upcloud-csi-storage-class.yml"
     state: "latest"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - manifests.changed

--- a/roles/kubernetes-apps/policy_controller/calico/tasks/main.yml
+++ b/roles/kubernetes-apps/policy_controller/calico/tasks/main.yml
@@ -20,7 +20,7 @@
     - {name: calico-kube-controllers, file: calico-kube-crb.yml, type: clusterrolebinding}
   register: calico_kube_manifests
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - rbac_enabled or item.type not in rbac_resources
 
 - name: Start of Calico kube controllers
@@ -37,7 +37,7 @@
   until: calico_kube_controller_start is succeeded
   retries: 4
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - not item is skipped
   loop_control:
     label: "{{ item.item.file }}"

--- a/roles/kubernetes-apps/registry/tasks/main.yml
+++ b/roles/kubernetes-apps/registry/tasks/main.yml
@@ -68,7 +68,7 @@
     mode: 0644
   with_items: "{{ registry_templates }}"
   register: registry_manifests
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: Registry | Apply manifests
   kube:
@@ -79,7 +79,7 @@
     filename: "{{ kube_config_dir }}/addons/registry/{{ item.item.file }}"
     state: "latest"
   with_items: "{{ registry_manifests.results }}"
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: Registry | Create PVC manifests
   template:
@@ -92,7 +92,7 @@
   when:
     - registry_storage_class != none and registry_storage_class
     - registry_disk_size != none and registry_disk_size
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Registry | Apply PVC manifests
   kube:
@@ -106,4 +106,4 @@
   when:
     - registry_storage_class != none and registry_storage_class
     - registry_disk_size != none and registry_disk_size
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane

--- a/roles/kubernetes-apps/snapshots/cinder-csi/tasks/main.yml
+++ b/roles/kubernetes-apps/snapshots/cinder-csi/tasks/main.yml
@@ -6,7 +6,7 @@
     mode: 0644
   register: manifests
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Kubernetes Snapshots | Add Cinder CSI Snapshot Class
   kube:
@@ -14,5 +14,5 @@
     filename: "{{ kube_config_dir }}/cinder-csi-snapshot-class.yml"
     state: "latest"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - manifests.changed

--- a/roles/kubernetes-apps/snapshots/snapshot-controller/tasks/main.yml
+++ b/roles/kubernetes-apps/snapshots/snapshot-controller/tasks/main.yml
@@ -6,7 +6,7 @@
     name: "{{ snapshot_controller_namespace }}"
     resource: "namespace"
     state: "exists"
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
   tags: snapshot-controller
 
 - name: Snapshot Controller | Generate Manifests
@@ -20,7 +20,7 @@
     - {name: snapshot-controller, file: snapshot-controller.yml}
   register: snapshot_controller_manifests
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - item.apply | default(True) | bool
   tags: snapshot-controller
 
@@ -32,7 +32,7 @@
   with_items:
     - "{{ snapshot_controller_manifests.results }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - not item is skipped
   loop_control:
     label: "{{ item.item.file }}"

--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -5,7 +5,7 @@
       {%- if loadbalancer_apiserver is defined and loadbalancer_apiserver.address is defined -%}
       {{ loadbalancer_apiserver.address }}
       {%- elif kubeconfig_localhost_ansible_host is defined and kubeconfig_localhost_ansible_host -%}
-      {{ hostvars[groups['kube_control_plane'][0]].ansible_host }}
+      {{ hostvars[first_kube_control_plane].ansible_host }}
       {%- else -%}
       {{ kube_apiserver_access_address }}
       {%- endif -%}

--- a/roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml
@@ -23,11 +23,11 @@
 
 - name: Parse certificate key if not set
   set_fact:
-    kubeadm_certificate_key: "{{ hostvars[groups['kube_control_plane'][0]]['kubeadm_upload_cert'].stdout_lines[-1] | trim }}"
+    kubeadm_certificate_key: "{{ hostvars[first_kube_control_plane]['kubeadm_upload_cert'].stdout_lines[-1] | trim }}"
   run_once: yes
   when:
-    - hostvars[groups['kube_control_plane'][0]]['kubeadm_upload_cert'] is defined
-    - hostvars[groups['kube_control_plane'][0]]['kubeadm_upload_cert'] is not skipped
+    - hostvars[first_kube_control_plane]['kubeadm_upload_cert'] is defined
+    - hostvars[first_kube_control_plane]['kubeadm_upload_cert'] is not skipped
 
 - name: Create kubeadm ControlPlane config
   template:

--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -186,7 +186,7 @@
 - name: set kubeadm certificate key
   set_fact:
     kubeadm_certificate_key: "{{ item | regex_search('--certificate-key ([^ ]+)','\\1') | first }}"
-  with_items: "{{ hostvars[groups['kube_control_plane'][0]]['kubeadm_init'].stdout_lines | default([]) }}"
+  with_items: "{{ hostvars[first_kube_control_plane]['kubeadm_init'].stdout_lines | default([]) }}"
   when:
     - kubeadm_certificate_key is not defined
     - (item | trim) is match('.*--certificate-key.*')

--- a/roles/kubernetes/control-plane/tasks/main.yml
+++ b/roles/kubernetes/control-plane/tasks/main.yml
@@ -61,9 +61,6 @@
     kube_apiserver_enable_admission_plugins: "{{ kube_apiserver_enable_admission_plugins | difference(['SecurityContextDeny']) | union(['PodSecurityPolicy']) | unique }}"
   when: podsecuritypolicy_enabled
 
-- name: Define nodes already joined to existing cluster and first_kube_control_plane
-  import_tasks: define-first-kube-control.yml
-
 - name: Include kubeadm setup
   import_tasks: kubeadm-setup.yml
 

--- a/roles/kubernetes/kubeadm/tasks/kubeadm_etcd_node.yml
+++ b/roles/kubernetes/kubeadm/tasks/kubeadm_etcd_node.yml
@@ -1,7 +1,7 @@
 ---
 - name: Parse certificate key if not set
   set_fact:
-    kubeadm_certificate_key: "{{ hostvars[groups['kube_control_plane'][0]]['kubeadm_certificate_key'] }}"
+    kubeadm_certificate_key: "{{ hostvars[first_kube_control_plane]['kubeadm_certificate_key'] }}"
   when: kubeadm_certificate_key is undefined
 
 - name: Create kubeadm cert controlplane config

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -25,7 +25,7 @@
     get_checksum: no
     get_mime: no
   register: kubeadm_ca_stat
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   run_once: true
 
 - name: Calculate kubeadm CA cert hash
@@ -36,14 +36,14 @@
   when:
     - kubeadm_ca_stat.stat is defined
     - kubeadm_ca_stat.stat.exists
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   run_once: true
   changed_when: false
 
 - name: Create kubeadm token for joining nodes with 24h expiration (default)
   command: "{{ bin_dir }}/kubeadm token create"
   register: temp_token
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   when: kubeadm_token is not defined
   changed_when: false
 
@@ -138,7 +138,7 @@
   args:
     executable: /bin/bash
   run_once: true
-  delegate_to: "{{ groups['kube_control_plane']|first }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   delegate_facts: false
   when:
     - kubeadm_config_api_fqdn is not defined
@@ -158,7 +158,7 @@
 - name: Restart all kube-proxy pods to ensure that they load the new configmap
   command: "{{ kubectl }} delete pod -n kube-system -l k8s-app=kube-proxy --force --grace-period=0"
   run_once: true
-  delegate_to: "{{ groups['kube_control_plane']|first }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   delegate_facts: false
   when:
     - kubeadm_config_api_fqdn is not defined
@@ -174,3 +174,9 @@
     - inventory_hostname not in groups['kube_control_plane']
     - kube_network_plugin in ["calico", "flannel", "canal", "cilium"] or cilium_deploy_additionally | default(false) | bool
     - kube_network_plugin != "calico" or calico_datastore == "etcd"
+
+- name: Update kubernetes cluster-info
+  include_tasks: update_cluster_info.yml
+  when:
+    - etcd_deployment_type == "kubeadm"
+    - inventory_hostname == first_kube_control_plane

--- a/roles/kubernetes/kubeadm/tasks/update_cluster_info.yml
+++ b/roles/kubernetes/kubeadm/tasks/update_cluster_info.yml
@@ -1,0 +1,83 @@
+---
+- name: Load ca.crt
+  shell: set -o pipefail && cat "{{ kube_apiserver_client_cert }}" | base64 --wrap=0
+  args:
+    executable: /bin/bash
+    warn: false
+  register: kube_cluster_info_ca_crt_raw
+  run_once: true
+  check_mode: false
+  changed_when: false
+
+- name: Get current kubernetes cluster-info
+  command: "{{ kubectl }} -n kube-public get configmap cluster-info -o jsonpath --template '{.data.kubeconfig}'"
+  register: kube_cluster_info_last_raw
+  run_once: true
+  changed_when: false
+  tags:
+    - kube-cluster-info
+
+- name: Parse current kubernetes cluster-info
+  set_fact:
+    kube_cluster_info_ca_crt: "{{ kube_cluster_info_ca_crt_raw.stdout }}"
+    kube_cluster_info_server_address: "https://{{ first_kube_control_plane_address }}:{{ kube_apiserver_port }}"
+    kube_cluster_info_last: "{{ kube_cluster_info_last_raw.stdout | from_yaml }}"
+  run_once: true
+  tags:
+    - kube-cluster-info
+
+- name: Check that cluster-info is dictionary
+  assert:
+    msg: "Kubernetes cluster-info must be a kind of YAML dictionary"
+    that: kube_cluster_info_last is mapping
+  tags:
+    - kube-cluster-info
+
+- name: Change kubernetes cluster-info cluster status
+  set_fact:
+    kube_cluster_info_clusters: >
+      {{
+        ( kube_cluster_info_clusters | default([]) )
+        + [
+            (
+              item | combine({
+                "cluster": {
+                  "certificate-authority-data": kube_cluster_info_ca_crt,
+                  "server": kube_cluster_info_server_address,
+                },
+              })
+            )
+            if item.name == ""
+            else item
+          ]
+      }}
+  run_once: true
+  loop: "{{ kube_cluster_info_last['clusters'] }}"
+  tags:
+    - kube-cluster-info
+
+- name: Change kubernetes cluster-info
+  set_fact:
+    kube_cluster_info: "{{ kube_cluster_info_last | combine({ 'clusters': kube_cluster_info_clusters }) }}"
+  run_once: true
+  tags:
+    - kube-cluster-info
+
+- name: Update kubernetes cluster-info
+  command:
+    cmd: "{{ kubectl }} apply -f -"
+    stdin: |
+      ---
+      apiVersion: v1
+      data:
+        kubeconfig: |
+          {{ kube_cluster_info | to_nice_yaml(indent=2) | indent(width=4) }}
+      kind: ConfigMap
+      metadata:
+        name: cluster-info
+        namespace: kube-public
+  register: kube_cluster_info_update
+  run_once: true
+  changed_when: kube_cluster_info_update.rc == 0
+  tags:
+    - kube-cluster-info

--- a/roles/kubernetes/node-label/tasks/main.yml
+++ b/roles/kubernetes/node-label/tasks/main.yml
@@ -9,7 +9,7 @@
   until: result.status == 200
   retries: 10
   delay: 6
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: Set role node label to empty list
   set_fact:
@@ -44,6 +44,6 @@
   command: >-
       {{ kubectl }} label node {{ kube_override_hostname | default(inventory_hostname) }} {{ item }} --overwrite=true
   loop: "{{ role_node_labels + inventory_node_labels }}"
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   changed_when: false
 ...

--- a/roles/kubernetes/tokens/tasks/check-tokens.yml
+++ b/roles/kubernetes/tokens/tasks/check-tokens.yml
@@ -5,7 +5,7 @@
     get_attributes: no
     get_checksum: yes
     get_mime: no
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   register: known_tokens_master
   run_once: true
 

--- a/roles/kubernetes/tokens/tasks/gen_tokens.yml
+++ b/roles/kubernetes/tokens/tasks/gen_tokens.yml
@@ -5,7 +5,7 @@
     dest: "{{ kube_script_dir }}/kube-gen-token.sh"
     mode: 0700
   run_once: yes
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   when: gen_tokens|default(false)
 
 - name: Gen_tokens | generate tokens for master components
@@ -18,7 +18,7 @@
   register: gentoken_master
   changed_when: "'Added' in gentoken_master.stdout"
   run_once: yes
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   when: gen_tokens|default(false)
 
 - name: Gen_tokens | generate tokens for node components
@@ -31,14 +31,14 @@
   register: gentoken_node
   changed_when: "'Added' in gentoken_node.stdout"
   run_once: yes
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   when: gen_tokens|default(false)
 
 - name: Gen_tokens | Get list of tokens from first master
   command: "find {{ kube_token_dir }} -maxdepth 1 -type f"
   register: tokens_list
   check_mode: no
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   run_once: true
   when: sync_tokens|default(false)
 
@@ -49,7 +49,7 @@
     executable: /bin/bash
   register: tokens_data
   check_mode: no
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   run_once: true
   when: sync_tokens|default(false)
 
@@ -60,5 +60,5 @@
   when:
     - inventory_hostname in groups['kube_control_plane']
     - sync_tokens|default(false)
-    - inventory_hostname != groups['kube_control_plane'][0]
+    - inventory_hostname != first_kube_control_plane
     - tokens_data.stdout

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -543,29 +543,28 @@ is_kube_master: "{{ inventory_hostname in groups['kube_control_plane'] }}"
 kube_apiserver_count: "{{ groups['kube_control_plane'] | length }}"
 kube_apiserver_address: "{{ ip | default(fallback_ips[inventory_hostname]) }}"
 kube_apiserver_access_address: "{{ access_ip | default(kube_apiserver_address) }}"
-first_kube_control_plane_address: "{{ hostvars[groups['kube_control_plane'][0]]['access_ip'] | default(hostvars[groups['kube_control_plane'][0]]['ip'] | default(fallback_ips[groups['kube_control_plane'][0]])) }}"
 loadbalancer_apiserver_localhost: "{{ loadbalancer_apiserver is not defined }}"
 loadbalancer_apiserver_type: "nginx"
 # applied if only external loadbalancer_apiserver is defined, otherwise ignored
 apiserver_loadbalancer_domain_name: "lb-apiserver.kubernetes.local"
-kube_apiserver_global_endpoint: |-
-  {% if loadbalancer_apiserver is defined -%}
-      https://{{ apiserver_loadbalancer_domain_name }}:{{ loadbalancer_apiserver.port|default(kube_apiserver_port) }}
-  {%- elif loadbalancer_apiserver_localhost and (loadbalancer_apiserver_port is not defined or loadbalancer_apiserver_port == kube_apiserver_port) -%}
-      https://localhost:{{ kube_apiserver_port }}
-  {%- else -%}
-      https://{{ first_kube_control_plane_address }}:{{ kube_apiserver_port }}
-  {%- endif %}
-kube_apiserver_endpoint: |-
-  {% if loadbalancer_apiserver is defined -%}
-      https://{{ apiserver_loadbalancer_domain_name }}:{{ loadbalancer_apiserver.port|default(kube_apiserver_port) }}
-  {%- elif not is_kube_master and loadbalancer_apiserver_localhost -%}
-      https://localhost:{{ loadbalancer_apiserver_port|default(kube_apiserver_port) }}
-  {%- elif is_kube_master -%}
-      https://{{ kube_apiserver_bind_address | regex_replace('0\.0\.0\.0','127.0.0.1') }}:{{ kube_apiserver_port }}
-  {%- else -%}
-      https://{{ first_kube_control_plane_address }}:{{ kube_apiserver_port }}
-  {%- endif %}
+# kube_apiserver_global_endpoint: |-
+#   {% if loadbalancer_apiserver is defined -%}
+#       https://{{ apiserver_loadbalancer_domain_name }}:{{ loadbalancer_apiserver.port|default(kube_apiserver_port) }}
+#   {%- elif loadbalancer_apiserver_localhost and (loadbalancer_apiserver_port is not defined or loadbalancer_apiserver_port == kube_apiserver_port) -%}
+#       https://localhost:{{ kube_apiserver_port }}
+#   {%- else -%}
+#       https://{{ first_kube_control_plane_address }}:{{ kube_apiserver_port }}
+#   {%- endif %}
+# kube_apiserver_endpoint: |-
+#   {% if loadbalancer_apiserver is defined -%}
+#       https://{{ apiserver_loadbalancer_domain_name }}:{{ loadbalancer_apiserver.port|default(kube_apiserver_port) }}
+#   {%- elif not is_kube_master and loadbalancer_apiserver_localhost -%}
+#       https://localhost:{{ loadbalancer_apiserver_port|default(kube_apiserver_port) }}
+#   {%- elif is_kube_master -%}
+#       https://{{ kube_apiserver_bind_address | regex_replace('0\.0\.0\.0','127.0.0.1') }}:{{ kube_apiserver_port }}
+#   {%- else -%}
+#       https://{{ first_kube_control_plane_address }}:{{ kube_apiserver_port }}
+#   {%- endif %}
 kube_apiserver_client_cert: "{{ kube_cert_dir }}/ca.crt"
 kube_apiserver_client_key: "{{ kube_cert_dir }}/ca.key"
 

--- a/roles/kubespray-defaults/tasks/define-first-kube-control.yml
+++ b/roles/kubespray-defaults/tasks/define-first-kube-control.yml
@@ -1,0 +1,50 @@
+---
+
+- name: Check which kube-control nodes are already members of the cluster
+  command: "{{ bin_dir }}/kubectl get nodes --selector=node-role.kubernetes.io/control-plane -o json"
+  register: kube_control_planes_raw
+  ignore_errors: yes
+  changed_when: false
+
+- name: Set fact joined_control_planes
+  set_fact:
+    joined_control_planes: "{{ ((kube_control_planes_raw.stdout| from_json)['items'])| default([]) | map (attribute='metadata') | map (attribute='name') | list }}"
+  delegate_to: item
+  loop: "{{ groups['kube_control_plane'] }}"
+  when: kube_control_planes_raw is succeeded
+  run_once: yes
+
+- name: Set fact first_kube_control_plane
+  set_fact:
+    first_kube_control_plane: "{{ joined_control_planes|default([]) | first | default(groups['kube_control_plane'] | first) }}"
+
+- name: Set fact first_kube_control_plane_address
+  when: first_kube_control_plane_address is not defined
+  set_fact:
+    first_kube_control_plane_address: "{{ hostvars[first_kube_control_plane]['access_ip'] | default(hostvars[first_kube_control_plane]['ip']) | default(fallback_ips.get(first_kube_control_plane, '127.0.0.1')) }}"
+
+- name: Set fact kube_apiserver_global_endpoint
+  when: kube_apiserver_global_endpoint is not defined
+  set_fact:
+    kube_apiserver_global_endpoint: |-
+      {% if loadbalancer_apiserver is defined -%}
+          https://{{ apiserver_loadbalancer_domain_name }}:{{ loadbalancer_apiserver.port|default(kube_apiserver_port) }}
+      {%- elif loadbalancer_apiserver_localhost and (loadbalancer_apiserver_port is not defined or loadbalancer_apiserver_port == kube_apiserver_port) -%}
+          https://localhost:{{ kube_apiserver_port }}
+      {%- else -%}
+          https://{{ first_kube_control_plane_address }}:{{ kube_apiserver_port }}
+      {%- endif %}
+
+- name: Set fact kube_apiserver_endpoint
+  when: kube_apiserver_endpoint is not defined
+  set_fact:
+    kube_apiserver_endpoint: |-
+      {% if loadbalancer_apiserver is defined -%}
+          https://{{ apiserver_loadbalancer_domain_name }}:{{ loadbalancer_apiserver.port|default(kube_apiserver_port) }}
+      {%- elif not is_kube_master and loadbalancer_apiserver_localhost -%}
+          https://localhost:{{ loadbalancer_apiserver_port|default(kube_apiserver_port) }}
+      {%- elif is_kube_master -%}
+          https://{{ kube_apiserver_bind_address | regex_replace('0\.0\.0\.0','127.0.0.1') }}:{{ kube_apiserver_port }}
+      {%- else -%}
+          https://{{ first_kube_control_plane_address }}:{{ kube_apiserver_port }}
+      {%- endif %}

--- a/roles/kubespray-defaults/tasks/fallback_ips.yml
+++ b/roles/kubespray-defaults/tasks/fallback_ips.yml
@@ -28,6 +28,10 @@
   become: no
   run_once: yes
 
+- name: create fallback_ips_parsed
+  set_fact:
+    fallback_ips_parsed: "{{ hostvars.localhost.fallback_ips_base | from_yaml }}"
+
 - name: set fallback_ips
   set_fact:
-    fallback_ips: "{{ hostvars.localhost.fallback_ips_base | from_yaml }}"
+    fallback_ips: "{{ fallback_ips_parsed if fallback_ips_parsed is mapping else {} }}"

--- a/roles/kubespray-defaults/tasks/main.yaml
+++ b/roles/kubespray-defaults/tasks/main.yaml
@@ -31,3 +31,10 @@
     - etcd_kubeadm_enabled is defined and etcd_kubeadm_enabled
   tags:
     - always
+
+- name: Define nodes already joined to existing cluster and first_kube_control_plane
+  import_tasks: define-first-kube-control.yml
+  when:
+    - "'bootstrap-os' not in ansible_play_role_names"
+  tags:
+    - always

--- a/roles/network_plugin/calico/tasks/check.yml
+++ b/roles/network_plugin/calico/tasks/check.yml
@@ -5,7 +5,7 @@
       - ipip is not defined
     msg: "'ipip' configuration variable is deprecated, please configure your inventory with 'calico_ipip_mode' set to 'Always' or 'CrossSubnet' according to your specific needs"
   run_once: True
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
 
 - name: Stop if legacy encapsulation variables are detected (ipip_mode)
   assert:
@@ -13,7 +13,7 @@
       - ipip_mode is not defined
     msg: "'ipip_mode' configuration variable is deprecated, please configure your inventory with 'calico_ipip_mode' set to 'Always' or 'CrossSubnet' according to your specific needs"
   run_once: True
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
 
 - name: Stop if legacy encapsulation variables are detected (calcio_ipam_autoallocateblocks)
   assert:
@@ -21,7 +21,7 @@
       - calcio_ipam_autoallocateblocks is not defined
     msg: "'calcio_ipam_autoallocateblocks' configuration variable is deprecated, it's a typo, please configure your inventory with 'calico_ipam_autoallocateblocks' set to 'true' or 'false' according to your specific needs"
   run_once: True
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
 
 
 - name: Stop if incompatible network plugin and cloudprovider
@@ -33,7 +33,7 @@
   when:
     - cloud_provider is defined and cloud_provider == 'azure'
   run_once: True
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
 
 - name: Stop if supported Calico versions
   assert:
@@ -41,14 +41,14 @@
       - "calico_version in calico_crds_archive_checksums.keys()"
     msg: "Calico version not supported {{ calico_version }} not in {{ calico_crds_archive_checksums.keys() }}"
   run_once: True
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
 
 - name: Check if calico exists
   stat:
     path: "{{ bin_dir }}/calicoctl.sh"
   register: calico_exists
   run_once: True
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
 
 - name: Check that current calico version is enough for upgrade
   block:
@@ -68,7 +68,7 @@
           Minimum version is {{ calico_min_version_required }} supported by the previous kubespray release.
           But current version is {{ calico_version_on_server.stdout }}.
   run_once: True
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   when: calico_exists.stat.exists
 
 - name: "Check that cluster_id is set if calico_rr enabled"
@@ -78,9 +78,9 @@
     msg: "A unique cluster_id is required if using calico_rr"
   when:
     - peer_with_calico_rr
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
   run_once: True
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
 
 - name: "Check that calico_rr nodes are in k8s_cluster group"
   assert:
@@ -90,7 +90,7 @@
   when:
     - '"calico_rr" in group_names'
   run_once: True
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
 
 - name: "Check vars defined correctly"
   assert:
@@ -99,7 +99,7 @@
       - "calico_pool_name is match('^[a-zA-Z0-9-_\\\\.]{2,63}$')"
     msg: "calico_pool_name contains invalid characters"
   run_once: True
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
 
 - name: "Check calico network backend defined correctly"
   assert:
@@ -107,7 +107,7 @@
       - "calico_network_backend in ['bird', 'vxlan', 'none']"
     msg: "calico network backend is not 'bird', 'vxlan' or 'none'"
   run_once: True
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
 
 - name: "Check ipip and vxlan mode defined correctly"
   assert:
@@ -116,7 +116,7 @@
       - "calico_vxlan_mode in ['Always', 'CrossSubnet', 'Never']"
     msg: "calico inter host encapsulation mode is not 'Always', 'CrossSubnet' or 'Never'"
   run_once: True
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
 
 - name: "Check ipip and vxlan mode if simultaneously enabled"
   assert:
@@ -126,7 +126,7 @@
   when:
     - "calico_ipip_mode in ['Always', 'CrossSubnet']"
   run_once: True
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
 
 - name: "Check ipip and vxlan mode if simultaneously enabled"
   assert:
@@ -136,7 +136,7 @@
   when:
     - "calico_vxlan_mode in ['Always', 'CrossSubnet']"
   run_once: True
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
 
 - name: "Get Calico {{ calico_pool_name }} configuration"
   command: "{{ bin_dir }}/calicoctl.sh get ipPool {{ calico_pool_name }} -o json"
@@ -145,14 +145,14 @@
   check_mode: no
   register: calico
   run_once: True
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
 
 - name: "Set calico_pool_conf"
   set_fact:
     calico_pool_conf: '{{ calico.stdout | from_json }}'
   when: calico.rc == 0 and calico.stdout
   run_once: True
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
 
 - name: "Check if inventory match current cluster configuration"
   assert:
@@ -165,7 +165,7 @@
   when:
     - calico_pool_conf is defined
   run_once: True
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
 
 - name: "Check kdd calico_datastore if calico_apiserver_enabled"
   assert:
@@ -174,7 +174,7 @@
   when:
     - calico_apiserver_enabled
   run_once: True
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
 
 - name: "Check kdd calico_datastore if typha_enabled"
   assert:
@@ -183,7 +183,7 @@
   when:
     - typha_enabled
   run_once: True
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
 
 - name: "Check ipip mode is Never for calico ipv6"
   assert:
@@ -193,4 +193,4 @@
   when:
     - enable_dual_stack_networks
   run_once: True
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -51,13 +51,13 @@
   include_tasks: typha_certs.yml
   when:
     - typha_secure
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Calico | Generate apiserver certs
   include_tasks: calico_apiserver_certs.yml
   when:
     - calico_apiserver_enabled
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Calico | Install calicoctl wrapper script
   template:
@@ -92,14 +92,14 @@
   delay: "{{ retry_stagger | random + 3 }}"
   changed_when: false
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Calico | Ensure that calico_pool_cidr is within kube_pods_subnet when defined
   assert:
     that: "[calico_pool_cidr] | ipaddr(kube_pods_subnet) | length == 1"
     msg: "{{ calico_pool_cidr }} is not within or equal to {{ kube_pods_subnet }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - 'calico_conf.stdout == "0"'
     - calico_pool_cidr is defined
 
@@ -115,7 +115,7 @@
   delay: "{{ retry_stagger | random + 3 }}"
   changed_when: false
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - enable_dual_stack_networks
 
 - name: Calico | Ensure that calico_pool_cidr_ipv6 is within kube_pods_subnet_ipv6 when defined
@@ -123,7 +123,7 @@
     that: "[calico_pool_cidr_ipv6] | ipaddr(kube_pods_subnet_ipv6) | length == 1"
     msg: "{{ calico_pool_cidr_ipv6 }} is not within or equal to {{ kube_pods_subnet_ipv6 }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - calico_conf_ipv6.stdout is defined and calico_conf_ipv6.stdout == "0"
     - calico_pool_cidr_ipv6 is defined
     - enable_dual_stack_networks
@@ -158,7 +158,7 @@
         filename: "{{ kube_config_dir }}/kdd-crds.yml"
         state: "latest"
       when:
-        - inventory_hostname == groups['kube_control_plane'][0]
+        - inventory_hostname == first_kube_control_plane
   when:
     - inventory_hostname in groups['kube_control_plane']
     - calico_datastore == "kdd"
@@ -205,7 +205,7 @@
         stdin: "{{ _felix_config is string | ternary(_felix_config, _felix_config|to_json) }}"
       changed_when: False
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - block:
     - name: Calico | Get existing calico network pool
@@ -244,7 +244,7 @@
         stdin: "{{ _calico_pool is string | ternary(_calico_pool, _calico_pool|to_json) }}"
       changed_when: False
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - block:
     - name: Calico | Get existing calico ipv6 network pool
@@ -283,7 +283,7 @@
         stdin: "{{ _calico_pool_ipv6 is string | ternary(_calico_pool_ipv6, _calico_pool_ipv6|to_json) }}"
       changed_when: False
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - enable_dual_stack_networks | bool
 
 - name: Populate Service External IPs
@@ -346,7 +346,7 @@
         stdin: "{{ _bgp_config is string | ternary(_bgp_config, _bgp_config|to_json) }}"
       changed_when: False
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Calico | Create calico manifests
   template:
@@ -382,14 +382,14 @@
   changed_when: false
   register: calico_apiserver_cabundle
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - calico_apiserver_enabled
 
 - name: Calico | set calico apiserver caBundle fact
   set_fact:
     calico_apiserver_cabundle: "{{ calico_apiserver_cabundle.stdout }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - calico_apiserver_enabled
 
 - name: Calico | Create calico manifests for apiserver
@@ -416,7 +416,7 @@
     - "{{ calico_node_manifests.results }}"
     - "{{ calico_node_typha_manifest.results }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - not item is skipped
   loop_control:
     label: "{{ item.item.file }}"
@@ -432,7 +432,7 @@
   with_items:
     - "{{ calico_apiserver_manifest.results }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - not item is skipped
   loop_control:
     label: "{{ item.item.file }}"
@@ -464,7 +464,7 @@
   until: resource_result is succeeded
   retries: 4
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - calico_datastore == "kdd"
 
 - include_tasks: peer_with_calico_rr.yml

--- a/roles/network_plugin/calico/tasks/peer_with_calico_rr.yml
+++ b/roles/network_plugin/calico/tasks/peer_with_calico_rr.yml
@@ -57,7 +57,7 @@
   with_items:
     - "{{ groups['calico_rr'] | default([]) }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - calico_rr_id is not defined or calico_group_id is not defined
 
 - name: Calico | Configure route reflectors to peer with each other
@@ -83,4 +83,4 @@
   with_items:
     - "{{ groups['calico_rr'] | default([]) }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane

--- a/roles/network_plugin/calico/tasks/peer_with_router.yml
+++ b/roles/network_plugin/calico/tasks/peer_with_router.yml
@@ -21,7 +21,7 @@
   with_items:
     - "{{ peers|selectattr('scope','defined')|selectattr('scope','equalto', 'global')|list|default([]) }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Calico | Configure node asNumber for per node peering
   command:
@@ -72,6 +72,6 @@
   delay: "{{ retry_stagger | random + 3 }}"
   with_items:
     - "{{ peers|selectattr('scope','undefined')|list|default([]) | union(peers|selectattr('scope','defined')|selectattr('scope','equalto', 'node')|list|default([])) }}"
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   when:
     - inventory_hostname in groups['k8s_cluster']

--- a/roles/network_plugin/calico/tasks/pre.yml
+++ b/roles/network_plugin/calico/tasks/pre.yml
@@ -24,7 +24,7 @@
   args:
     executable: /bin/bash
   register: calico_kubelet_name
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   when:
   - "cloud_provider is defined"
 

--- a/roles/network_plugin/cilium/tasks/apply.yml
+++ b/roles/network_plugin/cilium/tasks/apply.yml
@@ -8,7 +8,7 @@
     filename: "{{ kube_config_dir }}/{{ item.item.name }}-{{ item.item.file }}"
     state: "latest"
   loop: "{{ cilium_node_manifests.results }}"
-  when: inventory_hostname == groups['kube_control_plane'][0] and not item is skipped
+  when: inventory_hostname == first_kube_control_plane and not item is skipped
 
 - name: Cilium | Wait for pods to run
   command: "{{ kubectl }} -n kube-system get pods -l k8s-app=cilium -o jsonpath='{.items[?(@.status.containerStatuses[0].ready==false)].metadata.name}'"  # noqa 601
@@ -17,7 +17,7 @@
   retries: "{{ cilium_rolling_restart_wait_retries_count | int }}"
   delay: "{{ cilium_rolling_restart_wait_retries_delay_seconds | int }}"
   failed_when: false
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: Cilium | Hubble install
   kube:
@@ -29,5 +29,5 @@
     state: "latest"
   loop: "{{ cilium_hubble_manifests.results }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0] and not item is skipped
+    - inventory_hostname == first_kube_control_plane and not item is skipped
     - cilium_enable_hubble and cilium_hubble_install

--- a/roles/network_plugin/cilium/tasks/install.yml
+++ b/roles/network_plugin/cilium/tasks/install.yml
@@ -38,7 +38,7 @@
     group: root
     mode: 0755
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - cilium_hubble_install
 
 - name: Cilium | Create Cilium node manifests
@@ -78,7 +78,7 @@
     - {name: hubble, file: service.yml, type: service}
   register: cilium_hubble_manifests
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
     - cilium_enable_hubble and cilium_hubble_install
     - item.when | default(True) | bool
 

--- a/roles/network_plugin/flannel/tasks/main.yml
+++ b/roles/network_plugin/flannel/tasks/main.yml
@@ -18,4 +18,4 @@
     - {name: kube-flannel, file: cni-flannel.yml, type: ds}
   register: flannel_node_manifests
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane

--- a/roles/network_plugin/kube-ovn/tasks/main.yml
+++ b/roles/network_plugin/kube-ovn/tasks/main.yml
@@ -3,7 +3,7 @@
   command: "{{ kubectl }} label --overwrite node {{ item }} kube-ovn/role=master"
   loop: "{{ kube_ovn_central_hosts }}"
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: Kube-OVN | Create Kube-OVN manifests
   template:

--- a/roles/network_plugin/kube-router/tasks/annotate.yml
+++ b/roles/network_plugin/kube-router/tasks/annotate.yml
@@ -3,19 +3,19 @@
   command: "{{ kubectl }} annotate --overwrite node {{ ansible_hostname }} {{ item }}"
   with_items:
   - "{{ kube_router_annotations_master }}"
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   when: kube_router_annotations_master is defined and inventory_hostname in groups['kube_control_plane']
 
 - name: kube-router | Add annotations on kube_node
   command: "{{ kubectl }} annotate --overwrite node {{ ansible_hostname }} {{ item }}"
   with_items:
   - "{{ kube_router_annotations_node }}"
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   when: kube_router_annotations_node is defined and inventory_hostname in groups['kube_node']
 
 - name: kube-router | Add common annotations on all servers
   command: "{{ kubectl }} annotate --overwrite node {{ ansible_hostname }} {{ item }}"
   with_items:
   - "{{ kube_router_annotations_all }}"
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   when: kube_router_annotations_all is defined and inventory_hostname in groups['k8s_cluster']

--- a/roles/network_plugin/kube-router/tasks/main.yml
+++ b/roles/network_plugin/kube-router/tasks/main.yml
@@ -58,5 +58,5 @@
     src: kube-router.yml.j2
     dest: "{{ kube_config_dir }}/kube-router.yml"
     mode: 0644
-  delegate_to: "{{ groups['kube_control_plane'] | first }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   run_once: true

--- a/roles/network_plugin/macvlan/tasks/main.yml
+++ b/roles/network_plugin/macvlan/tasks/main.yml
@@ -3,7 +3,7 @@
   command: "{{ kubectl }} get nodes {{ kube_override_hostname | default(inventory_hostname) }} -o jsonpath='{.spec.podCIDR}'"
   changed_when: false
   register: node_pod_cidr_cmd
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
 
 - name: Macvlan | set node_pod_cidr
   set_fact:

--- a/roles/network_plugin/multus/tasks/main.yml
+++ b/roles/network_plugin/multus/tasks/main.yml
@@ -10,7 +10,7 @@
     - {name: multus-clusterrole, file: multus-clusterrole.yml, type: clusterrole}
     - {name: multus-clusterrolebinding, file: multus-clusterrolebinding.yml, type: clusterrolebinding}
   register: multus_manifest_1
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when: inventory_hostname == first_kube_control_plane
 
 - name: Multus | Check container engine type
   set_fact:
@@ -28,7 +28,7 @@
   vars:
     query: "*|[?container_manager=='{{ container_manager }}']|[0].inventory_hostname"
     vars_from_node: "{{ hostvars|json_query(query) }}"
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   when:
     - item.engine in container_manager_types
     - hostvars[inventory_hostname].container_manager == item.engine

--- a/roles/network_plugin/ovn4nfv/tasks/main.yml
+++ b/roles/network_plugin/ovn4nfv/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: ovn4nfv | Label control-plane node
   command: >-
-    {{ kubectl }} label --overwrite node {{ groups['kube_control_plane'] | first }} ovn4nfv-k8s-plugin=ovn-control-plane
+    {{ kubectl }} label --overwrite node {{ first_kube_control_plane }} ovn4nfv-k8s-plugin=ovn-control-plane
   when:
-    - inventory_hostname == groups['kube_control_plane'][0]
+    - inventory_hostname == first_kube_control_plane
 
 - name: ovn4nfv | Create ovn4nfv-k8s manifests
   template:

--- a/roles/remove-node/post-remove/tasks/main.yml
+++ b/roles/remove-node/post-remove/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: remove-node | Delete node
   command: "{{ kubectl }} delete node {{ kube_override_hostname|default(inventory_hostname) }}"
-  delegate_to: "{{ groups['kube_control_plane']|first }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   when:
     - groups['kube_control_plane'] | length > 0
     # ignore servers that are not nodes

--- a/roles/remove-node/pre-remove/tasks/main.yml
+++ b/roles/remove-node/pre-remove/tasks/main.yml
@@ -5,7 +5,7 @@
   register: nodes
   when:
     - groups['kube_control_plane'] | length > 0
-  delegate_to: "{{ groups['kube_control_plane']|first }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   changed_when: false
   run_once: true
 
@@ -23,7 +23,7 @@
     - kube_override_hostname|default(inventory_hostname) in nodes.stdout_lines
   register: result
   failed_when: result.rc != 0 and not allow_ungraceful_removal
-  delegate_to: "{{ groups['kube_control_plane']|first }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   until: result.rc == 0 or allow_ungraceful_removal
   retries: "{{ drain_retries }}"
   delay: "{{ drain_retry_delay_seconds }}"
@@ -32,7 +32,7 @@
   command: >-
     {{ kubectl }} get volumeattachments -o go-template={% raw %}'{{ range .items }}{{ .spec.nodeName }}{{ "\n" }}{{ end }}'{% endraw %}
   register: nodes_with_volumes
-  delegate_to: "{{ groups['kube_control_plane']|first }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   changed_when: false
   until: not (kube_override_hostname|default(inventory_hostname) in nodes_with_volumes.stdout_lines)
   retries: 3

--- a/roles/upgrade/post-upgrade/tasks/main.yml
+++ b/roles/upgrade/post-upgrade/tasks/main.yml
@@ -9,7 +9,7 @@
     --field-selector 'spec.nodeName=={{ kube_override_hostname|default(inventory_hostname) }}'
     --for=condition=Ready
     --timeout={{ upgrade_post_cilium_wait_timeout }}
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
 
 - name: Confirm node uncordon
   pause:
@@ -27,6 +27,6 @@
 
 - name: Uncordon node
   command: "{{ kubectl }} uncordon {{ kube_override_hostname|default(inventory_hostname) }}"
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   when:
     - needs_cordoning|default(false)

--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -21,7 +21,7 @@
     {{ kubectl }} get node {{ kube_override_hostname|default(inventory_hostname) }}
     -o jsonpath='{ range .status.conditions[?(@.type == "Ready")].status }{ @ }{ end }'
   register: kubectl_node_ready
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   failed_when: false
   changed_when: false
 
@@ -32,7 +32,7 @@
     {{ kubectl }} get node {{ kube_override_hostname|default(inventory_hostname) }}
     -o jsonpath='{ .spec.unschedulable }'
   register: kubectl_node_schedulable
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   failed_when: false
   changed_when: false
 
@@ -49,13 +49,13 @@
   block:
     - name: Cordon node
       command: "{{ kubectl }} cordon {{ kube_override_hostname|default(inventory_hostname) }}"
-      delegate_to: "{{ groups['kube_control_plane'][0] }}"
+      delegate_to: "{{ first_kube_control_plane }}"
       changed_when: true
 
     - name: Check kubectl version
       command: "{{ kubectl }} version --client --short"
       register: kubectl_version
-      delegate_to: "{{ groups['kube_control_plane'][0] }}"
+      delegate_to: "{{ first_kube_control_plane }}"
       run_once: yes
       changed_when: false
       when:
@@ -125,6 +125,6 @@
       fail:
         msg: "Failed to drain node {{ kube_override_hostname|default(inventory_hostname) }}"
       when: upgrade_node_fail_if_drain_fails
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  delegate_to: "{{ first_kube_control_plane }}"
   when:
     - needs_cordoning

--- a/tests/testcases/040_check-network-adv.yml
+++ b/tests/testcases/040_check-network-adv.yml
@@ -37,7 +37,7 @@
       until: ncs_pod.stdout.find('Running') != -1
       retries: 3
       delay: 10
-      when: inventory_hostname == groups['kube_control_plane'][0]
+      when: inventory_hostname == groups['kube_control_plane'] | first
 
     - name: Wait for netchecker agents
       shell: "set -o pipefail && {{ bin_dir }}/kubectl get pods -o wide --namespace {{ netcheck_namespace }} | grep '^netchecker-agent-.*Running'"
@@ -48,12 +48,12 @@
       retries: 3
       delay: 10
       failed_when: false
-      when: inventory_hostname == groups['kube_control_plane'][0]
+      when: inventory_hostname == groups['kube_control_plane'] | first
 
     - name: Get netchecker pods
       command: "{{ bin_dir }}/kubectl -n {{ netcheck_namespace }} describe pod -l app={{ item }}"
       run_once: true
-      delegate_to: "{{ groups['kube_control_plane'][0] }}"
+      delegate_to: "{{ groups['kube_control_plane'] | first }}"
       no_log: false
       with_items:
         - netchecker-agent
@@ -62,14 +62,14 @@
 
     - debug:  # noqa unnamed-task
         var: nca_pod.stdout_lines
-      when: inventory_hostname == groups['kube_control_plane'][0]
+      when: inventory_hostname == groups['kube_control_plane'] | first
 
     - name: Get netchecker agents
       uri:
         url: "http://{{ ansible_default_ipv4.address }}:{{ netchecker_port }}/api/v1/agents/"
         return_content: yes
       run_once: true
-      delegate_to: "{{ groups['kube_control_plane'][0] }}"
+      delegate_to: "{{ groups['kube_control_plane'] | first }}"
       register: agents
       retries: 18
       delay: "{{ agent_report_interval }}"
@@ -84,7 +84,7 @@
         url: "http://{{ ansible_default_ipv4.address }}:{{ netchecker_port }}/api/v1/connectivity_check"
         status_code: 200
         return_content: yes
-      delegate_to: "{{ groups['kube_control_plane'][0] }}"
+      delegate_to: "{{ groups['kube_control_plane'] | first }}"
       run_once: true
       register: connectivity_check
       retries: 3
@@ -104,13 +104,13 @@
       command: "{{ bin_dir }}/kubectl -n kube-system logs -l k8s-app=kube-proxy"
       no_log: false
       when:
-        - inventory_hostname == groups['kube_control_plane'][0]
+        - inventory_hostname == groups['kube_control_plane'] | first
         - not connectivity_check is success
 
     - name: Get logs from other apps
       command: "{{ bin_dir }}/kubectl -n kube-system logs -l k8s-app={{ item }} --all-containers"
       when:
-        - inventory_hostname == groups['kube_control_plane'][0]
+        - inventory_hostname == groups['kube_control_plane'] | first
         - not connectivity_check is success
       no_log: false
       with_items:
@@ -123,7 +123,7 @@
     - name: Parse agents list
       set_fact:
         agents_check_result: "{{ agents.content | from_json }}"
-      delegate_to: "{{ groups['kube_control_plane'][0] }}"
+      delegate_to: "{{ groups['kube_control_plane'] | first }}"
       run_once: true
       when:
         - agents is success
@@ -132,7 +132,7 @@
 
     - debug:  # noqa unnamed-task
         var: agents_check_result
-      delegate_to: "{{ groups['kube_control_plane'][0] }}"
+      delegate_to: "{{ groups['kube_control_plane'] | first }}"
       run_once: true
       when:
         - agents_check_result is defined
@@ -140,7 +140,7 @@
     - name: Parse connectivity check
       set_fact:
         connectivity_check_result: "{{ connectivity_check.content | from_json }}"
-      delegate_to: "{{ groups['kube_control_plane'][0] }}"
+      delegate_to: "{{ groups['kube_control_plane'] | first }}"
       run_once: true
       when:
         - connectivity_check is success
@@ -149,7 +149,7 @@
 
     - debug:  # noqa unnamed-task
         var: connectivity_check_result
-      delegate_to: "{{ groups['kube_control_plane'][0] }}"
+      delegate_to: "{{ groups['kube_control_plane'] | first }}"
       run_once: true
       when:
         - connectivity_check_result is defined
@@ -163,7 +163,7 @@
           - not connectivity_check_result.Absent
           - not connectivity_check_result.Outdated
         msg: "Connectivity check to netchecker agents failed"
-      delegate_to: "{{ groups['kube_control_plane'][0] }}"
+      delegate_to: "{{ groups['kube_control_plane'] | first }}"
       run_once: true
 
     - name: Create macvlan network conf
@@ -197,7 +197,7 @@
           }'
           EOF
       when:
-        - inventory_hostname == groups['kube_control_plane'][0]
+        - inventory_hostname == groups['kube_control_plane'] | first
         - kube_network_plugin_multus|default(false)|bool
 
     - name: Annotate pod with macvlan network
@@ -221,7 +221,7 @@
               image: dougbtv/centos-network
           EOF
       when:
-        - inventory_hostname == groups['kube_control_plane'][0]
+        - inventory_hostname == groups['kube_control_plane'] | first
         - kube_network_plugin_multus|default(false)|bool
 
     - name: Check secondary macvlan interface
@@ -231,5 +231,5 @@
       retries: 90
       changed_when: false
       when:
-        - inventory_hostname == groups['kube_control_plane'][0]
+        - inventory_hostname == groups['kube_control_plane'] | first
         - kube_network_plugin_multus|default(false)|bool


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind cleanup

**What this PR does / why we need it**:

The first kubernetes control plane node has a very important role in overall kubespray workflows. However, if the first node is out of order with the others, the kubernetes cluster configuration will fail catastrophically. For example, certificate loss due to accidental ETCD and Kubernetes SSL key renewal.

Keeping the order of the first nodes is very important, but there is always the potential for human error to cause problems. So, I want to force the dynamic discovery logic to consider one of the kubernetes control plane nodes that are still functioning as the first node, so that we don't run into issues with node order in the first place.

[Fortunately, I have been able to find that these attempts are already being made locally. Therefore, this PR will be a generalization of them. (#7989)](https://github.com/kubernetes-sigs/kubespray/blob/27ab364df59a0b5d01b89671179a9407d5edc6a1/roles/kubernetes/control-plane/tasks/define-first-kube-control.yml)

\> **BEFORE**
* groups['kube_control_plane'][0]
* groups['kube_control_plane'] | first

\> **AFTER**
* first_kube_control_plane
    - If there is one or more **running nodes**: Choose the first one of them
    - If there is no running nodes **(fresh install)**: Choose the first one of `kube_control_plane`

And if control planes are changed via `cluster.yml` and etc, it will automatically update the `cluster-info` to the first control plane node.

\> **BUG FIXES**
* [Fix a bug in parsing empty fallback_ips](https://github.com/kubernetes-sigs/kubespray/pull/9756/commits/6f4d888adb5bdd3439b7ba2118e771e646d0def2): Nodes without network adapters cannot assign `fallback_ips`. [The problem is that if all nodes do not have network adapters, the value of `fallback_ips_base` becomes `"---"`, so the value of `fallback_ips`, the result of yaml-parsing, becomes a **str object**.](https://github.com/kubernetes-sigs/kubespray/blob/0ff883afeb6966292d156b04dbd3205b8238b2e2/roles/kubespray-defaults/tasks/fallback_ips.yml#L17) This bug occurs when testing `molecule_docker`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3471 (only for `kube_control_plane`)
Fixes #9863

**Special notes for your reviewer**:

This PR has many changes for usage of `kube_control_plane | first`.

So many various tests are needed, but I can't be sure that this changes are complete yet, so I want to review with others.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Changing the order of kube_control_plane is now allowed freely.
cluster-info configmap is automatically updated to the first kube_control_plane.
```
