### PR TITLE
Allow the DNS stack to be backward compatible with an old dns_domain

### DIFF
--- a/docs/dns-stack.md
+++ b/docs/dns-stack.md
@@ -143,6 +143,22 @@ coredns_default_zone_cache_block: |
   }
 ```
 
+### Handle old/extra dns_domains
+
+If you need to change the dns_domain of your cluster for whatever reason (switching to or from `cluster.local` for example),
+and you have workloads that embed it in their configuration you can use the variable `old_dns_domains`.
+This will add some configuration to coredns and nodelocaldns to ensure the DNS requests using the old domain are handled correctly.
+Example:
+
+```yaml
+old_dns_domains:
+- example1.com
+- example2.com
+dns_domain: cluster.local
+```
+
+will make `my-svc.my-ns.svc.example1.com`, `my-svc.my-ns.svc.example2.com` and `my-svc.my-ns.svc.cluster.local` have the same DNS answer.
+
 ### systemd_resolved_disable_stub_listener
 
 Whether or not to set `DNSStubListener=no` when using systemd-resolved. Defaults to `true` on Flatcar.

--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -32,6 +32,10 @@ coredns_port: 53
 # coredns_additional_error_config: |
 #   consolidate 5m ".* i/o timeout$" warning
 
+# Configure coredns and nodelocaldns to correctly answer DNS queries when you changed
+# your 'dns_domain' and some workloads used it directly.
+old_dns_domains: []
+
 # dns_upstream_forward_extra_opts apply to coredns forward section as well as nodelocaldns upstream target forward section
 # dns_upstream_forward_extra_opts:
 #   policy: sequential

--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -49,6 +49,9 @@ data:
 {% if coredns_rewrite_block is defined %}
         {{ coredns_rewrite_block | indent(width=8, first=False) }}
 {% endif %}
+{% for old_dns_domain in old_dns_domains %}
+        rewrite name suffix {{ old_dns_domain }} {{ dns_domain }} answer auto
+{% endfor %}
         ready
         kubernetes {{ dns_domain }} {% if coredns_kubernetes_extra_domains is defined %}{{ coredns_kubernetes_extra_domains }} {% endif %}{% if enable_coredns_reverse_dns_lookups %}in-addr.arpa ip6.arpa {% endif %}{
           pods insecure

--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2
@@ -32,7 +32,7 @@ data:
     }
 {% endfor %}
 {% endif %}
-    {{ dns_domain }}:53 {
+    {{ ([dns_domain] + old_dns_domains) | join(' ') }}:53 {
         errors
         cache {
             success 9984 30


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

All domains in `old_dns_domains` are handled by nodelocaldns in the same server block
as the current dns_domain, while coredns performs a suffix rewrite of
each of the old dns domains to the current one.

This facilitates changing your dns_domain, for whatever reason, especially if some of your users/workloads embed the cluster dns_domain in their config.
(they should'nt, but they will)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The variable `old_dns_domains` (list) can be used for backward compatibility when changing `dns_domain`
```
