### PR TITLE
Use `yml` extension for `hosts.yml` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cp -rfp inventory/sample inventory/mycluster
 
 # Update Ansible inventory file with inventory builder
 declare -a IPS=(10.10.1.3 10.10.1.4 10.10.1.5)
-CONFIG_FILE=inventory/mycluster/hosts.yaml python3 contrib/inventory_builder/inventory.py ${IPS[@]}
+CONFIG_FILE=inventory/mycluster/hosts.yml python3 contrib/inventory_builder/inventory.py ${IPS[@]}
 
 # Review and change parameters under ``inventory/mycluster/group_vars``
 cat inventory/mycluster/group_vars/all/all.yml
@@ -39,13 +39,13 @@ cat inventory/mycluster/group_vars/k8s_cluster/k8s-cluster.yml
 # uninstalling old packages and interacting with various systemd daemons.
 # Without --become the playbook will fail to run!
 # And be mind it will remove the current kubernetes cluster (if it's running)!
-ansible-playbook -i inventory/mycluster/hosts.yaml  --become --become-user=root reset.yml
+ansible-playbook -i inventory/mycluster/hosts.yml  --become --become-user=root reset.yml
 
 # Deploy Kubespray with Ansible Playbook - run the playbook as root
 # The option `--become` is required, as for example writing SSL keys in /etc/,
 # installing packages and interacting with various systemd daemons.
 # Without --become the playbook will fail to run!
-ansible-playbook -i inventory/mycluster/hosts.yaml  --become --become-user=root cluster.yml
+ansible-playbook -i inventory/mycluster/hosts.yml  --become --become-user=root cluster.yml
 ```
 
 Note: When Ansible is already installed via system packages on the control node,

--- a/contrib/inventory_builder/inventory.py
+++ b/contrib/inventory_builder/inventory.py
@@ -25,7 +25,7 @@
 # Delete a host: inventory.py -10.10.1.3
 # Delete a host by id: inventory.py -node1
 #
-# Load a YAML or JSON file with inventory data: inventory.py load hosts.yaml
+# Load a YAML or JSON file with inventory data: inventory.py load hosts.yml
 # YAML file should be in the following format:
 #    group1:
 #      host1:
@@ -62,7 +62,7 @@ def get_var_as_bool(name, default):
 # Configurable as shell vars start
 
 
-CONFIG_FILE = os.environ.get("CONFIG_FILE", "./inventory/sample/hosts.yaml")
+CONFIG_FILE = os.environ.get("CONFIG_FILE", "./inventory/sample/hosts.yml")
 # Remove the reference of KUBE_MASTERS after some deprecation cycles.
 KUBE_CONTROL_HOSTS = int(os.environ.get("KUBE_CONTROL_HOSTS",
                          os.environ.get("KUBE_MASTERS", 2)))
@@ -448,7 +448,7 @@ Delete a host by id: inventory.py -node1
 
 Configurable env vars:
 DEBUG                   Enable debug printing. Default: True
-CONFIG_FILE             File to write config to Default: ./inventory/sample/hosts.yaml
+CONFIG_FILE             File to write config to Default: ./inventory/sample/hosts.yml
 HOST_PREFIX             Host prefix for generated hosts. Default: node
 KUBE_CONTROL_HOSTS      Set the number of kube-control-planes. Default: 2
 SCALE_THRESHOLD         Separate ETCD role if # of nodes >= 50

--- a/docs/mirror.md
+++ b/docs/mirror.md
@@ -31,7 +31,7 @@ cp -rfp inventory/sample inventory/mycluster
 
 # Update Ansible inventory file with inventory builder
 declare -a IPS=(10.10.1.3 10.10.1.4 10.10.1.5)
-CONFIG_FILE=inventory/mycluster/hosts.yaml python3 contrib/inventory_builder/inventory.py ${IPS[@]}
+CONFIG_FILE=inventory/mycluster/hosts.yml python3 contrib/inventory_builder/inventory.py ${IPS[@]}
 
 # Use the download mirror
 cp inventory/mycluster/group_vars/all/offline.yml inventory/mycluster/group_vars/all/mirror.yml
@@ -53,7 +53,7 @@ cat inventory/mycluster/group_vars/k8s_cluster/k8s-cluster.yml
 # The option `--become` is required, as for example writing SSL keys in /etc/,
 # installing packages and interacting with various systemd daemons.
 # Without --become the playbook will fail to run!
-ansible-playbook -i inventory/mycluster/hosts.yaml  --become --become-user=root cluster.yml
+ansible-playbook -i inventory/mycluster/hosts.yml  --become --become-user=root cluster.yml
 ```
 
 The above steps are by adding the "Use the download mirror" step to the [README.md](../README.md) steps.

