### PR TITLE
Revert "support CoreDNS use host network and config dns port (#10617)"

### DIFF
--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -16,8 +16,6 @@ coredns_ordinal_suffix: ""
 coredns_deployment_nodeselector: "kubernetes.io/os: linux"
 coredns_default_zone_cache_block: |
   cache 30
-coredns_host_network: false
-coredns_port: 53
 
 coredns_pod_disruption_budget: false
 # value for coredns pdb

--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -34,7 +34,7 @@ data:
     }
 {%   endfor %}
 {% endif %}
-    .:{{ coredns_port }} {
+    .:53 {
 {% if coredns_additional_configs is defined %}
         {{ coredns_additional_configs | indent(width=8, first=False) }}
 {% endif %}

--- a/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
@@ -24,7 +24,6 @@ spec:
       annotations:
         createdby: 'kubespray'
     spec:
-      hostNetwork: {{ coredns_host_network | default(false) }}
       securityContext:
         seccompProfile:
           type: RuntimeDefault
@@ -76,10 +75,10 @@ spec:
         - name: config-volume
           mountPath: /etc/coredns
         ports:
-        - containerPort: {{ coredns_port }}
+        - containerPort: 53
           name: dns
           protocol: UDP
-        - containerPort: {{ coredns_port }}
+        - containerPort: 53
           name: dns-tcp
           protocol: TCP
         - containerPort: 9153

--- a/roles/kubernetes-apps/ansible/templates/coredns-svc.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-svc.yml.j2
@@ -20,11 +20,9 @@ spec:
     - name: dns
       port: 53
       protocol: UDP
-      targetPort: "dns"
     - name: dns-tcp
       port: 53
       protocol: TCP
-      targetPort: "dns-tcp"
     - name: metrics
       port: 9153
       protocol: TCP


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This reverts commit bc5b38a77127de126bd35175862414367102e1bf.


**Which issue(s) this PR fixes**:
Fixes #10860

**Special notes for your reviewer**:
See https://github.com/kubernetes-sigs/kubespray/pull/10701#issuecomment-2108103329

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix upgrading DNS from 2.23.* releases
```

/cherrypick release-2.24
