### PR TITLE
Refactor NRI activation for containerd and CRI-O

### DIFF
--- a/docs/containerd.md
+++ b/docs/containerd.md
@@ -130,3 +130,13 @@ containerd_registries_mirrors:
 [RuntimeClass]: https://kubernetes.io/docs/concepts/containers/runtime-class/
 [runtime classes in containerd]: https://github.com/containerd/containerd/blob/main/docs/cri/config.md#runtime-classes
 [runtime-spec]: https://github.com/opencontainers/runtime-spec
+
+### Optional : NRI
+
+[Node Resource Interface](https://github.com/containerd/nri) (NRI) is disabled by default for the containerd. If you
+are using contained version v1.7.0 or above, then you can enable it with the
+following configuration:
+
+```yaml
+nri_enabled: true
+```

--- a/docs/cri-o.md
+++ b/docs/cri-o.md
@@ -62,3 +62,13 @@ The `allowed_annotations` configures `crio.conf` accordingly.
 
 The `crio_remap_enable` configures the `/etc/subuid` and `/etc/subgid` files to add an entry for the **containers** user.
 By default, 16M uids and gids are reserved for user namespaces (256 pods * 65536 uids/gids) at the end of the uid/gid space.
+
+## Optional : NRI
+
+[Node Resource Interface](https://github.com/containerd/nri) (NRI) is disabled by default for the CRI-O. If you
+are using CRI-O version v1.26.0 or above, then you can enable it with the
+following configuration:
+
+```yaml
+nri_enabled: true
+```

--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -64,9 +64,6 @@ containerd_enable_unprivileged_ports: false
 # If enabled it will allow non root users to use icmp sockets
 containerd_enable_unprivileged_icmp: false
 
-# If enabled, it will activate the NRI support in containerd
-containerd_nri_disable: true
-
 containerd_cfg_dir: /etc/containerd
 
 # Extra config to be put in {{ containerd_cfg_dir }}/config.toml literally

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -78,8 +78,10 @@ oom_score = {{ containerd_oom_score }}
 {% endif %}
 {% endfor %}
 
+{% if nri_enabled and containerd_version >= 1.7.0 %}
   [plugins."io.containerd.nri.v1.nri"]
-    disable = {{ containerd_nri_disable | default(true) | lower }}
+    disable = false
+{% endif %}
 
 {% if containerd_extra_args is defined %}
 {{ containerd_extra_args }}

--- a/roles/container-engine/cri-o/defaults/main.yml
+++ b/roles/container-engine/cri-o/defaults/main.yml
@@ -97,6 +97,3 @@ crio_man_files:
   8:
     - crio
     - crio-status
-
-# If set to true, it will enable the NRI support in cri-o
-crio_enable_nri: false

--- a/roles/container-engine/cri-o/templates/crio.conf.j2
+++ b/roles/container-engine/cri-o/templates/crio.conf.j2
@@ -377,7 +377,8 @@ enable_metrics = {{ crio_enable_metrics | bool | lower }}
 # The port on which the metrics server will listen.
 metrics_port = {{ crio_metrics_port }}
 
+{% if nri_enabled and crio_version >= v1.26.0 %}
 [crio.nri]
 
-# Enable or disable NRI (Node Resource Interface) support in CRI-O.
-enable_nri={{ crio_enable_nri | default(false) | lower }}
+enable_nri=true
+{% endif %}

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -270,6 +270,10 @@ deploy_container_engine: "{{ inventory_hostname in groups['k8s_cluster'] or etcd
 # Container for runtime
 container_manager: containerd
 
+# Enable Node Resource Interface in containerd or CRI-O. Requires crio_version >= v1.26.0
+# or containerd_version >= 1.7.0.
+nri_enabled: false
+
 # Enable Kata Containers as additional container runtime
 # When enabled, it requires `container_manager` different than Docker
 kata_containers_enabled: false


### PR DESCRIPTION
**What type of PR is this?**
 /kind cleanup

**What this PR does / why we need it**:
Refactor NRI (Node Resource Interface) activation in CRI-O and containerd. Introduce a shared variable, `nri_enabled`, to streamline the process. Currently, enabling NRI requires a separate update of defaults for each container runtime independently, without any verification of NRI support for the specific version of containerd or CRI-O in use.

With this commit, the previous approach is replaced. Now, a single variable, `nri_enabled`, handles this functionality which eases the functionality activation for the users. Also, this commit separates the responsibility of verifying NRI supported versions of containerd and CRI-O from cluster administrators, and leaves it to Ansible.

NRI initial supported version references in runtimes:
1. containerd [v1.7.0](https://github.com/containerd/containerd/releases/tag/v1.7.0)
2. CRI-O [v1.26.0](https://github.com/cri-o/cri-o/releases/tag/v1.26.0)

This is follow up improvement to https://github.com/kubernetes-sigs/kubespray/pull/10454

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Does this PR introduce a user-facing change?**:
```
Refactor NRI activation for containerd and CRI-O (remove `crio_enable_nri` and `containerd_nri_disable`) now only one var `nri_enabled` default to false
```
