### PR TITLE
[Terraform-Openstack] Add optional Octavia loadbalancer for Master Nodes

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -97,9 +97,10 @@ binaries available on hyperkube v1.4.3_coreos.0 or higher.
 
 ## Module Architecture
 
-The configuration is divided into three modules:
+The configuration is divided into four modules:
 
 - Network
+- Loadbalancer
 - IPs
 - Compute
 
@@ -297,6 +298,10 @@ For your cluster, edit `inventory/$CLUSTER/cluster.tfvars`.
 |`force_null_port_security` | Set `null` instead of `true` or `false` for `port_security`. `false` by default |
 |`k8s_nodes` | Map containing worker node definition, see explanation below |
 |`k8s_masters` | Map containing master node definition, see explanation for k8s_nodes and `sample-inventory/cluster.tfvars` |
+| `k8s_master_loadbalancer_enabled`| Enable and use an Octavia load balancer for the K8s master nodes |
+| `k8s_master_loadbalancer_listener_port` | Define via which port the K8s Api should be exposed. `6443` by default  |
+| `k8s_master_loadbalancer_server_port` | Define via which port the K8S api is available on the mas. `6443` by default |
+| `k8s_master_loadbalancer_public_ip` | Specify if an existing floating IP should be used for the load balancer. A new floating IP is assigned by default  |
 
 ##### k8s_nodes
 

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -1,15 +1,15 @@
 module "network" {
   source = "./modules/network"
 
-  external_net           = var.external_net
-  network_name           = var.network_name
-  subnet_cidr            = var.subnet_cidr
-  cluster_name           = var.cluster_name
-  dns_nameservers        = var.dns_nameservers
-  network_dns_domain     = var.network_dns_domain
-  use_neutron            = var.use_neutron
-  port_security_enabled  = var.port_security_enabled
-  router_id              = var.router_id
+  external_net          = var.external_net
+  network_name          = var.network_name
+  subnet_cidr           = var.subnet_cidr
+  cluster_name          = var.cluster_name
+  dns_nameservers       = var.dns_nameservers
+  network_dns_domain    = var.network_dns_domain
+  use_neutron           = var.use_neutron
+  port_security_enabled = var.port_security_enabled
+  router_id             = var.router_id
 }
 
 module "ips" {

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -1,15 +1,15 @@
 module "network" {
   source = "./modules/network"
 
-  external_net                        = var.external_net
-  network_name                        = var.network_name
-  subnet_cidr                         = var.subnet_cidr
-  cluster_name                        = var.cluster_name
-  dns_nameservers                     = var.dns_nameservers
-  network_dns_domain                  = var.network_dns_domain
-  use_neutron                         = var.use_neutron
-  port_security_enabled               = var.port_security_enabled
-  router_id                           = var.router_id
+  external_net           = var.external_net
+  network_name           = var.network_name
+  subnet_cidr            = var.subnet_cidr
+  cluster_name           = var.cluster_name
+  dns_nameservers        = var.dns_nameservers
+  network_dns_domain     = var.network_dns_domain
+  use_neutron            = var.use_neutron
+  port_security_enabled  = var.port_security_enabled
+  router_id              = var.router_id
 }
 
 module "ips" {

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -1,15 +1,15 @@
 module "network" {
   source = "./modules/network"
 
-  external_net          = var.external_net
-  network_name          = var.network_name
-  subnet_cidr           = var.subnet_cidr
-  cluster_name          = var.cluster_name
-  dns_nameservers       = var.dns_nameservers
-  network_dns_domain    = var.network_dns_domain
-  use_neutron           = var.use_neutron
-  port_security_enabled = var.port_security_enabled
-  router_id             = var.router_id
+  external_net                        = var.external_net
+  network_name                        = var.network_name
+  subnet_cidr                         = var.subnet_cidr
+  cluster_name                        = var.cluster_name
+  dns_nameservers                     = var.dns_nameservers
+  network_dns_domain                  = var.network_dns_domain
+  use_neutron                         = var.use_neutron
+  port_security_enabled               = var.port_security_enabled
+  router_id                           = var.router_id
 }
 
 module "ips" {
@@ -111,6 +111,24 @@ module "compute" {
     module.network.subnet_id
   ]
 }
+
+module "loadbalancer" {
+  source = "./modules/loadbalancer"
+
+  cluster_name                            = var.cluster_name
+  subnet_id                               = module.network.subnet_id
+  floatingip_pool                         = var.floatingip_pool
+  k8s_master_ips                          = module.compute.k8s_master_ips
+  k8s_master_loadbalancer_enabled         = var.k8s_master_loadbalancer_enabled
+  k8s_master_loadbalancer_listener_port   = var.k8s_master_loadbalancer_listener_port
+  k8s_master_loadbalancer_server_port     = var.k8s_master_loadbalancer_server_port
+  k8s_master_loadbalancer_public_ip       = var.k8s_master_loadbalancer_public_ip
+  
+  depends_on = [
+    module.compute.k8s_master
+  ]
+}
+
 
 output "private_subnet_id" {
   value = module.network.subnet_id

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -115,15 +115,15 @@ module "compute" {
 module "loadbalancer" {
   source = "./modules/loadbalancer"
 
-  cluster_name                            = var.cluster_name
-  subnet_id                               = module.network.subnet_id
-  floatingip_pool                         = var.floatingip_pool
-  k8s_master_ips                          = module.compute.k8s_master_ips
-  k8s_master_loadbalancer_enabled         = var.k8s_master_loadbalancer_enabled
-  k8s_master_loadbalancer_listener_port   = var.k8s_master_loadbalancer_listener_port
-  k8s_master_loadbalancer_server_port     = var.k8s_master_loadbalancer_server_port
-  k8s_master_loadbalancer_public_ip       = var.k8s_master_loadbalancer_public_ip
-  
+  cluster_name                          = var.cluster_name
+  subnet_id                             = module.network.subnet_id
+  floatingip_pool                       = var.floatingip_pool
+  k8s_master_ips                        = module.compute.k8s_master_ips
+  k8s_master_loadbalancer_enabled       = var.k8s_master_loadbalancer_enabled
+  k8s_master_loadbalancer_listener_port = var.k8s_master_loadbalancer_listener_port
+  k8s_master_loadbalancer_server_port   = var.k8s_master_loadbalancer_server_port
+  k8s_master_loadbalancer_public_ip     = var.k8s_master_loadbalancer_public_ip
+
   depends_on = [
     module.compute.k8s_master
   ]

--- a/contrib/terraform/openstack/modules/compute/outputs.tf
+++ b/contrib/terraform/openstack/modules/compute/outputs.tf
@@ -1,0 +1,3 @@
+output "k8s_master_ips" {
+  value = concat(openstack_compute_instance_v2.k8s_master_no_floating_ip.*, openstack_compute_instance_v2.k8s_master_no_floating_ip_no_etcd.*)
+}

--- a/contrib/terraform/openstack/modules/loadbalancer/main.tf
+++ b/contrib/terraform/openstack/modules/loadbalancer/main.tf
@@ -1,0 +1,54 @@
+resource "openstack_lb_loadbalancer_v2" "k8s_lb" {
+  count             = var.k8s_master_loadbalancer_enabled ? 1 : 0
+  name              = "${var.cluster_name}-api-loadbalancer"
+  vip_subnet_id     = var.subnet_id
+}
+
+resource "openstack_lb_listener_v2" "api_listener"{
+  count             = var.k8s_master_loadbalancer_enabled ? 1 : 0
+  name              = "api-listener"
+  protocol          = "TCP"
+  protocol_port     = var.k8s_master_loadbalancer_listener_port
+  loadbalancer_id   = openstack_lb_loadbalancer_v2.k8s_lb[0].id
+  depends_on        = [ openstack_lb_loadbalancer_v2.k8s_lb ]
+}
+
+resource "openstack_lb_pool_v2" "api_pool" {
+  count             = var.k8s_master_loadbalancer_enabled ? 1 : 0
+  name              = "api-pool"
+  protocol          = "TCP"
+  lb_method         = "ROUND_ROBIN"
+  listener_id       = openstack_lb_listener_v2.api_listener[0].id
+  depends_on        = [ openstack_lb_listener_v2.api_listener ]
+}
+
+resource "openstack_lb_member_v2" "lb_member" {
+  count             = var.k8s_master_loadbalancer_enabled ? length(var.k8s_master_ips) : 0
+  name              = var.k8s_master_ips[count.index].name
+  pool_id           = openstack_lb_pool_v2.api_pool[0].id
+  address           = var.k8s_master_ips[count.index].access_ip_v4
+  protocol_port     = var.k8s_master_loadbalancer_server_port
+  depends_on        = [ openstack_lb_pool_v2.api_pool ]
+}
+
+resource "openstack_lb_monitor_v2" "monitor" {
+  count       = var.k8s_master_loadbalancer_enabled ? 1 : 0
+  name        = "Api Monitor"
+  pool_id     = openstack_lb_pool_v2.api_pool[0].id
+  type        = "TCP"
+  delay       = 10
+  timeout     = 5
+  max_retries = 5
+}
+
+resource "openstack_networking_floatingip_v2" "floatip_1" {
+  count = var.k8s_master_loadbalancer_enabled && var.k8s_master_loadbalancer_public_ip == "" ? 1 : 0
+  pool = var.floatingip_pool
+}
+
+resource "openstack_networking_floatingip_associate_v2" "public_ip" {
+  count             = var.k8s_master_loadbalancer_enabled ? 1 : 0
+  floating_ip       = var.k8s_master_loadbalancer_public_ip != "" ? var.k8s_master_loadbalancer_public_ip : openstack_networking_floatingip_v2.floatip_1[0].address
+  port_id           = openstack_lb_loadbalancer_v2.k8s_lb[0].vip_port_id
+  depends_on        = [ openstack_lb_loadbalancer_v2.k8s_lb ]
+}

--- a/contrib/terraform/openstack/modules/loadbalancer/variables.tf
+++ b/contrib/terraform/openstack/modules/loadbalancer/variables.tf
@@ -1,0 +1,15 @@
+variable "cluster_name" {}
+
+variable "subnet_id" {}
+
+variable "floatingip_pool" {}
+
+variable "k8s_master_ips" {}
+
+variable "k8s_master_loadbalancer_enabled" {}
+
+variable "k8s_master_loadbalancer_listener_port" {}
+
+variable "k8s_master_loadbalancer_server_port" {}
+
+variable "k8s_master_loadbalancer_public_ip" {}

--- a/contrib/terraform/openstack/modules/loadbalancer/versions.tf
+++ b/contrib/terraform/openstack/modules/loadbalancer/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    openstack = {
+      source = "terraform-provider-openstack/openstack"
+    }
+  }
+  required_version = ">= 0.12.26"
+}

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -389,3 +389,23 @@ variable "group_vars_path" {
   type        = string
   default     = "./group_vars"
 }
+
+variable "k8s_master_loadbalancer_enabled" {
+  type        = bool
+  default     = "false"
+}
+
+variable "k8s_master_loadbalancer_listener_port" {
+  type        = string
+  default     = "6443"
+}
+
+variable "k8s_master_loadbalancer_server_port" {
+  type        = string
+  default     = 6443
+}
+
+variable "k8s_master_loadbalancer_public_ip" {
+  type        = string
+  default     = ""
+}

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -391,21 +391,21 @@ variable "group_vars_path" {
 }
 
 variable "k8s_master_loadbalancer_enabled" {
-  type        = bool
-  default     = "false"
+  type    = bool
+  default = "false"
 }
 
 variable "k8s_master_loadbalancer_listener_port" {
-  type        = string
-  default     = "6443"
+  type    = string
+  default = "6443"
 }
 
 variable "k8s_master_loadbalancer_server_port" {
-  type        = string
-  default     = 6443
+  type    = string
+  default = 6443
 }
 
 variable "k8s_master_loadbalancer_public_ip" {
-  type        = string
-  default     = ""
+  type    = string
+  default = ""
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:

Added possibility to build an Openstack octavia loadbalancer for the Kubernetes Api. 
The LoadBalancer is useful to make the cluster reachable from outside if only k8s_masters_no_floating_ip is set

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```
[Terraform-openstack] Added possibility to build an octavia loadbalancer for the Kubernetes Api.

```
