### PR TITLE
[kube-ovn]: update version v1.11.5

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -133,7 +133,7 @@ packet_centos7-calico-ha-once-localhost:
 
 packet_almalinux8-kube-ovn:
   stage: deploy-part2
-  extends: .packet_periodic
+  extends: .packet_pr
   when: on_success
 
 packet_almalinux8-calico:

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [calico](https://github.com/projectcalico/calico) v3.25.1
   - [cilium](https://github.com/cilium/cilium) v1.13.0
   - [flannel](https://github.com/flannel-io/flannel) v0.21.4
-  - [kube-ovn](https://github.com/alauda/kube-ovn) v1.10.7
+  - [kube-ovn](https://github.com/alauda/kube-ovn) v1.11.5
   - [kube-router](https://github.com/cloudnativelabs/kube-router) v1.5.1
   - [multus](https://github.com/k8snetworkplumbingwg/multus-cni) v3.8
   - [weave](https://github.com/weaveworks/weave) v2.8.1

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -123,7 +123,7 @@ cilium_version: "v1.13.0"
 cilium_cli_version: "v0.13.1"
 cilium_enable_hubble: false
 
-kube_ovn_version: "v1.10.7"
+kube_ovn_version: "v1.11.5"
 kube_ovn_dpdk_version: "19.11-{{ kube_ovn_version }}"
 kube_router_version: "v1.5.1"
 multus_version: "v3.8"

--- a/roles/network_plugin/kube-ovn/defaults/main.yml
+++ b/roles/network_plugin/kube-ovn/defaults/main.yml
@@ -67,6 +67,10 @@ kube_ovn_external_dns: alauda.cn
 # kube_ovn_default_gateway: 10.233.64.1,fd85:ee78:d8a6:8607::1:0
 kube_ovn_default_gateway_check: true
 kube_ovn_default_logical_gateway: false
+
+# u2o_interconnection
+kube_ovn_u2o_interconnection: false
+
 # kube_ovn_default_exclude_ips: 10.16.0.1
 kube_ovn_node_switch_cidr: 100.64.0.0/16
 kube_ovn_node_switch_cidr_ipv6: fd00:100:64::/64
@@ -98,8 +102,14 @@ kube_ovn_enable_ssl: false
 kube_ovn_dpdk_enabled: false
 kube_ovn_dpdk_tunnel_iface: br-phy
 
+## bind local ip
+kube_ovn_bind_local_ip_enabled: true
+
 ## eip snat
 kube_ovn_eip_snat_enabled: true
+
+# ls dnat mod dl dst
+kube_ovn_ls_dnat_mod_dl_dst: true
 
 ## keep vm ip
 kube_ovn_keep_vm_ip: true

--- a/roles/network_plugin/kube-ovn/templates/cni-kube-ovn-crd.yml.j2
+++ b/roles/network_plugin/kube-ovn/templates/cni-kube-ovn-crd.yml.j2
@@ -1,6 +1,145 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  name: vpc-dnses.kubeovn.io
+spec:
+  group: kubeovn.io
+  names:
+    plural: vpc-dnses
+    singular: vpc-dns
+    shortNames:
+      - vpc-dns
+    kind: VpcDns
+    listKind: VpcDnsList
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.active
+          name: Active
+          type: boolean
+        - jsonPath: .spec.vpc
+          name: Vpc
+          type: string
+        - jsonPath: .spec.subnet
+          name: Subnet
+          type: string
+      name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                vpc:
+                  type: string
+                subnet:
+                  type: string
+            status:
+              type: object
+              properties:
+                active:
+                  type: boolean
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastUpdateTime:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: switch-lb-rules.kubeovn.io
+spec:
+  group: kubeovn.io
+  names:
+    plural: switch-lb-rules
+    singular: switch-lb-rule
+    shortNames:
+      - slr
+    kind: SwitchLBRule
+    listKind: SwitchLBRuleList
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.vip
+          name: vip
+          type: string
+        - jsonPath: .status.ports
+          name: port(s)
+          type: string
+        - jsonPath: .status.service
+          name: service
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                namespace:
+                  type: string
+                vip:
+                  type: string
+                sessionAffinity:
+                  type: string
+                ports:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                      port:
+                        type: integer
+                        minimum: 1
+                        maximum: 65535
+                      protocol:
+                        type: string
+                      targetPort:
+                        type: integer
+                        minimum: 1
+                        maximum: 65535
+                    type: object
+                  type: array
+                selector:
+                  items:
+                    type: string
+                  type: array
+            status:
+              type: object
+              properties:
+                ports:
+                  type: string
+                service:
+                  type: string
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
   name: vpc-nat-gateways.kubeovn.io
 spec:
   group: kubeovn.io
@@ -43,6 +182,21 @@ spec:
                   type: array
                   items:
                     type: string
+                tolerations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      value:
+                        type: string
+                      effect:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -270,6 +424,14 @@ spec:
                   type: string
                 redo:
                   type: string
+                protocol:
+                  type: string
+                internalIp:
+                  type: string
+                internalPort:
+                  type: string
+                externalPort:
+                  type: string
                 conditions:
                   type: array
                   items:
@@ -385,11 +547,234 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  name: ovn-eips.kubeovn.io
+spec:
+  group: kubeovn.io
+  names:
+    plural: ovn-eips
+    singular: ovn-eip
+    shortNames:
+      - oeip
+    kind: OvnEip
+    listKind: OvnEipList
+  scope: Cluster
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+      - jsonPath: .spec.v4ip
+        name: IP
+        type: string
+      - jsonPath: .spec.macAddress
+        name: Mac
+        type: string
+      - jsonPath: .spec.type
+        name: Type
+        type: string
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            status:
+              type: object
+              properties:
+                v4Ip:
+                  type: string
+                macAddress:
+                  type: string
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastUpdateTime:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+            spec:
+              type: object
+              properties:
+                externalSubnet:
+                  type: string
+                type:
+                  type: string
+                v4ip:
+                  type: string
+                macAddress:
+                  type: string
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ovn-fips.kubeovn.io
+spec:
+  group: kubeovn.io
+  names:
+    plural: ovn-fips
+    singular: ovn-fip
+    shortNames:
+      - ofip
+    kind: OvnFip
+    listKind: OvnFipList
+  scope: Cluster
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+      - jsonPath: .status.vpc
+        name: Vpc
+        type: string
+      - jsonPath: .status.v4Eip
+        name: V4Eip
+        type: string
+      - jsonPath: .status.v4Ip
+        name: V4Ip
+        type: string
+      - jsonPath: .status.ready
+        name: Ready
+        type: boolean
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            status:
+              type: object
+              properties:
+                ready:
+                  type: boolean
+                v4Eip:
+                  type: string
+                v4Ip:
+                  type: string
+                macAddress:
+                  type: string
+                vpc:
+                  type: string
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastUpdateTime:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+            spec:
+              type: object
+              properties:
+                ovnEip:
+                  type: string
+                ipName:
+                  type: string
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ovn-snat-rules.kubeovn.io
+spec:
+  group: kubeovn.io
+  names:
+    plural: ovn-snat-rules
+    singular: ovn-snat-rule
+    shortNames:
+      - osnat
+    kind: OvnSnatRule
+    listKind: OvnSnatRuleList
+  scope: Cluster
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+      - jsonPath: .status.vpc
+        name: Vpc
+        type: string
+      - jsonPath: .status.v4Eip
+        name: V4Eip
+        type: string
+      - jsonPath: .status.v4ipCidr
+        name: V4Ip
+        type: string
+      - jsonPath: .status.ready
+        name: Ready
+        type: boolean
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            status:
+              type: object
+              properties:
+                ready:
+                  type: boolean
+                v4Eip:
+                  type: string
+                v4ipCidr:
+                  type: string
+                vpc:
+                  type: string
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastUpdateTime:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+            spec:
+              type: object
+              properties:
+                ovnEip:
+                  type: string
+                vpcSubnet:
+                  type: string
+                ipName:
+                  type: string
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
   name: vpcs.kubeovn.io
 spec:
   group: kubeovn.io
   versions:
     - additionalPrinterColumns:
+        - jsonPath: .status.enableExternal
+          name: EnableExternal
+          type: boolean
         - jsonPath: .status.standby
           name: Standby
           type: boolean
@@ -405,6 +790,8 @@ spec:
           properties:
             spec:
               properties:
+                enableExternal:
+                  type: boolean
                 namespaces:
                   items:
                     type: string
@@ -470,6 +857,8 @@ spec:
                   type: string
                 standby:
                   type: boolean
+                enableExternal:
+                  type: boolean
                 subnets:
                   items:
                     type: string
@@ -485,6 +874,10 @@ spec:
                 udpLoadBalancer:
                   type: string
                 udpSessionLoadBalancer:
+                  type: string
+                sctpLoadBalancer:
+                  type: string
+                sctpSessionLoadBalancer:
                   type: string
               type: object
           type: object
@@ -595,19 +988,19 @@ spec:
       additionalPrinterColumns:
       - name: V4IP
         type: string
-        jsonPath: .spec.v4ip
+        jsonPath: .status.v4ip
       - name: PV4IP
         type: string
         jsonPath: .spec.parentV4ip
       - name: Mac
         type: string
-        jsonPath: .spec.macAddress
+        jsonPath: .status.mac
       - name: PMac
         type: string
-        jsonPath: .spec.ParentMac
+        jsonPath: .spec.parentMac
       - name: V6IP
         type: string
-        jsonPath: .spec.v6ip
+        jsonPath: .status.v6ip
       - name: PV6IP
         type: string
         jsonPath: .spec.parentV6ip
@@ -731,6 +1124,9 @@ spec:
       - name: ExcludeIPs
         type: string
         jsonPath: .spec.excludeIps
+      - name: U2OInterconnectionIP
+        type: string
+        jsonPath: .status.u2oInterconnectionIP
       schema:
         openAPIV3Schema:
           type: object
@@ -751,6 +1147,8 @@ spec:
                 dhcpV4OptionsUUID:
                   type: string
                 dhcpV6OptionsUUID:
+                  type: string
+                u2oInterconnectionIP:
                   type: string
                 conditions:
                   type: array
@@ -810,6 +1208,8 @@ spec:
                   type: string
                 natOutgoing:
                   type: boolean
+                u2oRouting:
+                  type: boolean
                 externalEgressGateway:
                   type: string
                 policyRoutingPriority:
@@ -836,8 +1236,6 @@ spec:
                   type: boolean
                 disableInterConnection:
                   type: boolean
-                htbqos:
-                  type: string
                 enableDHCP:
                   type: boolean
                 dhcpV4Options:
@@ -872,6 +1270,8 @@ spec:
                           - allow
                           - drop
                           - reject
+                u2oInterconnection:
+                  type: boolean
   scope: Cluster
   names:
     plural: subnets
@@ -995,6 +1395,10 @@ spec:
                 ready:
                   type: boolean
                 readyNodes:
+                  type: array
+                  items:
+                    type: string
+                notReadyNodes:
                   type: array
                   items:
                     type: string
@@ -1127,34 +1531,3 @@ spec:
         status: {}
   conversion:
     strategy: None
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: htbqoses.kubeovn.io
-spec:
-  group: kubeovn.io
-  versions:
-    - name: v1
-      served: true
-      storage: true
-      additionalPrinterColumns:
-      - name: PRIORITY
-        type: string
-        jsonPath: .spec.priority
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              properties:
-                priority:
-                  type: string					# Value in range 0 to 4,294,967,295.
-  scope: Cluster
-  names:
-    plural: htbqoses
-    singular: htbqos
-    kind: HtbQos
-    shortNames:
-      - htbqos

--- a/roles/network_plugin/kube-ovn/templates/cni-kube-ovn.yml.j2
+++ b/roles/network_plugin/kube-ovn/templates/cni-kube-ovn.yml.j2
@@ -40,29 +40,34 @@ spec:
         - name: kube-ovn-controller
           image: {{ kube_ovn_container_image_repo }}:{{ kube_ovn_container_image_tag }}
           imagePullPolicy: {{ k8s_image_pull_policy }}
-          command:
-          - /kube-ovn/start-controller.sh
           args:
-            - --default-cidr={{ kube_pods_subnet }}{% if enable_dual_stack_networks %},{{ kube_ovn_pool_cidr_ipv6 | default(kube_pods_subnet_ipv6) }}{% endif %}{{''}}
-            - --default-gateway={% if kube_ovn_default_gateway is defined %}{{ kube_ovn_default_gateway }}{% endif %}{{''}}
-            - --default-gateway-check={{ kube_ovn_default_gateway_check|string }}
-            - --default-logical-gateway={{ kube_ovn_default_logical_gateway|string }}
-            - --default-exclude-ips={% if kube_ovn_default_exclude_ips is defined %}{{ kube_ovn_default_exclude_ips }}{% endif %}{{''}}
-            - --node-switch-cidr={{ kube_ovn_node_switch_cidr }}{% if enable_dual_stack_networks %},{{ kube_ovn_node_switch_cidr_ipv6 }}{% endif %}{{''}}
-            - --service-cluster-ip-range={{ kube_service_addresses }}{% if enable_dual_stack_networks %},{{ kube_service_addresses_ipv6 }}{% endif %}{{''}}
-            - --network-type={{ kube_ovn_network_type }}
-            - --default-interface-name={{ kube_ovn_default_interface_name|default('') }}
-            - --default-vlan-id={{ kube_ovn_default_vlan_id }}
-            - --pod-nic-type={{ kube_ovn_pod_nic_type }}
-            - --enable-lb={{ kube_ovn_enable_lb|string }}
-            - --enable-np={{ kube_ovn_enable_np|string }}
-            - --enable-eip-snat={{ kube_ovn_eip_snat_enabled }}
-            - --enable-external-vpc={{ kube_ovn_enable_external_vpc|string }}
-            - --logtostderr=false
-            - --alsologtostderr=true
-            - --log_file=/var/log/kube-ovn/kube-ovn-controller.log
-            - --log_file_max_size=0
-            - --keep-vm-ip={{ kube_ovn_keep_vm_ip }}
+          - /kube-ovn/start-controller.sh
+          - --default-cidr={{ kube_pods_subnet }}{% if enable_dual_stack_networks %},{{ kube_ovn_pool_cidr_ipv6 | default(kube_pods_subnet_ipv6) }}{% endif %}{{''}}
+          - --default-gateway={% if kube_ovn_default_gateway is defined %}{{ kube_ovn_default_gateway }}{% endif %}{{''}}
+          - --default-gateway-check={{ kube_ovn_default_gateway_check|string }}
+          - --default-logical-gateway={{ kube_ovn_default_logical_gateway|string }}
+          - --default-u2o-interconnection={{ kube_ovn_u2o_interconnection }}
+          - --default-exclude-ips={% if kube_ovn_default_exclude_ips is defined %}{{ kube_ovn_default_exclude_ips }}{% endif %}{{''}}
+          - --node-switch-cidr={{ kube_ovn_node_switch_cidr }}{% if enable_dual_stack_networks %},{{ kube_ovn_node_switch_cidr_ipv6 }}{% endif %}{{''}}
+          - --service-cluster-ip-range={{ kube_service_addresses }}{% if enable_dual_stack_networks %},{{ kube_service_addresses_ipv6 }}{% endif %}{{''}}
+          - --network-type={{ kube_ovn_network_type }}
+          - --default-interface-name={{ kube_ovn_default_interface_name|default('') }}
+          - --default-vlan-id={{ kube_ovn_default_vlan_id }}
+          - --ls-dnat-mod-dl-dst={{ kube_ovn_ls_dnat_mod_dl_dst }}
+          - --pod-nic-type={{ kube_ovn_pod_nic_type }}
+          - --enable-lb={{ kube_ovn_enable_lb|string }}
+          - --enable-np={{ kube_ovn_enable_np|string }}
+          - --enable-eip-snat={{ kube_ovn_eip_snat_enabled }}
+          - --enable-external-vpc={{ kube_ovn_enable_external_vpc|string }}
+          - --logtostderr=false
+          - --alsologtostderr=true
+          - --gc-interval=360
+          - --inspect-interval=20
+          - --log_file=/var/log/kube-ovn/kube-ovn-controller.log
+          - --log_file_max_size=0
+          - --enable-lb-svc=false
+          - --keep-vm-ip={{ kube_ovn_keep_vm_ip }}
+          - --pod-default-fip-type=""
           env:
             - name: ENABLE_SSL
               value: "{{ kube_ovn_enable_ssl | lower }}"
@@ -78,6 +83,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: OVN_DB_IPS
+              value: "{{ kube_ovn_central_ips }}"
+            - name: POD_IPS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIPs
+            - name: ENABLE_BIND_LOCAL_IP
+              value: "{{ kube_ovn_bind_local_ip_enabled }}"
           volumeMounts:
             - mountPath: /etc/localtime
               name: localtime
@@ -141,8 +154,13 @@ spec:
         type: infra
     spec:
       tolerations:
-      - operator: Exists
-      priorityClassName: system-cluster-critical
+        - effect: NoSchedule
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+        - key: CriticalAddonsOnly
+          operator: Exists
+      priorityClassName: system-node-critical
       serviceAccountName: ovn
       hostNetwork: true
       hostPID: true
@@ -157,6 +175,8 @@ spec:
         volumeMounts:
           - mountPath: /opt/cni/bin
             name: cni-bin
+          - mountPath: /usr/local/bin
+            name: local-bin
       containers:
       - name: cni-server
         image: {{ kube_ovn_container_image_repo }}:{{ kube_ovn_container_image_tag }}
@@ -172,7 +192,7 @@ spec:
           - --dpdk-tunnel-iface={{ kube_ovn_dpdk_tunnel_iface }}
           - --network-type={{ kube_ovn_network_type }}
           - --default-interface-name={{ kube_ovn_default_interface_name|default('') }}
-{% if kube_ovn_mtu is defined %}
+          {% if kube_ovn_mtu is defined %}
           - --mtu={{ kube_ovn_mtu }}
 {% endif %}
           - --cni-conf-name={{ kube_ovn_cni_config_priority }}-kube-ovn.conflist
@@ -184,7 +204,7 @@ spec:
           runAsUser: 0
           privileged: true
         env:
-          - name: kube_ovn_enable_ssl
+          - name: ENABLE_SSL
             value: "{{ kube_ovn_enable_ssl | lower }}"
           - name: POD_IP
             valueFrom:
@@ -198,6 +218,14 @@ spec:
             value: kube_ovn_fastpath.ko
           - name: RPMS
             value: openvswitch-kmod
+          - name: POD_IPS
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIPs
+          - name: ENABLE_BIND_LOCAL_IP
+            value: "{{ kube_ovn_bind_local_ip_enabled }}"
+          - name: DBUS_SYSTEM_BUS_ADDRESS
+            value: "unix:path=/host/var/run/dbus/system_bus_socket"
         volumeMounts:
           - name: host-modules
             mountPath: /lib/modules
@@ -213,6 +241,9 @@ spec:
             mountPropagation: Bidirectional
           - mountPath: /run/ovn
             name: host-run-ovn
+          - mountPath: /host/var/run/dbus
+            name: host-dbus
+            mountPropagation: HostToContainer
           - mountPath: /var/run/netns
             name: host-ns
             mountPropagation: HostToContainer
@@ -276,6 +307,9 @@ spec:
         - name: host-ns
           hostPath:
             path: /var/run/netns
+        - name: host-dbus
+          hostPath:
+            path: /var/run/dbus
         - name: host-log-ovs
           hostPath:
             path: /var/log/openvswitch
@@ -291,6 +325,9 @@ spec:
         - name: tmp
           hostPath:
             path: /tmp
+        - name: local-bin
+          hostPath:
+            path: /usr/local/bin
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -313,12 +350,12 @@ spec:
         component: network
         type: infra
     spec:
+      priorityClassName: system-node-critical
       serviceAccountName: ovn
       hostPID: true
       containers:
         - name: pinger
           image: {{ kube_ovn_container_image_repo }}:{{ kube_ovn_container_image_tag }}
-          imagePullPolicy: {{ k8s_image_pull_policy }}
           command:
           - /kube-ovn/kube-ovn-pinger
           args:
@@ -328,6 +365,7 @@ spec:
           - --alsologtostderr=true
           - --log_file=/var/log/kube-ovn/kube-ovn-pinger.log
           - --log_file_max_size=0
+          imagePullPolicy: {{ k8s_image_pull_policy }}
           securityContext:
             runAsUser: 0
             privileged: false
@@ -443,7 +481,10 @@ spec:
         type: infra
     spec:
       tolerations:
-      - operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+        - key: CriticalAddonsOnly
+          operator: Exists
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -469,6 +510,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: POD_IPS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIPs
+            - name: ENABLE_BIND_LOCAL_IP
+              value: "{{ kube_ovn_bind_local_ip_enabled }}"
           resources:
             requests:
               cpu: {{ kube_ovn_monitor_cpu_request }}
@@ -608,7 +655,7 @@ spec:
   ports:
     - port: 10665
       name: metrics
-{% if kube_ovn_ic_enable %}
+      {% if kube_ovn_ic_enable %}
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/roles/network_plugin/kube-ovn/templates/cni-ovn.yml.j2
+++ b/roles/network_plugin/kube-ovn/templates/cni-ovn.yml.j2
@@ -12,11 +12,6 @@ metadata:
     rbac.authorization.k8s.io/system-only: "true"
   name: system:ovn
 rules:
-  - apiGroups: ['policy']
-    resources: ['podsecuritypolicies']
-    verbs:     ['use']
-    resourceNames:
-      - kube-ovn
   - apiGroups:
       - "kubeovn.io"
     resources:
@@ -34,7 +29,6 @@ rules:
       - provider-networks/status
       - security-groups
       - security-groups/status
-      - htbqoses
       - iptables-eips
       - iptables-fip-rules
       - iptables-dnat-rules
@@ -43,6 +37,16 @@ rules:
       - iptables-fip-rules/status
       - iptables-dnat-rules/status
       - iptables-snat-rules/status
+      - ovn-eips
+      - ovn-fips
+      - ovn-snat-rules
+      - ovn-eips/status
+      - ovn-fips/status
+      - ovn-snat-rules/status
+      - switch-lb-rules
+      - switch-lb-rules/status
+      - vpc-dnses
+      - vpc-dnses/status
     verbs:
       - "*"
   - apiGroups:
@@ -78,6 +82,7 @@ rules:
     resources:
       - networkpolicies
       - services
+      - services/status
       - endpoints
       - statefulsets
       - daemonsets
@@ -105,16 +110,6 @@ rules:
       - leases
     verbs:
       - "*"
-  - apiGroups:
-      - "k8s.cni.cncf.io"
-    resources:
-      - network-attachment-definitions
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - update
   - apiGroups:
       - "kubevirt.io"
     resources:
@@ -245,12 +240,12 @@ spec:
           env:
             - name: ENABLE_SSL
               value: "{{ kube_ovn_enable_ssl | lower }}"
+            - name: NODE_IPS
+              value: "{{ kube_ovn_central_ips }}"
             - name: POD_IP
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: NODE_IPS
-              value: "{{ kube_ovn_central_ips }}"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -259,6 +254,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_IPS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIPs
+            - name: ENABLE_BIND_LOCAL_IP
+              value: "{{ kube_ovn_bind_local_ip_enabled }}"
           resources:
             requests:
               cpu: {{ kube_ovn_db_cpu_request }}
@@ -358,7 +359,7 @@ spec:
     spec:
       tolerations:
       - operator: Exists
-      priorityClassName: system-cluster-critical
+      priorityClassName: system-node-critical
       serviceAccountName: ovn
       hostNetwork: true
       hostPID: true
@@ -444,7 +445,7 @@ spec:
 {% else %}
                 - /kube-ovn/ovs-healthcheck.sh
 {% endif %}
-            initialDelaySeconds: 10
+            initialDelaySeconds: 60
             periodSeconds: 5
             failureThreshold: 5
             timeoutSeconds: 45


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:

Upgrade kube-ovn to v1.11.5 to fix connectivity CI error in almalinux8
The issue seems the same as the https://github.com/kubeovn/kube-ovn/pull/2535, and fix by the new version.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kubespray/issues/10095

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[kube-ovn]: update version v1.11.5
```
