### PR TITLE
Fix the kube-bench 1.3.7, 1.4.2  to enhance security

### DIFF
--- a/roles/kubernetes/control-plane/defaults/main/kube-scheduler.yml
+++ b/roles/kubernetes/control-plane/defaults/main/kube-scheduler.yml
@@ -4,7 +4,7 @@ kube_kubeadm_scheduler_extra_args: {}
 
 # Associated interface must be reachable by the rest of the cluster, and by
 # CLI/web clients.
-kube_scheduler_bind_address: 0.0.0.0
+kube_scheduler_bind_address: 127.0.0.1
 
 # ClientConnection options (e.g. Burst, QPS) except from kubeconfig.
 kube_scheduler_client_conn_extra_opts: {}

--- a/roles/kubernetes/control-plane/defaults/main/main.yml
+++ b/roles/kubernetes/control-plane/defaults/main/main.yml
@@ -26,7 +26,7 @@ kube_etcd_key_file: node-{{ inventory_hostname }}-key.pem
 
 # Associated interfaces must be reachable by the rest of the cluster, and by
 # CLI/web clients.
-kube_controller_manager_bind_address: 0.0.0.0
+kube_controller_manager_bind_address: 127.0.0.1
 
 # Leader election lease durations and timeouts for controller-manager
 kube_controller_manager_leader_elect_lease_duration: 15s


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:

Fix kube-bench check Fail 1.3.7, 1.4.2 by increase the default value of bind_address.
Ref to https://github.com/aquasecurity/kube-bench/blob/main/cfg/cis-1.24/master.yaml#L899

Use the same default config as the kubeadm: https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/phases/controlplane/manifests.go#L303

**Which issue(s) this PR fixes**:

Fixes  https://github.com/kubernetes-sigs/kubespray/issues/9933

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix kube-bench 1.3.7 to enhance security (kube_controller_manager: Ensure that the --bind-address argument is set to 127.0.0.1 (Automated))
Fix kube-bench 1.4.2 to enhance security (kube_scheduler: Ensure that the --bind-address argument is set to 127.0.0.1 (Automated))

```
