### PR TITLE
Cleanup packet more often and do not wait for namespace to be deleted

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -25,7 +25,8 @@
 
 packet_cleanup_old:
   stage: deploy-part1
-  extends: .packet_periodic
+  extends: .packet
+  only: ['master']
   script:
     - cd tests
     - make cleanup-packet

--- a/tests/cloud_playbooks/roles/cleanup-packet-ci/tasks/main.yml
+++ b/tests/cloud_playbooks/roles/cleanup-packet-ci/tasks/main.yml
@@ -9,7 +9,7 @@
   register: namespaces
 
 - name: Delete stale namespaces for more than 2 hours
-  command: "kubectl delete namespace {{ item.metadata.name }}"
+  command: "kubectl delete namespace {{ item.metadata.name }} --wait=false"
   failed_when: false
   loop: "{{ namespaces.resources }}"
   when:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
- Attempt to cleanup vms more often instead of daily
- Also do not wait for namespaces to be fully deleted
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
