### PR TITLE
bugfix: fix grep command without -w option causing prefix matched whi…

### DIFF
--- a/roles/etcd/tasks/configure.yml
+++ b/roles/etcd/tasks/configure.yml
@@ -130,7 +130,7 @@
     ETCDCTL_ENDPOINTS: "{{ etcd_events_access_addresses }}"
 
 - name: Configure | Check if member is in etcd cluster
-  shell: "{{ bin_dir }}/etcdctl member list | grep -q {{ etcd_access_address }}"
+  shell: "{{ bin_dir }}/etcdctl member list | grep -w -q {{ etcd_access_address }}"
   register: etcd_member_in_cluster
   ignore_errors: true  # noqa ignore-errors
   changed_when: false
@@ -146,7 +146,7 @@
     ETCDCTL_ENDPOINTS: "{{ etcd_access_addresses }}"
 
 - name: Configure | Check if member is in etcd-events cluster
-  shell: "{{ bin_dir }}/etcdctl member list | grep -q {{ etcd_access_address }}"
+  shell: "{{ bin_dir }}/etcdctl member list | grep -w -q {{ etcd_access_address }}"
   register: etcd_events_member_in_cluster
   ignore_errors: true  # noqa ignore-errors
   changed_when: false

--- a/roles/etcd/tasks/join_etcd-events_member.yml
+++ b/roles/etcd/tasks/join_etcd-events_member.yml
@@ -26,7 +26,7 @@
       {%- endfor -%}
 
 - name: Join Member | Ensure member is in etcd-events cluster
-  shell: "set -o pipefail && {{ bin_dir }}/etcdctl member list | grep {{ etcd_events_access_address }} >/dev/null"
+  shell: "set -o pipefail && {{ bin_dir }}/etcdctl member list | grep -w {{ etcd_events_access_address }} >/dev/null"
   args:
     executable: /bin/bash
   register: etcd_events_member_in_cluster

--- a/roles/etcd/tasks/join_etcd_member.yml
+++ b/roles/etcd/tasks/join_etcd_member.yml
@@ -27,7 +27,7 @@
       {%- endfor -%}
 
 - name: Join Member | Ensure member is in etcd cluster
-  shell: "set -o pipefail && {{ bin_dir }}/etcdctl member list | grep {{ etcd_access_address }} >/dev/null"
+  shell: "set -o pipefail && {{ bin_dir }}/etcdctl member list | grep -w {{ etcd_access_address }} >/dev/null"
   args:
     executable: /bin/bash
   register: etcd_member_in_cluster


### PR DESCRIPTION
bugfix: fix grep command without -w option causing prefix matched while adding one etcd member

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
when add a new etcd member to the existing cluster, the ansible role of etcd will check if the new etcd member ip is already in cluster with grep command **etcdctl member list | grep -q {{ etcd_access_address }} **. There is a chance that the new member ip string is prefix matched one of existing members, then the **Configure | Check if member is in etcd cluster** task will success with rc=0. For example, if there is a member with ip **192.168.7.8**4 in the existing cluster and want to add a new etcd member with ip **192.168.7.8**, then the check command will pass and won't execute member join command any more. One of the fix method is adding -w option for grep command, which mean whole words matching.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
