### PR TITLE
Spicify the runc path when we use the containerd container engine and change the bin_dir path.

### DIFF
--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -18,6 +18,7 @@ containerd_runc_runtime:
   base_runtime_spec: cri-base.json
   options:
     systemdCgroup: "{{ containerd_use_systemd_cgroup | ternary('true', 'false') }}"
+    binaryName: "{{ bin_dir }}/runc"
 
 containerd_additional_runtimes: []
 # Example for Kata Containers as additional runtime:

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -35,7 +35,11 @@ oom_score = {{ containerd_oom_score }}
 
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.{{ runtime.name }}.options]
 {% for key, value in runtime.options.items() %}
+{% if value|string != "true" and value|string != "false" %}
+            {{ key }} = "{{ value }}"
+{% else %}
             {{ key }} = {{ value }}
+{% endif %}
 {% endfor %}
 {% endfor %}
 {% if kata_containers_enabled %}

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -35,7 +35,7 @@ oom_score = {{ containerd_oom_score }}
 
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.{{ runtime.name }}.options]
 {% for key, value in runtime.options.items() %}
-{% if value|string != "true" and value|string != "false" %}
+{% if value | string != "true" and value | string != "false" %}
             {{ key }} = "{{ value }}"
 {% else %}
             {{ key }} = {{ value }}


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
when we use the containerd container engine and change the bin_dir path,  the installation will stop and with kubelet error:
`May 26 02:19:44 localhost containerd: time="2023-05-26T02:19:44.252978056-04:00" level=error msg="RunPodSandbox for &PodSandboxMetadata{Name:kube-scheduler-node1,Uid:bd557bf0bab279ad21231c6c93dfdecb,Namespace:kube-system,Attempt:0,} failed, error" error="failed to create containerd task: failed to create shim task: OCI runtime create failed: unable to retrieve OCI runtime error (open /run/containerd/io.containerd.runtime.v2.task/k8s.io/5d728ef6fd58040d715c1f60923185eee7645e0fbc5d9b7feb27760bc1ba329d/log.json: no such file or directory): exec: \"runc\": executable file not found in $PATH: unknown`

bugfix:
we need import the binaryName param metioned in the document:
```containerd_runc_runtime:
  name: runc
  type: "io.containerd.runc.v2"
  engine: ""
  root: ""
  options:
    systemdCgroup: "false"
    binaryName: /usr/local/bin/my-runc
  base_runtime_spec: cri-base.json
```

https://github.com/kubernetes-sigs/kubespray/blob/master/docs/containerd.md?plain=1#L58

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[containerd] Specify the runc path when we use the containerd container engine and change the bin_dir path.
```