### PR TITLE
fix: change the position of the containerd_extra_args parameter to make the parameter more universal.

### DIFF
--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -3,6 +3,10 @@ root = "{{ containerd_storage_dir }}"
 state = "{{ containerd_state_dir }}"
 oom_score = {{ containerd_oom_score }}
 
+{% if containerd_extra_args is defined %}
+{{ containerd_extra_args }}
+{% endif %}
+
 [grpc]
   max_recv_message_size = {{ containerd_grpc_max_recv_message_size }}
   max_send_message_size = {{ containerd_grpc_max_send_message_size }}
@@ -104,6 +108,3 @@ oom_score = {{ containerd_oom_score }}
     service_name = "{{ containerd_tracing_service_name }}"
 {% endif %}
 
-{% if containerd_extra_args is defined %}
-{{ containerd_extra_args }}
-{% endif %}


### PR DESCRIPTION
fix: change the position of the containerd_extra_args parameter to make the parameter more universal.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->


/kind bug

**What this PR does / why we need it**:

The template parameter containerd_extra_args is currently limited to the TOML global table, which is not versatile enough. It can be adjusted to be under the global table.

In my scenario, it can be configured as follows:

```yaml
containerd_extra_args: |
  plugins."io.containerd.grpc.v1.cri".device_ownership_from_security_context = true
```

And this adjustment should not break compatibility.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11007

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Change the position of the containerd_extra_args parameter to enhance its universality.
```


