### PR TITLE
add coredns_additional_configs to handle any extra configurations for…

### DIFF
--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -13,6 +13,10 @@ coredns_ordinal_suffix: ""
 coredns_deployment_nodeselector: "kubernetes.io/os: linux"
 coredns_default_zone_cache_block: |
   cache 30
+# coredns_additional_configs adds any extra configuration to coredns
+# coredns_additional_configs: |
+#   whoami
+#   local
 
 # dns_upstream_forward_extra_opts apply to coredns forward section as well as nodelocaldns upstream target forward section
 # dns_upstream_forward_extra_opts:

--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -31,6 +31,9 @@ data:
 {%   endfor %}
 {% endif %}
     .:53 {
+        {% if coredns_additional_configs is defined %}
+        {{ coredns_additional_configs | indent(width=8, first=False) }}
+        {% endif %}
         errors
         health {
             lameduck 5s


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
It adds the `coredns_additional_configuration` inventory variable to append defined configurations. It is useful when we need to add some configurations to the Corefile itself mostly when using external plugins of CoreDNS.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10023

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
Only if you use the new variable.
```release-note
Add `coredns_additional_configuration` variable to define extra Coredns configurations
```
