### PR TITLE
Remove always tag applied on bootstrap

### DIFF
--- a/playbooks/cluster.yml
+++ b/playbooks/cluster.yml
@@ -14,7 +14,6 @@
     - { role: bastion-ssh-config, tags: ["localhost", "bastion"] }
 
 - name: Gather facts
-  tags: always
   import_playbook: facts.yml
 
 - name: Prepare for etcd install

--- a/playbooks/scale.yml
+++ b/playbooks/scale.yml
@@ -14,7 +14,6 @@
     - { role: bastion-ssh-config, tags: ["localhost", "bastion"] }
 
 - name: Gather facts
-  tags: always
   import_playbook: facts.yml
 
 - name: Generate the etcd certificates beforehand

--- a/playbooks/upgrade_cluster.yml
+++ b/playbooks/upgrade_cluster.yml
@@ -14,7 +14,6 @@
     - { role: bastion-ssh-config, tags: ["localhost", "bastion"] }
 
 - name: Gather facts
-  tags: always
   import_playbook: facts.yml
 
 - name: Download images to ansible host cache via first kube_control_plane node


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

In PR #10069, Add bootstrap in facts.yaml. The `Gather facts` task already has `always` tag.

```yaml
- name: Gather facts
  hosts: k8s_cluster:etcd:calico_rr
  gather_facts: False
  tags: always
```

It seems that adding the `always` tag to the `bootstrap` task may not be necessary.
For example, this is a test for updating all add-ons .

```bash
ansible-playbook -b -i inventory/sample/hosts.ini cluster.yml --tags=apps
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Remove always tag applied on bootstrap
```
