### PR TITLE
CI: switch to unprivileged Kaniko to build pipeline images

### DIFF
--- a/.gitlab-ci/build.yml
+++ b/.gitlab-ci/build.yml
@@ -1,40 +1,32 @@
 ---
-.build:
+.build-container:
+  cache:
+    key: $CI_COMMIT_REF_SLUG
+    paths:
+      - image-cache
+  tags:
+    - packet
   stage: build
   image:
-    name: moby/buildkit:rootless
-    entrypoint: [""]
+    name: gcr.io/kaniko-project/executor:debug
+    entrypoint: ['']
   variables:
-    BUILDKITD_FLAGS: --oci-worker-no-process-sandbox
+    TAG: $CI_COMMIT_SHORT_SHA
+    PROJECT_DIR: $CI_PROJECT_DIR
+    DOCKERFILE: Dockerfile
+    GODEBUG: "http2client=0"
   before_script:
-    - mkdir ~/.docker
-    - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_REGISTRY_USER\",\"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > ~/.docker/config.json
-
-pipeline image:
-  extends: .build
+    - echo "{\"auths\":{\"$CI_REGISTRY\":{\"auth\":\"$(echo -n ${CI_REGISTRY_USER}:${CI_REGISTRY_PASSWORD} | base64)\"}}}" > /kaniko/.docker/config.json
   script:
-    - |
-      buildctl-daemonless.sh build \
-        --frontend=dockerfile.v0 \
-        --local context=. \
-        --local dockerfile=. \
-        --opt filename=./pipeline.Dockerfile \
-        --output type=image,name=$PIPELINE_IMAGE,push=true \
-        --import-cache type=registry,ref=$CI_REGISTRY_IMAGE/pipeline:cache
-  rules:
-    - if: '$CI_COMMIT_REF_NAME != $CI_DEFAULT_BRANCH'
+    - /kaniko/executor --cache=true
+                       --cache-dir=image-cache
+                       --context $PROJECT_DIR
+                       --dockerfile $PROJECT_DIR/$DOCKERFILE
+                       --label 'git-branch'=$CI_COMMIT_REF_SLUG
+                       --label 'git-tag=$CI_COMMIT_TAG'
+                       --destination $PIPELINE_IMAGE
 
-pipeline image and build cache:
-  extends: .build
-  script:
-    - |
-      buildctl-daemonless.sh build \
-        --frontend=dockerfile.v0 \
-        --local context=. \
-        --local dockerfile=. \
-        --opt filename=./pipeline.Dockerfile \
-        --output type=image,name=$PIPELINE_IMAGE,push=true \
-        --import-cache type=registry,ref=$CI_REGISTRY_IMAGE/pipeline:cache \
-        --export-cache type=registry,ref=$CI_REGISTRY_IMAGE/pipeline:cache,mode=max
-  rules:
-    - if: '$CI_COMMIT_REF_NAME == $CI_DEFAULT_BRANCH'
+pipeline-image:
+  extends: .build-container
+  variables:
+    DOCKERFILE: pipeline.Dockerfile

--- a/pipeline.Dockerfile
+++ b/pipeline.Dockerfile
@@ -38,11 +38,12 @@ RUN apt update -q \
     && apt autoremove -yqq --purge && apt clean && rm -rf /var/lib/apt/lists/* /var/log/*
 
 WORKDIR /kubespray
+ADD ./requirements.txt  /kubespray/requirements.txt
+ADD ./tests/requirements.txt /kubespray/tests/requirements.txt
+ADD ./roles/kubespray-defaults/defaults/main/main.yml /kubespray/roles/kubespray-defaults/defaults/main/main.yml
 
-RUN --mount=type=bind,target=./requirements.txt,src=./requirements.txt \
-    --mount=type=bind,target=./tests/requirements.txt,src=./tests/requirements.txt \
-    --mount=type=bind,target=./roles/kubespray-defaults/defaults/main/main.yml,src=./roles/kubespray-defaults/defaults/main/main.yml \
-    update-alternatives --install /usr/bin/python python /usr/bin/python3 1 \
+
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1 \
     && pip install --no-compile --no-cache-dir pip -U \
     && pip install --no-compile --no-cache-dir -r tests/requirements.txt \
     && KUBE_VERSION=$(sed -n 's/^kube_version: //p' roles/kubespray-defaults/defaults/main/main.yml) \


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
The CI is using privileged containers, and one of the jobs requiring it is the pipeline-image-build. 
This PR replaces the container build tool with Kaniko.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
