### PR TITLE
Metallb --lb-class cmd arg to support multiple LoadBalancer implementations

### DIFF
--- a/roles/kubernetes-apps/metallb/defaults/main.yml
+++ b/roles/kubernetes-apps/metallb/defaults/main.yml
@@ -13,3 +13,4 @@ metallb_speaker_tolerations:
     key: node-role.kubernetes.io/control-plane
     operator: Exists
 metallb_controller_tolerations: []
+metallb_loadbalancer_class: ""

--- a/roles/kubernetes-apps/metallb/templates/metallb.yaml.j2
+++ b/roles/kubernetes-apps/metallb/templates/metallb.yaml.j2
@@ -1724,8 +1724,8 @@ spec:
       - args:
         - --port={{ metallb_port }}
         - --log-level={{ metallb_log_level }}
-{% if 'loadbalancer_class' in metallb_config.keys() and metallb_config.loadbalancer_class != "" %}
-        - --lb-class={{ metallb_config.loadbalancer_class }}
+{% if metallb_loadbalancer_class != "" %}
+        - --lb-class={{ metallb_loadbalancer_class }}
 {% endif %}
         env:
         - name: METALLB_ML_SECRET_NAME
@@ -1817,8 +1817,8 @@ spec:
       - args:
         - --port={{ metallb_port }}
         - --log-level={{ metallb_log_level }}
-{% if 'loadbalancer_class' in metallb_config.keys() and metallb_config.loadbalancer_class != "" %}
-        - --lb-class={{ metallb_config.loadbalancer_class }}
+{% if metallb_loadbalancer_class != "" %}
+        - --lb-class={{ metallb_loadbalancer_class }}
 {% endif %}
         env:
         - name: METALLB_NODE_NAME

--- a/roles/kubernetes-apps/metallb/templates/metallb.yaml.j2
+++ b/roles/kubernetes-apps/metallb/templates/metallb.yaml.j2
@@ -1724,6 +1724,9 @@ spec:
       - args:
         - --port={{ metallb_port }}
         - --log-level={{ metallb_log_level }}
+{% if 'loadbalancer_class' in metallb_config.keys() and metallb_config.loadbalancer_class != "" %}
+        - --lb-class={{ metallb_config.loadbalancer_class }}
+{% endif %}
         env:
         - name: METALLB_ML_SECRET_NAME
           value: memberlist
@@ -1814,6 +1817,9 @@ spec:
       - args:
         - --port={{ metallb_port }}
         - --log-level={{ metallb_log_level }}
+{% if 'loadbalancer_class' in metallb_config.keys() and metallb_config.loadbalancer_class != "" %}
+        - --lb-class={{ metallb_config.loadbalancer_class }}
+{% endif %}
         env:
         - name: METALLB_NODE_NAME
           valueFrom:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
In this PR, I tried using the new Metallb feature (effective from version 0.13.2), which is the ability to specify the --lb-class command line argument. This argument instructs MetalLB to listen exclusively for the loadBalancerClass defined in the .spec.loadBalancerClass of the LoadBalancer manifest. 

In my scenario, this enhancement is very beneficial as I'm operating a cluster with multiple controllers that have the capability to monitor and manage the LoadBalancer service. Among these controllers are the cloud controller provided by my cloud provider and MetalLB respectively. 

With this little change, I have configured MetalLB to strictly monitor a specific type of LoadBalancer, while delegating the management of all other LoadBalancer entities to the cloud controller.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Not related to any particular issue

**Special notes for your reviewer**:
Thank you for your hard work! Version 2.23.0 is functioning smoothly. I'd really like to be able to specify loadBalancerClass in future releases
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Metallb --lb-class cmd arg to support multiple LoadBalancer implementations 
```
