### PR TITLE
fix: race condition on password lookup plugin

### DIFF
--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -185,6 +185,7 @@
   notify: Master | restart kubelet
 
 - name: Set kubeadm certificate key
+  run_once: true
   set_fact:
     kubeadm_certificate_key: "{{ item | regex_search('--certificate-key ([^ ]+)', '\\1') | first }}"
   with_items: "{{ hostvars[groups['kube_control_plane'][0]]['kubeadm_init'].stdout_lines | default([]) }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
set_fact task calls password lookup plugin on multiple nodes which fails because of race condition on the unique lock file

**Which issue(s) this PR fixes**:
Fixes #10012 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
