### PR TITLE
UpCloud: UpCloud terraform provider v2.12.0 with strict server groups

### DIFF
--- a/contrib/terraform/upcloud/README.md
+++ b/contrib/terraform/upcloud/README.md
@@ -140,4 +140,4 @@ terraform destroy --var-file cluster-settings.tfvars \
   * `backend_servers`: List of servers that traffic to the port should be forwarded to.
 * `server_groups`: Group servers together
   * `servers`: The servers that should be included in the group.
-  * `anti_affinity`: If anti-affinity should be enabled, try to spread the VMs out on separate nodes.
+  * `anti_affinity_policy`: Defines if a server group is an anti-affinity group. Setting this to "strict" or yes" will result in all servers in the group being placed on separate compute hosts. The value can be "strict", "yes" or "no". "strict" refers to strict policy doesn't allow servers in the same server group to be on the same host. "yes" refers to best-effort policy and tries to put servers on different hosts, but this is not guaranteed.

--- a/contrib/terraform/upcloud/cluster-settings.tfvars
+++ b/contrib/terraform/upcloud/cluster-settings.tfvars
@@ -18,7 +18,7 @@ ssh_public_keys = [
 
 # check list of available plan https://developers.upcloud.com/1.3/7-plans/
 machines = {
-  "master-0" : {
+  "control-plane-0" : {
     "node_type" : "master",
     # plan to use instead of custom cpu/mem
     "plan" : null,
@@ -133,9 +133,9 @@ loadbalancers = {
 server_groups = {
   # "control-plane" = {
   #   servers = [
-  #     "master-0"
+  #     "control-plane-0"
   #   ]
-  #   anti_affinity = true
+  #   anti_affinity_policy = "strict"
   # },
   # "workers" = {
   #   servers = [
@@ -143,6 +143,6 @@ server_groups = {
   #     "worker-1",
   #     "worker-2"
   #   ]
-  #   anti_affinity = true
+  #   anti_affinity_policy = "yes"
   # }
 }

--- a/contrib/terraform/upcloud/modules/kubernetes-cluster/main.tf
+++ b/contrib/terraform/upcloud/modules/kubernetes-cluster/main.tf
@@ -3,7 +3,7 @@ locals {
   disks = flatten([
     for node_name, machine in var.machines : [
       for disk_name, disk in machine.additional_disks : {
-        disk = disk
+        disk      = disk
         disk_name = disk_name
         node_name = node_name
       }
@@ -13,8 +13,8 @@ locals {
   lb_backend_servers = flatten([
     for lb_name, loadbalancer in var.loadbalancers : [
       for backend_server in loadbalancer.backend_servers : {
-        port = loadbalancer.target_port
-        lb_name = lb_name
+        port        = loadbalancer.target_port
+        lb_name     = lb_name
         server_name = backend_server
       }
     ]
@@ -22,7 +22,7 @@ locals {
 
   # If prefix is set, all resources will be prefixed with "${var.prefix}-"
   # Else don't prefix with anything
-  resource-prefix = "%{ if var.prefix != ""}${var.prefix}-%{ endif }"
+  resource-prefix = "%{if var.prefix != ""}${var.prefix}-%{endif}"
 }
 
 resource "upcloud_network" "private" {
@@ -38,7 +38,7 @@ resource "upcloud_network" "private" {
 
 resource "upcloud_storage" "additional_disks" {
   for_each = {
-    for disk in local.disks: "${disk.node_name}_${disk.disk_name}" => disk.disk
+    for disk in local.disks : "${disk.node_name}_${disk.disk_name}" => disk.disk
   }
 
   size  = each.value.size
@@ -61,8 +61,8 @@ resource "upcloud_server" "master" {
   zone     = var.zone
 
   template {
-  storage = var.template_name
-  size    = each.value.disk_size
+    storage = var.template_name
+    size    = each.value.disk_size
   }
 
   # Public network interface
@@ -81,14 +81,14 @@ resource "upcloud_server" "master" {
     ignore_changes = [storage_devices]
   }
 
-  firewall  = var.firewall_enabled
+  firewall = var.firewall_enabled
 
   dynamic "storage_devices" {
     for_each = {
       for disk_key_name, disk in upcloud_storage.additional_disks :
-        disk_key_name => disk
-        # Only add the disk if it matches the node name in the start of its name
-        if length(regexall("^${each.key}_.+", disk_key_name)) > 0
+      disk_key_name => disk
+      # Only add the disk if it matches the node name in the start of its name
+      if length(regexall("^${each.key}_.+", disk_key_name)) > 0
     }
 
     content {
@@ -138,14 +138,14 @@ resource "upcloud_server" "worker" {
     ignore_changes = [storage_devices]
   }
 
-  firewall  = var.firewall_enabled
+  firewall = var.firewall_enabled
 
   dynamic "storage_devices" {
     for_each = {
       for disk_key_name, disk in upcloud_storage.additional_disks :
-        disk_key_name => disk
-        # Only add the disk if it matches the node name in the start of its name
-        if length(regexall("^${each.key}_.+", disk_key_name)) > 0
+      disk_key_name => disk
+      # Only add the disk if it matches the node name in the start of its name
+      if length(regexall("^${each.key}_.+", disk_key_name)) > 0
     }
 
     content {
@@ -162,10 +162,10 @@ resource "upcloud_server" "worker" {
 }
 
 resource "upcloud_firewall_rules" "master" {
-  for_each = upcloud_server.master
+  for_each  = upcloud_server.master
   server_id = each.value.id
 
-  dynamic firewall_rule {
+  dynamic "firewall_rule" {
     for_each = var.master_allowed_remote_ips
 
     content {
@@ -181,7 +181,7 @@ resource "upcloud_firewall_rules" "master" {
     }
   }
 
-  dynamic firewall_rule {
+  dynamic "firewall_rule" {
     for_each = length(var.master_allowed_remote_ips) > 0 ? [1] : []
 
     content {
@@ -197,7 +197,7 @@ resource "upcloud_firewall_rules" "master" {
     }
   }
 
-  dynamic firewall_rule {
+  dynamic "firewall_rule" {
     for_each = var.k8s_allowed_remote_ips
 
     content {
@@ -213,7 +213,7 @@ resource "upcloud_firewall_rules" "master" {
     }
   }
 
-  dynamic firewall_rule {
+  dynamic "firewall_rule" {
     for_each = length(var.k8s_allowed_remote_ips) > 0 ? [1] : []
 
     content {
@@ -229,7 +229,7 @@ resource "upcloud_firewall_rules" "master" {
     }
   }
 
-  dynamic firewall_rule {
+  dynamic "firewall_rule" {
     for_each = var.master_allowed_ports
 
     content {
@@ -245,97 +245,97 @@ resource "upcloud_firewall_rules" "master" {
     }
   }
 
-  dynamic firewall_rule {
+  dynamic "firewall_rule" {
     for_each = var.firewall_default_deny_in ? ["tcp", "udp"] : []
 
     content {
-      action                 = "accept"
-      comment                = "UpCloud DNS"
-      source_port_end        = "53"
-      source_port_start      = "53"
-      direction              = "in"
-      family                 = "IPv4"
-      protocol               = firewall_rule.value
-      source_address_end     = "94.237.40.9"
-      source_address_start   = "94.237.40.9"
+      action               = "accept"
+      comment              = "UpCloud DNS"
+      source_port_end      = "53"
+      source_port_start    = "53"
+      direction            = "in"
+      family               = "IPv4"
+      protocol             = firewall_rule.value
+      source_address_end   = "94.237.40.9"
+      source_address_start = "94.237.40.9"
     }
   }
 
-  dynamic firewall_rule {
+  dynamic "firewall_rule" {
     for_each = var.firewall_default_deny_in ? ["tcp", "udp"] : []
 
     content {
-      action                 = "accept"
-      comment                = "UpCloud DNS"
-      source_port_end        = "53"
-      source_port_start      = "53"
-      direction              = "in"
-      family                 = "IPv4"
-      protocol               = firewall_rule.value
-      source_address_end     = "94.237.127.9"
-      source_address_start   = "94.237.127.9"
+      action               = "accept"
+      comment              = "UpCloud DNS"
+      source_port_end      = "53"
+      source_port_start    = "53"
+      direction            = "in"
+      family               = "IPv4"
+      protocol             = firewall_rule.value
+      source_address_end   = "94.237.127.9"
+      source_address_start = "94.237.127.9"
     }
   }
 
-  dynamic firewall_rule {
+  dynamic "firewall_rule" {
     for_each = var.firewall_default_deny_in ? ["tcp", "udp"] : []
 
     content {
-      action                 = "accept"
-      comment                = "UpCloud DNS"
-      source_port_end        = "53"
-      source_port_start      = "53"
-      direction              = "in"
-      family                 = "IPv6"
-      protocol               = firewall_rule.value
-      source_address_end     = "2a04:3540:53::1"
-      source_address_start   = "2a04:3540:53::1"
+      action               = "accept"
+      comment              = "UpCloud DNS"
+      source_port_end      = "53"
+      source_port_start    = "53"
+      direction            = "in"
+      family               = "IPv6"
+      protocol             = firewall_rule.value
+      source_address_end   = "2a04:3540:53::1"
+      source_address_start = "2a04:3540:53::1"
     }
   }
 
-  dynamic firewall_rule {
+  dynamic "firewall_rule" {
     for_each = var.firewall_default_deny_in ? ["tcp", "udp"] : []
 
     content {
-      action                 = "accept"
-      comment                = "UpCloud DNS"
-      source_port_end        = "53"
-      source_port_start      = "53"
-      direction              = "in"
-      family                 = "IPv6"
-      protocol               = firewall_rule.value
-      source_address_end     = "2a04:3544:53::1"
-      source_address_start   = "2a04:3544:53::1"
+      action               = "accept"
+      comment              = "UpCloud DNS"
+      source_port_end      = "53"
+      source_port_start    = "53"
+      direction            = "in"
+      family               = "IPv6"
+      protocol             = firewall_rule.value
+      source_address_end   = "2a04:3544:53::1"
+      source_address_start = "2a04:3544:53::1"
     }
   }
 
-  dynamic firewall_rule {
+  dynamic "firewall_rule" {
     for_each = var.firewall_default_deny_in ? ["udp"] : []
 
     content {
-      action                 = "accept"
-      comment                = "NTP Port"
-      source_port_end        = "123"
-      source_port_start      = "123"
-      direction              = "in"
-      family                 = "IPv4"
-      protocol               = firewall_rule.value
-      source_address_end     = "255.255.255.255"
-      source_address_start   = "0.0.0.0"
+      action               = "accept"
+      comment              = "NTP Port"
+      source_port_end      = "123"
+      source_port_start    = "123"
+      direction            = "in"
+      family               = "IPv4"
+      protocol             = firewall_rule.value
+      source_address_end   = "255.255.255.255"
+      source_address_start = "0.0.0.0"
     }
   }
 
-  dynamic firewall_rule {
+  dynamic "firewall_rule" {
     for_each = var.firewall_default_deny_in ? ["udp"] : []
 
     content {
-      action                 = "accept"
-      comment                = "NTP Port"
-      source_port_end        = "123"
-      source_port_start      = "123"
-      direction              = "in"
-      family                 = "IPv6"
-      protocol               = firewall_rule.value
+      action            = "accept"
+      comment           = "NTP Port"
+      source_port_end   = "123"
+      source_port_start = "123"
+      direction         = "in"
+      family            = "IPv6"
+      protocol          = firewall_rule.value
     }
   }
 
@@ -351,10 +351,10 @@ resource "upcloud_firewall_rules" "master" {
 }
 
 resource "upcloud_firewall_rules" "k8s" {
-  for_each = upcloud_server.worker
+  for_each  = upcloud_server.worker
   server_id = each.value.id
 
-  dynamic firewall_rule {
+  dynamic "firewall_rule" {
     for_each = var.k8s_allowed_remote_ips
 
     content {
@@ -370,7 +370,7 @@ resource "upcloud_firewall_rules" "k8s" {
     }
   }
 
-  dynamic firewall_rule {
+  dynamic "firewall_rule" {
     for_each = length(var.k8s_allowed_remote_ips) > 0 ? [1] : []
 
     content {
@@ -386,7 +386,7 @@ resource "upcloud_firewall_rules" "k8s" {
     }
   }
 
-  dynamic firewall_rule {
+  dynamic "firewall_rule" {
     for_each = var.worker_allowed_ports
 
     content {
@@ -402,97 +402,97 @@ resource "upcloud_firewall_rules" "k8s" {
     }
   }
 
-  dynamic firewall_rule {
+  dynamic "firewall_rule" {
     for_each = var.firewall_default_deny_in ? ["tcp", "udp"] : []
 
     content {
-      action                 = "accept"
-      comment                = "UpCloud DNS"
-      source_port_end        = "53"
-      source_port_start      = "53"
-      direction              = "in"
-      family                 = "IPv4"
-      protocol               = firewall_rule.value
-      source_address_end     = "94.237.40.9"
-      source_address_start   = "94.237.40.9"
+      action               = "accept"
+      comment              = "UpCloud DNS"
+      source_port_end      = "53"
+      source_port_start    = "53"
+      direction            = "in"
+      family               = "IPv4"
+      protocol             = firewall_rule.value
+      source_address_end   = "94.237.40.9"
+      source_address_start = "94.237.40.9"
     }
   }
 
-  dynamic firewall_rule {
+  dynamic "firewall_rule" {
     for_each = var.firewall_default_deny_in ? ["tcp", "udp"] : []
 
     content {
-      action                 = "accept"
-      comment                = "UpCloud DNS"
-      source_port_end        = "53"
-      source_port_start      = "53"
-      direction              = "in"
-      family                 = "IPv4"
-      protocol               = firewall_rule.value
-      source_address_end     = "94.237.127.9"
-      source_address_start   = "94.237.127.9"
+      action               = "accept"
+      comment              = "UpCloud DNS"
+      source_port_end      = "53"
+      source_port_start    = "53"
+      direction            = "in"
+      family               = "IPv4"
+      protocol             = firewall_rule.value
+      source_address_end   = "94.237.127.9"
+      source_address_start = "94.237.127.9"
     }
   }
 
-  dynamic firewall_rule {
+  dynamic "firewall_rule" {
     for_each = var.firewall_default_deny_in ? ["tcp", "udp"] : []
 
     content {
-      action                 = "accept"
-      comment                = "UpCloud DNS"
-      source_port_end        = "53"
-      source_port_start      = "53"
-      direction              = "in"
-      family                 = "IPv6"
-      protocol               = firewall_rule.value
-      source_address_end     = "2a04:3540:53::1"
-      source_address_start   = "2a04:3540:53::1"
+      action               = "accept"
+      comment              = "UpCloud DNS"
+      source_port_end      = "53"
+      source_port_start    = "53"
+      direction            = "in"
+      family               = "IPv6"
+      protocol             = firewall_rule.value
+      source_address_end   = "2a04:3540:53::1"
+      source_address_start = "2a04:3540:53::1"
     }
   }
 
-  dynamic firewall_rule {
+  dynamic "firewall_rule" {
     for_each = var.firewall_default_deny_in ? ["tcp", "udp"] : []
 
     content {
-      action                 = "accept"
-      comment                = "UpCloud DNS"
-      source_port_end        = "53"
-      source_port_start      = "53"
-      direction              = "in"
-      family                 = "IPv6"
-      protocol               = firewall_rule.value
-      source_address_end     = "2a04:3544:53::1"
-      source_address_start   = "2a04:3544:53::1"
+      action               = "accept"
+      comment              = "UpCloud DNS"
+      source_port_end      = "53"
+      source_port_start    = "53"
+      direction            = "in"
+      family               = "IPv6"
+      protocol             = firewall_rule.value
+      source_address_end   = "2a04:3544:53::1"
+      source_address_start = "2a04:3544:53::1"
     }
   }
 
-  dynamic firewall_rule {
+  dynamic "firewall_rule" {
     for_each = var.firewall_default_deny_in ? ["udp"] : []
 
     content {
-      action                 = "accept"
-      comment                = "NTP Port"
-      source_port_end        = "123"
-      source_port_start      = "123"
-      direction              = "in"
-      family                 = "IPv4"
-      protocol               = firewall_rule.value
-      source_address_end     = "255.255.255.255"
-      source_address_start   = "0.0.0.0"
+      action               = "accept"
+      comment              = "NTP Port"
+      source_port_end      = "123"
+      source_port_start    = "123"
+      direction            = "in"
+      family               = "IPv4"
+      protocol             = firewall_rule.value
+      source_address_end   = "255.255.255.255"
+      source_address_start = "0.0.0.0"
     }
   }
 
-  dynamic firewall_rule {
+  dynamic "firewall_rule" {
     for_each = var.firewall_default_deny_in ? ["udp"] : []
 
     content {
-      action                 = "accept"
-      comment                = "NTP Port"
-      source_port_end        = "123"
-      source_port_start      = "123"
-      direction              = "in"
-      family                 = "IPv6"
-      protocol               = firewall_rule.value
+      action            = "accept"
+      comment           = "NTP Port"
+      source_port_end   = "123"
+      source_port_start = "123"
+      direction         = "in"
+      family            = "IPv6"
+      protocol          = firewall_rule.value
     }
   }
 
@@ -535,9 +535,9 @@ resource "upcloud_loadbalancer_frontend" "lb_frontend" {
 
 resource "upcloud_loadbalancer_static_backend_member" "lb_backend_member" {
   for_each = {
-    for be_server in local.lb_backend_servers:
-      "${be_server.server_name}-lb-backend-${be_server.lb_name}" => be_server
-      if var.loadbalancer_enabled
+    for be_server in local.lb_backend_servers :
+    "${be_server.server_name}-lb-backend-${be_server.lb_name}" => be_server
+    if var.loadbalancer_enabled
   }
 
   backend      = upcloud_loadbalancer_backend.lb_backend[each.value.lb_name].id
@@ -550,9 +550,9 @@ resource "upcloud_loadbalancer_static_backend_member" "lb_backend_member" {
 }
 
 resource "upcloud_server_group" "server_groups" {
-  for_each      = var.server_groups
-  title         = each.key
-  anti_affinity = each.value.anti_affinity
-  labels        = {}
-  members       = [for server in each.value.servers : merge(upcloud_server.master, upcloud_server.worker)[server].id]
+  for_each             = var.server_groups
+  title                = each.key
+  anti_affinity_policy = each.value.anti_affinity_policy
+  labels               = {}
+  members              = [for server in each.value.servers : merge(upcloud_server.master, upcloud_server.worker)[server].id]
 }

--- a/contrib/terraform/upcloud/modules/kubernetes-cluster/output.tf
+++ b/contrib/terraform/upcloud/modules/kubernetes-cluster/output.tf
@@ -3,8 +3,8 @@ output "master_ip" {
   value = {
     for instance in upcloud_server.master :
     instance.hostname => {
-      "public_ip": instance.network_interface[0].ip_address
-      "private_ip": instance.network_interface[1].ip_address
+      "public_ip" : instance.network_interface[0].ip_address
+      "private_ip" : instance.network_interface[1].ip_address
     }
   }
 }
@@ -13,8 +13,8 @@ output "worker_ip" {
   value = {
     for instance in upcloud_server.worker :
     instance.hostname => {
-      "public_ip": instance.network_interface[0].ip_address
-      "private_ip": instance.network_interface[1].ip_address
+      "public_ip" : instance.network_interface[0].ip_address
+      "private_ip" : instance.network_interface[1].ip_address
     }
   }
 }

--- a/contrib/terraform/upcloud/modules/kubernetes-cluster/variables.tf
+++ b/contrib/terraform/upcloud/modules/kubernetes-cluster/variables.tf
@@ -15,11 +15,11 @@ variable "private_network_cidr" {}
 variable "machines" {
   description = "Cluster machines"
   type = map(object({
-    node_type       = string
-    plan            = string
-    cpu             = string
-    mem             = string
-    disk_size       =  number
+    node_type = string
+    plan      = string
+    cpu       = string
+    mem       = string
+    disk_size = number
     additional_disks = map(object({
       size = number
       tier = string
@@ -99,7 +99,7 @@ variable "server_groups" {
   description = "Server groups"
 
   type = map(object({
-    anti_affinity   = bool
-    servers = list(string)
+    anti_affinity_policy = string
+    servers              = list(string)
   }))
 }

--- a/contrib/terraform/upcloud/modules/kubernetes-cluster/versions.tf
+++ b/contrib/terraform/upcloud/modules/kubernetes-cluster/versions.tf
@@ -2,8 +2,8 @@
 terraform {
   required_providers {
     upcloud = {
-      source = "UpCloudLtd/upcloud"
-      version = "~>2.7.1"
+      source  = "UpCloudLtd/upcloud"
+      version = "~>2.12.0"
     }
   }
   required_version = ">= 0.13"

--- a/contrib/terraform/upcloud/sample-inventory/cluster.tfvars
+++ b/contrib/terraform/upcloud/sample-inventory/cluster.tfvars
@@ -18,7 +18,7 @@ ssh_public_keys = [
 
 # check list of available plan https://developers.upcloud.com/1.3/7-plans/
 machines = {
-  "master-0" : {
+  "control-plane-0" : {
     "node_type" : "master",
     # plan to use instead of custom cpu/mem
     "plan" : null,
@@ -28,7 +28,7 @@ machines = {
     "mem" : "4096"
     # The size of the storage in GB
     "disk_size" : 250
-    "additional_disks": {}
+    "additional_disks" : {}
   },
   "worker-0" : {
     "node_type" : "worker",
@@ -40,7 +40,7 @@ machines = {
     "mem" : "4096"
     # The size of the storage in GB
     "disk_size" : 250
-    "additional_disks": {
+    "additional_disks" : {
       # "some-disk-name-1": {
       #   "size": 100,
       #   "tier": "maxiops",
@@ -61,7 +61,7 @@ machines = {
     "mem" : "4096"
     # The size of the storage in GB
     "disk_size" : 250
-    "additional_disks": {
+    "additional_disks" : {
       # "some-disk-name-1": {
       #   "size": 100,
       #   "tier": "maxiops",
@@ -82,7 +82,7 @@ machines = {
     "mem" : "4096"
     # The size of the storage in GB
     "disk_size" : 250
-    "additional_disks": {
+    "additional_disks" : {
       # "some-disk-name-1": {
       #   "size": 100,
       #   "tier": "maxiops",
@@ -118,7 +118,7 @@ master_allowed_ports = []
 worker_allowed_ports = []
 
 loadbalancer_enabled = false
-loadbalancer_plan = "development"
+loadbalancer_plan    = "development"
 loadbalancers = {
   # "http" : {
   #   "port" : 80,
@@ -134,9 +134,9 @@ loadbalancers = {
 server_groups = {
   # "control-plane" = {
   #   servers = [
-  #     "master-0"
+  #     "control-plane-0"
   #   ]
-  #   anti_affinity = true
+  #   anti_affinity_policy = "strict"
   # },
   # "workers" = {
   #   servers = [
@@ -144,6 +144,6 @@ server_groups = {
   #     "worker-1",
   #     "worker-2"
   #   ]
-  #   anti_affinity = true
+  #   anti_affinity_policy = "yes"
   # }
 }

--- a/contrib/terraform/upcloud/variables.tf
+++ b/contrib/terraform/upcloud/variables.tf
@@ -136,8 +136,8 @@ variable "server_groups" {
   description = "Server groups"
 
   type = map(object({
-    anti_affinity = bool
-    servers       = list(string)
+    anti_affinity_policy = string
+    servers              = list(string)
   }))
 
   default = {}

--- a/contrib/terraform/upcloud/versions.tf
+++ b/contrib/terraform/upcloud/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     upcloud = {
       source  = "UpCloudLtd/upcloud"
-      version = "~>2.7.1"
+      version = "~>2.12.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Updates UpClouds terraform provider to 2.12.0.
Introducing server grouping for anti-affinity with strict and best effort server placement.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
UpCloud: Terraform provider updated to v2.12.0. Server groups with strict anti-affinity (move var from `anti_affinity_policy` to `anti_affinity`)
```
