### PR TITLE
Update Kubernetes PKI certificate file permissions

### DIFF
--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -194,12 +194,26 @@
   tags:
     - kube-proxy
 
+- name: Set kubernetes pki certificate file permissions
+  file:
+    path: "{{ kube_cert_dir }}/{{ item }}"
+    owner: root
+    group: root
+    mode: 0600
+  with_items:
+    - apiserver-kubelet-client.crt
+    - apiserver.crt
+    - front-proxy-ca.crt
+    - front-proxy-client.crt
+  when:
+    - inventory_hostname in groups['kube_control_plane']
+
 - name: Set ca.crt file permission
   file:
     path: "{{ kube_cert_dir }}/ca.crt"
     owner: root
     group: root
-    mode: "0644"
+    mode: 0600
 
 - name: Restart all kube-proxy pods to ensure that they load the new configmap
   command: "{{ kubectl }} delete pod -n kube-system -l k8s-app=kube-proxy --force --grace-period=0"

--- a/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
+++ b/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
@@ -5,6 +5,11 @@
     state: directory
     owner: "{{ kube_owner }}"
     mode: 0755
+  with_items:
+    - "{{ kube_config_dir }}"
+    - "{{ kube_manifest_dir }}"
+    - "{{ kube_script_dir }}"
+    - "{{ kubelet_flexvolumes_plugins_dir }}"
   when: inventory_hostname in groups['k8s_cluster']
   become: true
   tags:
@@ -17,11 +22,6 @@
     - network
     - master
     - node
-  with_items:
-    - "{{ kube_config_dir }}"
-    - "{{ kube_manifest_dir }}"
-    - "{{ kube_script_dir }}"
-    - "{{ kubelet_flexvolumes_plugins_dir }}"
 
 - name: Create other directories of root owner
   file:
@@ -29,6 +29,8 @@
     state: directory
     owner: root
     mode: 0755
+  with_items:
+    - "{{ bin_dir }}"
   when: inventory_hostname in groups['k8s_cluster']
   become: true
   tags:
@@ -41,9 +43,26 @@
     - network
     - master
     - node
-  with_items:
-    - "{{ kube_cert_dir }}"
-    - "{{ bin_dir }}"
+
+- name: Create kubernetes pki directory
+  file:
+    path: "{{ kube_cert_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0700
+  when: inventory_hostname in groups['k8s_cluster']
+  become: true
+  tags:
+    - kubelet
+    - k8s-secrets
+    - kube-controller-manager
+    - kube-apiserver
+    - bootstrap-os
+    - apps
+    - network
+    - master
+    - node
 
 - name: Check if kubernetes kubeadm compat cert dir exists
   stat:
@@ -61,7 +80,7 @@
     src: "{{ kube_cert_dir }}"
     dest: "{{ kube_cert_compat_dir }}"
     state: link
-    mode: 0755
+    mode: 0700
   when:
     - inventory_hostname in groups['k8s_cluster']
     - kube_cert_dir != kube_cert_compat_dir


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Align Kubernetes PKI certificate file permissions with key file permissions and reduce exposure of Kubernetes PKI certificates to non-root users, hence improving cluster security, specifically CIS `Kubernetes` benchmark compliance.

```
Summary Report for compliance: CIS Kubernetes Benchmarks v1.23
┌────────┬──────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬────────┬────────┐
│   ID   │ Severity │                                                  Control Name                                                   │ Status │ Issues │
├────────┼──────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────┼────────┤
│ 1.1.20 │ CRITICAL │ Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive                  │  FAIL  │   3    │
└────────┴──────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴────────┴────────┘
```

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

None.

**Does this PR introduce a user-facing change?**:

```release-note
None
```
