### PR TITLE
Don't try to set permissions recursively on cache+staging directory

### DIFF
--- a/roles/download/tasks/prep_download.yml
+++ b/roles/download/tasks/prep_download.yml
@@ -69,7 +69,6 @@
   file:
     path: "{{ local_release_dir }}/images"
     state: directory
-    recurse: yes
     mode: 0755
     owner: "{{ ansible_ssh_user | default(ansible_user_id) }}"
   when:
@@ -79,7 +78,6 @@
   file:
     path: "{{ download_cache_dir }}/images"
     state: directory
-    recurse: yes
     mode: 0755
   delegate_to: localhost
   connection: local


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This should avoid permissions problems when the user creating the
directory and the user creating the content are different (when
containers images are saved by root for instances, because the user
can't use the container runtime).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10051

**Special notes for your reviewer**:
We should probably also fix the "user selection" in the download role which looks a bit bad. But that should already workaround the permissions issue linked above.

If you're aware of adverse effects of doing this, please tell ^.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Download cache directory permissions are no longer reset recursively
```
