### PR TITLE
etcd: update to v3.5.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Note: Upstart/SysV init based OS types are not supported.
 
 - Core
   - [kubernetes](https://github.com/kubernetes/kubernetes) v1.28.5
-  - [etcd](https://github.com/etcd-io/etcd) v3.5.9
+  - [etcd](https://github.com/etcd-io/etcd) v3.5.10
   - [docker](https://www.docker.com/) v20.10 (see note)
   - [containerd](https://containerd.io/) v1.7.11
   - [cri-o](http://cri-o.io/) v1.27 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)

--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -134,9 +134,9 @@ skopeo_version: "v1.13.2"
 kube_major_version: "{{ kube_version | regex_replace('^v([0-9])+\\.([0-9]+)\\.[0-9]+', 'v\\1.\\2') }}"
 
 etcd_supported_versions:
-  v1.28: "v3.5.9"
-  v1.27: "v3.5.9"
-  v1.26: "v3.5.9"
+  v1.28: "v3.5.10"
+  v1.27: "v3.5.10"
+  v1.26: "v3.5.10"
 etcd_version: "{{ etcd_supported_versions[kube_major_version] }}"
 
 crictl_supported_versions:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
See kubernetes/kubernetes#121566

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update etcd version to 3.5.10 for kubernetes 1.28, 1.27 and 1.26
```
