### PR TITLE
project: fix arithmetic outside of jinja

### DIFF
--- a/contrib/dind/roles/dind-cluster/tasks/main.yaml
+++ b/contrib/dind/roles/dind-cluster/tasks/main.yaml
@@ -43,7 +43,7 @@
   package:
     name: "{{ item }}"
     state: present
-  with_items: "{{ distro_extra_packages }} + [ 'rsyslog', 'openssh-server' ]"
+  with_items: "{{ distro_extra_packages + [ 'rsyslog', 'openssh-server' ] }}"
 
 - name: Start needed services
   service:

--- a/tests/cloud_playbooks/roles/packet-ci/tasks/create-vms.yml
+++ b/tests/cloud_playbooks/roles/packet-ci/tasks/create-vms.yml
@@ -12,7 +12,7 @@
 
 - name: Template vm files for CI job
   set_fact:
-    vms_files: "{{ vms_files }} + [{{ lookup('ansible.builtin.template', 'vm.yml.j2') | from_yaml }}]"
+    vms_files: "{{ vms_files + [lookup('ansible.builtin.template', 'vm.yml.j2') | from_yaml] }}"
   vars:
     vms_files: []
   loop: "{{ range(1, vm_count|int + 1, 1) | list }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This feature no longer works on Ansible 6 / ansible-core 2.13. We do not support these version officially yet but this will help for the future upgrade and may help some people running those inadvertently.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
