### PR TITLE
bump docker version for openeuler linux

### DIFF
--- a/roles/bootstrap-os/tasks/openEuler.yml
+++ b/roles/bootstrap-os/tasks/openEuler.yml
@@ -1,0 +1,1 @@
+centos.yml

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -11,13 +11,6 @@
   set_fact:
     is_ostree: "{{ ostree.stat.exists }}"
 
-- name: Set docker_version for openEuler
-  set_fact:
-    docker_version: '19.03'
-  when: ansible_distribution == "openEuler"
-  tags:
-    - facts
-
 - name: Gather os specific variables
   include_vars: "{{ item }}"
   with_first_found:

--- a/roles/container-engine/docker/vars/openeuler.yml
+++ b/roles/container-engine/docker/vars/openeuler.yml
@@ -1,0 +1,1 @@
+kylin.yml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:

similar to the situation with https://github.com/kubernetes-sigs/kubespray/pull/11203, the Docker version is too old. Moreover, I found that OpenEuler can reuse the same docker vars as Kylin. Therefore, I used symbolic link files to handle this. The validation results look promising with Docker 26.1.

![image](https://github.com/kubernetes-sigs/kubespray/assets/10629406/eebd2449-4386-4382-9beb-400462574939)


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
bump docker version for openeuler linux
```
