### PR TITLE
Update doc after ansible-core upgrade to 2.14

### DIFF
--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -16,6 +16,16 @@ cd $KUBESPRAYDIR
 pip install -U -r requirements.txt
 ```
 
+In case you have a similar message when installing the requirements:
+
+```ShellSession
+ERROR: Could not find a version that satisfies the requirement ansible==7.6.0 (from -r requirements.txt (line 1)) (from versions: [...], 6.7.0)
+ERROR: No matching distribution found for ansible==7.6.0 (from -r requirements.txt (line 1))
+```
+
+It means that the version of Python you are running is not compatible with the version of Ansible that Kubespray supports.
+If the latest version supported according to pip is 6.7.0 it means you are running Python 3.8 or lower while you need at least Python 3.9 (see the table below).
+
 ### Ansible Python Compatibility
 
 Based on the table below and the available python version for your ansible host you should choose the appropriate ansible version to use with kubespray.

--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -10,11 +10,10 @@ It is recommended to deploy the ansible version used by kubespray into a python 
 ```ShellSession
 VENVDIR=kubespray-venv
 KUBESPRAYDIR=kubespray
-ANSIBLE_VERSION=2.12
-virtualenv  --python=$(which python3) $VENVDIR
+python3 -m venv $VENVDIR
 source $VENVDIR/bin/activate
 cd $KUBESPRAYDIR
-pip install -U -r requirements-$ANSIBLE_VERSION.txt
+pip install -U -r requirements.txt
 ```
 
 ### Ansible Python Compatibility
@@ -23,8 +22,7 @@ Based on the table below and the available python version for your ansible host 
 
 | Ansible Version | Python Version |
 |-----------------|----------------|
-| 2.11            | 2.7,3.5-3.9    |
-| 2.12            | 3.8-3.10       |
+| 2.14            | 3.9-3.11       |
 
 ## Inventory
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This updates documentation after the ansible-core 2.14 update that was merged yesterday. Also add a note for people running in older version than python 3.9 and using the `python -m venv` instead of `virtualenv` which is a deprecated way of doing virtual env / no longer available in some distros.

**Which issue(s) this PR fixes**:
Fixes #10255

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update doc for ansible-core 2.14 support and clarify issues running older python versions
```
