### PR TITLE
Upgrade ansible in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,13 +28,13 @@ RUN apt update -q \
        rsync \
        openssh-client \
     && pip install --no-compile --no-cache-dir \
-       ansible==5.7.1 \
-       ansible-core==2.12.10 \
-       cryptography==3.4.8 \
+       ansible==7.6.0 \
+       ansible-core==2.14.6 \
+       cryptography==41.0.1 \
        jinja2==3.1.2 \
        netaddr==0.8.0 \
        jmespath==1.0.1 \
-       MarkupSafe==2.1.2 \
+       MarkupSafe==2.1.3 \
        ruamel.yaml==0.17.21 \
     && KUBE_VERSION=$(sed -n 's/^kube_version: //p' roles/kubespray-defaults/defaults/main.yaml) \
     && curl -L https://dl.k8s.io/release/$KUBE_VERSION/bin/linux/$(dpkg --print-architecture)/kubectl -o /usr/local/bin/kubectl \


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Upgrade ansible to 7.0 and ansible-core to 2.14.x in Dockerfile .

```yaml
TASK [Check 2.14.0 <= Ansible version < 2.16.0] *****************************************************************************************************************
task path: /kubespray/playbooks/ansible_version.yml:11
fatal: [localhost]: FAILED! => {
    "assertion": "ansible_version.string is version(minimal_ansible_version, \">=\")",
    "changed": false,
    "evaluated_to": false,
    "msg": "Ansible must be between 2.14.0 and 2.16.0 exclusive - you have 2.12.10"
}
```

**Which issue(s) this PR fixes**:

Fixes #10190

**Special notes for your reviewer**:

```release-note
Upgrade ansible to 7.0 and ansible-core to 2.14.x in Dockerfile
```
