### PR TITLE
Fix Calico Installation

### DIFF
--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -157,6 +157,9 @@
         kubectl: "{{ bin_dir }}/kubectl"
         filename: "{{ kube_config_dir }}/kdd-crds.yml"
         state: "latest"
+      register: kubectl_result
+      until: kubectl_result is succeeded
+      retries: 5
       when:
         - inventory_hostname == groups['kube_control_plane'][0]
   when:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

* when installing calico, the kubespray job may go with the follwing error message:

```
3:40AM: changed: [g-master5]
3:40AM: Friday 12 May 2023  07:40:42 +0000 (0:00:00.765)       0:45:24.769 ************
3:41AM:
3:41AM: TASK [network_plugin/calico : Calico | Create Calico Kubernetes datastore resources] ***
3:41AM: fatal: [g-master1]: FAILED! => {"changed": false, "msg": "error running kubectl (/usr/local/bin/kubectl apply --force --filename=/etc/kubernetes/kdd-crds.yml) command (rc=1), out='customresourcedefinition.apiextensions.k8s.io/bgpconfigurations.crd.projectcalico.org created\ncustomresourcedefinition.apiextensions.k8s.io/bgppeers.crd.projectcalico.org created\ncustomresourcedefinition.apiextensions.k8s.io/blockaffinities.crd.projectcalico.org created\ncustomresourcedefinition.apiextensions.k8s.io/caliconodestatuses.crd.projectcalico.org created\ncustomresourcedefinition.apiextensions.k8s.io/felixconfigurations.crd.projectcalico.org created\ncustomresourcedefinition.apiextensions.k8s.io/globalnetworkpolicies.crd.projectcalico.org created\ncustomresourcedefinition.apiextensions.k8s.io/globalnetworksets.crd.projectcalico.org created\ncustomresourcedefinition.apiextensions.k8s.io/hostendpoints.crd.projectcalico.org created\ncustomresourcedefinition.apiextensions.k8s.io/ipamblocks.crd.projectcalico.org created\ncustomresourcedefinition.apiextensions.k8s.io/ipamconfigs.crd.projectcalico.org created\ncustomresourcedefinition.apiextensions.k8s.io/ipamhandles.crd.projectcalico.org created\ncustomresourcedefinition.apiextensions.k8s.io/ippools.crd.projectcalico.org created\ncustomresourcedefinition.apiextensions.k8s.io/ipreservations.crd.projectcalico.org created\ncustomresourcedefinition.apiextensions.k8s.io/kubecontrollersconfigurations.crd.projectcalico.org created\ncustomresourcedefinition.apiextensions.k8s.io/networkpolicies.crd.projectcalico.org created\ncustomresourcedefinition.apiextensions.k8s.io/networksets.crd.projectcalico.org created\n', err='Error from server: error when creating \"/etc/kubernetes/kdd-crds.yml\": etcdserver: request timed out\n'"}
3:41AM:
3:41AM: NO MORE HOSTS LEFT *************************************************************
3:41AM:
3:41AM: PLAY RECAP *********************************************************************
3:41AM: g-master1                  : ok=499  changed=128  unreachable=0    failed=1    skipped=559  rescued=0    ignored=1
3:41AM: g-master2                  : ok=367  changed=101  unreachable=0    failed=0    skipped=507  rescued=0    ignored=1
```

* So just retry it.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[Calico] Fix installation while applying CRD
```
