### PR TITLE
docs: vagrant-libvirt is tested in CI

### DIFF
--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -1,8 +1,8 @@
 # Vagrant
 
-Assuming you have Vagrant 2.0+ installed with virtualbox (it may work with libvirt/qemu or
-vmware, but is untested) you should be able to launch a 3 node Kubernetes
-cluster by simply running `vagrant up`.
+Assuming you have Vagrant 2.0+ installed with virtualbox or libvirt/qemu
+(vmware may work, but is untested) you should be able to launch a 3 node
+Kubernetes cluster by simply running `vagrant up`.
 
 This will spin up 3 VMs and install kubernetes on them.
 Once they are completed you can connect to any of them by running `vagrant ssh k8s-[1..3]`.


### PR DESCRIPTION

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Followup to #10836


**Special notes for your reviewer**:
We use vagrant-libvirt in CI, so it's not untested.
(Besides, that's what I use myself for testing locally, and it works with no trouble).

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
