### PR TITLE
Fix the kube-bench 1.2.20 to enhance security

### DIFF
--- a/docs/vars.md
+++ b/docs/vars.md
@@ -252,7 +252,7 @@ node_taints:
   The auditing parameters can be tuned via the following variables (which default values are shown below):
   * `audit_log_path`: /var/log/audit/kube-apiserver-audit.log
   * `audit_log_maxage`: 30
-  * `audit_log_maxbackups`: 1
+  * `audit_log_maxbackups`: 10
   * `audit_log_maxsize`: 100
   * `audit_policy_file`: "{{ kube_config_dir }}/audit-policy/apiserver-audit-policy.yaml"
 

--- a/roles/kubernetes/control-plane/defaults/main/main.yml
+++ b/roles/kubernetes/control-plane/defaults/main/main.yml
@@ -48,7 +48,7 @@ audit_log_path: /var/log/audit/kube-apiserver-audit.log
 # num days
 audit_log_maxage: 30
 # the num of audit logs to retain
-audit_log_maxbackups: 1
+audit_log_maxbackups: 10
 # the max size in MB to retain
 audit_log_maxsize: 100
 # policy file


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:

Fix kube-bench check Fail  1.2.20 by increase the default value of audit_log_maxbackups
Ref to https://github.com/aquasecurity/kube-bench/blob/main/cfg/cis-1.24/master.yaml#L627

**Which issue(s) this PR fixes**:

Fixes  https://github.com/kubernetes-sigs/kubespray/issues/9933

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix kube-bench  1.2.20 to enhance security (Ensure that the --audit-log-maxbackup argument is set to 10)
```
