### PR TITLE
Add Retry for restart kube-controller-manager

### DIFF
--- a/roles/kubernetes/preinstall/handlers/main.yml
+++ b/roles/kubernetes/preinstall/handlers/main.yml
@@ -78,6 +78,10 @@
 
 - name: Preinstall | restart kube-controller-manager crio/containerd
   shell: "{{ bin_dir }}/crictl pods --name kube-controller-manager* -q | xargs -I% --no-run-if-empty bash -c '{{ bin_dir }}/crictl stopp % && {{ bin_dir }}/crictl rmp %'"
+  register: preinstall_restart_controller_manager
+  retries: 10
+  delay: 1
+  until: preinstall_restart_controller_manager.rc == 0
   when:
     - container_manager in ['crio', 'containerd']
     - inventory_hostname in groups['kube_control_plane']


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:

* The following is the error message: 

```
4:07AM: Sunday 23 April 2023  08:07:10 +0000 (0:00:00.059)       0:15:16.738 ********** 
4:07AM: 
4:07AM: RUNNING HANDLER [kubernetes/preinstall : Preinstall | restart kube-controller-manager crio/containerd] ***
4:07AM: fatal: [gate-5-all]: FAILED! => {"changed": true, "cmd": "/usr/local/bin/crictl pods --name kube-controller-manager* -q | xargs -I% --no-run-if-empty bash -c '/usr/local/bin/crictl stopp % && /usr/local/bin/crictl rmp %'", "delta": "0:00:00.396997", "end": "2023-04-23 16:07:10.974322", "msg": "non-zero return code", "rc": 123, "start": "2023-04-23 16:07:10.577325", "stderr": "E0423 16:07:10.970938  108138 remote_runtime.go:295] \"RemovePodSandbox from runtime service failed\" err=\"rpc error: code = Unknown desc = failed to remove container \\\"1532049c5220deac260c5d75d54c97002693c42d371f16c0ede4ec4078f43634\\\": failed to set removing state for container \\\"1532049c5220deac260c5d75d54c97002693c42d371f16c0ede4ec4078f43634\\\": container is in starting state, can't be removed\" podSandboxID=\"2f443da62416698edf333e95bb44d267915e88931ce654d1b0e45a03f0e5ace2\"\nremoving the pod sandbox \"2f443da62416698edf333e95bb44d267915e88931ce654d1b0e45a03f0e5ace2\": rpc error: code = Unknown desc = failed to remove container \"1532049c5220deac260c5d75d54c97002693c42d371f16c0ede4ec4078f43634\": failed to set removing state for container \"1532049c5220deac260c5d75d54c97002693c42d371f16c0ede4ec4078f43634\": container is in starting state, can't be removed", "stderr_lines": ["E0423 16:07:10.970938  108138 remote_runtime.go:295] \"RemovePodSandbox from runtime service failed\" err=\"rpc error: code = Unknown desc = failed to remove container \\\"1532049c5220deac260c5d75d54c97002693c42d371f16c0ede4ec4078f43634\\\": failed to set removing state for container \\\"1532049c5220deac260c5d75d54c97002693c42d371f16c0ede4ec4078f43634\\\": container is in starting state, can't be removed\" podSandboxID=\"2f443da62416698edf333e95bb44d267915e88931ce654d1b0e45a03f0e5ace2\"", "removing the pod sandbox \"2f443da62416698edf333e95bb44d267915e88931ce654d1b0e45a03f0e5ace2\": rpc error: code = Unknown desc = failed to remove container \"1532049c5220deac260c5d75d54c97002693c42d371f16c0ede4ec4078f43634\": failed to set removing state for container \"1532049c5220deac260c5d75d54c97002693c42d371f16c0ede4ec4078f43634\": container is in starting state, can't be removed"], "stdout": "Stopped sandbox 2f443da62416698edf333e95bb44d267915e88931ce654d1b0e45a03f0e5ace2", "stdout_lines": ["Stopped sandbox 2f443da62416698edf333e95bb44d267915e88931ce654d1b0e45a03f0e5ace2"]}
4:07AM: Sunday 23 April 2023  08:07:11 +0000 (0:00:00.987)       0:15:17.726 ********** 
4:07AM: Sunday 23 April 2023  08:07:11 +0000 (0:00:00.000)       0:15:17.727 ********** 
```

* I just retry the command manually after seconds , And then the result of command is ok.

* Add retry for `restart kube-controller-manager crio/containerd` ,just like the following `restart kube-apiserver crio/containerd` in the same file.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add Retry for restart kube-controller-manager
```
