### PR TITLE
feat: support cilium 1.13.1

### DIFF
--- a/roles/network_plugin/cilium/templates/cilium/ds.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/ds.yml.j2
@@ -149,8 +149,10 @@ spec:
           mountPropagation: Bidirectional
         - name: cilium-run
           mountPath: /var/run/cilium
+{% if cilium_version | regex_replace('v') is version('1.13.1', '<') %}
         - name: cni-path
           mountPath: /host/opt/cni/bin
+{% endif %}
         - name: etc-cni-netd
           mountPath: /host/etc/cni/net.d
 {% if cilium_identity_allocation_mode == "kvstore" %}
@@ -304,6 +306,24 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+{% if cilium_version | regex_replace('v') is version('1.13.1', '>=') %}
+      # Install the CNI binaries in an InitContainer so we don't have a writable host mount in the agent
+      - name: install-cni-binaries
+        image: "{{cilium_image_repo}}:{{cilium_image_tag}}"
+        imagePullPolicy: {{ k8s_image_pull_policy }}
+        command:
+          - "/install-plugin.sh"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 10Mi
+        securityContext:
+          privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+          - name: cni-path
+            mountPath: /host/opt/cni/bin
+{% endif %}
       restartPolicy: Always
       priorityClassName: system-node-critical
       serviceAccount: cilium


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Cilium 1.13.1 changed how the cilium-cni binary gets placed in /opt/cni/bin, so that it takes place in an init container rather than in the main agent  (https://github.com/cilium/cilium/pull/24075). Consequently, that new init container needs to be included in the daemonset we generate.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

**Special notes for your reviewer**:
This is somewhat related to https://github.com/kubernetes-sigs/kubespray/pull/9879. That PR bumps the default Cilium version to 1.13.0. If this template is not fixed, users who set their Cilium version to anything above 1.13.0 will encounter CNI failures.
 
**Does this PR introduce a user-facing change?**:
This should be supported without the user needing to think about it, so I'm omitting a release note, but please let me know if one should be added.
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[Cilium] Support version below 1.13.x
```
