### PR TITLE
Provide missing advertise-address flag to kube-apiserver

### DIFF
--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
@@ -127,6 +127,7 @@ apiServer:
     anonymous-auth: "{{ kube_api_anonymous_auth }}"
 {% endif %}
     authorization-mode: {{ authorization_modes | join(',') }}
+    advertise-address: {{ kube_apiserver_address }}
     bind-address: {{ kube_apiserver_bind_address }}
 {% if kube_apiserver_enable_admission_plugins | length > 0 %}
     enable-admission-plugins: {{ kube_apiserver_enable_admission_plugins | join(',') }}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

It is already possible to override the address the kube-apiserver is running on with the `kube_apiserver_address` variable. This variable is already expanded in [line 10](https://github.com/kubernetes-sigs/kubespray/blob/5f35b66256e6204610c34d8acf3cdd4d800f4b92/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2#L10), however, it wasn't expanded for the kube-apiserver config and therefore, the kube-apiserver was started without the `--advertise-address` flag, causing it to implicitly fall back to the `--bind-address`. This PR fixes this, by passing on the `kube_apiserver_address` to the kube-apiserver.

**Which issue(s) this PR fixes**:

I'm not aware of an already existing ticket.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

NONE

```release-note
Provide missing advertise-address flag to kube-apiserver
```
