### PR TITLE
[Containerd - config] Make clearer that we can configure `ulimit -n` of `containerd` spawned pods

### DIFF
--- a/inventory/sample/group_vars/all/containerd.yml
+++ b/inventory/sample/group_vars/all/containerd.yml
@@ -24,6 +24,9 @@
 # containerd_grpc_max_recv_message_size: 16777216
 # containerd_grpc_max_send_message_size: 16777216
 
+# maximum number of file descriptors per container for the default runc (ulimit -n)
+# containerd_base_runtime_spec_rlimit_nofile: 65535
+
 # containerd_debug_level: "info"
 
 # containerd_metrics_address: ""


### PR DESCRIPTION
/kind documentation

Related to https://github.com/bitnami/charts/issues/27048.

**What this PR does / why we need it**:
Updates default doc values (commented), referred in https://kubespray.io/#/docs/CRI/containerd?id=base-runtime-specs-and-limiting-number-of-open-files.

**Does this PR introduce a user-facing change?**:
NONE

```release-note

```
