### PR TITLE
Remove documentation for removed in-tree openstack provider

### DIFF
--- a/docs/openstack.md
+++ b/docs/openstack.md
@@ -20,27 +20,11 @@ Kubespray has been tested on a number of OpenStack Public Clouds including (in a
 - [VexxHost](https://vexxhost.com/)
 - [Zetta](https://www.zetta.io/)
 
-## The in-tree cloud provider
+## The OpenStack cloud provider
 
-To deploy Kubespray on [OpenStack](https://www.openstack.org/) uncomment the `cloud_provider` option in `group_vars/all/all.yml` and set it to `openstack`.
+The cloud provider is configured to have Octavia by default in Kubespray.
 
-After that make sure to source in your OpenStack credentials like you would do when using `nova-client` or `neutron-client` by using `source path/to/your/openstack-rc` or `. path/to/your/openstack-rc`.
-
-For those who prefer to pass the OpenStack CA certificate as a string, one can
-base64 encode the cacert file and store it in the variable `openstack_cacert`.
-
-The next step is to make sure the hostnames in your `inventory` file are identical to your instance names in OpenStack.
-Otherwise [cinder](https://wiki.openstack.org/wiki/Cinder) won't work as expected.
-
-Unless you are using calico or kube-router you can now run the playbook.
-
-## The external cloud provider
-
-The in-tree cloud provider is deprecated and will be removed in a future version of Kubernetes. The target release for removing all remaining in-tree cloud providers is set to 1.21.
-
-The new cloud provider is configured to have Octavia by default in Kubespray.
-
-- Enable the new external cloud provider in `group_vars/all/all.yml`:
+- Enable the external OpenStack cloud provider in `group_vars/all/all.yml`:
 
   ```yaml
   cloud_provider: external


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

The in-tree cloud provider was [removed in Kubernetes 1.26](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.26.md#urgent-upgrade-notes). This PR simplifies the documentation by removing instructions related to this removed provider.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
