### PR TITLE
new  podnodeselector plugin configuration

### DIFF
--- a/docs/hardening.md
+++ b/docs/hardening.md
@@ -54,6 +54,11 @@ kube_apiserver_enable_admission_plugins:
   - PodNodeSelector
   - PodSecurity
 kube_apiserver_admission_control_config_file: true
+# Creates config file for PodNodeSelector
+# kube_apiserver_admission_plugins_needs_configuration: [PodNodeSelector]
+# Define the default node selector, by default all the workloads will be scheduled on nodes
+# with label network=srv1
+# kube_apiserver_admission_plugins_podnodeselector_default_node_selector: "network=srv1"
 # EventRateLimit plugin configuration
 kube_apiserver_admission_event_rate_limits:
   limit_1:

--- a/roles/kubernetes/control-plane/defaults/main/main.yml
+++ b/roles/kubernetes/control-plane/defaults/main/main.yml
@@ -138,6 +138,8 @@ kube_webhook_token_auth_url_skip_tls_verify: false
 kube_webhook_authorization: false
 kube_webhook_authorization_url_skip_tls_verify: false
 
+# Default podnodeselector
+kube_apiserver_admission_plugins_podnodeselector_default_node_selector: ""
 
 ## Variables for OpenID Connect Configuration https://kubernetes.io/docs/admin/authentication/
 ## To use OpenID you have to deploy additional an OpenID Provider (e.g Dex, Keycloak, ...)

--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -107,6 +107,15 @@
     - kube_apiserver_admission_control_config_file
     - item in kube_apiserver_admission_plugins_needs_configuration
   loop: "{{ kube_apiserver_enable_admission_plugins }}"
+  
+- name: Kubeadm | Configure default cluster podnodeslector
+  template:
+    src: "podnodeselector.yaml.j2"
+    dest: "{{ kube_config_dir }}/admission-controls/podnodeselector.yaml"
+    mode: 0640
+  when:
+    - kube_apiserver_admission_plugins_podnodeselector_default_node_selector is defined
+    - kube_apiserver_admission_plugins_podnodeselector_default_node_selector | length > 0
 
 - name: Kubeadm | Check apiserver.crt SANs
   vars:

--- a/roles/kubernetes/control-plane/templates/podnodeselector.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/podnodeselector.yaml.j2
@@ -1,0 +1,2 @@
+podNodeSelectorPluginConfig:
+  clusterDefaultNodeSelector: {{ kube_apiserver_admission_plugins_podnodeselector_default_node_selector }}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
Allows the users to configure the the `clusterDefaultNodeSelector`  from the config file
**Which issue(s) this PR fixes**:

Fixes #10412 

**Special notes for your reviewer**:

```release-note
This will introduce a new variable `kube_apiserver_admission_plugins_podnodeselector_default_node_selector`  that can be used with `kube_apiserver_admission_plugins_needs_configuration: [PodNodeSelector]` defined. So allows the users to configure PodNodeSelector plugin.
```
