### PR TITLE
add kube-profile config to the scheduler

### DIFF
--- a/docs/hardening.md
+++ b/docs/hardening.md
@@ -76,8 +76,6 @@ kube_controller_feature_gates: ["RotateKubeletServerCertificate=true"]
 
 ## kube-scheduler
 kube_scheduler_bind_address: 127.0.0.1
-kube_kubeadm_scheduler_extra_args:
-  profiling: false
 # AppArmor-based OS
 # kube_scheduler_feature_gates: ["AppArmor=true"]
 

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
@@ -351,6 +351,7 @@ scheduler:
 {% if kube_scheduler_feature_gates or kube_feature_gates %}
     feature-gates: "{{ kube_scheduler_feature_gates | default(kube_feature_gates, true) | join(',') }}"
 {% endif %}
+    profiling: "{{ kube_profiling }}"
 {% if kube_kubeadm_scheduler_extra_args|length > 0 %}
 {% for key in kube_kubeadm_scheduler_extra_args %}
     {{ key }}: "{{ kube_kubeadm_scheduler_extra_args[key] }}"

--- a/tests/files/packet_ubuntu20-calico-aio-hardening.yml
+++ b/tests/files/packet_ubuntu20-calico-aio-hardening.yml
@@ -70,8 +70,6 @@ kube_controller_feature_gates: ["RotateKubeletServerCertificate=true", "AppArmor
 
 ## kube-scheduler
 kube_scheduler_bind_address: 127.0.0.1
-kube_kubeadm_scheduler_extra_args:
-  profiling: false
 # AppArmor-based OS
 kube_scheduler_feature_gates: ["AppArmor=true"]
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:

The  `kube-profile` config is only worked on the `kube-apiserver` and `ccm`, but not the `kube-scheduler`, it's hard to use.
So add the config to the `kube-scheduler`,

Once the config is added, the hardening guild does not need to change the `kube_kubeadm_scheduler_extra_args`, because it can be configed using the `kube_profiling` with   `kube-apiserver` and `ccm` together.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kubespray/pull/9987

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add the  `kube-profile` config to the kubeadm's  `kube-scheduler` config.
```
