### PR TITLE
Enclose the cpu type with quotation marks in kubelet-config.v1beta1

### DIFF
--- a/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
@@ -64,7 +64,7 @@ clusterDNS:
 kubeReservedCgroup: {{ kube_reserved_cgroups }}
 kubeReserved:
 {% if is_kube_master | bool %}
-  cpu: {{ kube_master_cpu_reserved }}
+  cpu: "{{ kube_master_cpu_reserved }}"
   memory: {{ kube_master_memory_reserved }}
 {% if kube_master_ephemeral_storage_reserved is defined %}
   ephemeral-storage: {{ kube_master_ephemeral_storage_reserved }}
@@ -73,7 +73,7 @@ kubeReserved:
   pid: "{{ kube_master_pid_reserved }}"
 {% endif %}
 {% else %}
-  cpu: {{ kube_cpu_reserved }}
+  cpu: "{{ kube_cpu_reserved }}"
   memory: {{ kube_memory_reserved }}
 {% if kube_ephemeral_storage_reserved is defined %}
   ephemeral-storage: {{ kube_ephemeral_storage_reserved }}
@@ -87,7 +87,7 @@ kubeReserved:
 systemReservedCgroup: {{ system_reserved_cgroups }}
 systemReserved:
 {% if is_kube_master | bool %}
-  cpu: {{ system_master_cpu_reserved }}
+  cpu: "{{ system_master_cpu_reserved }}"
   memory: {{ system_master_memory_reserved }}
 {% if system_master_ephemeral_storage_reserved is defined %}
   ephemeral-storage: {{ system_master_ephemeral_storage_reserved }}
@@ -96,7 +96,7 @@ systemReserved:
   pid: "{{ system_master_pid_reserved }}"
 {% endif %}
 {% else %}
-  cpu: {{ system_cpu_reserved }}
+  cpu: "{{ system_cpu_reserved }}"
   memory: {{ system_memory_reserved }}
 {% if system_ephemeral_storage_reserved is defined %}
   ephemeral-storage: {{ system_ephemeral_storage_reserved }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When pass CPU resource config with an integer to kubelet-config.v1beta1, it will throw an error like `error failed to decode: json: cannot unmarshal number into Go struct field KubeletConfiguration.kubeReserved of type string`.
So it's easy to resolve by enclosing a pair of quotation marks.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
