### PR TITLE
Bump scheduler plugins version

### DIFF
--- a/docs/kubernetes-apps/scheduler_plugins.md
+++ b/docs/kubernetes-apps/scheduler_plugins.md
@@ -24,8 +24,8 @@ There are requirements for the version of Kubernetes, please see [Compatibility 
 
 | Scheduler Plugins | Compiled With K8s Version |
 | ----------------- | ------------------------- |
+| v0.28.9           | v1.28.9                   |
 | v0.27.8           | v1.27.8                   |
-| v0.26.8           | v1.26.7                   |
 
 ## Turning it on
 

--- a/roles/kubernetes-apps/meta/main.yml
+++ b/roles/kubernetes-apps/meta/main.yml
@@ -128,7 +128,7 @@ dependencies:
   - role: kubernetes-apps/scheduler_plugins
     when:
       - scheduler_plugins_enabled
-      - kube_major_version is version('v1.28', '<')
+      - kube_major_version is version('v1.29', '<')
       - inventory_hostname == groups['kube_control_plane'][0]
     tags:
       - scheduler_plugins

--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -156,10 +156,10 @@ crio_supported_versions:
   v1.27: v1.27.4
 crio_version: "{{ crio_supported_versions[kube_major_version] }}"
 
-# Scheduler plugins doesn't build for K8s 1.28 yet
+# Scheduler plugins doesn't build for K8s 1.29 yet
 scheduler_plugins_supported_versions:
   v1.29: 0
-  v1.28: 0
+  v1.28: v0.28.9
   v1.27: v0.27.8
 scheduler_plugins_version: "{{ scheduler_plugins_supported_versions[kube_major_version] }}"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
scheduler-plugins built the [new version](https://github.com/kubernetes-sigs/scheduler-plugins/releases/tag/v0.28.9) last month, this PR is to sync to Kubespray and clean up the old version.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
