### PR TITLE
Delegate prep_kubeadm_images to control plane

### DIFF
--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -8,10 +8,11 @@
     - upload
 
 - name: Download | Get kubeadm binary and list of required images
-  include_tasks: prep_kubeadm_images.yml
+  import_tasks: prep_kubeadm_images.yml
+  run_once: true
+  delegate_to: "{{ groups['kube_control_plane'][0] }}"
   when:
     - not skip_downloads
-    - inventory_hostname in groups['kube_control_plane']
   tags:
     - download
     - upload

--- a/roles/download/tasks/prep_kubeadm_images.yml
+++ b/roles/download/tasks/prep_kubeadm_images.yml
@@ -3,7 +3,6 @@
   fail:
     msg: "Kubeadm version {{ kubeadm_version }} do not matches kubernetes {{ kube_version }}"
   when:
-    - not skip_downloads | default(false)
     - not kubeadm_version == downloads.kubeadm.version
 
 - name: Prep_kubeadm_images | Download kubeadm binary
@@ -11,7 +10,6 @@
   vars:
     download: "{{ download_defaults | combine(downloads.kubeadm) }}"
   when:
-    - not skip_downloads | default(false)
     - downloads.kubeadm.enabled
 
 - name: Prep_kubeadm_images | Create kubeadm config
@@ -38,7 +36,6 @@
 - name: Prep_kubeadm_images | Generate list of required images
   command: "{{ bin_dir }}/kubeadm config images list --config={{ kube_config_dir }}/kubeadm-images.yaml"
   register: kubeadm_images_raw
-  run_once: true
   changed_when: false
   when:
     - not skip_kubeadm_images


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Doing this instead of checking for host membership prevent breaking for
cases where we don't run on control plane (--limit <nodes> for instance,
when scaling).
import_tasks is more approriate, since the tasks are not dynamic and we
always run them (mostly).


**Which issue(s) this PR fixes**:
Fixes #10912

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Establishing the list of kubeadm images is always delegated to first control plane node, preventing failure with --limit usages
```
