### PR TITLE
Fixed typos in inventory/sample/group_vars/k8s_cluster

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s_cluster/addons.yml
@@ -60,7 +60,7 @@ local_volume_provisioner_enabled: false
 
 # CSI Volume Snapshot Controller deployment, set this to true if your CSI is able to manage snapshots
 # currently, setting cinder_csi_enabled=true would automatically enable the snapshot controller
-# Longhorn is an extenal CSI that would also require setting this to true but it is not included in kubespray
+# Longhorn is an external CSI that would also require setting this to true but it is not included in kubespray
 # csi_snapshot_controller_enabled: false
 # csi snapshot namespace
 # snapshot_controller_namespace: kube-system
@@ -178,7 +178,7 @@ metallb_speaker_enabled: "{{ metallb_enabled }}"
 #   speaker:
 #     nodeselector:
 #       kubernetes.io/os: "linux"
-#     tollerations:
+#     tolerations:
 #       - key: "node-role.kubernetes.io/control-plane"
 #         operator: "Equal"
 #         value: ""

--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-calico.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-calico.yml
@@ -89,7 +89,7 @@ calico_pool_blocksize: 26
 # bird enable BGP routing, required for ipip and no encapsulation modes
 # calico_network_backend: vxlan
 
-# IP in IP and VXLAN is mutualy exclusive modes.
+# IP in IP and VXLAN is mutually exclusive modes.
 # set IP in IP encapsulation mode: "Always", "CrossSubnet", "Never"
 # calico_ipip_mode: 'Never'
 

--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
@@ -65,7 +65,7 @@
 # `cilium_enable_legacy_services` is deprecated in 1.6, removed in 1.9
 # cilium_enable_legacy_services: false
 
-# Unique ID of the cluster. Must be unique across all conneted clusters and
+# Unique ID of the cluster. Must be unique across all connected clusters and
 # in the range of 1 and 255. Only relevant when building a mesh of clusters.
 # This value is not defined by default
 # cilium_cluster_id:
@@ -75,7 +75,7 @@
 # cilium_deploy_additionally: false
 
 # Auto direct nodes routes can be used to advertise pods routes in your cluster
-# without any tunelling (with `cilium_tunnel_mode` sets to `disabled`).
+# without any tunneling (with `cilium_tunnel_mode` sets to `disabled`).
 # This works only if you have a L2 connectivity between all your nodes.
 # You wil also have to specify the variable `cilium_native_routing_cidr` to
 # make this work. Please refer to the cilium documentation for more


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This PR fixes typos in group vars of the sample inventory:
1. The main concern is about uncommenting the `metallb_config` in the user inventory (created by inventory builder): extra `l` letter in the `tollerations` word which affets the [metallb_config.controller.tolerations if-statement](https://github.com/kubernetes-sigs/kubespray/blob/ffda3656d179283031a91d8498700d10df55f1b6/roles/kubernetes-apps/metallb/templates/metallb.yaml.j2#L1755), since by default the `Tolerations` of the speaker contains only a default: `node-role.kubernetes.io/control-plane:NoSchedule op=Exists`, there is no custom defined toleration.
2. The other typo fixes in the sample inventory are just sort of cosmetic.
Note: _The current [install guide](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/metallb.md#install) and other corresponding metallb yamls are correct within tolerations usage._

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
