### PR TITLE
Avoid empty "supersede domain-name-servers" directives for dhclient.conf

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0020-set_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-set_facts.yml
@@ -185,8 +185,8 @@
   set_fact:
     nameserverentries: |-
       {{ (([nodelocaldns_ip] if enable_nodelocaldns else []) + (coredns_server | d([]) if not enable_nodelocaldns else []) + nameservers | d([]) + cloud_resolver | d([]) + (configured_nameservers | d([]) if not disable_host_nameservers | d() | bool else [])) | unique | join(',') }}
-    supersede_nameserver:
-      supersede domain-name-servers {{ (([nodelocaldns_ip] if enable_nodelocaldns else []) + (coredns_server | d([]) if not enable_nodelocaldns else []) + nameservers | d([]) + cloud_resolver | d([]) + (configured_nameservers | d([]) if not disable_host_nameservers | d() | bool else [])) | unique | join(', ') }};
+    dhclient_supersede_nameserver_entries_list: |-
+      {{ (([nodelocaldns_ip] if enable_nodelocaldns else []) + (coredns_server | d([]) if not enable_nodelocaldns else []) + nameservers | d([]) + cloud_resolver | d([]) + (configured_nameservers | d([]) if not disable_host_nameservers | d() | bool else [])) | unique }}
   when: not dns_early or dns_late
 
 # This task should run instead of the above task when cluster/nodelocal DNS hasn't
@@ -195,9 +195,16 @@
   set_fact:
     nameserverentries: |-
       {{ (nameservers | d([]) + cloud_resolver | d([]) + configured_nameservers | d([])) | unique | join(',') }}
-    supersede_nameserver:
-      supersede domain-name-servers {{ (nameservers | d([]) + cloud_resolver | d([])) | unique | join(', ') }};
+    dhclient_supersede_nameserver_entries_list: |-
+      {{ (nameservers | d([]) + cloud_resolver | d([])) | unique }}
   when: dns_early and not dns_late
+
+- name: Generate supersede_nameserver from dhclient_supersede_nameserver_entries_list
+  set_fact:
+    supersede_nameserver: |-
+      {%- if dhclient_supersede_nameserver_entries_list | length > 0 -%}
+      supersede domain-name-servers {{ dhclient_supersede_nameserver_entries_list | join(', ') }};
+      {%- endif -%}
 
 - name: Set etcd vars if using kubeadm mode
   set_fact:

--- a/roles/kubernetes/preinstall/tasks/0100-dhclient-hooks.yml
+++ b/roles/kubernetes/preinstall/tasks/0100-dhclient-hooks.yml
@@ -2,7 +2,7 @@
 - name: Configure dhclient to supersede search/domain/nameservers
   blockinfile:
     block: |-
-      {% for item in [supersede_domain, supersede_search, supersede_nameserver] -%}
+      {% for item in [supersede_domain, supersede_search, supersede_nameserver] | reject('equalto', '') -%}
       {{ item }}
       {% endfor %}
     path: "{{ dhclientconffile }}"


### PR DESCRIPTION
This patch aims to be minimal and intentionally:

- does not change the generation logic for `supersede_domain` and `supersede_search`
- does not change how `nameserverentries` (for NetworkManager) is built

It seems like `nameserverentries` in the "Generate nameservers for resolvconf, including cluster DNS" task is built the same way as `dhclient_supersede_nameserver_entries_list`. However, `nameserverentries` in the "Generate nameservers for resolvconf, not including cluster DNS" task (below) is built differently for some reason. It includes `configured_nameservers` as well. Due to these differences, I have refrained from reusing the same building logic (`dhclient_supersede_nameserver_entries_list`) for both.

If the `configured_nameservers` addition can be removed or made to apply to dhclient as well, we could potentially build a single list and then generate the `nameserverentries` and `supersede_nameserver` strings from it.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes a `dhclient.conf` corruption on etcd-only nodes on non-Network-Manager systems (Ubuntu 20.04, etc.)

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes-sigs/kubespray/issues/10947

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
