### PR TITLE
fix(cert manager): Fix cert_manager_trusted_internal_ca manifest

### DIFF
--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
@@ -964,6 +964,17 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+{% if cert_manager_trusted_internal_ca is defined %}
+          volumeMounts:
+          - mountPath: /etc/ssl/certs/internal-ca.pem
+            name: ca-internal-truststore
+            subPath: internal-ca.pem
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: ca-internal-truststore
+        name: ca-internal-truststore
+{% endif %}
 {% if cert_manager_tolerations %}
       tolerations:
         {{ cert_manager_tolerations | to_nice_yaml(indent=2) | indent(width=8) }}
@@ -982,17 +993,6 @@ spec:
 {% if cert_manager_dns_config %}
       dnsConfig:
         {{ cert_manager_dns_config | to_nice_yaml | indent(width=8) }}
-{% endif %}
-{% if cert_manager_trusted_internal_ca is defined %}
-          volumeMounts:
-          - mountPath: /etc/ssl/certs/internal-ca.pem
-            name: ca-internal-truststore
-            subPath: internal-ca.pem
-      volumes:
-      - configMap:
-          defaultMode: 420
-          name: ca-internal-truststore
-        name: ca-internal-truststore
 {% endif %}
 ---
 # Source: cert-manager/deploy/charts/cert-manager/templates/webhook-deployment.yaml


### PR DESCRIPTION
As described in #9921 the cert manager deployment fails if `cert_manager_trusted_internal_ca` is provided together with the dns policy.

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This moves the volume and mount, to the top of the conditionals in the cert manager manfiest, to fix the order.

**Which issue(s) this PR fixes**:
Fixes #9921

**Special notes for your reviewer**:
Alternatively, it would also be possible to split the `volumeMount` and the `volumes` definitions.

**Does this PR introduce a user-facing change?**:
```release-note
Fix `cert_manager_trusted_internal_ca` manifest failing when dns policy is set
```