### PR TITLE
reset_confirmation in reset.yml

### DIFF
--- a/playbooks/reset.yml
+++ b/playbooks/reset.yml
@@ -28,7 +28,7 @@
     - name: Check confirmation
       fail:
         msg: "Reset confirmation failed"
-      when: reset_confirmation.user_input != "yes"
+      when: (reset_confirmation.user_input | default('')) != "yes"
 
     - name: Gather information about installed services
       service_facts:

--- a/playbooks/reset.yml
+++ b/playbooks/reset.yml
@@ -29,7 +29,9 @@
     - name: Check confirmation
       fail:
         msg: "Reset confirmation failed"
-      when: ((reset_confirmation.user_input | default(reset_confirmation)) | default('no')) != "yes"
+      when:
+        - not reset_confirmation | default(false) | bool
+        - not reset_confirmation_prompt.user_input | default("") == "yes"
 
     - name: Gather information about installed services
       service_facts:

--- a/playbooks/reset.yml
+++ b/playbooks/reset.yml
@@ -25,10 +25,11 @@
       run_once: True
       when:
         - not (skip_confirmation | default(false) | bool)
+        - reset_confirmation is not defined
     - name: Check confirmation
       fail:
         msg: "Reset confirmation failed"
-      when: (reset_confirmation.user_input | default('')) != "yes"
+      when: ((reset_confirmation.user_input | default(reset_confirmation)) | default('no')) != "yes"
 
     - name: Gather information about installed services
       service_facts:

--- a/playbooks/reset.yml
+++ b/playbooks/reset.yml
@@ -28,7 +28,7 @@
     - name: Check confirmation
       fail:
         msg: "Reset confirmation failed"
-      when: reset_confirmation != "yes"
+      when: reset_confirmation.user_input != "yes"
 
     - name: Gather information about installed services
       service_facts:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> 
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
reset confirmation user input fix

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10287

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix reset_confirmation not working when inputing correct value
```
