### PR TITLE
fix: flatcar bootstrap

### DIFF
--- a/roles/bootstrap-os/files/bootstrap.sh
+++ b/roles/bootstrap-os/files/bootstrap.sh
@@ -39,4 +39,8 @@ mv -n "${PYPY_FILENAME}" pypy3
 ln -s ./pypy3/bin/pypy3 python
 $BINDIR/python --version
 
+# install PyYAML
+./python -m ensurepip
+./python -m pip install pyyaml
+
 touch $BINDIR/.bootstrapped

--- a/roles/kubernetes/preinstall/tasks/0081-ntp-configurations.yml
+++ b/roles/kubernetes/preinstall/tasks/0081-ntp-configurations.yml
@@ -30,7 +30,7 @@
     ntp_service_name: >-
       {% if ntp_package == "chrony" -%}
       chronyd
-      {%- elif ansible_os_family == 'RedHat' -%}
+      {%- elif ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk", "RedHat"] -%}
       ntpd
       {%- else -%}
       ntp


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
1. Fixes: Could not find the requested service ntp: host
2. Fixes: The error was: ModuleNotFoundError: No module named 'yaml'

Which issue(s) this PR fixes:

TASK [kubernetes/preinstall : Ensure NTP service is started and enabled] *****************************************************************************************************************************************************************
fatal: [node1]: FAILED! => {"changed": false, "msg": "Could not find the requested service ntp: host"}
fatal: [node2]: FAILED! => {"changed": false, "msg": "Could not find the requested service ntp: host"}
fatal: [node3]: FAILED! => {"changed": false, "msg": "Could not find the requested service ntp: host"}


TASK [helm-apps: Add Helm repositories]
*****************************************************************************************************************************************************************
An exception occured during task execution. To see the full traceback, use -vvv. The error was: ModuleNotFoundError: No module named 'yaml'

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix Flatcar bootstrap issues (yaml module missing and ntp issue)
```