### PR TITLE
Revert "implement download mirrors support (#8474)"

### DIFF
--- a/roles/download/tasks/download_file.yml
+++ b/roles/download/tasks/download_file.yml
@@ -53,41 +53,11 @@
     - download_force_cache
     - not download_localhost
 
-  # We check a number of mirrors that may hold the file and pick a working one at random
-  # This task will avoid logging it's parameters to not leak environment passwords in the log
-  - name: Download_file | Validate mirrors
-    uri:
-      url: "{{ mirror }}"
-      method: HEAD
-      validate_certs: "{{ download_validate_certs }}"
-      url_username: "{{ download.username | default(omit) }}"
-      url_password: "{{ download.password | default(omit) }}"
-      force_basic_auth: "{{ download.force_basic_auth | default(omit) }}"
-    delegate_to: "{{ download_delegate if download_force_cache else inventory_hostname }}"
-    run_once: "{{ download_force_cache }}"
-    register: uri_result
-    become: "{{ not download_localhost }}"
-    until: uri_result is success
-    retries: "{{ download_retries }}"
-    delay: "{{ retry_stagger | default(5) }}"
-    environment: "{{ proxy_env }}"
-    no_log: "{{ not (unsafe_show_logs | bool) }}"
-    loop: "{{ download.mirrors | default([download.url]) }}"
-    loop_control:
-      loop_var: mirror
-    ignore_errors: true
-
-  # Ansible 2.9 requires we convert a generator to a list
-  - name: Download_file | Get the list of working mirrors
-    set_fact:
-      valid_mirror_urls: "{{ uri_result.results | selectattr('failed', 'eq', False) | map(attribute='mirror') | list }}"
-    delegate_to: "{{ download_delegate if download_force_cache else inventory_hostname }}"
-
   # This must always be called, to check if the checksum matches. On no-match the file is re-downloaded.
   # This task will avoid logging it's parameters to not leak environment passwords in the log
   - name: Download_file | Download item
     get_url:
-      url: "{{ valid_mirror_urls | random }}"
+      url: "{{ download.url }}"
       dest: "{{ file_path_cached if download_force_cache else download.dest }}"
       owner: "{{ omit if download_localhost else (download.owner | default(omit)) }}"
       mode: "{{ omit if download_localhost else (download.mode | default(omit)) }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Revert #8474
There is no user of the download mirrors support in kubespray, for a long time.
So remove it, one less thing that can go wrong.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
