### PR TITLE
adding lower argument to cilium_kube_proxy

### DIFF
--- a/roles/network_plugin/cilium/templates/cilium/config.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/config.yml.j2
@@ -150,7 +150,7 @@ data:
   wait-bpf-mount: "false"
 {% endif %}
 
-  kube-proxy-replacement: "{{ cilium_kube_proxy_replacement }}"
+  kube-proxy-replacement: "{{ cilium_kube_proxy_replacement | lower }}"
 
 # `native-routing-cidr` is deprecated in 1.10, removed in 1.12.
 # Replaced by `ipv4-native-routing-cidr`


### PR DESCRIPTION
For some reason w/o this it's causing errors when using the new true value


/kind feature


**What this PR does / why we need it**:

fixes the new true statement value for cilium_kube_proxy_replacement


