### PR TITLE
add pdb to coredns

### DIFF
--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -18,6 +18,11 @@ coredns_default_zone_cache_block: |
   cache 30
 coredns_host_network: false
 coredns_port: 53
+
+coredns_pod_disruption_budget: false
+# value for coredns pdb
+coredns_pod_disruption_budget_max_unavailable: "30%"
+
 # coredns_additional_configs adds any extra configuration to coredns
 # coredns_additional_configs: |
 #   whoami

--- a/roles/kubernetes-apps/ansible/tasks/coredns.yml
+++ b/roles/kubernetes-apps/ansible/tasks/coredns.yml
@@ -14,6 +14,7 @@
     - { name: dns-autoscaler, file: dns-autoscaler.yml, type: deployment }
     - { name: dns-autoscaler, file: dns-autoscaler-clusterrole.yml, type: clusterrole }
     - { name: dns-autoscaler, file: dns-autoscaler-clusterrolebinding.yml, type: clusterrolebinding }
+    - { name: coredns, file: coredns-poddisruptionbudget.yml, type: poddisruptionbudget, condition: coredns_pod_disruption_budget }
     - { name: dns-autoscaler, file: dns-autoscaler-sa.yml, type: sa }
   register: coredns_manifests
   vars:
@@ -22,6 +23,7 @@
     - dns_mode in ['coredns', 'coredns_dual']
     - inventory_hostname == groups['kube_control_plane'][0]
     - enable_dns_autoscaler or item.name != 'dns-autoscaler'
+    - item.condition | default(True)
   tags:
     - coredns
 
@@ -34,6 +36,7 @@
     - { name: coredns, src: coredns-deployment.yml, file: coredns-deployment-secondary.yml, type: deployment }
     - { name: coredns, src: coredns-svc.yml, file: coredns-svc-secondary.yml, type: svc }
     - { name: dns-autoscaler, src: dns-autoscaler.yml, file: coredns-autoscaler-secondary.yml, type: deployment }
+    - { name: coredns, file: coredns-poddisruptionbudget.yml, type: poddisruptionbudget, condition: coredns_pod_disruption_budget }
   register: coredns_secondary_manifests
   vars:
     clusterIP: "{{ skydns_server_secondary }}"
@@ -42,5 +45,6 @@
     - dns_mode == 'coredns_dual'
     - inventory_hostname == groups['kube_control_plane'][0]
     - enable_dns_autoscaler or item.name != 'dns-autoscaler'
+    - item.condition | default(True)
   tags:
     - coredns

--- a/roles/kubernetes-apps/ansible/templates/coredns-poddisruptionbudget.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-poddisruptionbudget.yml.j2
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: coredns{{ coredns_ordinal_suffix }}
+spec:
+  maxUnavailable: {{ coredns_pod_disruption_budget_max_unavailable }}
+  selector:
+    matchLabels:
+      k8s-app: kube-dns{{ coredns_ordinal_suffix }}


### PR DESCRIPTION
What type of PR is this?

/kind feature

What this PR does / why we need it:
This PR introduces changes to enhance CoreDNS. The following modifications have been made:

- Introduced the `coredns_pod_disruption_budget` variable to enable/disable PodDisruptionBudget for CoreDNS.
- Set the default value of `coredns_pod_disruption_budget` to `false`.
- Added the `coredns_pod_disruption_budget_max_unavailable` variable to specify the maximum number of unavailable pods during disruptions. The default value is set to `1`.
- Created a new template `coredns-poddisruptionbudget.yml.j2` to generate the corresponding PodDisruptionBudget YAML file with configurable options.

These changes provide users with more control over CoreDNS's behavior during disruptions and enable fine-grained tuning of the PodDisruptionBudget settings.

Which issue(s) this PR fixes:
NONE

Special notes for your reviewer:
NONE

Does this PR introduce a user-facing change?:
```release-note
Add pdb to coredns
```
