### PR TITLE
[vSphere-csi-driver] Custom namespace fails playbook

### DIFF
--- a/roles/kubernetes-apps/csi_driver/vsphere/tasks/main.yml
+++ b/roles/kubernetes-apps/csi_driver/vsphere/tasks/main.yml
@@ -27,19 +27,6 @@
   register: vsphere_csi_manifests
   when: inventory_hostname == groups['kube_control_plane'][0]
 
-- name: vSphere CSI Driver | Apply a CSI secret manifest
-  command:
-    cmd: "{{ kubectl }} apply -f -"
-    stdin: "{{ vsphere_csi_secret_manifest.stdout }}"
-  when: inventory_hostname == groups['kube_control_plane'][0]
-  no_log: "{{ not (unsafe_show_logs|bool) }}"
-
-- name: vSphere CSI Driver | Generate a CSI secret manifest
-  command: "{{ kubectl }} create secret generic vsphere-config-secret --from-file=csi-vsphere.conf={{ kube_config_dir }}/vsphere-csi-cloud-config -n {{ vsphere_csi_namespace }} --dry-run --save-config -o yaml"
-  register: vsphere_csi_secret_manifest
-  when: inventory_hostname == groups['kube_control_plane'][0]
-  no_log: "{{ not (unsafe_show_logs|bool) }}"
-
 - name: vSphere CSI Driver | Apply Manifests
   kube:
     kubectl: "{{ bin_dir }}/kubectl"
@@ -52,3 +39,16 @@
     - not item is skipped
   loop_control:
     label: "{{ item.item }}"
+
+- name: vSphere CSI Driver | Generate a CSI secret manifest
+  command: "{{ kubectl }} create secret generic vsphere-config-secret --from-file=csi-vsphere.conf={{ kube_config_dir }}/vsphere-csi-cloud-config -n {{ vsphere_csi_namespace }} --dry-run --save-config -o yaml"
+  register: vsphere_csi_secret_manifest
+  when: inventory_hostname == groups['kube_control_plane'][0]
+  no_log: "{{ not (unsafe_show_logs|bool) }}"
+
+- name: vSphere CSI Driver | Apply a CSI secret manifest
+  command:
+    cmd: "{{ kubectl }} apply -f -"
+    stdin: "{{ vsphere_csi_secret_manifest.stdout }}"
+  when: inventory_hostname == groups['kube_control_plane'][0]
+  no_log: "{{ not (unsafe_show_logs|bool) }}"

--- a/roles/kubernetes-apps/csi_driver/vsphere/tasks/main.yml
+++ b/roles/kubernetes-apps/csi_driver/vsphere/tasks/main.yml
@@ -26,10 +26,16 @@
   register: vsphere_csi_manifests
   when: inventory_hostname == groups['kube_control_plane'][0]
 
+- name: vSphere CSI Driver | Check namespace exists
+  command: "{{ kubectl }} get ns {{ vsphere_csi_namespace }} -o yaml"
+  register: check_vsphere_namespace
+  ignore_errors: yes
+
 - name: vSphere CSI Driver | Create namespace
   command: "{{ kubectl }} create ns {{ vsphere_csi_namespace }}"
-  when: inventory_hostname == groups['kube_control_plane'][0]
-  ignore_errors: yes  # noqa ignore-errors
+  when:
+    - check_vsphere_namespace is failed
+    - inventory_hostname == groups['kube_control_plane'][0]
 
 - name: vSphere CSI Driver | Generate a CSI secret manifest
   command: "{{ kubectl }} create secret generic vsphere-config-secret --from-file=csi-vsphere.conf={{ kube_config_dir }}/vsphere-csi-cloud-config -n {{ vsphere_csi_namespace }} --dry-run --save-config -o yaml"

--- a/roles/kubernetes-apps/csi_driver/vsphere/tasks/main.yml
+++ b/roles/kubernetes-apps/csi_driver/vsphere/tasks/main.yml
@@ -16,7 +16,6 @@
     dest: "{{ kube_config_dir }}/{{ item }}"
     mode: 0644
   with_items:
-    - vsphere-csi-namespace.yml
     - vsphere-csi-driver.yml
     - vsphere-csi-controller-rbac.yml
     - vsphere-csi-node-rbac.yml
@@ -26,6 +25,11 @@
     - vsphere-csi-node.yml
   register: vsphere_csi_manifests
   when: inventory_hostname == groups['kube_control_plane'][0]
+
+- name: vSphere CSI Driver | Create namespace
+  command: "{{ kubectl }} create ns {{ vsphere_csi_namespace }}"
+  when: inventory_hostname == groups['kube_control_plane'][0]
+  ignore_errors: yes  # noqa ignore-errors
 
 - name: vSphere CSI Driver | Generate a CSI secret manifest
   command: "{{ kubectl }} create secret generic vsphere-config-secret --from-file=csi-vsphere.conf={{ kube_config_dir }}/vsphere-csi-cloud-config -n {{ vsphere_csi_namespace }} --dry-run --save-config -o yaml"

