### PR TITLE
[download] Don't fail on 304 Not Modified

### DIFF
--- a/roles/download/tasks/download_file.yml
+++ b/roles/download/tasks/download_file.yml
@@ -101,7 +101,9 @@
     run_once: "{{ download_force_cache }}"
     register: get_url_result
     become: "{{ not download_localhost }}"
-    until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+    until: "'OK' in get_url_result.msg or
+      'file already exists' in get_url_result.msg or
+      get_url_result.status_code == 304"
     retries: "{{ download_retries }}"
     delay: "{{ retry_stagger | default(5) }}"
     environment: "{{ proxy_env }}"


### PR DESCRIPTION
i.e when file was not modified since last download


**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:

If a file is already downloaded, the [timestamp of the file](https://github.com/ansible/ansible/blob/710c0a264e776f9824cdedc40df17383ba3fe40e/lib/ansible/modules/get_url.py#L600-L602) is sent to the server which returns `304 Not Modified`. Before this PR, this was considered as a failure.


```release-note
Don't fail on 304 Not Modified for an already downloaded file
```
