### PR TITLE
add auto_calculation for system_reserved resources

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -284,6 +284,14 @@ default_kubelet_config_dir: "{{ kube_config_dir }}/dynamic_kubelet_dir"
 ## The following two items need to be set when system_reserved is true
 # system_reserved_cgroups_for_service_slice: system.slice
 # system_reserved_cgroups: "/{{ system_reserved_cgroups_for_service_slice }}"
+# If systemd_reserved_auto_calculate is true, 
+# system_[master]_memory_reserved and system_[master]_cpu_reserved will be calculated
+# based on the number of CPUs and memory size of the host
+# cpu_reserved is calculated as 1% of the number of CPUs + 80m
+# memory_reserved is calculated as 5% of the memory size + 330Mi
+#system_reserved_auto_calculate: false
+# else you can set the values manually
+# Reservation for node hosts
 # system_memory_reserved: 512Mi
 # system_cpu_reserved: 500m
 # system_ephemeral_storage_reserved: 2Gi

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -46,6 +46,11 @@ kube_master_cpu_reserved: 200m
 
 # Set to true to reserve resources for system daemons
 system_reserved: false
+# If true, system_[master]_memory_reserved and system_[master]_cpu_reserved will be calculated
+# based on the number of CPUs and memory size of the host
+# cpu_reserved is calculated as 1% of the number of CPUs + 80m
+# memory_reserved is calculated as 5% of the memory size + 330Mi
+system_reserved_auto_calculate: false
 system_reserved_cgroups_for_service_slice: system.slice
 system_reserved_cgroups: "/{{ system_reserved_cgroups_for_service_slice }}"
 system_memory_reserved: 512Mi

--- a/roles/kubernetes/node/tasks/kubelet.yml
+++ b/roles/kubernetes/node/tasks/kubelet.yml
@@ -18,6 +18,35 @@
     - kubelet
     - kubeadm
 
+- name: Gather facts about the node
+  setup:
+    filter: ansible_memtotal_mb,ansible_processor_vcpus
+  tags:
+    - kubelet
+    - kubeadm
+
+- name: Check if system_reserved_auto_calculate is set
+  set_fact:
+    system_master_cpu_reserved: "{{ (ansible_processor_vcpus * 1000 * 0.01) | int + 80 }}m"
+    system_master_memory_reserved: "{{ (ansible_memtotal_mb * 0.05) | int + 330 }}Mi"
+  tags:
+    - kubelet
+    - kubeadm
+  when:
+    - system_reserved_auto_calculate == true
+    - is_kube_master == true
+
+- name: Check if system_reserved_auto_calculate is set
+  set_fact:
+    system_cpu_reserved: "{{ (ansible_processor_vcpus * 1000 * 0.01) | int + 80 }}m"
+    system_memory_reserved: "{{ (ansible_memtotal_mb * 0.05) | int + 330 }}Mi"
+  tags:
+    - kubelet
+    - kubeadm
+  when:
+    - system_reserved_auto_calculate == true
+    - is_kube_master == false
+
 - name: Write kubelet config file
   template:
     src: "kubelet-config.{{ kubeletConfig_api_version }}.yaml.j2"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:

Reserving resources helps to improve the stability of the cluster components. In my opinion, the resource consumption of the system also changes with the load of the node (Scheduled Pods), so there should also be a possibility to reserve the system resources relative to the node size.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Calculation was copied from here: https://cloud.google.com/anthos/clusters/docs/on-prem/latest/how-to/resources-available-pods I have added a new variable `system_reserved_auto_calculate` so that Kubespray users can decide whether they want to use the automatic calculation or assign absolute values.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
