### PR TITLE
Set/keep owner/group root/root when unarchiving kata-containers

### DIFF
--- a/roles/container-engine/kata-containers/tasks/main.yml
+++ b/roles/container-engine/kata-containers/tasks/main.yml
@@ -9,6 +9,8 @@
     src: "{{ downloads.kata_containers.dest }}"
     dest: "/"
     mode: 0755
+    owner: root
+    group: root
     remote_src: yes
 
 - name: Kata-containers | Create config directory


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The unarchiving task in the kata-containers role sets the owner/group of the kata-containers directories and files to the owner/group specified in the archive, which is `1001:123`. Because the kata-containers archive is unarchived in `/`, the owner/group of `/` is also changed to `1001:123` which is not wanted and breaks stuff.

**Does this PR introduce a user-facing change?**:
```release-note
[Kata] Set/keep owner/group root/root when unarchiving kata-containers
```
