### PR TITLE
configure crio to use kube reserved cgroup

### DIFF
--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -90,6 +90,20 @@
     remote_src: true
   notify: Restart crio
 
+- name: Cri-o | configure crio to use kube reserved cgroups
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/crio.service.d/00-slice.conf
+    owner: root
+    group: root
+    mode: '0644'
+    content: |
+      [Service]
+      Slice={{ kube_reserved_cgroups_for_service_slice }}
+  notify: Restart crio
+  when:
+    - kube_reserved is defined and kube_reserved is true
+    - kube_reserved_cgroups_for_service_slice is defined
+
 - name: Cri-o | update the bin dir for crio.service file
   replace:
     dest: /etc/systemd/system/crio.service


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
Fix for https://github.com/kubernetes-sigs/kubespray/issues/11027

I think enabling this feature was missed when support for crio was added.

It's enabled for docker using the docker systemd unit file:
https://github.com/kubernetes-sigs/kubespray/blob/master/roles/container-engine/docker/templates/docker.service.j2#L46

there is no ansible j2 template file for the crio systemd unit file as it's currently copied from the crio binary file to the host:
https://github.com/kubernetes-sigs/kubespray/blob/master/roles/container-engine/cri-o/tasks/main.yaml#L88

the best approach in this case seems to be to add a seperate `00-slice.conf` file.

with this fix in place, crio will run the correct systemd cgroup slice.

Before:
```
systemctl status crio.service
● crio.service - Container Runtime Interface for OCI (CRI-O)
   Loaded: loaded (/etc/systemd/system/crio.service; enabled; vendor preset: disabled)
   Active: active (running) since Tue 2024-03-12 10:06:49 PDT; 2 days ago
     Docs: https://github.com/cri-o/cri-o
 Main PID: 2402291 (crio)
    Tasks: 12
   Memory: 86.6M
   CGroup: /system.slice/crio.service <--------- still on system.slice
           └─2402291 /usr/local/bin/crio
````

After:
```
systemctl status crio.service
Redirecting to /bin/systemctl status crio.service
● crio.service - Container Runtime Interface for OCI (CRI-O)
   Loaded: loaded (/etc/systemd/system/crio.service; enabled; vendor preset: disabled)
  Drop-In: /etc/systemd/system/crio.service.d
           └─00-slice.conf
   Active: active (running) since Fri 2024-03-22 08:38:25 PDT; 21h ago
     Docs: https://github.com/cri-o/cri-o
 Main PID: 1389453 (crio)
    Tasks: 19
   Memory: 535.6M
   CGroup: /kube.slice/crio.service
           └─1389453 /usr/local/bin/crio
```

the kubelet errors:
```
Mar 15 02:28:37 worker01.mycluster.net kubelet[2421710]: E0315 02:28:37.703623 2421710 summary_sys_containers.go:48] "Failed to get system container stats" err="failed to get cgroup stats for \"/kube.slice/crio.service\": failed to get container info for \"/kube.slice/crio.service\": unknown container \"/kube.slice/crio.service\"" containerName="/kube.slice/crio.service"
Mar 15 02:28:45 worker01.mycluster.net kubelet[2421710]: E0315 02:28:45.000770 2421710 summary_sys_containers.go:83] "Failed to get system container stats" err="failed to get cgroup stats for \"/kube.slice/crio.service\": failed to get container info for \"/kube.slice/crio.service\": unknown container \"/kube.slice/crio.service\"" containerName="/kube.slice/crio.service"
Mar 15 02:28:47 worker01.mycluster.net kubelet[2421710]: E0315 02:28:47.717431 2421710 summary_sys_containers.go:48] "Failed to get system container stats" err="failed to get cgroup stats for \"/kube.slice/crio.service\": failed to get container info for \"/kube.slice/crio.service\": unknown container \"/kube.slice/crio.service\"" containerName="/kube.slice/crio.service"
```
also stop appearing in the logs once crio is restarted with this fix in place.

note: the fix only takes effect when the crio service is restarted.  it may not take effect during cluster upgrades unless crio is upgraded (which triggers a crio restart)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11027

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
configure crio container runtime to use kube reserved cgroup
```
