### PR TITLE
Revert OCCM standard dnsPolicy to ClusterFirst and make dnsPolicy con…

### DIFF
--- a/roles/kubernetes-apps/external_cloud_controller/openstack/defaults/main.yml
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/defaults/main.yml
@@ -23,3 +23,4 @@ external_openstack_cacert: "{{ lookup('env', 'OS_CACERT') }}"
 external_openstack_cloud_controller_extra_args: {}
 external_openstack_cloud_controller_image_tag: "v1.25.3"
 external_openstack_cloud_controller_bind_address: 127.0.0.1
+external_openstack_cloud_controller_dns_policy: ClusterFirst

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-controller-manager-ds.yml.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-controller-manager-ds.yml.j2
@@ -81,7 +81,9 @@ spec:
             - name: CLOUD_CONFIG
               value: /etc/config/cloud.conf
       hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
+{% if external_openstack_cloud_controller_dns_policy is defined %}
+      dnsPolicy: {{ external_openstack_cloud_controller_dns_policy }}
+{% endif %}
       volumes:
 {% if kubelet_flexvolumes_plugins_dir is defined %}
       - name: flexvolume-dir


### PR DESCRIPTION
…figurable to support 10618

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

 /kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Revert OCCM standard dnsPolicy to ClusterFirst to fix #10914 which was introduced with #10618 and make dnsPolicy configurable to furthermore support #10618

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10914 

**Special notes for your reviewer**:

The original manifest from OCCM has no dnsPolicy set at all and according to the Kubernetes documentation it falls on `ClusterFirst`. https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
That's the reason why I am using ClusterFirst as the default value for the new introduced variable.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Revert OCCM standard dnsPolicy to ClusterFirst to fix #10914 which was introduced with #10618 and make dnsPolicy configurable to furthermore support #10618
```
