### PR TITLE
Fixed joined_control_planes when ansible_hostvars references a variable

### DIFF
--- a/roles/kubernetes/control-plane/tasks/define-first-kube-control.yml
+++ b/roles/kubernetes/control-plane/tasks/define-first-kube-control.yml
@@ -9,7 +9,7 @@
 - name: Set fact joined_control_planes
   set_fact:
     joined_control_planes: "{{ ((kube_control_planes_raw.stdout | from_json)['items']) | default([]) | map(attribute='metadata') | map(attribute='name') | list }}"
-  delegate_to: item
+  delegate_to: "{{ item }}"
   loop: "{{ groups['kube_control_plane'] }}"
   when: kube_control_planes_raw is succeeded
   run_once: yes


### PR DESCRIPTION
/kind bug
**What this PR does / why we need it**:


**Which issue(s) this PR fixes**:
It did not openned an issue yet but here is the problem:

```
TASK [kubernetes_sigs.kubespray.kubernetes/control-plane : Set fact joined_control_planes] *************************************************************************************************
fatal: [my_master_node -> item]: FAILED! => {"msg": "'vpn_ip' is undefined. 'vpn_ip' is undefined"}
```
This occurs when I call the kubespray cluster playbook this way

```
- name: Kubespray setup
  ansible.builtin.import_playbook: kubernetes_sigs.kubespray.cluster
```

With the followgin variable declared in my group vars file `all.yml`
```
ansible_ssh_private_key_file: "~/.ssh/{{ inventory_hostname }}"
ansible_host: "{{ vpn_ip }}"
```

**Special notes for your reviewer**:
Have a good day 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
