### PR TITLE
Removed DEPRECATED --logtostderr from metrics-server

### DIFF
--- a/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
+++ b/roles/kubernetes-apps/metrics_server/templates/metrics-server-deployment.yaml.j2
@@ -32,7 +32,6 @@ spec:
         image: {{ metrics_server_image_repo }}:{{ metrics_server_image_tag }}
         imagePullPolicy: {{ k8s_image_pull_policy }}
         args:
-        - --logtostderr
         - --cert-dir=/tmp
         - --secure-port={{ metrics_server_container_port }}
 {% if metrics_server_kubelet_preferred_address_types %}


### PR DESCRIPTION
The --logtostderr is deprecated.

https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components


**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The `--logtostderr` of metrics-server is DEPRECATED.

    $ nerdctl --namespace k8s.io  run registry.k8s.io/metrics-server/metrics-server:v0.6.4`

outputs:

    --logtostderr                      log to standard error instead of files (DEPRECATED: will be removed in a future release, see https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components) (default true)


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Removed DEPRECATED `--logtostderr` from metrics-server
```

