### PR TITLE
Fix ciliums hubble relay configuration

### DIFF
--- a/roles/network_plugin/cilium/templates/hubble/config.yml.j2
+++ b/roles/network_plugin/cilium/templates/hubble/config.yml.j2
@@ -7,7 +7,7 @@ metadata:
   namespace: kube-system
 data:
   config.yaml: |
-    peer-service: "hubble-peer.kube-system.svc.cluster.local:443"
+    peer-service: "hubble-peer.kube-system.svc.{{ dns_domain }}:443"
     listen-address: :4245
     metrics-listen-address: ":9966"
     dial-timeout: 

--- a/roles/network_plugin/cilium/templates/hubble/config.yml.j2
+++ b/roles/network_plugin/cilium/templates/hubble/config.yml.j2
@@ -17,7 +17,8 @@ data:
     tls-client-cert-file: /var/lib/hubble-relay/tls/client.crt
     tls-client-key-file: /var/lib/hubble-relay/tls/client.key
     tls-hubble-server-ca-files: /var/lib/hubble-relay/tls/hubble-server-ca.crt
-    disable-server-tls: true
+    disable-server-tls: {% if cilium_hubble_tls_generate %}false{% else %}true{% endif %}
+    disable-client-tls: {% if cilium_hubble_tls_generate %}false{% else %}true{% endif %}
 ---
 # Source: cilium/templates/hubble-ui/configmap.yaml
 apiVersion: v1

--- a/roles/network_plugin/cilium/templates/hubble/config.yml.j2
+++ b/roles/network_plugin/cilium/templates/hubble/config.yml.j2
@@ -1,5 +1,5 @@
 ---
-# Source: cilium/templates/hubble-relay-configmap.yaml
+# Source: cilium helm chart: cilium/templates/hubble-relay/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,17 +7,17 @@ metadata:
   namespace: kube-system
 data:
   config.yaml: |
-    peer-service: unix:///var/run/cilium/hubble.sock
+    peer-service: "hubble-peer.kube-system.svc.cluster.local:443"
     listen-address: :4245
-    dial-timeout:
-    retry-timeout:
-    sort-buffer-len-max:
-    sort-buffer-drain-timeout:
+    metrics-listen-address: ":9966"
+    dial-timeout: 
+    retry-timeout: 
+    sort-buffer-len-max: 
+    sort-buffer-drain-timeout: 
     tls-client-cert-file: /var/lib/hubble-relay/tls/client.crt
     tls-client-key-file: /var/lib/hubble-relay/tls/client.key
     tls-hubble-server-ca-files: /var/lib/hubble-relay/tls/hubble-server-ca.crt
-    disable-server-tls: {% if cilium_hubble_tls_generate %}false{% else %}true{% endif %}
-    disable-client-tls: {% if cilium_hubble_tls_generate %}false{% else %}true{% endif %}
+    disable-server-tls: true
 ---
 # Source: cilium/templates/hubble-ui/configmap.yaml
 apiVersion: v1

--- a/roles/network_plugin/cilium/templates/hubble/deploy.yml.j2
+++ b/roles/network_plugin/cilium/templates/hubble/deploy.yml.j2
@@ -83,9 +83,6 @@ spec:
                   path: client.crt
                 - key: tls.key
                   path: client.key
-          - configMap:
-              name: hubble-ca-cert
-              items:
                 - key: ca.crt
                   path: hubble-server-ca.crt
         name: tls

--- a/roles/network_plugin/cilium/templates/hubble/service.yml.j2
+++ b/roles/network_plugin/cilium/templates/hubble/service.yml.j2
@@ -21,6 +21,27 @@ spec:
     targetPort: hubble-metrics
   selector:
     k8s-app: cilium
+---
+# Source: cilium/templates/hubble-relay/metrics-service.yaml
+# We use a separate service from hubble-relay which can be exposed externally
+kind: Service
+apiVersion: v1
+metadata:
+  name: hubble-relay-metrics
+  namespace: kube-system
+  labels:
+    k8s-app: hubble-relay
+spec:
+  clusterIP: None
+  type: ClusterIP
+  selector:
+    k8s-app: hubble-relay
+  ports:
+  - name: metrics
+    port: 9966
+    protocol: TCP
+    targetPort: prometheus
+
 {% endif %}
 ---
 # Source: cilium/templates/hubble-relay-service.yaml
@@ -56,3 +77,22 @@ spec:
       port: 80
       targetPort: 8081
   type: ClusterIP
+---
+# Source: cilium/templates/hubble/peer-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hubble-peer
+  namespace: kube-system
+  labels:
+    k8s-app: cilium
+spec:
+  selector:
+    k8s-app: cilium
+  ports:
+  - name: peer-service
+    port: 443
+    protocol: TCP
+    targetPort: 4244
+  internalTrafficPolicy: Local
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
This fixes the ContainerCreating status that appears because hubble relay has changed upstream. These changes are based on upstream cilium helm.

Hubble relay now uses k8s service to discover peers rather than unix socket. A new k8s service for peers and metrics are introduced

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/kubernetes-sigs/kubespray/issues/9870 and https://github.com/kubernetes-sigs/kubespray/pull/9613#issuecomment-1366336649
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix cilium's hubble relay configuration
```
