### PR TITLE
Fix modprobe module on Flatcar

### DIFF
--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -70,9 +70,12 @@
 
 - name: Verify br_netfilter module path exists
   file:
-    path: /etc/modules-load.d
+    path: "{{ item }}"
     state: directory
     mode: 0755
+  loop:
+    - /etc/modules-load.d
+    - /etc/modprobe.d
 
 - name: Enable br_netfilter module
   community.general.modprobe:

--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -68,6 +68,8 @@
   changed_when: false
   check_mode: no
 
+# TODO: Remove once upstream issue is fixed
+# https://github.com/ansible-collections/community.general/issues/7717
 - name: Verify br_netfilter module path exists
   file:
     path: "{{ item }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Fixes modprobe module failure on Flatcar due to missing `/etc/modprobe.d`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10677

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
