### PR TITLE
Revert #9869 "fix(contrib/terraform): do not add access_ip when not wanted"

### DIFF
--- a/contrib/terraform/terraform.py
+++ b/contrib/terraform/terraform.py
@@ -298,9 +298,6 @@ def openstack_host(resource, module_name):
     if 'floating_ip' in raw_attrs:
         attrs['private_ipv4'] = raw_attrs['network.0.fixed_ip_v4']
 
-    if 'metadata.use_access_ip' in raw_attrs and raw_attrs['metadata.use_access_ip'] == "0":
-        attrs.pop('access_ip')
-
     try:
         if 'metadata.prefer_ipv6' in raw_attrs and raw_attrs['metadata.prefer_ipv6'] == "1":
             attrs.update({


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix a bug where access_ip is double popped, resulting in a KeyError the 2nd time you try to pop it because it does not exist then.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/kubespray/issues/11426
by reverting https://github.com/kubernetes-sigs/kubespray/pull/9869

**Special notes for your reviewer**:
I'm not really sure about the reason for https://github.com/kubernetes-sigs/kubespray/pull/9869 but I'd suggest that it should be revisited differently in a way that doesn't introduce double popping.

An alternative "fix" would be to add `, None` in the 2nd pop (the pre-existing one that originally worked fine without an error) to avoid the exception but IMHO that would be a hack on top of a hack. Aside from the KeyError exception, the behaviour that was introduced in 9869 is popping the access_ip too early at an ineffective point in the code, because in some cases it gets added back in again later, so I think it would be cleaner to avoid the redundant and ineffective first pop in the first place to try to keep the code not too hard to follow...

**Does this PR introduce a user-facing change?**:
No, based on my testing access_ip was already removed as expected before this change when use_access_ip=0 is set.

```release-note
None
```