### PR TITLE
Fix etcd client generation

### DIFF
--- a/docs/test_cases.md
+++ b/docs/test_cases.md
@@ -1,6 +1,6 @@
 # Node Layouts
 
-There are six node layout types: `default`, `separate`, `ha`, `scale`, `all-in-one`, and `multinode`.
+There are six node layout types: `default`, `separate`, `ha`, `scale`, `all-in-one`, and `node-etcd-client`.
 
 `default` is a non-HA two nodes setup with one separate `kube_node`
 and the `etcd` group merged with the `kube_control_plane`.
@@ -18,7 +18,8 @@ never actually deployed, but certificates are generated for them.
 
 `all-in-one` layout use a single node for with `kube_control_plane`, `etcd` and `kube_node` merged.
 
-`multinode` layout consists of two separate `kube_node` and a merged single `etcd+kube_control_plane` node.
+`node-etcd-client` layout consists of a 4 nodes cluster, all of them in `kube_node`, first 3 in `etcd` and only one `kube_control_plane`.
+This is necessary to tests setups requiring that nodes are etcd clients (use of cilium as `network_plugin` for instance)
 
 Note, the canal network plugin deploys flannel as well plus calico policy controller.
 

--- a/playbooks/install_etcd.yml
+++ b/playbooks/install_etcd.yml
@@ -1,6 +1,21 @@
 ---
+- name: Add worker nodes to the etcd play if needed
+  hosts: kube_node
+  roles:
+    - { role: kubespray-defaults }
+  tasks:
+    - name: Check if nodes needs etcd client certs (depends on network_plugin)
+      group_by:
+        key: "_kubespray_needs_etcd"
+      when:
+        - kube_network_plugin in ["flannel", "canal", "cilium"] or
+          (cilium_deploy_additionally | default(false)) or
+          (kube_network_plugin == "calico" and calico_datastore == "etcd")
+        - etcd_deployment_type != "kubeadm"
+      tags: etcd
+
 - name: Install etcd
-  hosts: etcd:kube_control_plane
+  hosts: etcd:kube_control_plane:_kubespray_needs_etcd
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
@@ -12,20 +27,3 @@
         etcd_cluster_setup: true
         etcd_events_cluster_setup: "{{ etcd_events_cluster_enabled }}"
       when: etcd_deployment_type != "kubeadm"
-
-- name: Install etcd certs on nodes if required
-  hosts: k8s_cluster
-  gather_facts: False
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
-  environment: "{{ proxy_disable_env }}"
-  roles:
-    - { role: kubespray-defaults }
-    - role: etcd
-      tags: etcd
-      vars:
-        etcd_cluster_setup: false
-        etcd_events_cluster_setup: false
-      when:
-        - etcd_deployment_type != "kubeadm"
-        - kube_network_plugin in ["calico", "flannel", "canal", "cilium"] or cilium_deploy_additionally | default(false) | bool
-        - kube_network_plugin != "calico" or calico_datastore == "etcd"

--- a/tests/cloud_playbooks/roles/packet-ci/templates/inventory.j2
+++ b/tests/cloud_playbooks/roles/packet-ci/templates/inventory.j2
@@ -81,16 +81,20 @@ instance-2
 [broken_etcd]
 instance-1 etcd_member_name=etcd2
 instance-2 etcd_member_name=etcd3
-{% elif mode == "multinode" %}
+{% elif mode == "node-etcd-client" %}
 [kube_control_plane]
 instance-1
 
 [etcd]
 instance-1
-
-[kube_node]
 instance-2
 instance-3
+
+[kube_node]
+instance-1
+instance-2
+instance-3
+instance-4
 {% endif %}
 
 [k8s_cluster:children]

--- a/tests/cloud_playbooks/roles/packet-ci/vars/main.yml
+++ b/tests/cloud_playbooks/roles/packet-ci/vars/main.yml
@@ -7,7 +7,7 @@ _vm_count_dict:
   ha-recover: 3
   ha-recover-noquorum: 3
   all-in-one: 1
-  multinode: 3
+  node-etcd-client: 4
   default: 2
 
 vm_count: "{{ _vm_count_dict[mode | d('default')] }}"

--- a/tests/files/packet_ubuntu22-calico-etcd-datastore.yml
+++ b/tests/files/packet_ubuntu22-calico-etcd-datastore.yml
@@ -1,7 +1,7 @@
 ---
 # Instance settings
 cloud_image: ubuntu-2204
-mode: multinode
+mode: node-etcd-client
 vm_memory: 1600Mi
 
 # Kubespray settings


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
Instead of running the etcd role twice (etcd:kube_control_plane / kube_node), with the second runs only necessary on setup requiring clients certs on `kube_node` host, we dynamically define whether `kube_node` needs to be in the play.
Benefits:
- less tasks to run
- let's us use group_by in cleverly ways so that #10610 actually works

**Which issue(s) this PR fixes**:
Fixes #10757

**Special notes for your reviewer**:
Regarding the releases notes since this is a fix of a regression not released yet, maybe we should not include it in the releases notes ? (aka it's just noise)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix the cluster installation on cluster using etcd clients nodes (cilium / calico / ...)
```
