### PR TITLE
Added containernetworking-plugins to fcos bootstrap packages

### DIFF
--- a/roles/bootstrap-os/defaults/main.yml
+++ b/roles/bootstrap-os/defaults/main.yml
@@ -21,6 +21,7 @@ fedora_coreos_packages:
   - ethtool                 # required in kubeadm preflight phase for verifying the environment
   - ipset                   # required in kubeadm preflight phase for verifying the environment
   - conntrack-tools         # required by kube-proxy
+  - containernetworking-plugins  # required by crio
 
 ## General
 # Set the hostname to inventory_hostname


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
In older versions of Fedora CoreOS prior to 40, the installed by default podman package pulled in the containernetworking-plugins package, which in turn created the required binaries in /usr/libexec/cni/. 

Fedora CoreOS 40 has Podman v5, which no longer pulls in thee containernetworking-plugins package, and so crio fails to start:

```
crio[2938]: time="2024-06-06 23:05:05.356238776Z" level=fatal msg="validating network config: invalid plugin_dirs entry: mkdir /usr/libexec/cni: read-only file system"
```

I think this would also affect container runtimes other than crio aswell.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
