### PR TITLE
[containerd/tracing]: fix containerd tracing templating

### DIFF
--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -100,9 +100,9 @@ oom_score = {{ containerd_oom_score }}
   [plugins."io.containerd.tracing.processor.v1.otlp"]
     endpoint = "{{ containerd_tracing_endpoint }}"
     protocol = "{{ containerd_tracing_protocol }}"
-    {% if containerd_tracing_protocol == "grpc" %}
+{% if containerd_tracing_protocol == "grpc" %}
     insecure = false
-    {% endif %}
+{% endif %}
   [plugins."io.containerd.internal.v1.tracing"]
     sampling_ratio = {{ containerd_tracing_sampling_ratio }}
     service_name = "{{ containerd_tracing_service_name }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This MR fixes wrong templating for `containerd` tracing config. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # none

**Special notes for your reviewer**:
-
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[containerd] fixes wrong templating for tracing config

```
