### PR TITLE
Add vars to control kubelet systemd autostart

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -23,6 +23,10 @@ kubelet_kubelet_cgroups_cgroupfs: "/system.slice/kubelet.service"
 # Set systemd service hardening features
 kubelet_systemd_hardening: false
 
+# Set hosts and group where kubelet autostart will be disabled
+kubelet_systemd_autostart_disabled_hosts: []
+kubelet_systemd_autostart_disabled_group: ""
+
 # List of secure IPs for kubelet
 kubelet_secure_addresses: >-
   {%- for host in groups['kube_control_plane'] -%}

--- a/roles/kubernetes/node/tasks/kubelet.yml
+++ b/roles/kubernetes/node/tasks/kubelet.yml
@@ -42,10 +42,16 @@
 - name: Flush_handlers and reload-systemd
   meta: flush_handlers
 
+- name: Set kubelet systemd enabled parameter
+  set_fact:
+    kubelet_systemd_autostart_enabled: "{{ false if (kubelet_systemd_autostart_disabled_group and inventory_hostname in groups[kubelet_systemd_autostart_disabled_group]) or inventory_hostname in kubelet_systemd_autostart_disabled_hosts else true }}"
+  tags:
+    - kubelet
+
 - name: Enable kubelet
   service:
     name: kubelet
-    enabled: yes
+    enabled: "{{ kubelet_systemd_autostart_enabled }}"
     state: started
   tags:
     - kubelet


### PR DESCRIPTION

**What type of PR is this?**
/kind feature

**What this PR does / why we need it:**
In some cases with critical infrastructure part - it's good to not place workload on node automatically (e.g. database with storage/network problems) after reboot (expected or especially unexpected).

It provides the ability to control whether kubelet systemd unit on node should start after boot or not .
Added two additional vars: you can define list of hosts in `kubelet_systemd_autostart_disabled_hosts` and/or place name of inventory group in `kubelet_systemd_autostart_disabled_group`.

In large environments like ours (100s of workers) - it can be more efficient to use ansible built-in way with groups without vars overhead.
But as it's not common flow in kubespray to have a lot of groups - I left way without an addtional group.
And it's actually an open question to have both of them or just one with hosts var. So appreciate any feedback from the kubespray community or approvals =)

**Does this PR introduce a user-facing change?:**

Additinal `kubelet_systemd_autostart_disabled_hosts` and `kubelet_systemd_autostart_disabled_group` vars, empty by default
