### PR TITLE
[docker] Ability to define GPG key path for Docker APT

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -97,3 +97,9 @@ Adding extra options to pass to the docker daemon:
 ## This string should be exactly as you wish it to appear.
 docker_options: ""
 ```
+
+For Debian based distributions, set the path to store the GPG key to avoid using the default one used in `apt_key` module (e.g. /etc/apt/trusted.gpg)
+
+```yaml
+docker_repo_key_keyring: /etc/apt/trusted.gpg.d/docker.gpg
+```

--- a/roles/container-engine/docker/defaults/main.yml
+++ b/roles/container-engine/docker/defaults/main.yml
@@ -5,6 +5,9 @@ docker_cli_version: "{{ docker_version }}"
 docker_package_info:
   pkgs:
 
+# Path where to store repo key
+# docker_repo_key_keyring: /etc/apt/trusted.gpg.d/docker.gpg
+
 docker_repo_key_info:
   repo_keys:
 

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -57,6 +57,7 @@
   apt_key:
     id: "{{ item }}"
     url: "{{ docker_repo_key_info.url }}"
+    keyring: "{{ docker_repo_key_keyring|default(omit) }}"
     state: present
   register: keyserver_task_result
   until: keyserver_task_result is succeeded

--- a/tests/files/packet_debian12-docker.yml
+++ b/tests/files/packet_debian12-docker.yml
@@ -7,3 +7,4 @@ mode: default
 container_manager: docker
 etcd_deployment_type: docker
 resolvconf_mode: docker_dns
+docker_repo_key_keyring: /etc/apt/trusted.gpg.d/docker.gpg

--- a/tests/files/packet_ubuntu22-aio-docker.yml
+++ b/tests/files/packet_ubuntu22-aio-docker.yml
@@ -15,3 +15,4 @@ enable_nodelocaldns: False
 container_manager: docker
 etcd_deployment_type: docker
 resolvconf_mode: docker_dns
+docker_repo_key_keyring: /etc/apt/trusted.gpg.d/docker.gpg


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Enables setting a path for GPG key for Docker repo on Debian systems to avoid the well-known warning (`Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details`)

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[docker] Ability to define GPG key path for Docker APT (using new variable `docker_repo_key_keyring`)
```
