### PR TITLE
Bump CNI weave 2.8.1 to 2.8.7 (community version)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [kube-ovn](https://github.com/alauda/kube-ovn) v1.11.5
   - [kube-router](https://github.com/cloudnativelabs/kube-router) v2.0.0
   - [multus](https://github.com/k8snetworkplumbingwg/multus-cni) v3.8
-  - [weave](https://github.com/weaveworks/weave) v2.8.1
+  - [weave](https://github.com/rajch/weave) v2.8.7
   - [kube-vip](https://github.com/kube-vip/kube-vip) v0.8.0
 - Application
   - [cert-manager](https://github.com/jetstack/cert-manager) v1.13.2

--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -114,7 +114,7 @@ calico_apiserver_enabled: false
 flannel_version: "v0.22.0"
 flannel_cni_version: "v1.1.2"
 cni_version: "v1.3.0"
-weave_version: 2.8.1
+weave_version: 2.8.7
 
 cilium_version: "v1.15.4"
 cilium_cli_version: "v0.16.0"
@@ -250,9 +250,9 @@ netcheck_agent_image_tag: "{{ netcheck_version }}"
 netcheck_server_image_repo: "{{ docker_image_repo }}/mirantis/k8s-netchecker-server"
 netcheck_server_image_tag: "{{ netcheck_version }}"
 netcheck_etcd_image_tag: "v3.4.17"
-weave_kube_image_repo: "{{ docker_image_repo }}/weaveworks/weave-kube"
+weave_kube_image_repo: "{{ docker_image_repo }}/rajchaudhuri/weave-kube"
 weave_kube_image_tag: "{{ weave_version }}"
-weave_npc_image_repo: "{{ docker_image_repo }}/weaveworks/weave-npc"
+weave_npc_image_repo: "{{ docker_image_repo }}/rajchaudhuri/weave-npc"
 weave_npc_image_tag: "{{ weave_version }}"
 cilium_image_repo: "{{ quay_image_repo }}/cilium/cilium"
 cilium_image_tag: "{{ cilium_version }}"


### PR DESCRIPTION
**What type of PR is this?**

/kind api-change

**What this PR does / why we need it**:

Weaveworks has stopped maintaining the CNI, but another fork has taken over maintenance, so switch to that fork and update to the latest version.

**Which issue(s) this PR fixes**:

Fixed #11137

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Change weave CNI to community version and upgrade to the latest version (2.8.7)
```
