### PR TITLE
Add external_openstack_cacert file from host

### DIFF
--- a/roles/kubernetes-apps/external_cloud_controller/openstack/tasks/main.yml
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/tasks/main.yml
@@ -3,13 +3,14 @@
   include_tasks: openstack-credential-check.yml
   tags: external-openstack
 
-- name: External OpenStack Cloud Controller | Get base64 cacert
-  slurp:
+- name: External OpenStack Cloud Controller | Write cacert file
+  copy:
     src: "{{ external_openstack_cacert }}"
-  register: external_openstack_cacert_b64
+    dest: "{{ kube_config_dir }}/external-openstack-cacert.pem"
+    group: "{{ kube_cert_group }}"
+    mode: "0640"
   when:
     - inventory_hostname == groups['kube_control_plane'][0]
-    - external_openstack_cacert is defined
     - external_openstack_cacert | length > 0
   tags: external-openstack
 

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config-secret.yml.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config-secret.yml.j2
@@ -8,6 +8,3 @@ metadata:
   namespace: kube-system
 data:
   cloud.conf: {{ external_openstack_cloud_config_secret }}
-{% if external_openstack_cacert_b64.content is defined %}
-  ca.cert: {{ external_openstack_cacert_b64.content }}
-{% endif %}

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-controller-manager-ds.yml.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-controller-manager-ds.yml.j2
@@ -66,10 +66,11 @@ spec:
               name: cloud-config-volume
               readOnly: true
               subPath: cloud.conf
-            - mountPath: {{ kube_config_dir }}/external-openstack-cacert.pem
-              name: cloud-config-volume
+{% if external_openstack_cacert != "" %}
+            - name: external-openstack-cacert
+              mountPath: {{ kube_config_dir }}/external-openstack-cacert.pem
               readOnly: true
-              subPath: ca.cert
+{% endif %}
 {% if kubelet_flexvolumes_plugins_dir is defined %}
             - mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
               name: flexvolume-dir
@@ -110,3 +111,9 @@ spec:
       - name: cloud-config-volume
         secret:
           secretName: external-openstack-cloud-config
+{% if external_openstack_cacert != "" %}
+      - name: external-openstack-cacert
+        hostPath:
+          path: {{ kube_config_dir }}/external-openstack-cacert.pem
+          type: FileOrCreate
+{% endif %}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Same as with the in-tree openstack cloud controller, copy external_openstack_cacert file retrieved from ansible host to the control-plane for secret creation.

**Does this PR introduce a user-facing change?**:

```release-note
It remove the needs of manual copy of the openstack ca-cert file to the first control plane.
```
