### PR TITLE
tests: cleanup stale packet namespace automatically

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -23,6 +23,14 @@
   allow_failure: true
   extends: .packet
 
+packet_cleanup_old:
+  stage: deploy-part1
+  extends: .packet_periodic
+  script:
+    - cd tests
+    - make cleanup-packet
+  after_script: []
+
 # The ubuntu20-calico-aio jobs are meant as early stages to prevent running the full CI if something is horribly broken
 packet_ubuntu20-calico-aio:
   stage: deploy-part1

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -64,6 +64,8 @@ create-packet: init-packet
 	$(ANSIBLE_LOG_LEVEL) \
 	-e @"files/${CI_JOB_NAME}.yml" \
 	-e test_id=$(TEST_ID) \
+	-e branch="$(CI_COMMIT_BRANCH)" \
+	-e pipeline_id="$(CI_PIPELINE_ID)" \
 	-e inventory_path=$(INVENTORY)
 
 delete-packet:
@@ -71,6 +73,8 @@ delete-packet:
 	$(ANSIBLE_LOG_LEVEL) \
 	-e @"files/${CI_JOB_NAME}.yml" \
 	-e test_id=$(TEST_ID) \
+	-e branch="$(CI_COMMIT_BRANCH)" \
+	-e pipeline_id="$(CI_PIPELINE_ID)" \
 	-e inventory_path=$(INVENTORY)
 
 create-vagrant:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -77,6 +77,10 @@ delete-packet:
 	-e pipeline_id="$(CI_PIPELINE_ID)" \
 	-e inventory_path=$(INVENTORY)
 
+cleanup-packet:
+	ansible-playbook cloud_playbooks/cleanup-packet.yml -c local \
+	$(ANSIBLE_LOG_LEVEL)
+
 create-vagrant:
 	vagrant up
 	find / -name vagrant_ansible_inventory

--- a/tests/cloud_playbooks/cleanup-packet.yml
+++ b/tests/cloud_playbooks/cleanup-packet.yml
@@ -1,0 +1,7 @@
+---
+
+- hosts: localhost
+  gather_facts: no
+  become: true
+  roles:
+    - { role: cleanup-packet-ci }

--- a/tests/cloud_playbooks/roles/cleanup-packet-ci/tasks/main.yml
+++ b/tests/cloud_playbooks/roles/cleanup-packet-ci/tasks/main.yml
@@ -10,6 +10,7 @@
 
 - name: Delete stale namespaces for more than 2 hours
   command: "kubectl delete namespace {{ item.metadata.name }}"
+  failed_when: false
   loop: "{{ namespaces.resources }}"
   when:
     - (now() - (item.metadata.creationTimestamp | to_datetime("%Y-%m-%dT%H:%M:%SZ"))).total_seconds() >= 7200

--- a/tests/cloud_playbooks/roles/cleanup-packet-ci/tasks/main.yml
+++ b/tests/cloud_playbooks/roles/cleanup-packet-ci/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+
+- name: Fetch a list of namespaces
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Namespace
+    label_selectors:
+      - cijobs = true
+  register: namespaces
+
+- name: Delete stale namespaces for more than 2 hours
+  command: "kubectl delete namespace {{ item.metadata.name }}"
+  loop: "{{ namespaces.resources }}"
+  when:
+    - (now() - (item.metadata.creationTimestamp | to_datetime("%Y-%m-%dT%H:%M:%SZ"))).total_seconds() >= 7200

--- a/tests/cloud_playbooks/roles/packet-ci/tasks/cleanup-old-vms.yml
+++ b/tests/cloud_playbooks/roles/packet-ci/tasks/cleanup-old-vms.yml
@@ -1,0 +1,28 @@
+---
+
+- name: Fetch current namespace
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Namespace
+    name: "{{ test_name }}"
+    label_selectors:
+      - cijobs = true
+      - branch = {{ branch }}
+  register: current_namespace
+
+- name: Fetch a list of namespaces
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Namespace
+    label_selectors:
+      - cijobs = true
+      - branch = {{ branch }}
+  register: namespaces
+
+- name: Delete older namespaces
+  command: "kubectl delete namespace {{ item.metadata.name }}"
+  loop: "{{ namespaces.resources }}"
+  when:
+    - |-
+        (item.metadata.labels.pipeline_id | int)
+          < (current_namespace.resources[0].metadata.labels.pipeline_id | int)

