### PR TITLE
Add helm support for custom_cni deployment

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -260,6 +260,11 @@ packet_debian11-kubelet-csr-approver:
   extends: .packet_pr
   when: manual
 
+packet_debian12-custom-cni-helm:
+  stage: deploy-part2
+  extends: .packet_pr
+  when: manual
+
 # ### PR JOBS PART3
 # Long jobs (45min+)
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -11,7 +11,7 @@ amazon |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 centos7 |  :white_check_mark: | :x: | :x: | :white_check_mark: | :x: | :white_check_mark: | :x: | :white_check_mark: |
 debian10 |  :white_check_mark: | :white_check_mark: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: |
 debian11 |  :white_check_mark: | :x: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
-debian12 |  :white_check_mark: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
+debian12 |  :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
 fedora37 |  :white_check_mark: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x: |
 fedora38 |  :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x: | :x: |
 opensuse |  :x: | :x: | :x: | :x: | :x: | :x: | :x: | :x: |

--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-custom-cni.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-custom-cni.yml
@@ -1,0 +1,51 @@
+---
+# custom_cni network plugin configuration
+# There are two deployment options to choose from, select one
+
+## OPTION 1 - Static manifest files
+## With this option, referred manifest file will be deployed
+## as if the `kubectl apply -f` method was used with it.
+#
+## List of Kubernetes resource manifest files
+## See tests/files/custom_cni/README.md for example
+# custom_cni_manifests: []
+
+## OPTION 1 EXAMPLE - Cilium static manifests in Kubespray tree
+# custom_cni_manifests:
+#   - "{{ playbook_dir }}/../tests/files/custom_cni/cilium.yaml"
+
+## OPTION 2 - Helm chart application
+## This allows the CNI backend to be deployed to Kubespray cluster
+## as common Helm application.
+#
+## Helm release name - how the local instance of deployed chart will be named
+# custom_cni_chart_release_name: ""
+#
+## Kubernetes namespace to deploy into
+# custom_cni_chart_namespace: "kube-system"
+#
+## Helm repository name - how the local record of Helm repository will be named
+# custom_cni_chart_repository_name: ""
+#
+## Helm repository URL
+# custom_cni_chart_repository_url: ""
+#
+## Helm chart reference - path to the chart in the repository
+# custom_cni_chart_ref: ""
+#
+## Helm chart version
+# custom_cni_chart_version: ""
+#
+## Custom Helm values to be used for deployment
+# custom_cni_chart_values: ""
+
+## OPTION 2 EXAMPLE - Cilium deployed from official public Helm chart
+# custom_cni_chart_namespace: "kube-system"
+# custom_cni_chart_release_name: "cilium"
+# custom_cni_chart_repository_name: "cilium"
+# custom_cni_chart_repository_url: "https://helm.cilium.io"
+# custom_cni_chart_ref: "cilium/cilium"
+# custom_cni_chart_version: "1.14.2"
+# custom_cni_chart_values: |-
+#   cluster:
+#     name: "cilium-demo"

--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-custom-cni.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-custom-cni.yml
@@ -37,15 +37,15 @@
 # custom_cni_chart_version: ""
 #
 ## Custom Helm values to be used for deployment
-# custom_cni_chart_values: ""
+# custom_cni_chart_values: {}
 
 ## OPTION 2 EXAMPLE - Cilium deployed from official public Helm chart
-# custom_cni_chart_namespace: "kube-system"
-# custom_cni_chart_release_name: "cilium"
-# custom_cni_chart_repository_name: "cilium"
-# custom_cni_chart_repository_url: "https://helm.cilium.io"
-# custom_cni_chart_ref: "cilium/cilium"
-# custom_cni_chart_version: "1.14.2"
-# custom_cni_chart_values: |-
+# custom_cni_chart_namespace: kube-system
+# custom_cni_chart_release_name: cilium
+# custom_cni_chart_repository_name: cilium
+# custom_cni_chart_repository_url: https://helm.cilium.io
+# custom_cni_chart_ref: cilium/cilium
+# custom_cni_chart_version: 1.14.3
+# custom_cni_chart_values:
 #   cluster:
 #     name: "cilium-demo"

--- a/roles/network_plugin/custom_cni/defaults/main.yml
+++ b/roles/network_plugin/custom_cni/defaults/main.yml
@@ -6,6 +6,6 @@ custom_cni_chart_namespace: kube-system
 custom_cni_chart_release_name: ""
 custom_cni_chart_repository_name: ""
 custom_cni_chart_repository_url: ""
