### PR TITLE
[feat] Update pause image version to v3.9

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -117,7 +117,7 @@ flannel_version: "v0.21.4"
 flannel_cni_version: "v1.2.0"
 cni_version: "v1.3.0"
 weave_version: 2.8.1
-pod_infra_version: "3.8"
+pod_infra_version: "3.9"
 
 cilium_version: "v1.13.0"
 cilium_cli_version: "v0.13.1"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Update pause image version to v3.9 see: https://github.com/kubernetes/kubernetes/blob/v1.26.5/cmd/kubeadm/app/constants/constants.go#L419

**Which issue(s) this PR fixes**:

**Does this PR introduce a user-facing change?**:
<!--
NONE
-->
```release-note
Update pause image version to v3.9
```