### PR TITLE
Bump: OpenStack Cloud Controller Manager to 1.30.0

### DIFF
--- a/roles/kubernetes-apps/external_cloud_controller/openstack/defaults/main.yml
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/defaults/main.yml
@@ -21,6 +21,6 @@ external_openstack_cacert: "{{ lookup('env', 'OS_CACERT') }}"
 ##    arg1: "value1"
 ##    arg2: "value2"
 external_openstack_cloud_controller_extra_args: {}
-external_openstack_cloud_controller_image_tag: "v1.28.2"
+external_openstack_cloud_controller_image_tag: "v1.30.0"
 external_openstack_cloud_controller_bind_address: 127.0.0.1
 external_openstack_cloud_controller_dns_policy: ClusterFirst

--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -282,7 +282,7 @@ kube_router_image_tag: "{{ kube_router_version }}"
 multus_image_repo: "{{ github_image_repo }}/k8snetworkplumbingwg/multus-cni"
 multus_image_tag: "{{ multus_version }}"
 external_openstack_cloud_controller_image_repo: "registry.k8s.io/provider-os/openstack-cloud-controller-manager"
-external_openstack_cloud_controller_image_tag: "v1.28.2"
+external_openstack_cloud_controller_image_tag: "v1.30.0"
 
 kube_vip_image_repo: "{{ github_image_repo }}/kube-vip/kube-vip"
 kube_vip_image_tag: v0.8.0


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

- Because the k8s default version changed to 1.30, OCCM also followed it.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
OpenStack Cloud Controller Manager upgrade to 1.30.0
```
