### PR TITLE
Support multi-arch using the same image name

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -126,7 +126,7 @@ cilium_enable_hubble: false
 kube_ovn_version: "v1.10.7"
 kube_ovn_dpdk_version: "19.11-{{ kube_ovn_version }}"
 kube_router_version: "v1.5.1"
-multus_version: "v3.8-{{ image_arch }}"
+multus_version: "v3.8"
 helm_version: "v3.11.2"
 nerdctl_version: "1.0.0"
 krew_version: "v0.4.3"
@@ -1073,7 +1073,7 @@ nodelocaldns_image_repo: "{{ kube_image_repo }}/dns/k8s-dns-node-cache"
 nodelocaldns_image_tag: "{{ nodelocaldns_version }}"
 
 dnsautoscaler_version: 1.8.5
-dnsautoscaler_image_repo: "{{ kube_image_repo }}/cpa/cluster-proportional-autoscaler-{{ image_arch }}"
+dnsautoscaler_image_repo: "{{ kube_image_repo }}/cpa/cluster-proportional-autoscaler"
 dnsautoscaler_image_tag: "{{ dnsautoscaler_version }}"
 
 registry_version: "2.8.1"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Currently, `multus-cni` and `cluster-proportional-autoscaler` images can support multiple architectures under the same image name.

``` bash
$ podman manifest inspect ghcr.io/k8snetworkplumbingwg/multus-cni:v3.8
{
    "schemaVersion": 2,
    "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
    "manifests": [
        {
            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
            "size": 949,
            "digest": "sha256:66582fb04ecd00495942ccd5a36d194743935e4521c5605a5dc593c958a621a8",
            "platform": {
                "architecture": "amd64",
                "os": "linux"
            }
        },
        {
            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
            "size": 949,
            "digest": "sha256:6815f6f067106085b8bcf4e991e0d9d93ac2cc022c6df6845aedd2bcb11efd4b",
            "platform": {
                "architecture": "arm",
                "os": "linux",
                "variant": "v7"
            }
        },
        {
            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
            "size": 950,
            "digest": "sha256:d436f220e1ceb0caa723657130e029ef1caa7fe91d0e84be922f89231e7396af",
            "platform": {
                "architecture": "arm64",
                "os": "linux",
                "variant": "v8"
            }
        },
        {
            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
            "size": 949,
            "digest": "sha256:9a298163d425395e795d544c80c3a6dffb264129782d0d6693a911caf4ee0681",
            "platform": {
                "architecture": "ppc64le",
                "os": "linux"
            }
        },
        {
            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
            "size": 1790,
            "digest": "sha256:6b47b74afc85dcd8bc7e7d6b3ee28c99fba4b7c3f70666400f7c775d7ced01d1",
            "platform": {
                "architecture": "s390x",
                "os": "linux"
            }
        }
    ]
}

$ podman manifest inspect registry.k8s.io/cpa/cluster-proportional-autoscaler:1.8.5
{
    "schemaVersion": 2,
    "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
    "manifests": [
        {
            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
            "size": 739,
            "digest": "sha256:8ac5e2d7650f3767dac4925581ef14de51eaf27ad554bc7fb8af2be77b9e9b15",
            "platform": {
                "architecture": "amd64",
                "os": "linux"
            }
        },
        {
            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
            "size": 739,
            "digest": "sha256:1ddd42fc85066564a2fbedeb36e18d8b26de0ba81db6654541a4a79cdce0837f",
            "platform": {
                "architecture": "arm",
                "os": "linux"
            }
        },
        {
            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
            "size": 739,
            "digest": "sha256:260ba0a774e8419e006f2a5fde05d2b7ec3da8dec59b5caad578813848c09e31",
            "platform": {
                "architecture": "arm64",
                "os": "linux"
            }
        },
        {
            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
            "size": 739,
            "digest": "sha256:8b334af78628e86df93044310f93f8d44b77193e0909183bae7b083109722192",
            "platform": {
                "architecture": "ppc64le",
                "os": "linux"
            }
        }
    ]
}
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
