### PR TITLE
Jinja syntax pre-commit validation

### DIFF
--- a/.gitlab-ci/lint.yml
+++ b/.gitlab-ci/lint.yml
@@ -27,6 +27,14 @@ ansible-lint:
     - ansible-lint -v
   except: ['triggers', 'master']
 
+jinja-syntax-check:
+  extends: .job
+  stage: unit-tests
+  tags: [light]
+  script:
+    - "find -name '*.j2' -exec tests/scripts/check-templates.py {} +"
+  except: ['triggers', 'master']
+
 syntax-check:
   extends: .job
   stage: unit-tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,3 +69,12 @@ repos:
         entry: tests/scripts/md-table/test.sh
         language: script
         pass_filenames: false
+
+      - id: jinja-syntax-check
+        name: jinja-syntax-check
+        entry: tests/scripts/check-templates.py
+        language: python
+        types:
+          - jinja
+        additional_dependencies:
+          - Jinja2

--- a/tests/scripts/check-templates.py
+++ b/tests/scripts/check-templates.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+import sys
+from jinja2 import Environment
+
+env = Environment()
+for template in sys.argv[1:]:
+    with open(template) as t:
+        env.parse(t.read())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Allow to fail early (pre-commit time) for jinja error, rather than
waiting until executing the playbook and the invalid template.
This catch simple syntax errors like missing endif/endfor.
-> save CI and dev time


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
I could not find a simple jinja pre-commit hook in the wild.
dansabel tries to check filter names so it does not really work.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Jinja syntax pre-commit validation
```
