### PR TITLE
configure cluster-name for hubble relay

### DIFF
--- a/roles/network_plugin/cilium/templates/hubble/config.yml.j2
+++ b/roles/network_plugin/cilium/templates/hubble/config.yml.j2
@@ -8,6 +8,7 @@ metadata:
   namespace: kube-system
 data:
   config.yaml: |
+    cluster-name: "{{ cilium_cluster_name }}"
     peer-service: "hubble-peer.kube-system.svc.{{ dns_domain }}:443"
     listen-address: :4245
     metrics-listen-address: ":9966"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Configure `cluster-name` for Hubble relay so that it works properly when `cilium_cluster_name` is being customised.

**Which issue(s) this PR fixes**:

Fixes #10247

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
hubble relay will work when cilium_cluster_name is customised.
```
