### PR TITLE
Allow specifying CPU Manager Policy Options

### DIFF
--- a/docs/vars.md
+++ b/docs/vars.md
@@ -220,6 +220,14 @@ Stack](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/dns-stack.m
 
 * *kubelet_cpu_manager_policy* -  If set to `static`, allows pods with certain resource characteristics to be granted increased CPU affinity and exclusivity on the node. And it should be set with `kube_reserved` or `system-reserved`, enable this with the following guide:[Control CPU Management Policies on the Node](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/)
 
+* *kubelet_cpu_manager_policy_options* -  A dictionary of cpuManagerPolicyOptions to enable. Keep in mind to enable the corresponding feature gates and make sure to pass the booleans as string (i.e. don't forget the quotes)!
+
+```yml
+kubelet_cpu_manager_policy_options:
+    distribute-cpus-across-numa: "true"
+    full-pcpus-only: "true"
+```
+
 * *kubelet_topology_manager_policy* - Control the behavior of the allocation of CPU and Memory from different [NUMA](https://en.wikipedia.org/wiki/Non-uniform_memory_access) Nodes. Enable this with the following guide: [Control Topology Management Policies on a node](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager).
 
 * *kubelet_topology_manager_scope* - The Topology Manager can deal with the alignment of resources in a couple of distinct scopes: `container` and `pod`. See [Topology Manager Scopes](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager/#topology-manager-scopes).

--- a/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
@@ -160,6 +160,10 @@ seccompDefault: {{ kubelet_seccomp_default | bool }}
 {% if kubelet_cpu_manager_policy is defined %}
 cpuManagerPolicy: {{ kubelet_cpu_manager_policy }}
 {% endif %}
+{% if kubelet_cpu_manager_policy_options is defined %}
+cpuManagerPolicyOptions:
+  {{ kubelet_cpu_manager_policy_options | to_nice_yaml(indent=2) }}
+{% endif %}
 {% if kubelet_topology_manager_policy is defined %}
 topologyManagerPolicy: {{ kubelet_topology_manager_policy }}
 {% endif %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
Kubespray already provides the `kubelet_cpu_manager_policy` option to specify the `static` CPU Manager. However, it lacks the ability to also specify policy options. This PR adds `kubelet_cpu_manager_policy_options`, a YAML dictionary allowing to specify the policy options following the [official documentation](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy-options).


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

```release-note
Allow specifying CPU Manager Policy options through kubelet_cpu_manager_policy_options
```
