### PR TITLE
[WIP][CI] using packet instead of docker-machine gitlab runner

### DIFF
--- a/.gitlab-ci/molecule.yml
+++ b/.gitlab-ci/molecule.yml
@@ -1,7 +1,12 @@
 ---
 
 .molecule:
-  tags: [c3.small.x86]
+  variables:
+    ANSIBLE_TIMEOUT: "120"
+    CI_PLATFORM: packet
+    SSH_USER: kubespray
+  tags:
+    - packet
   only: [/^pr-.*$/]
   except: ['triggers']
   image: $PIPELINE_IMAGE


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind failing-test


**What this PR does / why we need it**:

The CI has been broken since 4 day ago. The error logs: 
```
[0KRunning with gitlab-runner 15.8.0 (12335144)[0;m
[0K  on docker-machine-small Pu4iHLzh, system ID: s_ee4d7455704e[0;m
section_start:1696760275:resolve_secrets
[0K[0K[36;1mResolving secrets[0;m[0;m
section_end:1696760275:resolve_secrets
[0Ksection_start:1696760275:prepare_executor
[0K[0K[36;1mPreparing the "docker+machine" executor[0;m[0;m
[31;1mERROR: Preparation failed: exit status 1[0;m
[32;1mWill be retried in 3s ...[0;m
[31;1mERROR: Preparation failed: exit status 1[0;m
[32;1mWill be retried in 3s ...[0;m
[31;1mERROR: Preparation failed: exit status 1[0;m
[32;1mWill be retried in 3s ...[0;m
section_end:1696760345:prepare_executor
[0K[31;1mERROR: Job failed (system failure): exit status 1[0;m
```

There may be something wrong with the docker-machine runner, and the docker-machine has been deprecated by docker for years.

So the best solution is to change the `docker-machine` runner to the  [next Runner Auto-scaling Architecture](https://docs.gitlab.com/ee/architecture/blueprints/runner_scaling/#next-runner-auto-scaling-architecture).

And the PR is to using the packet instead of docker-machine gitlab runner to make the CI run successful now.

TODO: using next Runner Auto-scaling Architecture  instead of docker-machine gitlab runner

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
using packet instead of docker-machine gitlab runner
```
