### PR TITLE
[apiserver-kubelet/tracing]: add distributed tracing config variables

### DIFF
--- a/roles/kubernetes/control-plane/defaults/main/main.yml
+++ b/roles/kubernetes/control-plane/defaults/main/main.yml
@@ -235,3 +235,10 @@ kubeadm_upgrade_auto_cert_renewal: true
 
 # Bash alias of kubectl to interact with Kubernetes cluster much easier
 # kubectl_alias: k
+
+## Enable distributed tracing for kube-apiserver
+## For the clusters with version lower than v1.27; you have to enable the feature by adding 'APIServerTracing=true' to the `kube_apiserver_feature_gates` list
+## When upgrading the cluster to v1.27; you should remove it from the `kube_apiserver_feature_gates` list
+kube_apiserver_tracing: false
+kube_apiserver_tracing_endpoint: 0.0.0.0:4317
+kube_apiserver_tacing_samplingRatePerMillion: 100

--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -68,6 +68,20 @@
     mode: 0640
   when: kubernetes_audit_webhook | default(false)
 
+- name: Create apiserver tracing config directory
+  file:
+    path: "{{ kube_config_dir }}/tracing"
+    state: directory
+    mode: 0640
+  when: kube_apiserver_tracing
+
+- name: Write apiserver tracing config yaml
+  template:
+    src: apiserver-tracing.yaml.j2
+    dest: "{{ kube_config_dir }}/tracing/apiserver-tracing.yaml"
+    mode: 0640
+  when: kube_apiserver_tracing
+
 # Nginx LB(default), If kubeadm_config_api_fqdn is defined, use other LB by kubeadm controlPlaneEndpoint.
 - name: Set kubeadm_config_api_fqdn define
   set_fact:

--- a/roles/kubernetes/control-plane/templates/apiserver-tracing.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/apiserver-tracing.yaml.j2
@@ -1,0 +1,8 @@
+{% if kube_major_version == "v1.26" %}
+apiVersion: apiserver.config.k8s.io/v1alpha1
+{% else %}
+apiVersion: apiserver.config.k8s.io/v1beta1
+{% endif %}
+kind: TracingConfiguration
+endpoint: {{ kube_apiserver_tracing_endpoint }}
+samplingRatePerMillion: {{ kube_apiserver_tacing_samplingRatePerMillion }}

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
@@ -227,6 +227,9 @@ apiServer:
 {% if kubelet_rotate_server_certificates %}
     kubelet-certificate-authority: {{ kube_cert_dir }}/ca.crt
 {% endif %}
+{% if kube_apiserver_tracing %}
+    tracing-config-file: {{ kube_config_dir }}/tracing/apiserver-tracing.yaml
+{% endif %}
 {% if kubernetes_audit or kube_token_auth | default(true) or kube_webhook_token_auth | default(false) or ( cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws", "gce"] ) or apiserver_extra_volumes or ssl_ca_dirs | length %}
   extraVolumes:
 {% if cloud_provider is defined and cloud_provider in ["openstack", "azure", "vsphere", "aws", "gce"] %}
@@ -265,6 +268,13 @@ apiServer:
     hostPath: {{ kube_config_dir }}/admission-controls
     mountPath: {{ kube_config_dir }}
     readOnly: false
+    pathType: DirectoryOrCreate
+{% endif %}
+{% if kube_apiserver_tracing %}
+  - name: tracing
+    hostPath: {{ kube_config_dir }}/tracing
+    mountPath: {{ kube_config_dir }}/tracing
+    readOnly: true
     pathType: DirectoryOrCreate
 {% endif %}
 {% for volume in apiserver_extra_volumes %}

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -253,3 +253,11 @@ kube_proxy_ipvs_modules:
 conntrack_modules:
   - nf_conntrack
   - nf_conntrack_ipv4
+
+
+## Enable distributed tracing for kubelet
+## For the clusters with version lower than v1.27; you have to enable the feature by adding 'KubeletTracing=true' to the `kubelet_feature_gates` list
+## When upgrading the cluster to v1.27; you should remove it from the `kubelet_feature_gates` list
+kubelet_tracing: false
+kubelet_tracing_endpoint: 0.0.0.0:4317
+kubelet_tracing_samplingRatePerMillion: 100

--- a/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
@@ -168,3 +168,8 @@ topologyManagerPolicy: {{ kubelet_topology_manager_policy }}
 {% if kubelet_topology_manager_scope is defined %}
 topologyManagerScope: {{ kubelet_topology_manager_scope }}
 {% endif %}
+{% if kubelet_tracing %}
+tracing:
+  endpoint: {{ kubelet_tracing_endpoint }}
+  samplingRatePerMillion: {{ kubelet_tracing_samplingRatePerMillion }}
+{% endif %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This MR contains some enhancements that make possible to enable distributed tracing for `kubelet` and `kube-apiserver` components. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # none

**Special notes for your reviewer**:
`APIServerTracing` and `KubeletTracing` have been graduated to beta version with v1.27. Since Kubespray still supports v1.26; this MR is designed to support both v1.26 and higher versions regarding these features.

Refs: 
* [Feature Gates](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/)
* [Traces For Kubernetes System Components](https://kubernetes.io/docs/concepts/cluster-administration/system-traces/)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[kube-apiserver,kubelet] added distributed tracing config variables (`kubelet_tracing`,`kubelet_tracing_endpoint`,`kubelet_tracing_samplingRatePerMillion`,`kube_apiserver_tracing`,`kube_apiserver_tracing_endpoint`,`kube_apiserver_tacing_samplingRatePerMillion`), it is disabled by default for both components.
```
