### PR TITLE
Add configuration option for NRI in crio & containerd

### DIFF
--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -64,6 +64,9 @@ containerd_enable_unprivileged_ports: false
 # If enabled it will allow non root users to use icmp sockets
 containerd_enable_unprivileged_icmp: false
 
+# If enabled, it will activate the NRI support in containerd
+containerd_nri_disable: true
+
 containerd_cfg_dir: /etc/containerd
 
 # Extra config to be put in {{ containerd_cfg_dir }}/config.toml literally

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -78,6 +78,9 @@ oom_score = {{ containerd_oom_score }}
 {% endif %}
 {% endfor %}
 
+  [plugins."io.containerd.nri.v1.nri"]
+    disable = {{ containerd_nri_disable | default(true) | lower }}
+
 {% if containerd_extra_args is defined %}
 {{ containerd_extra_args }}
 {% endif %}

--- a/roles/container-engine/cri-o/defaults/main.yml
+++ b/roles/container-engine/cri-o/defaults/main.yml
@@ -97,3 +97,6 @@ crio_man_files:
   8:
     - crio
     - crio-status
+
+# If set to true, it will enable the NRI support in cri-o
+crio_enable_nri: false

--- a/roles/container-engine/cri-o/templates/crio.conf.j2
+++ b/roles/container-engine/cri-o/templates/crio.conf.j2
@@ -376,3 +376,8 @@ enable_metrics = {{ crio_enable_metrics | bool | lower }}
 
 # The port on which the metrics server will listen.
 metrics_port = {{ crio_metrics_port }}
+
+[crio.nri]
+
+# Enable or disable NRI (Node Resource Interface) support in CRI-O.
+enable_nri={{ crio_enable_nri | default(false) | lower }}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

[Node Resource Interface (NRI)](https://github.com/containerd/nri) is a common framework for plugging domain or vendor-specific custom logic into container runtime like containerd/cri-o. Here we are introducing the configuration flags (`containerd_disable_nri`, `crio_enable_nri`) to provide cluster administrators the flexibility to opt in or out (defaulted to 'out' in both runtimes in line with their default configurations) of this feature.

- Ref to the containerd NRI configuration: https://github.com/containerd/containerd/blob/main/docs/NRI.md
- Ref to the CRI-O NRI configuration: https://github.com/cri-o/cri-o/blob/main/docs/crio.conf.5.md#crionri-table

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Does this PR introduce a user-facing change?**:
```release-note
Add configuration option for NRI (disable by default) in crio & containerd (using new `containerd_nri_disable` and `crio_enable_nri`)
```
