### PR TITLE
[kubernetes] Kube-scheduler: remove/update deprecated component component config v1beta3

### DIFF
--- a/roles/kubernetes/control-plane/templates/kubescheduler-config.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubescheduler-config.yaml.j2
@@ -1,5 +1,4 @@
-{% set kubescheduler_config_api_version = "v1beta3" %}
-apiVersion: kubescheduler.config.k8s.io/{{ kubescheduler_config_api_version | d('v1') }}
+apiVersion: kubescheduler.config.k8s.io/v1
 kind: KubeSchedulerConfiguration
 clientConnection:
   kubeconfig: "{{ kube_config_dir }}/scheduler.conf"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Kube-scheduler: remove/update deprecated component component config v1beta3
Reference: https://github.com/kubernetes/kubernetes/pull/112257

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Kube-scheduler: remove/update deprecated component component config v1beta3.
```
