### PR TITLE
Doc: variable cilium_ipsec_key must be base64 encoded

### DIFF
--- a/docs/cilium.md
+++ b/docs/cilium.md
@@ -141,7 +141,7 @@ cilium_encryption_enabled: true
 cilium_encryption_type: "ipsec"
 ```
 
-The third variable is `cilium_ipsec_key.` You need to create a secret key string for this variable.
+The third variable is `cilium_ipsec_key`. You need to create a secret key string for this variable.
 Kubespray does not automate this process.
 Cilium documentation currently recommends creating a key using the following command:
 
@@ -149,7 +149,11 @@ Cilium documentation currently recommends creating a key using the following com
 echo "3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
 ```
 
-Note that Kubespray handles secret creation. So you only need to pass the key as the `cilium_ipsec_key` variable.
+Note that Kubespray handles secret creation. So you only need to pass the key as the `cilium_ipsec_key` variable, base64 encoded:
+
+```shell
+echo "cilium_ipsec_key: "$(echo -n "3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128" | base64 -w0)
+```
 
 ### Wireguard Encryption
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

The variable `cilium_ipsec_key` had wrong instruction that lead to an error. The value must be base64 encoded.

This paragraph now:
* tells that the value must be base64 encoded
* gives an example to generate the variable the right way

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Variable cilium_ipsec_key must be base64 encoded
```
