### PR TITLE
terraform-openstack: Added possibility to enable dhcp flag critical on one interface

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -318,6 +318,7 @@ k8s_nodes:
         mount_path: string # Path to where the partition should be mounted
         partition_start: string # Where the partition should start (e.g. 10GB ). Note, if you set the partition_start to 0 there will be no space left for the root partition
         partition_end: string # Where the partition should end (e.g. 10GB or -1 for end of volume)
+      netplan_critical_dhcp_interface: string # Name of interface to set the dhcp flag critical = true, to circumvent [this issue](https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1776013).
 ```
 
 For example:

--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -19,8 +19,7 @@ data "cloudinit_config" "cloudinit" {
   part {
     content_type =  "text/cloud-config"
     content = templatefile("${path.module}/templates/cloudinit.yaml.tmpl", {
-      # template_file doesn't support lists
-      extra_partitions = ""
+      extra_partitions = []
     })
   }
 }

--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -19,7 +19,8 @@ data "cloudinit_config" "cloudinit" {
   part {
     content_type =  "text/cloud-config"
     content = templatefile("${path.module}/templates/cloudinit.yaml.tmpl", {
-      extra_partitions = []
+      extra_partitions = [],
+      netplan_critical_dhcp_interface = ""
     })
   }
 }
@@ -820,7 +821,8 @@ resource "openstack_compute_instance_v2" "k8s_nodes" {
   flavor_id         = each.value.flavor
   key_pair          = openstack_compute_keypair_v2.k8s.name
   user_data         = each.value.cloudinit != null ? templatefile("${path.module}/templates/cloudinit.yaml.tmpl", {
-    extra_partitions = each.value.cloudinit.extra_partitions
+    extra_partitions = each.value.cloudinit.extra_partitions,
+    netplan_critical_dhcp_interface = each.value.cloudinit.netplan_critical_dhcp_interface,
   }) : data.cloudinit_config.cloudinit.rendered
 
   dynamic "block_device" {

--- a/contrib/terraform/openstack/modules/compute/templates/cloudinit.yaml.tmpl
+++ b/contrib/terraform/openstack/modules/compute/templates/cloudinit.yaml.tmpl
@@ -1,4 +1,4 @@
-%{~ if length(extra_partitions) > 0 }
+%{~ if length(extra_partitions) > 0 || netplan_critical_dhcp_interface != "" }
 #cloud-config
 bootcmd:
 %{~ for idx, partition in extra_partitions }
@@ -8,11 +8,26 @@ bootcmd:
 %{~ endfor }
 
 runcmd:
+%{~ if netplan_critical_dhcp_interface != "" }
+  - netplan apply
+%{~ endif }
 %{~ for idx, partition in extra_partitions }
   - mkdir -p ${partition.mount_path}
   - chown nobody:nogroup ${partition.mount_path}
   - mount ${partition.partition_path} ${partition.mount_path}
-%{~ endfor }
+%{~ endfor ~}
+
+%{~ if netplan_critical_dhcp_interface != "" }
+write_files:
+  - path: /etc/netplan/90-critical-dhcp.yaml
+    content: |
+      network:
+        version: 2
+        ethernets:
+          ${ netplan_critical_dhcp_interface }:
+            dhcp4: true
+            critical: true
+%{~ endif }
 
 mounts:
 %{~ for idx, partition in extra_partitions }

--- a/contrib/terraform/openstack/modules/compute/variables.tf
+++ b/contrib/terraform/openstack/modules/compute/variables.tf
@@ -149,6 +149,7 @@ variable "k8s_nodes" {
         partition_end   = string
         mount_path      = string
       })), [])
+      netplan_critical_dhcp_interface = optional(string, "")
     }))
   }))
 }

--- a/contrib/terraform/openstack/modules/compute/variables.tf
+++ b/contrib/terraform/openstack/modules/compute/variables.tf
@@ -142,13 +142,13 @@ variable "k8s_nodes" {
     additional_server_groups = optional(list(string))
     server_group           = optional(string)
     cloudinit              = optional(object({
-      extra_partitions = list(object({
+      extra_partitions = optional(list(object({
         volume_path     = string
         partition_path  = string
         partition_start = string
         partition_end   = string
         mount_path      = string
-      }))
+      })), [])
     }))
   }))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

We wanted to be able to set the `critical` dhcp flag on the main interface to make the VM not releasing the IP on network hiccups. I also fixed a small "TODO" now when we've changed to the `cloudinit_config` resource instead of the `template_file` resource so we now default to an empty list instead of a empty string.

The change is opt-in and should not cause any changes for existing clusters.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
terraform-openstack: Added possibility to enable dhcp flag critical on one interface
```
