### PR TITLE
systemd-resolved: use a drop-in for kubespray dns

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0061-systemd-resolved.yml
+++ b/roles/kubernetes/preinstall/tasks/0061-systemd-resolved.yml
@@ -1,8 +1,14 @@
 ---
-- name: Write resolved.conf
+- name: Create systemd-resolved drop-in directory
+  file:
+    state: directory
+    name: /etc/systemd/resolved.conf.d/
+    mode: 0755
+
+- name: Write Kubespray DNS settings to systemd-resolved
   template:
     src: resolved.conf.j2
-    dest: /etc/systemd/resolved.conf
+    dest: /etc/systemd/resolved.conf.d/kubespray.conf
     owner: root
     group: root
     mode: 0644

--- a/roles/kubernetes/preinstall/templates/resolved.conf.j2
+++ b/roles/kubernetes/preinstall/templates/resolved.conf.j2
@@ -1,21 +1,15 @@
 [Resolve]
-{% if dns_early is sameas true and dns_late is sameas false %}
-#DNS=
-{% else %}
+{% if not dns_early and dns_late %}
 DNS={{ ([nodelocaldns_ip] if enable_nodelocaldns else coredns_server )| list | join(' ') }}
 {% endif %}
 FallbackDNS={{ ( upstream_dns_servers|d([]) + nameservers|d([]) + cloud_resolver|d([])) | unique | join(' ') }}
-{% if remove_default_searchdomains is sameas true and searchdomains|default([])|length != 0 %}
+{% if remove_default_searchdomains and searchdomains|default([])|length != 0 %}
 Domains={{ searchdomains|default([]) | join(' ') }}
 {% else %}
 Domains={{ ([ 'default.svc.' + dns_domain, 'svc.' + dns_domain ] + searchdomains|default([])) | join(' ') }}
 {% endif %}
-#LLMNR=no
-#MulticastDNS=no
 DNSSEC=no
 Cache=no-negative
 {% if systemd_resolved_disable_stub_listener | bool %}
 DNSStubListener=no
-{% else %}
-#DNSStubListener=yes
 {% endif %}

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -314,6 +314,7 @@
     - /etc/dnsmasq.d
     - /etc/dnsmasq.conf
     - /etc/dnsmasq.d-available
+    - /etc/systemd/resolved.conf.d/kubespray.conf
     - /etc/etcd.env
     - /etc/calico
     - /etc/NetworkManager/conf.d/calico.conf


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This avoid needlessly overriding things and make cleanup easier.
Also simplifies the template a bit.

**Which issue(s) this PR fixes**:
Fixes #10724

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
systemd-resolved settings are now put in `/etc/systemd/systemd/resolved.conf.d/kubespray.conf`
```
