### PR TITLE
Refactor check_galaxy + fix version

### DIFF
--- a/docs/ansible_collection.md
+++ b/docs/ansible_collection.md
@@ -15,7 +15,7 @@ Kubespray can be installed as an [Ansible collection](https://docs.ansible.com/a
    collections:
    - name: https://github.com/kubernetes-sigs/kubespray
      type: git
-     version: v2.23.1
+     version: master # use the appropriate tag or branch for the version you need
    ```
 
 2. Install your collection

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: kubernetes_sigs
 description: Deploy a production ready Kubernetes cluster
 name: kubespray
-version: 2.23.1
+version: 2.24.0
 readme: README.md
 authors:
   - luksi1

--- a/tests/scripts/check_galaxy_version.sh
+++ b/tests/scripts/check_galaxy_version.sh
@@ -2,17 +2,10 @@
 set -e
 
 version_from_galaxy=$(grep "^version:" galaxy.yml | awk '{print $2}')
-version_from_docs=$(grep -P "^\s+version:\sv\d+\.\d+\.\d+" docs/ansible_collection.md | awk '{print $2}')
 
 if [[ $KUBESPRAY_VERSION != "v${version_from_galaxy}" ]]
 then
 	echo "Please update galaxy.yml version to match the KUBESPRAY_VERSION. Be sure to remove the \"v\" to adhere"
 	echo "to semenatic versioning"
-	exit 1
-fi
-
-if [[ $KUBESPRAY_VERSION != "${version_from_docs}" ]]
-then
-	echo "Please update the documentation for Ansible collections under docs/ansible_collection.md to reflect the KUBESPRAY_VERSION"
 	exit 1
 fi

--- a/tests/scripts/check_galaxy_version.sh
+++ b/tests/scripts/check_galaxy_version.sh
@@ -3,9 +3,10 @@ set -e
 
 version_from_galaxy=$(grep "^version:" galaxy.yml | awk '{print $2}')
 
-if [[ $KUBESPRAY_VERSION != "v${version_from_galaxy}" ]]
+# TODO: compute the next expected version somehow
+if [[ $KUBESPRAY_VERSION == "v${version_from_galaxy}" ]]
 then
-	echo "Please update galaxy.yml version to match the KUBESPRAY_VERSION. Be sure to remove the \"v\" to adhere"
-	echo "to semenatic versioning"
+	echo "Please update galaxy.yml version to match the next KUBESPRAY_VERSION."
+	echo "Be sure to remove the \"v\" to adhere to semantic versioning"
 	exit 1
 fi


### PR DESCRIPTION
**What type of PR is this?**
> /kind design

**What this PR does / why we need it**:

- Set galaxy.yml to 1.24.0

- Remove checks for docs using exact tags
  Instead use a more generic documentation for installing kubespray as a
  collection from git.

- Check KUBESPRAY_VERSION != galaxy.yml version


**Special notes for your reviewer**:

See #10664 and #10727

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
