### PR TITLE
Use systemd for disabling swap when it's used

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0010-swapoff.yml
+++ b/roles/kubernetes/preinstall/tasks/0010-swapoff.yml
@@ -4,21 +4,10 @@
     name: swap.target
     masked: true
 
-# kubelet fails even if ansible_swaptotal_mb = 0
-- name: Check swap
-  command: /sbin/swapon -s
-  register: swapon
-  changed_when: no
-
 - name: Disable swap
   command: /sbin/swapoff -a
-  when:
-    - swapon.stdout
-  ignore_errors: "{{ ansible_check_mode }}"  # noqa ignore-errors
 
 - name: Disable swapOnZram for Fedora
   command: touch /etc/systemd/zram-generator.conf
   when:
-    - swapon.stdout
     - ansible_distribution in ['Fedora']
-  ignore_errors: "{{ ansible_check_mode }}"  # noqa ignore-errors

--- a/roles/kubernetes/preinstall/tasks/0010-swapoff.yml
+++ b/roles/kubernetes/preinstall/tasks/0010-swapoff.yml
@@ -1,12 +1,8 @@
 ---
-- name: Remove swapfile from /etc/fstab
-  ansible.posix.mount:
-    name: "{{ item }}"
-    fstype: swap
-    state: absent
-  loop:
-    - swap
-    - none
+- name: Mask swap.target (persist swapoff)
+  ansible.builtin.systemd_service:
+    name: swap.target
+    masked: true
 
 # kubelet fails even if ansible_swaptotal_mb = 0
 - name: Check swap

--- a/roles/kubernetes/preinstall/tasks/0010-swapoff.yml
+++ b/roles/kubernetes/preinstall/tasks/0010-swapoff.yml
@@ -6,8 +6,3 @@
 
 - name: Disable swap
   command: /sbin/swapoff -a
-
-- name: Disable swapOnZram for Fedora
-  command: touch /etc/systemd/zram-generator.conf
-  when:
-    - ansible_distribution in ['Fedora']


### PR DESCRIPTION
- Disable swap with systemd when it's used
- Unconditionally disable swap
- Don't explicitly disable swapOnZram

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This relies on systemd instead of fstab to disable swap + some cleanups and simplifications.
On systemd system, mount and swap configuration is achieved by .mount and .swap units, and fstab is only one source for those (they can be manually created or generated from fstab of a gpt partition table for example). Hence it's more appropriate the swap.target, on which all of theses mechanisms should depend.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10581

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Swap is now disabled using systemd (mask of swap.target)
```
