### PR TITLE
Add extra_vars support to vagrant setup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -80,6 +80,7 @@ $ansible_tags ||= ENV['VAGRANT_ANSIBLE_TAGS'] || ""
 $vagrant_dir ||= File.join(File.dirname(__FILE__), ".vagrant")
 
 $playbook ||= "cluster.yml"
+$extra_vars ||= {}
 
 host_vars = {}
 
@@ -276,6 +277,7 @@ Vagrant.configure("2") do |config|
           ansible.host_key_checking = false
           ansible.raw_arguments = ["--forks=#{$num_instances}", "--flush-cache", "-e ansible_become_pass=vagrant"]
           ansible.host_vars = host_vars
+          ansible.extra_vars = $extra_vars
           if $ansible_tags != ""
             ansible.tags = [$ansible_tags]
           end

--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -85,6 +85,11 @@ cat << EOF > vagrant/config.rb
 \$network_plugin = "flannel"
 \$inventory = "$INV"
 \$shared_folders = { 'temp/docker_rpms' => "/var/cache/yum/x86_64/7/docker-ce/packages" }
+\$extra_vars = {
+    dns_domain: my.custom.domain
+}
+# or
+\$extra_vars = "path/to/extra/vars/file.yml"
 EOF
 
 # make the rpm cache


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Allow to specify extra_vars in vagrant/config.rb

Make it easier to test reproducers using extra vars.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add extra_vars support to vagrant setup
```