-custom_cni_chart_ref: "{{ custom_cni_chart_repository_name }}/"
+custom_cni_chart_ref: ""
 custom_cni_chart_version: ""
 custom_cni_chart_values: ""

--- a/roles/network_plugin/custom_cni/defaults/main.yml
+++ b/roles/network_plugin/custom_cni/defaults/main.yml
@@ -1,3 +1,11 @@
 ---
 
 custom_cni_manifests: []
+
+custom_cni_chart_namespace: kube-system
+custom_cni_chart_release_name: ""
+custom_cni_chart_repository_name: ""
+custom_cni_chart_repository_url: ""
+custom_cni_chart_ref: "{{ custom_cni_chart_repository_name }}/"
+custom_cni_chart_version: ""
+custom_cni_chart_values: ""

--- a/roles/network_plugin/custom_cni/defaults/main.yml
+++ b/roles/network_plugin/custom_cni/defaults/main.yml
@@ -8,4 +8,4 @@ custom_cni_chart_repository_name: ""
 custom_cni_chart_repository_url: ""
 custom_cni_chart_ref: ""
 custom_cni_chart_version: ""
-custom_cni_chart_values: ""
+custom_cni_chart_values: {}

--- a/roles/network_plugin/custom_cni/meta/main.yml
+++ b/roles/network_plugin/custom_cni/meta/main.yml
@@ -1,0 +1,19 @@
+dependencies:
+  - role: helm-apps
+    when:
+      - inventory_hostname == groups['kube_control_plane'][0]
+      - custom_cni_chart_release_name | length > 0
+    environment:
+      http_proxy: "{{ http_proxy | default('') }}"
+      https_proxy: "{{ https_proxy | default('') }}"
+    release_common_opts: {}
+    releases:
+      - name: "{{ custom_cni_chart_release_name }}"
+        namespace: "{{ custom_cni_chart_namespace }}"
+        chart_ref: "{{ custom_cni_chart_ref }}"
+        chart_version: "{{ custom_cni_chart_version }}"
+        wait: true
+        values: "{{ custom_cni_chart_values }}"
+    repositories:
+      - name: "{{ custom_cni_chart_repository_name }}"
+        url: "{{ custom_cni_chart_repository_url }}"

--- a/roles/network_plugin/custom_cni/meta/main.yml
+++ b/roles/network_plugin/custom_cni/meta/main.yml
@@ -1,3 +1,4 @@
+---
 dependencies:
   - role: helm-apps
     when:

--- a/roles/network_plugin/custom_cni/tasks/main.yml
+++ b/roles/network_plugin/custom_cni/tasks/main.yml
@@ -4,7 +4,7 @@
   - name: Custom CNI | Check Custom CNI Manifests
     assert:
       that:
-        - "custom_cni_manifests | length > 0"
+      - "custom_cni_manifests | length > 0"
       msg: "custom_cni_manifests should not be empty"
 
   - name: Custom CNI | Copy Custom manifests

--- a/roles/network_plugin/custom_cni/tasks/main.yml
+++ b/roles/network_plugin/custom_cni/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: Custom CNI | Manifest deployment
+  when: not custom_cni_chart_release_name | length > 0
   block:
   - name: Custom CNI | Check Custom CNI Manifests
     assert:
@@ -26,4 +27,3 @@
     loop: "{{ custom_cni_manifests }}"
     delegate_to: "{{ groups['kube_control_plane'] | first }}"
     run_once: true
-  when: not custom_cni_chart_release_name | length > 0

--- a/roles/network_plugin/custom_cni/tasks/main.yml
+++ b/roles/network_plugin/custom_cni/tasks/main.yml
@@ -1,26 +1,29 @@
 ---
-- name: Custom CNI | Check Custom CNI Manifests
-  assert:
-    that:
-      - "custom_cni_manifests | length > 0"
-    msg: "custom_cni_manifests should not be empty"
+- name: Custom CNI | Manifest deployment
+  block:
+  - name: Custom CNI | Check Custom CNI Manifests
+    assert:
+      that:
+        - "custom_cni_manifests | length > 0"
+      msg: "custom_cni_manifests should not be empty"
 
