### PR TITLE
[release-2.23] Change default cri-o versions for Kubernetes 1.25, 1.26

### DIFF
--- a/roles/download/defaults/main/main.yml
+++ b/roles/download/defaults/main/main.yml
@@ -146,8 +146,8 @@ crictl_version: "{{ crictl_supported_versions[kube_major_version] }}"
 
 crio_supported_versions:
   v1.27: v1.27.1
-  v1.26: v1.26.3
-  v1.25: v1.25.3
+  v1.26: v1.26.4
+  v1.25: v1.25.4
 crio_version: "{{ crio_supported_versions[kube_major_version] }}"
 
 yq_version: "v4.35.1"


### PR DESCRIPTION
 **What type of PR is this?** 

/kind flake
 
 **What this PR does / why we need it**: 
Update cri-o versions for Kubernetes 1.25, 1.26

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

``` release-note
cri-o versions for Kubernetes 1.25, 1.26
```
