### PR TITLE
Correct cilium metrics port mapping

### DIFF
--- a/roles/network_plugin/cilium/templates/hubble/deploy.yml.j2
+++ b/roles/network_plugin/cilium/templates/hubble/deploy.yml.j2
@@ -43,6 +43,11 @@ spec:
           ports:
             - name: grpc
               containerPort: 4245
+{% if cilium_enable_prometheus %}
+            - name: prometheus
+              containerPort: 9966
+              protocol: TCP
+{% endif %}
           readinessProbe:
             tcpSocket:
               port: grpc

--- a/roles/network_plugin/cilium/templates/hubble/service.yml.j2
+++ b/roles/network_plugin/cilium/templates/hubble/service.yml.j2
@@ -8,7 +8,7 @@ metadata:
   namespace: kube-system
   annotations:
     prometheus.io/scrape: 'true'
-    prometheus.io/port: "9091"
+    prometheus.io/port: "{{ cilium_hubble_scrape_port }}"
   labels:
     k8s-app: hubble
 spec:
@@ -31,6 +31,9 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: hubble-relay
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: "9966"
 spec:
   clusterIP: None
   type: ClusterIP


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

 /kind bug

**What this PR does / why we need it**:

Currently the prometheus scrape annotations in metrics services point to wrong ports. 
They point to the service port, but must point to the port exposed on the port, as prometheus queries the pods not the service

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Use correct ports in cilium metrics services if metrics are enabled.
```
