### PR TITLE
Removes Ansible reinstall in CI pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,10 +39,6 @@ variables:
 
 before_script:
   - ./tests/scripts/rebase.sh
-  - update-alternatives --install /usr/bin/python python /usr/bin/python3 1
-  - python -m pip uninstall -y ansible ansible-base ansible-core
-  - python -m pip install -r tests/requirements.txt
-  - ansible-galaxy install -r tests/requirements.yml
   - mkdir -p /.ssh
 
 .job: &job

--- a/.gitlab-ci/lint.yml
+++ b/.gitlab-ci/lint.yml
@@ -67,11 +67,6 @@ tox-inventory-builder:
   extends: .job
   before_script:
     - ./tests/scripts/rebase.sh
-    - apt-get update && apt-get install -y python3-pip
-    - update-alternatives --install /usr/bin/python python /usr/bin/python3 10
-    - python -m pip uninstall -y ansible ansible-base ansible-core
-    - python -m pip install -r tests/requirements.txt
-    - ansible-galaxy install -r tests/requirements.yml
   script:
     - pip3 install tox
     - cd contrib/inventory_builder && tox

--- a/.gitlab-ci/molecule.yml
+++ b/.gitlab-ci/molecule.yml
@@ -9,11 +9,6 @@
   stage: deploy-part1
   before_script:
     - tests/scripts/rebase.sh
-    - apt-get update && apt-get install -y python3-pip
-    - update-alternatives --install /usr/bin/python python /usr/bin/python3 10
-    - python -m pip uninstall -y ansible ansible-base ansible-core
-    - python -m pip install -r tests/requirements.txt
-    - ansible-galaxy install -r tests/requirements.yml
     - ./tests/scripts/vagrant_clean.sh
   script:
     - ./tests/scripts/molecule_run.sh

--- a/.gitlab-ci/vagrant.yml
+++ b/.gitlab-ci/vagrant.yml
@@ -13,11 +13,6 @@
   image: $PIPELINE_IMAGE
   services: []
   before_script:
-    - apt-get update && apt-get install -y python3-pip
-    - update-alternatives --install /usr/bin/python python /usr/bin/python3 10
-    - python -m pip uninstall -y ansible ansible-base ansible-core
-    - python -m pip install -r tests/requirements.txt
-    - ansible-galaxy install -r tests/requirements.yml
     - ./tests/scripts/vagrant_clean.sh
   script:
     - ./tests/scripts/testcases_run.sh

--- a/pipeline.Dockerfile
+++ b/pipeline.Dockerfile
@@ -29,6 +29,7 @@ RUN apt update -q \
          gnupg2 \
          software-properties-common \
          unzip \
+         libvirt-clients \
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
     && add-apt-repository "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
     && apt update -q \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 ansible==7.6.0
-ansible-core==2.14.6
 cryptography==41.0.1
 jinja2==3.1.2
 jmespath==1.0.1

--- a/tests/scripts/testcases_prepare.sh
+++ b/tests/scripts/testcases_prepare.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -euxo pipefail
 
-/usr/bin/python -m pip uninstall -y ansible ansible-base ansible-core
-/usr/bin/python -m pip install -r tests/requirements.txt
-ansible-galaxy install -r tests/requirements.yml
 mkdir -p /.ssh
 mkdir -p cluster-dump
 mkdir -p $HOME/.ssh

--- a/tests/scripts/vagrant_clean.sh
+++ b/tests/scripts/vagrant_clean.sh
@@ -3,8 +3,6 @@ set -euxo pipefail
 
 # Cleanup vagrant VMs to avoid name conflicts
 
-apt-get install -y libvirt-clients
-
 for i in $(virsh list --name)
 do
     virsh destroy "$i"


### PR DESCRIPTION
**What type of PR is this?**

> /kind cleanup

**What this PR does / why we need it**:

This removes the Ansible reinstall that is run on each job of the pipeline. These steps are already performed in the image. This should speed up the pipeline considerably.

**Which issue(s) this PR fixes**:

Fixes #10031 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

```release-note
[CI] Removes Ansible reinstall from build pipeline
```
