### PR TITLE
Add affinities to calico-typha and calico-kube-controllers

### DIFF
--- a/roles/kubernetes-apps/policy_controller/calico/defaults/main.yml
+++ b/roles/kubernetes-apps/policy_controller/calico/defaults/main.yml
@@ -5,6 +5,16 @@ calico_policy_controller_memory_limit: 256M
 calico_policy_controller_cpu_requests: 30m
 calico_policy_controller_memory_requests: 64M
 calico_policy_controller_deployment_nodeselector: "kubernetes.io/os: linux"
+# calico_policy_controller_affinity:
+#   nodeAffinity:
+#     preferredDuringSchedulingIgnoredDuringExecution:
+#       - weight: 100
+#         preference:
+#           matchExpressions:
+#             - key: node-role.kubernetes.io/control-plane
+#               operator: In
+#               values:
+#                 - ''
 
 # SSL
 calico_cert_dir: "/etc/calico/certs"

--- a/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-controllers.yml.j2
+++ b/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-controllers.yml.j2
@@ -6,6 +6,8 @@ metadata:
   labels:
     k8s-app: calico-kube-controllers
 spec:
+  # XXX The controllers can only have a single active instance.
+  # See: https://github.com/projectcalico/calico/blob/master/charts/calico/templates/calico-kube-controllers.yaml#L10
   replicas: 1
   strategy:
     type: Recreate
@@ -30,6 +32,10 @@ spec:
           operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+{% if calico_policy_controller_affinity is defined %}
+      affinity:
+        {{ calico_policy_controller_affinity | to_nice_yaml(indent=2) | indent(8) }}
+{% endif %}
 {% if policy_controller_extra_tolerations is defined %}
         {{ policy_controller_extra_tolerations | list | to_nice_yaml(indent=2) | indent(8) }}
 {% endif %}

--- a/roles/network_plugin/calico/templates/calico-typha.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-typha.yml.j2
@@ -64,6 +64,10 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
+{% if calico_typha_affinity is defined %}
+      affinity:
+        {{ calico_typha_affinity | to_nice_yaml(indent=2) | indent(8) }}
+{% endif %}
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       serviceAccountName: calico-node

--- a/roles/network_plugin/calico_defaults/defaults/main.yml
+++ b/roles/network_plugin/calico_defaults/defaults/main.yml
@@ -141,6 +141,24 @@ typha_max_connections_lower_limit: 300
 # Generate certifcates for typha<->calico-node communication
 typha_secure: false
 
+# Add typha affinities
+# calico_typha_affinity:
+#   nodeAffinity:
+#     preferredDuringSchedulingIgnoredDuringExecution:
+#       - weight: 100
+#         preference:
+#           matchExpressions:
+#             - key: node-role.kubernetes.io/control-plane
+#               operator: In
+#               values:
+#                 - ''
+#   podAntiAffinity:
+#     requiredDuringSchedulingIgnoredDuringExecution:
+#       - labelSelector:
+#           matchLabels:
+#             k8s-app: calico-typha
+#         topologyKey: kubernetes.io/hostname
+
 calico_feature_control: {}
 
 # Calico default BGP port


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add needed affinities and pod anti-affinities to calico components

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11123

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
`calico_typha_affinity`: let user add an affinity block to calico-typha deployment if needed
`calico_policy_controller_affinity`: let user add an affinity block to calico-kube-controllers if needed
```

