### PR TITLE
Fix RHEL subscription activation key by removing auto_attach and syspurpose

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-redhat.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-redhat.yml
@@ -35,13 +35,7 @@
     state: present
     org_id: "{{ rh_subscription_org_id }}"
     activationkey: "{{ rh_subscription_activation_key }}"
-    auto_attach: true
     force_register: true
-    syspurpose:
-      usage: "{{ rh_subscription_usage }}"
-      role: "{{ rh_subscription_role }}"
-      service_level_agreement: "{{ rh_subscription_sla }}"
-      sync: true
   notify: RHEL auto-attach subscription
   become: true
   when:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Remove `auto_attach` and `syspurpose` in RHEL subscription Organization ID/Activation Key registration.

**Which issue(s) this PR fixes**:

Fixes #10257

**Special notes for your reviewer**:

Both configurations can work, but I think the `syspurpose` parameter is unused and can be removed.

```yaml
  community.general.redhat_subscription:
    state: present
    org_id: "{{ rh_subscription_org_id }}"
    activationkey: "{{ rh_subscription_activation_key }}"
    force_register: true
    syspurpose:
      usage: "{{ rh_subscription_usage }}"
      role: "{{ rh_subscription_role }}"
      service_level_agreement: "{{ rh_subscription_sla }}"
      sync: true
```

```yaml
  community.general.redhat_subscription:
    state: present
    org_id: "{{ rh_subscription_org_id }}"
    activationkey: "{{ rh_subscription_activation_key }}"
    force_register: true
```

**Does this PR introduce a user-facing change?**:

```release-note
Remove `auto_attach` and `syspurpose` in RHEL subscription Organization ID/Activation Key registration.
```
