### PR TITLE
make sure peers is defined.

### DIFF
--- a/roles/network_plugin/calico/tasks/peer_with_router.yml
+++ b/roles/network_plugin/calico/tasks/peer_with_router.yml
@@ -19,10 +19,9 @@
   until: output.rc == 0
   delay: "{{ retry_stagger | random + 3 }}"
   with_items:
-    - "{{ peers | selectattr('scope', 'defined') | selectattr('scope', 'equalto', 'global') | list | default([]) }}"
+    - "{{ peers | default([]) | selectattr('scope', 'defined') | selectattr('scope', 'equalto', 'global') | list }}"
   when:
     - inventory_hostname == groups['kube_control_plane'][0]
-    - peers is defined
 
 - name: Calico | Get node for per node peering
   command:
@@ -108,8 +107,7 @@
   until: output.rc == 0
   delay: "{{ retry_stagger | random + 3 }}"
   with_items:
-    - "{{ peers | selectattr('scope', 'undefined') | list | default([]) | union(peers | selectattr('scope', 'defined') | selectattr('scope', 'equalto', 'node') | list | default([])) }}"
+    - "{{ peers | default([]) | selectattr('scope', 'undefined') | list | union(peers | default([]) | selectattr('scope', 'defined') | selectattr('scope', 'equalto', 'node') | list ) }}"
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
   when:
     - inventory_hostname in groups['k8s_cluster']
-    - peers is defined

--- a/roles/network_plugin/calico/tasks/peer_with_router.yml
+++ b/roles/network_plugin/calico/tasks/peer_with_router.yml
@@ -22,6 +22,7 @@
     - "{{ peers | selectattr('scope', 'defined') | selectattr('scope', 'equalto', 'global') | list | default([]) }}"
   when:
     - inventory_hostname == groups['kube_control_plane'][0]
+    - peers is defined
 
 - name: Calico | Get node for per node peering
   command:
@@ -111,3 +112,4 @@
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
   when:
     - inventory_hostname in groups['k8s_cluster']
+    - peers is defined


### PR DESCRIPTION
Check if peers is defined when peering with routers

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

In case you have your bgp filters and bgp peers configured on gitops like Argocd then i need to make sure nodetonode mesh is disabled and do peering via Argo. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

This change is required to make a way for peering with ToR out of Kubespray

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Check if peers is defined when peering with routers

```
