### PR TITLE
upcloud: v5.6.0 and better server groups

### DIFF
--- a/contrib/terraform/upcloud/modules/kubernetes-cluster/variables.tf
+++ b/contrib/terraform/upcloud/modules/kubernetes-cluster/variables.tf
@@ -20,6 +20,7 @@ variable "machines" {
     cpu       = string
     mem       = string
     disk_size = number
+    server_group : string
     additional_disks = map(object({
       size = number
       tier = string
@@ -104,6 +105,5 @@ variable "server_groups" {
 
   type = map(object({
     anti_affinity_policy = string
-    servers              = list(string)
   }))
 }

--- a/contrib/terraform/upcloud/modules/kubernetes-cluster/versions.tf
+++ b/contrib/terraform/upcloud/modules/kubernetes-cluster/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     upcloud = {
       source  = "UpCloudLtd/upcloud"
-      version = "~>2.12.0"
+      version = "~>5.6.0"
     }
   }
   required_version = ">= 0.13"

--- a/contrib/terraform/upcloud/variables.tf
+++ b/contrib/terraform/upcloud/variables.tf
@@ -32,6 +32,7 @@ variable "machines" {
     cpu       = string
     mem       = string
     disk_size = number
+    server_group : string
     additional_disks = map(object({
       size = number
       tier = string
@@ -142,7 +143,6 @@ variable "server_groups" {
 
   type = map(object({
     anti_affinity_policy = string
-    servers              = list(string)
   }))
 
   default = {}

--- a/contrib/terraform/upcloud/versions.tf
+++ b/contrib/terraform/upcloud/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     upcloud = {
       source  = "UpCloudLtd/upcloud"
-      version = "~>2.12.0"
+      version = "~>5.6.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Bumps upcloud terraform module to v5.6.0. 
This to add the config option for servers to specify server group. 

Before the server had to be created, then added to the server group. 
If the server did not full fill the server group policy, it had to be manually rebooted. 
Before adding it to the server group. 

This new way eliminates this manual process. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Bump UpCloud terraform module to v5.6.0
UpCloud servers specify server groups to be apart of, eliminates manual rescheduling.  
```
