### PR TITLE
Optimze detecting if calico exists

### DIFF
--- a/roles/network_plugin/calico/tasks/check.yml
+++ b/roles/network_plugin/calico/tasks/check.yml
@@ -43,12 +43,19 @@
   run_once: True
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
 
-- name: Check if calico exists
+- name: Check if calicoctl.sh exists
   stat:
     path: "{{ bin_dir }}/calicoctl.sh"
-  register: calico_exists
+  register: calicoctl_sh_exists
   run_once: True
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
+
+- name: Check if calico ClusterInformation exists
+  command: "{{ bin_dir }}/calicoctl.sh get ClusterInformation"
+  register: clusterinformation_exists
+  run_once: True
+  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  when: calicoctl_sh_exists.stat.exists
 
 - name: Check that current calico version is enough for upgrade
   block:
@@ -69,7 +76,7 @@
           But current version is {{ calico_version_on_server.stdout }}.
   run_once: True
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
-  when: calico_exists.stat.exists
+  when: calicoctl_sh_exists.stat.exists and clusterinformation_exists.rc == 0
 
 - name: "Check that cluster_id is set if calico_rr enabled"
   assert:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind bug

**What this PR does / why we need it**:

* optimize detect the existence of calico, because sometimes the file `calicoctl.sh` exists  ,but not the related crds, such as `clusterinformations`.
* Add check for `ClusterInformation` of calico.

```
TASK [network_plugin/calico : Get current calico version] **********************
fatal: [node1]: FAILED! => {"changed": false,"stdout": "v3.24.5", "stdout_lines": ["v3.24.5"] , "cmd": "set -o pipefail && /usr/local/bin/calicoctl.sh version | grep 'Client Version:' | awk '{ print $3}'", "delta": "0:00:02.873448", "end": "2023-03-09 17:19:44.681338", "msg": "non-zero return code", "rc": 1, "start": "2023-03-09 17:19:41.807890", "stderr": "Unable to retrieve Cluster Version or Type: resource does not exist: ClusterInformation(default) with error: clusterinformations.crd.projectcalico.org \"default\" not found", "stderr_lines": ["Unable to retrieve Cluster Version or Type: resource does not exist: ClusterInformation(default) with error: clusterinformations.crd.projectcalico.org \"default\" not found"]}
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[Calico] Optimize the detection of calico existence 
```
