### PR TITLE
Bump docker version from 24.0 to 26.1

### DIFF
--- a/roles/container-engine/docker/defaults/main.yml
+++ b/roles/container-engine/docker/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-docker_version: '24.0'
+docker_version: '26.1'
 docker_cli_version: "{{ docker_version }}"
 
 docker_package_info:

--- a/roles/container-engine/docker/vars/amazon.yml
+++ b/roles/container-engine/docker/vars/amazon.yml
@@ -6,6 +6,8 @@ docker_versioned_pkg:
   '18.09': docker-18.09.9ce-2.amzn2
   '19.03': docker-19.03.13ce-1.amzn2
   '20.10': docker-20.10.7-5.amzn2
+  '24.0': docker-24.0.5-1.amzn2
+  '25.0': docker-25.0.3-1.amzn2
 
 docker_version: "latest"
 

--- a/roles/container-engine/docker/vars/debian.yml
+++ b/roles/container-engine/docker/vars/debian.yml
@@ -22,9 +22,10 @@ containerd_versioned_pkg:
   '1.6.15': "{{ containerd_package }}=1.6.15-1"
   '1.6.16': "{{ containerd_package }}=1.6.16-1"
   '1.6.18': "{{ containerd_package }}=1.6.18-1"
-  '1.6.28': "{{ containerd_package }}=1.6.28-1"
-  'stable': "{{ containerd_package }}=1.6.28-1"
-  'edge': "{{ containerd_package }}=1.6.28-1"
+  '1.6.28': "{{ containerd_package }}=1.6.28-2"
+  '1.6.31': "{{ containerd_package }}=1.6.31-1"
+  'stable': "{{ containerd_package }}=1.6.31-1"
+  'edge': "{{ containerd_package }}=1.6.31-1"
 
 # https://download.docker.com/linux/debian/
 docker_versioned_pkg:
@@ -34,6 +35,9 @@ docker_versioned_pkg:
   '20.10': docker-ce=5:20.10.20~3-0~debian-{{ ansible_distribution_release | lower }}
   '23.0': docker-ce=5:23.0.6-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
   '24.0': docker-ce=5:24.0.9-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
+  '25.0': docker-ce=5:25.0.5-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
+  '26.0': docker-ce=5:26.0.2-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
+  '26.1': docker-ce=5:26.1.2-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
   'stable': docker-ce=5:24.0.9-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
   'edge': docker-ce=5:24.0.9-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
 
@@ -44,8 +48,11 @@ docker_cli_versioned_pkg:
   '20.10': docker-ce-cli=5:20.10.20~3-0~debian-{{ ansible_distribution_release | lower }}
   '23.0': docker-ce-cli=5:23.0.6-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
   '24.0': docker-ce-cli=5:24.0.9-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
-  'stable': docker-ce-cli=5:24.0.9-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
-  'edge': docker-ce-cli=5:24.0.9-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
+  '25.0': docker-ce-cli=5:25.0.5-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
+  '26.0': docker-ce-cli=5:26.0.2-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
+  '26.1': docker-ce-cli=5:26.1.2-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
+  'stable': docker-ce-cli=5:26.1.2-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
+  'edge': docker-ce-cli=5:26.1.2-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
 
 docker_package_info:
   pkgs:

--- a/roles/container-engine/docker/vars/fedora.yml
+++ b/roles/container-engine/docker/vars/fedora.yml
@@ -22,9 +22,10 @@ containerd_versioned_pkg:
   '1.6.15': "{{ containerd_package }}-1.6.15-3.1.fc{{ ansible_distribution_major_version }}"
   '1.6.16': "{{ containerd_package }}-1.6.16-3.1.fc{{ ansible_distribution_major_version }}"
   '1.6.18': "{{ containerd_package }}-1.6.18-3.1.fc{{ ansible_distribution_major_version }}"
