### PR TITLE
fix(contrib/terraform): do not add access_ip when not wanted

### DIFF
--- a/contrib/terraform/terraform.py
+++ b/contrib/terraform/terraform.py
@@ -298,6 +298,9 @@ def openstack_host(resource, module_name):
     if 'floating_ip' in raw_attrs:
         attrs['private_ipv4'] = raw_attrs['network.0.fixed_ip_v4']
 
+    if 'metadata.use_access_ip' in raw_attrs and raw_attrs['metadata.use_access_ip'] == "0":
+        attrs.pop('access_ip')
+
     try:
         if 'metadata.prefer_ipv6' in raw_attrs and raw_attrs['metadata.prefer_ipv6'] == "1":
             attrs.update({


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The documentation says that when setting `use_access_ip` to `0` in terraform, private IPs will be used to transmit internal cluster traffic.
But that's not the case when only using internal IPs without floating IPs, it still wants to use the public `access_ip_v4` instead of `ip`.
So this simple PR removes `access_ip` when internal IP usage is wanted.

**Does this PR introduce a user-facing change?**:
```release-note
Remove unneeded access_ip when not wanted
```
