### PR TITLE
Solves #2933: Allow http_proxy, https_proxy and no_proxy environment variables in cert-manager playbook

### DIFF
--- a/roles/kubernetes-apps/ingress_controller/cert_manager/defaults/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/defaults/main.yml
@@ -8,6 +8,11 @@ cert_manager_dns_policy: "ClusterFirst"
 cert_manager_dns_config: {}
 cert_manager_controller_extra_args: []
 
+## Allow http_proxy, https_proxy and no_proxy environment variables
+## Details https://github.com/kubernetes-sigs/kubespray/blob/master/docs/proxy.md
+cert_manager_http_proxy: "{{ http_proxy|default('') }}"
+cert_manager_https_proxy: "{{ https_proxy|default('') }}"
+cert_manager_no_proxy: "{{ no_proxy|default('') }}"
 
 ## Change leader election namespace when deploying on GKE Autopilot that forbid the changes on kube-system namespace.
 ## See https://github.com/jetstack/cert-manager/issues/3717

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
@@ -870,6 +870,18 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+{% if cert_manager_http_proxy is defined and cert_manager_http_proxy != "" %}
+          - name: HTTP_PROXY
+            value: "{{ cert_manager_http_proxy }}"
+{% endif %}
+{% if cert_manager_https_proxy is defined and cert_manager_https_proxy != "" %}
+          - name: HTTPS_PROXY
+            value: "{{ cert_manager_https_proxy }}"
+{% endif %}
+{% if cert_manager_no_proxy is defined and cert_manager_no_proxy != "" %}
+          - name: NO_PROXY
+            value: "{{ cert_manager_no_proxy }}"
+{% endif %}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -967,6 +979,18 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+{% if cert_manager_http_proxy is defined and cert_manager_http_proxy != "" %}
+          - name: HTTP_PROXY
+            value: "{{ cert_manager_http_proxy }}"
+{% endif %}
+{% if cert_manager_https_proxy is defined and cert_manager_https_proxy != "" %}
+          - name: HTTPS_PROXY
+            value: "{{ cert_manager_https_proxy }}"
+{% endif %}
+{% if cert_manager_no_proxy is defined and cert_manager_no_proxy != "" %}
+          - name: NO_PROXY
+            value: "{{ cert_manager_no_proxy }}"
+{% endif %}
 {% if cert_manager_trusted_internal_ca is defined %}
           volumeMounts:
           - mountPath: /etc/ssl/certs/internal-ca.pem
@@ -1083,6 +1107,18 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+{% if cert_manager_http_proxy is defined and cert_manager_http_proxy != "" %}
+          - name: HTTP_PROXY
+            value: "{{ cert_manager_http_proxy }}"
+{% endif %}
+{% if cert_manager_https_proxy is defined and cert_manager_https_proxy != "" %}
+          - name: HTTPS_PROXY
+            value: "{{ cert_manager_https_proxy }}"
+{% endif %}
+{% if cert_manager_no_proxy is defined and cert_manager_no_proxy != "" %}
+          - name: NO_PROXY
+            value: "{{ cert_manager_no_proxy }}"
+{% endif %}
 {% if cert_manager_tolerations %}
       tolerations:
         {{ cert_manager_tolerations | to_nice_yaml(indent=2) | indent(width=8) }}


### PR DESCRIPTION
Allow http_proxy, https_proxy and no_proxy environment variables in cert-manager playbook

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Allows to get TLS certificates if the cluster is located in a closed circuit with access to the Internet only through a proxy

**Which issue(s) this PR fixes**:
Fixes #2933

**Special notes for your reviewer**:
No notes

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
