### PR TITLE
Make calico-kube-controllers log level configurable

### DIFF
--- a/roles/kubernetes-apps/policy_controller/calico/defaults/main.yml
+++ b/roles/kubernetes-apps/policy_controller/calico/defaults/main.yml
@@ -5,6 +5,7 @@ calico_policy_controller_memory_limit: 256M
 calico_policy_controller_cpu_requests: 30m
 calico_policy_controller_memory_requests: 64M
 calico_policy_controller_deployment_nodeselector: "kubernetes.io/os: linux"
+calico_policy_controller_log_level: info
 
 # SSL
 calico_cert_dir: "/etc/calico/certs"

--- a/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-controllers.yml.j2
+++ b/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-controllers.yml.j2
@@ -60,6 +60,8 @@ spec:
               - -r
             periodSeconds: 10
           env:
+            - name: LOG_LEVEL
+              value: {{ calico_policy_controller_log_level }}
 {% if calico_datastore == "kdd" %}
             - name: ENABLED_CONTROLLERS
               value: node


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Enables changing log level in calico-kube-controllers by introducing `calico_policy_controller_log_level` which defaults to "info" (the current value without config).
Reducing verbosity may be handy

**Which issue(s) this PR fixes**:
None that I know of

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
User has the ability to configure calico-kube-controllers log level
```