### PR TITLE
Added variables cilium_enable_host_firewall and cilium_policy_audit_mode for configmap/cilium-config

### DIFF
--- a/docs/CNI/cilium.md
+++ b/docs/CNI/cilium.md
@@ -170,20 +170,40 @@ Kubespray currently supports Linux distributions with Wireguard Kernel mode on L
 
 ## Bandwidth Manager
 
-Cilium’s bandwidth manager supports the kubernetes.io/egress-bandwidth Pod annotation.
+Cilium's bandwidth manager supports the kubernetes.io/egress-bandwidth Pod annotation.
 
 Bandwidth enforcement currently does not work in combination with L7 Cilium Network Policies.
 In case they select the Pod at egress, then the bandwidth enforcement will be disabled for those Pods.
 
 Bandwidth Manager requires a v5.1.x or more recent Linux kernel.
 
-For further information, make sure to check the official [Cilium documentation.](https://docs.cilium.io/en/v1.12/gettingstarted/bandwidth-manager/)
+For further information, make sure to check the official [Cilium documentation](https://docs.cilium.io/en/latest/network/kubernetes/bandwidth-manager/)
 
 To use this function, set the following parameters
 
 ```yml
 cilium_enable_bandwidth_manager: true
 ```
+
+## Host Firewall
+
+Host Firewall enforces security policies for Kubernetes nodes. It is disable by default, since it can break the cluster connectivity.
+
+```yaml
+cilium_enable_host_firewall: true
+```
+
+For further information, check [host firewall documentation](https://docs.cilium.io/en/latest/security/host-firewall/)
+
+## Policy Audit Mode
+
+When _Policy Audit Mode_ is enabled, no network policy is enforced. This feature helps to validate the impact of host policies before enforcing them.
+
+```yaml
+cilium_policy_audit_mode: true
+```
+
+It is disable by default, and should not be enabled in production.
 
 ## Install Cilium Hubble
 

--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
@@ -145,6 +145,10 @@ cilium_l2announcements: false
 ### A time interval at which the agent attempts to reload config from disk
 # cilium_ip_masq_resync_interval: 60s
 
+### Host Firewall and Policy Audit Mode
+# cilium_enable_host_firewall: false
+# cilium_policy_audit_mode: false
+
 # Hubble
 ### Enable Hubble without install
 # cilium_enable_hubble: false

--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -322,3 +322,5 @@ cilium_certgen_args:
 #       resourceNames:
 #       - toto
 cilium_clusterrole_rules_operator_extra_vars: []
+cilium_enable_host_firewall: false
+cilium_policy_audit_mode: false

--- a/roles/network_plugin/cilium/templates/cilium/config.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/config.yml.j2
@@ -138,13 +138,17 @@ data:
   enable-l2-announcements: "{{ cilium_l2announcements }}"
 
   # Enable Bandwidth Manager
-  # Cilium’s bandwidth manager supports the kubernetes.io/egress-bandwidth Pod annotation.
+  # Cilium's bandwidth manager supports the kubernetes.io/egress-bandwidth Pod annotation.
   # Bandwidth enforcement currently does not work in combination with L7 Cilium Network Policies.
   # In case they select the Pod at egress, then the bandwidth enforcement will be disabled for those Pods.
   # Bandwidth Manager requires a v5.1.x or more recent Linux kernel.
 {% if cilium_enable_bandwidth_manager %}
   enable-bandwidth-manager: "true"
 {% endif %}
+
+  # Host Firewall and Policy Audit Mode
+  enable-host-firewall: "{{ cilium_enable_host_firewall | capitalize }}"
+  policy-audit-mode: "{{ cilium_policy_audit_mode | capitalize }}"
 
   # Name of the cluster. Only relevant when building a mesh of clusters.
   cluster-name: "{{ cilium_cluster_name }}"


### PR DESCRIPTION
**What type of PR is this?**

> /kind feature

**Special notes for your reviewer**:

In order to enable (Cilium Host Firewall](https://docs.cilium.io/en/latest/security/host-firewall/) and the recommended PolicyAuditMode that prevents unwanted side effects during testing, we have added 2 variables to _cilium_ role and to inventory (features are disabled by default) : 

```yaml
cilium_enable_host_firewall: false
cilium_policy_audit_mode: false
```

These features are then added in ConfigMap/cilium-config by _cilium_ role - here set to "true" for the demo. Quotes and capitalized values in this configmap are required.
```yaml
enable-host-firewall: "True"
policy-audit-mode: "False"
```

We have added related documentation in `docs/cilium.md`

**Does this PR introduce a user-facing change?**:

No facing change. Default settings are set to "false", so there is no difference to cilium behavior when keeping default values.

```release-note
Add optional support for _Host Firewall_ and _PolicyAuditMode_ features in Cilium
```
