### PR TITLE
Change maximal_ansible_version to 2.15

### DIFF
--- a/playbooks/ansible_version.yml
+++ b/playbooks/ansible_version.yml
@@ -5,7 +5,7 @@
   become: no
   vars:
     minimal_ansible_version: 2.14.0
-    maximal_ansible_version: 2.16.0
+    maximal_ansible_version: 2.15.0
     ansible_connection: local
   tags: always
   tasks:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The Kubespray does not support the Ansible 2.15 now. There is also not CI support for Ansible 2.15.
And there are some issues about the 2.15 .

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
WorkAround  https://github.com/kubernetes-sigs/kubespray/issues/10375

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Change maximal_ansible_version to 2.15(exclusive)
```
