### PR TITLE
fix: use super-admin.conf for kube-vip on first master when it exists

### DIFF
--- a/roles/kubernetes/node/tasks/loadbalancer/kube-vip.yml
+++ b/roles/kubernetes/node/tasks/loadbalancer/kube-vip.yml
@@ -21,6 +21,17 @@
     get_mime: no
   register: kubeadm_already_run
 
+- name: Kube-vip | Set admin.conf
+  set_fact: 
+    kube_vip_admin_conf:  admin.conf
+
+- name: Kube-vip | Set admin.conf for first Control Plane
+  set_fact:
+    kube_vip_admin_conf: super-admin.conf
+  when:
+    - inventory_hostname == groups['kube_control_plane'] | first
+    - (stat_kube_vip_super_admin.stat.exists and stat_kube_vip_super_admin.stat.isreg) or (not kubeadm_already_run.stat.exists )
+
 - name: Kube-vip | Write static pod
   template:
     src: manifests/kube-vip.manifest.j2

--- a/roles/kubernetes/node/tasks/loadbalancer/kube-vip.yml
+++ b/roles/kubernetes/node/tasks/loadbalancer/kube-vip.yml
@@ -22,8 +22,8 @@
   register: kubeadm_already_run
 
 - name: Kube-vip | Set admin.conf
-  set_fact: 
-    kube_vip_admin_conf:  admin.conf
+  set_fact:
+    kube_vip_admin_conf: admin.conf
 
 - name: Kube-vip | Set admin.conf for first Control Plane
   set_fact:

--- a/roles/kubernetes/node/tasks/loadbalancer/kube-vip.yml
+++ b/roles/kubernetes/node/tasks/loadbalancer/kube-vip.yml
@@ -6,6 +6,21 @@
     - kube_proxy_mode == 'ipvs' and not kube_proxy_strict_arp
     - kube_vip_arp_enabled
 
+- name: Kube-vip | Check if super-admin.conf exists
+  stat:
+    path: "{{ kube_config_dir }}/super-admin.conf"
+  failed_when: false
+  changed_when: false
+  register: stat_kube_vip_super_admin
+
+- name: Kube-vip | Check if kubeadm has already run
+  stat:
+    path: "/var/lib/kubelet/config.yaml"
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
+  register: kubeadm_already_run
+
 - name: Kube-vip | Write static pod
   template:
     src: manifests/kube-vip.manifest.j2

--- a/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
@@ -119,6 +119,6 @@ spec:
   hostNetwork: true
   volumes:
   - hostPath:
-      path: /etc/kubernetes/admin.conf
+      path: /etc/kubernetes/{% if inventory_hostname == (groups['kube_control_plane'] | first) and ((stat_kube_vip_super_admin.stat.exists and stat_kube_vip_super_admin.stat.isreg) or (not kubeadm_already_run.stat.exists )) %}super-{% endif %}admin.conf
     name: kubeconfig
 status: {}

--- a/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
@@ -119,6 +119,6 @@ spec:
   hostNetwork: true
   volumes:
   - hostPath:
-      path: /etc/kubernetes/{% if inventory_hostname == (groups['kube_control_plane'] | first) and ((stat_kube_vip_super_admin.stat.exists and stat_kube_vip_super_admin.stat.isreg) or (not kubeadm_already_run.stat.exists )) %}super-{% endif %}admin.conf
+      path: /etc/kubernetes/{{kube_vip_admin_conf}}
     name: kubeconfig
 status: {}


### PR DESCRIPTION
What type of PR is this?

/kind bug

What this PR does / why we need it:

Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes-sigs/kubespray/issues/11229

Special notes for your reviewer:

Tested manually for fresh ha cluster install, cluster upgrade, worker node add/remove, control plane node add/remove, first control plane reordering and remove.

Does this PR introduce a user-facing change?:
```
Added workarounds to support initial k8s v1.29+ installation with kube-vip enabled
```