### PR TITLE
Migrate node-role.kubernetes.io/master to node-role.kubernetes.io/control-plane

### DIFF
--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -243,7 +243,6 @@
   command: "{{ kubectl }} taint node {{ inventory_hostname }} {{ item }}"
   delegate_to: "{{ first_kube_control_plane }}"
   with_items:
-    - "node-role.kubernetes.io/master:NoSchedule-"
     - "node-role.kubernetes.io/control-plane:NoSchedule-"
   when: inventory_hostname in groups['kube_node']
   failed_when: false

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
@@ -19,8 +19,6 @@ nodeRegistration:
 {% if inventory_hostname in groups['kube_control_plane'] and inventory_hostname not in groups['kube_node'] %}
   taints:
   - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-  - effect: NoSchedule
     key: node-role.kubernetes.io/control-plane
 {% else %}
   taints: []

--- a/roles/kubernetes/control-plane/templates/kubeadm-controlplane.v1beta3.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-controlplane.v1beta3.yaml.j2
@@ -22,8 +22,6 @@ nodeRegistration:
 {% if inventory_hostname in groups['kube_control_plane'] and inventory_hostname not in groups['kube_node'] %}
   taints:
   - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-  - effect: NoSchedule
     key: node-role.kubernetes.io/control-plane
 {% else %}
   taints: []

--- a/roles/upgrade/post-upgrade/tasks/main.yml
+++ b/roles/upgrade/post-upgrade/tasks/main.yml
@@ -11,6 +11,15 @@
     --timeout={{ upgrade_post_cilium_wait_timeout }}
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
 
+- name: Ensure control-plane taints after upgrade
+  command: "{{ kubectl }} taint --overwrite node {{ kube_override_hostname|default(inventory_hostname) }} {{ item }}"
+  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  with_items:
+    - "node-role.kubernetes.io/control-plane:NoSchedule"
+  when:
+    - inventory_hostname in groups['kube_control_plane']
+    - inventory_hostname not in groups['kube_node']
+
 - name: Confirm node uncordon
   pause:
     echo: yes

--- a/roles/upgrade/post-upgrade/tasks/main.yml
+++ b/roles/upgrade/post-upgrade/tasks/main.yml
@@ -11,15 +11,6 @@
     --timeout={{ upgrade_post_cilium_wait_timeout }}
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
 
-- name: Ensure control-plane taints after upgrade
-  command: "{{ kubectl }} taint --overwrite node {{ kube_override_hostname|default(inventory_hostname) }} {{ item }}"
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
-  with_items:
-    - "node-role.kubernetes.io/control-plane:NoSchedule"
-  when:
-    - inventory_hostname in groups['kube_control_plane']
-    - inventory_hostname not in groups['kube_node']
-
 - name: Confirm node uncordon
   pause:
     echo: yes

--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -46,6 +46,31 @@
       false
       {%- endif %}
 
+# Legacy taint: key = node-role.kubernetes.io/master, effect = NoSchedule
+# New taint: key = node-role.kubernetes.io/control-plane, effect = NoSchedule
+#
+# During the upgrade to k8s v1.25 legacy taint is deleted:
+#   https://github.com/kubernetes/kubernetes/commit/ddd046f3dd88186cbc83b57e83144db96eae4af4
+#
+# In order to avoid taint lost we need to ensure node-role.kubernetes.io/control-plane:NoSchedule
+# if node-role.kubernetes.io/master:NoSchedule is set prior to k8s upgrade
+- name: See if node has legacy taints
+  command: >
+    {{ kubectl }} get node {{ kube_override_hostname | default(inventory_hostname) }}
+    -o jsonpath='{.spec.taints[?(@.key=="node-role.kubernetes.io/master")]}'
+  register: kubectl_node_legacy_taints
+  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  failed_when: false
+  changed_when: false
+
+- name: Migrate node legacy taints
+  command: >
+    {{ kubectl }} taint --overwrite node {{ kube_override_hostname | default(inventory_hostname) }}
+    node-role.kubernetes.io/control-plane:NoSchedule
+  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  when:
+    - kubectl_node_legacy_taints.stdout | length
+
 - name: Node draining
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
   when:


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Since kubeadm 1.25, legacy `control-plane` taints are deleted:

https://github.com/kubernetes/kubernetes/commit/ddd046f3dd88186cbc83b57e83144db96eae4af4

This PR aligns `control-plane` taints definitions and ensure that taints are not lost during upgrade.

**Which issue(s) this PR fixes**:
Fixes #10217

**Special notes for your reviewer**:

After debating with @MrFreezeex in https://github.com/kubernetes-sigs/kubespray/pull/10464 we came to the conclusion that we should ensure the following:

> - `master`: Just keep in the changes in the `kubeadm` configuration files to remove the legacy taint in fresh installations. Also we can include the changes suggested in https://github.com/kubernetes-sigs/kubespray/pull/10464#issuecomment-1758395518 since every cluster installed using the future 2.24.X won't have the legacy taint and every cluster upgraded using the future 2.24.X will be already with k8s 1.25.
> 
> - `release-2.23`: Include the option to enforcing the control plane taint in order to avoid missing all control plane taints if upgrading to k8s 1.25. In this case we can tune this PR in orde to avoid this change of behavior about force tainting any node during the upgrade.  Also, as you have said, I think is a good idea mentioning the users that have already upgraded their clusters to k8s v1.25 to check their control plane taints, since it can be already missing. Also I think the best idea is to delegate them the operation to re-added manually.

This PR tries to accomplish the `release-2.23` requirements.

**Does this PR introduce a user-facing change?**:
```release-note
Migrate node-role.kubernetes.io/master to node-role.kubernetes.io/control-plane
```