### PR TITLE
Dockerfile ubuntu base image update to 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use imutable image tags rather than mutable tags (like ubuntu:20.04)
-FROM ubuntu:focal-20220531
+# Use imutable image tags rather than mutable tags (like ubuntu:22.04)
+FROM ubuntu:jammy-20230308
 # Some tools like yamllint need this
 # Pip needs this as well at the moment to install ansible
 # (and potentially other packages) 

--- a/pipeline.Dockerfile
+++ b/pipeline.Dockerfile
@@ -1,5 +1,5 @@
-# Use imutable image tags rather than mutable tags (like ubuntu:20.04)
-FROM ubuntu:focal-20220531
+# Use imutable image tags rather than mutable tags (like ubuntu:22.04)
+FROM ubuntu:jammy-20230308
 # Some tools like yamllint need this
 # Pip needs this as well at the moment to install ansible
 # (and potentially other packages)


### PR DESCRIPTION
/kind cleanup

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
dockerfile update ubuntu version to 22.04 which has newer system packages with fewer

```
