### PR TITLE
workaround for terraform bug related to no_floating and extra_groups

### DIFF
--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -851,7 +851,7 @@ resource "openstack_compute_instance_v2" "k8s_nodes" {
 
   metadata = {
     ssh_user         = var.ssh_user
-    kubespray_groups = "kube_node,k8s_cluster,%{if each.value.floating_ip == false}no_floating,%{endif}${var.supplementary_node_groups}${each.value.extra_groups != null ? ",${each.value.extra_groups}" : ""}"
+    kubespray_groups = "kube_node,k8s_cluster,%{if !each.value.floating_ip}no_floating,%{endif}${var.supplementary_node_groups}${each.value.extra_groups != null ? ",${each.value.extra_groups}" : ""}"
     depends_on       = var.network_router_id
     use_access_ip    = var.use_access_ip
   }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Using `!` instead of `== false` avoids the problem described in the linked issue and is probably better practice for boolean comparison anyway.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/kubespray/issues/10763

**Special notes for your reviewer**:
I tested if floating_ip is true, no_floating is removed:
```
~ "kubespray_groups" = "kube_node,k8s_cluster,no_floating,," -> "kube_node,k8s_cluster,,"
```
and adding an extra group works:
```
~ "kubespray_groups" = "kube_node,k8s_cluster,no_floating,," -> "kube_node,k8s_cluster,,floaty_node"
```
Also if floating_ip is false, the no_floating group remains as expected, and if an extra group is added it fixes the bug:
```
~ "kubespray_groups" = "kube_node,k8s_cluster,no_floating,," -> "kube_node,k8s_cluster,no_floating,,gpu_node"
```
So in all cases this has the expected result.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Workaround for terraform bug related to no_floating and extra_groups
```