### PR TITLE
flexibility configuration of resources for cilium

### DIFF
--- a/roles/network_plugin/cilium/templates/cilium/ds.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/ds.yml.j2
@@ -121,13 +121,27 @@ spec:
             exec:
               command:
               - /cni-uninstall.sh
+{% if cilium_cpu_limit or cilium_memory_limit or cilium_cpu_requests or cilium_memory_requests %}
         resources:
+{% if cilium_cpu_limit or cilium_memory_limit %}
           limits:
+{% if cilium_cpu_limit %}
             cpu: {{ cilium_cpu_limit }}
+{% endif %}
+{% if cilium_memory_limit %}
             memory: {{ cilium_memory_limit }}
+{% endif %}
+{% endif %}
+{% if cilium_cpu_requests or cilium_memory_requests %}
           requests:
+{% if cilium_cpu_requests %}
             cpu: {{ cilium_cpu_requests }}
+{% endif %}
+{% if cilium_memory_requests %}
             memory: {{ cilium_memory_requests }}
+{% endif %}
+{% endif %}
+{% endif %}
 {% if cilium_enable_prometheus or cilium_enable_hubble_metrics %}
         ports:
 {% endif %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
Flexible resources management for cilium

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11051

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Allows you to disable CPU limits, which is a good practice in many environments
```
