### PR TITLE
Fix: kube-apiserver tag will overwrite secrets-at-rest token if used independently

### DIFF
--- a/roles/kubernetes/control-plane/tasks/encrypt-at-rest.yml
+++ b/roles/kubernetes/control-plane/tasks/encrypt-at-rest.yml
@@ -38,5 +38,3 @@
     owner: root
     group: "{{ kube_cert_group }}"
     mode: 0640
-  tags:
-    - kube-apiserver

--- a/roles/kubernetes/control-plane/tasks/main.yml
+++ b/roles/kubernetes/control-plane/tasks/main.yml
@@ -28,6 +28,8 @@
   import_tasks: encrypt-at-rest.yml
   when:
     - kube_encrypt_secret_data
+  tags:
+    - kube-apiserver
 
 - name: Install | Copy kubectl binary from download dir
   copy:


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
If a user runs `update-cluster.yml` with tag `kube-apiserver` the playbook will not check whether or not the secrets-at-rest encryption token is already defined and will instead generate a new token and replace it potentially rendering secrets into an inaccessible  and unrecoverable state.

This PR applies the tag to all tasks in the file as they are all needed to properly determine the course of action.

**Which issue(s) this PR fixes**:
Fixes #10459

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

```release-note
Fix 'kube-apiserver' tag inappropriately overwriting secrets at rest encryption token
```
