### PR TITLE
CI require a 'lgtm' or 'ok-to-test' labels to run

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,8 +2,8 @@
 stages:
   - build
   - unit-tests
-  - deploy-part1
   - moderator
+  - deploy-part1
   - deploy-part2
   - deploy-part3
   - deploy-special
@@ -65,14 +65,30 @@ before_script:
 
 # For failfast, at least 1 job must be defined in .gitlab-ci.yml
 # Premoderated with manual actions
-ci-authorized:
-  extends: .job
+ci-not-authorized:
   stage: moderator
+  before_script: []
+  after_script: []
+  rules:
+    # LGTM or ok-to-test labels
+    - if: $PR_LABELS =~ /.*,(lgtm|ok-to-test).*|^(lgtm|ok-to-test).*/i
+      variables:
+        CI_OK_TO_TEST: '0'
+      when: always
+    - if: $CI_PIPELINE_SOURCE == "schedule" || $CI_PIPELINE_SOURCE == "trigger"
+      variables:
+        CI_OK_TO_TEST: '0'
+    - if: $CI_COMMIT_BRANCH == "master"
+      variables:
+        CI_OK_TO_TEST: '0'
+    - when: always
+      variables:
+        CI_OK_TO_TEST: '1'
   script:
-    - /bin/sh scripts/premoderator.sh
-  except: ['triggers', 'master']
-  # Disable ci moderator
-  only: []
+    - exit $CI_OK_TO_TEST
+  tags:
+    - light
+
 
 include:
   - .gitlab-ci/build.yml


### PR DESCRIPTION
- Implement script changes to require a 'lgtm' or 'ok-to-test' label for running CI
- Update the 'moderator' stage rules to not run the job by default unless specific conditions are met


**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
To stop running 'expensive' CI on all PR without a maintainer review.

```release-note
NONE
```
