### PR TITLE
[feature] Update CoreDNS manifests

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/coredns-clusterrole.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-clusterrole.yml.j2
@@ -7,26 +7,26 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
   name: system:coredns
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - endpoints
-      - services
-      - pods
-      - namespaces
-    verbs:
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-    verbs:
-      - get
-  - apiGroups:
-      - discovery.k8s.io
-    resources:
-      - endpointslices
-    verbs:
-      - list
-      - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  - pods
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch

--- a/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
@@ -22,9 +22,11 @@ spec:
       labels:
         k8s-app: kube-dns{{ coredns_ordinal_suffix }}
       annotations:
-        seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
         createdby: 'kubespray'
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       nodeSelector:
         {{ coredns_deployment_nodeselector }}
       priorityClassName: system-cluster-critical

--- a/roles/kubernetes-apps/ansible/templates/coredns-sa.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-sa.yml.j2
@@ -5,4 +5,5 @@ metadata:
   name: coredns
   namespace: kube-system
   labels:
+    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

* Remove deprecated annotation seccomp.security.alpha.kubernetes.io/pod
* Align with https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/dns/coredns/coredns.yaml.in

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```