### PR TITLE
Upgrade cilium version to 1.13.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Note: Upstart/SysV init based OS types are not supported.
 - Network Plugin
   - [cni-plugins](https://github.com/containernetworking/plugins) v1.2.0
   - [calico](https://github.com/projectcalico/calico) v3.25.1
-  - [cilium](https://github.com/cilium/cilium) v1.13.3
+  - [cilium](https://github.com/cilium/cilium) v1.13.4
   - [flannel](https://github.com/flannel-io/flannel) v0.22.0
   - [kube-ovn](https://github.com/alauda/kube-ovn) v1.11.5
   - [kube-router](https://github.com/cloudnativelabs/kube-router) v1.5.1

--- a/roles/download/defaults/main/main.yml
+++ b/roles/download/defaults/main/main.yml
@@ -119,7 +119,7 @@ cni_version: "v1.3.0"
 weave_version: 2.8.1
 pod_infra_version: "3.9"
 
-cilium_version: "v1.13.3"
+cilium_version: "v1.13.4"
 cilium_cli_version: "v0.14.5"
 cilium_enable_hubble: false
 


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
cilium/cilium  has released the latest version v1.13.4

https://github.com/cilium/cilium/releases/tag/v1.13.4

Thanks


