### PR TITLE
[containerd/tracing]: add distributed tracing config flags

### DIFF
--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -110,7 +110,7 @@ containerd_supported_distributions:
 # Enable container device interface
 enable_cdi: false
 
-# For containerd tracing configuration please check out the offical documentation: 
+# For containerd tracing configuration please check out the official documentation:
 # https://github.com/containerd/containerd/blob/main/docs/tracing.md
 containerd_tracing_enabled: false
 containerd_tracing_endpoint: "0.0.0.0:4317"

--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -109,3 +109,11 @@ containerd_supported_distributions:
 
 # Enable container device interface
 enable_cdi: false
+
+# For containerd tracing configuration please check out the offical documentation: 
+# https://github.com/containerd/containerd/blob/main/docs/tracing.md
+containerd_tracing_enabled: false
+containerd_tracing_endpoint: "0.0.0.0:4317"
+containerd_tracing_protocol: "grpc"
+containerd_tracing_sampling_ratio: 1.0
+containerd_tracing_service_name: "containerd"

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -92,6 +92,18 @@ oom_score = {{ containerd_oom_score }}
     disable = false
 {% endif %}
 
+{% if containerd_tracing_enabled %}
+  [plugins."io.containerd.tracing.processor.v1.otlp"]
+    endpoint = "{{ containerd_tracing_endpoint }}"
+    protocol = "{{ containerd_tracing_protocol }}"
+    {% if containerd_tracing_protocol == "grpc" %}
+    insecure = false
+    {% endif %}
+  [plugins."io.containerd.internal.v1.tracing"]
+    sampling_ratio = {{ containerd_tracing_sampling_ratio }}
+    service_name = "{{ containerd_tracing_service_name }}"
+{% endif %}
+
 {% if containerd_extra_args is defined %}
 {{ containerd_extra_args }}
 {% endif %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This MR contains some enhancements that make possible to enable distributed tracing for `containerd`. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # none

**Special notes for your reviewer**:
`Containerd` supports OpenTelemetry tracing since v1.6.0.

Refs: 
[Containerd Documentation](https://github.com/containerd/containerd/blob/main/docs/tracing.md)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[containerd] added distributed tracing config variables for containerd (`containerd_tracing_enabled`,`containerd_tracing_endpoint`,`containerd_tracing_protocol`, `containerd_tracing_sampling_ratio`,`containerd_tracing_service_name` ); it is disabled by default.

```
