### PR TITLE
Offline control plane recover

### DIFF
--- a/docs/recover-control-plane.md
+++ b/docs/recover-control-plane.md
@@ -3,11 +3,6 @@
 
 To recover from broken nodes in the control plane use the "recover\-control\-plane.yml" playbook.
 
-* Backup what you can
-* Provision new nodes to replace the broken ones
-* Place the surviving nodes of the control plane first in the "etcd" and "kube\_control\_plane" groups
-* Add the new nodes below the surviving control plane nodes in the "etcd" and "kube\_control\_plane" groups
-
 Examples of what broken means in this context:
 
 * One or more bare metal node(s) suffer from unrecoverable hardware failure
@@ -19,8 +14,12 @@ __Note that you need at least one functional node to be able to recover using th
 
 ## Runbook
 
+* Backup what you can
+* Provision new nodes to replace the broken ones
 * Move any broken etcd nodes into the "broken\_etcd" group, make sure the "etcd\_member\_name" variable is set.
 * Move any broken control plane nodes into the "broken\_kube\_control\_plane" group.
+* Place the surviving nodes of the control plane first in the "etcd" and "kube\_control\_plane" groups
+* Add the new nodes below the surviving control plane nodes in the "etcd" and "kube\_control\_plane" groups
 
 Then run the playbook with ```--limit etcd,kube_control_plane``` and increase the number of ETCD retries by setting ```-e etcd_retries=10``` or something even larger. The amount of retries required is difficult to predict.
 

--- a/docs/recover-control-plane.md
+++ b/docs/recover-control-plane.md
@@ -34,7 +34,6 @@ The playbook attempts to figure out it the etcd quorum is intact. If quorum is l
 ## Caveats
 
 * The playbook has only been tested with fairly small etcd databases.
-* If your new control plane nodes have new ip addresses you may have to change settings in various places.
 * There may be disruptions while running the playbook.
 * There are absolutely no guarantees.
 

--- a/roles/recover_control_plane/etcd/tasks/main.yml
+++ b/roles/recover_control_plane/etcd/tasks/main.yml
@@ -39,6 +39,7 @@
   delegate_to: "{{ item }}"
   with_items: "{{ groups['broken_etcd'] }}"
   ignore_errors: true  # noqa ignore-errors
+  ignore_unreachable: true
   when:
     - groups['broken_etcd']
     - has_quorum


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

1. bug fix:

    Add `ignore_unreachable: true` to `Remove etcd data dir` task, so that the playbook does not fail with node "unreachable" state when the broken etcd node is unreachable.

2. documentation

    - The runbook steps are in two different paragraphs in two different sections. Combine them to make runbook steps clear.
    - At the bottom there's a suggestion:
        > https://github.com/kubernetes-sigs/kubespray/blob/d583d331b5e50057acb601c0fa41802bee20c4ef/docs/recover-control-plane.md#L38
    
        I find the wording to be a bit confusing, makes it not super useful as a suggestion to users:
        - what does "may" mean? Do I need to update IPs or not?
        - what are these "various places" exactly? How do I know that I didn't miss any places?
        In fact, The suggestion was added in 48a182844c9c3438e36c78cbc4518c962e0a9ab2 4 years ago. But a new task added 2 years ago, in ee0f1e9d58ed8bf1fd13ff1eb1527678fe4fa6da, automatically update API server arg with updated etcd node ip addresses. Please let me know if I am wrong, but from what I found in the repo, and based on my experience using the playbook last week, this suggestion seems to be unnecessary at this point.

**Which issue(s) this PR fixes**:

Fixes #10649

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Fixes running `recover-control-plane.yml` with offline broken etcd nodes.
```
