### PR TITLE
Updates requirements to the latest available versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:focal-20220531
 # Some tools like yamllint need this
 # Pip needs this as well at the moment to install ansible
-# (and potentially other packages)
+# (and potentially other packages) 
 # See: https://github.com/pypa/pip/issues/10219
 ENV LANG=C.UTF-8 \
     DEBIAN_FRONTEND=noninteractive \
@@ -28,10 +28,10 @@ RUN apt update -q \
        ansible==5.7.1 \
        ansible-core==2.12.5 \
        cryptography==3.4.8 \
-       jinja2==2.11.3 \
-       netaddr==0.7.19 \
+       jinja2==3.1.2 \
+       netaddr==0.8.0 \
        jmespath==1.0.1 \
-       MarkupSafe==1.1.1 \
+       MarkupSafe==2.1.2 \
        ruamel.yaml==0.17.21 \
     && KUBE_VERSION=$(sed -n 's/^kube_version: //p' roles/kubespray-defaults/defaults/main.yaml) \
     && curl -L https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/$(dpkg --print-architecture)/kubectl -o /usr/local/bin/kubectl \

--- a/requirements-2.11.txt
+++ b/requirements-2.11.txt
@@ -1,10 +1,10 @@
 ansible==4.10.0
 ansible-core==2.11.11
 cryptography==3.4.8
-jinja2==2.11.3
-jmespath==0.9.5
-MarkupSafe==1.1.1
-netaddr==0.7.19
-pbr==5.4.4
-ruamel.yaml==0.16.10
+jinja2==3.1.2
+jmespath==1.0.1
+MarkupSafe==2.1.2
+netaddr==0.8.0
+pbr==5.11.1
+ruamel.yaml==0.17.21
 ruamel.yaml.clib==0.2.7

--- a/requirements-2.12.txt
+++ b/requirements-2.12.txt
@@ -1,10 +1,10 @@
 ansible==5.7.1
 ansible-core==2.12.5
 cryptography==3.4.8
-jinja2==2.11.3
-jmespath==0.9.5
-MarkupSafe==1.1.1
-netaddr==0.7.19
-pbr==5.4.4
-ruamel.yaml==0.16.10
+jinja2==3.1.2
+jmespath==1.0.1
+MarkupSafe==2.1.2
+netaddr==0.8.0
+pbr==5.11.1
+ruamel.yaml==0.17.21
 ruamel.yaml.clib==0.2.7


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This is simply live cycle management, which also solves a bug regarding Jinja2 and Ansible.

**Which issue(s) this PR fixes**:

*Automatically closes linked issue when PR is merged.
Fixes #9919 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

None

```release-note
Upgrades the following Python libraries to their latest available releases:

- cryptography
- jinja2
- jmespath
- MarkupSafe
- netaddr
- pbr
- ruamel.yaml
- ruamel.yaml.clib
```
