### PR TITLE
feat: Allow conditional reset_connection after system_upgrade

### DIFF
--- a/roles/upgrade/system-upgrade/defaults/main.yml
+++ b/roles/upgrade/system-upgrade/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+system_upgrade_conn_reset: false
+# system_upgrade_post_reboot_delay: 0
+# system_upgrade_pre_reboot_delay: 0
+# system_upgrade_reboot_timeout: 600
+# system_upgrade_test_command: "whoami"

--- a/roles/upgrade/system-upgrade/tasks/apt.yml
+++ b/roles/upgrade/system-upgrade/tasks/apt.yml
@@ -11,3 +11,8 @@
   - apt_upgrade.changed or system_upgrade_reboot == 'always'
   - system_upgrade_reboot != 'never'
   reboot:
+    msg: "INFO: Reboot issued by Kubespray roles/upgrade/system-upgrade"
+    post_reboot_delay: {{ system_upgrade_post_reboot_delay | default(omit) }}
+    pre_reboot_delay: {{ system_upgrade_pre_reboot_delay | default(omit) }}
+    reboot_timeout: {{ system_upgrade_reboot_timeout | default(omit) }}
+    test_command: {{ system_upgrade_test_command | default(omit) }}

--- a/roles/upgrade/system-upgrade/tasks/main.yml
+++ b/roles/upgrade/system-upgrade/tasks/main.yml
@@ -15,3 +15,8 @@
   include_tasks: yum.yml
   tags:
   - system-upgrade-yum
+
+- name: Ansible SSH connection reset
+  meta: reset_connection
+  when:
+  - system_upgrade_conn_reset

--- a/roles/upgrade/system-upgrade/tasks/yum.yml
+++ b/roles/upgrade/system-upgrade/tasks/yum.yml
@@ -10,3 +10,8 @@
   - yum_upgrade.changed or system_upgrade_reboot == 'always'
   - system_upgrade_reboot != 'never'
   reboot:
+    msg: "INFO: Reboot issued by Kubespray roles/upgrade/system-upgrade"
+    post_reboot_delay: {{ system_upgrade_post_reboot_delay | default(omit) }}
+    pre_reboot_delay: {{ system_upgrade_pre_reboot_delay | default(omit) }}
+    reboot_timeout: {{ system_upgrade_reboot_timeout | default(omit) }}
+    test_command: {{ system_upgrade_test_command | default(omit) }}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
* Add optional `meta: reset_connection` task for system/ansible.cfg configurations which require it.
* Allow for further customization of reboot task and reboot msg

**Which issue(s) this PR fixes**:
Fixes #10690 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Allow users to issue an ansible SSH connection reset after system_upgrade reboots and further customize the reboot command itself.
```
