### PR TITLE
Add configuration to create cilium CNI plugin file when cilium>=1.14.0

### DIFF
--- a/roles/network_plugin/cilium/templates/cilium/config.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/config.yml.j2
@@ -69,6 +69,13 @@ data:
   # custom-cni-conf to "true", otherwise Cilium may overwrite the configuration.
   custom-cni-conf: "false"
 
+{% if cilium_version | regex_replace('v') is version('1.14.0', '>=') %}
+  # Tell the agent to generate and write a CNI configuration file
+  write-cni-conf-when-ready: /host/etc/cni/net.d/05-cilium.conflist
+  cni-exclusive: "{{ cilium_cni_exclusive }}"
+  cni-log-file: "{{ cilium_cni_log_file }}"
+{% endif %}
+
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets
   # that will be seen in monitor output.


### PR DESCRIPTION


**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
This PR is linked to this one #10945 as requested by @yankay.

Cilium 1.14.0 is no longer creating its cni plugin file under /etc/cni/net.d by default. To fix this we must add the write-cni-conf-when-ready key inside the cilium-config configMap .

This will also fix the fact that the keys cilium_cni_exclusive and cilium_cni_log_file are no longer used in this role when deploying cilium >= 1.14.0 .
**Which issue(s) this PR fixes**:

Fixes #10887

**Special notes for your reviewer**:
it needs to be cherry-picked to the branch release-2.24 after. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
