### PR TITLE
don't overwrite changes to openstack allowed_address_pairs

### DIFF
--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -304,6 +304,10 @@ resource "openstack_networking_port_v2" "k8s_master_port" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [ allowed_address_pairs ]
+  }
+
   depends_on = [
     var.network_router_id
   ]
@@ -370,6 +374,10 @@ resource "openstack_networking_port_v2" "k8s_masters_port" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [ allowed_address_pairs ]
+  }
+
   depends_on = [
     var.network_router_id
   ]
@@ -432,6 +440,10 @@ resource "openstack_networking_port_v2" "k8s_master_no_etcd_port" {
     content {
       subnet_id = var.private_subnet_id
     }
+  }
+
+  lifecycle {
+    ignore_changes = [ allowed_address_pairs ]
   }
 
   depends_on = [
@@ -560,6 +572,10 @@ resource "openstack_networking_port_v2" "k8s_master_no_floating_ip_port" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [ allowed_address_pairs ]
+  }
+
   depends_on = [
     var.network_router_id
   ]
@@ -618,6 +634,10 @@ resource "openstack_networking_port_v2" "k8s_master_no_floating_ip_no_etcd_port"
     content {
       subnet_id = var.private_subnet_id
     }
+  }
+
+  lifecycle {
+    ignore_changes = [ allowed_address_pairs ]
   }
 
   depends_on = [
@@ -679,6 +699,10 @@ resource "openstack_networking_port_v2" "k8s_node_port" {
     content {
       subnet_id = var.private_subnet_id
     }
+  }
+
+  lifecycle {
+    ignore_changes = [ allowed_address_pairs ]
   }
 
   depends_on = [
@@ -747,6 +771,10 @@ resource "openstack_networking_port_v2" "k8s_node_no_floating_ip_port" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [ allowed_address_pairs ]
+  }
+
   depends_on = [
     var.network_router_id
   ]
@@ -806,6 +834,10 @@ resource "openstack_networking_port_v2" "k8s_nodes_port" {
     content {
       subnet_id = var.private_subnet_id
     }
+  }
+
+  lifecycle {
+    ignore_changes = [ allowed_address_pairs ]
   }
 
   depends_on = [


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Ignores changes to allowed_address_pairs for the following openstack_networking_port_v2 resources:
- k8s_master_port
- k8s_masters_port
- k8s_master_no_etcd_port
- k8s_master_no_floating_ip_port
- k8s_master_no_floating_ip_no_etcd_port
- k8s_node_port
- k8s_node_no_floating_ip_port
- k8s_nodes_port

This way users who need to customize openstack allowed address pairs can do so without worrying about `terraform apply` overwriting those changes and possibly breaking their clusters.


**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/kubespray/issues/10759

**Special notes for your reviewer**:
See https://github.com/kubernetes-sigs/kubespray/issues/10759


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Don't overwrite changes to openstack allowed_address_pairs #10760
```

