### PR TITLE
Fix calicoctl failure on workers when peering with router

### DIFF
--- a/roles/network_plugin/calico/tasks/peer_with_router.yml
+++ b/roles/network_plugin/calico/tasks/peer_with_router.yml
@@ -44,6 +44,7 @@
   retries: 4
   until: output.rc == 0
   delay: "{{ retry_stagger | random + 3 }}"
+  delegate_to: "{{ groups['kube_control_plane'][0] }}"
   when:
     - inventory_hostname in groups['k8s_cluster']
     - local_as is defined


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Fixes calicoctl crashing on worker nodes when attempting to set local_as.

```
fatal: [k8s04]: FAILED! => {"attempts": 4, "changed": true, "cmd": ["/opt/bin/calicoctl.sh", "apply", "-f", "-"], "delta": "0:00:00.099705", "end": "2023-11-30 18:11:07.581359", "msg": "non-zero return code", "rc": 1, "start": "2023-11-30 18:11:07.481654", "stderr": "Failed to apply 'Node' resource: [connection is unauthorized: nodes \"k8s04\" is forbidden: User \"system:serviceaccount:kube-system:calico-cni-plugin\" cannot update resource \"nodes/status\" in API group \"\" at the cluster scope]", "stderr_lines": ["Failed to apply 'Node' resource: [connection is unauthorized: nodes \"k8s04\" is forbidden: User \"system:serviceaccount:kube-system:calico-cni-plugin\" cannot update resource \"nodes/status\" in API group \"\" at the cluster scope]"], "stdout": "", "stdout_lines": []}
```
**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
