### PR TITLE
Make fallback_ips run only on reachable nodes

### DIFF
--- a/roles/kubespray-defaults/tasks/fallback_ips.yml
+++ b/roles/kubespray-defaults/tasks/fallback_ips.yml
@@ -2,6 +2,29 @@
 # Set 127.0.0.1 as fallback IP if we do not have host facts for host
 # ansible_default_ipv4 isn't what you think.
 # Thanks https://medium.com/opsops/ansible-default-ipv4-is-not-what-you-think-edb8ab154b10
+- name: Create a list
+  set_fact:
+    reachable_nodes: []
+  run_once: yes
+
+- name: Testing connection to hosts
+  ansible.builtin.wait_for:
+    port: 22
+    host: "{{ item }}"
+    search_regex: OpenSSH
+    timeout : 10
+  connection: local
+  register: reachability_status
+  ignore_errors: true
+  loop: "{{ groups['k8s_cluster'] + groups['etcd']|default([]) + groups['calico_rr']  | unique }}"
+  run_once: yes
+
+- name: Create a list of reachable nodes
+  set_fact:
+    reachable_nodes: "{{ reachable_nodes + [item.item] }}"
+  when: item.failed == False
+  with_items: "{{ reachability_status.results }}"
+  no_log: true
 
 - name: Gather ansible_default_ipv4 from all hosts
   setup:
@@ -10,7 +33,7 @@
   delegate_to: "{{ item }}"
   delegate_facts: yes
   when: hostvars[item].ansible_default_ipv4 is not defined
-  loop: "{{ (groups['k8s_cluster']|default([]) + groups['etcd']|default([]) + groups['calico_rr']|default([])) | unique }}"
+  loop: "{{ reachable_nodes }}"
   run_once: yes
   tags: always
 
@@ -18,7 +41,7 @@
   set_fact:
     fallback_ips_base: |
       ---
-      {% for item in (groups['k8s_cluster']|default([]) + groups['etcd']|default([]) + groups['calico_rr']|default([]))|unique %}
+      {% for item in (reachable_nodes) %}
       {% set found = hostvars[item].get('ansible_default_ipv4') %}
       {{ item }}: "{{ found.get('address', '127.0.0.1') }}"
       {% endfor %}


### PR DESCRIPTION
The need for this change described in the issue [9863](https://github.com/kubernetes-sigs/kubespray/issues/9863) 

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR adds the feature of running on only reachable hosts while running the fallback_ips.
I am working with static nodes in my workplace and sometimes there are several nodes unavailable due to debug/upgrades/failures,
I am working with AWX and in order to run the scale without any issues, I need updated inventory, which means always commenting out unreachable nodes and pushing to the desired branch.
I am sure I am not the only one with this kind of problem, if there are other options please let me know.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9863 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
