### PR TITLE
Add documentation for configuring nat outgoing ipv6

### DIFF
--- a/docs/calico.md
+++ b/docs/calico.md
@@ -222,6 +222,14 @@ calico_node_livenessprobe_timeout: 10
 calico_node_readinessprobe_timeout: 10
 ```
 
+### Optional :  Enable NAT with IPv6
+
+To allow outgoing IPv6 traffic going from pods to the Internet, enable the following:
+
+```yml
+nat_outgoing_ipv6: true  # NAT outgoing ipv6 (default value: false).
+```
+
 ## Config encapsulation for cross server traffic
 
 Calico supports two types of encapsulation: [VXLAN and IP in IP](https://docs.projectcalico.org/v3.11/networking/vxlan-ipip). VXLAN is the more mature implementation and enabled by default, please check your environment if you need *IP in IP* encapsulation.
@@ -235,7 +243,7 @@ If you are running your cluster with the default calico settings and are upgradi
 * perform a manual migration to vxlan before upgrading kubespray (see migrating from IP in IP to VXLAN below)
 * pin the pre-2.19 settings in your ansible inventory (see IP in IP mode settings below)
 
-**Note:**: Vxlan in ipv6 only supported when kernel >= 3.12. So if your kernel version < 3.12, Please don't set `calico_vxlan_mode_ipv6: vxlanAlways`. More details see [#Issue 6877](https://github.com/projectcalico/calico/issues/6877).
+**Note:**: Vxlan in ipv6 only supported when kernel >= 3.12. So if your kernel version < 3.12, Please don't set `calico_vxlan_mode_ipv6: Always`. More details see [#Issue 6877](https://github.com/projectcalico/calico/issues/6877).
 
 ### IP in IP mode
 

--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-calico.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-calico.yml
@@ -11,6 +11,7 @@ calico_cni_name: k8s-pod-network
 
 # Enables Internet connectivity from containers
 # nat_outgoing: true
+# nat_outgoing_ipv6: false
 
 # Enables Calico CNI "host-local" IPAM plugin
 # calico_ipam_host_local: true

--- a/roles/network_plugin/calico_defaults/defaults/main.yml
+++ b/roles/network_plugin/calico_defaults/defaults/main.yml
@@ -4,6 +4,7 @@ calico_cni_name: k8s-pod-network
 
 # Enables Internet connectivity from containers
 nat_outgoing: true
+nat_outgoing_ipv6: false
 
 # add default ippool name
 calico_pool_name: "default-pool"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

The variable `nat_outgoing_ipv6` is not documented anywhere, and it needs to be enabled if you want outgoing ipv6 traffic from pods.

Also fixed the value set for `calico_vxlan_mode_ipv6`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
