### PR TITLE
add option to enable cdi for containerd

### DIFF
--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -105,3 +105,6 @@ containerd_supported_distributions:
   - "UnionTech"
   - "UniontechOS"
   - "openEuler"
+
+# Enable container device interface
+enable_cdi: false

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -20,6 +20,10 @@ oom_score = {{ containerd_oom_score }}
     max_container_log_line_size = {{ containerd_max_container_log_line_size }}
     enable_unprivileged_ports = {{ containerd_enable_unprivileged_ports | default(false) | lower }}
     enable_unprivileged_icmp = {{ containerd_enable_unprivileged_icmp | default(false) | lower }}
+{% if enable_cdi %}
+    enable_cdi = true
+    cdi_spec_dirs = ["/etc/cdi", "/var/run/cdi"]
+{% endif %}
     [plugins."io.containerd.grpc.v1.cri".containerd]
       default_runtime_name = "{{ containerd_default_runtime | default('runc') }}"
       snapshotter = "{{ containerd_snapshotter | default('overlayfs') }}"


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
Add option to enable CDI for containerd which is by default disabled.
https://github.com/cncf-tags/container-device-interface#why-is-cdi-needed
https://github.com/cncf-tags/container-device-interface#containerd-configuration

Which issue(s) this PR fixes:


Fixes https://github.com/kubernetes-sigs/kubespray/issues/10598

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

Add Boolean option `enable_cdi` by default is disabled / false, when user will enable this option it will configure containerd configuration to enable cdi