### PR TITLE
[Cherry-Pick] Use calico_pool_blocksize from cluster when existing (#10516)

### DIFF
--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -233,10 +233,20 @@
           }
 
     - name: Calico | Process calico network pool
-      set_fact:
-        _calico_pool: "{{ _calico_pool_cmd.stdout | from_json | combine(_calico_pool, recursive=True) }}"
       when:
         - _calico_pool_cmd is success
+      block:
+        - name: Calico | Get current calico network pool blocksize
+          set_fact:
+            _calico_blocksize: >
+              {
+                "spec": {
+                  "blockSize": {{ (_calico_pool_cmd.stdout | from_json).spec.blockSize }}
+                }
+              }
+        - name: Calico | Merge calico network pool
+          set_fact:
+            _calico_pool: "{{ _calico_pool_cmd.stdout | from_json | combine(_calico_pool, _calico_blocksize, recursive=True) }}"
 
     - name: Calico | Configure calico network pool
       command:
@@ -272,10 +282,20 @@
           }
 
     - name: Calico | Process calico ipv6 network pool
-      set_fact:
-        _calico_pool_ipv6: "{{ _calico_pool_ipv6_cmd.stdout | from_json | combine(_calico_pool_ipv6, recursive=True) }}"
       when:
         - _calico_pool_ipv6_cmd is success
+      block:
+        - name: Calico | Get current calico ipv6 network pool blocksize
+          set_fact:
+            _calico_blocksize_ipv6: >
+              {
+                "spec": {
+                  "blockSize": {{ (_calico_pool_ipv6_cmd.stdout | from_json).spec.blockSize }}
+                }
+              }
+        - name: Calico | Merge calico ipv6 network pool
+          set_fact:
+            _calico_pool_ipv6: "{{ _calico_pool_ipv6_cmd.stdout | from_json | combine(_calico_pool_ipv6, _calico_blocksize_ipv6, recursive=True) }}"
 
     - name: Calico | Configure calico ipv6 network pool
       command:


### PR DESCRIPTION
The blockSize attribute from Calico IPPool resources cannot be changed once set [1]. Consequently, we use the one currently defined when configuring the existing IPPool, avoiding upgrade errors by trying to change it.

In particular, this can be useful when calico_pool_blocksize default changes in kubespray, which would otherwise force users to add an explicit setting to their inventories.

[1]: https://docs.tigera.io/calico/latest/reference/resources/ippool#spec

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

The blockSize attribute from Calico IPPool resources cannot be changed
once set [1](https://docs.tigera.io/calico/latest/reference/resources/ippool#spec). Consequently, we use the one currently defined when
configuring the existing IPPool, avoiding upgrade errors by trying to
change it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

https://github.com/kubernetes-sigs/kubespray/pull/9055#issuecomment-1876155710

**Special notes for your reviewer**:

this PR cherry-pick https://github.com/kubernetes-sigs/kubespray/pull/10516 to release-2.21

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
