### PR TITLE
Remove crio package configuration

### DIFF
--- a/roles/container-engine/cri-o/tasks/cleanup.yaml
+++ b/roles/container-engine/cri-o/tasks/cleanup.yaml
@@ -121,7 +121,5 @@
 
 - name: CRI-O | Remove CRI-O package configuration files
   file:
-    name: "{{ item }}"
+    name: /etc/crio/crio.conf.d/01-crio-runc.conf
     state: absent
-  loop:
-    - /etc/crio/crio.conf.d/01-crio-runc.conf

--- a/roles/container-engine/cri-o/tasks/cleanup.yaml
+++ b/roles/container-engine/cri-o/tasks/cleanup.yaml
@@ -118,3 +118,10 @@
     - cri-o
     - cri-o-runc
     - oci-systemd-hook
+
+- name: CRI-O | Remove CRI-O package configuration files
+  file:
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - /etc/crio/crio.conf.d/01-crio-runc.conf


### PR DESCRIPTION

**What type of PR is this?**

 /kind cleanup

**What this PR does / why we need it**:

I upgraded my previous ubuntu server with CRI-O installed via apt and encountered the following error:
```
TASK [container-engine/cri-o : Cri-o | ensure crio service is started and enabled] ***
fatal: [k8s-1]: FAILED! => {"changed": false, "msg": "Unable to start service crio: Job for crio.service failed because the control process exited with error code.\nSee \"systemctl status crio.service\" and \"journalctl -xeu crio.service\" for details.\n"}
```

The root cause is that CRI-O installed via apt creating the '/etc/crio/crio.conf.d/01-crio-runc.conf' file.

```yaml
[crio.runtime.runtimes.runc]
runtime_path = "/usr/lib/cri-o-runc/sbin/runc"
runtime_type = "oci"
runtime_root = "/run/runc"
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
[crio] Remove crio package configuration during cleanup
```
