### PR TITLE
Fix Cilium template  error

### DIFF
--- a/docs/cilium.md
+++ b/docs/cilium.md
@@ -4,7 +4,7 @@
 
 IP Address Management (IPAM) is responsible for the allocation and management of IP addresses used by network endpoints (container and others) managed by Cilium. The default mode is "Cluster Scope".
 
-You can set the following parameters:
+You can set the following parameters, for example: cluster-pool, kubernetes:
 
 ```yml
 cilium_ipam_mode: cluster-pool
@@ -13,15 +13,16 @@ cilium_ipam_mode: cluster-pool
 ### Set the cluster Pod CIDRs
 
 Cluster Pod CIDRs use the kube_pods_subnet value by default.
-If your node network is in the same range you will lose connectivity to other nodes
-
+If your node network is in the same range you will lose connectivity to other nodes.
+Defaults to kube_pods_subnet if not set.
 You can set the following parameters:
 
 ```yml
 cilium_pool_cidr: 10.233.64.0/18
 ```
 
-When cilium_enable_ipv6 is used, you need to set the IPV6 value:
+When cilium_enable_ipv6 is used. Defaults to kube_pods_subnet_ipv6 if not set.
+you need to set the IPV6 value:
 
 ```yml
 cilium_pool_cidr_ipv6: fd85:ee78:d8a6:8607::1:0000/112
@@ -31,13 +32,14 @@ cilium_pool_cidr_ipv6: fd85:ee78:d8a6:8607::1:0000/112
 
 When cilium IPAM uses the "Cluster Scope" mode, it will pre-allocate a segment of IP to each node,
 schedule the Pod to this node, and then allocate IP from here. cilium_pool_mask_size Specifies
-the size allocated from cluster Pod CIDR to node.ipam.podCIDRs
+the size allocated from cluster Pod CIDR to node.ipam.podCIDRs.
+Defaults to kube_network_node_prefix if not set.
 
 ```yml
-cilium_pool_mask_size: "26"
+cilium_pool_mask_size: "24"
 ```
 
-cilium_pool_mask_size Specifies the size allocated to node.ipam.podCIDRs from cluster Pod IPV6 CIDR
+cilium_pool_mask_size Specifies the size allocated to node.ipam.podCIDRs from cluster Pod IPV6 CIDR. Defaults to kube_network_node_prefix_ipv6 if not set.
 
 ```yml
 cilium_pool_mask_size_ipv6: "120"

--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -157,19 +157,22 @@ cilium_hubble_tls_generate: false
 cilium_ipam_mode: cluster-pool
 
 # Cluster Pod CIDRs use the kube_pods_subnet value by default.
-# If your node network is in the same range you will lose connectivity to other nodes
-cilium_pool_cidr: "{{ kube_pods_subnet | 10.233.64.0/18 }}"
+# If your node network is in the same range you will lose connectivity to other nodes.
+# Defaults to kube_pods_subnet if not set.
+# cilium_pool_cidr: 10.233.64.0/18
 
-# When cilium_enable_ipv6 is used, you need to set the IPV6 value
-cilium_pool_cidr_ipv6: "{{ kube_pods_subnet_ipv6 | fd85:ee78:d8a6:8607::1:0000/112 }}"
+# When cilium_enable_ipv6 is used, you need to set the IPV6 value.  Defaults to kube_pods_subnet_ipv6 if not set.
+# cilium_pool_cidr_ipv6: fd85:ee78:d8a6:8607::1:0000/112
 
 # When cilium IPAM uses the "Cluster Scope" mode, it will pre-allocate a segment of IP to each node,
 # schedule the Pod to this node, and then allocate IP from here. cilium_pool_mask_size Specifies
 # the size allocated from cluster Pod CIDR to node.ipam.podCIDRs
-cilium_pool_mask_size: "26"
+# Defaults to kube_network_node_prefix if not set.
+# cilium_pool_mask_size: "24"
 
 # cilium_pool_mask_size Specifies the size allocated to node.ipam.podCIDRs from cluster Pod IPV6 CIDR
-cilium_pool_mask_size_ipv6: "120"
+# Defaults to kube_network_node_prefix_ipv6 if not set.
+# cilium_pool_mask_size_ipv6: "120"
 
 
 # Extra arguments for the Cilium agent

--- a/roles/network_plugin/cilium/templates/cilium/config.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/config.yml.j2
@@ -206,11 +206,11 @@ data:
   # IPAM settings
   ipam: "{{ cilium_ipam_mode }}"
 {% if cilium_ipam_mode == "cluster-pool" %}
-  cluster-pool-ipv4-cidr: {% cilium_pool_cidr | default(kube_pods_subnet) %}
-  cluster-pool-ipv4-mask-size: {% cilium_pool_mask_size %}
+  cluster-pool-ipv4-cidr: "{{ cilium_pool_cidr | default(kube_pods_subnet) }}"
+  cluster-pool-ipv4-mask-size: "{{ cilium_pool_mask_size | default(kube_network_node_prefix) }}"
 {% if cilium_enable_ipv6 %}
-  cluster-pool-ipv6-cidr: {% cilium_pool_cidr_ipv6 | default(kube_pods_subnet_ipv6) %}
-  cluster-pool-ipv6-mask-size: {% cilium_pool_mask_size_ipv6 %}
+  cluster-pool-ipv6-cidr: "{{ cilium_pool_cidr_ipv6 | default(kube_pods_subnet_ipv6) }}"
+  cluster-pool-ipv6-mask-size: "{{ cilium_pool_mask_size_ipv6 | default(kube_network_node_prefix_ipv6) }}"
 {% endif %}
 {% endif %}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fix the Cilium CI error, and change the default value to the kubespray default.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fix: https://github.com/kubernetes-sigs/kubespray/issues/9901

**Special notes for your reviewer**:

https://github.com/kubernetes-sigs/kubespray/pull/9443 - merged 2 days ago
Another Fix: https://github.com/kubernetes-sigs/kubespray/pull/9896

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
