### PR TITLE
Restart kube-proxy pods only on configmap changes

### DIFF
--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -158,6 +158,17 @@
     - loadbalancer_apiserver is defined
   notify: Kubeadm | restart kubelet
 
+- name: Get current resourceVersion of kube-proxy configmap
+  command: "{{ kubectl }} get configmap kube-proxy -n kube-system -o jsonpath='{.metadata.resourceVersion}'"
+  register: original_configmap_resource_version
+  run_once: true
+  delegate_to: "{{ groups['kube_control_plane'] | first }}"
+  delegate_facts: false
+  when:
+    - kube_proxy_deployed
+  tags:
+    - kube-proxy
+
 # FIXME(mattymo): Need to point to localhost, otherwise masters will all point
 #                 incorrectly to first master, creating SPoF.
 - name: Update server field in kube-proxy kubeconfig
@@ -194,6 +205,17 @@
   tags:
     - kube-proxy
 
+- name: Get new resourceVersion of kube-proxy configmap
+  command: "{{ kubectl }} get configmap kube-proxy -n kube-system -o jsonpath='{.metadata.resourceVersion}'"
+  register: new_configmap_resource_version
+  run_once: true
+  delegate_to: "{{ groups['kube_control_plane'] | first }}"
+  delegate_facts: false
+  when:
+    - kube_proxy_deployed
+  tags:
+    - kube-proxy
+
 - name: Set ca.crt file permission
   file:
     path: "{{ kube_cert_dir }}/ca.crt"
@@ -210,6 +232,7 @@
     - kubeadm_config_api_fqdn is not defined or loadbalancer_apiserver is defined
     - kubeadm_discovery_address != kube_apiserver_endpoint | replace("https://", "") or loadbalancer_apiserver is defined
     - kube_proxy_deployed
+    - original_configmap_resource_version.stdout != new_configmap_resource_version.stdout
   tags:
     - kube-proxy
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind feature

**What this PR does / why we need it**:

**AS-IS:** When using the `kubernetes/kubeadm` role in a cluster using kube-proxy, the kube-proxy DaemonSet Pods are restarted **everytime**.

**TO-BE:** The kube-proxy DaemonSet Pods are restarted **only if** there are changes in the `kube-proxy` ConfigMap within the `kube-system` namespace. This can be achieved by simply comparing the resourceVersion of the ConfigMap before and after the tasks to detect any changes. This can reduce unnecessary restarts.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11400

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
