### PR TITLE
Option to configure dependencies for kubelet.service

### DIFF
--- a/docs/ansible/vars.md
+++ b/docs/ansible/vars.md
@@ -243,6 +243,10 @@ kubelet_cpu_manager_policy_options:
 
     By default the `kubelet_secure_addresses` is set with the `10.0.0.110` the ansible control host uses `eth0` to  connect to the machine. In case you want to use `eth1` as the outgoing interface on which `kube-apiserver` connects to the `kubelet`s, you should override the variable in this way: `kubelet_secure_addresses: "192.168.1.110"`.
 
+* *kubelet_systemd_wants_dependencies* - List of kubelet service dependencies, other than container runtime.
+
+  If you use nfs dynamically mounted volumes, sometimes rpc-statd does not start within the kubelet. You can fix it with this parameter : `kubelet_systemd_wants_dependencies: ["rpc-statd.service"]` This will add `Wants=rpc-statd.service` in `[Unit]` section of /etc/systemd/system/kubelet.service
+
 * *node_labels* - Labels applied to nodes via `kubectl label node`.
   For example, labels can be set in the inventory as variables or more widely in group_vars.
   *node_labels* can only be defined as a dict:

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -23,6 +23,9 @@ kubelet_kubelet_cgroups_cgroupfs: "/system.slice/kubelet.service"
 # Set systemd service hardening features
 kubelet_systemd_hardening: false
 
+# Kubelet service dependencies other than container runtime
+kubelet_systemd_wants_dependencies: []
+
 # List of secure IPs for kubelet
 kube_node_addresses: >-
   {%- for host in (groups['kube_control_plane'] + groups['kube_node'] + groups['etcd']) | unique -%}

--- a/roles/kubernetes/node/templates/kubelet.service.j2
+++ b/roles/kubernetes/node/templates/kubelet.service.j2
@@ -7,6 +7,11 @@ Wants=docker.socket
 {% else %}
 Wants={{ container_manager }}.service
 {% endif %}
+{% for kubelet_dependency in kubelet_systemd_wants_dependencies|default([]) %}
+{% if kubelet_dependency|length > 0 %}
+Wants={{ kubelet_dependency }}
+{% endif %}
+{% endfor %}
 
 [Service]
 EnvironmentFile=-{{ kube_config_dir }}/kubelet.env


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

It helps to solve issues related to kubelet systemd service dependencies, such as nfs and rpc-statd issues.

**Special notes for your reviewer**:

Tested : 
* add `kubelet_systemd_wants_dependencies: ["rpc-statd.service"]` in inventory file `group_vars/k8s_cluster/k8s-cluster.yaml`
* apply full cluster.yml playbook
* on servers, the line `Wants=rpc-statd.service` is correctly added to `[Unit]` section
* `systemctl stop rpc-statd`
* `systemctl restart kubelet`
* `systemctl status rpc-statd`
* result OK : rpc-statd is started

**Does this PR introduce a user-facing change?**:
 No change in actual config as long as the variable `kubelet_systemd_wants_dependencies` is not defined
```
