### PR TITLE
Fix etcdctl.sh TLS file paths when not using kubeadm.

### DIFF
--- a/roles/etcdctl_etcdutl/templates/etcdctl.sh.j2
+++ b/roles/etcdctl_etcdutl/templates/etcdctl.sh.j2
@@ -8,7 +8,7 @@ etcdctl \
   --cert {{ kube_cert_dir }}/etcd/server.crt \
   --key {{ kube_cert_dir }}/etcd/server.key "$@"
 {% else %}
-  --cacert {{ etcd_cert_dir }}/etcd/ca.crt \
-  --cert {{ etcd_cert_dir }}/etcd/server.crt \
-  --key {{ etcd_cert_dir }}/etcd/server.key "$@"
-  {% endif %}
+  --cacert {{ etcd_cert_dir }}/ca.pem \
+  --cert {{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem \
+  --key {{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem "$@"
+{% endif %}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes the path of the certificates use in the etcdctl.sh wrapper when the deployment type is not kubeadm.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
I use the same path as in CLI settings of etcd.env.j2.

**Does this PR introduce a user-facing change?**:
```release-note
Fixes the path of the certificates use in the etcdctl.sh wrapper when the deployment type is not kubeadm.
```
