### PR TITLE
Fix ntp installation on SLES and openSUSE

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0081-ntp-configurations.yml
+++ b/roles/kubernetes/preinstall/tasks/0081-ntp-configurations.yml
@@ -30,7 +30,7 @@
     ntp_service_name: >-
       {% if ntp_package == "chrony" -%}
       chronyd
-      {%- elif ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk", "RedHat"] -%}
+      {%- elif ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk", "RedHat", "Suse"] -%}
       ntpd
       {%- else -%}
       ntp


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
The NTP service name on SLES or openSUSE is `ntpd` and not `ntp`. Adding `Suse` to the list fix the issue.

Before fix, when running the `cluster.yml` playbook, it fails with message:

```
TASK [kubernetes/preinstall : Ensure NTP service is started and enabled] *********************************************
fatal: [k8s-master-2.home.lan]: FAILED! => {"changed": false, "msg": "Could not find the requested service ntp: host"}
fatal: [k8s-master-1.home.lan]: FAILED! => {"changed": false, "msg": "Could not find the requested service ntp: host"}
fatal: [k8s-worker-3.home.lan]: FAILED! => {"changed": false, "msg": "Could not find the requested service ntp: host"}
fatal: [k8s-worker-2.home.lan]: FAILED! => {"changed": false, "msg": "Could not find the requested service ntp: host"}
fatal: [k8s-worker-1.home.lan]: FAILED! => {"changed": false, "msg": "Could not find the requested service ntp: host"}
fatal: [k8s-master-3.home.lan]: FAILED! => {"changed": false, "msg": "Could not find the requested service ntp: host"}
fatal: [k8s-worker-4.home.lan]: FAILED! => {"changed": false, "msg": "Could not find the requested service ntp: host"}
fatal: [k8s-worker-5.home.lan]: FAILED! => {"changed": false, "msg": "Could not find the requested service ntp: host"}
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix ntp installation on SLES and openSUSE
```
