### PR TITLE
helm: fix pyyaml package on RH distros

### DIFF
--- a/roles/kubernetes-apps/helm/vars/centos-7.yml
+++ b/roles/kubernetes-apps/helm/vars/centos-7.yml
@@ -1,0 +1,2 @@
+---
+pyyaml_package: PyYAML

--- a/roles/kubernetes-apps/helm/vars/centos-9.yml
+++ b/roles/kubernetes-apps/helm/vars/centos-9.yml
@@ -1,2 +1,0 @@
----
-pyyaml_package: python3-pyyaml

--- a/roles/kubernetes-apps/helm/vars/centos.yml
+++ b/roles/kubernetes-apps/helm/vars/centos.yml
@@ -1,2 +1,2 @@
 ---
-pyyaml_package: PyYAML
+pyyaml_package: python3-pyyaml

--- a/roles/kubernetes-apps/helm/vars/redhat-7.yml
+++ b/roles/kubernetes-apps/helm/vars/redhat-7.yml
@@ -1,0 +1,2 @@
+---
+pyyaml_package: PyYAML

--- a/roles/kubernetes-apps/helm/vars/redhat-9.yml
+++ b/roles/kubernetes-apps/helm/vars/redhat-9.yml
@@ -1,2 +1,0 @@
----
-pyyaml_package: python3-pyyaml

--- a/roles/kubernetes-apps/helm/vars/redhat.yml
+++ b/roles/kubernetes-apps/helm/vars/redhat.yml
@@ -1,2 +1,2 @@
 ---
-pyyaml_package: PyYAML
+pyyaml_package: python3-pyyaml

--- a/roles/kubernetes-apps/helm/vars/suse.yml
+++ b/roles/kubernetes-apps/helm/vars/suse.yml
@@ -1,2 +1,2 @@
 ---
-pyyaml_package: PyYAML
+pyyaml_package: python3-pyyaml


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
This fixes a package name (pyyaml) installation in the helm role. The correct package is `PyYAML` for centos7 (and derivatives) and `python3-pyyaml` for the rest (8/9 and suse). So basically the cuttoff for the name change was wrong (should be centos8 and not 9).
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix helm (kubelet-csr-approver) installation on redhat distro
```
