### PR TITLE
[ingress-nginx]  Enable to fix the nodePort of ingress-nginx service 

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s_cluster/addons.yml
@@ -100,6 +100,8 @@ rbd_provisioner_enabled: false
 ingress_nginx_enabled: false
 # ingress_nginx_host_network: false
 # ingress_nginx_service_type: LoadBalancer
+# ingress_nginx_service_nodeport_http: 30080
+# ingress_nginx_service_nodeport_https: 30081
 ingress_publish_status_address: ""
 # ingress_nginx_nodeselector:
 #   kubernetes.io/os: "linux"

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
@@ -2,6 +2,8 @@
 ingress_nginx_namespace: "ingress-nginx"
 ingress_nginx_host_network: false
 ingress_nginx_service_type: LoadBalancer
+ingress_nginx_service_nodeport_http: ""
+ingress_nginx_service_nodeport_https: ""
 ingress_publish_status_address: ""
 ingress_nginx_nodeselector:
   kubernetes.io/os: "linux"

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/svc-ingress-nginx.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/svc-ingress-nginx.yml.j2
@@ -14,10 +14,16 @@ spec:
       port: 80
       targetPort: 80
       protocol: TCP
+{% if (ingress_nginx_service_type == 'NodePort' or ingress_nginx_service_type == 'LoadBalancer') and ingress_nginx_service_nodeport_http %}
+      nodePort: {{ingress_nginx_service_nodeport_http | int}}
+{% endif %}
     - name: https
       port: 443
       targetPort: 443
       protocol: TCP
+{% if (ingress_nginx_service_type == 'NodePort' or ingress_nginx_service_type == 'LoadBalancer') and ingress_nginx_service_nodeport_https %}
+      nodePort: {{ingress_nginx_service_nodeport_https | int}}
+{% endif %}
   selector:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Auto creation of Service/ingress-nginx was added by #10925.
In this change, we can choose serviceType.
However, we can’t fix nodePort when choose NodePort or LoadBalancer as serviceType.

In this PR, I’ve added `ingress_nginx_service_nodeport_http` and `ingress_nginx_service_nodeport_https` properties in `addons.yml` to fix nodePort.

**Which issue(s) this PR fixes**:
Fixes 

**Does this PR introduce a user-facing change?**:

```release-note
User has a possibility to fix nodePort of ingress-nginx service with property in addons.yaml
```