### PR TITLE
Installation framework for python packages

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
@@ -320,11 +320,14 @@
 - name: Verify that the packages list structure is valid
   ansible.utils.validate:
     criteria: "{{ lookup('file', 'pkgs-schema.json') }}"
-    data: "{{ pkgs }}"
+    data: "{{ os_pkgs }}"
 
-- name: Verify that the packages list is sorted
+- name: Verify that package lists are sorted
   vars:
-    pkgs_lists: "{{ pkgs.keys() | list }}"
+    pkgs_lists: "{{ lookup('vars', item + '_pkgs').keys() | list }}"
   assert:
     that: "pkgs_lists | sort == pkgs_lists"
     fail_msg: "pkgs is not sorted: {{ pkgs_lists | ansible.utils.fact_diff(pkgs_lists | sort) }}"
+  loop:
+    - os
+    - python

--- a/roles/kubernetes/preinstall/tasks/0070-system-packages.yml
+++ b/roles/kubernetes/preinstall/tasks/0070-system-packages.yml
@@ -59,12 +59,13 @@
   tags:
     - bootstrap-os
 
-- name: Install packages requirements
+- name: Install requirements
+  tags:
+    - bootstrap-os
   vars:
     # The json_query for selecting packages name is split for readability
     # see files/pkgs-schema.json for the structure of `pkgs`
     # and the matching semantics
-    full_query: "[? value | (enabled == null || enabled) && ( {{ filters_os }} ) && ( {{ filters_groups }} ) ].key"
     filters_groups: "groups | @ == null || [? contains(`{{ group_names }}`, @)]"
     filters_os: "os == null || (os | ( {{ filters_family }} ) || ( {{ filters_distro }} ))"
     dquote: !unsafe '"'
@@ -75,12 +76,30 @@
                           contains(not_null(versions, `[]`), '{{ ansible_distribution_version }}') ||
                           contains(not_null(releases, `[]`), '{{ ansible_distribution_release }}')"
     filters_family: "families && contains(families, '{{ ansible_os_family }}')"
-  package:
-    name: "{{ pkgs | dict2items | to_json|from_json | community.general.json_query(full_query) }}"
-    state: present
-  register: pkgs_task_result
-  until: pkgs_task_result is succeeded
-  retries: "{{ pkg_install_retries }}"
-  delay: "{{ retry_stagger | random + 3 }}"
-  tags:
-    - bootstrap-os
+    to_install: "{{ pkgs | dict2items | to_json|from_json | community.general.json_query(full_query) }}"
+  block:
+    - name: Install system packages
+      vars:
+        full_query: "[? value | (enabled == null || enabled) && ( {{ filters_os }} ) && ( {{ filters_groups }} ) ].key"
+        pkgs: "{{ os_pkgs }}"
+      package:
+        name: "{{ to_install }}"
+        state: present
+      register: pkgs_task_result
+      until: pkgs_task_result is succeeded
+      retries: "{{ pkg_install_retries }}"
+      delay: "{{ retry_stagger | random + 3 }}"
+    - name: Install virtualenv with needed packages
+      vars:
+        full_query: "[? value | ( {{ filters_groups }} ) ].key"
+        pkgs: "{{ python_pkgs }}"
+      ansible.builtin.pip:
+        name: "{{ to_install }}"
+        extra_args: "--only-binary :all:"
+        # FIXME: add --no-deps and --requires-hashes, use a fully resolved stack with hashes
+        # (see https://pip.pypa.io/en/stable/topics/secure-installs/)
+        virtualenv_site_packages: true
+        virtualenv: "{{ kubespray_virtualenv }}"
+        virtualenv_command: "{{ ansible_facts.python.executable }} -m venv"
+      when:
+        - to_install | length != 0

--- a/roles/kubernetes/preinstall/vars/main.yml
+++ b/roles/kubernetes/preinstall/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-pkgs:
+os_pkgs:
   apparmor: &debian_family_base
     os:
       families:
@@ -104,3 +104,5 @@ pkgs:
   tar: {}
   unzip: {}
   xfsprogs: {}
+
+python_pkgs: {}

--- a/roles/kubespray-defaults/defaults/main/main.yml
+++ b/roles/kubespray-defaults/defaults/main/main.yml
@@ -6,6 +6,8 @@ ansible_ssh_common_args: "{% if 'bastion' in groups['all'] %} -o ProxyCommand='s
 # selinux state
 preinstall_selinux_state: permissive
 
+kubespray_virtualenv: "/opt/virtualenvs/kubespray"
+
 # Setting this value to false will fail
 # For details, read this comment https://github.com/kubernetes-sigs/kubespray/pull/11016#issuecomment-2004985001
 kube_api_anonymous_auth: true


### PR DESCRIPTION
**What type of PR is this?**
/kind design

**What this PR does / why we need it**:
Some ansible module requires specific python libraries on the hosts
managed by ansible.
In particular, the kubernetes.core.k8s module (which is a better
alternative than our own custom kubernetes-sigs.kubespray.kube module)
require "kubernetes".
Another potential useful candidate would be python "cryptography", which
would allow us to use the community.crypto collection, advantageously
replacing the ad-hoc stuff we have in roles/etcd.

To allow granular python packages installation (only install where
needed), we reuse the infrastructure introduced in 663fcd104 (Filter
packages installation by OS and by group, 2024-04-05) to also install
python packages in a dedicated kubespray virtualenv.

This is the last preparation PR for #10701 (which I'm gonna update after posting this)

**Special notes for your reviewer**:

- This is missing supply-chain security (I plan to use pip-tools to compile fully resolved stack with hashes, see commits)

- I'm not completely decided on the way to use different ansible modules which requires different python stacks:
  1. All packages in one virtualenv
  2. One virtualenv for each module or module set (`kubernetes.core.k8s` / `community.crypto.*` for instances)

2 might be preferrable to avoid dependencies clashs, but I don't know if this is an actual concern in practice ; I'd appreciate opinions on that.

/cc @MrFreezeex @mzaian @floryut @ErikJiang @yankay

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
