### PR TITLE
[kube-router] Add option to disable bgp-graceful-restart (10488)

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-kube-router.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-kube-router.yml
@@ -19,6 +19,9 @@
 # Add LoadBalancer IP of service status as set by the LB provider to the RIB so that it gets advertised to the BGP peers.
 # kube_router_advertise_loadbalancer_ip: false
 
+# Enables BGP graceful restarts
+# kube_router_bgp_graceful_restart: true
+
 # Adjust manifest of kube-router daemonset template with DSR needed changes
 # kube_router_enable_dsr: false
 

--- a/roles/network_plugin/kube-router/defaults/main.yml
+++ b/roles/network_plugin/kube-router/defaults/main.yml
@@ -18,6 +18,9 @@ kube_router_advertise_external_ip: false
 # Add LoadBalancer IP of service status as set by the LB provider to the RIB so that it gets advertised to the BGP peers.
 kube_router_advertise_loadbalancer_ip: false
 
+# Enables BGP graceful restarts
+kube_router_bgp_graceful_restart: true
+
 # Adjust manifest of kube-router daemonset template with DSR needed changes
 kube_router_enable_dsr: false
 

--- a/roles/network_plugin/kube-router/templates/kube-router.yml.j2
+++ b/roles/network_plugin/kube-router/templates/kube-router.yml.j2
@@ -39,7 +39,7 @@ spec:
         - --run-firewall={{ kube_router_run_firewall | bool }}
         - --run-service-proxy={{ kube_router_run_service_proxy | bool }}
         - --kubeconfig=/var/lib/kube-router/kubeconfig
-        - --bgp-graceful-restart=true
+        - --bgp-graceful-restart={{ kube_router_bgp_graceful_restart }}
 {% if kube_router_advertise_cluster_ip %}
         - --advertise-cluster-ip
 {% endif %}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This makes it possible to disable BGP graceful restarts for kube-router

**Which issue(s) this PR fixes**:
Fixes #10488 

**Does this PR introduce a user-facing change?**:
It adds a new configuration setting but the default value is set to true which matches the existing behavior. This just gives us the option to set it to false.

```release-note
[Kube-router] Add `kube_router_bgp_graceful_restart` optional setting for disabling graceful BGP restarts (default to true)
```
