### PR TITLE
etcd/backup: native ansible modules instead of shell

### DIFF
--- a/roles/etcd/handlers/backup_cleanup.yml
+++ b/roles/etcd/handlers/backup_cleanup.yml
@@ -2,11 +2,21 @@
 - name: Cleanup etcd backups
   command: /bin/true
   notify:
+    - Find old etcd backups
     - Remove old etcd backups
 
+- name: Find old etcd backups
+  ansible.builtin.find:
+    file_type: directory
+    recurse: false
+    paths: "{{ etcd_backup_prefix }}"
+    patterns: "etcd-*"
+  register: _etcd_backups
+  when: etcd_backup_retention_count >= 0
+
 - name: Remove old etcd backups
-  shell:
-    chdir: "{{ etcd_backup_prefix }}"
-    cmd: "set -o pipefail && find . -name 'etcd-*' -type d | sort -n | head -n -{{ etcd_backup_retention_count }} | xargs rm -rf"
-    executable: /bin/bash
+  ansible.builtin.file:
+    state: absent
+    path: "{{ item }}"
+  loop: "{{ (_etcd_backups.files | sort(attribute='ctime', reverse=True))[etcd_backup_retention_count:] | map(attribute='path') }}"
   when: etcd_backup_retention_count >= 0


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

This make native ansible features (dry-run, changed state) easier to
have, and should have a minimal performance impact, since it only runs
on the etcd members.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
etcd/backup: use native ansible modules instead of shell
```
