### PR TITLE
Add additional checking for calico rr cluster_id

### DIFF
--- a/roles/network_plugin/calico/tasks/check.yml
+++ b/roles/network_plugin/calico/tasks/check.yml
@@ -82,11 +82,12 @@
           Minimum version is {{ calico_min_version_required }} supported by the previous kubespray release.
           But current version is {{ calico_version_on_server.stdout }}.
 
-- name: "Check that cluster_id is set if calico_rr enabled"
+- name: "Check that cluster_id is set and a valid IPv4 address if calico_rr enabled"
   assert:
     that:
       - cluster_id is defined
-    msg: "A unique cluster_id is required if using calico_rr"
+      - cluster_id is ansible.utils.ipv4
+    msg: "A unique cluster_id is required if using calico_rr, and it must be a valid IPv4 address"
   when:
     - peer_with_calico_rr
     - inventory_hostname == groups['kube_control_plane'][0]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Calico RouteReflectorClusterID is [an ipv4 address](https://github.com/projectcalico/calico/blob/master/libcalico-go/lib/validator/v3/validator_test.go#L1938-L1941). However, there is no explicit check in Kubespray, which may make errors difficult to troubleshoot.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
