### PR TITLE
[CI] fix tf-elastx_cleanup fail

### DIFF
--- a/scripts/openstack-cleanup/main.py
+++ b/scripts/openstack-cleanup/main.py
@@ -59,6 +59,9 @@ def main():
                     except Exception as ex:
                         print("Failed to delete subnet from router as %s", ex)
 
+        for ip in conn.network.ips():
+            fn_if_old(conn.network.delete_ip, ip)
+                
         # After removing unnecessary subnet from router, retry to delete ports
         map_if_old(conn.network.delete_port,
                    conn.network.ports())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind failing-test

**What this PR does / why we need it**:

there is an issue with tf-elastx_cleanup job apparently, we get openstack.exceptions.ConflictException: ConflictException: 409: Client Error for url: https://ops.elastx.cloud:9696/v2.0/ports/95013297-b455-41f6-aa1d-6a0e1f50a0bc, Port 95013297-b455-41f6-aa1d-6a0e1f50a0bc cannot be deleted directly via the port API: has device owner network:floatingip  on every new CI 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[CI] fix tf-elastx_cleanup fail
```
