### PR TITLE
`remove_default_searchdomains` inconsistent default value

### DIFF
--- a/roles/kubernetes/preinstall/templates/resolved.conf.j2
+++ b/roles/kubernetes/preinstall/templates/resolved.conf.j2
@@ -5,10 +5,10 @@
 DNS={{ ([nodelocaldns_ip] if enable_nodelocaldns else coredns_server )| list | join(' ') }}
 {% endif %}
 FallbackDNS={{ ( upstream_dns_servers|d([]) + nameservers|d([]) + cloud_resolver|d([])) | unique | join(' ') }}
-{% if remove_default_searchdomains is sameas false or (remove_default_searchdomains is sameas true and searchdomains|default([])|length==0)%}
-Domains={{ ([ 'default.svc.' + dns_domain, 'svc.' + dns_domain ] + searchdomains|default([])) | join(' ') }}
-{% else %}
+{% if remove_default_searchdomains is sameas true and searchdomains|default([])|length != 0 %}
 Domains={{ searchdomains|default([]) | join(' ') }}
+{% else %}
+Domains={{ ([ 'default.svc.' + dns_domain, 'svc.' + dns_domain ] + searchdomains|default([])) | join(' ') }}
 {% endif %}
 #LLMNR=no
 #MulticastDNS=no


### PR DESCRIPTION
**What type of PR is this?**

 /kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9948

**Special notes for your reviewer**:

when `remove_default_searchdomains ` is undefined

```yaml
# remove_default_searchdomains: false
```

In ansible, default value is false .

```yaml
- name: set default dns if remove_default_searchdomains is false
  set_fact:
    default_searchdomains: ["default.svc.{{ dns_domain }}", "svc.{{ dns_domain }}"]
  when: not remove_default_searchdomains|default()|bool or (remove_default_searchdomains|default()|bool and searchdomains|default([])|length==0)
```

In Jinja, if undefined, it does not match `remove_default_searchdomains is sameas false`, and the default value is true.

```j2
{% if remove_default_searchdomains is sameas false or (remove_default_searchdomains is sameas true and searchdomains|default([])|length==0)%}
Domains={{ ([ 'default.svc.' + dns_domain, 'svc.' + dns_domain ] + searchdomains|default([])) | join(' ') }}
{% else %}
Domains={{ searchdomains|default([]) | join(' ') }}
{% endif %}
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Correctly handle remove_default_searchdomains  when value is undefined
```
