### PR TITLE
adding option to skip kube-proxy

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -120,6 +120,7 @@ kube_network_node_prefix_ipv6: 120
 kube_apiserver_ip: "{{ kube_service_addresses | ansible.utils.ipaddr('net') | ansible.utils.ipaddr(1) | ansible.utils.ipaddr('address') }}"
 kube_apiserver_port: 6443  # (https)
 
+kubeadm_skip_kube_proxy: false 
 # Kube-proxy proxyMode configuration.
 # Can be ipvs, iptables
 kube_proxy_mode: ipvs

--- a/roles/kubernetes/control-plane/defaults/main/main.yml
+++ b/roles/kubernetes/control-plane/defaults/main/main.yml
@@ -240,3 +240,4 @@ kubeadm_upgrade_auto_cert_renewal: true
 kube_apiserver_tracing: false
 kube_apiserver_tracing_endpoint: 0.0.0.0:4317
 kube_apiserver_tracing_sampling_rate_per_million: 100
+kubeadm_skip_kube_proxy: false

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
@@ -32,6 +32,10 @@ nodeRegistration:
 patches:
   directory: {{ kubeadm_patches.dest_dir }}
 {% endif %}
+{% if kubeadm_skip_kube_proxy %}
+skipPhases:
+- addon/kube_proxy
+{% endif %}
 ---
 apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration


### PR DESCRIPTION
/kind feature


**What this PR does / why we need it**:

This provides the capability and option to skip kube-proxy, when it's not needed. 

Default is set to false

helps with options for cilium