### PR TITLE
Use calico_pool_blocksize from cluster when existing

### DIFF
--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -232,10 +232,20 @@
           }
 
     - name: Calico | Process calico network pool
-      set_fact:
-        _calico_pool: "{{ _calico_pool_cmd.stdout | from_json | combine(_calico_pool, recursive=True) }}"
       when:
         - _calico_pool_cmd is success
+      block:
+        - name: Calico | Get current calico network pool blocksize
+          set_fact:
+            _calico_blocksize: >
+              {
+                "spec": {
+                  "blockSize": {{ (_calico_pool_cmd.stdout | from_json).spec.blockSize }}
+                }
+              }
+        - name: Calico | Merge calico network pool
+          set_fact:
+            _calico_pool: "{{ _calico_pool_cmd.stdout | from_json | combine(_calico_pool, _calico_blocksize, recursive=True) }}"
 
     - name: Calico | Configure calico network pool
       command:
@@ -273,10 +283,20 @@
           }
 
     - name: Calico | Process calico ipv6 network pool
-      set_fact:
-        _calico_pool_ipv6: "{{ _calico_pool_ipv6_cmd.stdout | from_json | combine(_calico_pool_ipv6, recursive=True) }}"
       when:
         - _calico_pool_ipv6_cmd is success
+      block:
+        - name: Calico | Get current calico ipv6 network pool blocksize
+          set_fact:
+            _calico_blocksize_ipv6: >
+              {
+                "spec": {
+                  "blockSize": {{ (_calico_pool_ipv6_cmd.stdout | from_json).spec.blockSize }}
+                }
+              }
+        - name: Calico | Merge calico ipv6 network pool
+          set_fact:
+            _calico_pool_ipv6: "{{ _calico_pool_ipv6_cmd.stdout | from_json | combine(_calico_pool_ipv6, _calico_blocksize_ipv6, recursive=True) }}"
 
     - name: Calico | Configure calico ipv6 network pool
       command:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

The blockSize attribute from Calico IPPool resources cannot be changed
once set [1]. Consequently, we use the one currently defined when
configuring the existing IPPool, avoiding upgrade errors by trying to
change it.

In particular, this can be useful when calico_pool_blocksize default
changes in kubespray, which would otherwise force users to add an
explicit setting to their inventories.

[1]: https://docs.tigera.io/calico/latest/reference/resources/ippool#spec


**Special notes for your reviewer**:

We faced that problem while upgrading our cluster (to 2.19.1). We have some clusters which have different blockSize (for reasons unclear to me), and while setting the correct value (instead of the default) is not that long, it's still a bit annoying.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[calico] Use calico_pool_blocksize from cluster when existing
```
