### PR TITLE
[metallb] add config option for IPAddressPool avoidBuggyIPs

### DIFF
--- a/docs/metallb.md
+++ b/docs/metallb.md
@@ -73,7 +73,6 @@ metallb_config:
     primary:
       ip_range:
         - 192.0.1.0-192.0.1.254
-      auto_assign: true
 
     pool1:
       ip_range:
@@ -82,8 +81,8 @@ metallb_config:
 
     pool2:
       ip_range:
-        - 192.0.2.2-192.0.2.2
-      auto_assign: false
+        - 192.0.3.0/24
+      avoid_buggy_ips: true # When set to true, .0 and .255 addresses will be avoided.
 ```
 
 ## Layer2 Mode

--- a/roles/kubernetes-apps/metallb/templates/pools.yaml.j2
+++ b/roles/kubernetes-apps/metallb/templates/pools.yaml.j2
@@ -16,7 +16,7 @@ spec:
 {% for ip_range in pool.ip_range %}
   - "{{ ip_range }}"
 {% endfor %}
-  autoAssign: {{ pool.auto_assign }}
-  avoidBuggyIPs: true
+  autoAssign: {{ pool.auto_assign | default(true) }}
+  avoidBuggyIPs: {{ pool.avoid_buggy_ips | default(false) }}
 
 {% endfor %}


### PR DESCRIPTION
* Add avoid_buggy_ips as optional
* Revert avoid_buggy_ips default back to false
* Change auto_assign to optional, default true

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**: Brings back the option to configure MetalLB IPAddressPool `avoidBuggyIPs` and changes the defaults to match with MetalLB defaults.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10457

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[metallb] Add option to set avoidBuggyIPs in IPAddressPools and change the default back to false
```
