### PR TITLE
[feature] Correct CoreDNS versions for kubernetes releases

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -1076,7 +1076,7 @@ haproxy_image_tag: 2.6.6-alpine
 # Coredns version should be supported by corefile-migration (or at least work with)
 # bundle with kubeadm; if not 'basic' upgrade can sometimes fail
 
-coredns_version: "{{ 'v1.10.1' if (kube_version is version('v1.25.0','>=')) else 'v1.8.6' }}"
+coredns_version: "{{ 'v1.10.1' if (kube_version is version('v1.27.0','>=')) else 'v1.9.3' }}"
 coredns_image_is_namespaced: "{{ (coredns_version is version('v1.7.1','>=')) }}"
 
 coredns_image_repo: "{{ kube_image_repo }}{{'/coredns/coredns' if (coredns_image_is_namespaced | bool) else '/coredns' }}"


### PR DESCRIPTION
 **What type of PR is this?**
 
/kind feature
/kind bug
 
 **What this PR does / why we need it**: 

coredns v1.10.1 is supported only by kubernetes 1.27.x and higher. 1.25-1.26 is compatible with v1.9.3 See: https://github.com/coredns/deployment/blob/master/kubernetes/CoreDNS-k8s_version.md

**Which issue(s) this PR fixes:**

**Does this PR introduce a user-facing change?**:
<!--
NONE
-->
```release-note
Add corresponding coredns versions to all the supported kubernetes releases.
```
