### PR TITLE
cri-o: fix crio restart on config change

### DIFF
--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -193,8 +193,7 @@
     name: crio
     state: restarted
   when:
-    - config_install.changed
-    - reg_auth_install.changed
+    - config_install.changed or reg_auth_install.changed
     - not service_start.changed
 
 - name: cri-o | verify that crio is running


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix cri-o restart on config change, the condition should be an "or" instead of an "and".

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix cri-o restart if config change
```
