### PR TITLE
docs: add Cilium CNI to sidebar

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -13,6 +13,7 @@
 * CNI
   * [Calico](docs/calico.md)
   * [Flannel](docs/flannel.md)
+  * [Cilium](docs/cilium.md)
   * [Kube Router](docs/kube-router.md)
   * [Kube OVN](docs/kube-ovn.md)
   * [Weave](docs/weave.md)


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Kubespray docs sidebar missed a link to the Cilium CNI documentation, but it was already available.

**Does this PR introduce a user-facing change?**:
```release-note
Add link to Cilium CNI documentation
```
