### PR TITLE
Retries ssh connection for Gather node certs

### DIFF
--- a/roles/etcd/tasks/gen_nodes_certs_script.yml
+++ b/roles/etcd/tasks/gen_nodes_certs_script.yml
@@ -14,6 +14,8 @@
     - "{{ my_etcd_node_certs }}"
 
 - name: Gen_certs | Gather node certs
+  vars:
+    ansible_ssh_retries: 10
   shell: "set -o pipefail && tar cfz - -C {{ etcd_cert_dir }} {{ my_etcd_node_certs | join(' ') }} | base64 --wrap=0"
   args:
     executable: /bin/bash


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This allows the 'Gen_certs | Gather node certs' tasks to work with a forks count > 10 and the default
configuration of sshd, which is to limit multiplexed sessions to 10. (see MaxSessions in sshd_config).

Since this is a delegate_to task, it connects to the same host (first
etcd) for each node in the cluster, thus easily going above 10.

Raising the ssh connection attempts allow for more robustness, without
decreasing the forks count or serialising the tasks, which could slow
the task (or the playbook as a whole, if decreasing forks).


**Which issue(s) this PR fixes**:
Fixes #10514

**Special notes for your reviewer**:

The possible issue I see is if the user has set a ansible_ssh_retries higher that 10 (for whatever reasons).
In this case we will lower this, which could have consequences.
However, I think that is an unlikely scenario, though possible.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
