### PR TITLE
Remove deprecated udpIdleTimeout field in KubeProxyConfiguration

### DIFF
--- a/roles/kubernetes/control-plane/defaults/main/kube-proxy.yml
+++ b/roles/kubernetes/control-plane/defaults/main/kube-proxy.yml
@@ -112,7 +112,3 @@ kube_proxy_oom_score_adj: -999
 # portRange is the range of host ports (beginPort-endPort, inclusive) that may be consumed
 # in order to proxy service traffic. If unspecified, 0, or (0-0) then ports will be randomly chosen.
 kube_proxy_port_range: ''
-
-# udpIdleTimeout is how long an idle UDP connection will be kept open (e.g. '250ms', '2s').
-# Must be greater than 0. Only applicable for proxyMode=userspace.
-kube_proxy_udp_idle_timeout: 250ms

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
@@ -417,7 +417,6 @@ mode: {{ kube_proxy_mode }}
 nodePortAddresses: {{ kube_proxy_nodeport_addresses }}
 oomScoreAdj: {{ kube_proxy_oom_score_adj }}
 portRange: {{ kube_proxy_port_range }}
-udpIdleTimeout: {{ kube_proxy_udp_idle_timeout }}
 {% if kube_proxy_feature_gates or kube_feature_gates %}
 {% set feature_gates = ( kube_proxy_feature_gates | default(kube_feature_gates, true) ) %}
 featureGates:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Remove deprecated udpIdleTimeout field in KubeProxyConfiguration, please refer to: https://github.com/kubernetes/kubernetes/pull/112133 and https://github.com/kubernetes/kubernetes/issues/103860

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Remove deprecated udpIdleTimeout field in KubeProxyConfiguration
```
