### PR TITLE
add the ability to configure extra args to the different cinder-csi-p…

### DIFF
--- a/roles/kubernetes-apps/csi_driver/cinder/defaults/main.yml
+++ b/roles/kubernetes-apps/csi_driver/cinder/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-
 cinder_csi_attacher_image_tag: "v4.4.2"
 cinder_csi_provisioner_image_tag: "v3.6.2"
 cinder_csi_snapshotter_image_tag: "v6.3.2"
@@ -35,3 +34,15 @@ cinder_csi_controller_replicas: 1
 # cinder_csi_rescan_on_resize: true
 
 cinder_tolerations: []
+
+## Dictionaries of extra arguments to add to the cinder CSI plugin containers
+## Format:
+##  cinder_csi_attacher_extra_args:
+##    arg1: "value1"
+##    arg2: "value2"
+cinder_csi_attacher_extra_args: {}
+cinder_csi_provisioner_extra_args: {}
+cinder_csi_snapshotter_extra_args: {}
+cinder_csi_resizer_extra_args: {}
+cinder_csi_plugin_extra_args: {}
+cinder_liveness_probe_extra_args: {}

--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin.yml.j2
@@ -32,6 +32,7 @@ spec:
             - "--default-fstype=ext4"
 {% for key, value in cinder_csi_attacher_extra_args.items() %}
             - "{{ '--' + key + '=' + value }}"
+{% endfor %}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -54,6 +55,7 @@ spec:
 {% endif %}
 {% for key, value in cinder_csi_provisioner_extra_args.items() %}
             - "{{ '--' + key + '=' + value }}"
+{% endfor %}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -72,6 +74,7 @@ spec:
 {% endif %}
 {% for key, value in cinder_csi_snapshotter_extra_args.items() %}
             - "{{ '--' + key + '=' + value }}"
+{% endfor %}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -90,6 +93,7 @@ spec:
 {% endif %}
 {% for key, value in cinder_csi_resizer_extra_args.items() %}
             - "{{ '--' + key + '=' + value }}"
+{% endfor %}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -103,6 +107,7 @@ spec:
             - "--csi-address=$(ADDRESS)"
 {% for key, value in cinder_liveness_probe_extra_args.items() %}
             - "{{ '--' + key + '=' + value }}"
+{% endfor %}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -119,6 +124,7 @@ spec:
             - "--cluster=$(CLUSTER_NAME)"
 {% for key, value in cinder_csi_plugin_extra_args.items() %}
             - "{{ '--' + key + '=' + value }}"
+{% endfor %}
           env:
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock

--- a/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/cinder/templates/cinder-csi-controllerplugin.yml.j2
@@ -30,6 +30,8 @@ spec:
             - --leader-election=true
 {% endif %}
             - "--default-fstype=ext4"
+{% for key, value in cinder_csi_attacher_extra_args.items() %}
+            - "{{ '--' + key + '=' + value }}"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -50,6 +52,8 @@ spec:
 {% if cinder_csi_controller_replicas is defined and cinder_csi_controller_replicas > 1 %}
             - "--leader-election=true"
 {% endif %}
+{% for key, value in cinder_csi_provisioner_extra_args.items() %}
+            - "{{ '--' + key + '=' + value }}"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -66,6 +70,8 @@ spec:
 {% if cinder_csi_controller_replicas is defined and cinder_csi_controller_replicas > 1 %}
             - --leader-election=true
 {% endif %}
+{% for key, value in cinder_csi_snapshotter_extra_args.items() %}
+            - "{{ '--' + key + '=' + value }}"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -82,6 +88,8 @@ spec:
 {% if cinder_csi_controller_replicas is defined and cinder_csi_controller_replicas > 1 %}
             - --leader-election=true
 {% endif %}
+{% for key, value in cinder_csi_resizer_extra_args.items() %}
+            - "{{ '--' + key + '=' + value }}"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -93,6 +101,8 @@ spec:
           imagePullPolicy: {{ k8s_image_pull_policy }}
           args:
             - "--csi-address=$(ADDRESS)"
+{% for key, value in cinder_liveness_probe_extra_args.items() %}
+            - "{{ '--' + key + '=' + value }}"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -107,6 +117,8 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--cloud-config=$(CLOUD_CONFIG)"
             - "--cluster=$(CLUSTER_NAME)"
+{% for key, value in cinder_csi_plugin_extra_args.items() %}
+            - "{{ '--' + key + '=' + value }}"
           env:
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock


### PR DESCRIPTION
…lugin containers

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:

Adds the possibility to add extra arguments to the various containers in the cinder-csi plugin.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11115 

**Special notes for your reviewer**:

In #11115 is only the request for the liveness-probe container. But I thought it would also be interesting to be able to configure the other containers in the csi-cinder daemonset with extra arguments. I am open to both ways.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Adds the possibility to add extra arguments to the various containers in the cinder-csi plugin.
new introduced variables:

cinder_csi_attacher_extra_args: {}
cinder_csi_provisioner_extra_args: {}
cinder_csi_snapshotter_extra_args: {}
cinder_csi_resizer_extra_args: {}
cinder_csi_plugin_extra_args: {}
cinder_liveness_probe_extra_args: {}
```
