### PR TITLE
Add crictl 1.26.1 for Kubernetes v1.26

### DIFF
--- a/roles/download/defaults/main/main.yml
+++ b/roles/download/defaults/main/main.yml
@@ -141,7 +141,7 @@ etcd_version: "{{ etcd_supported_versions[kube_major_version] }}"
 crictl_supported_versions:
   v1.28: "v1.28.0"
   v1.27: "v1.27.1"
-  v1.26: "v1.26.0"
+  v1.26: "v1.26.1"
 crictl_version: "{{ crictl_supported_versions[kube_major_version] }}"
 
 crio_supported_versions:


### PR DESCRIPTION
 **What type of PR is this?** 

/kind flake
 
 **What this PR does / why we need it**: 
Update crictl to version v1.26.1 for Kubernetes 1.26
This patch release is fixing [CVE-2022-41723](https://github.com/advisories/GHSA-vvpx-j8f3-3w6h)
Release notes here: https://github.com/kubernetes-sigs/cri-tools/releases/tag/v1.26.1

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

``` release-note
Update crictl to version v1.26.1 for Kubernetes 1.26
```
