### PR TITLE
Switch back pre-commit hook misspell to upstream

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,9 +45,8 @@ repos:
           - netaddr==1.2.1
           - distlib
 
-  - repo: https://github.com/VannTen/misspell
-    # Waiting on https://github.com/golangci/misspell/pull/19 to get merged
-    rev: 8592a4e
+  - repo: https://github.com/golangci/misspell
+    rev: v0.6.0
     hooks:
       - id: misspell
         exclude: "OWNERS_ALIASES$"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The pull request adding the pre-commit hook config in golangci/misspell was merged.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
