### PR TITLE
fix: config hostname as string type in kubeadmConfig rendering

### DIFF
--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
@@ -14,7 +14,7 @@ certificateKey: {{ kubeadm_certificate_key }}
 {% endif %}
 nodeRegistration:
 {% if kube_override_hostname | default('') %}
-  name: {{ kube_override_hostname }}
+  name: "{{ kube_override_hostname }}"
 {% endif %}
 {% if inventory_hostname in groups['kube_control_plane'] and inventory_hostname not in groups['kube_node'] %}
   taints:
@@ -76,17 +76,17 @@ etcd:
 {% endfor %}
     serverCertSANs:
 {% for san in etcd_cert_alt_names %}
-      - {{ san }}
+      - "{{ san }}"
 {% endfor %}
 {% for san in etcd_cert_alt_ips %}
-      - {{ san }}
+      - "{{ san }}"
 {% endfor %}
     peerCertSANs:
 {% for san in etcd_cert_alt_names %}
-      - {{ san }}
+      - "{{ san }}"
 {% endfor %}
 {% for san in etcd_cert_alt_ips %}
-      - {{ san }}
+      - "{{ san }}"
 {% endfor %}
 {% endif %}
 dns:
@@ -294,7 +294,7 @@ apiServer:
 {% endif %}
   certSANs:
 {% for san in apiserver_sans %}
-  - {{ san }}
+  - "{{ san }}"
 {% endfor %}
   timeoutForControlPlane: 5m0s
 controllerManager:
@@ -416,7 +416,7 @@ conntrack:
   tcpEstablishedTimeout: {{ kube_proxy_conntrack_tcp_established_timeout }}
 enableProfiling: {{ kube_proxy_enable_profiling }}
 healthzBindAddress: {{ kube_proxy_healthz_bind_address }}
-hostnameOverride: {{ kube_override_hostname }}
+hostnameOverride: "{{ kube_override_hostname }}"
 iptables:
   masqueradeAll: {{ kube_proxy_masquerade_all }}
   masqueradeBit: {{ kube_proxy_masquerade_bit }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When rendering the kubeadm configuration file, the hostname may sometimes be a numeric name. 
If double quotes are not added, kubeadm init may detect it as a numeric type and throw an error.

Examples of such error messages are as follows:
``` json
{
   "attempts":3,
   "changed":true,
   "cmd":[
      "timeout",
      "-k",
      "300s",
      "300s",
      "/usr/local/bin/kubeadm",
      "init",
      "--config=/etc/kubernetes/kubeadm-config.yaml",
      "--ignore-preflight-errors=all",
      "--v=8",
      "--skip-phases=addon/coredns",
      "--upload-certs"
   ],
   "delta":"0:00:01.092516",
   "end":"2024-01-30 21:48:15.252523",
   "failed_when_result":true,
   "msg":"non-zero return code",
   "rc":1,
   "start":"2024-01-30 21:48:14.160007",
   "stderr":"I0130 21:48:14.241241   25813 initconfiguration.go:255] loading configuration from \"/etc/kubernetes/kubeadm-config.yaml\"\nW0130 21:48:14.247196   25813 initconfiguration.go:307] error unmarshaling configuration schema.GroupVersionKind{Group:\"kubeadm.k8s.io\", Version:\"v1beta3\", Kind:\"ClusterConfiguration\"}: json: cannot unmarshal number into Go struct field APIServer.apiServer.certSANs of type string\njson: cannot unmarshal number into Go struct field APIServer.apiServer.certSANs of type string",
   "stderr_lines":[
      "I0130 21:48:14.241241   25813 initconfiguration.go:255] loading configuration from \"/etc/kubernetes/kubeadm-config.yaml\"",
      "W0130 21:48:14.247196   25813 initconfiguration.go:307] error unmarshaling configuration schema.GroupVersionKind{Group:\"kubeadm.k8s.io\", Version:\"v1beta3\", Kind:\"ClusterConfiguration\"}: json: cannot unmarshal number into Go struct field APIServer.apiServer.certSANs of type string",
      "json: cannot unmarshal number into Go struct field APIServer.apiServer.certSANs of type string"
   ],
   "stdout":"",
   "stdout_lines":[
      
   ]
}
```
``` json
{
   "attempts":3,
   "changed":true,
   "cmd":[
      "timeout",
      "-k",
      "300s",
      "300s",
      "/usr/local/bin/kubeadm",
      "init",
      "--config=/etc/kubernetes/kubeadm-config.yaml",
      "--ignore-preflight-errors=all",
      "--skip-phases=addon/coredns",
      "--upload-certs"
   ],
   "delta":"0:00:00.043053",
   "end":"2024-03-06 04:53:59.038113",
   "failed_when_result":true,
   "invocation":{
      "module_args":{
         "_raw_params":"timeout -k 300s 300s /usr/local/bin/kubeadm init --config=/etc/kubernetes/kubeadm-config.yaml --ignore-preflight-errors=all --skip-phases=addon/coredns --upload-certs",
         "_uses_shell":false,
         "argv":null,
         "chdir":null,
         "creates":null,
         "executable":null,
         "removes":null,
         "stdin":null,
         "stdin_add_newline":true,
         "strip_empty_ends":true
      }
   },
   "msg":"non-zero return code",
   "rc":1,
   "start":"2024-03-06 04:53:58.995060",
   "stderr":"W0306 04:53:59.036571   24390 initconfiguration.go:306] error unmarshaling configuration schema.GroupVersionKind{Group:\"kubeadm.k8s.io\", Version:\"v1beta3\", Kind:\"InitConfiguration\"}: json: cannot unmarshal number into Go struct field NodeRegistrationOptions.nodeRegistration.name of type string\njson: cannot unmarshal number into Go struct field NodeRegistrationOptions.nodeRegistration.name of type string\nTo see the stack trace of this error execute with --v=5 or higher",
   "stderr_lines":[
      "W0306 04:53:59.036571   24390 initconfiguration.go:306] error unmarshaling configuration schema.GroupVersionKind{Group:\"kubeadm.k8s.io\", Version:\"v1beta3\", Kind:\"InitConfiguration\"}: json: cannot unmarshal number into Go struct field NodeRegistrationOptions.nodeRegistration.name of type string",
      "json: cannot unmarshal number into Go struct field NodeRegistrationOptions.nodeRegistration.name of type string",
      "To see the stack trace of this error execute with --v=5 or higher"
   ],
   "stdout":"",
   "stdout_lines":[
      
   ]
}
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10864

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
