### PR TITLE
Add systemd_resolved_disable_stub_listener

### DIFF
--- a/docs/dns-stack.md
+++ b/docs/dns-stack.md
@@ -143,6 +143,11 @@ coredns_default_zone_cache_block: |
   }
 ```
 
+### systemd_resolved_disable_stub_listener
+
+Whether or not to set `DNSStubListener=no` when using systemd-resolved. Defaults to `true` on Flatcar.
+You might need to set it to `true` if CoreDNS fails to start with `address already in use` errors.
+
 ## DNS modes supported by Kubespray
 
 You can modify how Kubespray sets up DNS for your cluster with the variables ``dns_mode`` and ``resolvconf_mode``.

--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -140,3 +140,6 @@ redhat_os_family_extensions:
 # Extending some distributions into the debian os family
 debian_os_family_extensions:
   - "UnionTech OS Server 20"
+
+# Sets DNSStubListener=no, useful if you get "0.0.0.0:53: bind: address already in use"
+systemd_resolved_disable_stub_listener: "{{ ansible_os_family in ['Flatcar', 'Flatcar Container Linux by Kinvolk'] }}"

--- a/roles/kubernetes/preinstall/templates/resolved.conf.j2
+++ b/roles/kubernetes/preinstall/templates/resolved.conf.j2
@@ -14,7 +14,7 @@ Domains={{ searchdomains|default([]) | join(' ') }}
 #MulticastDNS=no
 DNSSEC=no
 Cache=no-negative
-{% if ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"] %}
+{% if systemd_resolved_disable_stub_listener | bool %}
 DNSStubListener=no
 {% else %}
 #DNSStubListener=yes


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Exposes the option to set `DNSStubListener=no` to the users via a new variable, `systemd_resolved_disable_stub_listener`.

PR #9160 fixed this issue for Flatcar, but I ran into it on a Rocky Linux 9 VM which was configured to use systemd-resolved. I realize this is not the way the distribution ships, but I don't see anything wrong with exposing this setting to users.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Added `systemd_resolved_disable_stub_listener` variable to disable systemd-resolved's stub listener, defaults to `true` on Flatcar.
```
