### PR TITLE
terraform-aws: variable driven ami selection

### DIFF
--- a/contrib/terraform/aws/README.md
+++ b/contrib/terraform/aws/README.md
@@ -50,70 +50,32 @@ Example (this one assumes you are using Ubuntu)
 ansible-playbook -i ./inventory/hosts ./cluster.yml -e ansible_user=ubuntu -b --become-user=root --flush-cache
 ```
 
-***Using other distrib than Ubuntu***
-If you want to use another distribution than Ubuntu 18.04 (Bionic) LTS, you can modify the search filters of the 'data "aws_ami" "distro"' in variables.tf.
+## Using other distrib than Ubuntu***
 
-For example, to use:
+To leverage a Linux distribution other than Ubuntu 18.04 (Bionic) LTS for your Terraform configurations, you can adjust the AMI search filters within the 'data "aws_ami" "distro"' block by utilizing variables in your `terraform.tfvars` file. This approach ensures a flexible configuration that adapts to various Linux distributions without directly modifying the core Terraform files.
 
-- Debian Jessie, replace 'data "aws_ami" "distro"' in variables.tf with
+### Example Usages:
 
-```ini
-data "aws_ami" "distro" {
-  most_recent = true
+- **Debian Jessie**: To configure the usage of Debian Jessie, insert the subsequent lines into your `terraform.tfvars`:
 
-  filter {
-    name   = "name"
-    values = ["debian-jessie-amd64-hvm-*"]
-  }
+  ```hcl
+  ami_name_pattern        = "debian-jessie-amd64-hvm-*"
+  ami_owners              = ["379101102735"]
+  ```
 
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
+- **Ubuntu 16.04**: To utilize Ubuntu 16.04 instead, apply the following configuration in your `terraform.tfvars`:
 
-  owners = ["379101102735"]
-}
-```
+  ```hcl
+  ami_name_pattern        = "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-*"
+  ami_owners              = ["099720109477"]
+  ```
 
-- Ubuntu 16.04, replace 'data "aws_ami" "distro"' in variables.tf with
+- **Centos 7**: For employing Centos 7, incorporate these lines into your `terraform.tfvars`:
 
-```ini
-data "aws_ami" "distro" {
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-*"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  owners = ["099720109477"]
-}
-```
-
-- Centos 7, replace 'data "aws_ami" "distro"' in variables.tf with
-
-```ini
-data "aws_ami" "distro" {
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["dcos-centos7-*"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  owners = ["688023202711"]
-}
-```
+  ```hcl
+  ami_name_pattern        = "dcos-centos7-*"
+  ami_owners              = ["688023202711"]
+  ```
 
 ## Connecting to Kubernetes
 

--- a/contrib/terraform/aws/README.md
+++ b/contrib/terraform/aws/README.md
@@ -54,7 +54,7 @@ ansible-playbook -i ./inventory/hosts ./cluster.yml -e ansible_user=ubuntu -b --
 
 To leverage a Linux distribution other than Ubuntu 18.04 (Bionic) LTS for your Terraform configurations, you can adjust the AMI search filters within the 'data "aws_ami" "distro"' block by utilizing variables in your `terraform.tfvars` file. This approach ensures a flexible configuration that adapts to various Linux distributions without directly modifying the core Terraform files.
 
-### Example Usages:
+### Example Usages
 
 - **Debian Jessie**: To configure the usage of Debian Jessie, insert the subsequent lines into your `terraform.tfvars`:
 

--- a/contrib/terraform/aws/variables.tf
+++ b/contrib/terraform/aws/variables.tf
@@ -20,20 +20,38 @@ variable "aws_cluster_name" {
   description = "Name of AWS Cluster"
 }
 
+variable "ami_name_pattern" {
+  description = "The name pattern to use for AMI lookup"
+  type        = string
+  default     = "debian-10-amd64-*"
+}
+
+variable "ami_virtualization_type" {
+  description = "The virtualization type to use for AMI lookup"
+  type        = string
+  default     = "hvm"
+}
+
+variable "ami_owners" {
+  description = "The owners to use for AMI lookup"
+  type        = list(string)
+  default     = ["136693071363"]
+}
+
 data "aws_ami" "distro" {
   most_recent = true
 
   filter {
     name   = "name"
-    values = ["debian-10-amd64-*"]
+    values = [var.ami_name_pattern]
   }
 
   filter {
     name   = "virtualization-type"
-    values = ["hvm"]
+    values = [var.ami_virtualization_type]
   }
 
-  owners = ["136693071363"] # Debian-10
+  owners = var.ami_owners
 }
 
 //AWS VPC Variables


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:

This PR enhances the AMI selection mechanism by making it variable-driven, enabling users to specify AMI filters directly through variables, thereby improving usability and customization. It aims to provide more flexibility to the users in selecting various AMIs for different distributions without altering the main Terraform files.

- **Variables Driven AMI**: Users can now specify `ami_name_pattern`, `ami_owners` and `ami_virtualization_type` through variables, enhancing configurability.
- **Documentation Update**: The README is updated to guide users on how to utilize this new variable-driven AMI selection method.

**Which issue(s) this PR fixes**:
**Special notes for reviewers**:

The `variables.tf` file is modified to accept `ami_name_pattern`, `ami_owners` and `ami_virtualization_type` as variables, ensuring that users can specify their preferred AMI without altering main files. This change is backward compatible as it keeps default values in line with the existing hardcoded configuration, ensuring no disruption for users who wish to continue using the existing method.

The README has been updated to reflect these changes and guide users on how to apply them. It provides examples and outlines the step-by-step method for specifying AMI attributes through variables.

Your feedback and insights regarding this implementation and its impact on the user experience would be highly valued.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
terraform-aws: variable driven ami selection (`ami_name_pattern`/`ami_virtualization_type`/`ami_owners`)
```