### PR TITLE
Add configuration to create cilium CNI plugin file when cilium>=1.14.0

### DIFF
--- a/roles/network_plugin/cilium/templates/cilium/config.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/config.yml.j2
@@ -69,6 +69,13 @@ data:
   # custom-cni-conf to "true", otherwise Cilium may overwrite the configuration.
   custom-cni-conf: "false"
 
+{% if cilium_version | regex_replace('v') is version('1.14.0', '>=') %}
+  # Tell the agent to generate and write a CNI configuration file
+  write-cni-conf-when-ready: /etc/cni/net.d/05-cilium.conflist
+  cni-exclusive: "{{ cilium_cni_exclusive }}"
+  cni-log-file: "{{ cilium_cni_log_file }}"
+{% endif %}
+
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets
   # that will be seen in monitor output.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
Cilium 1.14.0 is no longer creating its cni plugin file under `/etc/cni/net.d` by default. To fix this we must add the `write-cni-conf-when-ready` key inside the `cilium-config` configMap .

This will also fix the fact that the keys `cilium_cni_exclusive` and `cilium_cni_log_file` are no longer used when deploying cilium 1.14.0 .

**Which issue(s) this PR fixes**:
Fixes #10887

**Special notes for your reviewer**:
/sig network

This change was introduce in Cilium 1.14 with this [commit](https://github.com/cilium/cilium/commit/bf060c972f8d63eb7c525fc90860928979ae962c) .

They removed the script (cni-install.sh) that was in charge of creating the cni-plugin file.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
