### PR TITLE
[#10148] The download.timeout can be changed.

### DIFF
--- a/roles/download/tasks/download_file.yml
+++ b/roles/download/tasks/download_file.yml
@@ -93,6 +93,7 @@
       url_username: "{{ download.username | default(omit) }}"
       url_password: "{{ download.password | default(omit) }}"
       force_basic_auth: "{{ download.force_basic_auth | default(omit) }}"
+      timeout: "{{ download.timeout | default(omit) }}"
     delegate_to: "{{ download_delegate if download_force_cache else inventory_hostname }}"
     run_once: "{{ download_force_cache }}"
     register: get_url_result


### PR DESCRIPTION
The download.timeout can be changed by variable download.timeout with value in seconds.

Reference:
  https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html#parameter-timeout


**What type of PR is this?**
> /kind feature


**What this PR does / why we need it**:
If got a slow connection to url usually it's github, it might be timeout.

**Which issue(s) this PR fixes**:

Fixes #10148

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add `download.timeout` to update  download timeout value
```
