### PR TITLE
Add a way to configure restarted networking service name in reset.

### DIFF
--- a/roles/reset/defaults/main.yml
+++ b/roles/reset/defaults/main.yml
@@ -1,3 +1,18 @@
 ---
 flush_iptables: true
 reset_restart_network: true
+
+reset_restart_network_service_name: >-
+  {% if ansible_os_family == "RedHat" -%}
+  {%-
+    if ansible_distribution_major_version | int >= 8
+    or is_fedora_coreos or ansible_distribution == "Fedora" -%}
+  NetworkManager
+  {%- else -%}
+  network
+  {%- endif -%}
+  {%- elif ansible_distribution == "Ubuntu" -%}
+  systemd-networkd
+  {%- elif ansible_os_family == "Debian" -%}
+  networking
+  {%- endif %}

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -429,19 +429,7 @@
 
 - name: Reset | Restart network
   service:
-    # noqa: jinja[spacing]
-    name: >-
-      {% if ansible_os_family == "RedHat" -%}
-      {%- if ansible_distribution_major_version | int >= 8 or is_fedora_coreos or ansible_distribution == "Fedora" -%}
-      NetworkManager
-      {%- else -%}
-      network
-      {%- endif -%}
-      {%- elif ansible_distribution == "Ubuntu" -%}
-      systemd-networkd
-      {%- elif ansible_os_family == "Debian" -%}
-      networking
-      {%- endif %}
+    name: "{{ reset_restart_network_service_name }}"
     state: restarted
   when:
     - ansible_os_family not in ["Flatcar", "Flatcar Container Linux by Kinvolk"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
When running the reseting playbook, the networking service may be restart and there is no way to configure the name of the service.
The guessing is very basic and may not work in all cases (for example the Debian 12 cloud image use Netplan + Networkd by default).
This PR fixes that by letting the end-user the ability to manually configure the service name.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add a variable reset_restart_network_service_name in the reset role to be able to configure the name of the service which is restarted.
```
