### PR TITLE
Fix crio_version version comparison

### DIFF
--- a/roles/container-engine/cri-o/templates/crio.conf.j2
+++ b/roles/container-engine/cri-o/templates/crio.conf.j2
@@ -382,7 +382,7 @@ enable_metrics = {{ crio_enable_metrics | bool | lower }}
 # The port on which the metrics server will listen.
 metrics_port = {{ crio_metrics_port }}
 
-{% if nri_enabled and crio_version >= v1.26.0 %}
+{% if nri_enabled and crio_version is version('v1.26.0', operator='>=') %}
 [crio.nri]
 
 enable_nri=true


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The syntax `{% if crio_version >= v1.26.0 %}` won't work, and will raise an error.
The correct syntax is `{% if crio_version is version('v1.26.0', operator='ge') %}`.

Before fix, when running role container-engine/cri-o the crio.conf templates fails with message : 
```
TASK [container-engine/cri-o : Cri-o | install cri-o config] ******************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: 'v1' is undefined. 'v1' is undefined
fatal: [kube-poc-compute1]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'v1' is undefined. 'v1' is undefined"}
```