### PR TITLE
fix - bug fix on Start resource multus

### DIFF
--- a/roles/kubernetes-apps/network_plugin/multus/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/multus/tasks/main.yml
@@ -16,3 +16,4 @@
     multus_nodes_list: "{{ groups['k8s_cluster'] if ansible_play_batch | length == ansible_play_hosts_all | length else ansible_play_batch }}"
   when:
     - not item is skipped
+  ignore_errors: true


### PR DESCRIPTION
recently i'm trying to update my cluster from 1.28.5 to 1.29.X and i set the `kube_network_plugin_multus` to false but still trying to start the multus services....

so i add the ignore error :laughing: to fix my issue maybe help someone :)

thanks a lot :wink: 