### PR TITLE
[etcd] make etcd 3.5.12 default

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Note: Upstart/SysV init based OS types are not supported.
 
 - Core
   - [kubernetes](https://github.com/kubernetes/kubernetes) v1.29.3
-  - [etcd](https://github.com/etcd-io/etcd) v3.5.10
+  - [etcd](https://github.com/etcd-io/etcd) v3.5.12
   - [docker](https://www.docker.com/) v24.0 (see [Note](#container-runtime-notes))
   - [containerd](https://containerd.io/) v1.7.13
   - [cri-o](http://cri-o.io/) v1.29.1 (experimental: see [CRI-O Note](docs/cri-o.md). Only on fedora, ubuntu and centos based OS)

--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -139,9 +139,9 @@ pod_infra_supported_versions:
 pod_infra_version: "{{ pod_infra_supported_versions[kube_major_version] }}"
 
 etcd_supported_versions:
-  v1.29: "v3.5.10"
-  v1.28: "v3.5.10"
-  v1.27: "v3.5.10"
+  v1.29: "v3.5.12"
+  v1.28: "v3.5.12"
+  v1.27: "v3.5.12"
 etcd_version: "{{ etcd_supported_versions[kube_major_version] }}"
 
 crictl_supported_versions:


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

etcd 3.5.12 has become default for the "1.27, 1.28, 1.29" releases. For more reference check the cherry-picks PRs of https://github.com/kubernetes/kubernetes/pull/123150

**Does this PR introduce a user-facing change?**:
<!--
NONE
-->
```release-note
[etcd] Default version to 3.5.12 for k8s 1.27 , 1.28 , 1.29
```