### PR TITLE
fix kube_reserved so it only controls kubeReservedCgroup

### DIFF
--- a/docs/operations/cgroups.md
+++ b/docs/operations/cgroups.md
@@ -1,6 +1,6 @@
 # cgroups
 
-To avoid the rivals for resources between containers or the impact on the host in Kubernetes, the kubelet components will rely on cgroups to limit the container’s resources usage.
+To avoid resource contention between containers and host daemons in Kubernetes, the kubelet components can use cgroups to limit resource usage.
 
 ## Enforcing Node Allocatable
 
@@ -20,8 +20,9 @@ Here is an example:
 ```yaml
 kubelet_enforce_node_allocatable: "pods,kube-reserved,system-reserved"
 
-# Reserve this space for kube resources
-# Set to true to reserve resources for kube daemons
+# Set kube_reserved to true to run kubelet and container-engine daemons in a dedicated cgroup.
+# This is required if you want to enforce limits on the resource usage of these daemons.
+# It is not required if you just want to make resource reservations (kube_memory_reserved, kube_cpu_reserved, etc.)
 kube_reserved: true
 kube_reserved_cgroups_for_service_slice: kube.slice
 kube_reserved_cgroups: "/{{ kube_reserved_cgroups_for_service_slice }}"

--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -262,7 +262,7 @@ default_kubelet_config_dir: "{{ kube_config_dir }}/dynamic_kubelet_dir"
 # kubelet_runtime_cgroups_cgroupfs: "/system.slice/{{ container_manager }}.service"
 # kubelet_kubelet_cgroups_cgroupfs: "/system.slice/kubelet.service"
 
-# Optionally reserve this space for kube daemons.
+# Whether to run kubelet and container-engine daemons in a dedicated cgroup.
 # kube_reserved: false
 ## Uncomment to override default values
 ## The following two items need to be set when kube_reserved is true

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -34,7 +34,7 @@ kube_node_addresses: >-
 kubelet_secure_addresses: "localhost link-local {{ kube_pods_subnet }} {{ kube_node_addresses }}"
 
 # Reserve this space for kube resources
-# Set to true to reserve resources for kube daemons
+# Whether to run kubelet and container-engine daemons in a dedicated cgroup. (Not required for resource reservations).
 kube_reserved: false
 kube_reserved_cgroups_for_service_slice: kube.slice
 kube_reserved_cgroups: "/{{ kube_reserved_cgroups_for_service_slice }}"

--- a/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
@@ -62,6 +62,7 @@ clusterDNS:
 {# Node reserved CPU/memory #}
 {% if kube_reserved | bool %}
 kubeReservedCgroup: {{ kube_reserved_cgroups }}
+{% endif %}
 kubeReserved:
 {% if is_kube_master | bool %}
   cpu: "{{ kube_master_cpu_reserved }}"
@@ -80,7 +81,6 @@ kubeReserved:
 {% endif %}
 {% if kube_pid_reserved is defined %}
   pid: "{{ kube_pid_reserved }}"
-{% endif %}
 {% endif %}
 {% endif %}
 {% if system_reserved | bool %}


### PR DESCRIPTION
**What type of PR is this?**

 /kind bug

**What this PR does / why we need it**:
I believe there may have been a misapprehension in the implementation of https://github.com/kubernetes-sigs/kubespray/pull/9209

It introduced a new kube_reserved variable with a default value of false, and made all kubeReserved declarations conditional on it. I believe this was a mistake as the [documentation](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/) makes it clear that you can set kubeReserved without kubeReservedCgroup, for the purposes of reserving resources without enforcing, which is the safest default behaviour.

This MR restores the previous behaviour - kubeReserved can/should always be defined and does not depend on or require the creation of separate cgroups, or running daemons in those cgroups, or configuring `kubeReservedCgroup`. The important primary purpose of this is to reduce the Node Allocatable resource amount to guarantee resources for k8s daemons purely on a scheduling basis, even if their cgroup config is not modified.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes-sigs/kubespray/issues/9692

**Special notes for your reviewer**:
Please see [this comment](https://github.com/kubernetes-sigs/kubespray/pull/9209#issuecomment-2216685514) 
This is just what I have been trying to figure out for the last several days. Let's review carefully to make sure it's right.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
This restores the pre-9209 behaviour of reserving a small default amount of RAM and CPU to ensure stability of k8s daemons.
```
