### PR TITLE
fix undefined retries variable when copying etcdctl

### DIFF
--- a/roles/etcdctl_etcdutl/tasks/main.yml
+++ b/roles/etcdctl_etcdutl/tasks/main.yml
@@ -9,7 +9,7 @@
     - etcdutl
   register: etcdxtl_install_result
   until: etcdxtl_install_result.rc == 0
-  retries: "{{ etcd_retries }}"
+  retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   changed_when: false
   when: container_manager ==  "docker"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:
``` bash
TASK [etcdctl_etcdutl : Copy etcdctl and etcdutl binary from docker container] ****************************************************************************************************************************
fatal: [master]: FAILED! => {"msg": "The field 'retries' has an invalid value, which includes an undefined variable. The error was: 'etcd_retries' is undefined. 'etcd_retries' is undefined

The error appears to be in '/kubespray/roles/etcdctl_etcdutl/tasks/main.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

---
- name: Copy etcdctl and etcdutl binary from docker container
  ^ here
"}
```
The `etcd_retries` parameter is not defined in `etcdctl_etcdutl` role. As far as I know, this [variable](https://github.com/kubernetes-sigs/kubespray/blob/master/roles/etcd/defaults/main.yml#L86) is only defined in `etcd` role.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
