### PR TITLE
add host-based calculation for kube cpu/memory reserved resources

### DIFF
--- a/docs/operations/cgroups.md
+++ b/docs/operations/cgroups.md
@@ -30,11 +30,6 @@ kube_memory_reserved: 256Mi
 kube_cpu_reserved: 100m
 # kube_ephemeral_storage_reserved: 2Gi
 # kube_pid_reserved: "1000"
-# Reservation for master hosts
-kube_master_memory_reserved: 512Mi
-kube_master_cpu_reserved: 200m
-# kube_master_ephemeral_storage_reserved: 2Gi
-# kube_master_pid_reserved: "1000"
 
 # Set to true to reserve resources for system daemons
 system_reserved: true
@@ -44,11 +39,6 @@ system_memory_reserved: 512Mi
 system_cpu_reserved: 500m
 # system_ephemeral_storage_reserved: 2Gi
 # system_pid_reserved: "1000"
-# Reservation for master hosts
-system_master_memory_reserved: 256Mi
-system_master_cpu_reserved: 250m
-# system_master_ephemeral_storage_reserved: 2Gi
-# system_master_pid_reserved: "1000"
 ```
 
 After the setup, the cgroups hierarchy is as follows:
@@ -72,7 +62,7 @@ After the setup, the cgroups hierarchy is as follows:
 
 ## Automatic Resource Reservation Calculation
 
-While manually specifying resource reservations for kube and system daemons  works, Kubespray offers a more convenient approach. You can set the `kube_enable_auto_reserved_resources` flag to `true`. This instructs Kubespray to automatically calculate appropriate resource reservations for `kube_[master]_cpu_reserved` and `kube_[master]_memory_reserved` based on your host size. This eliminates the need for manual configuration, simplifying the process.
+While manually specifying resource reservations for kube and system daemons  works, Kubespray offers a more convenient approach. You can set the `kube_enable_auto_reserved_resources` flag to `true`. This instructs Kubespray to automatically calculate appropriate resource reservations for `kube_cpu_reserved` and `kube_memory_reserved` based on your host size. This eliminates the need for manual configuration, simplifying the process.
 
 When `kube_enable_auto_reserved_resources` is set to `true`, Kubespray calculates resource reservations as follows:
 

--- a/docs/operations/cgroups.md
+++ b/docs/operations/cgroups.md
@@ -70,4 +70,17 @@ After the setup, the cgroups hierarchy is as follows:
 └── ...
 ```
 
+## Automatic Resource Reservation Calculation
+
+While manually specifying resource reservations for kube and system daemons  works, Kubespray offers a more convenient approach. You can set the `kube_enable_auto_reserved_resources` flag to `true`. This instructs Kubespray to automatically calculate appropriate resource reservations for `kube_[master]_cpu_reserved` and `kube_[master]_memory_reserved` based on your host size. This eliminates the need for manual configuration, simplifying the process.
+
+When `kube_enable_auto_reserved_resources` is set to `true`, Kubespray calculates resource reservations as follows:
+
+CPU: 1% of the total CPU cores on the host machine + 80 millicores
+Memory: 5% of the total available system memory + 330 Megabytes
+
+This approach ensures that kubelet has sufficient resources to function properly while leaving the majority of resources available for your workloads.
+
+After the setup, the cgroups hierarchy remains the same as before.
+
 You can learn more in the [official kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/).

--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -264,6 +264,10 @@ default_kubelet_config_dir: "{{ kube_config_dir }}/dynamic_kubelet_dir"
 
 # Whether to run kubelet and container-engine daemons in a dedicated cgroup.
 # kube_reserved: false
+# If kube_enable_auto_reserved_resources is true,
+# the cpu and memory values are calculated based on the number of CPUs and memory size of the host.
+# The calculation formulas can be seen in https://github.com/kubernetes-sigs/kubespray/blob/master/docs/cgroups.md
+# kube_enable_auto_reserved_resources: false
 ## Uncomment to override default values
 ## The following two items need to be set when kube_reserved is true
 # kube_reserved_cgroups_for_service_slice: kube.slice

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -9,7 +9,7 @@ kubelet_bind_address: "{{ ip | default('0.0.0.0') }}"
 kube_resolv_conf: "/etc/resolv.conf"
 
 # Set to empty to avoid cgroup creation
-kubelet_enforce_node_allocatable: "\"\""
+kubelet_enforce_node_allocatable: '""'
 
 # Set runtime and kubelet cgroups when using systemd as cgroup driver (default)
 kube_service_cgroups: "{% if kube_reserved %}{{ kube_reserved_cgroups_for_service_slice }}{% else %}system.slice{% endif %}"
@@ -32,13 +32,14 @@ kube_node_addresses: >-
     {{ hostvars[host]['ip'] | default(fallback_ips[host]) }}{{ ' ' if not loop.last else '' }}
   {%- endfor -%}
 kubelet_secure_addresses: "localhost link-local {{ kube_pods_subnet }} {{ kube_node_addresses }}"
-
 # Reserve this space for kube resources
 # Whether to run kubelet and container-engine daemons in a dedicated cgroup. (Not required for resource reservations).
 kube_reserved: false
+kube_enable_auto_reserved_resources: false
+kube_reserved_cgroups_for_service_slice: kube.slice
 kube_reserved_cgroups: "/{{ kube_reserved_cgroups_for_service_slice }}"
-kube_memory_reserved: "256Mi"
-kube_cpu_reserved: "100m"
+kube_memory_reserved: "{{ kube_enable_auto_reserved_resources | ternary((ansible_memtotal_mb * 0.05 + 330) | int | string ~ 'Mi', '256Mi') }}"
+kube_cpu_reserved: "{{ kube_enable_auto_reserved_resources | ternary((ansible_processor_vcpus * 1000 * 0.01 + 80) | int | string ~ 'm', '100m') }}"
 kube_ephemeral_storage_reserved: "500Mi"
 kube_pid_reserved: "1000"
 
@@ -248,7 +249,6 @@ kube_proxy_ipvs_modules:
 conntrack_modules:
   - nf_conntrack
   - nf_conntrack_ipv4
-
 
 ## Enable distributed tracing for kubelet
 kubelet_tracing: false

--- a/roles/kubernetes/node/tasks/kubelet.yml
+++ b/roles/kubernetes/node/tasks/kubelet.yml
@@ -18,6 +18,15 @@
     - kubelet
     - kubeadm
 
+- name: Gather facts about the node
+  setup:
+    filter: ansible_memtotal_mb,ansible_processor_vcpus
+  tags:
+    - kubelet
+    - kubeadm
+  when:
+    - kube_enable_auto_reserved_resources
+
 - name: Write kubelet config file
   template:
     src: "kubelet-config.{{ kubeletConfig_api_version }}.yaml.j2"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:

Reserving resources helps to improve the stability of the cluster components. In my opinion, the resource consumption of the kbelet also changes with the load of the node (Scheduled Pods), so there should also be a possibility to reserve the system resources relative to the node size.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Follow up PR for #10830

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
enable kube_enable_auto_reserved_resources to allow kubespray to calculate kubeReserved values for cpu and memory based on host-size (default disabled)
```
