### PR TITLE
[release-2.24] [ingress-nginx] Fix nginx controller leader election RBAC permissions

### DIFF
--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
@@ -48,6 +48,7 @@ spec:
           args:
             - /nginx-ingress-controller
             - --configmap=$(POD_NAMESPACE)/ingress-nginx
+            - --election-id=ingress-controller-leader-{{ ingress_nginx_class }}
             - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-services
             - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
             - --annotations-prefix=nginx.ingress.kubernetes.io

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/role-ingress-nginx.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/role-ingress-nginx.yml.j2
@@ -28,23 +28,17 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
-    # Defaults to "<election-id>-<ingress-class>"
-    # Here: "<ingress-controller-leader>-<nginx>"
-    # This has to be adapted if you change either parameter
-    # when launching the nginx-ingress-controller.
+    # Defaults to "<election-id>", defined in 
+    # ds-ingress-nginx-controller.yml.js
+    # by a command-line argument.
+    # 
+    # This is the correct behaviour for ingress-controller
+    # version 1.8.1
     resourceNames: ["ingress-controller-leader-{{ ingress_nginx_class }}"]
     verbs: ["get", "update"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    # Defaults to "<election-id>-<ingress-class>"
-    # Here: "<ingress-controller-leader>-<nginx>"
-    # This has to be adapted if you change either parameter
-    # when launching the nginx-ingress-controller.
-    resourceNames: ["ingress-controller-leader-{{ ingress_nginx_class }}"]
-    verbs: ["get", "update"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["create"]


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:

cherry-pick of #10569

This fix has been merged to [release-2.23](https://github.com/kubernetes-sigs/kubespray/pull/10569) and [master](https://github.com/kubernetes-sigs/kubespray/pull/10913) branch, but doesn't seems to have been merged to release-2.24 yes.

rf: https://github.com/kubernetes-sigs/kubespray/pull/10569#issuecomment-2051824517

**Which issue(s) this PR fixes**:
Fixes #10276

**Does this PR introduce a user-facing change?**:

```release-note
Fix nginx controller leader election RBAC
```
