### PR TITLE
Fix CentOS 7 yum repo baseurl update

### DIFF
--- a/roles/bootstrap-os/tasks/centos.yml
+++ b/roles/bootstrap-os/tasks/centos.yml
@@ -80,12 +80,32 @@
     - { option: "name", value: "CentOS-{{ ansible_distribution_major_version }} - Extras" }
     - { option: "enabled", value: "1" }
     - { option: "gpgcheck", value: "0" }
-    - { option: "baseurl", value: "http://mirror.centos.org/{{ 'altarch' if (ansible_distribution_major_version | int) <= 7 and ansible_architecture == 'aarch64' else 'centos' }}/{{ ansible_distribution_major_version }}/extras/$basearch/{% if ansible_distribution_major_version | int > 7 %}os/{% endif %}" }
+    - { option: "baseurl", value: "http://vault.centos.org/{{ 'altarch' if (ansible_distribution_major_version | int) <= 7 and ansible_architecture == 'aarch64' else 'centos' }}/{{ ansible_distribution_major_version }}/extras/$basearch/{% if ansible_distribution_major_version | int > 7 %}os/{% endif %}" }
   when:
     - use_oracle_public_repo | default(true)
     - '''ID="ol"'' in os_release.stdout_lines'
     - (ansible_distribution_version | float) >= 7.6
     - (ansible_distribution_version | float) < 9
+
+# CentOS 7 EOL at July 1, 2024.
+- name: Disable CentOS 7 mirrorlist in CentOS-Base.repo
+  replace:
+    path: /etc/yum.repos.d/CentOS-Base.repo
+    regexp: '^mirrorlist='
+    replace: '#mirrorlist='
+  become: true
+  when:
+    - ansible_distribution_major_version == "7"
+
+# CentOS 7 EOL at July 1, 2024.
+- name: Update CentOS 7 baseurl in CentOS-Base.repo
+  replace:
+    path: /etc/yum.repos.d/CentOS-Base.repo
+    regexp: '^#baseurl=http:\/\/mirror.centos.org'
+    replace: 'baseurl=http:\/\/vault.centos.org'
+  become: true
+  when:
+    - ansible_distribution_major_version == "7"
 
 # CentOS ships with python installed
 


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test
/kind feature

**What this PR does / why we need it**:

- We previously removed the CI tests for CentOS 7 EOL, but the release-2.25 branch didn't keep up with the CI changes during this period, so `release-2.25` could not be updated.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
CentOS 7 yum repo baseurl update
```
