### PR TITLE
Check nameserver only when dns is enable

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-set_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-set_facts.yml
@@ -91,6 +91,7 @@
     - configured_nameservers is defined
     - not (upstream_dns_servers is defined and upstream_dns_servers | length > 0)
     - not (disable_host_nameservers | default(false))
+    - dns_mode in ['coredns', 'coredns_dual']
 
 - name: NetworkManager | Check if host has NetworkManager
   # noqa command-instead-of-module - Should we use service_facts for this?


### PR DESCRIPTION
**What type of PR is this?**

 /kind bug

**What this PR does / why we need it**:

In PR #9502, Add a check for non-empty nameservers in /etc/resolv.conf for CoreDNS. 
Should not check when `dns_mode` is set to `manual` or `none`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Check nameserver only when dns is enable
```
