### PR TITLE
Enable containerd 'discard_unpacked_layers' by default

### DIFF
--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -36,6 +36,10 @@ containerd_default_base_runtime_spec_patch:
         hard: "{{ containerd_base_runtime_spec_rlimit_nofile }}"
         soft: "{{ containerd_base_runtime_spec_rlimit_nofile }}"
 
+# Can help reduce disk usage
+# https://github.com/containerd/containerd/discussions/6295
+containerd_discard_unpacked_layers: true
+
 containerd_base_runtime_specs:
   cri-base.json: "{{ containerd_default_base_runtime_spec | combine(containerd_default_base_runtime_spec_patch, recursive=1) }}"
 

--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -7,8 +7,8 @@ containerd_systemd_dir: "/etc/systemd/system/containerd.service.d"
 # Ref: https://github.com/kubernetes-sigs/kubespray/pull/9275#issuecomment-1246499242
 containerd_oom_score: 0
 
-# containerd_default_runtime: "runc"
-# containerd_snapshotter: "native"
+containerd_default_runtime: "runc"
+containerd_snapshotter: "overlayfs"
 
 containerd_runc_runtime:
   name: runc

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -4,29 +4,29 @@ state = "{{ containerd_state_dir }}"
 oom_score = {{ containerd_oom_score }}
 
 [grpc]
-  max_recv_message_size = {{ containerd_grpc_max_recv_message_size | default(16777216) }}
-  max_send_message_size = {{ containerd_grpc_max_send_message_size | default(16777216) }}
+  max_recv_message_size = {{ containerd_grpc_max_recv_message_size }}
+  max_send_message_size = {{ containerd_grpc_max_send_message_size }}
 
 [debug]
-  level = "{{ containerd_debug_level | default('info') }}"
+  level = "{{ containerd_debug_level }}"
 
 [metrics]
-  address = "{{ containerd_metrics_address | default('') }}"
-  grpc_histogram = {{ containerd_metrics_grpc_histogram | default(false) | lower }}
+  address = "{{ containerd_metrics_address }}"
+  grpc_histogram = {{ containerd_metrics_grpc_histogram | lower }}
 
 [plugins]
   [plugins."io.containerd.grpc.v1.cri"]
     sandbox_image = "{{ pod_infra_image_repo }}:{{ pod_infra_image_tag }}"
     max_container_log_line_size = {{ containerd_max_container_log_line_size }}
-    enable_unprivileged_ports = {{ containerd_enable_unprivileged_ports | default(false) | lower }}
-    enable_unprivileged_icmp = {{ containerd_enable_unprivileged_icmp | default(false) | lower }}
+    enable_unprivileged_ports = {{ containerd_enable_unprivileged_ports | lower }}
+    enable_unprivileged_icmp = {{ containerd_enable_unprivileged_icmp | lower }}
 {% if enable_cdi %}
     enable_cdi = true
     cdi_spec_dirs = ["/etc/cdi", "/var/run/cdi"]
 {% endif %}
     [plugins."io.containerd.grpc.v1.cri".containerd]
-      default_runtime_name = "{{ containerd_default_runtime | default('runc') }}"
-      snapshotter = "{{ containerd_snapshotter | default('overlayfs') }}"
+      default_runtime_name = "{{ containerd_default_runtime }}"
+      snapshotter = "{{ containerd_snapshotter }}"
       [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
 {% for runtime in [containerd_runc_runtime] + containerd_additional_runtimes %}
         [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.{{ runtime.name }}]

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -27,6 +27,7 @@ oom_score = {{ containerd_oom_score }}
     [plugins."io.containerd.grpc.v1.cri".containerd]
       default_runtime_name = "{{ containerd_default_runtime }}"
       snapshotter = "{{ containerd_snapshotter }}"
+      discard_unpacked_layers = {{ containerd_discard_unpacked_layers | lower }}
       [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
 {% for runtime in [containerd_runc_runtime] + containerd_additional_runtimes %}
         [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.{{ runtime.name }}]


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
- containerd: Remove redundant 'default' filters (part of #10697)
- containerd: enable 'discard_unpacked_layers' by default
-> should help with disk usage, prompted by #10195

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[Containerd] Enable by default `discard_unpacked_layers` to save some space (see https://github.com/containerd/containerd/discussions/6295)
```
