### PR TITLE
Delete the probe option of cilium_kube_proxy_replacement

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
@@ -51,8 +51,8 @@
 #
 # Only effective when monitor aggregation is set to "medium" or higher.
 # cilium_monitor_aggregation_flags: "all"
-# Kube Proxy Replacement mode (strict/probe/partial)
-# cilium_kube_proxy_replacement: probe
+# Kube Proxy Replacement mode (strict/partial)
+# cilium_kube_proxy_replacement: partial
 
 # If upgrading from Cilium < 1.5, you may want to override some of these options
 # to prevent service disruptions. See also:

--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -45,8 +45,8 @@ cilium_enable_prometheus: false
 cilium_enable_portmap: false
 # Monitor aggregation level (none/low/medium/maximum)
 cilium_monitor_aggregation: medium
-# Kube Proxy Replacement mode (strict/probe/partial)
-cilium_kube_proxy_replacement: probe
+# Kube Proxy Replacement mode (strict/partial)
+cilium_kube_proxy_replacement: partial
 
 # If upgrading from Cilium < 1.5, you may want to override some of these options
 # to prevent service disruptions. See also:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
In the cilium v1.13, the option `probe` of  `kube-proxy-replacement` has been removed, so when creating clusters with cilium, the cilium pod can not run.
https://docs.cilium.io/en/stable/operations/upgrade/#removed-options

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes  https://github.com/kubean-io/kubean/issues/604

**Special notes for your reviewer**:
I set `cilium_kube_proxy_replacement` to `partial` or `strict`, both can work.
```
I0326 17:23:22.771672 3571066 service.go:38] ... podStatus is: Running
I0326 17:24:22.784877 3571066 service.go:38] ... podStatus is: Running
I0326 17:25:22.812402 3571066 service.go:38] ... podStatus is: Running
I0326 17:26:22.826294 3571066 service.go:38] ... podStatus is: Running
I0326 17:27:22.868775 3571066 service.go:38] ... podStatus is: Running
I0326 17:28:22.885784 3571066 service.go:38] ... podStatus is: Succeeded
Name: cluster1-kubeconf NameSpace: kubean-system
I0326 17:28:22.898857 3571066 service.go:67] ****get cluster success
I0326 17:28:22.916177 3571066 service.go:78] ---- Waiting Pods in %s to be Running ---kube-system
I0326 17:28:23.025626 3571066 service.go:87] Waiting cilium-bfhcdto be Running...
I0326 17:28:23.042074 3571066 service.go:87] Waiting cilium-bwtggto be Running...
I0326 17:28:23.065051 3571066 service.go:87] Waiting cilium-operator-64d9fbb8f5-bd5dxto be Running...
I0326 17:28:23.079821 3571066 service.go:87] Waiting cilium-operator-64d9fbb8f5-tw8vbto be Running...
I0326 17:28:23.092883 3571066 service.go:87] Waiting coredns-7759f8769f-cf4c4to be Running...
I0326 17:28:23.104870 3571066 service.go:87] Waiting coredns-7759f8769f-n2r86to be Running...
I0326 17:28:23.121759 3571066 service.go:87] Waiting dns-autoscaler-59449f7494-prqrrto be Running...
I0326 17:28:23.131207 3571066 service.go:87] Waiting etcd-node1to be Running...
I0326 17:28:23.140231 3571066 service.go:87] Waiting kube-apiserver-node1to be Running...
I0326 17:28:23.150694 3571066 service.go:87] Waiting kube-controller-manager-node1to be Running...
I0326 17:28:23.167577 3571066 service.go:87] Waiting kube-proxy-7zpj9to be Running...
I0326 17:28:23.332763 3571066 service.go:87] Waiting kube-proxy-kz979to be Running...
I0326 17:28:23.535907 3571066 service.go:87] Waiting kube-scheduler-node1to be Running...
I0326 17:28:23.731405 3571066 service.go:87] Waiting metrics-server-575c65464c-vkt6dto be Running...
I0326 17:28:23.933004 3571066 service.go:87] Waiting nginx-proxy-node2to be Running...
I0326 17:28:24.130525 3571066 create_cilium_cluster_test.go:60] On line, sonobuoy check

```

Does this PR introduce a user-facing change?:

This would cause a change to the repository's structure, meaning downstream users would either need to change their code to point to the `playbooks` directory or use the `ansible.builtin.import_playbook` module

```release-note
[Cilium] Delete the probe option of cilium_kube_proxy_replacement 
```
