### PR TITLE
crictl allow setting grace period for stop containers upon reset

### DIFF
--- a/roles/reset/defaults/main.yml
+++ b/roles/reset/defaults/main.yml
@@ -18,7 +18,4 @@ reset_restart_network_service_name: >-
   {%- endif %}
 
 # crictl stop container grace period
-cri_stop_containers_timeout: 60
-
-# crictl stop pod grace period
-cri_stop_pods_timeout: 60
+cri_stop_containers_grace_period: 0

--- a/roles/reset/defaults/main.yml
+++ b/roles/reset/defaults/main.yml
@@ -16,3 +16,9 @@ reset_restart_network_service_name: >-
   {%- elif ansible_os_family == "Debian" -%}
   networking
   {%- endif %}
+
+# crictl stop container grace period
+cri_stop_containers_timeout: 60
+
+# crictl stop pod grace period
+cri_stop_pods_timeout: 60

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -52,7 +52,7 @@
   register: crictl
 
 - name: Reset | stop all cri containers
-  shell: "set -o pipefail && {{ bin_dir }}/crictl ps -q | xargs -r {{ bin_dir }}/crictl -t {{ cri_stop_containers_timeout }}s stop"
+  shell: "set -o pipefail && {{ bin_dir }}/crictl ps -q | xargs -r {{ bin_dir }}/crictl -t 60s stop -t {{ cri_stop_containers_grace_period }}"
   args:
     executable: /bin/bash
   register: remove_all_cri_containers
@@ -100,7 +100,7 @@
   when: container_manager == "crio"
 
 - name: Reset | stop all cri pods
-  shell: "set -o pipefail && {{ bin_dir }}/crictl pods -q | xargs -r {{ bin_dir }}/crictl -t {{ cri_stop_pods_timeout }}s stopp"
+  shell: "set -o pipefail && {{ bin_dir }}/crictl pods -q | xargs -r {{ bin_dir }}/crictl -t 60s stopp"
   args:
     executable: /bin/bash
   register: remove_all_cri_containers

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -52,7 +52,7 @@
   register: crictl
 
 - name: Reset | stop all cri containers
-  shell: "set -o pipefail && {{ bin_dir }}/crictl ps -q | xargs -r {{ bin_dir }}/crictl -t 60s stop"
+  shell: "set -o pipefail && {{ bin_dir }}/crictl ps -q | xargs -r {{ bin_dir }}/crictl -t {{ cri_stop_containers_timeout }}s stop"
   args:
     executable: /bin/bash
   register: remove_all_cri_containers
@@ -100,7 +100,7 @@
   when: container_manager == "crio"
 
 - name: Reset | stop all cri pods
-  shell: "set -o pipefail && {{ bin_dir }}/crictl pods -q | xargs -r {{ bin_dir }}/crictl -t 60s stopp"
+  shell: "set -o pipefail && {{ bin_dir }}/crictl pods -q | xargs -r {{ bin_dir }}/crictl -t {{ cri_stop_pods_timeout }}s stopp"
   args:
     executable: /bin/bash
   register: remove_all_cri_containers


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Kubespray upon cluster reset has default 0 second or no grace period for stopping containers. we would like to allow containers to gracefully terminate themselves given a cri_stop_containers_grace_period.

```
# crictl stop container grace period
cri_stop_containers_grace_period: 0
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
allow kubespray user to set grace period for stop containers upon cluster reset
keep same default to 0 as was before this change

```
crictl allow setting grace period for stop containers upon reset (using `cri_stop_containers_grace_period`)
```


