### PR TITLE
Remove mirwan from approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,7 +3,6 @@ aliases:
     - cristicalin
     - floryut
     - liupeng0518
-    - mirwan
     - mzaian
     - oomichi
     - yankay


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Since they are no longer in the kubernetes-sigs organization, they can no longer be assigned PR to approve.
https://github.com/kubernetes-sigs/kubespray/pull/10857#issuecomment-1947977213
kubernetes/org@75563bf779132a448bef4328aa01f6b2bddc7c33

Apparently the OWNERS validations does not allow non-org members to be in emeritus approvers as well...

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Remove mirwan from approvers
```

@mirwan Thanks for you contributions o/
