### PR TITLE
Enable UEFI for vagrant rockylinux boxes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -244,6 +244,13 @@ Vagrant.configure("2") do |config|
         SHELL
       end
 
+      # Rockylinux boxes needs UEFI
+      if ["rockylinux8", "rockylinux9"].include? $os
+        config.vm.provider "libvirt" do |domain|
+          domain.loader = "/usr/share/OVMF/x64/OVMF_CODE.fd"
+        end
+      end
+
       # Disable firewalld on oraclelinux/redhat vms
       if ["oraclelinux","oraclelinux8","rhel7","rhel8","rockylinux8"].include? $os
         node.vm.provision "shell", inline: "systemctl stop firewalld; systemctl disable firewalld"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
See https://forums.rockylinux.org/t/vagrant-box-rockylinux-8-v7-0-0-with-libvirt-provider-fails-to-boot/8212

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
