### PR TITLE
Increase ansible timeout to 300

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -11,6 +11,7 @@ gathering = smart
 fact_caching = jsonfile
 fact_caching_connection = /tmp
 fact_caching_timeout = 86400
+timeout = 300
 stdout_callback = default
 display_skipped_hosts = no
 library = ./library


### PR DESCRIPTION

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:
For large clusters, ansible plays can take a very long time, so failing a play is very expensive.
This increases the ansible timeout so that some nodes that might be slow to respond will still have a chance to save the play.
On small clusters there should not be any disadvantage.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
