### PR TITLE
Only download kubeadm images where needed

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,6 +11,7 @@ tags:
 repository: https://github.com/kubernetes-sigs/kubespray
 dependencies:
   ansible.utils: '>=2.5.0'
+  community.general: '>=3.0.0'
 build_ignore:
   - .github
   - '*.tar.gz'

--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -22,6 +22,28 @@
   vars:
     download: "{{ download_defaults | combine(item.value) }}"
     include_file: "download_{% if download.container %}container{% else %}file{% endif %}.yml"
+    kubeadm_images: "{{ skip_kubeadm_images | ternary({}, _kubeadm_images) }}"
+    # The trick (converting list of tuples to list of dicts) below come from
+    # https://docs.ansible.com/ansible/latest/collections/community/general/dict_filter.html#examples
+    _kubeadm_images: "{{ dict(names | map('regex_replace', '^(.*)', 'kubeadm_\\1') |
+      zip( repos | zip(_tags) |
+      map('zip', keys) | map('map', 'reverse') | map('community.general.dict') |
+      map('combine', defaults))) |
+      dict2items | rejectattr('key', 'in', excluded) | items2dict }}"
+    keys:
+      - repo
+      - tag
+    images: "{{ kubeadm_images_raw.stdout_lines | map('split', ':') }}"
+    _tags: "{{ images | map(attribute=1) }}"
+    repos: "{{ images | map(attribute=0) }}"
+    names: "{{ repos | map('split', '/') | map(attribute=-1) }}"
+    defaults:
+      groups: k8s_cluster
+      enabled: true
+      container: true
+    excluded:
+      - kubeadm_coredns
+      - kubeadm_pause
   when:
     - not skip_downloads | default(false)
     - download.enabled

--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -26,24 +26,38 @@
     # The trick (converting list of tuples to list of dicts) below come from
     # https://docs.ansible.com/ansible/latest/collections/community/general/dict_filter.html#examples
     _kubeadm_images: "{{ dict(names | map('regex_replace', '^(.*)', 'kubeadm_\\1') |
-      zip( repos | zip(_tags) |
+      zip( repos | zip(_tags, _groups) |
       map('zip', keys) | map('map', 'reverse') | map('community.general.dict') |
       map('combine', defaults))) |
       dict2items | rejectattr('key', 'in', excluded) | items2dict }}"
     keys:
       - repo
       - tag
+      - groups
     images: "{{ kubeadm_images_raw.stdout_lines | map('split', ':') }}"
     _tags: "{{ images | map(attribute=1) }}"
     repos: "{{ images | map(attribute=0) }}"
     names: "{{ repos | map('split', '/') | map(attribute=-1) }}"
+    _groups: "{{ names | map('extract', images_groups) }}"
     defaults:
-      groups: k8s_cluster
       enabled: true
       container: true
     excluded:
       - kubeadm_coredns
       - kubeadm_pause
+    images_groups:
+      coredns: []
+      pause: []
+      kube-proxy:
+        - k8s_cluster
+      etcd:
+        - etcd
+      kube-scheduler:
+        - kube_control_plane
+      kube-controller-manager:
+        - kube_control_plane
+      kube-apiserver:
+        - kube_control_plane
   when:
     - not skip_downloads
     - download.enabled

--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Download | Prepare working directories and variables
   import_tasks: prep_download.yml
   when:
-    - not skip_downloads | default(false)
+    - not skip_downloads
   tags:
     - download
     - upload
@@ -10,7 +10,7 @@
 - name: Download | Get kubeadm binary and list of required images
   include_tasks: prep_kubeadm_images.yml
   when:
-    - not skip_downloads | default(false)
+    - not skip_downloads
     - inventory_hostname in groups['kube_control_plane']
   tags:
     - download
@@ -45,7 +45,7 @@
       - kubeadm_coredns
       - kubeadm_pause
   when:
-    - not skip_downloads | default(false)
+    - not skip_downloads
     - download.enabled
     - item.value.enabled
     - (not (item.value.container | default(false))) or (item.value.container and download_container)

--- a/roles/download/tasks/prep_kubeadm_images.yml
+++ b/roles/download/tasks/prep_kubeadm_images.yml
@@ -36,36 +36,9 @@
     state: file
 
 - name: Prep_kubeadm_images | Generate list of required images
-  shell: "set -o pipefail && {{ bin_dir }}/kubeadm config images list --config={{ kube_config_dir }}/kubeadm-images.yaml | grep -Ev 'coredns|pause'"
-  args:
-    executable: /bin/bash
+  command: "{{ bin_dir }}/kubeadm config images list --config={{ kube_config_dir }}/kubeadm-images.yaml"
   register: kubeadm_images_raw
   run_once: true
   changed_when: false
-  when:
-    - not skip_kubeadm_images | default(false)
-
-- name: Prep_kubeadm_images | Parse list of images
-  vars:
-    kubeadm_images_list: "{{ kubeadm_images_raw.stdout_lines }}"
-  set_fact:
-    kubeadm_image:
-      key: "kubeadm_{{ (item | regex_replace('^(?:.*\\/)*', '')).split(':')[0] }}"
-      value:
-        enabled: true
-        container: true
-        repo: "{{ item | regex_replace('^(.*):.*$', '\\1') }}"
-        tag: "{{ item | regex_replace('^.*:(.*)$', '\\1') }}"
-        groups: k8s_cluster
-  loop: "{{ kubeadm_images_list | flatten(levels=1) }}"
-  register: kubeadm_images_cooked
-  run_once: true
-  when:
-    - not skip_kubeadm_images | default(false)
-
-- name: Prep_kubeadm_images | Convert list of images to dict for later use
-  set_fact:
-    kubeadm_images: "{{ kubeadm_images_cooked.results | map(attribute='ansible_facts.kubeadm_image') | list | items2dict }}"
-  run_once: true
   when:
     - not skip_kubeadm_images | default(false)

--- a/roles/download/tasks/prep_kubeadm_images.yml
+++ b/roles/download/tasks/prep_kubeadm_images.yml
@@ -20,7 +20,7 @@
     dest: "{{ kube_config_dir }}/kubeadm-images.yaml"
     mode: 0644
   when:
-    - not skip_kubeadm_images | default(false)
+    - not skip_kubeadm_images
 
 - name: Prep_kubeadm_images | Copy kubeadm binary from download dir to system path
   copy:
@@ -41,4 +41,4 @@
   run_once: true
   changed_when: false
   when:
-    - not skip_kubeadm_images | default(false)
+    - not skip_kubeadm_images


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

1. Some cleanup of the download role in the kubeadm part (less facts, more vars, removing useless usage of `default`)
1. Modify kubeadm images download dictionaries so we only download the images where needed. In particular, this will avoid downloading etcd and control plane images on all `k8s_cluster` nodes, which should save some time, particularly on big clusters.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9094

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubeadm images are now only downloaded where needed
```
