### PR TITLE
[calico] add v3.25.1 and make it default

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [cri-o](http://cri-o.io/) v1.24 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)
 - Network Plugin
   - [cni-plugins](https://github.com/containernetworking/plugins) v1.2.0
-  - [calico](https://github.com/projectcalico/calico) v3.25.0
+  - [calico](https://github.com/projectcalico/calico) v3.25.1
   - [canal](https://github.com/projectcalico/canal) (given calico/flannel versions)
   - [cilium](https://github.com/cilium/cilium) v1.13.0
   - [flannel](https://github.com/flannel-io/flannel) v0.20.2

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -103,7 +103,7 @@ github_image_repo: "ghcr.io"
 
 # TODO(mattymo): Move calico versions to roles/network_plugins/calico/defaults
 # after migration to container download
-calico_version: "v3.25.0"
+calico_version: "v3.25.1"
 calico_ctl_version: "{{ calico_version }}"
 calico_cni_version: "{{ calico_version }}"
 calico_flexvol_version: "{{ calico_version }}"
@@ -579,24 +579,28 @@ cni_binary_checksums:
 
 calicoctl_binary_checksums:
   arm:
+    v3.25.1: 0
     v3.25.0: 0
     v3.24.5: 0
     v3.23.3: 0
     v3.22.4: 0
     v3.21.6: 0
   amd64:
+    v3.25.1: 13565e5304209ffaa93df3ba722e6f623b66c76057ca8ff5c5864fa13176fe48
     v3.25.0: 5a464075ccbaa8715882de6b32fe82b41488e904fa66b19c48ee6388cf48b1b8
     v3.24.5: 01e6c8a2371050f9edd0ade9dcde89da054e84d8e96bd4ba8cf82806c8d3e8e7
     v3.23.3: d9c04ab15bad9d8037192abd2aa4733a01b0b64a461c7b788118a0d6747c1737
     v3.22.4: cc412783992abeba6dc01d7bc67bdb2e3a0cf2f27fc3334bdfc02d326c3c9e15
     v3.21.6: 20335301841ba1dd0795e834ecce0d8e6b89f0b01d781dcc95339419462b3b67
   arm64:
+    v3.25.1: 83084be5de90a94bfd7a10da5758acbf200ddd68fa24ee4e7e1dedc8935aa41d
     v3.25.0: 6eda153187ab76821903cf6bb69fe11b016529c3344e2dd1a0f7f3cb3069ded0
     v3.24.5: 2d56b768ed346129b0249261db27d97458cfb35f98bd028a0c817a23180ab2d2
     v3.23.3: 741b222f9bb10b7b5e268e5362796061c8862d4f785bb6b9c4f623ea143f4682
     v3.22.4: e84ba529091818282012fd460e7509995156e50854781c031c81e4f6c715a39a
     v3.21.6: 8f4ca86e21364eb23fb4676a0a1ed9e751c8a044360b22eae9ee6af7e81c3d59
   ppc64le:
+    v3.25.1: 43f7a19c3f81a658349d727283f201ce5a560dc9a9f7e56d70961755f4196135
     v3.25.0: 15545aa42dfafb12b68070253e649dfbfdb4b495935e4717d2f04c46500d1a9e
     v3.24.5: 4c40d1703a31eb1d1786287fbf295d614eb9594a4748e505a03a2fbb6eda85b4
     v3.23.3: f83efcd8d3d7c96dfe8e596dc9739eb5d9616626a6afba29b0af97e5c222575a
@@ -621,6 +625,7 @@ ciliumcli_binary_checksums:
     v0.12.5: 0
 
 calico_crds_archive_checksums:
+  v3.25.1: 361b0e0e6d64156f0e1b2fbfd18d13217d188eee614eec5de6b05ac0deaab372
   v3.25.0: 117b4493ad933f24ea6fb82eabfad300da2dd926995bb8c55336595d38c72881
   v3.24.5: 10320b45ebcf4335703d692adacc96cdd3a27de62b4599238604bd7b0bedccc3
   v3.23.3: d25f5c9a3adeba63219f3c8425a8475ebfbca485376a78193ec1e4c74e7a6115


### PR DESCRIPTION
 **What type of PR is this?**
 
 /kind feature
 
 **What this PR does / why we need it**: 

This PR adds calico version v3.25.1 and make it default

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[calico] upgrade default calico version to v3.25.1
```