### PR TITLE
Fix CentOS typo

### DIFF
--- a/roles/kubernetes/preinstall/vars/main.yml
+++ b/roles/kubernetes/preinstall/vars/main.yml
@@ -97,7 +97,7 @@ pkgs:
           major_versions:
           - "8"
           - "9"
-        Centos: *major_redhat_like
+        CentOS: *major_redhat_like
   rsync: {}
   socat: {}
   software-properties-common: *debian_family_base


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The name reported in ansible_distribution is "CentOS", so this could
break some things.
Fix a typo in #11131

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