-  '1.6.28': "{{ containerd_package }}-1.6.28-3.1.fc{{ ansible_distribution_major_version }}"
-  'stable': "{{ containerd_package }}-1.6.28-3.1.fc{{ ansible_distribution_major_version }}"
-  'edge': "{{ containerd_package }}-1.6.28-3.1.fc{{ ansible_distribution_major_version }}"
+  '1.6.28': "{{ containerd_package }}-1.6.28-3.2.fc{{ ansible_distribution_major_version }}"
+  '1.6.31': "{{ containerd_package }}-1.6.31-3.1.fc{{ ansible_distribution_major_version }}"
+  'stable': "{{ containerd_package }}-1.6.31-3.1.fc{{ ansible_distribution_major_version }}"
+  'edge': "{{ containerd_package }}-1.6.31-3.1.fc{{ ansible_distribution_major_version }}"
 
 # https://docs.docker.com/install/linux/docker-ce/fedora/
 # https://download.docker.com/linux/fedora/<fedora-version>/x86_64/stable/Packages/
@@ -34,8 +35,10 @@ docker_versioned_pkg:
   '20.10': docker-ce-20.10.20-3.fc{{ ansible_distribution_major_version }}
   '23.0': docker-ce-3:23.0.6-1.fc{{ ansible_distribution_major_version }}
   '24.0': docker-ce-3:24.0.9-1.fc{{ ansible_distribution_major_version }}
