### PR TITLE
Avoid potential loop_var shadowing

### DIFF
--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -24,10 +24,12 @@
       - vars/
       skip: True
   - name: Include tasks
-    include_tasks: "{{ item }}"
+    include_tasks: "{{ included_tasks_file }}"
     with_first_found:
     - <<: *search
       paths: []
+    loop_control:
+      loop_var: included_tasks_file
 
 
 - name: Create remote_tmp for it is used by another module


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
With CentOS, kubespray currently produces the following warning:

```
[WARNING]: TASK: bootstrap-os : Enable Oracle Linux repo: The loop variable
'item' is already in use. You should set the `loop_var` value in the
`loop_control` option for the task to something else to avoid variable
collisions and unexpected behavior.
```

This could bites us in nasty ways, so fix it.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
