### PR TITLE
feat/kube-vip-cloud-provider-autodeploy

### DIFF
--- a/docs/kube-vip.md
+++ b/docs/kube-vip.md
@@ -33,11 +33,17 @@ loadbalancer_apiserver:
 # LoadBalancer for services
 kube_vip_services_enabled: false
 # kube_vip_services_interface: ens320
+# kube_vip_cloud_provider_enabled: true
+# kube_vip_cloud_provider_ip_pools:
+#   cidr-global: 172.16.0.0/24
+#   cidr-default: 192.168.0.200/30,192.168.0.200/29
+#   range-development: 192.168.0.210-192.168.0.220
+#   cidr-ipv6: 2001::10/127
 ```
 
 > Note: When using `kube-vip` as LoadBalancer for services,
-[additional manual steps](https://kube-vip.io/docs/usage/cloud-provider/)
-are needed.
+> [additional manual steps](https://kube-vip.io/docs/usage/cloud-provider/)
+> are needed.
 
 If using [local traffic policy](https://kube-vip.io/docs/usage/kubernetes-services/#external-traffic-policy-kube-vip-v050):
 
@@ -58,8 +64,8 @@ kube_vip_bgp_enabled: true
 kube_vip_local_as: 65000
 kube_vip_bgp_routerid: 192.168.0.2
 kube_vip_bgppeers:
-- 192.168.0.10:65000::false
-- 192.168.0.11:65000::false
+  - 192.168.0.10:65000::false
+  - 192.168.0.11:65000::false
 # kube_vip_bgp_peeraddress:
 # kube_vip_bgp_peerpass:
 # kube_vip_bgp_peeras:

--- a/inventory/sample/group_vars/k8s_cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s_cluster/addons.yml
@@ -259,6 +259,15 @@ kube_vip_enabled: false
 #   port: 6443
 # kube_vip_interface: eth0
 # kube_vip_services_enabled: false
+# ---
+# Kube VIP Cloud Provider
+# kube_vip_cloud_provider_enabled: false
+# Define your own IP Pools or leave empty {}
+# kube_vip_cloud_provider_ip_pools:
+#   cidr-global: 172.16.0.0/24
+#   cidr-default: 192.168.0.200/30,192.168.0.200/29
+#   range-development: 192.168.0.210-192.168.0.220
+#   cidr-ipv6: 2001::10/127
 
 # Node Feature Discovery
 node_feature_discovery_enabled: false

--- a/roles/kubernetes-apps/cloud_controller/kube-vip-cloud-provider/defaults/main.yml
+++ b/roles/kubernetes-apps/cloud_controller/kube-vip-cloud-provider/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+kube_vip_cloud_provider_enabled: false
+kube_vip_cloud_provider_ip_pools: {}

--- a/roles/kubernetes-apps/cloud_controller/kube-vip-cloud-provider/tasks/main.yml
+++ b/roles/kubernetes-apps/cloud_controller/kube-vip-cloud-provider/tasks/main.yml
@@ -1,0 +1,49 @@
+---
+
+- name: Kube-VIP Cloud Provider  | Check kube-vip settings for kube-vip cloud provider
+  fail:
+    msg: "kube-vip cloud provider require kube_vip_enabled = true and kube_vip_services_enabled = true"
+  when:
+    - kube_vip_enabled
+    - kube_vip_services_enabled
+
+- name: Kube-VIP Cloud Provider | Create addon dir
+  file:
+    path: "{{ kube_config_dir }}/addons/kube_vip_cloud_provider"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+  when:
+    - inventory_hostname == groups['kube_control_plane'][0]
+
+- name: Kube-VIP Cloud Provider | Templates list
+  set_fact:
+    kube_vip_cloud_provider_templates:
+      - { name: cm-kube-vip-cloud-provider, file: cm-kube-vip-cloud-provider.yml, type: cm }
+      - { name: sa-kube-vip-cloud-provider, file: sa-kube-vip-cloud-provider.yml, type: sa }
+      - { name: cr-kube-vip-cloud-provider, file: cr-kube-vip-cloud-provider.yml, type: clusterrole }
+      - { name: crb-kube-vip-cloud-provider, file: crb-kube-vip-cloud-provider.yml, type: clusterrolebinding }
+      - { name: deploy-kube-vip-cloud-provider, file: deploy-kube-vip-cloud-provider.yml", type: deploy }
+
+- name: Kube-VIP Cloud Provider | Create manifests
+  template:
+    src: "{{ item.file }}.j2"
+    dest: "{{ kube_config_dir }}/addons/kube_vip_cloud_provider/{{ item.file }}"
+    mode: 0644
+  with_items: "{{ kube_vip_cloud_provider_templates }}"
+  register: kube_vip_cloud_provider_manifests
+  when:
+    - inventory_hostname == groups['kube_control_plane'][0]
+
+- name: Kube-VIP Cloud Provider| Apply manifests
+  kube:
+    name: "{{ item.item.name }}"
+    namespace: "kube-system"
+    kubectl: "{{ bin_dir }}/kubectl"
+    resource: "{{ item.item.type }}"
+    filename: "{{ kube_config_dir }}/addons/kube_vip_cloud_provider/{{ item.item.file }}"
+    state: "latest"
+  with_items: "{{ kube_vip_cloud_provider_manifests.results }}"
+  when:
+    - inventory_hostname == groups['kube_control_plane'][0]

--- a/roles/kubernetes-apps/cloud_controller/kube-vip-cloud-provider/templates/cm-kube-vip-cloud-provider.yml.j2
+++ b/roles/kubernetes-apps/cloud_controller/kube-vip-cloud-provider/templates/cm-kube-vip-cloud-provider.yml.j2
@@ -1,0 +1,13 @@
+---
+
+{% if kube_vip_cloud_provider_ip_pools is defined and kube_vip_cloud_provider_ip_pools | length > 0 %}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubevip
+  namespace: kube-system
+data:
+{% for pool_name, pool in kube_vip_cloud_provider_ip_pools.items() %}
+  {{ pool_name }}: {{ pool }}
+{% endfor %}
+{% endif %}

--- a/roles/kubernetes-apps/cloud_controller/kube-vip-cloud-provider/templates/cr-kube-vip-cloud-provider.yml.j2
+++ b/roles/kubernetes-apps/cloud_controller/kube-vip-cloud-provider/templates/cr-kube-vip-cloud-provider.yml.j2
@@ -1,0 +1,18 @@
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: system:kube-vip-cloud-controller-role
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "create", "update", "list", "put"]
+  - apiGroups: [""]
+    resources: ["configmaps", "endpoints","events","services/status", "leases"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["nodes", "services"]
+    verbs: ["list","get","watch","update"]

--- a/roles/kubernetes-apps/cloud_controller/kube-vip-cloud-provider/templates/crb-kube-vip-cloud-provider.yml.j2
+++ b/roles/kubernetes-apps/cloud_controller/kube-vip-cloud-provider/templates/crb-kube-vip-cloud-provider.yml.j2
@@ -1,0 +1,14 @@
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:kube-vip-cloud-controller-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kube-vip-cloud-controller-role
+subjects:
+- kind: ServiceAccount
+  name: kube-vip-cloud-controller
+  namespace: kube-system

--- a/roles/kubernetes-apps/cloud_controller/kube-vip-cloud-provider/templates/deploy-kube-vip-cloud-provider.yml.j2
+++ b/roles/kubernetes-apps/cloud_controller/kube-vip-cloud-provider/templates/deploy-kube-vip-cloud-provider.yml.j2
@@ -1,0 +1,54 @@
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-vip-cloud-provider
+  namespace: kube-system
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: kube-vip
+      component: kube-vip-cloud-provider
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: kube-vip
+        component: kube-vip-cloud-provider
+    spec:
+      containers:
+      - command:
+        - /kube-vip-cloud-provider
+        - --leader-elect-resource-name=kube-vip-cloud-controller
+        image: {{ kube_vip_cloud_provider_image_repo }}:{{ kube_vip_cloud_provider_image_tag }}
+        name: kube-vip-cloud-provider
+        imagePullPolicy: Always
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      serviceAccountName: kube-vip-cloud-controller
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        effect: NoSchedule
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 10
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+          - weight: 10
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists

--- a/roles/kubernetes-apps/cloud_controller/kube-vip-cloud-provider/templates/sa-kube-vip-cloud-provider.yml.j2
+++ b/roles/kubernetes-apps/cloud_controller/kube-vip-cloud-provider/templates/sa-kube-vip-cloud-provider.yml.j2
@@ -1,0 +1,7 @@
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-vip-cloud-controller
+  namespace: kube-system

--- a/roles/kubernetes-apps/meta/main.yml
+++ b/roles/kubernetes-apps/meta/main.yml
@@ -111,6 +111,15 @@ dependencies:
     tags:
       - oci
 
+  - role: kubernetes-apps/cloud_controller/kube-vip-cloud-provider
+    when:
+      - kube_vip_enabled
+      - kube_vip_services_enabled
+      - kube_vip_cloud_provider_enabled
+      - inventory_hostname == groups['kube_control_plane'][0]
+    tags:
+      - kube_vip_cloud_provider
+
   - role: kubernetes-apps/metallb
     when:
       - metallb_enabled

--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -279,6 +279,8 @@ multus_image_tag: "{{ multus_version }}"
 
 kube_vip_image_repo: "{{ github_image_repo }}/kube-vip/kube-vip"
 kube_vip_image_tag: v0.5.12
+kube_vip_cloud_provider_image_repo: "{{ github_image_repo }}/kube-vip/kube-vip-cloud-provider"
+kube_vip_cloud_provider_image_tag: v0.0.9
 nginx_image_repo: "{{ docker_image_repo }}/library/nginx"
 nginx_image_tag: 1.25.2-alpine
 haproxy_image_repo: "{{ docker_image_repo }}/library/haproxy"
@@ -887,6 +889,15 @@ downloads:
     repo: "{{ kube_vip_image_repo }}"
     tag: "{{ kube_vip_image_tag }}"
     sha256: "{{ kube_vip_digest_checksum | default(None) }}"
+    groups:
+    - kube_control_plane
+
+  kube-vip-cloud-provider:
+    enabled: "{{ kube_vip_cloud_provider_enabled }}"
+    container: true
+    repo: "{{ kube_vip_cloud_provider_image_repo }}"
+    tag: "{{ kube_vip_cloud_provider_image_tag }}"
+    sha256: "{{ kube_vip_cloud_provider_digest_checksum | default(None) }}"
     groups:
     - kube_control_plane
 

--- a/roles/kubespray-defaults/defaults/main/main.yml
+++ b/roles/kubespray-defaults/defaults/main/main.yml
@@ -66,6 +66,8 @@ ignore_assert_errors: false
 
 kube_vip_enabled: false
 
+kube_vip_cloud_provider_enabled: false
+
 # nginx-proxy configure
 nginx_config_dir: "/etc/nginx"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Kube VIP addon contains a setting that let us load-balance services (kube_vip_services_enabled: true), however to make it work, we need to deploy Kube VIP Cloud Provider manually when cluster is deployed.

In order to make this ready in the out of the box manner, I've added a possibility to deploy Cloud Provider that will include all required settings (just one variable actually).

It doesn't cost us much space and trouble, but makes more sense related to service loadbalancing setting that can be set like right now.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
User have possibility to set two new settings in addons (Line 263):

# Kube VIP Cloud Provider
kube_vip_cloud_provider_enabled: false
# Define your own IP Pools or leave empty {}
kube_vip_cloud_provider_ip_pools:
  cidr-global: 172.16.0.0/24
  cidr-default: 192.168.0.200/30,192.168.0.200/29
  range-development: 192.168.0.210-192.168.0.220
  cidr-ipv6: 2001::10/127

```
