### PR TITLE
Feat: dependabot initial config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels: [ "dependencies" ]


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
- Add dependabot help maintainers update dependencies to the latest

**Which issue(s) this PR fixes**:
Fixes #11008 

**Special notes for your reviewer**:
<img width="406" alt="image" src="https://github.com/kubernetes-sigs/kubespray/assets/17496418/a6ba1e90-ea33-45d0-908d-10f1c3504990">
- Default `open-pull-requests-limit` is five, and add `dependencies` label. If you need to make further adjustments, please let me know.
- Additional config manual: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#configuration-options-for-the-dependabotyml-file
- FYI, Jaeger dependabot config: https://github.com/jaegertracing/jaeger/blob/main/.github/dependabot.yml

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
