### PR TITLE
Refactor cgroup and kubelet enforceNodeAllocatable

### DIFF
--- a/docs/operations/cgroups.md
+++ b/docs/operations/cgroups.md
@@ -1,73 +1,42 @@
 # cgroups
 
-To avoid resource contention between containers and host daemons in Kubernetes, the kubelet components can use cgroups to limit resource usage.
+To avoid resource contention between containers and host daemons in Kubernetes,
+the kubelet components can use cgroups to limit resource usage.
 
-## Enforcing Node Allocatable
+## Node Allocatable
 
-You can use `kubelet_enforce_node_allocatable` to set node allocatable enforcement.
+Node Allocatable is calculated by subtracting from the node capacity:
 
-```yaml
-# A comma separated list of levels of node allocatable enforcement to be enforced by kubelet.
-kubelet_enforce_node_allocatable: "pods"
-# kubelet_enforce_node_allocatable: "pods,kube-reserved"
-# kubelet_enforce_node_allocatable: "pods,kube-reserved,system-reserved"
-```
+- kube-reserved reservations
+- system-reserved reservations
+- hard eviction thresholds
 
-Note that to enforce kube-reserved or system-reserved, `kube_reserved_cgroups` or `system_reserved_cgroups` needs to be specified respectively.
-
-Here is an example:
+You can set those reservations:
 
 ```yaml
-kubelet_enforce_node_allocatable: "pods,kube-reserved,system-reserved"
-
-# Set kube_reserved to true to run kubelet and container-engine daemons in a dedicated cgroup.
-# This is required if you want to enforce limits on the resource usage of these daemons.
-# It is not required if you just want to make resource reservations (kube_memory_reserved, kube_cpu_reserved, etc.)
-kube_reserved: true
-kube_reserved_cgroups_for_service_slice: kube.slice
-kube_reserved_cgroups: "/{{ kube_reserved_cgroups_for_service_slice }}"
 kube_memory_reserved: 256Mi
 kube_cpu_reserved: 100m
-# kube_ephemeral_storage_reserved: 2Gi
-# kube_pid_reserved: "1000"
-# Reservation for master hosts
-kube_master_memory_reserved: 512Mi
-kube_master_cpu_reserved: 200m
-# kube_master_ephemeral_storage_reserved: 2Gi
-# kube_master_pid_reserved: "1000"
+kube_ephemeral_storage_reserved: 2Gi
+kube_pid_reserved: "1000"
 
-# Set to true to reserve resources for system daemons
-system_reserved: true
-system_reserved_cgroups_for_service_slice: system.slice
-system_reserved_cgroups: "/{{ system_reserved_cgroups_for_service_slice }}"
+# System daemons (sshd, network manager, ...)
 system_memory_reserved: 512Mi
 system_cpu_reserved: 500m
-# system_ephemeral_storage_reserved: 2Gi
-# system_pid_reserved: "1000"
-# Reservation for master hosts
-system_master_memory_reserved: 256Mi
-system_master_cpu_reserved: 250m
-# system_master_ephemeral_storage_reserved: 2Gi
-# system_master_pid_reserved: "1000"
+system_ephemeral_storage_reserved: 2Gi
+system_pid_reserved: "1000"
 ```
 
-After the setup, the cgroups hierarchy is as follows:
+By default, the kubelet will enforce Node Allocatable for pods, which means
+pods will be evicted when resource usage excess Allocatable.
 
