### PR TITLE
make kube-vip LeaderElection variables configurable

### DIFF
--- a/docs/kube-vip.md
+++ b/docs/kube-vip.md
@@ -76,3 +76,11 @@ In addition, [load-balancing method](https://kube-vip.io/docs/installation/flags
 ```yaml
 kube_vip_lb_fwdmethod: masquerade
 ```
+
+If you want to adjust the parameters of [kube-vip LeaderElection](https://kube-vip.io/docs/installation/flags/#environment-variables):
+
+```yaml
+kube_vip_leaseduration: 30
+kube_vip_renewdeadline: 20
+kube_vip_retryperiod: 4
+```

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -87,6 +87,9 @@ kube_vip_address:
 kube_vip_enableServicesElection: false
 kube_vip_lb_enable: false
 kube_vip_lb_fwdmethod: local
+kube_vip_leaseduration: 5
+kube_vip_renewdeadline: 3
+kube_vip_retryperiod: 1
 
 # Requests for load balancer app
 loadbalancer_apiserver_memory_requests: 32M

--- a/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
@@ -48,11 +48,11 @@ spec:
     - name: vip_leaderelection
       value: "true"
     - name: vip_leaseduration
-      value: "5"
+      value: {{ kube_vip_leaseduration | string | to_json }}
     - name: vip_renewdeadline
-      value: "3"
+      value: {{ kube_vip_renewdeadline | string | to_json }}
     - name: vip_retryperiod
-      value: "1"
+      value: {{ kube_vip_retryperiod | string | to_json }}
 {% endif %}
 {% if kube_vip_bgp_enabled %}
     - name: bgp_enable


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
Extend kube-vip's ability in Kubespray to set LeaderElection params.

**Which issue(s) this PR fixes**:

Fixes #10927

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add kube-vip LeaderElection variables `vip_leaseduration,  vip_renewdeadline, vip_retryperiod` options for kube-vip
```
