### PR TITLE
Add support for ETCD_EXPERIMENTAL_PEER_SKIP_CLIENT_SAN_VERIFICATION

### DIFF
--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -119,6 +119,10 @@ etcd_experimental_initial_corrupt_check: true
 # in the production environment.
 unsafe_show_logs: false
 
+# Skip client SAN verification
+# https://etcd.io/docs/v3.4/op-guide/configuration/#--experimental-peer-skip-client-san-verification
+etcd_experimental_disable_client_san_verification: false
+
 # Enable distributed tracing
 # https://etcd.io/docs/v3.5/op-guide/monitoring/#distributed-tracing
 etcd_experimental_enable_distributed_tracing: false

--- a/roles/etcd/templates/etcd.env.j2
+++ b/roles/etcd/templates/etcd.env.j2
@@ -69,6 +69,10 @@ ETCDCTL_CERT={{ etcd_cert_dir }}/admin-{{ inventory_hostname }}.pem
 # https://groups.google.com/a/kubernetes.io/g/dev/c/B7gJs88XtQc/m/rSgNOzV2BwAJ?utm_medium=email&utm_source=footer
 ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK={{ etcd_experimental_initial_corrupt_check }}
 
+{% if etcd_experimental_disable_client_san_verification %}
+ETCD_EXPERIMENTAL_PEER_SKIP_CLIENT_SAN_VERIFICATION=true
+{% endif %}
+
 {% if etcd_experimental_enable_distributed_tracing %}
 ETCD_EXPERIMENTAL_ENABLE_DISTRIBUTED_TRACING=true
 ETCD_EXPERIMENTAL_DISTRIBUTED_TRACING_SAMPLE_RATE={{ etcd_experimental_distributed_tracing_sample_rate }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

I'm trying to install kubernetes with kubespray in 6 VMs (3 control plane, 3 workers). These VMs run under libvirt connected to bridges in NAT mode, distributed across 3 servers. So when etcd receives the connections it only sees the gateway IPs and this error appears:

```
Mar  6 18:18:38 k8s-node1-cp-01 etcd[12276]: {"level":"warn","ts":"2024-03-06T18:18:38.715552Z","caller":"embed/config_logging.go:160","msg":"rejected connection","remote-addr":"10.80.0.1:47716","server-name":"","ip-addresses":["10.80.0.119","10.90.0.131","10.100.0.123","127.0.0.1"],"dns-names":["localhost","node1","node2","node3","lb-apiserver.kubernetes.local","etcd.kube-system.svc.cluster.local","etcd.kube-system.svc","etcd.kube-system","etcd"],"error":"tls: \"10.80.0.1\" does not match any of DNSNames [\"localhost\" \"node1\" \"node2\" \"node3\" \"lb-apiserver.kubernetes.local\" \"etcd.kube-system.svc.cluster.local\" \"etcd.kube-system.svc\" \"etcd.kube-system\" \"etcd\"] (lookup etcd on 127.0.0.53:53: server misbehaving)"}
```

10.80.0.1 is the IP address of gateway.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
There is no github issue associated, I am reporting and providing the PR at the same time.

This PR adds a way of bypassing the SAN client verification, according to the etc documentation here: https://etcd.io/docs/v3.4/op-guide/configuration/#--experimental-peer-skip-client-san-verification

It also mentions: " This can be helpful e.g. if cluster members run in different networks behind a NAT."

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
