### PR TITLE
Ignore errors in check mode performing "Disable swapOnZram for Fedora"

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0010-swapoff.yml
+++ b/roles/kubernetes/preinstall/tasks/0010-swapoff.yml
@@ -25,3 +25,4 @@
   when:
     - swapon.stdout
     - ansible_distribution in ['Fedora']
+  ignore_errors: "{{ ansible_check_mode }}"  # noqa ignore-errors


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This is a followup for https://github.com/kubernetes-sigs/kubespray/pull/6703 covering later added Disable swapOnZram for Fedora facing the same problem as an original issue

**Which issue(s) this PR fixes**:

Fixes #6642

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
