### PR TITLE
fix: skip multus when not defined

### DIFF
--- a/roles/kubernetes-apps/network_plugin/multus/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/multus/tasks/main.yml
@@ -9,7 +9,7 @@
     state: "latest"
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
   run_once: true
-  with_items: "{{ multus_manifest_1.results + (multus_nodes_list | map('extract', hostvars, 'multus_manifest_2') | list | json_query('[].results')) }}"
+  with_items: "{{ (multus_manifest_1.results | default([])) + (multus_nodes_list | map('extract', hostvars, 'multus_manifest_2.results') | default([]) | list) }}"
   loop_control:
     label: "{{ item.item.name if item != None else 'skipped' }}"
   vars:


### PR DESCRIPTION
 /kind bug

when multus is not installed/defined cluster playbook run would fail:
```
TASK [kubernetes-apps/network_plugin/multus : Multus | Start resources] 
fatal: [host -> {{ groups['kube_control_plane'][0] }}]: FAILED! => 
{"msg": "Error in jmespath.search in json_query filter plugin:
'ansible.vars.hostvars.HostVarsVars object' has no attribute 'multus_manifest_2'"}
```

```release-note
Fix: skip multus when not defined

The default=[] part ensures that if multus_manifest_2 is not defined or doesn't have the 'results' attribute, it defaults to an empty list ([]).
This prevents potential errors that might occur if trying to access attributes on an undefined variable.
```
