### PR TITLE
etcd: use dynamic group for certs generation check

### DIFF
--- a/roles/etcd/tasks/check_certs.yml
+++ b/roles/etcd/tasks/check_certs.yml
@@ -88,49 +88,12 @@
     - kube_network_plugin != "calico" or calico_datastore == "etcd"
     - force_etcd_cert_refresh or not item in etcdcert_master.files | map(attribute='path') | list
 
-- name: "Check_certs | Set 'gen_master_certs' object to track whether member and admin certs exist on first etcd node"
-  set_fact:
-    # noqa: jinja[spacing]
-    gen_master_certs: |-
-      {
-      {% set etcd_members = groups['etcd'] -%}
-      {% set existing_certs = etcdcert_master.files | map(attribute='path') | list | sort %}
-      {% for host in etcd_members -%}
-        {% set member_cert = "%s/member-%s.pem" | format(etcd_cert_dir, host) %}
-        {% set member_key = "%s/member-%s-key.pem" | format(etcd_cert_dir, host) %}
-        {% set admin_cert = "%s/admin-%s.pem" | format(etcd_cert_dir, host) %}
-        {% set admin_key = "%s/admin-%s-key.pem" | format(etcd_cert_dir, host) %}
-        {% if force_etcd_cert_refresh -%}
-        "{{ host }}": True,
-        {% elif member_cert in existing_certs and member_key in existing_certs and admin_cert in existing_certs and admin_key in existing_certs  -%}
-        "{{ host }}": False,
-        {% else -%}
-        "{{ host }}": True,
-        {% endif -%}
-      {% endfor %}
-      }
-  run_once: true
-
-- name: "Check_certs | Set 'gen_node_certs' object to track whether node certs exist on first etcd node"
-  set_fact:
-    # noqa: jinja[spacing]
-    gen_node_certs: |-
-      {
-      {% set k8s_nodes = groups['k8s_cluster'] -%}
-      {% set existing_certs = etcdcert_master.files | map(attribute='path') | list | sort %}
-      {% for host in k8s_nodes -%}
-        {% set host_cert = "%s/node-%s.pem" | format(etcd_cert_dir, host) %}
-        {% set host_key = "%s/node-%s-key.pem" | format(etcd_cert_dir, host) %}
-        {% if force_etcd_cert_refresh -%}
-        "{{ host }}": True,
-        {% elif host_cert in existing_certs and host_key in existing_certs -%}
-        "{{ host }}": False,
-        {% else -%}
-        "{{ host }}": True,
-        {% endif -%}
-      {% endfor %}
-      }
-  run_once: true
+- name: "Check_certs | Set 'gen_*_certs' groups to track which nodes needs to have certs generated on first etcd node"
+  vars:
+    existing_certs: etcdcert_master.files | map(attribute='path')
+  ansible.builtin.group_by:
+    key: "gen_{{ item.node_type }}_certs_{{ force_etcd_cert_refresh or item.certs is not subset(existing_certs) }}"
+  loop: "{{ cert_files | dict2items(key_name='node_type', value_name='certs') }}"
 
 - name: "Check_certs | Set 'etcd_member_requires_sync' to true if ca or member/admin cert and key don't exist on etcd member or checksum doesn't match"
   set_fact:
@@ -167,5 +130,5 @@
   when:
     - etcd_member_requires_sync | default(false) or
       kubernetes_host_requires_sync | default(false) or
-      (inventory_hostname in gen_master_certs and gen_master_certs[inventory_hostname]) or
-      (inventory_hostname in gen_node_certs and gen_node_certs[inventory_hostname])
+      'gen_master_certs_True' in group_names or
+      'gen_node_certs_True' in group_names

--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -41,18 +41,8 @@
 - name: Gen_certs | run cert generation script for etcd and kube control plane nodes
   command: "bash -x {{ etcd_script_dir }}/make-ssl-etcd.sh -f {{ etcd_config_dir }}/openssl.conf -d {{ etcd_cert_dir }}"
   environment:
-    MASTERS: |-
-      {% for m in groups['etcd'] %}
-        {% if gen_master_certs[m] %}
-          {{ m }}
-        {% endif %}
-      {% endfor %}
-    HOSTS: |-
-      {% for h in groups['kube_control_plane'] %}
-        {% if gen_node_certs[h] %}
-          {{ h }}
-        {% endif %}
-      {% endfor %}
+    MASTERS: "{{ groups['gen_master_certs_True'] | ansible.builtin.intersect(groups['etcd']) | join(' ') }}"
+    HOSTS: "{{ groups['gen_node_certs_True'] | ansible.builtin.intersect(groups['kube_control_plane']) | join(' ') }}"
   run_once: yes
   delegate_to: "{{ groups['etcd'][0] }}"
   when: gen_certs | default(false)
@@ -61,12 +51,7 @@
 - name: Gen_certs | run cert generation script for all clients
   command: "bash -x {{ etcd_script_dir }}/make-ssl-etcd.sh -f {{ etcd_config_dir }}/openssl.conf -d {{ etcd_cert_dir }}"
   environment:
-    HOSTS: |-
-      {% for h in groups['k8s_cluster'] %}
-        {% if gen_node_certs[h] %}
-          {{ h }}
-        {% endif %}
-      {% endfor %}
+    HOSTS: "{{ groups['gen_node_certs_True'] | ansible.builtin.intersect(groups['k8s_cluster']) | join(' ') }}"
   run_once: yes
   delegate_to: "{{ groups['etcd'][0] }}"
   when:

--- a/roles/etcd/vars/main.yml
+++ b/roles/etcd/vars/main.yml
@@ -1,0 +1,10 @@
+---
+cert_files:
+  master:
+  - "{{ etcd_cert_dir }}/member-{{ inventory_hostname }}.pem"
+  - "{{ etcd_cert_dir }}/member-{{ inventory_hostname }}-key.pem"
+  - "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem"
+  - "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
+  node:
+  - "{{ etcd_cert_dir}}/node-{{ inventory_hostname }}.pem"
+  - "{{ etcd_cert_dir}}/node-{{ inventory_hostname }}-key.pem"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
We take advantage of group_by to create the list of nodes needing new
certs, instead of manually looping inside a Jinja template.

This should make the role more readable and less susceptible to
whitespace problems.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
might fixes #10609

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
etcd: use dynamic group for certs generation check
```
