### PR TITLE
Update etcd version on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Note: Upstart/SysV init based OS types are not supported.
 
 - Core
   - [kubernetes](https://github.com/kubernetes/kubernetes) v1.27.5
-  - [etcd](https://github.com/etcd-io/etcd) v3.5.6
+  - [etcd](https://github.com/etcd-io/etcd) v3.5.7
   - [docker](https://www.docker.com/) v20.10 (see note)
   - [containerd](https://containerd.io/) v1.7.5
   - [cri-o](http://cri-o.io/) v1.27 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Update readme with etcd version which reflects to the supported versions for kubernetes 1.27 

**Does this PR introduce a user-facing change?**:
<!--
NONE
-->
```release-note
[etcd] Default version to 3.5.7 for kubernetes 1.27
```