### PR TITLE
force update helm repo if exists on host

### DIFF
--- a/roles/helm-apps/vars/main.yml
+++ b/roles/helm-apps/vars/main.yml
@@ -7,3 +7,4 @@ helm_defaults:
 
 helm_repository_defaults:
   binary_path: "{{ bin_dir }}/helm"
+  force_update: true


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Kupesray fails on second run playbook `cluster.yml` when install custom_cni

```
TASK [helm-apps : Add Helm repositories] ***************************************
failed: [devops-k8s-master1.node.dev.ostrovok.in] (item={'name': 'cilium', 'url': 'https://helm.cilium.io'/}) => changed=false 
  ansible_loop_var: item
  item:
    name: cilium
    url: https://helm.cilium.io/
  msg: Repository already have a repository named cilium
```

add `force_update: true` to add helm repo task