-```bash
-/ (Cgroups Root)
-├── kubepods.slice
-│   ├── ...
-│   ├── kubepods-besteffort.slice
-│   ├── kubepods-burstable.slice
-│   └── ...
-├── kube.slice
-│   ├── ...
-│   ├── {{container_manager}}.service
-│   ├── kubelet.service
-│   └── ...
-├── system.slice
-│   └── ...
-└── ...
+You can optionnaly enforce the reservations for kube-reserved and
+system-reserved, but proceed with caution (see [the kubernetes
+guidelines](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#general-guidelines)).
+
+```yaml
+enforce_allocatable_pods: true # default
+enforce_allocatable_kube_reserved: true
+enforce_allocatable_system_reseverd: true
 ```
 
 You can learn more in the [official kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/).

--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -250,47 +250,35 @@ default_kubelet_config_dir: "{{ kube_config_dir }}/dynamic_kubelet_dir"
 # Download kubectl onto the host that runs Ansible in {{ bin_dir }}
 # kubectl_localhost: false
 
-# A comma separated list of levels of node allocatable enforcement to be enforced by kubelet.
-# Acceptable options are 'pods', 'system-reserved', 'kube-reserved' and ''. Default is "".
-# kubelet_enforce_node_allocatable: pods
+## Reserving compute resources
+# https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
 
-## Set runtime and kubelet cgroups when using systemd as cgroup driver (default)
-# kubelet_runtime_cgroups: "/{{ kube_service_cgroups }}/{{ container_manager }}.service"
-# kubelet_kubelet_cgroups: "/{{ kube_service_cgroups }}/kubelet.service"
-
-## Set runtime and kubelet cgroups when using cgroupfs as cgroup driver
-# kubelet_runtime_cgroups_cgroupfs: "/system.slice/{{ container_manager }}.service"
-# kubelet_kubelet_cgroups_cgroupfs: "/system.slice/kubelet.service"
-
-# Whether to run kubelet and container-engine daemons in a dedicated cgroup.
-# kube_reserved: false
+# Optionally reserve resources for kube daemons.
 ## Uncomment to override default values
-## The following two items need to be set when kube_reserved is true
-# kube_reserved_cgroups_for_service_slice: kube.slice
-# kube_reserved_cgroups: "/{{ kube_reserved_cgroups_for_service_slice }}"
 # kube_memory_reserved: 256Mi
 # kube_cpu_reserved: 100m
 # kube_ephemeral_storage_reserved: 2Gi
 # kube_pid_reserved: "1000"
-# Reservation for control plane hosts
-# kube_master_memory_reserved: 512Mi
-# kube_master_cpu_reserved: 200m
-# kube_master_ephemeral_storage_reserved: 2Gi
-# kube_master_pid_reserved: "1000"
 
 ## Optionally reserve resources for OS system daemons.
-# system_reserved: true
 ## Uncomment to override default values
-## The following two items need to be set when system_reserved is true
-# system_reserved_cgroups_for_service_slice: system.slice
-# system_reserved_cgroups: "/{{ system_reserved_cgroups_for_service_slice }}"
 # system_memory_reserved: 512Mi
 # system_cpu_reserved: 500m
 # system_ephemeral_storage_reserved: 2Gi
-## Reservation for master hosts
-# system_master_memory_reserved: 256Mi
-# system_master_cpu_reserved: 250m
-# system_master_ephemeral_storage_reserved: 2Gi
+# system_pid_reserved: "1000"
+#
+# Make the kubelet enforce with cgroups the limits of Pods
+# enforce_allocatable_pods: true
+
+# Enforce kube_*_reserved as limits
+# WARNING: this limits the resources the kubelet and the container engine can
+# use which can cause instability on your nodes
+# enforce_allocatable_kube_reserved: false
+
+# Enforce system_*_reserved as limits
+# WARNING: this limits the resources system daemons can use which can lock you
+# out of your nodes (by OOMkilling sshd for instance)
+# enforce_allocatable_system_reserved: false
 
 ## Eviction Thresholds to avoid system OOMs
 # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#eviction-thresholds

--- a/roles/container-engine/containerd/templates/containerd.service.j2
+++ b/roles/container-engine/containerd/templates/containerd.service.j2
@@ -36,10 +36,8 @@ LimitMEMLOCK={{ containerd_limit_mem_lock }}
 # Only systemd 226 and above support this version.
 TasksMax=infinity
 OOMScoreAdjust=-999
-# Set the cgroup slice of the service so that kube reserved takes effect
-{% if kube_reserved is defined and kube_reserved|bool %}
-Slice={{ kube_reserved_cgroups_for_service_slice }}
-{% endif %}
+# Set the cgroup slice of the service to optionally enforce resource limitations
+Slice={{ kube_slice }}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/container-engine/cri-dockerd/templates/cri-dockerd.service.j2
+++ b/roles/container-engine/cri-dockerd/templates/cri-dockerd.service.j2
@@ -35,10 +35,8 @@ LimitCORE=infinity
 TasksMax=infinity
 Delegate=yes
 KillMode=process
-# Set the cgroup slice of the service so that kube reserved takes effect
-{% if kube_reserved is defined and kube_reserved|bool %}
-Slice={{ kube_reserved_cgroups_for_service_slice }}
-{% endif %}
+# Set the cgroup slice of the service to optionally enforce resource limitations
+Slice={{ kube_slice }}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -90,7 +90,7 @@
     remote_src: true
   notify: Restart crio
 
-- name: Cri-o | configure crio to use kube reserved cgroups
+- name: Cri-o | configure crio to run in the kube slice
   ansible.builtin.copy:
     dest: /etc/systemd/system/crio.service.d/00-slice.conf
     owner: root
@@ -98,11 +98,8 @@
     mode: '0644'
     content: |
       [Service]
-      Slice={{ kube_reserved_cgroups_for_service_slice }}
+      Slice={{ kube_slice }}
   notify: Restart crio
-  when:
-    - kube_reserved is defined and kube_reserved is true
-    - kube_reserved_cgroups_for_service_slice is defined
 
 - name: Cri-o | update the bin dir for crio.service file
   replace:

--- a/roles/container-engine/cri-o/templates/crio.conf.j2
+++ b/roles/container-engine/cri-o/templates/crio.conf.j2
@@ -114,11 +114,7 @@ conmon = "{{ crio_conmon }}"
 {% if crio_cgroup_manager == "cgroupfs" %}
 conmon_cgroup = "pod"
 {% else %}
-{% if kube_reserved is defined and kube_reserved|bool %}
-conmon_cgroup = "{{ kube_reserved_cgroups_for_service_slice }}"
-{% else %}
-conmon_cgroup = "system.slice"
-{% endif %}
+conmon_cgroup = "{{ kube_slice }}"
 {% endif %}
 
 # Environment variable list for the conmon process, used for passing necessary

--- a/roles/container-engine/docker/templates/docker.service.j2
+++ b/roles/container-engine/docker/templates/docker.service.j2
@@ -32,10 +32,8 @@ TimeoutStartSec=1min
 Restart=on-failure
 StartLimitBurst=3
 StartLimitInterval=60s
-# Set the cgroup slice of the service so that kube reserved takes effect
-{% if kube_reserved is defined and kube_reserved|bool %}
-Slice={{ kube_reserved_cgroups_for_service_slice }}
-{% endif %}
+# Set the cgroup slice of the service to optionally enforce resource limitations
+Slice={{ kube_slice }}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -11,15 +11,6 @@ kube_resolv_conf: "/etc/resolv.conf"
 # Set to empty to avoid cgroup creation
 kubelet_enforce_node_allocatable: "\"\""
 
-# Set runtime and kubelet cgroups when using systemd as cgroup driver (default)
-kube_service_cgroups: "{% if kube_reserved %}{{ kube_reserved_cgroups_for_service_slice }}{% else %}system.slice{% endif %}"
-kubelet_runtime_cgroups: "/{{ kube_service_cgroups }}/{{ container_manager }}.service"
-kubelet_kubelet_cgroups: "/{{ kube_service_cgroups }}/kubelet.service"
-
-# Set runtime and kubelet cgroups when using cgroupfs as cgroup driver
-kubelet_runtime_cgroups_cgroupfs: "/system.slice/{{ container_manager }}.service"
-kubelet_kubelet_cgroups_cgroupfs: "/system.slice/kubelet.service"
-
 # Set systemd service hardening features
 kubelet_systemd_hardening: false
 
@@ -41,6 +32,10 @@ kube_memory_reserved: "256Mi"
 kube_cpu_reserved: "100m"
 kube_ephemeral_storage_reserved: "500Mi"
 kube_pid_reserved: "1000"
+
+# Set slice for host system daemons (sshd, NetworkManager, ...)
+# You probably don't want to change this
+system_slice: system.slice
 
 # Set to true to reserve resources for system daemons
 system_reserved: false

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -8,9 +8,6 @@ kubelet_bind_address: "{{ ip | default('0.0.0.0') }}"
 # resolv.conf to base dns config
 kube_resolv_conf: "/etc/resolv.conf"
 
-# Set to empty to avoid cgroup creation
-kubelet_enforce_node_allocatable: "\"\""
-
 # Set systemd service hardening features
 kubelet_systemd_hardening: false
 
@@ -24,27 +21,37 @@ kube_node_addresses: >-
   {%- endfor -%}
 kubelet_secure_addresses: "localhost link-local {{ kube_pods_subnet }} {{ kube_node_addresses }}"
 
-# Reserve this space for kube resources
-# Whether to run kubelet and container-engine daemons in a dedicated cgroup. (Not required for resource reservations).
-kube_reserved: false
-kube_reserved_cgroups: "/{{ kube_reserved_cgroups_for_service_slice }}"
+## Reserving compute resources
+# https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
+
+# Resource reservations for kube daemons
 kube_memory_reserved: "256Mi"
 kube_cpu_reserved: "100m"
 kube_ephemeral_storage_reserved: "500Mi"
-kube_pid_reserved: "1000"
+kube_pid_reserved: 1000
 
 # Set slice for host system daemons (sshd, NetworkManager, ...)
 # You probably don't want to change this
 system_slice: system.slice
 
-# Set to true to reserve resources for system daemons
-system_reserved: false
-system_reserved_cgroups_for_service_slice: system.slice
-system_reserved_cgroups: "/{{ system_reserved_cgroups_for_service_slice }}"
+# Resource reservations for system daemons
 system_memory_reserved: "512Mi"
 system_cpu_reserved: "500m"
 system_ephemeral_storage_reserved: "500Mi"
 system_pid_reserved: 1000
+
+# Make the kubelet enforce with cgroups the limits of Pods
+enforce_allocatable_pods: true
+
+# Enforce kube_*_reserved as limits
+# WARNING: this limits the resources the kubelet and the container engine can
+# use which can cause instability on your nodes
+enforce_allocatable_kube_reserved: false
+
+# Enforce system_*_reserved as limits
+# WARNING: this limits the resources system daemons can use which can lock you
+# out of your nodes (by OOMkilling sshd for instance)
+enforce_allocatable_system_reserved: false
 
 ## Eviction Thresholds to avoid system OOMs
 # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#eviction-thresholds

--- a/roles/kubernetes/node/tasks/facts.yml
+++ b/roles/kubernetes/node/tasks/facts.yml
@@ -39,12 +39,6 @@
     kubelet_cgroup_driver: "{{ kubelet_cgroup_driver_detected }}"
   when: kubelet_cgroup_driver is undefined
 
-- name: Set kubelet_cgroups options when cgroupfs is used
-  set_fact:
-    kubelet_runtime_cgroups: "{{ kubelet_runtime_cgroups_cgroupfs }}"
-    kubelet_kubelet_cgroups: "{{ kubelet_kubelet_cgroups_cgroupfs }}"
-  when: kubelet_cgroup_driver == 'cgroupfs'
-
 - name: Set kubelet_config_extra_args options when cgroupfs is used
   set_fact:
     kubelet_config_extra_args: "{{ kubelet_config_extra_args | combine(kubelet_config_extra_args_cgroupfs) }}"

--- a/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
@@ -33,7 +33,7 @@ address: {{ kubelet_bind_address }}
 readOnlyPort: {{ kube_read_only_port }}
 healthzPort: {{ kubelet_healthz_port }}
 healthzBindAddress: {{ kubelet_healthz_bind_address }}
-kubeletCgroups: {{ kubelet_kubelet_cgroups }}
+kubeletCgroups: {{ kube_slice_cgroup ~ 'kubelet.service' }}
 clusterDomain: {{ dns_domain }}
 {% if kubelet_protect_kernel_defaults | bool %}
 protectKernelDefaults: true
@@ -63,7 +63,7 @@ clusterDNS:
 {# Node reserved CPU/memory #}
 {% for scope in "kube", "system" %}
 {% if lookup('ansible.builtin.vars', scope + "_reserved") | bool %}
-{{ scope }}ReservedCgroup: {{ lookup('ansible.builtin.vars', scope + '_reserved_cgroups') }}
+{{ scope }}ReservedCgroup: {{ lookup('ansible.builtin.vars', scope + '_slice_cgroup') }}
 {% endif %}
 {{ scope }}Reserved:
 {% for resource in "cpu", "memory", "ephemeral-storage", "pid" %}

--- a/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
@@ -15,12 +15,13 @@ authorization:
 {% else %}
   mode: AlwaysAllow
 {% endif %}
-{% if kubelet_enforce_node_allocatable is defined and kubelet_enforce_node_allocatable != "\"\"" %}
-{% set kubelet_enforce_node_allocatable_list = kubelet_enforce_node_allocatable.split(",") %}
 enforceNodeAllocatable:
-{% for item in kubelet_enforce_node_allocatable_list %}
+{% if enforce_node_allocatable %}
+{% for item in enforce_node_allocatable %}
 - {{ item }}
 {% endfor %}
+{% else %}
+- none # don't enforce anything
 {% endif %}
 staticPodPath: {{ kube_manifest_dir }}
 cgroupDriver: {{ kubelet_cgroup_driver | default('systemd') }}
@@ -62,9 +63,7 @@ clusterDNS:
 {% endfor %}
 {# Node reserved CPU/memory #}
 {% for scope in "kube", "system" %}
-{% if lookup('ansible.builtin.vars', scope + "_reserved") | bool %}
 {{ scope }}ReservedCgroup: {{ lookup('ansible.builtin.vars', scope + '_slice_cgroup') }}
-{% endif %}
 {{ scope }}Reserved:
 {% for resource in "cpu", "memory", "ephemeral-storage", "pid" %}
   {{ resource }}: "{{ lookup('ansible.builtin.vars', scope + '_' ~ (resource | replace('-', '_')) + '_reserved') }}"

--- a/roles/kubernetes/node/templates/kubelet.env.v1beta1.j2
+++ b/roles/kubernetes/node/templates/kubelet.env.v1beta1.j2
@@ -11,7 +11,7 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 --config={{ kube_config_dir }}/kubelet-config.yaml \
 --kubeconfig={{ kube_config_dir }}/kubelet.conf \
 {# end kubeadm specific settings #}
---runtime-cgroups={{ kubelet_runtime_cgroups }} \
+--runtime-cgroups={{ kube_slice_cgroup ~ container_manager ~ '.service' }} \
 {% endset %}
 
 KUBELET_ARGS="{{ kubelet_args_base }} {{ kubelet_custom_flags | join(' ') }}"

--- a/roles/kubernetes/node/templates/kubelet.service.j2
+++ b/roles/kubernetes/node/templates/kubelet.service.j2
@@ -14,9 +14,7 @@ Wants={{ kubelet_dependency }}
 {% endfor %}
 
 [Service]
-{% if kube_reserved|bool %}
-Slice={{ kube_reserved_cgroups_for_service_slice }}
-{% endif %}
+Slice={{ kube_slice }}
 EnvironmentFile=-{{ kube_config_dir }}/kubelet.env
 ExecStart={{ bin_dir }}/kubelet \
 		$KUBE_LOGTOSTDERR \

--- a/roles/kubernetes/node/templates/kubelet.service.j2
+++ b/roles/kubernetes/node/templates/kubelet.service.j2
@@ -14,25 +14,10 @@ Wants={{ kubelet_dependency }}
 {% endfor %}
 
 [Service]
-EnvironmentFile=-{{ kube_config_dir }}/kubelet.env
-{% if system_reserved|bool %}
-ExecStartPre=/bin/mkdir -p /sys/fs/cgroup/cpu/{{ system_reserved_cgroups_for_service_slice }}
-ExecStartPre=/bin/mkdir -p /sys/fs/cgroup/cpuacct/{{ system_reserved_cgroups_for_service_slice }}
-ExecStartPre=/bin/mkdir -p /sys/fs/cgroup/cpuset/{{ system_reserved_cgroups_for_service_slice }}
-ExecStartPre=/bin/mkdir -p /sys/fs/cgroup/hugetlb/{{ system_reserved_cgroups_for_service_slice }}
-ExecStartPre=/bin/mkdir -p /sys/fs/cgroup/memory/{{ system_reserved_cgroups_for_service_slice }}
-ExecStartPre=/bin/mkdir -p /sys/fs/cgroup/pids/{{ system_reserved_cgroups_for_service_slice }}
-ExecStartPre=/bin/mkdir -p /sys/fs/cgroup/systemd/{{ system_reserved_cgroups_for_service_slice }}
-{% endif %}
 {% if kube_reserved|bool %}
-ExecStartPre=/bin/mkdir -p /sys/fs/cgroup/cpu/{{ kube_reserved_cgroups_for_service_slice }}
-ExecStartPre=/bin/mkdir -p /sys/fs/cgroup/cpuacct/{{ kube_reserved_cgroups_for_service_slice }}
-ExecStartPre=/bin/mkdir -p /sys/fs/cgroup/cpuset/{{ kube_reserved_cgroups_for_service_slice }}
-ExecStartPre=/bin/mkdir -p /sys/fs/cgroup/hugetlb/{{ kube_reserved_cgroups_for_service_slice }}
-ExecStartPre=/bin/mkdir -p /sys/fs/cgroup/memory/{{ kube_reserved_cgroups_for_service_slice }}
-ExecStartPre=/bin/mkdir -p /sys/fs/cgroup/pids/{{ kube_reserved_cgroups_for_service_slice }}
-ExecStartPre=/bin/mkdir -p /sys/fs/cgroup/systemd/{{ kube_reserved_cgroups_for_service_slice }}
+Slice={{ kube_reserved_cgroups_for_service_slice }}
 {% endif %}
+EnvironmentFile=-{{ kube_config_dir }}/kubelet.env
 ExecStart={{ bin_dir }}/kubelet \
 		$KUBE_LOGTOSTDERR \
 		$KUBE_LOG_LEVEL \

--- a/roles/kubernetes/node/vars/main.yml
+++ b/roles/kubernetes/node/vars/main.yml
@@ -1,0 +1,3 @@
+---
+kube_slice_cgroup: "/{{ kube_slice.split('-') | join('.slice/') }}/"
+system_slice_cgroup: "/{{ system_slice.split('-') | join('.slice/') }}/"

--- a/roles/kubernetes/node/vars/main.yml
+++ b/roles/kubernetes/node/vars/main.yml
@@ -1,3 +1,8 @@
 ---
 kube_slice_cgroup: "/{{ kube_slice.split('-') | join('.slice/') }}/"
 system_slice_cgroup: "/{{ system_slice.split('-') | join('.slice/') }}/"
+enforce_node_allocatable_stub:
+  pods: "{{ enforce_allocatable_pods }}"
+  kube-reserved: "{{ enforce_allocatable_kube_reserved }}"
+  system-reserved: "{{ enforce_allocatable_system_reserved }}"
+enforce_node_allocatable: "{{ enforce_node_allocatable_stub | dict2items | selectattr('value') | map(attribute='key') }}"

--- a/roles/kubespray-defaults/defaults/main/main.yml
+++ b/roles/kubespray-defaults/defaults/main/main.yml
@@ -34,9 +34,6 @@ kube_proxy_mode: ipvs
 ## The timeout for init first control-plane
 kubeadm_init_timeout: 300s
 
-# TODO: remove this
-kube_reserved_cgroups_for_service_slice: kube.slice
-
 ## List of kubeadm init phases that should be skipped during control plane setup
 ## By default 'addon/coredns' is skipped
 ## 'addon/kube-proxy' gets skipped for some network plugins

--- a/roles/kubespray-defaults/defaults/main/main.yml
+++ b/roles/kubespray-defaults/defaults/main/main.yml
@@ -23,6 +23,11 @@ kube_version: v1.30.4
 ## The minimum version working
 kube_version_min_required: v1.28.0
 
+# TODO: put this default to more specific place -> needed by roles container-engine+kubernetes/node
+# Set the systemd slice for kubernetes-related daemons: kubelet and container engine
+# You probably don't want to change this
+kube_slice: runtime.slice
+
 ## Kube Proxy mode One of ['iptables', 'ipvs']
 kube_proxy_mode: ipvs
 

--- a/tests/files/packet_almalinux8-crio.yml
+++ b/tests/files/packet_almalinux8-crio.yml
@@ -6,3 +6,9 @@ mode: default
 # Kubespray settings
 container_manager: crio
 auto_renew_certificates: true
+
+# Test cgroups
+
+enforce_allocatable_kube_reserved: true
+enforce_allocatable_system_reserved: true
+kube_slice: nested-runtime.slice

--- a/tests/files/packet_amazon-linux-2-all-in-one.yml
+++ b/tests/files/packet_amazon-linux-2-all-in-one.yml
@@ -2,3 +2,8 @@
 # Instance settings
 cloud_image: amazon-linux-2
 mode: all-in-one
+
+enforce_allocatable_kube_reserved: true
+enforce_allocatable_system_reserved: true
+kube_slice: nested-runtime.slice
+kubelet_cgroup_driver: cgroupfs

--- a/tests/files/packet_ubuntu20-crio.yml
+++ b/tests/files/packet_ubuntu20-crio.yml
@@ -8,3 +8,9 @@ container_manager: crio
 
 download_localhost: false
 download_run_once: true
+
+# Cgroups
+enforce_allocatable_kube_reserved: true
+enforce_allocatable_system_reserved: true
+kube_slice: nested-runtime.slice
+kubelet_cgroup_driver: cgroupfs

--- a/tests/files/packet_ubuntu24-calico-all-in-one.yml
+++ b/tests/files/packet_ubuntu24-calico-all-in-one.yml
@@ -23,5 +23,5 @@ containerd_registries_mirrors:
         capabilities: ["pull", "resolve", "push"]
         skip_verify: true
 
-kube_reserved: true
-system_reserved: true
+enforce_allocatable_kube_reserved: true
+enforce_allocatable_system_reserved: true

--- a/tests/files/packet_ubuntu24-calico-all-in-one.yml
+++ b/tests/files/packet_ubuntu24-calico-all-in-one.yml
@@ -25,3 +25,4 @@ containerd_registries_mirrors:
 
 enforce_allocatable_kube_reserved: true
 enforce_allocatable_system_reserved: true
+kube_slice: nested-runtime.slice


### PR DESCRIPTION
**What type of PR is this?**
/kind design
Documentation/Bug are probably relevant as well

**What this PR does / why we need it**:
#9209 introduced knobs for using https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/

However, IMO, it leaks a bunch of stuff to the user that it should not.

This is an attempt to streamline the configuration and reduce variance of the jinja templates.

See the commits message for more detailed explanation.

closes #8870 (this one is a superset)
Require #10643 
Also, this should fix `journactl -u kubelet` not getting kubelet logs (because kubelet jumped out of the service cgroup)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
action required
`kubelet_enforce_node_allocatable` is removed, use instead `enforce_allocatable_{pods,kube_reserved,system_reserved}`
`system_reserved` and `kube_reserved` are removed, use instead `enforce_allocatable_{kube,system}_reserved`
The kubelet and container manager service will by default run in the `runtime.slice` 
{kube,system}_reserved_cgroups and {kube,system}_reserved_cgroups_for_service are removed, use `{kube,system}_slice` to customize their slice
The system slice is no longer created by kubelet on startup
The kube slice creation is delegated to systemd
The system and kube slice are now indifferent to the cgroup driver used
For cri-o with systemd cgroup-driver, use `kube_slice` variable for conmon_cgroup instead of "system.slice" 
```
