### PR TITLE
[podSecurityConfiguration]: fix apiVersion and change default policy …

### DIFF
--- a/roles/kubernetes/control-plane/defaults/main/main.yml
+++ b/roles/kubernetes/control-plane/defaults/main/main.yml
@@ -106,11 +106,11 @@ kube_apiserver_admission_event_rate_limits: {}
 
 kube_pod_security_use_default: false
 kube_pod_security_default_enforce: baseline
-kube_pod_security_default_enforce_version: latest
+kube_pod_security_default_enforce_version: "{{ kube_major_version }}"
 kube_pod_security_default_audit: restricted
-kube_pod_security_default_audit_version: latest
+kube_pod_security_default_audit_version: "{{ kube_major_version }}"
 kube_pod_security_default_warn: restricted
-kube_pod_security_default_warn_version: latest
+kube_pod_security_default_warn_version: "{{ kube_major_version }}"
 kube_pod_security_exemptions_usernames: []
 kube_pod_security_exemptions_runtime_class_names: []
 kube_pod_security_exemptions_namespaces:

--- a/roles/kubernetes/control-plane/templates/podsecurity.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/podsecurity.yaml.j2
@@ -1,5 +1,5 @@
 {% if kube_pod_security_use_default %}
-apiVersion: pod-security.admission.config.k8s.io/v1beta1
+apiVersion: pod-security.admission.config.k8s.io/v1
 kind: PodSecurityConfiguration
 defaults:
   enforce: "{{ kube_pod_security_default_enforce }}"


### PR DESCRIPTION
Signed-off-by: Ugur Can Ozturk ugurozturk918@gmail.com

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:
According to the [documentation](https://v1-25.docs.kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-admission-controller/), the api version of `pod-security.admission.config.k8s.io` was upgraded to `v1` with version `v1.25`. Even though `v1beta1` and `v1alpha1` are not deprecated yet, I think we should use v1 one. 

And using the latest security standards can be confusing for people following the special version of Kubernetes documentation. It would be good if we change the security standard versions not to latest but same as major Kubernetes version to prevent this confusion. Even if it will be set as latest, it will be more appropriate for the user to do this consciously.

**Which issue(s) this PR fixes**:
-
Fixes #

**Special notes for your reviewer**:
For testing purposes, a new cluster was set up and tested.

**Does this PR introduce a user-facing change?**:
```release-note
Unless the pod security standard versions are changed on intentionally, as default it will be the same major version with Kubernetes version.
```
