### PR TITLE
[WIP] Update kube.py - don't force apply by default

### DIFF
--- a/plugins/modules/kube.py
+++ b/plugins/modules/kube.py
@@ -169,13 +169,13 @@ class KubeManager(object):
             return None
         return out.splitlines()
 
-    def create(self, check=True, force=True):
+    def create(self, check=True):
         if check and self.exists():
             return []
 
         cmd = ['apply']
 
-        if force:
+        if self.force:
             cmd.append('--force')
 
         if self.wait:
@@ -191,11 +191,11 @@ class KubeManager(object):
 
         return self._execute(cmd)
 
-    def replace(self, force=True):
+    def replace(self):
 
         cmd = ['apply']
 
-        if force:
+        if self.force:
             cmd.append('--force')
 
         if self.wait:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind design

**What this PR does / why we need it**:

This PR ensures that applying manifests to clusters doesn't default to force (delete and create).

In #7113, it was highlighted that the CoreDNS deployment manifests are force applied, resulting in downtime for production clusters at the end of upgrades. This is due to the `latest` state within the `kube` module force applying by default, despite there being an additional `force` parameter available. We can see that the `latest` state is used for applying the CoreDNS and nodelocaldns manifests:

https://github.com/kubernetes-sigs/kubespray/blob/master/roles/kubernetes-apps/ansible/tasks/main.yml#L39-L46

One problem this may cause is with manifests that feature changes to immutable fields, and will require testing as part of this PR

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7113

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
