### PR TITLE
Update coredns rolling update strategy

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
@@ -12,7 +12,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 0
+      maxUnavailable: 1
       maxSurge: 10%
   selector:
     matchLabels:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In a two-node cluster(1 master, 1 worker), when upgrading the cluster(e.g. from 1.26.0 to 1.26.7), a coredns pod in pending state will eventually appear. 

```
$ kubectl get -n kube-system pod | grep coredns
coredns-5ffbf89ff4-wpsl8                   0/1     Pending   0             35m
coredns-d77484b69-lwnc8                    1/1     Running   0             34m
coredns-f8cb45497-ptwn7                    1/1     Running   1 (35m ago)   36m
```
```
$ kubectl get -n kube-system rs | grep coredns
coredns-5ffbf89ff4                   1         1         0       36m
coredns-d77484b69                    1         1         1       53m
coredns-f8cb45497                    1         1         1       37m
```

This can be solved by increasing the number of `maxUnavailable`, it is reasonable to set as 1.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Set the `maxUnavailable` of the coredns rolling update strategy to 1
```
