### PR TITLE
Fix invalid hubble yaml if cilium_hubble_tls_generate is enabled

### DIFF
--- a/roles/network_plugin/cilium/templates/hubble/deploy.yml.j2
+++ b/roles/network_plugin/cilium/templates/hubble/deploy.yml.j2
@@ -60,7 +60,8 @@ spec:
           - mountPath: /var/lib/hubble-relay/tls
             name: tls
             readOnly: true
-          {% endif %}
+          {%- endif %}
+
       restartPolicy: Always
       serviceAccount: hubble-relay
       serviceAccountName: hubble-relay
@@ -96,7 +97,8 @@ spec:
                 - key: tls.key
                   path: server.key
         name: tls
-      {% endif %}
+      {%- endif %}
+
 ---
 # Source: cilium/templates/hubble-ui/deployment.yaml
 kind: Deployment


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix errors in the Hubble template when `cilium_hubble_tls_generate` due to whitespace issues.

**Which issue(s) this PR fixes**:
Fixes #10429 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[Cilium] Fix invalid hubble yaml if `cilium_hubble_tls_generate` is enabled
```
