### PR TITLE
Remove deprecated crio_pids_limit

### DIFF
--- a/docs/cri-o.md
+++ b/docs/cri-o.md
@@ -40,21 +40,7 @@ crio_registries:
         insecure: false
 ```
 
-## Note about pids_limit
-
-For heavily mult-threaded workloads like databases, the default of 1024 for pids-limit is too low.
-This parameter controls not just the number of processes but also the amount of threads
-(since a thread is technically a process with shared memory). See [cri-o#1921]
-
-In order to increase the default `pids_limit` for cri-o based deployments you need to set the `crio_pids_limit`
-for your `k8s_cluster` ansible group or per node depending on the use case.
-
-```yaml
-crio_pids_limit: 4096
-```
-
 [CRI-O]: https://cri-o.io/
-[cri-o#1921]: https://github.com/cri-o/cri-o/issues/1921
 
 ## Note about user namespaces
 

--- a/roles/container-engine/cri-o/defaults/main.yml
+++ b/roles/container-engine/cri-o/defaults/main.yml
@@ -73,10 +73,6 @@ youki_runtime:
 crio_download_base: "download.opensuse.org/repositories/devel:kubic:libcontainers:stable"
 crio_download_crio: "http://{{ crio_download_base }}:/cri-o:/"
 
-# Configure the cri-o pids limit, increase this for heavily multi-threaded workloads
-# see https://github.com/cri-o/cri-o/issues/1921
-crio_pids_limit: 1024
-
 # Reserve 16M uids and gids for user namespaces (256 pods * 65536 uids/gids)
 # at the end of the uid/gid space
 crio_remap_enable: false

--- a/roles/container-engine/cri-o/templates/crio.conf.j2
+++ b/roles/container-engine/cri-o/templates/crio.conf.j2
@@ -205,9 +205,6 @@ default_mounts = [
 #
 #default_mounts_file = ""
 
-# Maximum number of processes allowed in a container.
-pids_limit = {{ crio_pids_limit }}
-
 # Maximum sized allowed for the container log file. Negative numbers indicate
 # that no size limit is imposed. If it is positive, it must be >= 8192 to
 # match/exceed conmon's read buffer. The file is truncated and re-opened so the


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Remove deprecated crio_pids_limit as per https://github.com/cri-o/cri-o/pull/5831
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[cri-o] Remove deprecated crio_pids_limit (default is now unlimited)
```
