### PR TITLE
fix: use dl.k8s.io, not kubernetes-release bucket

### DIFF
--- a/scripts/download_hash.sh
+++ b/scripts/download_hash.sh
@@ -169,7 +169,8 @@ function _get_checksum {
     readonly github_releases_url="$github_url/%s/releases/download/$version/%s"
     readonly github_archive_url="$github_url/%s/archive/%s"
     readonly google_url="https://storage.googleapis.com"
-    readonly k8s_url="$google_url/kubernetes-release/release/$version/bin/$os/$arch/%s"
+    readonly release_url="https://dl.k8s.io"
+    readonly k8s_url="$release_url/release/$version/bin/$os/$arch/%s"
 
     # Download URLs
     declare -A urls=(


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/priority important-soon

#### What this PR does / why we need it:
There are still references to https://storage.googleapis.com/kubernetes-release instead of https://dl.k8s.io/

dl.k8s.io is the correct advertised download host and will eventually move to be fastly shielding a fully community-owned bucket

ref: https://github.com/kubernetes/k8s.io/issues/2396

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```
