### PR TITLE
Fix: remove --config option from kubeadm upgrade (#11350)

### DIFF
--- a/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
@@ -15,7 +15,6 @@
     {{ bin_dir }}/kubeadm
     upgrade apply -y {{ kube_version }}
     --certificate-renewal={{ kubeadm_upgrade_auto_cert_renewal }}
-    --config={{ kube_config_dir }}/kubeadm-config.yaml
     --ignore-preflight-errors=all
     --allow-experimental-upgrades
     --etcd-upgrade={{ (etcd_deployment_type == "kubeadm") | bool | lower }}
@@ -37,7 +36,6 @@
     {{ bin_dir }}/kubeadm
     upgrade apply -y {{ kube_version }}
     --certificate-renewal={{ kubeadm_upgrade_auto_cert_renewal }}
-    --config={{ kube_config_dir }}/kubeadm-config.yaml
     --ignore-preflight-errors=all
     --allow-experimental-upgrades
     --etcd-upgrade={{ (etcd_deployment_type == "kubeadm") | bool | lower }}


### PR DESCRIPTION
We can't mix some options with --config for kubeadm upgrade. The --config on upgrade (with InitConfiguration/ClusterConfiguration) is deprecated, and should be removed.

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix upgrade issue of `kubespray upgrade`.
This removes `--config` option.

**Which issue(s) this PR fixes**:
Fixes #11350

**Special notes for your reviewer**:
I have no confidence of side effects of removing the `--config` options.
Please consider the effects. If it is not acceptable, please reject this PR.

**Does this PR introduce a user-facing change?**:
```release-note
Disables reconfiguring the cluster during upgrade (remove --config option from kubeadm upgrade apply)
```
