### PR TITLE
fix: specify owner to kube_owner in task of copy cni plugins

### DIFF
--- a/roles/network_plugin/cni/tasks/main.yml
+++ b/roles/network_plugin/cni/tasks/main.yml
@@ -12,4 +12,5 @@
     src: "{{ downloads.cni.dest }}"
     dest: "/opt/cni/bin"
     mode: 0755
+    owner: "{{ kube_owner }}"
     remote_src: yes


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
Every time I run `scale.yml`, the following tasks always shows changed.
```
TASK [network_plugin/cni : CNI | make sure /opt/cni/bin exists] ****************************************************************************************************************************************************************************
changed: [k8s-cp-01]
changed: [k8s-cp-03]
changed: [k8s-cp-02]
Saturday 02 September 2023  09:08:11 +0000 (0:00:01.805)       0:16:12.735 ****

TASK [network_plugin/cni : CNI | Copy cni plugins] *****************************************************************************************************************************************************************************************
changed: [k8s-cp-03]
changed: [k8s-cp-02]
changed: [k8s-cp-01]
```
Task of `Copy cni plugins`  did not set owner to `{{ kube_owner }}` in `unarchive` module, so the owner of `/opt/cni/bin` will be changed to root, which is inconsistent with the previous task.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
```release-note
Fix specify owner to kube_owner in task of copy cni plugins
```
