### PR TITLE
fix manage-offline-files script - wrong path

### DIFF
--- a/contrib/offline/manage-offline-files.sh
+++ b/contrib/offline/manage-offline-files.sh
@@ -39,6 +39,6 @@ if [ $? -ne 0 ]; then
     sudo "${runtime}" run \
         --restart=always -d -p ${NGINX_PORT}:80 \
         --volume "${OFFLINE_FILES_DIR}:/usr/share/nginx/html/download" \
-        --volume "$(pwd)"/nginx.conf:/etc/nginx/nginx.conf \
+        --volume "${CURRENT_DIR}"/nginx.conf:/etc/nginx/nginx.conf \
         --name nginx nginx:alpine
 fi


### PR DESCRIPTION
fix for the directory path in script so it works even when launched from another directory