### PR TITLE
docs: add containerd command to restart nginx-proxy

### DIFF
--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -90,6 +90,9 @@ In all hosts, restart nginx-proxy pod. This pod is a local proxy for the apiserv
 ```sh
 # run in every host
 docker ps | grep k8s_nginx-proxy_nginx-proxy | awk '{print $1}' | xargs docker restart
+
+# or with containerd
+crictl ps | grep nginx-proxy | awk '{print $1}' | xargs crictl stop
 ```
 
 ### 3) Remove old control plane nodes


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

When using `containerd` as container engine, the command to restart nginx-proxy after adding a control plane node is invalid as it uses docker.

**Which issue(s) this PR fixes**:

Fixes #10404

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Document containerd command to restart nginx-proxy container when adding control plane node
```
