### PR TITLE
Fix calico host local ipam

### DIFF
--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -310,6 +310,10 @@ spec:
               value: "{{ calico_node_ignorelooserpf }}"
             - name: CALICO_MANAGE_CNI
               value: "true"
+{% if calico_ipam_host_local %}
+            - name: USE_POD_CIDR
+              value: "true"
+{% endif %}
 {% if calico_node_extra_envs is defined %}
 {% for key in calico_node_extra_envs %}
             - name: {{ key }}

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -38,7 +38,7 @@ spec:
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
       initContainers:
-{% if calico_datastore == "kdd" %}
+{% if calico_datastore == "kdd" and not calico_ipam_host_local %}
         # This container performs upgrade from host-local IPAM to calico-ipam.
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
@@ -428,7 +428,7 @@ spec:
           hostPath:
             path: /run/xtables.lock
             type: FileOrCreate
-{% if calico_datastore == "kdd" %}
+{% if calico_datastore == "kdd" and not calico_ipam_host_local %}
         # Mount in the directory for host-local IPAM allocations. This is
         # used when upgrading from host-local to calico-ipam, and can be removed
         # if not using the upgrade-ipam init container.

--- a/roles/network_plugin/calico/templates/calico-typha.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-typha.yml.j2
@@ -136,11 +136,10 @@ spec:
             name: cacert
             readOnly: true
 {% endif %}
-          # Needed for version >=3.7 when the 'host-local' ipam is used
-          # Should never happen given templates/cni-calico.conflist.j2
-          # Configure route aggregation based on pod CIDR.
-          # - name: USE_POD_CIDR
-          #   value: "true"
+{% if calico_ipam_host_local %}
+          - name: USE_POD_CIDR
+            value: "true"
+{% endif %}
         livenessProbe:
           httpGet:
             path: /liveness


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:

The init container upgrade-ipam should only be added for calico-ipam, because otherwise it would clear the state of the host-local plugin, potentially causing it to reassign IPs that are still in use.

Additionally, the environment variable USE_POD_CIDR is necessary for the host-local plugin.

https://github.com/projectcalico/calico/blob/4efd1bfd914b0c59086531c8c5a5ac5b593c18b1/charts/calico/templates/calico-node.yaml#L279
https://github.com/projectcalico/calico/blob/4efd1bfd914b0c59086531c8c5a5ac5b593c18b1/charts/calico/templates/calico-typha.yaml#L133

```release-note
NONE
```
