### PR TITLE
Patch for modprobe_nf_conntrack for new Linux Kernel, when using ipvs

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -248,3 +248,7 @@ kube_proxy_ipvs_modules:
   - ip_vs_sh
   - ip_vs_wlc
   - ip_vs_lc
+
+# Ensure IPVS required kernel module is picked based on Linux Kernel version
+# in reference to: https://github.com/kubernetes/kubernetes/blob/master/pkg/proxy/ipvs/README.md#run-kube-proxy-in-ipvs-mode
+conntrack_module: "{{ ansible_kernel is version_compare('4.19', '>=') | ternary('nf_conntrack', 'nf_conntrack_ipv4') }}"

--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -117,21 +117,21 @@
   tags:
     - kube-proxy
 
-- name: Modprobe nf_conntrack_ipv4
+- name: "Modprobe {{ conntrack_module }}"
   community.general.modprobe:
-    name: nf_conntrack_ipv4
+    name: "{{ conntrack_module }}"
     state: present
-  register: modprobe_nf_conntrack_ipv4
+  register: modprobe_conntrack_module
   ignore_errors: true  # noqa ignore-errors
   when:
     - kube_proxy_mode == 'ipvs'
   tags:
     - kube-proxy
 
-- name: Add nf_conntrack_ipv4 kube-proxy ipvs module list
+- name: "Add {{ conntrack_module }} kube-proxy ipvs module list"
   set_fact:
-    kube_proxy_ipvs_modules: "{{ kube_proxy_ipvs_modules + ['nf_conntrack_ipv4'] }}"
-  when: modprobe_nf_conntrack_ipv4 is success
+    kube_proxy_ipvs_modules: "{{ kube_proxy_ipvs_modules + [conntrack_module] }}"
+  when: modprobe_conntrack_module is success
   tags:
     - kube-proxy
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**Which issue(s) this PR fixes**:

While running the head for a Node with Ubuntu 22.04 (Linux 5.15.0-88-generic), I noticed a failed message for `modprobe_nf_conntrack_ipv4`.
Sorry, I missed to copy it.

Upon some search, I came across [kubernetes/.../pkg/util/ipvs/ipvs.go#L129](https://github.com/kubernetes/kubernetes/blob/38f5dc8e7b75c16db29105b7c2314bfd3100840d/pkg/util/ipvs/ipvs.go#L129) and some other threads as well.
This gave me understanding that with Kernel > 4.19, the `modprobe nf_conntrack` is to be used instead of `modprobe nf_conntrack_ipv4`; which I also checked on the VM I was using to be true.

This patch simply adds logic to Ansible Role to check Kernel Version and pick required `nf_conntrack` or `nf_conntrack_ipv4` based on it.


**Special notes for your reviewer**:

This is my first PR to KubeSpray... sorry, if I missed any pre-requisite or best practice for the PR.


**Does this PR introduce a user-facing change?**:
```release-note
Patch for modprobe_nf_conntrack for new Linux Kernel, when using ipvs
```