### PR TITLE
Cleanup galaxy.yml 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,7 @@ repos:
           - jsonschema==4.22.0
           - jmespath==1.0.1
           - netaddr==1.2.1
+          - distlib
 
   - repo: https://github.com/VannTen/misspell
     # Waiting on https://github.com/golangci/misspell/pull/19 to get merged
@@ -80,6 +81,7 @@ repos:
         language: python
         additional_dependencies:
           - ansible-core>=2.16.4
+          - distlib
         entry: tests/scripts/collection-build-install.sh
         pass_filenames: false
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,42 +9,12 @@ authors:
 tags:
   - infrastructure
 repository: https://github.com/kubernetes-sigs/kubespray
+issues: https://github.com/kubernetes-sigs/kubespray/issues
+documentation: https://kubespray.io
 license_file: LICENSE
 dependencies:
   ansible.utils: '>=2.5.0'
   community.general: '>=3.0.0'
-build_ignore:
-  - .github
-  - '*.tar.gz'
-  - extra_playbooks
-  - inventory
-  - scripts
-  - test-infra
-  - .ansible-lint
-  - .editorconfig
-  - .gitignore
-  - .gitlab-ci
-  - .gitlab-ci.yml
-  - .gitmodules
-  - .markdownlint.yaml
-  - .nojekyll
-  - .pre-commit-config.yaml
-  - .yamllint
-  - Dockerfile
-  - FILES.json
-  - MANIFEST.json
-  - Makefile
-  - Vagrantfile
-  - _config.yml
-  - ansible.cfg
-  - requirements*txt
-  - setup.cfg
-  - setup.py
-  - index.html
-  - reset.yml
-  - cluster.yml
-  - scale.yml
-  - recover-control-plane.yml
-  - remove-node.yml
-  - upgrade-cluster.yml
-  - library
+manifest:
+  directives:
+    - recursive-exclude tests **


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
We include too much stuff in the collection, in particular apparently contrib/ and .vagrant/ (?)

**Special notes for your reviewer**:
On top of #11226
@ant31, done this one as a separate PR to test the gitlab integration

EDIT: There is only the last commit not in master, I don't know why Github is unable to show the actuall diff :thinking: 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
contrib playbooks are no longer included in the ansible kubespray collection
```
