### PR TITLE
feat: feature flag to not forward proxy settings to docker

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -103,3 +103,8 @@ For Debian based distributions, set the path to store the GPG key to avoid using
 ```yaml
 docker_repo_key_keyring: /etc/apt/trusted.gpg.d/docker.gpg
 ```
+
+The proxy settings are forwarded to the Docker daemon by default. Set this to `false` if you don't want Docker's outgoing traffic to use the proxy. Note that this flag will have no effect if the `http_proxy` or `https_proxy` variables are not set.
+```yaml
+docker_forward_proxy: true
+```

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -105,6 +105,7 @@ docker_repo_key_keyring: /etc/apt/trusted.gpg.d/docker.gpg
 ```
 
 The proxy settings are forwarded to the Docker daemon by default. Set this to `false` if you don't want Docker's outgoing traffic to use the proxy. Note that this flag will have no effect if the `http_proxy` or `https_proxy` variables are not set.
+
 ```yaml
 docker_forward_proxy: true
 ```

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -27,3 +27,10 @@ Since workers are included in the no_proxy variable, by default, docker engine w
 pods will restart) when adding or removing workers.  To override this behaviour by only including control plane nodes in the
 no_proxy variable, set:
 `no_proxy_exclude_workers: true`
+
+## Forward proxy to docker
+
+By default, the `http_proxy` and `no_proxy` settings will be forwarded to the docker engine.
+Sometimes you might use a proxy for binary file downloads while using a container registry mirror for image downloads.
+If the proxy server cannot access the self-hosted registry, set:
+`docker_forward_proxy: false`

--- a/roles/container-engine/docker/defaults/main.yml
+++ b/roles/container-engine/docker/defaults/main.yml
@@ -65,3 +65,6 @@ docker_ubuntu_repo_repokey: '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
 docker_debian_repo_base_url: "https://download.docker.com/linux/debian"
 docker_debian_repo_gpgkey: 'https://download.docker.com/linux/debian/gpg'
 docker_debian_repo_repokey: '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
+
+# Forward the http_proxy settings to the docker by default
+docker_forward_proxy: true

--- a/roles/container-engine/docker/tasks/systemd.yml
+++ b/roles/container-engine/docker/tasks/systemd.yml
@@ -11,7 +11,7 @@
     dest: /etc/systemd/system/docker.service.d/http-proxy.conf
     mode: 0644
   notify: Restart docker
-  when: http_proxy is defined or https_proxy is defined
+  when: docker_forward_proxy and (http_proxy is defined or https_proxy is defined)
 
 - name: Get systemd version
   # noqa command-instead-of-module - systemctl is called intentionally here


### PR DESCRIPTION
This PR add a `docker_forward_proxy` flag which can make user decide whether use proxy setting in the docker or not.

By default, The proxy settings are forwarded to the Docker daemon, but in many circumstances the user is merely setting `http_proxy` or `https_proxy` for downloading the image and binary during setup stage, and not want to use proxy for the whole container runtime.  This new flag can help user decide where to use the proxy.