### PR TITLE
Migrate CI_BUILD_ID to CI_JOB_ID

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ variables:
   GITLAB_REPOSITORY: 'kargo-ci/kubernetes-sigs-kubespray'
   ANSIBLE_FORCE_COLOR: "true"
   MAGIC: "ci check this"
-  TEST_ID: "$CI_PIPELINE_ID-$CI_BUILD_ID"
+  TEST_ID: "$CI_PIPELINE_ID-$CI_JOB_ID"
   CI_TEST_VARS: "./tests/files/${CI_JOB_NAME}.yml"
   CI_TEST_REGISTRY_MIRROR: "./tests/common/_docker_hub_registry_mirror.yml"
   CI_TEST_SETTING: "./tests/common/_kubespray_test_settings.yml"

--- a/scripts/premoderator.sh
+++ b/scripts/premoderator.sh
@@ -2,18 +2,18 @@
 # A naive premoderation script to allow Gitlab CI pipeline on a specific PRs' comment
 # Exits with 0, if the pipeline is good to go
 # Exits with 1, if the user is not allowed to start pipeline
-# Exits with 2, if script is unable to get issue id from CI_BUILD_REF_NAME variable
+# Exits with 2, if script is unable to get issue id from CI_COMMIT_REF_NAME variable
 # Exits with 3, if missing the magic comment in the pipeline to start the pipeline
 
 CURL_ARGS="-fs --retry 4 --retry-delay 5"
 MAGIC="${MAGIC:-ci check this}"
 exit_code=0
 
-# Get PR number from CI_BUILD_REF_NAME
-issue=$(echo ${CI_BUILD_REF_NAME} | perl -ne '/^pr-(\d+)-\S+$/ && print $1')
+# Get PR number from CI_COMMIT_REF_NAME
+issue=$(echo ${CI_COMMIT_REF_NAME} | perl -ne '/^pr-(\d+)-\S+$/ && print $1')
 
 if [ "$issue" = "" ]; then
-  echo "Unable to get issue id from: $CI_BUILD_REF_NAME"
+  echo "Unable to get issue id from: $CI_COMMIT_REF_NAME"
   exit 2
 fi
 

--- a/tests/scripts/testcases_run.sh
+++ b/tests/scripts/testcases_run.sh
@@ -57,9 +57,9 @@ fi
 # Check out latest tag if testing upgrade
 test "${UPGRADE_TEST}" != "false" && git fetch --all && git checkout "$KUBESPRAY_VERSION"
 # Checkout the CI vars file so it is available
-test "${UPGRADE_TEST}" != "false" && git checkout "${CI_BUILD_REF}" tests/files/${CI_JOB_NAME}.yml
-test "${UPGRADE_TEST}" != "false" && git checkout "${CI_BUILD_REF}" ${CI_TEST_REGISTRY_MIRROR}
-test "${UPGRADE_TEST}" != "false" && git checkout "${CI_BUILD_REF}" ${CI_TEST_SETTING}
+test "${UPGRADE_TEST}" != "false" && git checkout "${CI_COMMIT_SHA}" tests/files/${CI_JOB_NAME}.yml
+test "${UPGRADE_TEST}" != "false" && git checkout "${CI_COMMIT_SHA}" ${CI_TEST_REGISTRY_MIRROR}
+test "${UPGRADE_TEST}" != "false" && git checkout "${CI_COMMIT_SHA}" ${CI_TEST_SETTING}
 
 # Create cluster
 ansible-playbook ${ANSIBLE_LOG_LEVEL} -e @${CI_TEST_SETTING} -e @${CI_TEST_REGISTRY_MIRROR} -e @${CI_TEST_VARS} -e local_release_dir=${PWD}/downloads --limit "all:!fake_hosts" cluster.yml
@@ -68,7 +68,7 @@ ansible-playbook ${ANSIBLE_LOG_LEVEL} -e @${CI_TEST_SETTING} -e @${CI_TEST_REGIS
 if [ "${UPGRADE_TEST}" != "false" ]; then
   test "${UPGRADE_TEST}" == "basic" && PLAYBOOK="cluster.yml"
   test "${UPGRADE_TEST}" == "graceful" && PLAYBOOK="upgrade-cluster.yml"
-  git checkout "${CI_BUILD_REF}"
+  git checkout "${CI_COMMIT_SHA}"
   ansible-playbook ${ANSIBLE_LOG_LEVEL} -e @${CI_TEST_SETTING} -e @${CI_TEST_REGISTRY_MIRROR} -e @${CI_TEST_VARS} -e local_release_dir=${PWD}/downloads --limit "all:!fake_hosts" $PLAYBOOK
 fi
 


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Update CI_BUILD_ID var to CI_JOB_ID

**Which issue(s) this PR fixes**:
Fixes failing jobs, ie: https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/4262404058
https://docs.gitlab.com/ee/update/deprecations.html#ci_build_-predefined-variables
> The predefined CI/CD variables that start with CI_BUILD_* were deprecated in GitLab 9.0, and will be removed in GitLab 16.0. If you still use these variables, be sure to change to the replacement [predefined variables](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html) which are functionally identical

**Special notes for your reviewer**:
CI_BUILD_ID var has been removed from gitlab codebase https://gitlab.com/gitlab-org/gitlab/-/issues/389376
gitlab instance has migrate to a new version shipping that change.

**Does this PR introduce a user-facing change?**:
```release-note
[CI] Migrate CI_BUILD_ID to CI_JOB_ID and CI_BUILD_REF to CI_COMMIT_SHA following gitlab upgrade
```
