### PR TITLE
containerd.runtimes.<name>.options to preserve quotes for non-boolean values and normalize boolean values (#9913)

### DIFF
--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -35,11 +35,9 @@ oom_score = {{ containerd_oom_score }}
 
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.{{ runtime.name }}.options]
 {% for key, value in runtime.options.items() %}
-{% if value | string != "true" and value | string != "false" %}
-            {{ key }} = "{{ value }}"
-{% else %}
+{% set is_bool = value|string|lower in ['true', 'false'] %}
+{% set value = value|lower if is_bool else '"' ~ value ~ '"' %}
             {{ key }} = {{ value }}
-{% endif %}
 {% endfor %}
 {% endfor %}
 {% if kata_containers_enabled %}


### PR DESCRIPTION
This commit modifies the Jinja2 template for generating the containerd configuration file to handle a specific requirement: preserving quotes for non-boolean values in `containerd_additional_runtimes.<name>.options`.

The update is necessary due to the mixed data types in the options field:

1. Boolean values (true, false) and their string equivalents ("true", "false") should be rendered without quotes.
2. Non-boolean string values should be rendered with quotes.

The logic implemented checks if a value is a boolean or the string representation of a boolean. If it is, we ensure it's rendered as a lowercase `true` or `false` without quotes.

If the value is not a boolean or a string equivalent of a boolean, we render it with quotes, preserving the original formatting.

While the logic may seem verbose, it's necessary to accommodate the differing requirements for boolean and non-boolean values within the configuration file, ensuring the generated configurations are correctly formatted and functional.

----

## Tested with different values

### input

```
containerd_runc_runtime:
  name: runc
...
  options:
    systemdCgroup: "{{ containerd_use_systemd_cgroup | ternary('true', 'false') }}"
    testA: True
    testB: true
    testC: "True"
    testD: "true"
    testE: truE
    testF: "truE"
    testG: /some/path/abc
    testH: "/some/path/abc"
    testI: '/some/path/abc'

```

## output

```
# cat /etc/containerd/config.toml
...
          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
            systemdCgroup = true
            testA = true
            testB = true
            testC = true
            testD = true
            testE = true
            testF = true
            testG = "/some/path/abc"
            testH = "/some/path/abc"
            testI = "/some/path/abc"
        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
          runtime_type = "io.containerd.runc.v2"
...
```