### PR TITLE
[feature] Update dns-autoscaler

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -1072,7 +1072,7 @@ nodelocaldns_version: "1.22.18"
 nodelocaldns_image_repo: "{{ kube_image_repo }}/dns/k8s-dns-node-cache"
 nodelocaldns_image_tag: "{{ nodelocaldns_version }}"
 
-dnsautoscaler_version: 1.8.5
+dnsautoscaler_version: v1.8.8
 dnsautoscaler_image_repo: "{{ kube_image_repo }}/cpa/cluster-proportional-autoscaler"
 dnsautoscaler_image_tag: "{{ dnsautoscaler_version }}"
 

--- a/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
@@ -30,12 +30,13 @@ spec:
       labels:
         k8s-app: dns-autoscaler{{ coredns_ordinal_suffix }}
       annotations:
-        seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
     spec:
       nodeSelector:
         {{ dns_autoscaler_deployment_nodeselector}}
       priorityClassName: system-cluster-critical
       securityContext:
+        seccompProfile:
+          type: RuntimeDefault
         supplementalGroups: [ 65534 ]
         fsGroup: 65534
       nodeSelector:


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

* Remove deprecated annotation seccomp.security.alpha.kubernetes.io/pod
* Update cluster-proportional-autoscaler container to version 1.8.6

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update dns-autoscaler configuration and remove deprecated annotations
```