### PR TITLE
Fix typo mistake in roles/kubernetes/control-plane/tasks/define-first-kube-control.yml

### DIFF
--- a/roles/kubernetes/control-plane/tasks/define-first-kube-control.yml
+++ b/roles/kubernetes/control-plane/tasks/define-first-kube-control.yml
@@ -6,7 +6,7 @@
   ignore_errors: yes
   changed_when: false
 
-- name: Set fact joined_control_panes
+- name: Set fact joined_control_planes
   set_fact:
     joined_control_planes: "{{ ((kube_control_planes_raw.stdout | from_json)['items']) | default([]) | map(attribute='metadata') | map(attribute='name') | list }}"
   delegate_to: item


### PR DESCRIPTION
Fix 'Set fact joined_control_panes' into 'Set fact joined_control_planes'

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation


**What this PR does / why we need it**:

This PR is for fixing typo mistake in roles/kubernetes/control-plane/tasks/define-first-kube-control.yml.

I wonder that this change is really needed but I think its better that fix this kind of mistake

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
It doesn't related with any issue.

**Special notes for your reviewer**:

Nothing.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix typo mistake in roles/kubernetes/control-plane/tasks/define-first-kube-control.yml 
```

