### PR TITLE
Avoid creating metallb config if unnecessary

### DIFF
--- a/roles/kubernetes-apps/metallb/templates/layer3.yaml.j2
+++ b/roles/kubernetes-apps/metallb/templates/layer3.yaml.j2
@@ -2,6 +2,8 @@
 # yamllint disable-file
 ---
 # Create layer3 configuration
+{% if metallb_config.layer3 is defined %}
+
 {% if metallb_config.layer3.communities is defined %}
 {% for community_name, community in metallb_config.layer3.communities.items() %}
 ---
@@ -123,3 +125,5 @@ spec:
   {% endif -%}
 
 {% endfor %}
+
+{% endif %}

--- a/roles/kubernetes-apps/metallb/templates/metallb.yml.j2
+++ b/roles/kubernetes-apps/metallb/templates/metallb.yml.j2
@@ -1755,7 +1755,7 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
-{% if metallb_config.controller.tolerations %}
+{% if metallb_config.controller is defined and metallb_config.controller.tolerations %}
       tolerations:
         {{ metallb_config.controller.tolerations | to_nice_yaml(indent=2) | indent(width=8) }}
 {% endif %}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

To avoid the following error during setting metallb up, this adds some conditions:
```
 TASK [kubernetes_sigs.kubespray.kubernetes-apps/metallb : Kubernetes Apps | Lay Down MetalLB] ***
 [..]
  An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: 'dict object' has no attribute 'controller'
  failed: [k8s-master-1] (item=metallb.yml) => {"ansible_loop_var": "item", "changed": false, "item": "metallb.yml", "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'controller'"}
  An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: 'dict object' has no attribute 'layer3'
  failed: [k8s-master-1] (item=layer3.yaml) => {"ansible_loop_var": "item", "changed": false, "item": "layer3.yaml", "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'layer3'"}
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10143

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Avoid creating metallb config if unnecessary
```
