### PR TITLE
Add ingressclass for ingress_nginx

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s_cluster/addons.yml
@@ -125,6 +125,8 @@ ingress_publish_status_address: ""
 #   - --default-ssl-certificate=default/foo-tls
 # ingress_nginx_termination_grace_period_seconds: 300
 # ingress_nginx_class: nginx
+# ingress_nginx_without_class: true
+# ingress_nginx_default: false
 
 # ALB ingress controller deployment
 ingress_alb_enabled: false

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
@@ -13,7 +13,9 @@ ingress_nginx_configmap_tcp_services: {}
 ingress_nginx_configmap_udp_services: {}
 ingress_nginx_extra_args: []
 ingress_nginx_termination_grace_period_seconds: 300
-# ingress_nginx_class: nginx
+ingress_nginx_class: nginx
+ingress_nginx_without_class: true
+ingress_nginx_default: false
 ingress_nginx_webhook_enabled: false
 ingress_nginx_webhook_job_ttl: 1800
 

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/tasks/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/tasks/main.yml
@@ -22,6 +22,7 @@
       - { name: clusterrolebinding-ingress-nginx, file: clusterrolebinding-ingress-nginx.yml, type: clusterrolebinding }
       - { name: role-ingress-nginx, file: role-ingress-nginx.yml, type: role }
       - { name: rolebinding-ingress-nginx, file: rolebinding-ingress-nginx.yml, type: rolebinding }
+      - { name: ingressclass-nginx, file: ingressclass-nginx.yml, type: ingressclass }
       - { name: ds-ingress-nginx-controller, file: ds-ingress-nginx-controller.yml, type: ds }
     ingress_nginx_templates_for_webhook:
       - { name: admission-webhook-configuration, file: admission-webhook-configuration.yml, type: sa }

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
@@ -51,9 +51,8 @@ spec:
             - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-services
             - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
             - --annotations-prefix=nginx.ingress.kubernetes.io
-{% if ingress_nginx_class is defined %}
             - --ingress-class={{ ingress_nginx_class }}
-{% else %}
+{% if ingress_nginx_without_class %}
             - --watch-ingress-without-class=true
 {% endif %}
 {% if ingress_nginx_host_network %}

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingressclass-nginx.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ingressclass-nginx.yml.j2
@@ -1,0 +1,13 @@
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: {{ ingress_nginx_class }}
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+{% if ingress_nginx_default %}
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: "true"
+{%- endif %}
+spec:
+  controller: k8s.io/ingress-nginx

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/role-ingress-nginx.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/role-ingress-nginx.yml.j2
@@ -32,7 +32,7 @@ rules:
     # Here: "<ingress-controller-leader>-<nginx>"
     # This has to be adapted if you change either parameter
     # when launching the nginx-ingress-controller.
-    resourceNames: [{% if ingress_class is defined %}"ingress-controller-leader-{{ ingress_nginx_class | default('nginx') }}"{% else %}"ingress-controller-leader"{% endif %}]
+    resourceNames: ["ingress-controller-leader-{{ ingress_nginx_class }}"]
     verbs: ["get", "update"]
   - apiGroups: [""]
     resources: ["events"]
@@ -43,7 +43,7 @@ rules:
     # Here: "<ingress-controller-leader>-<nginx>"
     # This has to be adapted if you change either parameter
     # when launching the nginx-ingress-controller.
-    resourceNames: [{% if ingress_class is defined %}"ingress-controller-leader-{{ ingress_nginx_class | default('nginx') }}"{% else %}"ingress-controller-leader"{% endif %}]
+    resourceNames: ["ingress-controller-leader-{{ ingress_nginx_class }}"]
     verbs: ["get", "update"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Starting with Kubernetes 1.18 the ingress class resources was introduced to replace the widely adapted (but never formalised) `kubernetes.io/ingress.class` annotation.
This PR adds the ingressClass for nginx, and adds options to configure it as the default, as well as disabling the `watch-ingress-without-class` attribute for the nginx-controller

**Which issue(s) this PR fixes**:
Fixes #9936
Fixes #10014

**Special notes for your reviewer**:
As the ingress_nginx daemonset isn't configured for multiple ingresses in one deployment, the ingressClass resource is scoped to the cluster (which is the default)

**Does this PR introduce a user-facing change?**:
```release-note
Add ingressClass resource for ingress_nginx by default
```
