### PR TITLE
remove cri-o using crio_bin_files

### DIFF
--- a/roles/container-engine/cri-o/tasks/reset.yml
+++ b/roles/container-engine/cri-o/tasks/reset.yml
@@ -81,21 +81,10 @@
   tags:
     - reset_crio
 
-- name: CRI-O | Remove dpkg hold
-  dpkg_selections:
-    name: "{{ item }}"
-    selection: install
-  when: ansible_pkg_mgr == 'apt'
-  changed_when: false
-  with_items: "{{ crio_packages }}"
-  tags:
-    - reset_crio
-
-- name: CRI-O | Uninstall CRI-O package
-  package:
+- name: CRI-O | Remove CRI-O binaries
+  file:
     name: "{{ item }}"
     state: absent
-  when: not is_ostree
-  with_items: "{{ crio_packages }}"
+  with_items: "{{ crio_bin_files }}"
   tags:
     - reset_crio


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

```text
TASK [container-engine/cri-o : CRI-O | Uninstall CRI-O package] ****************
task path: /kubespray/roles/container-engine/cri-o/tasks/reset.yml:94
fatal: [k8s-192-168-57-17]: FAILED! => {
    "msg": "'crio_packages' is undefined"
}
```

Replace `crio_packages` with `crio_bin_files` In #9374 
But `crio_packages` remains in reset.yml 

```
TASK [container-engine/cri-o : CRI-O | Uninstall CRI-O package] *************************************************************************************************
fatal: [k8s-192-168-57-17]: FAILED! => {"msg": "'crio_packages' is undefined"}
```

```
- name: CRI-O | Remove dpkg hold
  dpkg_selections:
    name: "{{ item }}"
    selection: install
  when: ansible_pkg_mgr == 'apt'
  changed_when: false
  with_items: "{{ crio_packages }}"
  tags:
    - reset_crio

- name: CRI-O | Uninstall CRI-O package
  package:
    name: "{{ item }}"
    state: absent
  when: not is_ostree
  with_items: "{{ crio_packages }}"
  tags:
    - reset_crio
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Replace "crio_packages" with "crio_bin_files" 
```
