### PR TITLE
tests/packet-ci: sanitize branch name for kubernetes labels

### DIFF
--- a/tests/cloud_playbooks/roles/packet-ci/defaults/main.yml
+++ b/tests/cloud_playbooks/roles/packet-ci/defaults/main.yml
@@ -6,6 +6,9 @@ vm_cpu_sockets: 1
 vm_cpu_threads: 2
 vm_memory: 2048Mi
 
+# Replace invalid characters so that we can use the branch name in kubernetes labels
+branch_name_sane: "{{ branch | regex_replace('/', '-') }}"
+
 # Request/Limit allocation settings
 
 cpu_allocation_ratio: 0.5

--- a/tests/cloud_playbooks/roles/packet-ci/tasks/cleanup-old-vms.yml
+++ b/tests/cloud_playbooks/roles/packet-ci/tasks/cleanup-old-vms.yml
@@ -6,7 +6,7 @@
     kind: Namespace
     label_selectors:
       - cijobs = true
-      - branch = {{ branch }}
+      - branch = {{ branch_name_sane }}
   register: namespaces
 
 - name: Delete older namespaces

--- a/tests/cloud_playbooks/roles/packet-ci/tasks/create-vms.yml
+++ b/tests/cloud_playbooks/roles/packet-ci/tasks/create-vms.yml
@@ -3,7 +3,7 @@
 - name: "Create CI namespace {{ test_name }} for test vms"
   shell: |-
     kubectl create namespace {{ test_name }} &&
-      kubectl label namespace {{ test_name }} cijobs=true branch="{{ branch }}" pipeline_id="{{ pipeline_id }}"
+      kubectl label namespace {{ test_name }} cijobs=true branch="{{ branch_name_sane }}" pipeline_id="{{ pipeline_id }}"
   changed_when: false
 
 - name: "Create temp dir /tmp/{{ test_name }} for CI files"


### PR DESCRIPTION

**What type of PR is this?**
/kind bug
/kind flake

**What this PR does / why we need it**:
'/' doesn't work in kubernetes label so we replace it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Fixing issue encountered on https://github.com/kubernetes-sigs/kubespray/pull/10198
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Sanitize branch name in testing before using it in kubernetes label for packet-ci
```
