### PR TITLE
[2.22] Add containerd_insecure_registries content

### DIFF
--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -50,6 +50,13 @@ containerd_metrics_grpc_histogram: false
 containerd_registries:
   "docker.io": "https://registry-1.docker.io"
 
+# Added support for specifying insecure registries.
+# Use this section to define internal or private registries
+# that you wish to bypass SSL/TLS verification for.
+# Example:
+# containerd_insecure_registries:
+#  "internal-registry" : "http://192.168.1.100:5000"
+
 containerd_max_container_log_line_size: -1
 
 # If enabled it will allow non root users to use port numbers <1024


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

 /kind documentation


**What this PR does / why we need it**:
The file /kubespray/roles/download/defaults/main.yml on line 76 makes a reference to the containerd_insecure_registries. However, there was no corresponding entry or guidance on this variable in the /kubespray/roles/container-engine/containerd/defaults/main.yml file. This PR aims to rectify that by adding the necessary documentation and example entry, ensuring clarity and completeness for the users.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Introduced guidance and an example entry for the `containerd_insecure_registries` variable in the `/kubespray/roles/container-engine/containerd/defaults/main.yml` file.
```
