### PR TITLE
fix(multus): hostvars has no attribute 'multus_manifest_2'

### DIFF
--- a/roles/kubernetes-apps/network_plugin/multus/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/multus/tasks/main.yml
@@ -9,7 +9,7 @@
     state: "latest"
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
   run_once: true
-  with_items: "{{ multus_manifest_1.results + (multus_nodes_list | map('extract', hostvars, 'multus_manifest_2') | list | json_query('[].results')) }}"
+  with_items: "{{ multus_manifest_1.results + (multus_nodes_list | map('extract', hostvars) | selectattr('multus_manifest_2', 'defined') | map(attribute='multus_manifest_2') | list | json_query('[].results')) }}"
   loop_control:
     label: "{{ item.item.name if item != None else 'skipped' }}"
   vars:


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:

This PR fixes the following error when running the `upgrade_cluster.yml` playbook with `--limit=kube_node`:

```
TASK [kubernetes-apps/network_plugin/multus : Multus | Start resources] ******************************************************************************************************************************************************************************************************************************************************
fatal: [worker1 -> {{ groups['kube_control_plane'][0] }}]: FAILED! => {"msg": "Error in jmespath.search in json_query filter plugin:\n'ansible.vars.hostvars.HostVarsVars object' has no attribute 'multus_manifest_2'"}
```

This error seems to be happening because `with_items` is evaluated even if the task should be skipped (here `kube_network_plugin_multus` is `false`).

To fix this, we use the `selectattr` filter to provide a fallback value when the attribute doesn’t exist, which in turns make the error go away.

**Which issue(s) this PR fixes**:

Didn’t bother opening an issue, went to fixing right away.

**Special notes for your reviewer**:

I can’t test the behavior with multus enabled, but in theory it should work the same as before.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
