### PR TITLE
Document "Remove access to cluster from anonymous users"

### DIFF
--- a/docs/hardening.md
+++ b/docs/hardening.md
@@ -71,6 +71,8 @@ kube_apiserver_admission_event_rate_limits:
     qps: 50
     burst: 100
 kube_profiling: false
+# Remove anonymous access to cluster
+remove_anonymous_access: true
 
 ## kube-controller-manager
 kube_controller_manager_bind_address: 127.0.0.1


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Add `remove_anonymous_access ` doc to `hardening.md`

See https://github.com/kubernetes-sigs/kubespray/pull/11016

