### PR TITLE
Update control plane node replacement steps in doc

### DIFF
--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -133,7 +133,13 @@ If the node you want to remove is not online, you should add `reset_nodes=false`
 
 Change ip of old kube_control_plane node with ip of live kube_control_plane node (`server` field). Also, update `certificate-authority-data` field if you changed certs.
 
-### 4) Add new control plane node
+### 4) Edit kubeadm-config configmap in kube-system namespace
+
+`kubectl -n kube-system edit cm kubeadm-config`
+
+Change ip of old kube_control_plane node with ip of live kube_control_plane node (`controlPlaneEndpoint` field).
+
+### 5) Add new control plane node
 
 Update inventory (if needed)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

During the process of replacing the first control plane node, it is necessary to update the `controlPlaneEndpoint` field in the `kubeadm-config` ConfigMap. Otherwise, the `kubeadm join` command will attempt to request the old endpoint IP, resulting in the following error:

```
TASK [kubernetes/control-plane : Reset cert directory] *************************
changed: [node1]
Thursday 18 January 2024  06:19:01 +0000 (0:00:00.602)       0:08:25.479 ******
FAILED - RETRYING: [node1]: Joining control plane node to the cluster. (3 retries left).
FAILED - RETRYING: [node1]: Joining control plane node to the cluster. (2 retries left).
FAILED - RETRYING: [node1]: Joining control plane node to the cluster. (1 retries left).

TASK [kubernetes/control-plane : Joining control plane node to the cluster.] ***
fatal: [node1]: FAILED! => {
  "attempts": 3,
  "changed": true,
  "cmd":
    [
      "/usr/local/bin/kubeadm",
      "join",
      "--config",
      "/etc/kubernetes/kubeadm-controlplane.yaml",
      "--ignore-preflight-errors=all",
      "--skip-phases=",
    ],
  "delta": "0:00:32.614898",
  "end": "2024-01-18 01:21:34.494544",
  "msg": "non-zero return code",
  "rc": 1,
  "start": "2024-01-18 01:21:01.879646",
  "stderr": "W0118 01:21:02.122427   21004 utils.go:69] The recommended value for \"clusterDNS\" in \"KubeletConfiguration\" is: [10.233.0.10]; the provided value is: [169.254.25.10]\n\t[WARNING Firewalld]: firewalld is active, please ensure ports [6443 10250] are open or your cluster may not function correctly\n\t[WARNING FileAvailable--etc-kubernetes-manifests-kube-apiserver.yaml]: /etc/kubernetes/manifests/kube-apiserver.yaml already exists\n\t[WARNING FileAvailable--etc-kubernetes-manifests-kube-controller-manager.yaml]: /etc/kubernetes/manifests/kube-controller-manager.yaml already exists\n\t[WARNING FileAvailable--etc-kubernetes-manifests-kube-scheduler.yaml]: /etc/kubernetes/manifests/kube-scheduler.yaml already exists\nerror execution phase check-etcd: could not retrieve the list of etcd endpoints: Get \"https://172.30.41.161:6443/api/v1/namespaces/kube-system/pods?labelSelector=component%3Detcd%2Ctier%3Dcontrol-plane\": dial tcp 172.30.41.161:6443: connect: connection refused\nTo see the stack trace of this error execute with --v=5 or higher",
  "stderr_lines":
    [
      'W0118 01:21:02.122427   21004 utils.go:69] The recommended value for "clusterDNS" in "KubeletConfiguration" is: [10.233.0.10]; the provided value is: [169.254.25.10]',
      "\t[WARNING Firewalld]: firewalld is active, please ensure ports [6443 10250] are open or your cluster may not function correctly",
      "\t[WARNING FileAvailable--etc-kubernetes-manifests-kube-apiserver.yaml]: /etc/kubernetes/manifests/kube-apiserver.yaml already exists",
      "\t[WARNING FileAvailable--etc-kubernetes-manifests-kube-controller-manager.yaml]: /etc/kubernetes/manifests/kube-controller-manager.yaml already exists",
      "\t[WARNING FileAvailable--etc-kubernetes-manifests-kube-scheduler.yaml]: /etc/kubernetes/manifests/kube-scheduler.yaml already exists",
      'error execution phase check-etcd: could not retrieve the list of etcd endpoints: Get "https://172.30.41.161:6443/api/v1/namespaces/kube-system/pods?labelSelector=component%3Detcd%2Ctier%3Dcontrol-plane": dial tcp 172.30.41.161:6443: connect: connection refused',
      "To see the stack trace of this error execute with --v=5 or higher",
    ],
  "stdout": "[preflight] Running pre-flight checks\n[preflight] Reading configuration from the cluster...\n[preflight] FYI: You can look at this config file with 'kubectl -n kube-system get cm kubeadm-config -o yaml'\n[preflight] Running pre-flight checks before initializing the new control plane instance\n[preflight] Pulling images required for setting up a Kubernetes cluster\n[preflight] This might take a minute or two, depending on the speed of your internet connection\n[preflight] You can also perform this action in beforehand using 'kubeadm config images pull'\n[download-certs] Downloading the certificates in Secret \"kubeadm-certs\" in the \"kube-system\" Namespace\n[certs] Using certificateDir folder \"/etc/kubernetes/ssl\"\n[certs] Using the existing \"apiserver\" certificate and key\n[certs] Using the existing \"apiserver-kubelet-client\" certificate and key\n[certs] Using the existing \"front-proxy-client\" certificate and key\n[certs] Using the existing \"etcd/healthcheck-client\" certificate and key\n[certs] Using the existing \"apiserver-etcd-client\" certificate and key\n[certs] Using the existing \"etcd/server\" certificate and key\n[certs] Using the existing \"etcd/peer\" certificate and key\n[certs] Valid certificates and keys now exist in \"/etc/kubernetes/ssl\"\n[certs] Using the existing \"sa\" key\n[kubeconfig] Generating kubeconfig files\n[kubeconfig] Using kubeconfig folder \"/etc/kubernetes\"\n[kubeconfig] Using existing kubeconfig file: \"/etc/kubernetes/admin.conf\"\n[kubeconfig] Using existing kubeconfig file: \"/etc/kubernetes/controller-manager.conf\"\n[kubeconfig] Using existing kubeconfig file: \"/etc/kubernetes/scheduler.conf\"\n[control-plane] Using manifest folder \"/etc/kubernetes/manifests\"\n[control-plane] Creating static Pod manifest for \"kube-apiserver\"\n[control-plane] Creating static Pod manifest for \"kube-controller-manager\"\n[control-plane] Creating static Pod manifest for \"kube-scheduler\"\n[check-etcd] Checking that the etcd cluster is healthy",
  "stdout_lines":
    [
      "[preflight] Running pre-flight checks",
      "[preflight] Reading configuration from the cluster...",
      "[preflight] FYI: You can look at this config file with 'kubectl -n kube-system get cm kubeadm-config -o yaml'",
      "[preflight] Running pre-flight checks before initializing the new control plane instance",
      "[preflight] Pulling images required for setting up a Kubernetes cluster",
      "[preflight] This might take a minute or two, depending on the speed of your internet connection",
      "[preflight] You can also perform this action in beforehand using 'kubeadm config images pull'",
      '[download-certs] Downloading the certificates in Secret "kubeadm-certs" in the "kube-system" Namespace',
      '[certs] Using certificateDir folder "/etc/kubernetes/ssl"',
      '[certs] Using the existing "apiserver" certificate and key',
      '[certs] Using the existing "apiserver-kubelet-client" certificate and key',
      '[certs] Using the existing "front-proxy-client" certificate and key',
      '[certs] Using the existing "etcd/healthcheck-client" certificate and key',
      '[certs] Using the existing "apiserver-etcd-client" certificate and key',
      '[certs] Using the existing "etcd/server" certificate and key',
      '[certs] Using the existing "etcd/peer" certificate and key',
      '[certs] Valid certificates and keys now exist in "/etc/kubernetes/ssl"',
      '[certs] Using the existing "sa" key',
      "[kubeconfig] Generating kubeconfig files",
      '[kubeconfig] Using kubeconfig folder "/etc/kubernetes"',
      '[kubeconfig] Using existing kubeconfig file: "/etc/kubernetes/admin.conf"',
      '[kubeconfig] Using existing kubeconfig file: "/etc/kubernetes/controller-manager.conf"',
      '[kubeconfig] Using existing kubeconfig file: "/etc/kubernetes/scheduler.conf"',
      '[control-plane] Using manifest folder "/etc/kubernetes/manifests"',
      '[control-plane] Creating static Pod manifest for "kube-apiserver"',
      '[control-plane] Creating static Pod manifest for "kube-controller-manager"',
      '[control-plane] Creating static Pod manifest for "kube-scheduler"',
      "[check-etcd] Checking that the etcd cluster is healthy",
    ],
}

```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
