### PR TITLE
Support overriding cni directory owner

### DIFF
--- a/roles/network_plugin/cni/defaults/main.yml
+++ b/roles/network_plugin/cni/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+cni_bin_owner: "{{ kube_owner }}"

--- a/roles/network_plugin/cni/tasks/main.yml
+++ b/roles/network_plugin/cni/tasks/main.yml
@@ -4,7 +4,7 @@
     path: /opt/cni/bin
     state: directory
     mode: 0755
-    owner: "{{ kube_owner }}"
+    owner: "{{ cni_bin_owner }}"
     recurse: true
 
 - name: CNI | Copy cni plugins
@@ -12,5 +12,5 @@
     src: "{{ downloads.cni.dest }}"
     dest: "/opt/cni/bin"
     mode: 0755
-    owner: "{{ kube_owner }}"
+    owner: "{{ cni_bin_owner }}"
     remote_src: yes


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Allows optionally setting the owner of `/opt/cni/bin/` (and it's contents) to a user other than `kube`.

**Which issue(s) this PR fixes**:
Fixes #10928
Also requested by #10499

**Special notes for your reviewer**:
The new variable is optional, and when not used, will keep existing behavior.

**Does this PR introduce a user-facing change?**:

```release-note
Added an optional variable (`cni_bin_owner`) to allow the user to set a different owner for `/opt/cni/bin/` and it's contents.
```
