### PR TITLE
Move runroot from crio.conf to storage.conf

### DIFF
--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -133,6 +133,8 @@
       value: '"overlay"'
     - option: graphroot
       value: '"/var/lib/containers/storage"'
+    - option: runroot
+      value: '"/var/run/containers/storage"'
 
 # metacopy=on is available since 4.19 and was backported to RHEL 4.18 kernel
 - name: Cri-o | set metacopy mount options correctly

--- a/roles/container-engine/cri-o/templates/crio.conf.j2
+++ b/roles/container-engine/cri-o/templates/crio.conf.j2
@@ -20,7 +20,8 @@
 root = "/var/lib/containers/storage"
 
 # Path to the "run directory". CRI-O stores all of its state in this directory.
-runroot = "/var/run/containers/storage"
+# Read from /etc/containers/storage.conf first so unnecessary here
+# runroot = "/var/run/containers/storage"
 
 # Storage driver used to manage the storage of images and containers. Please
 # refer to containers-storage.conf(5) to see all available storage drivers.


### PR DESCRIPTION
**What type of PR is this?**
/kind container-managers

**What this PR does / why we need it**:
Fix crio jobs failing since moving to 1.27

**Which issue(s) this PR fixes**:
Fixes #10367 

**Special notes for your reviewer**:
Got a thread in k8s slack https://kubernetes.slack.com/archives/CAZH62UR1/p1692279077580139
Will followup in the issue (or here) the exact root cause of this issue since 1.27

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[crio] `runroot` now needs to be setup in storage.conf instead of crio.conf
```
