### PR TITLE
fix: Remove the archived debian apt repository when installing docker-engine

### DIFF
--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -67,6 +67,17 @@
   environment: "{{ proxy_env }}"
   when: ansible_pkg_mgr == 'apt'
 
+# ref to https://github.com/kubernetes-sigs/kubespray/issues/11086
+- name: Remove the archived debian apt repository
+  lineinfile:
+    path: /etc/apt/sources.list
+    regexp: 'buster-backports'
+    state: absent
+    backup: yes
+  when:
+    - ansible_os_family == 'Debian'
+    - ansible_distribution_release == "buster"
+
 - name: Ensure docker-ce repository is enabled
   apt_repository:
     repo: "{{ item }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind failing-test


**What this PR does / why we need it**:

After buster-backports going into archived, which is related to this announcement.
https://lists.debian.org/debian-devel-announce/2024/03/msg00003.html

It causes error.
Remove the archived debian apt repository when installing docker-engine

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kubespray/issues/11086

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Remove the archived debian apt repository when installing docker-engine
```
