### PR TITLE
Add scheduler plugins support

### DIFF
--- a/docs/kubernetes-apps/scheduler_plugins.md
+++ b/docs/kubernetes-apps/scheduler_plugins.md
@@ -1,0 +1,33 @@
+# Scheduler plugins for Kubernetes
+
+[`scheduler-plugins`](https://github.com/kubernetes-sigs/scheduler-plugins) is out-of-tree scheduler plugins based on the [scheduler framework](https://kubernetes.io/docs/concepts/scheduling-eviction/scheduling-framework/).
+
+The kube-scheduler binary includes a list of plugins. But We only integrate some of them currently. The reasons for that are:
+
+- Some plugins need to run a separate scheduler pod, meaning that there are at least two schedulers in the cluster. Running multi-scheduler will inevitably encounter resource conflicts when the cluster is short of resources. Therefore, it is not recommended in the production env.  
+- Some plugins are still in Alpha stage(not stable enough).
+
+So we will be using an unified scheduler and hence keep the resources conflict-free. That means we should replace the default-scheduler, there are some automatic jobs coming in Kubespray, we need to ensure that doesn't break anything.
+
+## Compatibility Matrix
+
+There are requirements for the version of Kubernetes, please see [Compatibility Matrix
+](https://github.com/kubernetes-sigs/scheduler-plugins/tree/master?tab=readme-ov-file#compatibility-matrix). It deserves our attention.
+
+## Current integrated plugins
+
+- [CoScheduling](https://github.com/kubernetes-sigs/scheduler-plugins/tree/master/pkg/coscheduling) [Beta]
+- [CapacityScheduling](https://github.com/kubernetes-sigs/scheduler-plugins/tree/master/pkg/capacityscheduling) [Beta]
+- [NodeResources](https://github.com/kubernetes-sigs/scheduler-plugins/tree/master/pkg/noderesources) [Beta]
+
+## Turning it on
+
+  The `scheduler_plugins_enabled` option is used to enable the scheduler plugins. It will install scheduler controller first, but then it won't install any plugins if the option `scheduler_plugins` is set empty, it's possible to install plugins manually after the completion of cluster provisioning.
+
+  So, set a value to `scheduler_plugins` option, plugins will be installed when the cluster is provisioning by Kubespray. It must be in [support list](#current-integrated-plugins).
+
+  In addition, to use custom scheduler configuration, set a value for `scheduler_plugins_custom_profile` option. Note that it only changes the profile of `default-scheduler`.
+
+## Leverage plugin
+
+  Once the plugin is installed, we can apply CRs into cluster. For example, if using `CoScheduling`, we can apply the CR and test the deployment in the [example](https://github.com/kubernetes-sigs/scheduler-plugins/blob/master/doc/install.md#test-coscheduling).

--- a/roles/kubernetes-apps/meta/main.yml
+++ b/roles/kubernetes-apps/meta/main.yml
@@ -124,3 +124,10 @@ dependencies:
       - inventory_hostname == groups['kube_control_plane'][0]
     tags:
       - argocd
+
+  - role: kubernetes-apps/scheduler_plugins
+    when:
+      - scheduler_plugins_enabled
+      - inventory_hostname in groups['kube_control_plane']
+    tags:
+      - scheduler_plugins

--- a/roles/kubernetes-apps/scheduler_plugins/defaults/main.yml
+++ b/roles/kubernetes-apps/scheduler_plugins/defaults/main.yml
@@ -1,0 +1,96 @@
+---
+scheduler_plugins_controller_replicas: 1
+
+# Global gate to enable or disable scheduler plugins.
+scheduler_plugins_enabled: false
+
+# List of currently supported scheduler plugins.
+scheduler_plugins_supported_list:
+  - CoScheduling
+  - CapacityScheduling
+  - NodeResources
+
+# List of scheduler plugins to be enabled.
+scheduler_plugins:
+  - CoScheduling
+
+# Path to kubeSchedulerConfiguration file.
+scheduler_configuration_path: "{{ kube_config_dir }}/scheduler-config.yml"
+
+# Additional KubeSchedulerConfiguration settings (e.g. metricsBindAddress).
+kube_scheduler_config_extra_opts: {}
+
+# List of scheduler extenders (dicts), each holding the values of how to
+# communicate with the extender.
+kube_scheduler_extenders: []
+
+# Leader Election options (e.g. ResourceName, RetryPerion) except from
+# LeaseDuration and Renew deadline which are defined in following vars.
+kube_scheduler_leader_elect_extra_opts: {}
+
+# Leader election lease duration
+kube_scheduler_leader_elect_lease_duration: 15s
+
+# Leader election lease timeout
+kube_scheduler_leader_elect_renew_deadline: 10s
+
+# Custom profile for enabled scheduler plugins (effect on default-scheduler).
+scheduler_plugins_custom_profile: ""
+
+# Default profile for CoScheduling (effect on default-scheduler).
+scheduler_plugins_coscheduling_profile: |-
+  plugins:
+    preFilter:
+      enabled:
+      - name: CapacityScheduling
+    postFilter:
+      enabled:
+      - name: CapacityScheduling
+      disabled:
+      - name: "*"
+    reserve:
+      enabled:
+      - name: CapacityScheduling
+
+# Default profile for CapacityScheduling (effect on default-scheduler).
+scheduler_plugins_capacityscheduling_profile: |-
+  plugins:
+    queueSort:
+      enabled:
+      - name: Coscheduling
+      disabled:
+      - name: "*"
+    preFilter:
+      enabled:
+      - name: Coscheduling
+    postFilter:
+      enabled:
+      - name: Coscheduling
+    permit:
+      enabled:
+      - name: Coscheduling
+    reserve:
+      enabled:
+      - name: Coscheduling
+  pluginConfig:
+  - name: Coscheduling
+    args:
+      permitWaitingTimeSeconds: 10
+
+# Default profile for NodeResources (effect on default-scheduler).
+scheduler_plugins_noderesources_profile: |-
+  plugins:
+    score:
+      enabled:
+      - name: NodeResourcesAllocatable
+      disabled:
+      - name: "*"
+  pluginConfig:
+  - name: NodeResourcesAllocatable
+    args:
+      mode: Least
+      resources:
+      - name: cpu
+        weight: 1000000
+      - name: memory
+        weight: 1

--- a/roles/kubernetes-apps/scheduler_plugins/plugins/tasks/apply_plugin.yml
+++ b/roles/kubernetes-apps/scheduler_plugins/plugins/tasks/apply_plugin.yml
@@ -1,0 +1,34 @@
+---
+- name: Schedler Plugins | Set scheduler plugin template lists
+  when: inventory_hostname == groups['kube_control_plane'][0]
+  tags:
+    - scheduler_plugins
+  set_fact:
+    scheduler_plugins_templates:
+      CoScheduling:
+        - { name: coscheduling-crd, file: coscheduling-crd.yml }
+      CapacityScheduling:
+        - { name: capacityscheduling-crd, file: capacityscheduling-crd.yml }
+      NodeResources: []
+
+- name: Scheduler Plugins {{ plugin }} | Create manifests
+  template:
+    src: "{{ item.file }}.j2"
+    dest: "{{ kube_config_dir }}/scheduler-plugins/{{ item.file }}"
+    mode: 0644
+  with_items: "{{ scheduler_plugins_templates[plugin] }}"
+  register: coscheduling_manifests
+  when: inventory_hostname == groups['kube_control_plane'][0]
+  tags:
+    - scheduler_plugins
+
+- name: Scheduler Plugins {{ plugin }} | Apply manifests
+  kube:
+    name: "{{ item.item.name }}"
+    kubectl: "{{ bin_dir }}/kubectl"
+    filename: "{{ kube_config_dir }}/scheduler-plugins/{{ item.item.file }}"
+    state: "latest"
+  with_items: "{{ coscheduling_manifests.results }}"
+  when: inventory_hostname == groups['kube_control_plane'][0]
+  tags:
+    - scheduler_plugins

--- a/roles/kubernetes-apps/scheduler_plugins/plugins/tasks/main.yml
+++ b/roles/kubernetes-apps/scheduler_plugins/plugins/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+- name: Scheduler Plugins | Ensure dir exists
+  file:
+    path: "{{ kube_config_dir }}/scheduler-plugins"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+  when: inventory_hostname == groups['kube_control_plane'][0]
+  tags:
+    - scheduler_plugins
+
+- name: Scheduler Plugins | Enable plugins
+  include_tasks: apply_plugin.yml
+  with_items: "{{ scheduler_plugins }}"
+  vars:
+    plugin: "{{ item }}"
+  when: inventory_hostname == groups['kube_control_plane'][0]
+  tags:
+    - scheduler_plugins
+
+- name: Scheduler Plugins | Create scheduler configuration
+  template:
+    src: "scheduler-config.yml.j2"
+    dest: "{{ scheduler_configuration_path }}"
+    mode: 0644
+  vars:
+    enable_leader_election: "{{ (groups['kube_control_plane'] | length) > 1 }}"
+  when: inventory_hostname in groups['kube_control_plane']
+  tags:
+    - scheduler_plugins
+
+- name: Scheduler Plugins | Patch kube-scheduler
+  import_tasks: patch_kube_scheduler.yml
+  when: inventory_hostname in groups['kube_control_plane']
+  tags:
+    - scheduler_plugins

--- a/roles/kubernetes-apps/scheduler_plugins/plugins/tasks/patch_kube_scheduler.yml
+++ b/roles/kubernetes-apps/scheduler_plugins/plugins/tasks/patch_kube_scheduler.yml
@@ -1,0 +1,62 @@
+---
+- name: Scheduler Plugins | Backup kube-scheduler.yaml
+  copy:
+    src: "{{ kube_manifest_dir }}/kube-scheduler.yaml"
+    dest: "{{ kube_config_dir }}/kube-scheduler.yaml"
+    remote_src: true
+    mode: preserve
+    force: false     # backup only once
+  when: inventory_hostname in groups['kube_control_plane']
+  tags:
+    - scheduler_plugins
+
+- name: Scheduler Plugins | Download yq
+  include_tasks: "../../../../download/tasks/download_file.yml"
+  vars:
+    download: "{{ download_defaults | combine(downloads.yq) }}"
+  when: inventory_hostname in groups['kube_control_plane']
+  tags:
+    - scheduler_plugins
+
+- name: Scheduler Plugins | Copy yq binary from download dir
+  copy:
+    src: "{{ downloads.yq.dest }}"
+    dest: "{{ bin_dir }}/yq"
+    mode: 0755
+    remote_src: yes
+  when: inventory_hostname in groups['kube_control_plane']
+  tags:
+    - scheduler_plugins
+
+- name: Scheduler Plugins | Create yq patch for kube-scheduler
+  template:
+    src: kube-scheduler-patch.yq.j2
+    dest: "{{ kube_config_dir }}/scheduler-plugins/kube-scheduler-patch.yq"
+    mode: 0644
+  when: inventory_hostname in groups['kube_control_plane']
+  tags:
+    - scheduler_plugins
+
+- name: Scheduler Plugins | Patch {{ kube_manifest_dir }}/kube-scheduler.yaml
+  command: "{{ bin_dir }}/yq -i --from-file {{ kube_config_dir }}/scheduler-plugins/kube-scheduler-patch.yq {{ kube_manifest_dir }}/kube-scheduler.yaml"
+  when: inventory_hostname in groups['kube_control_plane']
+  tags:
+    - scheduler_plugins
+
+- name: Scheduler Plugins | Remove kube-scheduler pods immediately
+  command: "{{ kubectl }} -n kube-system delete pods -l component=kube-scheduler,tier=control-plane"
+  when: inventory_hostname == groups['kube_control_plane'][0]
+
+- name: Scheduler Plugins | Wait for kube-scheduler pod to be ready
+  command: "{{ kubectl }} -n kube-system get pods -l component=kube-scheduler,tier=control-plane -o jsonpath='{.items[?(@.status.containerStatuses[0].ready==false)].metadata.name}'"   # noqa ignore-errors
+  register: pods_not_ready
+  until: pods_not_ready.stdout.find("kube-scheduler")==-1
+  retries: 30
+  delay: 10
+  ignore_errors: true
+  delegate_to: "{{ groups['kube_control_plane'] | first }}"
+  run_once: true
+  changed_when: false
+  when: inventory_hostname in groups['kube_control_plane']
+  tags:
+    - scheduler_plugins

--- a/roles/kubernetes-apps/scheduler_plugins/plugins/templates/capacityscheduling-crd.yml.j2
+++ b/roles/kubernetes-apps/scheduler_plugins/plugins/templates/capacityscheduling-crd.yml.j2
@@ -1,0 +1,82 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/scheduler-plugins/pull/52
+    controller-gen.kubebuilder.io/version: v0.11.1
+  creationTimestamp: null
+  name: elasticquotas.scheduling.x-k8s.io
+spec:
+  group: scheduling.x-k8s.io
+  names:
+    kind: ElasticQuota
+    listKind: ElasticQuotaList
+    plural: elasticquotas
+    shortNames:
+    - eq
+    - eqs
+    singular: elasticquota
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ElasticQuota sets elastic quota restrictions per namespace
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ElasticQuotaSpec defines the Min and Max for Quota.
+            properties:
+              max:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: Max is the set of desired max limits for each named resource.
+                  The usage of max is based on the resource configurations of successfully
+                  scheduled pods.
+                type: object
+              min:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: Min is the set of desired guaranteed limits for each
+                  named resource.
+                type: object
+            type: object
+          status:
+            description: ElasticQuotaStatus defines the observed use.
+            properties:
+              used:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: Used is the current observed total usage of the resource
+                  in the namespace.
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/roles/kubernetes-apps/scheduler_plugins/plugins/templates/coscheduling-crd.yml.j2
+++ b/roles/kubernetes-apps/scheduler_plugins/plugins/templates/coscheduling-crd.yml.j2
@@ -1,0 +1,97 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/scheduler-plugins/pull/50
+    controller-gen.kubebuilder.io/version: v0.11.1
+  creationTimestamp: null
+  name: podgroups.scheduling.x-k8s.io
+spec:
+  group: scheduling.x-k8s.io
+  names:
+    kind: PodGroup
+    listKind: PodGroupList
+    plural: podgroups
+    shortNames:
+    - pg
+    - pgs
+    singular: podgroup
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PodGroup is a collection of Pod; used for batch workload.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of the desired behavior of the pod group.
+            properties:
+              minMember:
+                description: MinMember defines the minimal number of members/tasks
+                  to run the pod group; if there's not enough resources to start all
+                  tasks, the scheduler will not start anyone.
+                format: int32
+                type: integer
+              minResources:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: MinResources defines the minimal resource of members/tasks
+                  to run the pod group; if there's not enough resources to start all
+                  tasks, the scheduler will not start anyone.
+                type: object
+              scheduleTimeoutSeconds:
+                description: ScheduleTimeoutSeconds defines the maximal time of members/tasks
+                  to wait before run the pod group;
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: Status represents the current information about a pod group.
+              This data may not be up to date.
+            properties:
+              failed:
+                description: The number of pods which reached phase Failed.
+                format: int32
+                type: integer
+              occupiedBy:
+                description: OccupiedBy marks the workload (e.g., deployment, statefulset)
+                  UID that occupy the podgroup. It is empty if not initialized.
+                type: string
+              phase:
+                description: Current phase of PodGroup.
+                type: string
+              running:
+                description: The number of actively running pods.
+                format: int32
+                type: integer
+              scheduleStartTime:
+                description: ScheduleStartTime of the group
+                format: date-time
+                type: string
+              succeeded:
+                description: The number of pods which reached phase Succeeded.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/roles/kubernetes-apps/scheduler_plugins/plugins/templates/kube-scheduler-patch.yq.j2
+++ b/roles/kubernetes-apps/scheduler_plugins/plugins/templates/kube-scheduler-patch.yq.j2
@@ -1,0 +1,8 @@
+{# Step 6 in https://github.com/kubernetes-sigs/scheduler-plugins/blob/v0.27.8/doc/install.md#as-a-single-scheduler-replacing-the-vanilla-default-scheduler #}
+del(.spec.containers[0].command[] | select(test("--config=|--kubeconfig=|--leader-elect=")))  |
+del(.spec.containers[0].volumeMounts[] | select(.name == "sched-cc")) |
+del(.spec.volumes[] | select(.name == "sched-cc")) |
+.spec.containers[0].command += "--config={{ scheduler_configuration_path }}" |
+.spec.containers[0].image = "{{ scheduler_plugins_kube_scheduler_image_repo }}:{{ scheduler_plugins_kube_scheduler_image_tag }}" |
+.spec.containers[0].volumeMounts += {"mountPath": "{{ scheduler_configuration_path }}", "name": "sched-cc", "readOnly": true} |
+.spec.volumes += {"hostPath": {"path": "{{ scheduler_configuration_path }}", "type": "FileOrCreate"}, "name": "sched-cc"}

--- a/roles/kubernetes-apps/scheduler_plugins/plugins/templates/scheduler-config.yml.j2
+++ b/roles/kubernetes-apps/scheduler_plugins/plugins/templates/scheduler-config.yml.j2
@@ -1,0 +1,30 @@
+apiVersion: kubescheduler.config.k8s.io/v1
+kind: KubeSchedulerConfiguration
+leaderElection:
+  leaderElect: {{ enable_leader_election | lower }}
+  leaseDuration: {{ kube_scheduler_leader_elect_lease_duration }}
+  renewDeadline: {{ kube_scheduler_leader_elect_renew_deadline }}
+{% for key in kube_scheduler_leader_elect_extra_opts %}
+  {{ key }}: {{ kube_scheduler_leader_elect_extra_opts[key] }}
+{% endfor %}
+clientConnection:
+  kubeconfig: {{ kube_config_dir }}/scheduler.conf
+{% if kube_scheduler_extenders %}
+extenders:
+{{ kube_scheduler_extenders | to_nice_yaml(indent=2, width=256) }}
+{% endif %}
+profiles:
+- schedulerName: default-scheduler
+{% if scheduler_plugins_custom_profile is defined and scheduler_plugins_custom_profile != "" %}
+{{ scheduler_plugins_custom_profile | indent(2, true) }}
+{% else %}
+{% set profile = {} %}
+{% for scheduler_plugin in scheduler_plugins %}
+{% set profile_var = 'scheduler_plugins_' + (scheduler_plugin | lower) + '_profile' %}
+{% set _ = profile.update(profile | combine((lookup('vars', profile_var) | from_yaml), recursive=True, list_merge='append_rp')) %}
+{% endfor %}
+{{ profile | to_nice_yaml(indent=2, width=256) | indent(2, true) }}
+{% endif %}
+{% for key in kube_scheduler_config_extra_opts %}
+{{ key }}: {{ kube_scheduler_config_extra_opts[key] }}
+{% endfor %}

--- a/roles/kubernetes-apps/scheduler_plugins/tasks/main.yml
+++ b/roles/kubernetes-apps/scheduler_plugins/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Scheduler Plugins | Check if the scheduler plugins are supported
+  assert:
+    that:
+      - "(scheduler_plugins | intersect(scheduler_plugins_supported_list) | length) == (scheduler_plugins | length) or scheduler_plugins | length == 0"
+    msg: "{{ scheduler_plugins | difference(scheduler_plugins_supported_list) | join(',') }} is/are not in the list of supported scheduler plugins"
+  when:
+    - scheduler_plugins_enabled
+    - inventory_hostname == groups['kube_control_plane'][0]
+  tags:
+    - scheduler_plugins
+
+- name: Scheduler Plugins | Install plugin controller
+  include_tasks: plugins_controller.yml
+  when: scheduler_plugins_enabled
+  tags:
+    - scheduler_plugins
+
+- name: Scheduler Plugins | Install plugin
+  include_role:
+    name: kubernetes-apps/scheduler_plugins/plugins
+  when:
+    - scheduler_plugins_enabled
+    - scheduler_plugins | length > 0
+  tags:
+    - scheduler_plugins

--- a/roles/kubernetes-apps/scheduler_plugins/tasks/plugins_controller.yml
+++ b/roles/kubernetes-apps/scheduler_plugins/tasks/plugins_controller.yml
@@ -1,0 +1,53 @@
+---
+- name: Scheduler Plugins | Create dir
+  file:
+    path: "{{ kube_config_dir }}/scheduler-plugins"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+  when: inventory_hostname == groups['kube_control_plane'][0]
+  tags:
+    - scheduler_plugins
+
+- name: Scheduler Plugins | Create manifests
+  template:
+    src: "{{ item.file }}.j2"
+    dest: "{{ kube_config_dir }}/scheduler-plugins/{{ item.file }}"
+    mode: 0644
+  with_items:
+    - { name: plugins-cr, file: plugins-cr.yml, type: cr }
+    - { name: plugins-crb, file: plugins-crb.yml, type: crb }
+    - { name: controller-ns, file: controller-ns.yml, type: ns }
+    - { name: controller-sa, file: controller-sa.yml, type: sa }
+    - { name: controller-cr, file: controller-cr.yml, type: cr }
+    - { name: controller-crb, file: controller-crb.yml, type: crb }
+    - { name: controller-deploy, file: controller-deploy.yml, type: deployment }
+  register: scheduler_plugins_manifests
+  when: inventory_hostname == groups['kube_control_plane'][0]
+  tags:
+    - scheduler_plugins
+
+- name: Scheduler Plugins | Apply manifests
+  kube:
+    name: "{{ item.item.name }}"
+    kubectl: "{{ bin_dir }}/kubectl"
+    resource: "{{ item.item.type }}"
+    filename: "{{ kube_config_dir }}/scheduler-plugins/{{ item.item.file }}"
+    state: "latest"
+  with_items: "{{ scheduler_plugins_manifests.results }}"
+  when: inventory_hostname == groups['kube_control_plane'][0]
+  tags:
+    - scheduler_plugins
+
+- name: Scheduler Plugins | Wait for scheduler-plugins-controller pods to be ready
+  command: "{{ kubectl }} -n scheduler-plugins get pods -l app=scheduler-plugins-controller -o jsonpath='{.items[?(@.status.containerStatuses[0].ready==false)].metadata.name}'"   # noqa ignore-errors
+  register: pods_not_ready
+  until: pods_not_ready.stdout.find("scheduler-plugins-controller")==-1
+  retries: 30
+  delay: 10
+  ignore_errors: true
+  changed_when: false
+  when: inventory_hostname == groups['kube_control_plane'][0]
+  tags:
+    - scheduler_plugins

--- a/roles/kubernetes-apps/scheduler_plugins/templates/controller-cr.yml.j2
+++ b/roles/kubernetes-apps/scheduler_plugins/templates/controller-cr.yml.j2
@@ -1,0 +1,14 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: scheduler-plugins-controller
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["scheduling.x-k8s.io"]
+  resources: ["podgroups", "elasticquotas", "podgroups/status", "elasticquotas/status"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch", "update"]

--- a/roles/kubernetes-apps/scheduler_plugins/templates/controller-crb.yml.j2
+++ b/roles/kubernetes-apps/scheduler_plugins/templates/controller-crb.yml.j2
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: scheduler-plugins-controller
+subjects:
+- kind: ServiceAccount
+  name: scheduler-plugins-controller
+  namespace: scheduler-plugins
+roleRef:
+  kind: ClusterRole
+  name: scheduler-plugins-controller
+  apiGroup: rbac.authorization.k8s.io

--- a/roles/kubernetes-apps/scheduler_plugins/templates/controller-deploy.yml.j2
+++ b/roles/kubernetes-apps/scheduler_plugins/templates/controller-deploy.yml.j2
@@ -1,0 +1,22 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: scheduler-plugins-controller
+  namespace: scheduler-plugins
+  labels:
+    app: scheduler-plugins-controller
+spec:
+  replicas: {{ scheduler_plugins_controller_replicas }}
+  selector:
+    matchLabels:
+      app: scheduler-plugins-controller
+  template:
+    metadata:
+      labels:
+        app: scheduler-plugins-controller
+    spec:
+      serviceAccountName: scheduler-plugins-controller
+      containers:
+      - name: scheduler-plugins-controller
+        image: {{ scheduler_plugins_controller_image_repo }}:{{ scheduler_plugins_controller_image_tag }}
+        imagePullPolicy: {{ k8s_image_pull_policy }}

--- a/roles/kubernetes-apps/scheduler_plugins/templates/controller-ns.yml.j2
+++ b/roles/kubernetes-apps/scheduler_plugins/templates/controller-ns.yml.j2
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: scheduler-plugins

--- a/roles/kubernetes-apps/scheduler_plugins/templates/controller-sa.yml.j2
+++ b/roles/kubernetes-apps/scheduler_plugins/templates/controller-sa.yml.j2
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: scheduler-plugins-controller
+  namespace: scheduler-plugins

--- a/roles/kubernetes-apps/scheduler_plugins/templates/plugins-cr.yml.j2
+++ b/roles/kubernetes-apps/scheduler_plugins/templates/plugins-cr.yml.j2
@@ -1,0 +1,15 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:kube-scheduler:plugins
+rules:
+- apiGroups: ["scheduling.x-k8s.io"]
+  resources: ["podgroups", "elasticquotas", "podgroups/status", "elasticquotas/status"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+# for network-aware plugins add the following lines (scheduler-plugins v.0.24.9)
+#- apiGroups: [ "appgroup.diktyo.k8s.io" ]
+#  resources: [ "appgroups" ]
+#  verbs: [ "get", "list", "watch", "create", "delete", "update", "patch" ]
+#- apiGroups: [ "networktopology.diktyo.k8s.io" ]
+#  resources: [ "networktopologies" ]
+#  verbs: [ "get", "list", "watch", "create", "delete", "update", "patch" ]

--- a/roles/kubernetes-apps/scheduler_plugins/templates/plugins-crb.yml.j2
+++ b/roles/kubernetes-apps/scheduler_plugins/templates/plugins-crb.yml.j2
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:kube-scheduler:plugins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kube-scheduler:plugins
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: system:kube-scheduler

--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -151,6 +151,11 @@ crio_supported_versions:
   v1.26: v1.26.4
 crio_version: "{{ crio_supported_versions[kube_major_version] }}"
 
+scheduler_plugins_supported_versions:
+  v1.27: v0.27.8
+  v1.26: v0.26.7
+scheduler_plugins_version: "{{ scheduler_plugins_supported_versions[kube_major_version] }}"
+
 yq_version: "v4.35.2"
 
 # Download URLs
@@ -288,6 +293,11 @@ nodelocaldns_image_tag: "{{ nodelocaldns_version }}"
 dnsautoscaler_version: v1.8.8
 dnsautoscaler_image_repo: "{{ kube_image_repo }}/cpa/cluster-proportional-autoscaler"
 dnsautoscaler_image_tag: "{{ dnsautoscaler_version }}"
+
+scheduler_plugins_controller_image_repo: "{{ kube_image_repo }}/scheduler-plugins/controller"
+scheduler_plugins_controller_image_tag: "{{ scheduler_plugins_version }}"
+scheduler_plugins_kube_scheduler_image_repo: "{{ kube_image_repo }}/scheduler-plugins/kube-scheduler"
+scheduler_plugins_kube_scheduler_image_tag: "{{ scheduler_plugins_version }}"
 
 registry_version: "2.8.1"
 registry_image_repo: "{{ docker_image_repo }}/library/registry"

--- a/roles/kubespray-defaults/defaults/main/main.yml
+++ b/roles/kubespray-defaults/defaults/main/main.yml
@@ -681,3 +681,34 @@ sysctl_file_path: "/etc/sysctl.d/99-sysctl.conf"
 
 system_upgrade: false
 system_upgrade_reboot: on-upgrade  # never, always
+
+# Global gate to enable or disable scheduler plugins.
+scheduler_plugins_enabled: false
+# Plugins include CoSchedulgin, CapacityScheduling, NodeResources
+# By default, no plugins would be installed
+scheduler_plugins: []
+# Custom profile for enabled scheduler plugins (effect on default-scheduler), for example:
+# scheduler_plugins_custom_profile: |-
+#   plugins:
+#     queueSort:
+#       enabled:
+#       - name: Coscheduling
+#       disabled:
+#       - name: "*"
+#     preFilter:
+#       enabled:
+#       - name: Coscheduling
+#     postFilter:
+#       enabled:
+#       - name: Coscheduling
+#     permit:
+#       enabled:
+#       - name: Coscheduling
+#     reserve:
+#       enabled:
+#       - name: Coscheduling
+#   pluginConfig:
+#     - name: Coscheduling
+#       args:
+#         permitWaitingTimeSeconds: 10
+scheduler_plugins_custom_profile: ""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
These scheduler plugins are exercised in large companies. There are some benefits:

- Enhanced Scheduling Features: scheduler-plugins provides a series of advanced scheduling features, such as co-scheduling, capacity-scheduling, node resources, and so on. These features help users manage cluster resources more flexibly and optimize resource allocation and application performance.
- Simplify deployment and management: Integrating scheduler-plugins into Kubespray simplifies the deployment and management of Kubernetes clusters. Users can easily enable and configure advanced scheduler-plugins while deploying a Kubernetes cluster using Kubespray.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
option `scheduler_plugins_enabled` enable or disable the installation scheduler plugins
option `scheduler_plugins` describe the plugins name
option `scheduler_plugins_custom_profile` override the profile on default-scheduler
```
