### PR TITLE
Seperate container engine installation tasks from "Preapre for etcd install" in playbooks/cluster.yml

### DIFF
--- a/playbooks/cluster.yml
+++ b/playbooks/cluster.yml
@@ -16,6 +16,15 @@
 - name: Gather facts
   import_playbook: facts.yml
 
+- name: Install container engine
+  hosts: k8s_cluster:etcd
+  gather_facts: False
+  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
+  roles:
+    - { role: kubespray-defaults }
+    - { role: "container-engine", tags: "container-engine", when: deploy_container_engine }
+
 - name: Prepare for etcd install
   hosts: k8s_cluster:etcd
   gather_facts: False
@@ -24,7 +33,6 @@
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes/preinstall, tags: preinstall }
-    - { role: "container-engine", tags: "container-engine", when: deploy_container_engine }
     - { role: download, tags: download, when: "not skip_downloads" }
 
 - name: Install etcd


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind design

**What this PR does / why we need it**:

To make playbooks.cluster.yaml structure more explicit.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10585

**Special notes for your reviewer**:

If you think that it's not really necessary, you can close this PR and related issue.

I also want to move `- { role: download, tags: download, when: "not skip_downloads" }` into Install container engine task but there is some dependencies related with `kubernetes/preinstall` so I didn't work about it.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Seperate Installing container engine task from `Prepare for etcd install` task in `playbooks/cluster.yml` 
```
