### PR TITLE
Adjust kubelet_event_record_qps to K8S default

### DIFF
--- a/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
@@ -135,9 +135,7 @@ tlsCipherSuites:
 - {{ tls }}
 {% endfor %}
 {% endif %}
-{% if kubelet_event_record_qps %}
 eventRecordQPS: {{ kubelet_event_record_qps }}
-{% endif %}
 shutdownGracePeriod: {{ kubelet_shutdown_grace_period }}
 shutdownGracePeriodCriticalPods: {{ kubelet_shutdown_grace_period_critical_pods }}
 {% if not kubelet_fail_swap_on %}

--- a/roles/kubespray-defaults/defaults/main/main.yml
+++ b/roles/kubespray-defaults/defaults/main/main.yml
@@ -645,9 +645,9 @@ host_os: >-
   {{ ansible_system }}
   {%- endif -%}
 
-# Sets the eventRecordQPS parameter in kubelet-config.yaml. The default value is 5 (see types.go)
+# Sets the eventRecordQPS parameter in kubelet-config.yaml.
 # Setting it to 0 allows unlimited requests per second.
-kubelet_event_record_qps: 5
+kubelet_event_record_qps: 50
 
 proxy_env_defaults:
   http_proxy: "{{ http_proxy | default('') }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Use the same default as K8S (we should not unecessarily deviate from K8S defaults)
Also remove redundant check in the kubelet config template (we define a default, so the setting will always be "true")

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10753

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
eventRecordQPS (in kubelet config) now uses Kubernetes default value (50)
```
