### PR TITLE
fix wrong path of cilium CNI plugin file

### DIFF
--- a/roles/network_plugin/cilium/templates/cilium/config.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/config.yml.j2
@@ -71,7 +71,7 @@ data:
 
 {% if cilium_version | regex_replace('v') is version('1.14.0', '>=') %}
   # Tell the agent to generate and write a CNI configuration file
-  write-cni-conf-when-ready: /etc/cni/net.d/05-cilium.conflist
+  write-cni-conf-when-ready: /host/etc/cni/net.d/05-cilium.conflist
   cni-exclusive: "{{ cilium_cni_exclusive }}"
   cni-log-file: "{{ cilium_cni_log_file }}"
 {% endif %}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

Made a mistake in my previous PR #10945. The path where cilium needs to write the cni plugin file is the path mounted by the DeamonSet so it should be `/host/etc/cni/net.d/05-cilium.conflist`. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10887

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
