### PR TITLE
Update kubelet systemd service default allowed IP addresses for cluster hardening

### DIFF
--- a/docs/hardening.md
+++ b/docs/hardening.md
@@ -105,7 +105,7 @@ kubelet_systemd_hardening: true
 # IP addresses, kubelet_secure_addresses allows you
 # to specify the IP from which the kubelet
 # will receive the packets.
-kubelet_secure_addresses: "192.168.10.110 192.168.10.111 192.168.10.112"
+kubelet_secure_addresses: "localhost link-local {{ kube_pods_subnet }} 192.168.10.110 192.168.10.111 192.168.10.112"
 
 # additional configurations
 kube_owner: root

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -24,10 +24,11 @@ kubelet_kubelet_cgroups_cgroupfs: "/system.slice/kubelet.service"
 kubelet_systemd_hardening: false
 
 # List of secure IPs for kubelet
-kubelet_secure_addresses: >-
-  {%- for host in groups['kube_control_plane'] -%}
+kube_node_addresses: >-
+  {%- for host in (groups['kube_control_plane'] + groups['kube_node'] + groups['etcd']) | unique -%}
     {{ hostvars[host]['ip'] | default(fallback_ips[host]) }}{{ ' ' if not loop.last else '' }}
   {%- endfor -%}
+kubelet_secure_addresses: "localhost link-local {{ kube_pods_subnet }} {{ kube_node_addresses }}"
 
 # Reserve this space for kube resources
 # Set to true to reserve resources for kube daemons


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Adds `localhost link-local {{ kube_pods_subnet }}` (default 10.233.64.0/18) to the list of allowed IP addresses `IPAddressAllow` in the `kubelet.service` configuration to resolve an issue preventing `kube-proxy` pods from starting correctly when `kubelet_systemd_hardening: true` is applied to Kubernetes clusters.

**Which issue(s) this PR fixes**:

Fixes #10744 

**Special notes for your reviewer**:

None.

**Does this PR introduce a user-facing change?**:

```release-note
None.
```
