### PR TITLE
[release-2.23] [ingress-nginx] Fix nginx controller leader election RBAC permissions

### DIFF
--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
@@ -48,6 +48,7 @@ spec:
           args:
             - /nginx-ingress-controller
             - --configmap=$(POD_NAMESPACE)/ingress-nginx
+            - --election-id=ingress-controller-leader-{{ ingress_nginx_class }}
             - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-services
             - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
             - --annotations-prefix=nginx.ingress.kubernetes.io

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/role-ingress-nginx.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/role-ingress-nginx.yml.j2
@@ -28,23 +28,17 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
-    # Defaults to "<election-id>-<ingress-class>"
-    # Here: "<ingress-controller-leader>-<nginx>"
-    # This has to be adapted if you change either parameter
-    # when launching the nginx-ingress-controller.
+    # Defaults to "<election-id>", defined in 
+    # ds-ingress-nginx-controller.yml.js
+    # by a command-line argument.
+    # 
+    # This is the correct behaviour for ingress-controller
+    # version 1.8.1
     resourceNames: ["ingress-controller-leader-{{ ingress_nginx_class }}"]
     verbs: ["get", "update"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    # Defaults to "<election-id>-<ingress-class>"
-    # Here: "<ingress-controller-leader>-<nginx>"
-    # This has to be adapted if you change either parameter
-    # when launching the nginx-ingress-controller.
-    resourceNames: ["ingress-controller-leader-{{ ingress_nginx_class }}"]
-    verbs: ["get", "update"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["create"]


### PR DESCRIPTION
 **What type of PR is this?** 

/kind bug
 
 **What this PR does / why we need it**: 
cherry-pick of https://github.com/kubernetes-sigs/kubespray/pull/10282
Under the original code, leader election failed for ingress controllers as a result of mismatch between election-id in the controller config, and the resourceName in the relevant rule of role 'ingress-nginx'. This appeared in the contoller logs.

To fix the issue, a command-line option was added to container execution (--election-id=...).

Now, the election-id agrees with the resourceName provided in the role-ingress-nginx.yml file. A comment in that file was changed to reflect the new logic.

Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes-sigs/kubespray/issues/10276

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

``` release-note
Fix nginx controller leader election RBAC permissions
```
