### PR TITLE
Gvisor features

### DIFF
--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -25,8 +25,19 @@ containerd_additional_runtimes: []
 #    type: "io.containerd.kata.v2"
 #    engine: ""
 #    root: ""
+# Example for Gvisor Containers as additional runtime with options:
+#  - name: runsc
+#    type: io.containerd.runsc.v1
+#    engine: ""
+#    root: ""
+#    options:
+#      TypeUrl: '"io.containerd.runsc.v1.options"'
+#      ConfigPath: '"{{ containerd_cfg_dir }}/runsc.toml"'
 
 containerd_base_runtime_spec_rlimit_nofile: 65535
+
+# Definition of the platform for the runtime runsc (used by gvisor)
+containerd_runsc_platform: "kvm"
 
 containerd_default_base_runtime_spec_patch:
   process:

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -111,6 +111,15 @@
     mode: 0640
   notify: restart containerd
 
+- name: containerd | Copy runsc config file
+  template:
+    src: runsc.toml.j2
+    dest: "{{ containerd_cfg_dir }}/runsc.toml"
+    owner: "root"
+    mode: 0640
+  notify: restart containerd
+  when: gvisor_enabled
+
 - block:
     - name: containerd ｜ Create registry directories
       file:

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -42,10 +42,6 @@ oom_score = {{ containerd_oom_score }}
         [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-qemu]
           runtime_type = "io.containerd.kata-qemu.v2"
 {% endif %}
-{% if gvisor_enabled %}
-        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc]
-          runtime_type = "io.containerd.runsc.v1"
-{% endif %}
     [plugins."io.containerd.grpc.v1.cri".registry]
 {% if containerd_use_config_path is defined and containerd_use_config_path|bool %}
       config_path = "{{ containerd_cfg_dir }}/certs.d"

--- a/roles/container-engine/containerd/templates/runsc.toml.j2
+++ b/roles/container-engine/containerd/templates/runsc.toml.j2
@@ -1,0 +1,2 @@
+[runsc_config]
+  platform = "{{ containerd_runsc_platform }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
We need this evolution to be able to add options for the runtime runsc
It's useful for gVisor and specify a specific platform for runsc.

**Which issue(s) this PR fixes**:
Fixes #10272 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
"action required" 
if gvisor_enabled is set to true, it should be completed by an additionnal runtime definition

containerd_additional_runtimes:
  - name: runsc
    type: io.containerd.runsc.v1
    engine: ""
    root: ""
```
