### PR TITLE
feat(coredns): coredns_rewrite_block to perform internal message rewriting

### DIFF
--- a/docs/dns-stack.md
+++ b/docs/dns-stack.md
@@ -64,6 +64,10 @@ Custom options to be added to the kubernetes coredns plugin.
 
 Extra domains to be forwarded to the kubernetes coredns plugin.
 
+### coredns_rewrite_block
+
+[Rewrite](https://coredns.io/plugins/rewrite/) plugin block to perform internal message rewriting.
+
 ### coredns_external_zones
 
 Array of optional external zones to coredns forward queries to. It's  injected into

--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -14,6 +14,13 @@ coredns_deployment_nodeselector: "kubernetes.io/os: linux"
 coredns_default_zone_cache_block: |
   cache 30
 
+# coredns_rewrite_block: |
+#   rewrite stop {
+#     name regex (.*)\.my\.domain {1}.svc.cluster.local
+#     answer name (.*)\.svc\.cluster\.local {1}.my.domain
+#   }
+
+
 # dns_upstream_forward_extra_opts apply to coredns forward section as well as nodelocaldns upstream target forward section
 # dns_upstream_forward_extra_opts:
 #   policy: sequential

--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -35,6 +35,9 @@ data:
         health {
             lameduck 5s
         }
+{% if coredns_rewrite_block is defined %}
+        {{ coredns_rewrite_block | indent(width=8, first=False) }}
+{% endif %}
         ready
         kubernetes {{ dns_domain }} {% if coredns_kubernetes_extra_domains is defined %}{{ coredns_kubernetes_extra_domains }} {% endif %}{% if enable_coredns_reverse_dns_lookups %}in-addr.arpa ip6.arpa {% endif %}{
           pods insecure


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
Adds a variable `coredns_rewrite_block` so that we can perform internal message rewriting.
It is really useful when we want for instance multiple internal domain names that resolve to `cluster.local`:
```
rewrite stop {
  name regex (.*)\.my\.domain {1}.svc.cluster.local
  answer name (.*)\.svc\.cluster\.local {1}.my.domain
}
```

**Does this PR introduce a user-facing change?**:
```release-note
Add `coredns_rewrite_block` to perform internal message rewriting
```
