### PR TITLE
Use cluster_name variable instead of hardcoded value in cinder-csi controller plugin

### DIFF
--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin.yml.j2
@@ -111,7 +111,7 @@ spec:
             - name: CLOUD_CONFIG
               value: /etc/config/cloud.conf
             - name: CLUSTER_NAME
-              value: kubernetes
+              value: {{ cluster_name }}
           ports:
             - containerPort: 9808
               name: healthz


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
"Kubernetes" hardcoded value should be a variable

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
closes #9927, as the original PR is 9927 and all credits should go to @gyurco


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Cinder-CSI now use `cluster_name` variable instead of the default hardcoded "kubernetes" value
```
