### PR TITLE
Make netchecker log levels configurable

### DIFF
--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -94,6 +94,11 @@ netchecker_server_user: 1000
 netchecker_agent_group: 1000
 netchecker_server_group: 1000
 
+# Log levels
+netchecker_agent_log_level: 5
+netchecker_server_log_level: 5
+netchecker_etcd_log_level: info
+
 # Dashboard
 dashboard_replicas: 1
 

--- a/roles/kubernetes-apps/ansible/templates/netchecker-agent-ds.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-agent-ds.yml.j2
@@ -35,7 +35,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           args:
-            - "-v=5"
+            - "-v={{ netchecker_agent_log_level }}"
             - "-alsologtostderr=true"
             - "-serverendpoint=netchecker-service:8081"
             - "-reportinterval={{ agent_report_interval }}"

--- a/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-ds.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-ds.yml.j2
@@ -37,7 +37,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           args:
-            - "-v=5"
+            - "-v={{ netchecker_agent_log_level }}"
             - "-alsologtostderr=true"
             - "-serverendpoint=netchecker-service:8081"
             - "-reportinterval={{ agent_report_interval }}"

--- a/roles/kubernetes-apps/ansible/templates/netchecker-server-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-server-deployment.yml.j2
@@ -43,7 +43,7 @@ spec:
           ports:
             - containerPort: 8081
           args:
-            - -v=5
+            - -v={{ netchecker_server_log_level }}
             - -logtostderr
             - -kubeproxyinit=false
             - -endpoint=0.0.0.0:8081
@@ -58,6 +58,7 @@ spec:
             - --data-dir=/var/lib/etcd
             - --enable-v2
             - --force-new-cluster
+            - -–log-level={{ netchecker_etcd_log_level }}
           volumeMounts:
             - mountPath: /var/lib/etcd
               name: etcd-data

--- a/roles/kubernetes-apps/ansible/templates/netchecker-server-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-server-deployment.yml.j2
@@ -51,6 +51,9 @@ spec:
         - name: etcd
           image: "{{ etcd_image_repo }}:{{ netcheck_etcd_image_tag }}"
           imagePullPolicy: {{ k8s_image_pull_policy }}
+          env:
+            - name: ETCD_LOG_LEVEL
+              value: "{{ netchecker_etcd_log_level }}"
           command:
             - etcd
             - --listen-client-urls=http://127.0.0.1:2379
@@ -58,7 +61,6 @@ spec:
             - --data-dir=/var/lib/etcd
             - --enable-v2
             - --force-new-cluster
-            - -–log-level={{ netchecker_etcd_log_level }}
           volumeMounts:
             - mountPath: /var/lib/etcd
               name: etcd-data


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Enables changing log levels in netchecker components by introducing related variable for each of them.
Reducing verbosity may be handy

**Which issue(s) this PR fixes**:
None that I know of

**Special notes for your reviewer**:
log-level for etcd has been set explicitly but uses etcd default value (as stated in https://etcd.io/docs/v3.4/op-guide/configuration/#--log-level) in order not to change the current behaviour

**Does this PR introduce a user-facing change?**:
```release-note
User has the ability to configure netchecker components log levels
```