### PR TITLE
fix: duplicate images coming with <none>:<none> tag 

### DIFF
--- a/playbooks/cluster.yml
+++ b/playbooks/cluster.yml
@@ -46,7 +46,7 @@
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray-defaults }
-    - { role: kubernetes/kubeadm, tags: kubeadm}
+    - { role: kubernetes/kubeadm, tags: kubeadm }
     - { role: kubernetes/node-label, tags: node-label }
     - { role: kubernetes/node-taint, tags: node-taint }
     - { role: network_plugin, tags: network }
@@ -92,3 +92,12 @@
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes/preinstall, when: "dns_mode != 'none' and resolvconf_mode == 'host_resolvconf'", tags: resolvconf, dns_late: true }
+
+- name: Cleanup dangling images
+  hosts: k8s_cluster
+  gather_facts: False
+  tasks:
+    - name: Remove duplicate <none>:<none> tagged images
+      command: "nerdctl rmi $(nerdctl images -q --filter dangling=true)"
+      when: container_manager == "containerd"
+      ignore_errors: yes

--- a/playbooks/cluster.yml
+++ b/playbooks/cluster.yml
@@ -100,4 +100,4 @@
     - name: Remove duplicate <none>:<none> tagged images
       command: "nerdctl rmi $(nerdctl images -q --filter dangling=true)"
       when: container_manager == "containerd"
-      ignore_errors: yes
+      failed_when: false

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -141,3 +141,9 @@
     daemon_reload: yes
     enabled: yes
     state: started
+
+- name: Remove duplicate <none>:<none> tagged images
+  command: "nerdctl rmi $(nerdctl images -q --filter dangling=true)"
+  when: container_manager == "containerd"
+  ignore_errors: yes
+

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -146,3 +146,4 @@
   command: "nerdctl rmi $(nerdctl images -q --filter dangling=true)"
   when: container_manager == "containerd"
   ignore_errors: yes
+

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -146,4 +146,3 @@
   command: "nerdctl rmi $(nerdctl images -q --filter dangling=true)"
   when: container_manager == "containerd"
   ignore_errors: yes
-


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
This PR resolves the issue of duplicate Docker images showing up with `<none>:<none>` tags when using containerd and nerdctl. The solution involves adding a task to remove these duplicate images after containerd setup.

**Which issue(s) this PR fixes**:
Fixes #11101

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fixed issue of duplicate Docker images with <none>:<none> tags by removing dangling images post containerd setup.
```