### PR TITLE
Allow vagrant directory location to be configurable

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,6 +77,8 @@ $libvirt_nested ||= false
 $ansible_verbosity ||= false
 $ansible_tags ||= ENV['VAGRANT_ANSIBLE_TAGS'] || ""
 
+$vagrant_dir ||= File.join(File.dirname(__FILE__), ".vagrant")
+
 $playbook ||= "cluster.yml"
 
 host_vars = {}
@@ -96,7 +98,7 @@ $inventory = File.absolute_path($inventory, File.dirname(__FILE__))
 # if $inventory has a hosts.ini file use it, otherwise copy over
 # vars etc to where vagrant expects dynamic inventory to be
 if ! File.exist?(File.join(File.dirname($inventory), "hosts.ini"))
-  $vagrant_ansible = File.join(File.dirname(__FILE__), ".vagrant", "provisioners", "ansible")
+  $vagrant_ansible = File.join(File.absolute_path($vagrant_dir), "provisioners", "ansible")
   FileUtils.mkdir_p($vagrant_ansible) if ! File.exist?($vagrant_ansible)
   $vagrant_inventory = File.join($vagrant_ansible,"inventory")
   FileUtils.rm_f($vagrant_inventory)


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:

In the case were vagrant is not invoked directly from the repository, but from another location, and the Vagrantfile is "included" into another, we need to be able to specify where the location of the vagrant directory is, as of now it's hardcoded relative to the Vagrantfile location. This commit fix it.


**Which issue(s) this PR fixes**:

Fixes #10717 

**Does this PR introduce a user-facing change?**:

```release-note
Allows .vagrant folder location to be configured
```
