### PR TITLE
[containerd] add hashes for versions 1.7.1, 1.6.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [kubernetes](https://github.com/kubernetes/kubernetes) v1.26.3
   - [etcd](https://github.com/etcd-io/etcd) v3.5.6
   - [docker](https://www.docker.com/) v20.10 (see note)
-  - [containerd](https://containerd.io/) v1.7.0
+  - [containerd](https://containerd.io/) v1.7.1
   - [cri-o](http://cri-o.io/) v1.24 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)
 - Network Plugin
   - [cni-plugins](https://github.com/containernetworking/plugins) v1.2.0

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -82,7 +82,7 @@ runc_version: v1.1.7
 kata_containers_version: 2.4.1
 youki_version: 0.0.1
 gvisor_version: 20210921
-containerd_version: 1.7.0
+containerd_version: 1.7.1
 cri_dockerd_version: 0.3.0
 
 # this is relevant when container_manager == 'docker'
@@ -849,7 +849,9 @@ containerd_archive_checksums:
     1.6.18: 0
     1.6.19: 0
     1.6.20: 0
+    1.6.21: 0
     1.7.0: 0
+    1.7.1: 0
   arm64:
     1.5.5: 0
     1.5.7: 0
@@ -885,7 +887,9 @@ containerd_archive_checksums:
     1.6.18: 56b83a0bc955edc5ebaa3bd0f788e654b63395be00fcb1bd03ff4bdfe4b5e1e7
     1.6.19: 25a0dd6cce4e1058824d6dc277fc01dc45da92539ccb39bb6c8a481c24d2476e
     1.6.20: c3e6a054b18b20fce06c7c3ed53f0989bb4b255c849bede446ebca955f07a9ce
+    1.6.21: d713d8fbec491705ffe8c33ecc9051a904f6eedc92574928e1d33616f291c583
     1.7.0: e7e5be2d9c92e076f1e2e15c9f0a6e0609ddb75f7616999b843cba92d01e4da2
+    1.7.1: 1f828dc063e3c24b0840b284c5635b5a11b1197d564c97f9e873b220bab2b41b
   amd64:
     1.5.5: 8efc527ffb772a82021800f0151374a3113ed2439922497ff08f2596a70f10f1
     1.5.7: 109fc95b86382065ea668005c376360ddcd8c4ec413e7abe220ae9f461e0e173
@@ -921,7 +925,9 @@ containerd_archive_checksums:
     1.6.18: c4e516376a2392520a87abea94baf2045cc3a67e9e0c90c75fb6ed038170561e
     1.6.19: 3262454d9b3581f4d4da0948f77dde1be51cfc42347a1548bc9ab6870b055815
     1.6.20: bb9a9ccd6517e2a54da748a9f60dc9aa9d79d19d4724663f2386812f083968e2
+    1.6.21: 04dcc1b99368492caee758583e531392683268197e58156888a3cea2941117b6
     1.7.0: b068b05d58025dc9f2fc336674cac0e377a478930f29b48e068f97c783a423f0
+    1.7.1: 9504771bcb816d3b27fab37a6cf76928ee5e95a31eb41510a7d10ae726e01e85
   ppc64le:
     1.5.5: 0
     1.5.7: 0
@@ -957,7 +963,9 @@ containerd_archive_checksums:
     1.6.18: b7083473061a61200d04f500ad4a96813d1b09f71b2d427019076836c2a49836
     1.6.19: 18cf11b6dfc980aca8792a2cd3ea7afed6379c2988ca6fe9e53a19a0bece5a2d
     1.6.20: f3ee666fdd31031f07cbb7bad24f0181fad1094ba36273dc61f8fa5a570b5311
+    1.6.21: 196d91799070a5ff2f5f3b6efe8516c5377f299d38012b6c0cf4ae77fc8c22c5
     1.7.0: 051e897d3ee5b8c8097f65be447fea2d29226b583ca5d9ed78e9aebcf4e69889
+    1.7.1: 17d97ef55c6ce7af9778dbafb5e73f577d1b34220043a91cccde49dbcc610342
 skopeo_binary_checksums:
   arm:
     v1.10.0: 0


### PR DESCRIPTION
**What type of PR is this?**

/kind container-managers

**What this PR does / why we need it**:
containerd 1.7.1 release notes https://github.com/containerd/containerd/releases/tag/v1.7.1
update runc binary to v1.1.7 for both versions
The containerd 1.7.x release is the last major release of containerd 1.x before 2.0
Add hashes for containerd versions 1.7.1
Add hashes for containerd versions 1.6.21
Make containerd 1.7.1 default

**Does this PR introduce a user-facing change?**:
<!--
NONE
-->
```release-note
[containerd] Add hashes for containerd versions 1.7.1, 1.6.21
```