### PR TITLE
Update almalinux-8 base image to 8.9

### DIFF
--- a/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
@@ -57,8 +57,8 @@ images:
 
   almalinux-8:
     filename: AlmaLinux-8-GenericCloud-latest.x86_64.qcow2
-    url: https://repo.almalinux.org/almalinux/8.5/cloud/x86_64/images/AlmaLinux-8-GenericCloud-8.5-20211119.x86_64.qcow2
-    checksum: sha256:d629247b12802157be127db53a7fcb484b80fceae9896d750c953a51a8c6688f
+    url: https://repo.almalinux.org/almalinux/8.9/cloud/x86_64/images/AlmaLinux-8-GenericCloud-8.9-20231128.x86_64.qcow2
+    checksum: sha256:a1686bc537bce699b512e3233666f5b8f69ed797ff1ce0af52c17fdc52942621
     converted: true
     tag: "latest"
 


### PR DESCRIPTION
**What type of PR is this?**
 /kind failing-test

**What this PR does / why we need it**:
We recently have almalinux-8 jobs failing in CI because of GPG errors.
8.5 is apparently deprecated, so we upgrade to latest minor -> Should fix GPG errors


**Special notes for your reviewer**:
No idea who can actually build the images and push then to quay.io though

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update almalinux-8 base image to 8.9
```
