### PR TITLE
Move perma failing jobs in CI to manual run

### DIFF
--- a/.gitlab-ci/molecule.yml
+++ b/.gitlab-ci/molecule.yml
@@ -61,23 +61,23 @@ molecule_cri-o:
 molecule_kata:
   extends: .molecule
   stage: deploy-part3
-  allow_failure: true
   script:
     - ./tests/scripts/molecule_run.sh -i container-engine/kata-containers
-  when: on_success
+  when: manual
+# FIXME: this test is broken (perma-failing)
 
 molecule_gvisor:
   extends: .molecule
   stage: deploy-part3
-  allow_failure: true
   script:
     - ./tests/scripts/molecule_run.sh -i container-engine/gvisor
-  when: on_success
+  when: manual
+# FIXME: this test is broken (perma-failing)
 
 molecule_youki:
   extends: .molecule
   stage: deploy-part3
-  allow_failure: true
   script:
     - ./tests/scripts/molecule_run.sh -i container-engine/youki
-  when: on_success
+  when: manual
+# FIXME: this test is broken (perma-failing)

--- a/.gitlab-ci/vagrant.yml
+++ b/.gitlab-ci/vagrant.yml
@@ -18,12 +18,12 @@
     - ./tests/scripts/testcases_run.sh
   after_script:
     - chronic ./tests/scripts/testcases_cleanup.sh
-  allow_failure: true
 
 vagrant_ubuntu20-calico-dual-stack:
   stage: deploy-part2
   extends: .vagrant
-  when: on_success
+  when: manual
+# FIXME: this test if broken (perma-failing)
 
 vagrant_ubuntu20-weave-medium:
   stage: deploy-part2
@@ -55,7 +55,8 @@ vagrant_ubuntu20-kube-router-svc-proxy:
 vagrant_fedora37-kube-router:
   stage: deploy-part2
   extends: .vagrant
-  when: on_success
+  when: manual
+# FIXME: this test if broken (perma-failing)
 
 vagrant_centos7-kube-router:
   stage: deploy-part2


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
Some our CI jobs are perma-failing and "allowed to fail".
Thus they takes up CI resources while not guarding anything.
Move them to manual instead, which should free some CI resources.

If/when we fix the underlying use case, we should re-enable those tests.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Move perma failing jobs in CI to manual run
```
