### PR TITLE
[etcd] make etcd 3.5.9 default

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Note: Upstart/SysV init based OS types are not supported.
 
 - Core
   - [kubernetes](https://github.com/kubernetes/kubernetes) v1.27.6
-  - [etcd](https://github.com/etcd-io/etcd) v3.5.7
+  - [etcd](https://github.com/etcd-io/etcd) v3.5.9
   - [docker](https://www.docker.com/) v20.10 (see note)
   - [containerd](https://containerd.io/) v1.7.5
   - [cri-o](http://cri-o.io/) v1.27 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)

--- a/roles/download/defaults/main/main.yml
+++ b/roles/download/defaults/main/main.yml
@@ -133,9 +133,9 @@ skopeo_version: "v1.13.2"
 kube_major_version: "{{ kube_version | regex_replace('^v([0-9])+\\.([0-9]+)\\.[0-9]+', 'v\\1.\\2') }}"
 
 etcd_supported_versions:
-  v1.27: "v3.5.7"
-  v1.26: "v3.5.6"
-  v1.25: "v3.5.6"
+  v1.27: "v3.5.9"
+  v1.26: "v3.5.9"
+  v1.25: "v3.5.9"
 etcd_version: "{{ etcd_supported_versions[kube_major_version] }}"
 
 crictl_supported_versions:


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

etcd 3.5.9 is default for the k8s [v1.26](https://github.com/kubernetes/kubernetes/blob/release-1.26/build/dependencies.yaml#L57-L58) [v1.27](https://github.com/kubernetes/kubernetes/blob/release-1.27/build/dependencies.yaml#L64-L65) [1.25](https://github.com/kubernetes/kubernetes/blob/release-1.25/build/dependencies.yaml#L57-L58) releases. 

The new version is already in the respective branches for these releases. Previous etcd versions contains High CVEs. See the discussion here: https://github.com/kubernetes/kubernetes/issues/117648

**Does this PR introduce a user-facing change?**:
<!--
NONE
-->
```release-note
[etcd] Default version to 3.5.9 for k8s 1.25 , 1.26 , 1.27
```