### PR TITLE
Fix Flatcar bug #11268 missing default value for ansible_interpreter_python_fallback variable

### DIFF
--- a/roles/bootstrap-os/tasks/flatcar.yml
+++ b/roles/bootstrap-os/tasks/flatcar.yml
@@ -23,7 +23,7 @@
 
 - name: Make interpreter discovery works on Flatcar
   set_fact:
-    ansible_interpreter_python_fallback: "{{ ansible_interpreter_python_fallback + [ '/opt/bin/python' ] }}"
+    ansible_interpreter_python_fallback: "{{ (ansible_interpreter_python_fallback | default([])) + [ '/opt/bin/python' ] }}"
 
 - name: Disable auto-upgrade
   systemd_service:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
In some scenarios, a kubespray upgrade of a Flatcar based cluster fails with v2.25.0. This is due to the variable `ansible_interpreter_python_fallback` being referenced in file `roles/bootstrap-os/tasks/flatcar.yml` also this variable may not exist. This PR sets a default value of [] (empty list) in the case the `ansible_interpreter_python_fallback` variable does not exists.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11268 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
