### PR TITLE
exclude terraform.tfstate backups in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ contrib/offline/offline-files.tar.gz
 .cache
 *.bak
 *.tfstate
-*.tfstate.backup
+*.tfstate*backup
 *.lock.hcl
 .terraform/
 contrib/terraform/aws/credentials.tfvars


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Newer versions of Terraform use timestamps in the backup name, e.g. `terraform.tfstate.1614728479.backup`

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Exclude terraform.tfstate backups in .gitignore
```