### PR TITLE
re-add root user for kubelet service

### DIFF
--- a/roles/kubernetes/node/templates/kubelet.service.j2
+++ b/roles/kubernetes/node/templates/kubelet.service.j2
@@ -9,6 +9,7 @@ Wants={{ container_manager }}.service
 {% endif %}
 
 [Service]
+User=root
 EnvironmentFile=-{{ kube_config_dir }}/kubelet.env
 {% if system_reserved|bool %}
 ExecStartPre=/bin/mkdir -p /sys/fs/cgroup/cpu/{{ system_reserved_cgroups_for_service_slice }}


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
We need to re-add 'User=root' in the kubelet service so that, before the cluster is brought up, when imagePullSecrets cannot be used, the kubelet can have the ability to read the /root/.docker/config.json file for authentication with a private registry and pull the necessary images such as apiserver, etcd, and others from the private registry.

**Does this PR introduce a user-facing change?**:
```NONE```

