### PR TITLE
Fix missing src attribute

### DIFF
--- a/roles/kubernetes-apps/ansible/tasks/coredns.yml
+++ b/roles/kubernetes-apps/ansible/tasks/coredns.yml
@@ -36,7 +36,7 @@
     - { name: coredns, src: coredns-deployment.yml, file: coredns-deployment-secondary.yml, type: deployment }
     - { name: coredns, src: coredns-svc.yml, file: coredns-svc-secondary.yml, type: svc }
     - { name: dns-autoscaler, src: dns-autoscaler.yml, file: coredns-autoscaler-secondary.yml, type: deployment }
-    - { name: coredns, file: coredns-poddisruptionbudget.yml, type: poddisruptionbudget, condition: coredns_pod_disruption_budget }
+    - { name: coredns, src: coredns-poddisruptionbudget.yml, file: coredns-poddisruptionbudget.yml, type: poddisruptionbudget, condition: coredns_pod_disruption_budget }
   register: coredns_secondary_manifests
   vars:
     clusterIP: "{{ skydns_server_secondary }}"


### PR DESCRIPTION
With kubespray 2.24.0 ansible crashes with a syntax error while running upgrade-cluster.yml, because the src attribute is missing.

/kind bug

```release-note
NONE
```
