### PR TITLE
Move control plane certs renewal "spread out" into the systemd timer

### DIFF
--- a/roles/kubernetes/control-plane/defaults/main/main.yml
+++ b/roles/kubernetes/control-plane/defaults/main/main.yml
@@ -222,8 +222,7 @@ event_ttl_duration: "1h0m0s"
 ## Automatically renew K8S control plane certificates on first Monday of each month
 auto_renew_certificates: false
 # First Monday of each month
-auto_renew_certificates_systemd_calendar: "{{ 'Mon *-*-1,2,3,4,5,6,7 03:' ~
-  groups['kube_control_plane'].index(inventory_hostname) ~ '0:00' }}"
+auto_renew_certificates_systemd_calendar: "Mon *-*-1,2,3,4,5,6,7 03:00:00"
 # kubeadm renews all the certificates during control plane upgrade.
 # If we have requirement like without renewing certs upgrade the cluster,
 # we can opt out from the default behavior by setting kubeadm_upgrade_auto_cert_renewal to false

--- a/roles/kubernetes/control-plane/templates/k8s-certs-renew.timer.j2
+++ b/roles/kubernetes/control-plane/templates/k8s-certs-renew.timer.j2
@@ -5,6 +5,7 @@ Description=Timer to renew K8S control plane certificates
 OnCalendar={{ auto_renew_certificates_systemd_calendar }}
 RandomizedDelaySec={{ 10 * (groups['kube_control_plane'] | length) }}min
 FixedRandomDelay=yes
+Persistent=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/kubernetes/control-plane/templates/k8s-certs-renew.timer.j2
+++ b/roles/kubernetes/control-plane/templates/k8s-certs-renew.timer.j2
@@ -3,6 +3,8 @@ Description=Timer to renew K8S control plane certificates
 
 [Timer]
 OnCalendar={{ auto_renew_certificates_systemd_calendar }}
+RandomizedDelaySec={{ 10 * (groups['kube_control_plane'] | length) }}min
+FixedRandomDelay=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Instead of relying on the index for spacing out the auto renewal of certifcates, we instead use 'RandomizedDelaySec' and 'FixedRandomDelay' in the timer unit file.
This prevents having an invalid OnCalendar spec when there is more than 6 control plane nodes.

We also make the timer "Persistent" to avoid missing renewal if the node was offline during the scheduled time for the renewal.

**Special notes for your reviewer**:

Alternative to #10594

Two potential downsides with the random approach:
- renewal order is not predictable (at least the first time)
- Less customizable. We could add a var to opt-in/opt-out of that behavior if really necessary

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The auto renewal of control plane nodes certificates delay (different for each node to avoid concurrent renewal) is now randomized in a fixed way by node. This means it will happend each time with the same delay for the same node.
action required: if you were using a non-default value for auto_renew_certificates_systemd_calendar, you should review the new unit file.
```
