### PR TITLE
[external-lb]: kubelet.conf server address and kube-proxy api-server address fix

### DIFF
--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -129,6 +129,17 @@
     - kubeadm_discovery_address != kube_apiserver_endpoint | replace("https://", "")
   notify: Kubeadm | restart kubelet
 
+- name: Update server field in kubelet kubeconfig - external lb
+  lineinfile:
+    dest: "{{ kube_config_dir }}/kubelet.conf"
+    regexp: '^    server: https'
+    line: '    server: {{ kube_apiserver_endpoint }}'
+    backup: yes
+  when:
+    - not is_kube_master
+    - loadbalancer_apiserver is defined
+  notify: Kubeadm | restart kubelet
+
 # FIXME(mattymo): Need to point to localhost, otherwise masters will all point
 #                 incorrectly to first master, creating SPoF.
 - name: Update server field in kube-proxy kubeconfig

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -160,6 +160,22 @@
   tags:
     - kube-proxy
 
+- name: Update server field in kube-proxy kubeconfig - external lb
+  shell: >-
+    set -o pipefail && {{ kubectl }} get configmap kube-proxy -n kube-system -o yaml
+    | sed 's#server:.*#server: {{kube_apiserver_endpoint}}#g'
+    | {{ kubectl }} replace -f -
+  args:
+    executable: /bin/bash
+  run_once: true
+  delegate_to: "{{ groups['kube_control_plane'] | first }}"
+  delegate_facts: false
+  when:
+    - kube_proxy_deployed
+    - loadbalancer_apiserver is defined
+  tags:
+    - kube-proxy
+
 - name: Set ca.crt file permission
   file:
     path: "{{ kube_cert_dir }}/ca.crt"
@@ -173,8 +189,8 @@
   delegate_to: "{{ groups['kube_control_plane'] | first }}"
   delegate_facts: false
   when:
-    - kubeadm_config_api_fqdn is not defined
-    - kubeadm_discovery_address != kube_apiserver_endpoint | replace("https://", "")
+    - kubeadm_config_api_fqdn is not defined or loadbalancer_apiserver is defined
+    - kubeadm_discovery_address != kube_apiserver_endpoint | replace("https://", "") or loadbalancer_apiserver is defined
     - kube_proxy_deployed
   tags:
     - kube-proxy


### PR DESCRIPTION

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
When trying to configure external lb address for already provisioned clusters; it does not set correct external lb fqdn address for worker nodes, instead of it sets first controlplane's ip address. 

The problem is that kubeadm does not update the kubeadm-config configmap in kube-system namespace; it only creates it in kubeadm init phase, even though it creates new ClusterConfiguration on controlplane node in `/etc/kubernetes/kubeadm-config.yaml` path. Since worker nodes fetch configMap on the cluster when the `kubeadm join ...` command is run, it was fetching old clusterConfig in already provisioned clusters.

To fix this problem, we added a new task to update kubelet.conf in worker nodes. We also noticed that kube_proxy was not getting the right address for external lb is the case; and we added logic to update kube_proxy config as well. 


**Special notes for your reviewer**:
For testing purposes, a new cluster was set up and tested.


**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
