### PR TITLE
do not disable SELinux surreptitiously

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
+++ b/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
@@ -19,7 +19,6 @@
     - ansible_os_family == "RedHat"
     - "'Amazon' not in ansible_distribution"
     - slc.stat.exists
-  changed_when: False
   tags:
     - bootstrap-os
 


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
I would argue that Kubespray should be secure by default, [not disable SELinux by default](https://github.com/kubernetes-sigs/kubespray/blob/master/roles/kubespray-defaults/defaults/main/main.yml#L7).  The SELinux default configuration is targeted and enforcing on EL-based operating systems, so I would only expect applications/deployments such as Kubespray to change this secure by default system setting if it is a workaround for specific documented issues.  It's a lot easier to start secure by default when first deploying a cluster, making sure everything works when going through the testing and commissioning process at first, than after the fact when everything has already been deployed and running for years.

But anyway if SELinux is being disabled by default, it must not be done in a secretive way, hiding the change from users and concealing the fact that an important security layer is being disabled!!

**Special notes for your reviewer**:

This PR removes `changed_when: False` so that users can see that a change has been applied when Kubespray is disabling SELinux.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
