### PR TITLE
support CoreDNS use host network and config dns port

### DIFF
--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -16,6 +16,8 @@ coredns_ordinal_suffix: ""
 coredns_deployment_nodeselector: "kubernetes.io/os: linux"
 coredns_default_zone_cache_block: |
   cache 30
+coredns_host_network: false
+coredns_port: 53
 # coredns_additional_configs adds any extra configuration to coredns
 # coredns_additional_configs: |
 #   whoami

--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -34,7 +34,7 @@ data:
     }
 {%   endfor %}
 {% endif %}
-    .:53 {
+    .:{{ coredns_port }} {
 {% if coredns_additional_configs is defined %}
         {{ coredns_additional_configs | indent(width=8, first=False) }}
 {% endif %}

--- a/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
@@ -24,6 +24,7 @@ spec:
       annotations:
         createdby: 'kubespray'
     spec:
+      hostNetwork: {{ coredns_host_network | default(false) }}
       securityContext:
         seccompProfile:
           type: RuntimeDefault
@@ -75,10 +76,10 @@ spec:
         - name: config-volume
           mountPath: /etc/coredns
         ports:
-        - containerPort: 53
+        - containerPort: {{ coredns_port }}
           name: dns
           protocol: UDP
-        - containerPort: 53
+        - containerPort: {{ coredns_port }}
           name: dns-tcp
           protocol: TCP
         - containerPort: 9153

--- a/roles/kubernetes-apps/ansible/templates/coredns-svc.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-svc.yml.j2
@@ -20,9 +20,11 @@ spec:
     - name: dns
       port: 53
       protocol: UDP
+      targetPort: "dns"
     - name: dns-tcp
       port: 53
       protocol: TCP
+      targetPort: "dns-tcp"
     - name: metrics
       port: 9153
       protocol: TCP


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Some CNI plugins that have some performance overhead, especially overlay network like flannel vxlan and calico ipip. 
We want CoreDNS use host network to improve performance. 

And our environment has some special features. In order to improve performance, CNI are not used in some clusters and only HostNetwork Pods are allowed to be created, so I need to make CoreDNS also in HostNetwork mode.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Support CoreDNS use host network & config CoreDNS port
```
