### PR TITLE
[kubernetes] Support kubernetes 1.30

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,11 +160,11 @@ Note: Upstart/SysV init based OS types are not supported.
 ## Supported Components
 
 - Core
-  - [kubernetes](https://github.com/kubernetes/kubernetes) v1.29.5
+  - [kubernetes](https://github.com/kubernetes/kubernetes) v1.30.2
   - [etcd](https://github.com/etcd-io/etcd) v3.5.12
   - [docker](https://www.docker.com/) v26.1
   - [containerd](https://containerd.io/) v1.7.16
-  - [cri-o](http://cri-o.io/) v1.29.1 (experimental: see [CRI-O Note](docs/CRI/cri-o.md). Only on fedora, ubuntu and centos based OS)
+  - [cri-o](http://cri-o.io/) v1.30.2 (experimental: see [CRI-O Note](docs/CRI/cri-o.md). Only on fedora, ubuntu and centos based OS)
 - Network Plugin
   - [cni-plugins](https://github.com/containernetworking/plugins) v1.2.0
   - [calico](https://github.com/projectcalico/calico) v3.27.3

--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -17,7 +17,7 @@ kube_token_dir: "{{ kube_config_dir }}/tokens"
 kube_api_anonymous_auth: true
 
 ## Change this to use another Kubernetes version, e.g. a current beta release
-kube_version: v1.29.5
+kube_version: v1.30.2
 
 # Where the binaries will be downloaded.
 # Note: ensure that you've enough disk space (about 1G)

--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -133,27 +133,32 @@ skopeo_version: "v1.15.0"
 kube_major_version: "{{ kube_version | regex_replace('^v([0-9])+\\.([0-9]+)\\.[0-9]+', 'v\\1.\\2') }}"
 
 pod_infra_supported_versions:
+  v1.30: "3.9"
   v1.29: "3.9"
   v1.28: "3.9"
 pod_infra_version: "{{ pod_infra_supported_versions[kube_major_version] }}"
 
 etcd_supported_versions:
+  v1.30: "v3.5.12"
   v1.29: "v3.5.12"
   v1.28: "v3.5.12"
 etcd_version: "{{ etcd_supported_versions[kube_major_version] }}"
 
 crictl_supported_versions:
+  v1.30: "v1.30.0"
   v1.29: "v1.29.0"
   v1.28: "v1.28.0"
 crictl_version: "{{ crictl_supported_versions[kube_major_version] }}"
 
 crio_supported_versions:
+  v1.30: v1.30.2
   v1.29: v1.29.1
   v1.28: v1.28.4
 crio_version: "{{ crio_supported_versions[kube_major_version] }}"
 
 # Scheduler plugins doesn't build for K8s 1.29 yet
 scheduler_plugins_supported_versions:
+  v1.30: 0
   v1.29: 0
   v1.28: v0.28.9
 scheduler_plugins_version: "{{ scheduler_plugins_supported_versions[kube_major_version] }}"
@@ -357,6 +362,7 @@ csi_livenessprobe_image_repo: "{{ kube_image_repo }}/sig-storage/livenessprobe"
 csi_livenessprobe_image_tag: "v2.5.0"
 
 snapshot_controller_supported_versions:
+  v1.30: "v7.0.2"
   v1.29: "v7.0.2"
   v1.28: "v7.0.2"
 snapshot_controller_image_repo: "{{ kube_image_repo }}/sig-storage/snapshot-controller"

--- a/roles/kubespray-defaults/defaults/main/main.yml
+++ b/roles/kubespray-defaults/defaults/main/main.yml
@@ -18,7 +18,7 @@ kubelet_fail_swap_on: true
 kubelet_swap_behavior: LimitedSwap
 
 ## Change this to use another Kubernetes version, e.g. a current beta release
-kube_version: v1.29.5
+kube_version: v1.30.2
 
 ## The minimum version working
 kube_version_min_required: v1.28.0


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Support Kubernetes 1.30

* Make kubernetes v1.30.2 default

**Which issue(s) this PR fixes**:
Fixes #11109

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Make kubernetes v1.30.2 default
```