--- a/tests/cloud_playbooks/roles/packet-ci/tasks/cleanup-old-vms.yml
+++ b/tests/cloud_playbooks/roles/packet-ci/tasks/cleanup-old-vms.yml
@@ -1,15 +1,5 @@
 ---
 
-- name: Fetch current namespace
-  kubernetes.core.k8s_info:
-    api_version: v1
-    kind: Namespace
-    name: "{{ test_name }}"
-    label_selectors:
-      - cijobs = true
-      - branch = {{ branch }}
-  register: current_namespace
-
 - name: Fetch a list of namespaces
   kubernetes.core.k8s_info:
     api_version: v1
@@ -24,6 +14,4 @@
   failed_when: false
   loop: "{{ namespaces.resources }}"
   when:
-    - |-
-        (item.metadata.labels.pipeline_id | int)
-          < (current_namespace.resources[0].metadata.labels.pipeline_id | int)
+    - (item.metadata.labels.pipeline_id | int) < (pipeline_id | int)

--- a/tests/cloud_playbooks/roles/packet-ci/tasks/cleanup-old-vms.yml
+++ b/tests/cloud_playbooks/roles/packet-ci/tasks/cleanup-old-vms.yml
@@ -21,6 +21,7 @@
 
 - name: Delete older namespaces
   command: "kubectl delete namespace {{ item.metadata.name }}"
+  failed_when: false
   loop: "{{ namespaces.resources }}"
   when:
     - |-

--- a/tests/cloud_playbooks/roles/packet-ci/tasks/create-vms.yml
+++ b/tests/cloud_playbooks/roles/packet-ci/tasks/create-vms.yml
@@ -1,7 +1,9 @@
 ---
 
 - name: "Create CI namespace {{ test_name }} for test vms"
-  command: "kubectl create namespace {{ test_name }}"
+  shell: |-
+    kubectl create namespace {{ test_name }} &&
+      kubectl label namespace {{ test_name }} cijobs=true branch="{{ branch }}" pipeline_id="{{ pipeline_id }}"
   changed_when: false
 
 - name: "Create temp dir /tmp/{{ test_name }} for CI files"

--- a/tests/cloud_playbooks/roles/packet-ci/tasks/main.yml
+++ b/tests/cloud_playbooks/roles/packet-ci/tasks/main.yml
@@ -7,11 +7,11 @@
   set_fact:
     vm_count: "{%- if mode in ['separate', 'separate-scale', 'ha', 'ha-scale', 'ha-recover', 'ha-recover-noquorum'] -%}{{ 3|int }}{%- elif mode == 'aio' -%}{{ 1|int }}{%- else -%}{{ 2|int }}{%- endif -%}"
 
+- import_tasks: cleanup-old-vms.yml
+
 - import_tasks: create-vms.yml
   when:
     - not vm_cleanup
-
-- import_tasks: cleanup-old-vms.yml
 
 - import_tasks: delete-vms.yml
   when:

--- a/tests/cloud_playbooks/roles/packet-ci/tasks/main.yml
+++ b/tests/cloud_playbooks/roles/packet-ci/tasks/main.yml
@@ -11,6 +11,8 @@
   when:
     - not vm_cleanup
 
+- import_tasks: cleanup-old-vms.yml
+
 - import_tasks: delete-vms.yml
   when:
     - vm_cleanup | default(false)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Trying to automatically cleanup stale packet vms from Gitlab cancelled jobs with two different approaches:
- Automatically delete packet namespaces older than 2 hours periodically
- Delete namespace from the same branch with an older pipeline 

Pushing to the same branch should make the previous pipeline cancelled and they appears as the same branch on GItlab. So if we have a namespace with the same branch and an older pipeline id we know that we can delete it. Note that we are doing that in the first place because Gitlab cannot execute any script after a job has been cancelled, so we would be left with vms/namespaces hanging in case of cancelled jobs...

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
