### PR TITLE
Fix openssl SAN check on newer versions of OpenSSL

### DIFF
--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -145,12 +145,14 @@
       loop: "{{ apiserver_ips }}"
       register: apiserver_sans_ip_check
       changed_when: apiserver_sans_ip_check.stdout is not search('does match certificate')
+      failed_when: apiserver_sans_ip_check.rc != 0 and apiserver_sans_ip_check.stdout is not search('does NOT match certificate')
     - name: Kubeadm | Check apiserver.crt SAN hosts
       command:
         cmd: "openssl x509 -noout -in {{ kube_cert_dir }}/apiserver.crt -checkhost {{ item }}"
       loop: "{{ apiserver_hosts }}"
       register: apiserver_sans_host_check
       changed_when: apiserver_sans_host_check.stdout is not search('does match certificate')
+      failed_when: apiserver_sans_host_check.rc != 0 and apiserver_sans_host_check.stdout is not search('does NOT match certificate')
 
 - name: Kubeadm | regenerate apiserver cert 1/2
   file:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
Newer versions of OpenSSL appear to return an exit code of 1 if the checkhost doesn't match. Older versions of OpenSSL seem to return a 0 regardless of if it matched or not:

```
[root@lab-loadbalancer-01-lon1-uk ~]# openssl version
OpenSSL 3.1.1 30 May 2023 (Library: OpenSSL 3.1.1 30 May 2023)

[root@lab-loadbalancer-01-lon1-uk ~]# openssl x509 -noout -in apiserver.crt -checkhost lab-master-01-lon1-uk.cluster.local && echo "Matched" || echo "Did not match"
Hostname lab-master-01-lon1-uk.cluster.local does match certificate
Matched

[root@lab-loadbalancer-01-lon1-uk ~]# openssl x509 -noout -in apiserver.crt -checkhost i-should-not-match && echo "Matched" || echo "Did not match"
Hostname i-should-not-match does NOT match certificate
Matched

root@lab-master-01-lon1-uk:/etc/kubernetes/ssl# openssl version
OpenSSL 3.2.1 30 Jan 2024 (Library: OpenSSL 3.2.1 30 Jan 2024)

root@lab-master-01-lon1-uk:/etc/kubernetes/ssl# openssl x509 -noout -in apiserver.crt -checkhost lab-master-01-lon1-uk.cluster.local && echo "Matched" || echo "Did not match"
Hostname lab-master-01-lon1-uk.cluster.local does match certificate
Matched

root@lab-master-01-lon1-uk:/etc/kubernetes/ssl# openssl x509 -noout -in apiserver.crt -checkhost i-should-not-match && echo "Matched" || echo "Did not match"
Hostname i-should-not-match does NOT match certificate
Did not match
```

This causes ansible to exit on the SAN check:

```
TASK [kubernetes/control-plane : Kubeadm | Check apiserver.crt SAN hosts] ***************************************************
....
failed: [lab-master-01-lon1-uk.k8s.intahnet.co.uk] (item=lab-master-01-lon1-uk.cluster.local) => {"ansible_loop_var": "item", "changed": true, "cmd": ["openssl", "x509", "-noout", "-in", "/etc/kubernetes/ssl/apiserver.crt", "-checkhost", "lab-master-01-lon1-uk.cluster.local"], "delta": "0:00:00.022344", "end": "2024-06-07 06:19:02.072828", "item": "lab-master-01-lon1-uk.cluster.local", "msg": "non-zero return code", "rc": 1, "start": "2024-06-07 06:19:02.050484", "stderr": "", "stderr_lines": [], "stdout": "Hostname lab-master-01-lon1-uk.cluster.local does NOT match certificate", "stdout_lines": ["Hostname lab-master-01-lon1-uk.cluster.local does NOT match certificate"]}
....

NO MORE HOSTS LEFT **********************************************************************************************************
```

Adding `ignore_errors: true` should fix this

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
