### PR TITLE
revert env section deletion

### DIFF
--- a/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-controller-deployment.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-controller-deployment.yml.j2
@@ -224,6 +224,12 @@ spec:
             # needed only for topology aware setup
             #- "--feature-gates=Topology=true"
             #- "--strict-topology"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
 {% if vsphere_csi_provisioner_resources | length > 0 %}
           resources:
             {{ vsphere_csi_provisioner_resources | default({}) | to_nice_yaml | trim | indent(width=12) }}


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:  Relates to https://github.com/kubernetes-sigs/kubespray/pull/10451#issuecomment-1827786678

**Which issue(s) this PR fixes**:  `OnConnectionLoss callback only supported for unix:// addresses`
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**: Revert env section in csi-provisioner container

**Does this PR introduce a user-facing change?**:  NONE
