### PR TITLE
Fix download retry when get_url has no status_code.

### DIFF
--- a/roles/download/tasks/download_file.yml
+++ b/roles/download/tasks/download_file.yml
@@ -103,7 +103,7 @@
     become: "{{ not download_localhost }}"
     until: "'OK' in get_url_result.msg or
       'file already exists' in get_url_result.msg or
-      (get_url_result is defined and get_url_result.status_code == 304)"
+      get_url_result.status_code | default() == 304"
     retries: "{{ download_retries }}"
     delay: "{{ retry_stagger | default(5) }}"
     environment: "{{ proxy_env }}"

--- a/roles/download/tasks/download_file.yml
+++ b/roles/download/tasks/download_file.yml
@@ -103,7 +103,7 @@
     become: "{{ not download_localhost }}"
     until: "'OK' in get_url_result.msg or
       'file already exists' in get_url_result.msg or
-      get_url_result.status_code == 304"
+      (get_url_result is defined and get_url_result.status_code == 304)"
     retries: "{{ download_retries }}"
     delay: "{{ retry_stagger | default(5) }}"
     environment: "{{ proxy_env }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Sometime the return of `get_url`  doesn't have a `status_code`, so we need to check if it's defined before we check its value to avoid an evaluation error.

**Which issue(s) this PR fixes**:
Fixes #10494

**Special notes for your reviewer**:
Should be backported in 2.23, the bug is introduce in the new 2.23.1 version.

**Does this PR introduce a user-facing change?**:
```release-note
Fix download retry when get_url has no status_code
```
