### PR TITLE
Disable podCIDR allocation from control-plane when using calico

### DIFF
--- a/roles/kubernetes/control-plane/meta/main.yml
+++ b/roles/kubernetes/control-plane/meta/main.yml
@@ -9,3 +9,4 @@ dependencies:
     when:
       - etcd_deployment_type == "kubeadm"
       - not (ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk", "ClearLinux"] or is_fedora_coreos)
+  - role: network_plugin/calico_defaults

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
@@ -95,7 +95,7 @@ dns:
 networking:
   dnsDomain: {{ dns_domain }}
   serviceSubnet: "{{ kube_service_addresses }}{{ ',' + kube_service_addresses_ipv6 if enable_dual_stack_networks else '' }}"
-{% if kube_network_plugin is defined and kube_network_plugin not in ["kube-ovn"] %}
+{% if kube_control_plane_allocate_node_cidrs %}
   podSubnet: "{{ kube_pods_subnet }}{{ ',' + kube_pods_subnet_ipv6 if enable_dual_stack_networks else '' }}"
 {% endif %}
 {% if kubeadm_feature_gates %}

--- a/roles/kubernetes/control-plane/vars/main.yaml
+++ b/roles/kubernetes/control-plane/vars/main.yaml
@@ -1,3 +1,4 @@
 ---
 # list of admission plugins that needs to be configured
 kube_apiserver_admission_plugins_needs_configuration: [EventRateLimit, PodSecurity]
+kube_control_plane_allocate_node_cidrs: "{{ kube_network_plugin is defined and (kube_network_plugin != 'kube-ovn' or not (kube_network_plugin == 'calico' and calico_ipam_host_local)) }}"

--- a/roles/network_plugin/calico/meta/main.yml
+++ b/roles/network_plugin/calico/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: network_plugin/calico_defaults

--- a/roles/network_plugin/calico/tasks/check.yml
+++ b/roles/network_plugin/calico/tasks/check.yml
@@ -168,7 +168,7 @@
 - name: "Check if inventory match current cluster configuration"
   assert:
     that:
-      - calico_pool_conf.spec.blockSize | int == (calico_pool_blocksize | default(kube_network_node_prefix) | int)
+      - calico_pool_conf.spec.blockSize | int == calico_pool_blocksize | int)
       - calico_pool_conf.spec.cidr == (calico_pool_cidr | default(kube_pods_subnet))
       - not calico_pool_conf.spec.ipipMode is defined or calico_pool_conf.spec.ipipMode == calico_ipip_mode
       - not calico_pool_conf.spec.vxlanMode is defined or calico_pool_conf.spec.vxlanMode == calico_vxlan_mode

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -223,7 +223,7 @@
               "name": "{{ calico_pool_name }}",
             },
             "spec": {
-              "blockSize": {{ calico_pool_blocksize | default(kube_network_node_prefix) }},
+              "blockSize": "{{ calico_pool_blocksize }}",
               "cidr": "{{ calico_pool_cidr | default(kube_pods_subnet) }}",
               "ipipMode": "{{ calico_ipip_mode }}",
               "vxlanMode": "{{ calico_vxlan_mode }}",
@@ -274,7 +274,7 @@
               "name": "{{ calico_pool_name }}-ipv6",
             },
             "spec": {
-              "blockSize": {{ calico_pool_blocksize_ipv6 | default(kube_network_node_prefix_ipv6) }},
+              "blockSize": "{{ calico_pool_blocksize_ipv6 }}",
               "cidr": "{{ calico_pool_cidr_ipv6 | default(kube_pods_subnet_ipv6) }}",
               "ipipMode": "{{ calico_ipip_mode_ipv6 }}",
               "vxlanMode": "{{ calico_vxlan_mode_ipv6 }}",

--- a/roles/network_plugin/calico_defaults/defaults/main.yml
+++ b/roles/network_plugin/calico_defaults/defaults/main.yml
@@ -16,14 +16,14 @@ calico_vxlan_mode: Always  # valid values are 'Always', 'Never' and 'CrossSubnet
 calico_cni_pool: true
 calico_cni_pool_ipv6: true
 
-# add default ippool blockSize (defaults kube_network_node_prefix)
+# add default ippool blockSize
 calico_pool_blocksize: 26
 
 # Calico doesn't support ipip tunneling for the IPv6.
 calico_ipip_mode_ipv6: Never
 calico_vxlan_mode_ipv6: Never
 
-# add default ipv6 ippool blockSize (defaults kube_network_node_prefix_ipv6)
+# add default ipv6 ippool blockSize
 calico_pool_blocksize_ipv6: 122
 
 # Calico network backend can be 'bird', 'vxlan' and 'none'

--- a/roles/network_plugin/calico_defaults/defaults/main.yml
+++ b/roles/network_plugin/calico_defaults/defaults/main.yml
@@ -161,6 +161,10 @@ calico_ipam_autoallocateblocks: true
 # Calico IPAM maxBlocksPerHost, default 0
 calico_ipam_maxblocksperhost: 0
 
+# Calico host local IPAM (use node .spec.podCIDR)
+
+calico_ipam_host_local: false
+
 # Calico apiserver (only with kdd)
 calico_apiserver_enabled: false
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Calico does not use the .spec.podCIDR field for its IP address
management.
Furthermore, it can false positives from the kube controller manager if
kube_network_node_prefix and calico_pool_blocksize are unaligned, which
is the case with the default shipped by kubespray.

If the subnets obtained from using kube_network_node_prefix are bigger,
this would result at some point in the control plane thinking it does
not have subnets left for a new node, while calico will work without
problems.

+ some cleanup on variables (see second commit message for details).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Not in this repo, but it avoids the issue described here projectcalico/calico#7722

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kube-controller-manager will no longer assign pod CIDRs to cluster nodes when using calico (with its default IPAM)
```
