### PR TITLE
clean up /etc/hosts file if populate_inventory_to_hosts_file is false

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0090-etchosts.yml
+++ b/roles/kubernetes/preinstall/tasks/0090-etchosts.yml
@@ -13,7 +13,6 @@
   connection: local
   delegate_facts: yes
   run_once: yes
-  when: populate_inventory_to_hosts_file
 
 - name: Hosts | populate inventory into hosts file
   blockinfile:

--- a/roles/kubernetes/preinstall/tasks/0090-etchosts.yml
+++ b/roles/kubernetes/preinstall/tasks/0090-etchosts.yml
@@ -1,32 +1,30 @@
 ---
-- name: Hosts | update inventory in hosts file
+- name: Hosts | create hosts list from inventory
+  set_fact:
+    etc_hosts_inventory_block: |-
+      {% for item in (groups['k8s_cluster'] + groups['etcd'] | default([]) + groups['calico_rr'] | default([])) | unique -%}
+      {% if 'access_ip' in hostvars[item] or 'ip' in hostvars[item] or 'ansible_default_ipv4' in hostvars[item] -%}
+      {{ hostvars[item]['access_ip'] | default(hostvars[item]['ip'] | default(hostvars[item]['ansible_default_ipv4']['address'])) }}
+      {%- if ('ansible_hostname' in hostvars[item] and item != hostvars[item]['ansible_hostname']) %} {{ hostvars[item]['ansible_hostname'] }}.{{ dns_domain }} {{ hostvars[item]['ansible_hostname'] }} {% else %} {{ item }}.{{ dns_domain }} {{ item }} {% endif %}
+
+      {% endif %}
+      {% endfor %}
+  delegate_to: localhost
+  connection: local
+  delegate_facts: yes
+  run_once: yes
   when: populate_inventory_to_hosts_file
-  block:
-    - name: Hosts | create list from inventory
-      set_fact:
-        etc_hosts_inventory_block: |-
-          {% for item in (groups['k8s_cluster'] + groups['etcd'] | default([]) + groups['calico_rr'] | default([])) | unique -%}
-          {% if 'access_ip' in hostvars[item] or 'ip' in hostvars[item] or 'ansible_default_ipv4' in hostvars[item] -%}
-          {{ hostvars[item]['access_ip'] | default(hostvars[item]['ip'] | default(hostvars[item]['ansible_default_ipv4']['address'])) }}
-          {%- if ('ansible_hostname' in hostvars[item] and item != hostvars[item]['ansible_hostname']) %} {{ hostvars[item]['ansible_hostname'] }}.{{ dns_domain }} {{ hostvars[item]['ansible_hostname'] }} {% else %} {{ item }}.{{ dns_domain }} {{ item }} {% endif %}
 
-          {% endif %}
-          {% endfor %}
-      delegate_to: localhost
-      connection: local
-      delegate_facts: yes
-      run_once: yes
-
-    - name: Hosts | populate inventory into hosts file
-      blockinfile:
-        path: /etc/hosts
-        block: "{{ hostvars.localhost.etc_hosts_inventory_block }}"
-        state: present
-        create: yes
-        backup: yes
-        unsafe_writes: yes
-        marker: "# Ansible inventory hosts {mark}"
-        mode: 0644
+- name: Hosts | populate inventory into hosts file
+  blockinfile:
+    path: /etc/hosts
+    block: "{{ hostvars.localhost.etc_hosts_inventory_block }}"
+    state: "{{ 'present' if populate_inventory_to_hosts_file else 'absent' }}"
+    create: yes
+    backup: yes
+    unsafe_writes: yes
+    marker: "# Ansible inventory hosts {mark}"
+    mode: 0644
 
 - name: Hosts | populate kubernetes loadbalancer address into hosts file
   lineinfile:


### PR DESCRIPTION

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Previously, the populate_inventory_to_hosts_file variable could only be used to prevent adding entries into /etc/hosts. Once added, there was no way to remove them except manually. Now, if populate_inventory_to_hosts_file is false, ansible will remove the entries from /etc/hosts (applying negative configuration which is good for consistency) so you don't have to manually clean them up.

**Special notes for your reviewer**:
Aside from removing the block indentation, the only real change is
```
-    state: present
+    state: "{{ 'present' if populate_inventory_to_hosts_file else 'absent' }}"
```
and removing the when condition from blockinfile so it always runs.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
If populate_inventory_to_hosts_file is false, now ansible will ensure the host entries from /etc/host are absent instead of merely not adding them.
```
