### PR TITLE
cilium: Fix the configuration of tls for hubble

### DIFF
--- a/roles/network_plugin/cilium/templates/hubble/config.yml.j2
+++ b/roles/network_plugin/cilium/templates/hubble/config.yml.j2
@@ -1,3 +1,4 @@
+#jinja2: trim_blocks:False
 ---
 # Source: cilium helm chart: cilium/templates/hubble-relay/configmap.yaml
 apiVersion: v1
@@ -16,6 +17,8 @@ data:
     sort-buffer-drain-timeout: 
     tls-client-cert-file: /var/lib/hubble-relay/tls/client.crt
     tls-client-key-file: /var/lib/hubble-relay/tls/client.key
+    tls-server-cert-file: /var/lib/hubble-relay/tls/server.crt
+    tls-server-key-file: /var/lib/hubble-relay/tls/server.key
     tls-hubble-server-ca-files: /var/lib/hubble-relay/tls/hubble-server-ca.crt
     disable-server-tls: {% if cilium_hubble_tls_generate %}false{% else %}true{% endif %}
     disable-client-tls: {% if cilium_hubble_tls_generate %}false{% else %}true{% endif %}

--- a/roles/network_plugin/cilium/templates/hubble/deploy.yml.j2
+++ b/roles/network_plugin/cilium/templates/hubble/deploy.yml.j2
@@ -79,12 +79,21 @@ spec:
           - secret:
               name: hubble-relay-client-certs
               items:
+                - key: ca.crt
+                  path: hubble-server-ca.crt
                 - key: tls.crt
                   path: client.crt
                 - key: tls.key
                   path: client.key
                 - key: ca.crt
                   path: hubble-server-ca.crt
+          - secret:
+              name: hubble-server-certs
+              items:
+                - key: tls.crt
+                  path: server.crt
+                - key: tls.key
+                  path: server.key
         name: tls
 ---
 # Source: cilium/templates/hubble-ui/deployment.yaml


### PR DESCRIPTION
**What type of PR is this?**
/kind applications

**What this PR does / why we need it**:

The TLS file is generated by CloneJob as Secret. Make sure to specify it.

https://github.com/kubernetes-sigs/kubespray/blob/99115ad04b9da4c6c2e3352e72a175e00bc32678/roles/network_plugin/cilium/templates/hubble/cronjob.yml.j2#L43

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates: https://github.com/kubernetes-sigs/kubespray/pull/9876

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[Cilium] Fix the configuration of TLS for hubble
```
