### PR TITLE
[2.24] Add configuration to create cilium CNI plugin file when cilium>=1.14.0 (#10966)

### DIFF
--- a/roles/network_plugin/cilium/templates/cilium/config.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/config.yml.j2
@@ -71,7 +71,7 @@ data:
 
 {% if cilium_version | regex_replace('v') is version('1.14.0', '>=') %}
   # Tell the agent to generate and write a CNI configuration file
-  write-cni-conf-when-ready: /etc/cni/net.d/05-cilium.conflist
+  write-cni-conf-when-ready: /host/etc/cni/net.d/05-cilium.conflist
   cni-exclusive: "{{ cilium_cni_exclusive }}"
   cni-log-file: "{{ cilium_cni_log_file }}"
 {% endif %}


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Cherry-pick #10966 to fix volumeMount inside cilium agent 
**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
We should have included this in release v2.24.1 since I made a mistake with the volumeMount path inside cilium agent. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