--- a/docs/offline-environment.md
+++ b/docs/offline-environment.md
@@ -141,12 +141,12 @@ Once all artifacts are in place and your inventory properly set up, you can run 
 regular `cluster.yaml` command:
 
 ```bash
-ansible-playbook -i inventory/my_airgap_cluster/hosts.yaml -b cluster.yml
+ansible-playbook -i inventory/my_airgap_cluster/hosts.yml -b cluster.yml
 ```
 
 If you use [Kubespray Container Image](#recommended-way:-kubespray-container-image), you can mount your inventory inside
 the container:
 
 ```bash
-docker run --rm -it -v path_to_inventory/my_airgap_cluster:inventory/my_airgap_cluster myprivateregisry.com/kubespray/kubespray:v2.14.0 ansible-playbook -i inventory/my_airgap_cluster/hosts.yaml -b cluster.yml
+docker run --rm -it -v path_to_inventory/my_airgap_cluster:inventory/my_airgap_cluster myprivateregisry.com/kubespray/kubespray:v2.14.0 ansible-playbook -i inventory/my_airgap_cluster/hosts.yml -b cluster.yml
 ```

--- a/docs/setting-up-your-first-cluster.md
+++ b/docs/setting-up-your-first-cluster.md
@@ -216,10 +216,10 @@ Update Ansible inventory file with inventory builder:
 
 ```ShellSession
 declare -a IPS=($(gcloud compute instances list --filter="tags.items=kubernetes-the-kubespray-way" --format="value(EXTERNAL_IP)"  | tr '\n' ' '))
-CONFIG_FILE=inventory/mycluster/hosts.yaml python3 contrib/inventory_builder/inventory.py ${IPS[@]}
+CONFIG_FILE=inventory/mycluster/hosts.yml python3 contrib/inventory_builder/inventory.py ${IPS[@]}
 ```
 
-Open the generated `inventory/mycluster/hosts.yaml` file and adjust it so
+Open the generated `inventory/mycluster/hosts.yml` file and adjust it so
 that controller-0, controller-1 and controller-2 are control plane nodes and
 worker-0, worker-1 and worker-2 are worker nodes. Also update the `ip` to the respective local VPC IP and
 remove the `access_ip`.
@@ -242,7 +242,7 @@ the kubernetes cluster, just change the 'false' to 'true' for
 Now we will deploy the configuration:
 
 ```ShellSession
-ansible-playbook -i inventory/mycluster/hosts.yaml -u $USERNAME -b -v --private-key=~/.ssh/id_rsa cluster.yml
+ansible-playbook -i inventory/mycluster/hosts.yml -u $USERNAME -b -v --private-key=~/.ssh/id_rsa cluster.yml
 ```
 
 Ansible will now execute the playbook, this can take up to 20 minutes.
@@ -596,7 +596,7 @@ If you want to keep the VMs and just remove the cluster state, you can simply
  run another Ansible playbook:
 
 ```ShellSession
-ansible-playbook -i inventory/mycluster/hosts.yaml -u $USERNAME -b -v --private-key=~/.ssh/id_rsa reset.yml
+ansible-playbook -i inventory/mycluster/hosts.yml -u $USERNAME -b -v --private-key=~/.ssh/id_rsa reset.yml
 ```
 
 Resetting the cluster to the VMs original state usually takes about a couple


### PR DESCRIPTION
**What type of PR is this?**
> /kind documentation

**What this PR does / why we need it**:

Currently, there is a mix between yml and yaml extensions used for yaml files with `yml` being used for everything but the `hosts.yaml` file. This is IMHO complicates things both for users and automation.

Moreover, the main readme file uses hosts.yaml whilst getting started uses hosts.yml, which leads to errors when users switch from one page to the other.


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
inventory generation script will create hosts.yml files instead of hosts.yaml when no CONFIG_FILE env var is set.
```
