### PR TITLE
add cilium_hubble_event_buffer_capacity & cilium_hubble_event_queue_size vars

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
@@ -156,6 +156,13 @@
 ### Enable auto generate certs if cilium_hubble_install: true
 # cilium_hubble_tls_generate: false
 
+### Tune cilium_hubble_event_buffer_capacity & cilium_hubble_event_queue_size values to avoid dropping events when hubble is under heavy load
+### Capacity of Hubble events buffer. The provided value must be one less than an integer power of two and no larger than 65535
+### (ie: 1, 3, ..., 2047, 4095, ..., 65535) (default 4095)
+# cilium_hubble_event_buffer_capacity: 4095
+### Buffer size of the channel to receive monitor events.
+# cilium_hubble_event_queue_size: 50
+
 # IP address management mode for v1.9+.
 # https://docs.cilium.io/en/v1.9/concepts/networking/ipam/
 # cilium_ipam_mode: kubernetes

--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -152,6 +152,12 @@ cilium_hubble_install: false
 ### Enable auto generate certs if cilium_hubble_install: true
 cilium_hubble_tls_generate: false
 
+### Capacity of Hubble events buffer. The provided value must be one less than an integer power of two and no larger than 65535
+### (ie: 1, 3, ..., 2047, 4095, ..., 65535) (default 4095)
+# cilium_hubble_event_buffer_capacity: 4095
+### Buffer size of the channel to receive monitor events.
+# cilium_hubble_event_queue_size: 50
+
 # The default IP address management mode is "Cluster Scope".
 # https://docs.cilium.io/en/stable/concepts/networking/ipam/
 cilium_ipam_mode: cluster-pool

--- a/roles/network_plugin/cilium/tasks/check.yml
+++ b/roles/network_plugin/cilium/tasks/check.yml
@@ -61,3 +61,9 @@
   when:
     - cilium_ipsec_enabled is defined
     - cilium_ipsec_enabled
+
+- name: Stop if cilium_hubble_event_buffer_capacity is not a power of 2 minus 1 and is not between 1 and 65535
+  assert:
+    that: "cilium_hubble_event_buffer_capacity in [1, 3, 7, 15, 31, 63, 127, 255, 511, 1023, 2047, 4095, 8191, 16383, 32767, 65535]"
+    msg: "Error: cilium_hubble_event_buffer_capacity:{{ cilium_hubble_event_buffer_capacity }} is not a power of 2 minus 1 and it should be between 1 and 65535."
+  when: cilium_hubble_event_buffer_capacity is defined

--- a/roles/network_plugin/cilium/templates/cilium/config.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/config.yml.j2
@@ -180,6 +180,12 @@ data:
     {{ hubble_metrics_cycle }}
 {% endfor %}
 {% endif %}
+{% if cilium_hubble_event_buffer_capacity is defined %}
+  hubble-event-buffer-capacity: "{{ cilium_hubble_event_buffer_capacity }}"
+{% endif %}
+{% if cilium_hubble_event_queue_size is defined %}
+  hubble-event-queue-size: "{{ cilium_hubble_event_queue_size }}"
+{% endif %}
   hubble-listen-address: ":4244"
 {% if cilium_enable_hubble and cilium_hubble_install %}
   hubble-disable-tls: "{% if cilium_hubble_tls_generate %}false{% else %}true{% endif %}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
On loaded k8s clusters, cilium hubble can drop events. This can been seen in the hubble logs with messages: hubble events queue is full; dropping messages

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #10942`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10942

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
add cilium_hubble_event_buffer_capacity & cilium_hubble_event_queue_size vars
```
