### PR TITLE
Allow to override etcd listen-metrics-urls configuration

### DIFF
--- a/docs/etcd.md
+++ b/docs/etcd.md
@@ -44,3 +44,9 @@ kubeEtcd:
   service:
     enabled: false
 ```
+
+To fully override metrics exposition urls, define it in the inventory with:
+
+```yaml
+etcd_listen_metrics_urls: "http://0.0.0.0:2381"
+```

--- a/roles/etcd/templates/etcd.env.j2
+++ b/roles/etcd/templates/etcd.env.j2
@@ -5,7 +5,9 @@ ETCD_INITIAL_ADVERTISE_PEER_URLS={{ etcd_peer_url }}
 ETCD_INITIAL_CLUSTER_STATE={% if etcd_cluster_is_healthy.rc == 0 | bool %}existing{% else %}new{% endif %}
 
 ETCD_METRICS={{ etcd_metrics }}
-{% if etcd_metrics_port is defined %}
+{% if etcd_listen_metrics_urls is defined %}
+ETCD_LISTEN_METRICS_URLS={{ etcd_listen_metrics_urls }}
+{% elif etcd_metrics_port is defined %}
 ETCD_LISTEN_METRICS_URLS=http://{{ etcd_address }}:{{ etcd_metrics_port }},http://127.0.0.1:{{ etcd_metrics_port }}
 {% endif %}
 ETCD_LISTEN_CLIENT_URLS=https://{{ etcd_address }}:2379,https://127.0.0.1:2379

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
@@ -58,6 +58,9 @@ etcd:
       election-timeout: "{{ etcd_election_timeout }}"
       heartbeat-interval: "{{ etcd_heartbeat_interval }}"
       auto-compaction-retention: "{{ etcd_compaction_retention }}"
+{% if etcd_listen_metrics_urls is defined %}
+      listen-metrics-urls: "{{ etcd_listen_metrics_urls }}"
+{% endif %}
 {% if etcd_snapshot_count is defined %}
       snapshot-count: "{{ etcd_snapshot_count }}"
 {% endif %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
Right now, the configuration for this parameter is different when etcd_deployment_type is kubeadm. What this PR does is to allow to override this configuration to cover all scenarios.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Allow to override etcd listen-metrics-urls configuration (using `etcd_listen_metrics_urls` variable)
```
