### PR TITLE
Add test for coredns_dual in CI

### DIFF
--- a/tests/files/packet_debian12-calico.yml
+++ b/tests/files/packet_debian12-calico.yml
@@ -2,3 +2,7 @@
 # Instance settings
 cloud_image: debian-12
 mode: default
+
+# Kubespray settings
+
+dns_mode: coredns_dual


### PR DESCRIPTION
**What type of PR is this?**
 /kind feature

**What this PR does / why we need it**:

Add a test case for the dns_mode=coredns_dual.
This will avoid regression such as #10816.

**Special notes for your reviewer**:
I've put it in debian12-calico because:
1. No other specific settings in that test
1. debian12 is the latest version we support, should not be removed for a while.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
`dns_mode: coredns_dual` is now tested in CI.
```
