### PR TITLE
Remove openstack feature gate and legacy in-tree provider documentation

### DIFF
--- a/docs/openstack.md
+++ b/docs/openstack.md
@@ -20,23 +20,9 @@ Kubespray has been tested on a number of OpenStack Public Clouds including (in a
 - [VexxHost](https://vexxhost.com/)
 - [Zetta](https://www.zetta.io/)
 
-## The in-tree cloud provider
-
-To deploy Kubespray on [OpenStack](https://www.openstack.org/) uncomment the `cloud_provider` option in `group_vars/all/all.yml` and set it to `openstack`.
-
-After that make sure to source in your OpenStack credentials like you would do when using `nova-client` or `neutron-client` by using `source path/to/your/openstack-rc` or `. path/to/your/openstack-rc`.
-
-For those who prefer to pass the OpenStack CA certificate as a string, one can
-base64 encode the cacert file and store it in the variable `openstack_cacert`.
-
-The next step is to make sure the hostnames in your `inventory` file are identical to your instance names in OpenStack.
-Otherwise [cinder](https://wiki.openstack.org/wiki/Cinder) won't work as expected.
-
-Unless you are using calico or kube-router you can now run the playbook.
-
 ## The external cloud provider
 
-The in-tree cloud provider is deprecated and will be removed in a future version of Kubernetes. The target release for removing all remaining in-tree cloud providers is set to 1.21.
+The legacy in-tree cloud provider has been removed from Kubernetes.
 
 The new cloud provider is configured to have Octavia by default in Kubespray.
 
@@ -66,15 +52,6 @@ The new cloud provider is configured to have Octavia by default in Kubespray.
   ```
 
 - If you are using OpenStack loadbalancer(s) replace the `openstack_lbaas_subnet_id` with the new `external_openstack_lbaas_subnet_id`. **Note** The new cloud provider is using Octavia instead of Neutron LBaaS by default!
-- Enable 3 feature gates to allow migration of all volumes and storage classes (if you have any feature gates already set just add the 3 listed below):
-
-  ```yaml
-  kube_feature_gates:
-  - CSIMigration=true
-  - CSIMigrationOpenStack=true
-  - ExpandCSIVolumes=true
-  ```
-
 - If you are in a case of a multi-nic OpenStack VMs (see [kubernetes/cloud-provider-openstack#407](https://github.com/kubernetes/cloud-provider-openstack/issues/407) and [#6083](https://github.com/kubernetes-sigs/kubespray/issues/6083) for explanation), you should override the default OpenStack networking configuration:
 
   ```yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

Removes documentation about the legacy in-tree OpenStack provider ([removed 1.26](https://kubernetes.io/blog/2022/09/26/storage-in-tree-to-csi-migration-status-update-1.25/)) and the following feature gates:
- `CSIMigration` (removed 1.26)
- `CSIMigrationOpenStack` (removed 1.25)
- `ExpandCSIVolumes` (removed 1.26)
[Removed feature gate list](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates-removed/)

Specifying the feature gates as suggested by current documentation causes the kubelet to error out.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10250

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
