### PR TITLE
support disable dns autoscaler when use CoreDNS

### DIFF
--- a/roles/kubernetes-apps/ansible/tasks/coredns.yml
+++ b/roles/kubernetes-apps/ansible/tasks/coredns.yml
@@ -21,6 +21,7 @@
   when:
     - dns_mode in ['coredns', 'coredns_dual']
     - inventory_hostname == groups['kube_control_plane'][0]
+    - enable_dns_autoscaler or item.name != 'dns-autoscaler'
   tags:
     - coredns
 
@@ -40,5 +41,6 @@
   when:
     - dns_mode == 'coredns_dual'
     - inventory_hostname == groups['kube_control_plane'][0]
+    - enable_dns_autoscaler or item.name != 'dns-autoscaler'
   tags:
     - coredns

--- a/roles/kubespray-defaults/defaults/main/main.yml
+++ b/roles/kubespray-defaults/defaults/main/main.yml
@@ -99,6 +99,9 @@ docker_dns_options:
 # Can be coredns, coredns_dual, manual, or none
 dns_mode: coredns
 
+# Enable dns autoscaler
+enable_dns_autoscaler: true
+
 # Enable nodelocal dns cache
 enable_nodelocaldns: true
 enable_nodelocaldns_secondary: false


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
support disable dns autoscaler when use CoreDNS

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Support disable dns autoscaler when use CoreDNS
```

