### PR TITLE
local_path_provisioner: fix invalid podhelper yaml

### DIFF
--- a/roles/kubernetes-apps/external_provisioner/local_path_provisioner/defaults/main.yml
+++ b/roles/kubernetes-apps/external_provisioner/local_path_provisioner/defaults/main.yml
@@ -6,4 +6,5 @@ local_path_provisioner_reclaim_policy: Delete
 local_path_provisioner_claim_root: /opt/local-path-provisioner/
 local_path_provisioner_is_default_storageclass: "true"
 local_path_provisioner_debug: false
+local_path_provisioner_helper_image_repo: "busybox"
 local_path_provisioner_helper_image_tag: "latest"

--- a/roles/kubernetes-apps/external_provisioner/local_path_provisioner/templates/local-path-storage-cm.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_path_provisioner/templates/local-path-storage-cm.yml.j2
@@ -30,6 +30,6 @@ data:
     spec:
       containers:
       - name: helper-pod
-        image: {% if local_path_provisioner_helper_image_repo is defined %}{{ local_path_provisioner_helper_image_repo }}:{{ local_path_provisioner_helper_image_tag }}{% else %}busybox{% endif %}
+        image: "{{ local_path_provisioner_helper_image_repo }}:{{ local_path_provisioner_helper_image_tag }}"
         imagePullPolicy: IfNotPresent
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
New line was not inserted between image and imagePullPolicy for some reasons with the jinja. Simplifying this altogether should fix this.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Should fix recent CI failure after the merge of https://github.com/kubernetes-sigs/kubespray/pull/10054
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
