### PR TITLE
Allow empty kube_node group

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
@@ -1,10 +1,7 @@
 ---
 - name: Stop if either kube_control_plane or kube_node group is empty
   assert:
-    that: "groups.get( item )"
-  with_items:
-    - kube_control_plane
-    - kube_node
+    that: groups.get( 'kube_control_plane' )
   run_once: true
   when: not ignore_assert_errors
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
While uncommon, provisioning only a control plane is a valid use case,
so don't block it.

**Which issue(s) this PR fixes**:
Fixes #11245

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Allow to run kubespray with an empty kube_node group, to provision only the control plane
```

/cherrypick release-2.25
