### PR TITLE
Support single-scheduler deployment mode for scheduler-plugins

### DIFF
--- a/docs/kubernetes-apps/scheduler_plugins.md
+++ b/docs/kubernetes-apps/scheduler_plugins.md
@@ -15,7 +15,17 @@ The kube-scheduler binary includes a list of plugins:
 - [PodState](https://github.com/kubernetes-sigs/scheduler-plugins/blob/master/pkg/podstate/README.md) [Sample]
 - [QualityOfService](https://github.com/kubernetes-sigs/scheduler-plugins/blob/master/pkg/qos/README.md) [Sample]
 
-Currently, we use [helm chart](https://github.com/kubernetes-sigs/scheduler-plugins/blob/master/manifests/install/charts/as-a-second-scheduler/README.md#installing-the-chart) to install the scheduler plugins, so that a second scheduler would be created and running. **Note that running multi-scheduler will inevitably encounter resource conflicts when the cluster is short of resources**.
+Currently supports selection of deployment modes by switching the `scheduler_plugins_single_scheduler_mode` (bool) option:
+
+- **single-scheduler mode** (default):
+
+    Only one scheduler is running. That would patch and replace the default scheduler. It's recommended for the production env.
+
+- **second-scheduler mode**:
+
+    Two schedulers are running. One is the default scheduler, and the other is the scheduler-plugins's scheduler.
+
+**Note that running multi-scheduler will inevitably encounter resource conflicts when the cluster is short of resources**.
 
 ## Compatibility Matrix
 
@@ -31,6 +41,12 @@ There are requirements for the version of Kubernetes, please see [Compatibility 
 
   The `scheduler_plugins_enabled` option is used to enable the installation of scheduler plugins.
 
+- For single-scheduler mode:
+
+  Just pass `kube_scheduler_profiles` option to specify the scheduler profiles.
+
+- For second-scheduler mode:
+
   You can enable or disable some plugins by setting the `scheduler_plugins_enabled_plugins` or `scheduler_plugins_disabled_plugins` option. They must be in the list we mentioned above.
 
   In addition, to use custom plugin configuration, set a value for `scheduler_plugins_plugin_config` option.
@@ -43,6 +59,8 @@ There are requirements for the version of Kubernetes, please see [Compatibility 
       args:
         permitWaitingTimeSeconds: 10 # default is 60
   ```
+
+  And more options can be found in the [main.yml](../../roles/kubernetes-apps/scheduler_plugins/defaults/main.yml).
 
 ## Leverage plugin
 

--- a/roles/kubernetes-apps/scheduler_plugins/defaults/main.yml
+++ b/roles/kubernetes-apps/scheduler_plugins/defaults/main.yml
@@ -1,7 +1,12 @@
 ---
 scheduler_plugins_enabled: false
 
+# second_scheduler or single_scheduler. See https://github.com/kubernetes-sigs/scheduler-plugins/blob/master/doc/install.md#install-release-v0278-and-use-coscheduling
+scheduler_plugins_single_scheduler_mode: true
+
 scheduler_plugins_namespace: scheduler-plugins
+
+scheduler_plugins_scheduler_name: scheduler-plugins-scheduler
 
 scheduler_plugins_controller_replicas: 1
 
@@ -27,3 +32,6 @@ scheduler_plugins_plugin_config:
   - name: Coscheduling
     args:
       permitWaitingTimeSeconds: 10      # default is 60
+
+# List of scheduler extenders (dicts), each holding the values of how to communicate with the extender.
+scheduler_plugins_scheduler_extenders: []

--- a/roles/kubernetes-apps/scheduler_plugins/tasks/main.yml
+++ b/roles/kubernetes-apps/scheduler_plugins/tasks/main.yml
@@ -10,22 +10,39 @@
   tags:
     - scheduler_plugins
 
+- name: Scheduler Plugins | Templates list
+  set_fact:
+    scheduler_plugins_templates:
+      - { name: appgroup, file: appgroup.diktyo.x-k8s.io_appgroups.yaml, type: crd }
+      - { name: networktopology, file: networktopology.diktyo.x-k8s.io_networktopologies.yaml, type: crd }
+      - { name: elasticquotas, file: scheduling.x-k8s.io_elasticquotas.yaml, type: crd }
+      - { name: podgroups, file: scheduling.x-k8s.io_podgroups.yaml, type: crd }
+      - { name: noderesourcetopologies, file: topology.node.k8s.io_noderesourcetopologies.yaml, type: crd }
+      - { name: namespace, file: namespace.yaml, type: namespace }
+      - { name: sa, file: sa-scheduler-plugins.yaml, type: serviceaccount }
+      - { name: rbac, file: rbac-scheduler-plugins.yaml, type: rbac }
+      - { name: deploy, file: deploy-scheduler-plugins.yaml, type: deployment }
+    scheduler_plugins_templates_for_second_mode:
+      - { name: cm, file: cm-scheduler-plugins.yaml, type: configmap }
+  when: inventory_hostname == groups['kube_control_plane'][0]
+  tags:
+    - scheduler_plugins
+
+- name: Scheduler Plugins | Templates list for second mode
+  set_fact:
+    scheduler_plugins_templates: "{{ scheduler_plugins_templates + scheduler_plugins_templates_for_second_mode }}"
+  when:
+    - inventory_hostname == groups['kube_control_plane'][0]
+    - not scheduler_plugins_single_scheduler_mode
+  tags:
+    - scheduler_plugins
+
 - name: Scheduler Plugins | Create manifests
   template:
     src: "{{ item.file }}.j2"
     dest: "{{ kube_config_dir }}/scheduler-plugins/{{ item.file }}"
     mode: 0644
-  with_items:
-    - { name: appgroup, file: appgroup.diktyo.x-k8s.io_appgroups.yaml, type: crd }
-    - { name: networktopology, file: networktopology.diktyo.x-k8s.io_networktopologies.yaml, type: crd }
-    - { name: elasticquotas, file: scheduling.x-k8s.io_elasticquotas.yaml, type: crd }
-    - { name: podgroups, file: scheduling.x-k8s.io_podgroups.yaml, type: crd }
-    - { name: noderesourcetopologies, file: topology.node.k8s.io_noderesourcetopologies.yaml, type: crd }
-    - { name: namespace, file: namespace.yaml, type: namespace }
-    - { name: sa, file: sa-scheduler-plugins.yaml, type: serviceaccount }
-    - { name: rbac, file: rbac-scheduler-plugins.yaml, type: rbac }
-    - { name: cm, file: cm-scheduler-plugins.yaml, type: configmap }
-    - { name: deploy, file: deploy-scheduler-plugins.yaml, type: deployment }
+  with_items: "{{ scheduler_plugins_templates }}"
   register: scheduler_plugins_manifests
   when: inventory_hostname == groups['kube_control_plane'][0]
   tags:
@@ -58,11 +75,13 @@
 - name: Scheduler Plugins | Wait for scheduler pods to be ready
   command: "{{ kubectl }} -n {{ scheduler_plugins_namespace }} get pods -l component=scheduler -o jsonpath='{.items[?(@.status.containerStatuses[0].ready==false)].metadata.name}'"   # noqa ignore-errors
   register: scheduler_pods_not_ready
-  until: scheduler_pods_not_ready.stdout.find("scheduler-plugins-scheduler")==-1
+  until: scheduler_pods_not_ready.stdout.find(scheduler_plugins_scheduler_name)==-1
   retries: 30
   delay: 10
   ignore_errors: true
   changed_when: false
-  when: inventory_hostname == groups['kube_control_plane'][0]
+  when:
+    - inventory_hostname == groups['kube_control_plane'][0]
+    - not scheduler_plugins_single_scheduler_mode
   tags:
     - scheduler_plugins

--- a/roles/kubernetes-apps/scheduler_plugins/templates/cm-scheduler-plugins.yaml.j2
+++ b/roles/kubernetes-apps/scheduler_plugins/templates/cm-scheduler-plugins.yaml.j2
@@ -9,14 +9,18 @@ data:
     kind: KubeSchedulerConfiguration
     leaderElection:
       leaderElect: {{ scheduler_plugins_scheduler_leader_elect | bool | lower }}
+{% if scheduler_plugins_scheduler_extenders %}
+    extenders:
+{{ scheduler_plugins_scheduler_extenders | to_nice_yaml(indent=6, width=256) }}
+{% endif %}
     profiles:
     # Compose all plugins in one profile
-    - schedulerName: scheduler-plugins-scheduler
+    - schedulerName: {{ scheduler_plugins_scheduler_name }}
       plugins:
         multiPoint:
           enabled:
-{% for enabeld_plugin in scheduler_plugins_enabled_plugins %}
-          - name: {{ enabeld_plugin }}
+{% for enabled_plugin in scheduler_plugins_enabled_plugins %}
+          - name: {{ enabled_plugin }}
 {% endfor %}
           disabled:
 {% for disabled_plugin in scheduler_plugins_disabled_plugins %}

--- a/roles/kubernetes-apps/scheduler_plugins/templates/deploy-scheduler-plugins.yaml.j2
+++ b/roles/kubernetes-apps/scheduler_plugins/templates/deploy-scheduler-plugins.yaml.j2
@@ -20,13 +20,14 @@ spec:
       - name: scheduler-plugins-controller
         image: {{ scheduler_plugins_controller_image_repo }}:{{ scheduler_plugins_controller_image_tag }}
         imagePullPolicy: {{ k8s_image_pull_policy }}
+{% if not scheduler_plugins_single_scheduler_mode %}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     component: scheduler
-  name: scheduler-plugins-scheduler
+  name: {{ scheduler_plugins_scheduler_name }}
   namespace: {{ scheduler_plugins_namespace }}
 spec:
   selector:
@@ -72,3 +73,4 @@ spec:
       - name: scheduler-config
         configMap:
           name: scheduler-config
+{% endif %}

--- a/roles/kubernetes-apps/scheduler_plugins/templates/rbac-scheduler-plugins.yaml.j2
+++ b/roles/kubernetes-apps/scheduler_plugins/templates/rbac-scheduler-plugins.yaml.j2
@@ -1,3 +1,4 @@
+{% if not scheduler_plugins_single_scheduler_mode %}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -67,12 +68,12 @@ rules:
   resources: ["podgroups", "elasticquotas", "podgroups/status", "elasticquotas/status"]
   verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
 # for network-aware plugins add the following lines (scheduler-plugins v0.27.8)
-#- apiGroups: [ "appgroup.diktyo.x-k8s.io" ]
-#  resources: [ "appgroups" ]
-#  verbs: [ "get", "list", "watch", "create", "delete", "update", "patch" ]
-#- apiGroups: [ "networktopology.diktyo.x-k8s.io" ]
-#  resources: [ "networktopologies" ]
-#  verbs: [ "get", "list", "watch", "create", "delete", "update", "patch" ]
+- apiGroups: [ "appgroup.diktyo.x-k8s.io" ]
+  resources: [ "appgroups" ]
+  verbs: [ "get", "list", "watch", "create", "delete", "update", "patch" ]
+- apiGroups: [ "networktopology.diktyo.x-k8s.io" ]
+  resources: [ "networktopologies" ]
+  verbs: [ "get", "list", "watch", "create", "delete", "update", "patch" ]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -86,6 +87,38 @@ subjects:
 - kind: ServiceAccount
   name: scheduler-plugins-scheduler
   namespace: {{ scheduler_plugins_namespace }}
+{% else %}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:kube-scheduler:plugins
+rules:
+- apiGroups: [ "topology.node.k8s.io" ]
+  resources: [ "noderesourcetopologies" ]
+  verbs: [ "get", "list", "watch" ]
+- apiGroups: ["scheduling.x-k8s.io"]
+  resources: ["podgroups", "elasticquotas", "podgroups/status", "elasticquotas/status"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+- apiGroups: [ "appgroup.diktyo.k8s.io" ]
+  resources: [ "appgroups" ]
+  verbs: [ "get", "list", "watch", "create", "delete", "update", "patch" ]
+- apiGroups: [ "networktopology.diktyo.k8s.io" ]
+  resources: [ "networktopologies" ]
+  verbs: [ "get", "list", "watch", "create", "delete", "update", "patch" ]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:kube-scheduler:plugins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kube-scheduler:plugins
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: system:kube-scheduler
+{% endif %}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -132,9 +165,11 @@ roleRef:
   kind: Role
   name: extension-apiserver-authentication-reader
 subjects:
+{% if not scheduler_plugins_single_scheduler_mode %}
 - kind: ServiceAccount
   name: scheduler-plugins-scheduler
   namespace: {{ scheduler_plugins_namespace }}
+{% endif %}
 - kind: ServiceAccount
   name: scheduler-plugins-controller
   namespace: {{ scheduler_plugins_namespace }}

--- a/roles/kubernetes-apps/scheduler_plugins/templates/sa-scheduler-plugins.yaml.j2
+++ b/roles/kubernetes-apps/scheduler_plugins/templates/sa-scheduler-plugins.yaml.j2
@@ -1,8 +1,10 @@
+{% if not scheduler_plugins_single_scheduler_mode %}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: scheduler-plugins-scheduler
   namespace: {{ scheduler_plugins_namespace }}
+{% endif %}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -92,6 +92,34 @@
   set_fact:
     kubeadmConfig_api_version: v1beta3
 
+- name: Kubeadm | Patch kube-scheduler manifest for scheduler-plugins
+  when:
+    - kube_major_version is version('v1.28', '<')
+    - scheduler_plugins_enabled is defined and scheduler_plugins_enabled
+    - scheduler_plugins_single_scheduler_mode is defined and scheduler_plugins_single_scheduler_mode
+  tags:
+    - scheduler_plugins
+  block:
+    - name: Enable kubeadm_patches
+      set_fact:
+        kubeadm_patches:
+          enabled: true
+          source_dir: "{{ inventory_dir }}/patches"
+          dest_dir: "{{ kube_config_dir }}/patches"
+      when: kubeadm_patches is not defined or not kubeadm_patches.enabled
+    - name: Ensure patch source dirs exists
+      file:
+        path: "{{ kubeadm_patches.source_dir }}"
+        state: directory
+        mode: 0640
+      delegate_to: localhost
+    - name: Render patches
+      template:
+        src: "kube-scheduler0+json.yaml.j2"
+        dest: "{{ kubeadm_patches.source_dir }}/kube-scheduler0+json.yaml"
+        mode: 0640
+      delegate_to: localhost
+
 - name: Kubeadm | Create kubeadm config
   template:
     src: "kubeadm-config.{{ kubeadmConfig_api_version }}.yaml.j2"

--- a/roles/kubernetes/control-plane/templates/kube-scheduler0+json.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kube-scheduler0+json.yaml.j2
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: "/spec/containers/0/image"
+  value: "{{ scheduler_plugins_scheduler_image_repo }}:{{ scheduler_plugins_scheduler_image_tag }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:

It's provides new features and enhancements after https://github.com/kubernetes-sigs/kubespray/pull/10747. That's mainly involved:

- add single-scheduler deployment mode supporting and a option to switch [deployment modes
](https://github.com/kubernetes-sigs/scheduler-plugins/blob/master/doc/install.md#install-release-v0278-and-use-coscheduling). Before this pr, it only supports the deployment of second-scheduler mode.
- add a little useful options (e.g. allow users change the name of scheduler-plugins scheduler in second-scheduler mode, etc). 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Support single-scheduler deployment mode for scheduler-plugins and provide option `scheduler_plugins_single_scheduler_mode` to switch it.
```
