### PR TITLE
use upstream default of etcd_snapshot_count

### DIFF
--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -613,7 +613,7 @@ etcd_events_peer_addresses: |-
 podsecuritypolicy_enabled: false
 etcd_heartbeat_interval: "250"
 etcd_election_timeout: "5000"
-etcd_snapshot_count: "10000"
+# etcd_snapshot_count: "10000"
 
 certificates_key_size: 2048
 certificates_duration: 36500


### PR DESCRIPTION

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Match the upstream default of etcd_snapshot_count decided by the etcd community, which was updated in v3.2 but not reflected in Kubespray.  This way kubespray will match the expectations people have of default etcd behaviour in other kubernetes distributions. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/kubespray/issues/9018

**Special notes for your reviewer**:
See https://etcd.io/docs/v3.4/op-guide/maintenance/

**Does this PR introduce a user-facing change?**:
etcd memory usage may increase. If your etcd nodes are memory constrained and you need to revert to the old setting, apply `etcd_snapshot_count: 10000` in your inventory.
