### PR TITLE
Fix PyYAML package name on SLES and openSUSE

### DIFF
--- a/roles/kubernetes-apps/helm/vars/suse.yml
+++ b/roles/kubernetes-apps/helm/vars/suse.yml
@@ -1,2 +1,2 @@
 ---
-pyyaml_package: python3-pyyaml
+pyyaml_package: python3-PyYAML


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The PyYAML Python package on SLES or openSUSE is `python-PyYAML` and not `python3-pyyaml`.

Before fix, when running the `cluster.yml` playbook, it fails with message:

```
TASK [kubernetes-apps/helm : Helm | Install PyYaml] ******************************************************************************************************************************************************************************************
fatal: [k8s-master-1.home.lan]: FAILED! => {"changed": false, "cmd": ["/usr/bin/zypper", "--quiet", "--non-interactive", "--xmlout", "install", "--type", "package", "--auto-agree-with-licenses", "--no-recommends", "--", "+python3-pyyaml"], "msg": "Package '+python3-pyyaml' not found.", "rc": 104, "stderr": "", "stderr_lines": [], "stdout": "<?xml version='1.0'?>\n<stream>\n<message type=\"error\">Package &apos;+python3-pyyaml&apos; not found.</message>\n</stream>\n", "stdout_lines": ["<?xml version='1.0'?>", "<stream>", "<message type=\"error\">Package &apos;+python3-pyyaml&apos; not found.</message>", "</stream>"]}
fatal: [k8s-master-2.home.lan]: FAILED! => {"changed": false, "cmd": ["/usr/bin/zypper", "--quiet", "--non-interactive", "--xmlout", "install", "--type", "package", "--auto-agree-with-licenses", "--no-recommends", "--", "+python3-pyyaml"], "msg": "Package '+python3-pyyaml' not found.", "rc": 104, "stderr": "", "stderr_lines": [], "stdout": "<?xml version='1.0'?>\n<stream>\n<message type=\"error\">Package &apos;+python3-pyyaml&apos; not found.</message>\n</stream>\n", "stdout_lines": ["<?xml version='1.0'?>", "<stream>", "<message type=\"error\">Package &apos;+python3-pyyaml&apos; not found.</message>", "</stream>"]}
fatal: [k8s-master-3.home.lan]: FAILED! => {"changed": false, "cmd": ["/usr/bin/zypper", "--quiet", "--non-interactive", "--xmlout", "install", "--type", "package", "--auto-agree-with-licenses", "--no-recommends", "--", "+python3-pyyaml"], "msg": "Package '+python3-pyyaml' not found.", "rc": 104, "stderr": "", "stderr_lines": [], "stdout": "<?xml version='1.0'?>\n<stream>\n<message type=\"error\">Package &apos;+python3-pyyaml&apos; not found.</message>\n</stream>\n", "stdout_lines": ["<?xml version='1.0'?>", "<stream>", "<message type=\"error\">Package &apos;+python3-pyyaml&apos; not found.</message>", "</stream>"]}
```

**Does this PR introduce a user-facing change?**:

```release-note
Fix Helm installation on SLES and openSUSE
```
