### PR TITLE
Allow cachable docker layers in image

### DIFF
--- a/.gitlab-ci/build.yml
+++ b/.gitlab-ci/build.yml
@@ -4,6 +4,7 @@ pipeline image:
   image: docker:20.10.22-cli
   variables:
     DOCKER_TLS_CERTDIR: ""
+    DOCKER_BUILDKIT: "1"
   services:
     - name: docker:20.10.22-dind
       # See https://gitlab.com/gitlab-org/gitlab-runner/-/issues/27300 for why this is required

--- a/pipeline.Dockerfile
+++ b/pipeline.Dockerfile
@@ -36,11 +36,12 @@ RUN apt update -q \
     && apt autoremove -yqq --purge && apt clean && rm -rf /var/lib/apt/lists/* /var/log/*
 
 WORKDIR /kubespray
-COPY . .
 
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1 \
+RUN --mount=type=bind,target=./requirements-2.12.txt,src=./requirements-2.12.txt \
+    --mount=type=bind,target=./tests/requirements-2.12.txt,src=./test/requirements-2.12.txt \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3 1 \
     && pip install --no-compile --no-cache-dir pip -U \
-    && pip install --no-compile --no-cache-dir -r tests/requirements.txt -r requirements.txt \
+    && pip install --no-compile --no-cache-dir -r tests/requirements-2.12.txt \
     && KUBE_VERSION=$(sed -n 's/^kube_version: //p' roles/kubespray-defaults/defaults/main.yaml) \
     && curl -L https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/$(dpkg --print-architecture)/kubectl -o /usr/local/bin/kubectl \
     && echo $(curl -L https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/$(dpkg --print-architecture)/kubectl.sha256) /usr/local/bin/kubectl | sha256sum --check \


### PR DESCRIPTION
**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:

This PR allows the pipeline image to use caching for each image layer. This will allow us to take advantage of remote caching. See #10015. Theoretically, this should speed up the build image stage from ca 10m to less than one.

**Which issue(s) this PR fixes**:

Fixes #10016 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE


```release-note
- Allows cacheable image layers in pipeline Dockerfile
```
