### PR TITLE
containerd: allow to configure fallback server

### DIFF
--- a/docs/containerd.md
+++ b/docs/containerd.md
@@ -35,13 +35,20 @@ containerd_registries_mirrors:
         skip_verify: false
 ```
 
-`containerd_registries_mirrors` is ignored for pulling images when `image_command_tool=nerdctl`
-(the default for `container_manager=containerd`). Use `crictl` instead, it supports
-`containerd_registries_mirrors` but lacks proper multi-arch support (see
-[#8375](https://github.com/kubernetes-sigs/kubespray/issues/8375)):
+containerd falls back to `https://{{ prefix }}` when none of the mirrors have the image.
+This can be changed with the [`server` field](https://github.com/containerd/containerd/blob/main/docs/hosts.md#server-field):
 
 ```yaml
-image_command_tool: crictl
+containerd_registries_mirrors:
+  - prefix: docker.io
+    mirrors:
+      - host: https://mirror.gcr.io
+        capabilities: ["pull", "resolve"]
+        skip_verify: false
+      - host: https://registry-1.docker.io
+        capabilities: ["pull", "resolve"]
+        skip_verify: false
+    server: https://mirror.example.org
 ```
 
 The `containerd_registries` and `containerd_insecure_registries` configs are deprecated.

--- a/roles/container-engine/containerd/templates/hosts.toml.j2
+++ b/roles/container-engine/containerd/templates/hosts.toml.j2
@@ -1,4 +1,4 @@
-server = "https://{{ item.prefix }}"
+server = "{{ item.server | default("https://" + item.prefix) }}"
 {% for mirror in item.mirrors %}
 [host."{{ mirror.host }}"]
   capabilities = ["{{ ([ mirror.capabilities ] | flatten ) | join('","') }}"]


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

We are in an airgapped env, and we don't want our clusters to try to reach public services.

(Also nerdctl limitation is now removed as we use /etc/containerd/certs.d/)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
containerd: allow to configure fallback server
```