--- a/roles/kubernetes-apps/csi_driver/vsphere/tasks/main.yml
+++ b/roles/kubernetes-apps/csi_driver/vsphere/tasks/main.yml
@@ -16,6 +16,7 @@
     dest: "{{ kube_config_dir }}/{{ item }}"
     mode: 0644
   with_items:
+    - vsphere-csi-namespace.yml
     - vsphere-csi-driver.yml
     - vsphere-csi-controller-rbac.yml
     - vsphere-csi-node-rbac.yml
@@ -26,28 +27,16 @@
   register: vsphere_csi_manifests
   when: inventory_hostname == groups['kube_control_plane'][0]
 
-- name: vSphere CSI Driver | Check namespace exists
-  command: "{{ kubectl }} get ns {{ vsphere_csi_namespace }} -o yaml"
-  register: check_vsphere_namespace
-  changed_when: false
-  ignore_errors: yes  # noqa ignore-errors
-
-- name: vSphere CSI Driver | Create namespace
-  command: "{{ kubectl }} create ns {{ vsphere_csi_namespace }}"
-  when:
-    - check_vsphere_namespace is failed
-    - inventory_hostname == groups['kube_control_plane'][0]
-
-- name: vSphere CSI Driver | Generate a CSI secret manifest
-  command: "{{ kubectl }} create secret generic vsphere-config-secret --from-file=csi-vsphere.conf={{ kube_config_dir }}/vsphere-csi-cloud-config -n {{ vsphere_csi_namespace }} --dry-run --save-config -o yaml"
-  register: vsphere_csi_secret_manifest
-  when: inventory_hostname == groups['kube_control_plane'][0]
-  no_log: "{{ not (unsafe_show_logs|bool) }}"
-
 - name: vSphere CSI Driver | Apply a CSI secret manifest
   command:
     cmd: "{{ kubectl }} apply -f -"
     stdin: "{{ vsphere_csi_secret_manifest.stdout }}"
+  when: inventory_hostname == groups['kube_control_plane'][0]
+  no_log: "{{ not (unsafe_show_logs|bool) }}"
+
+- name: vSphere CSI Driver | Generate a CSI secret manifest
+  command: "{{ kubectl }} create secret generic vsphere-config-secret --from-file=csi-vsphere.conf={{ kube_config_dir }}/vsphere-csi-cloud-config -n {{ vsphere_csi_namespace }} --dry-run --save-config -o yaml"
+  register: vsphere_csi_secret_manifest
   when: inventory_hostname == groups['kube_control_plane'][0]
   no_log: "{{ not (unsafe_show_logs|bool) }}"
 

--- a/roles/kubernetes-apps/csi_driver/vsphere/tasks/main.yml
+++ b/roles/kubernetes-apps/csi_driver/vsphere/tasks/main.yml
@@ -29,7 +29,8 @@
 - name: vSphere CSI Driver | Check namespace exists
   command: "{{ kubectl }} get ns {{ vsphere_csi_namespace }} -o yaml"
   register: check_vsphere_namespace
-  ignore_errors: yes # noqa ignore-errors
+  changed_when: false
+  ignore_errors: yes #noqa ignore-errors
 
 - name: vSphere CSI Driver | Create namespace
   command: "{{ kubectl }} create ns {{ vsphere_csi_namespace }}"

--- a/roles/kubernetes-apps/csi_driver/vsphere/tasks/main.yml
+++ b/roles/kubernetes-apps/csi_driver/vsphere/tasks/main.yml
@@ -29,7 +29,7 @@
 - name: vSphere CSI Driver | Check namespace exists
   command: "{{ kubectl }} get ns {{ vsphere_csi_namespace }} -o yaml"
   register: check_vsphere_namespace
-  ignore_errors: yes
+  ignore_errors: yes # noqa ignore-errors
 
 - name: vSphere CSI Driver | Create namespace
   command: "{{ kubectl }} create ns {{ vsphere_csi_namespace }}"

--- a/roles/kubernetes-apps/csi_driver/vsphere/tasks/main.yml
+++ b/roles/kubernetes-apps/csi_driver/vsphere/tasks/main.yml
@@ -30,7 +30,7 @@
   command: "{{ kubectl }} get ns {{ vsphere_csi_namespace }} -o yaml"
   register: check_vsphere_namespace
   changed_when: false
-  ignore_errors: yes #noqa ignore-errors
+  ignore_errors: yes  # noqa ignore-errors
 
 - name: vSphere CSI Driver | Create namespace
   command: "{{ kubectl }} create ns {{ vsphere_csi_namespace }}"

--- a/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-namespace.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-namespace.yml.j2
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: "{{ vsphere_csi_namespace }}"

--- a/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-namespace.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-namespace.yml.j2
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "{{ vsphere_csi_namespace }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Fixes the run of the `cluster.yml` playbook when `vsphere_csi_namespace` is set to non-default. Ex.: `vsphere_csi_namespace: "vmware-system-csi"`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9945

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
