### PR TITLE
Remove holmsten from approver (contrib/terraform)

### DIFF
--- a/contrib/terraform/OWNERS
+++ b/contrib/terraform/OWNERS
@@ -1,5 +1,3 @@
 # See the OWNERS docs at https://go.k8s.io/owners
-
 approvers:
-  - holmsten
   - miouge1


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Remove holmsten from approvers as they're no longer in kubernetes-sigs org.
https://github.com/kubernetes-sigs/kubespray/pull/10910#issuecomment-1948705011

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
