### PR TITLE
Merge stops and removes systemd services tasks in reset playbook

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -7,6 +7,8 @@
     - kubelet.service
     - cri-dockerd.service
     - cri-dockerd.socket
+    - etcd.service
+    - etcd-events.service
   failed_when: false
   tags:
     - services
@@ -24,6 +26,8 @@
     - crio.service.d/http-proxy.conf
     - k8s-certs-renew.service
     - k8s-certs-renew.timer
+    - etcd.service
+    - etcd-events.service
   register: services_removed
   tags:
     - services
@@ -133,28 +137,6 @@
       shell: "ip netns list | cut -d' ' -f 1 | xargs -n1 ip netns delete && {{ bin_dir }}/crictl rmp -a -f"
       ignore_errors: true  # noqa ignore-errors
       changed_when: true
-
-- name: Reset | stop etcd services
-  service:
-    name: "{{ item }}"
-    state: stopped
-  with_items:
-    - etcd
-    - etcd-events
-  failed_when: false
-  tags:
-    - services
-
-- name: Reset | remove etcd services
-  file:
-    path: "/etc/systemd/system/{{ item }}.service"
-    state: absent
-  with_items:
-    - etcd
-    - etcd-events
-  register: services_removed
-  tags:
-    - services
 
 - name: Reset | remove containerd
   when: container_manager == 'containerd'


### PR DESCRIPTION
**What type of PR is this?**

/kind design


**What this PR does / why we need it**:

This PR merges tasks stop and remove systemd services related with etcd (etcd.service, etcd-events.service).

There is no systemd daemon-reload tasks after stop and remove systemd services about etcd, so if you run command `$ systemctl status etcd` on etcd node after all reset tasks are done then output will be shown which indicate etcd systemd is stopped(inactivated).

It may feel confusing about the systemd services are really removed or not.

I think it's better apply this changes if there is no specific reason to seperate this tasks.

By the way, There are `crio` , `containerd` tags in `- name: Reset | remove services` task and I relocated the `etcd.service`, `etcd-events.service` systemd services `with_items` so I'm worried about it may cause some break in some specific reset usecases

**Which issue(s) this PR fixes**:

Fixes #10901 

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:

```release-note
Merge stop and remove systemd service task in reset/tasks/main.yml
```
