### PR TITLE
[nerdctl] upgrade to version 1.3.1

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -128,7 +128,7 @@ kube_ovn_dpdk_version: "19.11-{{ kube_ovn_version }}"
 kube_router_version: "v1.5.1"
 multus_version: "v3.8"
 helm_version: "v3.11.3"
-nerdctl_version: "1.0.0"
+nerdctl_version: "1.3.1"
 krew_version: "v0.4.3"
 skopeo_version: v1.10.0
 
@@ -793,13 +793,13 @@ gvisor_containerd_shim_binary_checksums:
 
 nerdctl_archive_checksums:
   arm:
-    1.0.0: 8fd283a2f2272b15f3df43cd79642c25f19f62c3c56ad58bb68afb7ed92904c2
+    1.3.1: ed24086dbea22612dbcc3d14ee6f1d152b0eb6905bd8c84d3413c1f4c8d45d10
   arm64:
-    1.0.0: 27622c9d95efe6d807d5f3770d24ddd71719c6ae18f76b5fc89663a51bcd6208
+    1.3.1: 9e82a6a34c89d3e6a65dc8d77a3723d796d71e0784f54a0c762a2a1940294e3b
   amd64:
-    1.0.0: 3e993d714e6b88d1803a58d9ff5a00d121f0544c35efed3a3789e19d6ab36964
+    1.3.1: 3ab552877100b336ebe3167aa57f66f99db763742f2bce9e6233644ef77fb7c9
   ppc64le:
-    1.0.0: 2fb02e629a4be16b194bbfc64819132a72ede1f52596bd8e1ec2beaf7c28c117
+    1.3.1: 21700f5fe8786ed7749b61b3dbd49e3f2345461e88fe2014b418a1bdeffbfb99
 
 containerd_archive_checksums:
   arm:


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds nerdctl version 1.3.1
The release changelog https://github.com/containerd/nerdctl/releases/tag/v1.3.1

**Does this PR introduce a user-facing change?**:
<!--
NONE
-->
```release-note
[nerdctl] update to version 1.3.1
```