### PR TITLE
[etcd] fix make-ssl-etcd.sh.j2; move pem files only if any new certs exist

### DIFF
--- a/roles/etcd/templates/make-ssl-etcd.sh.j2
+++ b/roles/etcd/templates/make-ssl-etcd.sh.j2
@@ -100,4 +100,6 @@ if [ -e "$SSLDIR/ca-key.pem" ]; then
     rm -f ca.pem ca-key.pem
 fi
 
-mv *.pem ${SSLDIR}/
+if [ -n "$(ls -A *.pem)" ]; then
+    mv *.pem ${SSLDIR}/
+fi


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR ensures that even if there are no newly created certificates, `make-ssl-etcd.sh` will exit safely.

**Which issue(s) this PR fixes**:

#9173 causes etcd role error in `Gen_certs | run cert generation script for etcd and kube control plane nodes` when all certificates for etcd and control planes are already issued.

```
+ set -o errexit
+ set -o pipefail
+ (( 4 ))
+ case "$1" in
+ CONFIG=/etc/ssl/etcd/openssl.conf
+ shift 2
+ (( 2 ))
+ case "$1" in
+ SSLDIR=/etc/ssl/etcd/ssl
+ shift 2
+ (( 0 ))
+ '[' -z /etc/ssl/etcd/openssl.conf ']'
+ '[' -z /etc/ssl/etcd/ssl ']'
++ mktemp -d /tmp/etcd_cacert.XXXXXX
+ tmpdir=/tmp/etcd_cacert.sWoENC
+ trap 'rm -rf "${tmpdir}"' EXIT
+ cd /tmp/etcd_cacert.sWoENC
+ mkdir -p /etc/ssl/etcd/ssl
+ '[' -e /etc/ssl/etcd/ssl/ca-key.pem ']'
+ cp /etc/ssl/etcd/ssl/ca.pem /etc/ssl/etcd/ssl/ca-key.pem .
+ '[' -n '      ' ']'
+ '[' -n '      ' ']'
+ '[' -e /etc/ssl/etcd/ssl/ca-key.pem ']'
+ rm -f ca.pem ca-key.pem
+ mv '*.pem' /etc/ssl/etcd/ssl/
mv: cannot stat ‘*.pem’: No such file or directory
+ rm -rf /tmp/etcd_cacert.sWoENC
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[etcd] fix make-ssl-etcd.sh.j2; move pem files only if any new certs exist
```
