### PR TITLE
containerd: add definition of `ignore_image_defined_volumes` for cri plugin

### DIFF
--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -61,6 +61,8 @@ containerd_registries_mirrors:
 
 containerd_max_container_log_line_size: -1
 
+containerd_ignore_image_defined_volumes: false
+
 # If enabled it will allow non root users to use port numbers <1024
 containerd_enable_unprivileged_ports: false
 # If enabled it will allow non root users to use icmp sockets

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -20,6 +20,7 @@ oom_score = {{ containerd_oom_score }}
 
 [plugins]
   [plugins."io.containerd.grpc.v1.cri"]
+    ignore_image_defined_volumes = {{ containerd_ignore_image_defined_volumes }}
     sandbox_image = "{{ pod_infra_image_repo }}:{{ pod_infra_image_tag }}"
     max_container_log_line_size = {{ containerd_max_container_log_line_size }}
     enable_unprivileged_ports = {{ containerd_enable_unprivileged_ports | lower }}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Ability to activate `ignore_image_defined_volumes` containerd cri plugin parameter when needed (default to false)

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
```release-note
containerd: ability to activate `ignore_image_defined_volumes` in cri plugin configuration
```
