### PR TITLE
Fix containerd config_path error when containerd_registries is config…

### DIFF
--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -73,3 +73,6 @@ containerd_limit_proc_num: "infinity"
 containerd_limit_core: "infinity"
 containerd_limit_open_file_num: "infinity"
 containerd_limit_mem_lock: "infinity"
+
+# If enabled it will use config_path and disable use mirrors config
+containerd_use_config_path: false

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -111,27 +111,26 @@
     mode: 0640
   notify: restart containerd
 
-- name: containerd ｜ Create registry directories
-  file:
-    path: "{{ containerd_cfg_dir }}/certs.d/{{ item.key }}"
-    state: directory
-    mode: 0755
-    recurse: true
-  with_dict: "{{ containerd_insecure_registries }}"
-  when: containerd_insecure_registries is defined
-
-- name: containerd ｜ Write hosts.toml file
-  blockinfile:
-    path: "{{ containerd_cfg_dir }}/certs.d/{{ item.key }}/hosts.toml"
-    mode: 0640
-    create: true
-    block: |
-      server = "{{ item.value }}"
-      [host."{{ item.value }}"]
-        capabilities = ["pull", "resolve", "push"]
-        skip_verify = true
-  with_dict: "{{ containerd_insecure_registries }}"
-  when: containerd_insecure_registries is defined
+- block:
+    - name: containerd ｜ Create registry directories
+      file:
+        path: "{{ containerd_cfg_dir }}/certs.d/{{ item.key }}"
+        state: directory
+        mode: 0755
+        recurse: true
+      with_dict: "{{ containerd_insecure_registries }}"
+    - name: containerd ｜ Write hosts.toml file
+      blockinfile:
+        path: "{{ containerd_cfg_dir }}/certs.d/{{ item.key }}/hosts.toml"
+        mode: 0640
+        create: true
+        block: |
+          server = "{{ item.value }}"
+          [host."{{ item.value }}"]
+            capabilities = ["pull", "resolve", "push"]
+            skip_verify = true
+      with_dict: "{{ containerd_insecure_registries }}"
+  when: containerd_use_config_path is defined and containerd_use_config_path|bool and containerd_insecure_registries is defined
 
 # you can sometimes end up in a state where everything is installed
 # but containerd was not started / enabled

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -47,9 +47,9 @@ oom_score = {{ containerd_oom_score }}
           runtime_type = "io.containerd.runsc.v1"
 {% endif %}
     [plugins."io.containerd.grpc.v1.cri".registry]
-{% if containerd_insecure_registries is defined and containerd_insecure_registries|length>0 %}
+{% if containerd_use_config_path is defined and containerd_use_config_path|bool %}
       config_path = "{{ containerd_cfg_dir }}/certs.d"
-{% endif %}
+{% else %}
       [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
 {% for registry, addr in containerd_registries.items() %}
         [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ registry }}"]
@@ -60,6 +60,7 @@ oom_score = {{ containerd_oom_score }}
         [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ registry }}"]
           endpoint = ["{{ ([ addr ] | flatten ) | join('","') }}"]
 {% endfor %}
+{% endif %}
 {% for addr in containerd_insecure_registries.values() | flatten | unique %}
         [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ addr }}".tls]
           insecure_skip_verify = true


### PR DESCRIPTION
…ed (#9770)

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Backport of #9770