### PR TITLE
[2.21] Cilium hubble certgen Job and CronJob wrong args (#9856)

### DIFF
--- a/roles/network_plugin/cilium/templates/hubble/cronjob.yml.j2
+++ b/roles/network_plugin/cilium/templates/hubble/cronjob.yml.j2
@@ -30,12 +30,10 @@ spec:
               # the values used in past runs by inspecting the completed pod.
               args:
                 - "--cilium-namespace=kube-system"
-                - "--hubble-ca-reuse-secret=true"
-                - "--hubble-ca-secret-name=hubble-ca-secret"
-                - "--hubble-ca-generate=true"
-                - "--hubble-ca-validity-duration=94608000s"
-                - "--hubble-ca-config-map-create=true"
-                - "--hubble-ca-config-map-name=hubble-ca-cert"
+                - "--ca-reuse-secret=true"
+                - "--ca-secret-name=hubble-ca-secret"
+                - "--ca-generate=true"
+                - "--ca-validity-duration=94608000s"
                 - "--hubble-server-cert-generate=true"
                 - "--hubble-server-cert-common-name=*.{{ cilium_cluster_name }}.hubble-grpc.cilium.io"
                 - "--hubble-server-cert-validity-duration=94608000s"

--- a/roles/network_plugin/cilium/templates/hubble/job.yml.j2
+++ b/roles/network_plugin/cilium/templates/hubble/job.yml.j2
@@ -26,12 +26,10 @@ spec:
           # the values used in past runs by inspecting the completed pod.
           args:
             - "--cilium-namespace=kube-system"
-            - "--hubble-ca-reuse-secret=true"
-            - "--hubble-ca-secret-name=hubble-ca-secret"
-            - "--hubble-ca-generate=true"
-            - "--hubble-ca-validity-duration=94608000s"
-            - "--hubble-ca-config-map-create=true"
-            - "--hubble-ca-config-map-name=hubble-ca-cert"
+            - "--ca-reuse-secret=true"
+            - "--ca-secret-name=hubble-ca-secret"
+            - "--ca-generate=true"
+            - "--ca-validity-duration=94608000s"
             - "--hubble-server-cert-generate=true"
             - "--hubble-server-cert-common-name=*.{{ cilium_cluster_name }}.hubble-grpc.cilium.io"
             - "--hubble-server-cert-validity-duration=94608000s"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR updates the arguments for cilium which have changed since v0.1.7.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9844

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[Cilium] Updates hubble certgen arguments (wrong since v0.1.7)
```
