### PR TITLE
Some update for the deploy on fedora coreos

### DIFF
--- a/docs/fcos.md
+++ b/docs/fcos.md
@@ -1,6 +1,6 @@
 # Fedora CoreOS
 
-Tested with stable version 34.20210611.3.0
+Tested with stable version 37.20230322.3.0
 
 Because package installation with `rpm-ostree` requires a reboot, playbook may fail while bootstrap.
 Restart playbook again.

--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -90,6 +90,13 @@
     remote_src: true
   notify: restart crio
 
+- name: cri-o | update the bin dir for crio.service file
+  replace:
+    dest: /etc/systemd/system/crio.service
+    regexp: "/usr/local/bin/crio"
+    replace: "{{ bin_dir }}/crio"
+  notify: restart crio
+
 - name: cri-o | copy default policy
   copy:
     src: "{{ local_release_dir }}/cri-o/contrib/policy.json"

--- a/roles/container-engine/cri-o/templates/crio.conf.j2
+++ b/roles/container-engine/cri-o/templates/crio.conf.j2
@@ -269,7 +269,11 @@ manage_ns_lifecycle = false
 namespaces_dir = "/var/run"
 
 # pinns_path is the path to find the pinns binary, which is needed to manage namespace lifecycle
+{% if bin_dir == "/usr/local/bin" %}
 pinns_path = ""
+{% else %}
+pinns_path = "{{ bin_dir }}/pinns"
+{% endif %}
 
 # The "crio.runtime.runtimes" table defines a list of OCI compatible runtimes.
 # The runtime to use is picked based on the runtime_handler provided by the CRI.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Some update for the deploy on fedora coreos:
- Test with new version of coreos: 37.20230322.3.0. 
  Both container engine(containerd and cri-o) is tested.
- Bugfix:
  When we use crio and change the var bin_dir to another dir, there will be some error about the new bin dir.