-  'stable': docker-ce-3:24.0.9-1.fc{{ ansible_distribution_major_version }}
-  'edge': docker-ce-3:24.0.9-1.fc{{ ansible_distribution_major_version }}
+  '26.0': docker-ce-3:26.0.2-1.fc{{ ansible_distribution_major_version }}
+  '26.1': docker-ce-3:26.1.2-1.fc{{ ansible_distribution_major_version }}
+  'stable': docker-ce-3:26.1.2-1.fc{{ ansible_distribution_major_version }}
+  'edge': docker-ce-3:26.1.2-1.fc{{ ansible_distribution_major_version }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
@@ -43,8 +46,10 @@ docker_cli_versioned_pkg:
   '20.10': docker-ce-cli-20.10.20-3.fc{{ ansible_distribution_major_version }}
   '23.0': docker-ce-cli-1:23.0.6-1.fc{{ ansible_distribution_major_version }}
   '24.0': docker-ce-cli-1:24.0.9-1.fc{{ ansible_distribution_major_version }}
-  'stable': docker-ce-cli-1:24.0.9-1.fc{{ ansible_distribution_major_version }}
-  'edge': docker-ce-cli-1:24.0.9-1.fc{{ ansible_distribution_major_version }}
+  '26.0': docker-ce-cli-1:26.0.2-1.fc{{ ansible_distribution_major_version }}
+  '26.1': docker-ce-cli-1:26.0.2-1.fc{{ ansible_distribution_major_version }}
+  'stable': docker-ce-cli-1:26.0.2-1.fc{{ ansible_distribution_major_version }}
+  'edge': docker-ce-cli-1:26.0.2-1.fc{{ ansible_distribution_major_version }}
 
 docker_package_info:
   enablerepo: "docker-ce"

--- a/roles/container-engine/docker/vars/redhat-7.yml
+++ b/roles/container-engine/docker/vars/redhat-7.yml
@@ -23,8 +23,9 @@ containerd_versioned_pkg:
   '1.6.16': "{{ containerd_package }}-1.6.16-3.1.el7"
   '1.6.18': "{{ containerd_package }}-1.6.18-3.1.el7"
   '1.6.28': "{{ containerd_package }}-1.6.28-3.1.el7"
-  'stable': "{{ containerd_package }}-1.6.28-3.1.el7"
-  'edge': "{{ containerd_package }}-1.6.18-3.1.el7"
+  '1.6.31': "{{ containerd_package }}-1.6.31-3.1.el7"
+  'stable': "{{ containerd_package }}-1.6.31-3.1.el7"
+  'edge': "{{ containerd_package }}-1.6.31-3.1.el7"
 
 # https://docs.docker.com/engine/installation/linux/centos/#install-from-a-package
 # https://download.docker.com/linux/centos/<centos_version>>/x86_64/stable/Packages/
@@ -36,8 +37,10 @@ docker_versioned_pkg:
   '20.10': docker-ce-20.10.20-3.el7
   '23.0': docker-ce-23.0.6-1.el7
   '24.0': docker-ce-24.0.9-1.el7
-  'stable': docker-ce-24.0.9-1.el7
-  'edge': docker-ce-24.0.9-1.el7
+  '26.0': docker-ce-26.0.2-1.el7
+  '26.1': docker-ce-26.1.2-1.el7
+  'stable': docker-ce-26.1.2-1.el7
+  'edge': docker-ce-26.1.2-1.el7
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
@@ -46,8 +49,10 @@ docker_cli_versioned_pkg:
   '20.10': docker-ce-cli-20.10.20-3.el7
   '23.0': docker-ce-cli-23.0.6-1.el7
   '24.0': docker-ce-cli-24.0.9-1.el7
-  'stable': docker-ce-cli-24.0.9-1.el7
-  'edge': docker-ce-cli-24.0.9-1.el7
+  '26.0': docker-ce-cli-26.0.2-1.el7
+  '26.1': docker-ce-cli-26.1.2-1.el7
+  'stable': docker-ce-cli-26.1.2-1.el7
+  'edge': docker-ce-cli-26.1.2-1.el7
 
 docker_package_info:
   enablerepo: "docker-ce"

--- a/roles/container-engine/docker/vars/redhat.yml
+++ b/roles/container-engine/docker/vars/redhat.yml
@@ -23,8 +23,9 @@ containerd_versioned_pkg:
   '1.6.16': "{{ containerd_package }}-1.6.16-3.1.el{{ ansible_distribution_major_version }}"
   '1.6.18': "{{ containerd_package }}-1.6.18-3.1.el{{ ansible_distribution_major_version }}"
   '1.6.28': "{{ containerd_package }}-1.6.28-3.1.el{{ ansible_distribution_major_version }}"
-  'stable': "{{ containerd_package }}-1.6.28-3.1.el{{ ansible_distribution_major_version }}"
-  'edge': "{{ containerd_package }}-1.6.28-3.1.el{{ ansible_distribution_major_version }}"
+  '1.6.31': "{{ containerd_package }}-1.6.31-3.1.el{{ ansible_distribution_major_version }}"
+  'stable': "{{ containerd_package }}-1.6.31-3.1.el{{ ansible_distribution_major_version }}"
+  'edge': "{{ containerd_package }}-1.6.31-3.1.el{{ ansible_distribution_major_version }}"
 
 # https://docs.docker.com/engine/installation/linux/centos/#install-from-a-package
 # https://download.docker.com/linux/centos/<centos_version>>/x86_64/stable/Packages/
@@ -36,8 +37,10 @@ docker_versioned_pkg:
   '20.10': docker-ce-3:20.10.20-3.el{{ ansible_distribution_major_version }}
   '23.0': docker-ce-3:23.0.6-1.el{{ ansible_distribution_major_version }}
   '24.0': docker-ce-3:24.0.9-1.el{{ ansible_distribution_major_version }}
-  'stable': docker-ce-3:24.0.9-1.el{{ ansible_distribution_major_version }}
-  'edge': docker-ce-3:24.0.9-1.el{{ ansible_distribution_major_version }}
+  '26.0': docker-ce-3:26.0.2-1.el{{ ansible_distribution_major_version }}
+  '26.1': docker-ce-3:26.1.2-1.el{{ ansible_distribution_major_version }}
+  'stable': docker-ce-3:26.1.2-1.el{{ ansible_distribution_major_version }}
+  'edge': docker-ce-3:26.1.2-1.el{{ ansible_distribution_major_version }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
@@ -46,8 +49,10 @@ docker_cli_versioned_pkg:
   '20.10': docker-ce-cli-1:20.10.20-3.el{{ ansible_distribution_major_version }}
   '23.0': docker-ce-cli-1:23.0.6-1.el{{ ansible_distribution_major_version }}
   '24.0': docker-ce-cli-1:24.0.9-1.el{{ ansible_distribution_major_version }}
-  'stable': docker-ce-cli-1:24.0.9-1.el{{ ansible_distribution_major_version }}
-  'edge': docker-ce-cli-1:24.0.9-1.el{{ ansible_distribution_major_version }}
+  '26.0': docker-ce-cli-1:26.0.2-1.el{{ ansible_distribution_major_version }}
+  '26.1': docker-ce-cli-1:26.1.2-1.el{{ ansible_distribution_major_version }}
+  'stable': docker-ce-cli-1:26.1.2-1.el{{ ansible_distribution_major_version }}
+  'edge': docker-ce-cli-1:26.1.2-1.el{{ ansible_distribution_major_version }}
 
 docker_package_info:
   enablerepo: "docker-ce"

--- a/roles/container-engine/docker/vars/ubuntu.yml
+++ b/roles/container-engine/docker/vars/ubuntu.yml
@@ -22,9 +22,10 @@ containerd_versioned_pkg:
   '1.6.15': "{{ containerd_package }}=1.6.15-1"
   '1.6.16': "{{ containerd_package }}=1.6.16-1"
   '1.6.18': "{{ containerd_package }}=1.6.18-1"
-  '1.6.28': "{{ containerd_package }}=1.6.28-1"
-  'stable': "{{ containerd_package }}=1.6.28-1"
-  'edge': "{{ containerd_package }}=1.6.28-1"
+  '1.6.28': "{{ containerd_package }}=1.6.28-2"
+  '1.6.31': "{{ containerd_package }}=1.6.31-1"
+  'stable': "{{ containerd_package }}=1.6.31-1"
+  'edge': "{{ containerd_package }}=1.6.31-1"
 
 # https://download.docker.com/linux/ubuntu/
 docker_versioned_pkg:
@@ -34,8 +35,10 @@ docker_versioned_pkg:
   '20.10': docker-ce=5:20.10.20~3-0~ubuntu-{{ ansible_distribution_release | lower }}
   '23.0': docker-ce=5:23.0.6-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
   '24.0': docker-ce=5:24.0.9-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
-  'stable': docker-ce=5:24.0.9-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
-  'edge': docker-ce=5:24.0.9-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
+  '26.0': docker-ce=5:26.0.2-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
+  '26.1': docker-ce=5:26.1.2-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
+  'stable': docker-ce=5:26.1.2-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
+  'edge': docker-ce=5:26.1.2-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
@@ -44,6 +47,8 @@ docker_cli_versioned_pkg:
   '20.10': docker-ce-cli=5:20.10.20~3-0~ubuntu-{{ ansible_distribution_release | lower }}
   '23.0': docker-ce-cli=5:23.0.6-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
   '24.0': docker-ce-cli=5:24.0.9-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
+  '26.0': docker-ce-cli=5:26.0.2-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
+  '26.1': docker-ce-cli=5:26.1.2-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
   'stable': docker-ce-cli=5:24.0.9-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
   'edge': docker-ce-cli=5:24.0.9-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

- Ubuntu 24.04 requirement support #11132

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

I didn't find `docker-ce` version 24 in `Ubuntu 24.04`. Could we upgrade `docker-ce` to the latest (26.1)? (maybe relate [README.md#container-runtime-notes](https://github.com/kubernetes-sigs/kubespray?tab=readme-ov-file#container-runtime-notes))

**Does this PR introduce a user-facing change?**:

```release-note
Docker upgrade from 24.0 to 26.1
```
