### PR TITLE
download: Remove deleted kubeadm config field

### DIFF
--- a/roles/download/templates/kubeadm-images.yaml.j2
+++ b/roles/download/templates/kubeadm-images.yaml.j2
@@ -20,6 +20,5 @@ etcd:
 {% endfor %}
 {% endif %}
 dns:
-  type: CoreDNS
   imageRepository: {{ coredns_image_repo | regex_replace('/coredns(?!/coredns).*$', '') }}
   imageTag: {{ coredns_image_tag }}


### PR DESCRIPTION

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Remove deprecated field

**Which issue(s) this PR fixes**:
Fixes #10926

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
