### PR TITLE
[flatcar] add python dependency check for helm-apps

### DIFF
--- a/roles/kubernetes-apps/helm/tasks/main.yml
+++ b/roles/kubernetes-apps/helm/tasks/main.yml
@@ -21,9 +21,7 @@
 
 - name: Helm | Install PyYaml [flatcar]
   include_tasks: pyyaml-flatcar.yml
-  when:
-    - pyyaml_package is undefined
-    - "'ID=flatcar' in os_release.stdout_lines"
+  when: ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
 
 - name: Helm | Download helm
   include_tasks: "../../../download/tasks/download_file.yml"

--- a/roles/kubernetes-apps/helm/tasks/main.yml
+++ b/roles/kubernetes-apps/helm/tasks/main.yml
@@ -17,6 +17,13 @@
   package:
     name: "{{ pyyaml_package }}"
     state: present
+  when: pyyaml_package is defined
+
+- name: Helm | Install PyYaml [flatcar]
+  include_tasks: pyyaml-flatcar.yml
+  when:
+    - pyyaml_package is undefined
+    - "'ID=flatcar' in os_release.stdout_lines"
 
 - name: Helm | Download helm
   include_tasks: "../../../download/tasks/download_file.yml"

--- a/roles/kubernetes-apps/helm/tasks/pyyaml-flatcar.yml
+++ b/roles/kubernetes-apps/helm/tasks/pyyaml-flatcar.yml
@@ -1,0 +1,22 @@
+---
+- name: Get installed pip version
+  command: "{{ ansible_python_interpreter if ansible_python_interpreter is defined else 'python' }} -m pip --version"
+  register: pip_version_output
+  ignore_errors: yes
+  changed_when: false
+
+- name: Get installed PyYAML version
+  command: "{{ ansible_python_interpreter if ansible_python_interpreter is defined else 'python' }} -m pip show PyYAML"
+  register: pyyaml_version_output
+  ignore_errors: yes
+  changed_when: false
+
+- name: Install pip
+  command: "{{ ansible_python_interpreter if ansible_python_interpreter is defined else 'python' }} -m ensurepip --upgrade"
+  when: (pyyaml_version_output is failed) and (pip_version_output is failed)
+
+- name: Install PyYAML
+  ansible.builtin.pip:
+    name:
+      - PyYAML
+  when: (pyyaml_version_output is failed)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

helm-apps require PyYAML <https://docs.ansible.com/ansible/latest/collections/kubernetes/core/helm_module.html> as a dependency on the node where the Helm binaries are executed. The setup process does not install PyYAML during the OS bootstrapping, which can cause helm apps to fail due to missing dependencies. 

```sh
 TASK [helm-apps : Add Helm repositories] ******************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ModuleNotFoundError: No module named 'yaml'
[WARNING]: Module did not set no_log for pass_credentials
failed: [cluster-k8s-az1-master1] (item={'name': 'kubelet-csr-approver', 'url': 'https://postfinance.github.io/kubelet-csr-approver'}) => {"ansible_loop_var": "item", "changed": false, "item": {"nam
e": "kubelet-csr-approver", "url": "https://postfinance.github.io/kubelet-csr-approver"}, "msg": "Failed to import the required Python library (yaml) on cluster-k8s-az1-master1's Python /opt/bin/pyt
hon. Please read the module documentation and install it in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documenta
tion on ansible_python_interpreter"}
```
The problem was encountered when activating `kubelet_rotate_server_certificates` with Flatcar as the operating system and kubespray release v2.22.0. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[flatcar] add python dependency check for helm-apps
```
