### PR TITLE
Use correct env var name for kube-vip per service leader election

### DIFF
--- a/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
@@ -40,6 +40,10 @@ spec:
     - name: svc_enable
       value: "true"
 {% endif %}
+{% if kube_vip_enableServicesElection %}
+    - name: svc_election
+      value: "true"
+{% endif %}
 {% if kube_vip_leader_election_enabled %}
     - name: vip_leaderelection
       value: "true"
@@ -70,10 +74,6 @@ spec:
 {% endif %}
     - name: address
       value: {{ kube_vip_address | to_json }}
-{% if kube_vip_enableServicesElection %}
-    - name: enableServicesElection
-      value: "true"
-{% endif %}
 {% if kube_vip_lb_enable %}
     - name: lb_enable
       value: "true"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

kube-vip uses a different env var name for enabling per service leader election as seen in the [code](https://github.com/kube-vip/kube-vip/blob/e4f42a3a4460dd76099610b66587d2cb45f9f080/pkg/kubevip/config_envvar.go#L131). This fixes it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Use correct env var name for kube-vip per service leader election
```
