### PR TITLE
Bump openstack-cloud-controller-manager from 1.25.3 to 1.28.2

### DIFF
--- a/inventory/sample/group_vars/all/openstack.yml
+++ b/inventory/sample/group_vars/all/openstack.yml
@@ -25,9 +25,9 @@
 # external_openstack_lbaas_network_id: "Neutron network ID to create LBaaS VIP"
 # external_openstack_lbaas_manage_security_groups: false
 # external_openstack_lbaas_create_monitor: false
-# external_openstack_lbaas_monitor_delay: 5
+# external_openstack_lbaas_monitor_delay: 5s
 # external_openstack_lbaas_monitor_max_retries: 1
-# external_openstack_lbaas_monitor_timeout: 3
+# external_openstack_lbaas_monitor_timeout: 3s
 # external_openstack_lbaas_internal_lb: false
 # external_openstack_network_ipv6_disabled: false
 # external_openstack_network_internal_networks: []
@@ -42,7 +42,7 @@
 # external_openstack_application_credential_secret:
 
 ## The tag of the external OpenStack Cloud Controller image
-# external_openstack_cloud_controller_image_tag: "latest"
+# external_openstack_cloud_controller_image_tag: "v1.28.2"
 
 ## Tags for the Cinder CSI images
 ## registry.k8s.io/sig-storage/csi-attacher

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/defaults/main.yml
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/defaults/main.yml
@@ -21,5 +21,5 @@ external_openstack_cacert: "{{ lookup('env', 'OS_CACERT') }}"
 ##    arg1: "value1"
 ##    arg2: "value2"
 external_openstack_cloud_controller_extra_args: {}
-external_openstack_cloud_controller_image_tag: "v1.25.3"
+external_openstack_cloud_controller_image_tag: "v1.28.2"
 external_openstack_cloud_controller_bind_address: 127.0.0.1

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-controller-manager-ds.yml.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-controller-manager-ds.yml.j2
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
         - name: openstack-cloud-controller-manager
-          image: {{ docker_image_repo }}/k8scloudprovider/openstack-cloud-controller-manager:{{ external_openstack_cloud_controller_image_tag }}
+          image: {{ external_openstack_cloud_controller_image_repo }}:{{ external_openstack_cloud_controller_image_tag }}
           args:
             - /bin/openstack-cloud-controller-manager
             - --v=1

--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -281,6 +281,8 @@ kube_router_image_repo: "{{ docker_image_repo }}/cloudnativelabs/kube-router"
 kube_router_image_tag: "{{ kube_router_version }}"
 multus_image_repo: "{{ github_image_repo }}/k8snetworkplumbingwg/multus-cni"
 multus_image_tag: "{{ multus_version }}"
+external_openstack_cloud_controller_image_repo: "registry.k8s.io/provider-os/openstack-cloud-controller-manager"
+external_openstack_cloud_controller_image_tag: "v1.28.2"
 
 kube_vip_image_repo: "{{ github_image_repo }}/kube-vip/kube-vip"
 kube_vip_image_tag: v0.5.12


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

OCCM registry change to `registry.k8s.io` and upgrade to Kubespray's current K8s version.

**Which issue(s) this PR fixes**:

Related #11107

**Special notes for your reviewer**:

`latest` tag is invalid in the OCCM image.

**Does this PR introduce a user-facing change?**:

```release-note
- OpenStack Cloud Controller Manager upgrade to 1.28.2
```
