### PR TITLE
Fix metrics-server for k8s 1.26

### DIFF
--- a/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
@@ -40,7 +40,7 @@ spec:
 {% endif %}
         - --kubelet-use-node-status-port
 {% if metrics_server_kubelet_insecure_tls %}
-        - --kubelet-insecure-tls
+        - --kubelet-insecure-tls=true
 {% endif %}
         - --metric-resolution={{ metrics_server_metric_resolution }}
         ports:


### PR DESCRIPTION
 **What type of PR is this?**
 
 /kind bug
 
 **What this PR does / why we need it**: 

Set `--kubelet-insecure-tls` to `--kubelet-insecure-tls=true` to fix metrics-server deployment
I also checked this version against older version of kubernetes '1.24.x' and it works fine.
Also see: https://github.com/kubernetes-sigs/metrics-server/issues/1266

**Which issue(s) this PR fixes:**
Fixes https://github.com/kubernetes-sigs/kubespray/issues/10178

**Does this PR introduce a user-facing change?**:
<!--
NONE
-->
```release-note
Fix metrics-server deployment to run with kubernetes 1.26+
```