-- name: Custom CNI | Copy Custom manifests
-  template:
-    src: "{{ item }}"
-    dest: "{{ kube_config_dir }}/{{ item | basename | replace('.j2', '') }}"
-    mode: 0644
-  loop: "{{ custom_cni_manifests }}"
-  delegate_to: "{{ groups['kube_control_plane'] | first }}"
-  run_once: true
+  - name: Custom CNI | Copy Custom manifests
+    template:
+      src: "{{ item }}"
+      dest: "{{ kube_config_dir }}/{{ item | basename | replace('.j2', '') }}"
+      mode: 0644
+    loop: "{{ custom_cni_manifests }}"
+    delegate_to: "{{ groups['kube_control_plane'] | first }}"
+    run_once: true
 
-- name: Custom CNI | Start Resources
-  kube:
-    namespace: "kube-system"
-    kubectl: "{{ bin_dir }}/kubectl"
-    filename: "{{ kube_config_dir }}/{{ item | basename | replace('.j2', '') }}"
-    state: "latest"
-    wait: true
-  loop: "{{ custom_cni_manifests }}"
-  delegate_to: "{{ groups['kube_control_plane'] | first }}"
-  run_once: true
+  - name: Custom CNI | Start Resources
+    kube:
+      namespace: "kube-system"
+      kubectl: "{{ bin_dir }}/kubectl"
+      filename: "{{ kube_config_dir }}/{{ item | basename | replace('.j2', '') }}"
+      state: "latest"
+      wait: true
+    loop: "{{ custom_cni_manifests }}"
+    delegate_to: "{{ groups['kube_control_plane'] | first }}"
+    run_once: true
+  when: not custom_cni_chart_release_name | length > 0

--- a/tests/files/packet_debian12-custom-cni-helm.yml
+++ b/tests/files/packet_debian12-custom-cni-helm.yml
@@ -4,6 +4,7 @@ cloud_image: debian-12
 mode: default
 
 # Kubespray settings
+kube_owner: root
 kube_network_plugin: custom_cni
 custom_cni_chart_namespace: kube-system
 custom_cni_chart_release_name: cilium
@@ -14,3 +15,8 @@ custom_cni_chart_version: 1.14.3
 custom_cni_chart_values:
   cluster:
     name: kubespray
+  hubble:
+    enabled: false
+  ipam:
+    operator:
+      clusterPoolIPv4PodCIDR: "{{ kube_pods_subnet }}"

--- a/tests/files/packet_debian12-custom-cni-helm.yml
+++ b/tests/files/packet_debian12-custom-cni-helm.yml
@@ -19,4 +19,5 @@ custom_cni_chart_values:
     enabled: false
   ipam:
     operator:
-      clusterPoolIPv4PodCIDR: "{{ kube_pods_subnet }}"
+      clusterPoolIPv4PodCIDRList:
+        - "{{ kube_pods_subnet }}"

--- a/tests/files/packet_debian12-custom-cni-helm.yml
+++ b/tests/files/packet_debian12-custom-cni-helm.yml
@@ -9,6 +9,8 @@ custom_cni_chart_namespace: kube-system
 custom_cni_chart_release_name: cilium
 custom_cni_chart_repository_name: cilium
 custom_cni_chart_repository_url: https://helm.cilium.io
-custom_cni_chart_ref: "cilium/cilium"
-custom_cni_chart_version: "1.14.2"
-custom_cni_chart_values: ""
+custom_cni_chart_ref: cilium/cilium
+custom_cni_chart_version: 1.14.3
+custom_cni_chart_values:
+  cluster:
+    name: kubespray

--- a/tests/files/packet_debian12-custom-cni-helm.yml
+++ b/tests/files/packet_debian12-custom-cni-helm.yml
@@ -1,0 +1,14 @@
+---
+# Instance settings
+cloud_image: debian-12
+mode: default
+
+# Kubespray settings
+kube_network_plugin: custom_cni
+custom_cni_chart_namespace: kube-system
+custom_cni_chart_release_name: cilium
+custom_cni_chart_repository_name: cilium
+custom_cni_chart_repository_url: https://helm.cilium.io
+custom_cni_chart_ref: "cilium/cilium"
+custom_cni_chart_version: "1.14.2"
+custom_cni_chart_values: ""


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add option to deploy **custom_cni** type of network backend using helm chart.

There is already manifest based method of custom network backend deployment implemented. Some backend providers (eg. Cilium) offer helm charts of their applications and prefer those for deployment and following upgrades. This change adds such exclusive option in addition to the existing manifest one.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
