### PR TITLE
fix multus include

### DIFF
--- a/roles/kubernetes-apps/network_plugin/multus/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/multus/tasks/main.yml
@@ -9,9 +9,10 @@
     state: "latest"
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
   run_once: true
-  with_items: "{{ multus_manifest_1.results }} + {{ multus_nodes_list|map('extract', hostvars, 'multus_manifest_2')|list|json_query('[].results') }}"
+  with_items: "{{ multus_manifest_1.results + (multus_nodes_list|map('extract', hostvars, 'multus_manifest_2')|list|json_query('[].results')) }}"
   loop_control:
     label: "{{ item.item.name }}"
   vars:
     multus_nodes_list: "{{ groups['k8s_cluster'] if ansible_play_batch|length == ansible_play_hosts_all|length else ansible_play_batch }}"
-  when: not item is skipped
+  when:
+    - not item is skipped


### PR DESCRIPTION
``
"msg": "Failed to template loop_control.label: 'ansible.utils.unsafe_proxy.AnsibleUnsafeText object' has no attribute 'item'. 'ansible.utils.unsafe_proxy.AnsibleUnsafeText object' has no attribute 'item'", "skip_reason": "Conditional result was False"} ``

case when multus should NOT be included.



/kind bug

**What this PR does / why we need it**:

if multus is not enabled, unable to deploy/upgrade.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

someone with multus should test this.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
