### PR TITLE
Fix etcd not starting up when using a custom access address

### DIFF
--- a/roles/etcd/templates/openssl.conf.j2
+++ b/roles/etcd/templates/openssl.conf.j2
@@ -25,6 +25,11 @@ authorityKeyIdentifier=keyid:always,issuer
 [alt_names]
 DNS.1 = localhost
 {% for host in groups['etcd'] %}
+{% if hostvars[host]['etcd_access_address'] is defined and not (hostvars[host]['etcd_access_address'] | ansible.utils.ipaddr) %}
+{# If defined, the address which etcd uses to access its members must be included in the SAN, otherwise etcd will fail with a TLS error upon startup. #}
+DNS.{{ counter["dns"] }} = {{ hostvars[host]['etcd_access_address'] }}{{ increment(counter, 'dns') }}
+{% endif %}
+{# This will always expand to inventory_hostname, which can be a completely arbitrary name, that etcd will not know or care about, hence this line is (probably) redundant. #}
 DNS.{{ counter["dns"] }} = {{ host }}{{ increment(counter, 'dns') }}
 {% endfor %}
 {% if apiserver_loadbalancer_domain_name is defined %}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

It is already possible to override the address of etcd via variables `etcd_address` and `etcd_access_address`. When configuring etcd to run in a DHCP network (nodes with dynamic IPs), it might be desirable to set

```
etcd_address: "0.0.0.0" # i.e. bind etcd to any address
etcd_access_address: "{{ ansible_fqdn }}" # access etcd via the host's FQDN
```

Currently, this results in a TLS error, because the certificate of etcd only includes the pure hostname and IPs, but it doesn't include `etcd_access_address` as subject alternative name (SAN). Hence, when etcd attempts to communicate via a custom access address, the certificate is untrusted and etcd fails to start up.

This PR fixes this, by including `etcd_access_address` as SAN.

**Which issue(s) this PR fixes**:

None I'm aware of.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

NONE

```release-note
Fix etcd not starting up when using a custom access address
```
