### PR TITLE
Fix network_plugin/cilium template

### DIFF
--- a/roles/network_plugin/cilium/templates/cilium/config.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/config.yml.j2
@@ -206,11 +206,11 @@ data:
   # IPAM settings
   ipam: "{{ cilium_ipam_mode }}"
 {% if cilium_ipam_mode == "cluster-pool" %}
-  cluster-pool-ipv4-cidr: {% cilium_pool_cidr | default(kube_pods_subnet) %}
-  cluster-pool-ipv4-mask-size: {% cilium_pool_mask_size %}
+  cluster-pool-ipv4-cidr: "{{ cilium_pool_cidr | default(kube_pods_subnet) }}"
+  cluster-pool-ipv4-mask-size: "{{ cilium_pool_mask_size }}"
 {% if cilium_enable_ipv6 %}
-  cluster-pool-ipv6-cidr: {% cilium_pool_cidr_ipv6 | default(kube_pods_subnet_ipv6) %}
-  cluster-pool-ipv6-mask-size: {% cilium_pool_mask_size_ipv6 %}
+  cluster-pool-ipv6-cidr: "{{ cilium_pool_cidr_ipv6 | default(kube_pods_subnet_ipv6) }}"
+  cluster-pool-ipv6-mask-size: "{{ cilium_pool_mask_size_ipv6 }}"
 {% endif %}
 {% endif %}
 


### PR DESCRIPTION
Fix cilium_pool_cidr.*  variables in network_plugin/cilium/templates/cilium /config.yml.j2

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
 
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
fix this error in template 

**Which issue(s) this PR fixes**:
```
(item={'name': 'cilium', 'file': 'config.yml', 'type': 'cm'}) => {"ansible_loop_var": "item", "changed": false, "item": {"file": "config.yml", "name": "cilium", "type": "cm"}, "msg": "AnsibleError: template error while templating string: Encountered unknown tag 'cilium_pool_cidr'. Jinja was looking for the following tags: 'elif' or 'else' or 'endif'. The innermost block that needs to be closed is 'if'.. String: ---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cilium-config\n  namespace: kube-system\ndata:\n  identity-allocation-mode: {{ cilium_identity_allocation_mode }}\n\n{% if cilium_identity_allocation_mode == \"kvstore\" %}\n  # This etcd-config contains the etcd endpoints of your cluster. If you use\n  # TLS please make sure you follow the tutor…
```
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9901

**Special notes for your reviewer**:
https://github.com/kubernetes-sigs/kubespray/pull/9443 - merged 2 days ago
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
