### PR TITLE
[2.24] Update KUBESPRAY_VERSION in galaxy.yml  v2.24.1

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: kubernetes_sigs
 description: Deploy a production ready Kubernetes cluster
 name: kubespray
-version: 2.24.1
+version: 2.24.2
 readme: README.md
 authors:
   - luksi1


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:
Update KUBESPRAY_VERSION in galaxy.yml  v2.24.1

Similar to: https://github.com/kubernetes-sigs/kubespray/pull/10801

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
```release-note
Update KUBESPRAY_VERSION in galaxy.yml  v2.24.1
```
