### PR TITLE
Cherry-pick:  [download] Don't fail on 304 Not Modified (#10452) 

### DIFF
--- a/roles/download/tasks/download_file.yml
+++ b/roles/download/tasks/download_file.yml
@@ -101,7 +101,9 @@
     run_once: "{{ download_force_cache }}"
     register: get_url_result
     become: "{{ not download_localhost }}"
-    until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
+    until: "'OK' in get_url_result.msg or
+      'file already exists' in get_url_result.msg or
+      get_url_result.status_code == 304"
     retries: "{{ download_retries }}"
     delay: "{{ retry_stagger | default(5) }}"
     environment: "{{ proxy_env }}"


### PR DESCRIPTION
Cherry pick of https://github.com/kubernetes-sigs/kubespray/pull/10452


**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
backport a fix: If a file is already downloaded, the [timestamp of the file](https://github.com/ansible/ansible/blob/710c0a264e776f9824cdedc40df17383ba3fe40e/lib/ansible/modules/get_url.py#L600-L602) is sent to the server which returns 304 Not Modified. Before this PR, this was considered as a failure.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Asked in https://github.com/kubernetes-sigs/kubespray/issues/10555

**Does this PR introduce a user-facing change?**:
```release-note
None
```
