### PR TITLE
Add node_taints to aws_inventory script (#10168)

### DIFF
--- a/contrib/aws_inventory/kubespray-aws-inventory.py
+++ b/contrib/aws_inventory/kubespray-aws-inventory.py
@@ -39,7 +39,7 @@ class SearchEC2Tags(object):
       hosts[group] = []
       tag_key = "kubespray-role"
       tag_value = ["*"+group+"*"]
-      region = os.environ['REGION']
+      region = os.environ['AWS_REGION']
 
       ec2 = boto3.resource('ec2', region)
       filters = [{'Name': 'tag:'+tag_key, 'Values': tag_value}, {'Name': 'instance-state-name', 'Values': ['running']}]
@@ -66,6 +66,11 @@ class SearchEC2Tags(object):
         node_labels_tag = list(filter(lambda t: t['Key'] == 'kubespray-node-labels', instance.tags))
         if node_labels_tag:
           ansible_host['node_labels'] = dict([ label.strip().split('=') for label in node_labels_tag[0]['Value'].split(',') ])
+
+        ##Set when instance actually has node_taints
+        node_taints_tag = list(filter(lambda t: t['Key'] == 'kubespray-node-taints', instance.tags))
+        if node_taints_tag:
+          ansible_host['node_taints'] = list([ taint.strip() for taint in node_taints_tag[0]['Value'].split(',') ])
 
         hosts[group].append(dns_name)
         hosts['_meta']['hostvars'][dns_name] = ansible_host

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -58,10 +58,22 @@ Guide:
 ```ShellSession
 export AWS_ACCESS_KEY_ID="xxxxx"
 export AWS_SECRET_ACCESS_KEY="yyyyy"
-export REGION="us-east-2"
+export AWS_REGION="us-east-2"
 ```
 
 - We will now create our cluster. There will be either one or two small changes. The first is that we will specify `-i inventory/kubespray-aws-inventory.py` as our inventory script. The other is conditional. If your AWS instances are public facing, you can set the `VPC_VISIBILITY` variable to `public` and that will result in public IP and DNS names being passed into the inventory. This causes your cluster.yml command to look like `VPC_VISIBILITY="public" ansible-playbook ... cluster.yml`
+
+**Optional** Using labels and taints
+
+To add labels to your kubernetes node, add the following tag to your instance:
+
+- Key: `kubespray-node-labels`
+- Value: `node-role.kubernetes.io/ingress=`
+
+To add taints to your kubernetes node, add the following tag to your instance:
+
+- Key: `kubespray-node-taints`
+- Value: `node-role.kubernetes.io/ingress=:NoSchedule`
 
 ## Kubespray configuration
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Allows to add `node_taints` to be added to the ec2 instance tags.

**Which issue(s) this PR fixes**:

Fixes #10168

**Special notes for your reviewer**:
The last change to the aws_inventory script has been long time ago. `REGION` environment variable is also deprecated and has been renamed to `AWS_REGION`.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
