### PR TITLE
Add support for Cilium Helm Chart deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ You can choose among ten network plugins. (default: `calico`, except Vagrant use
 
 - [cilium](http://docs.cilium.io/en/latest/): layer 3/4 networking (as well as layer 7 to protect and secure application protocols), supports dynamic insertion of BPF bytecode into the Linux kernel to implement security services, networking and visibility logic.
 
+  - [cilium-helm](https://docs.cilium.io/en/stable/helm-reference/): You can deploy an official Helm Chart managed by Cilium.
+
 - [weave](docs/CNI/weave.md): Weave is a lightweight container overlay network that doesn't require an external K/V database cluster.
     (Please refer to `weave` [troubleshooting documentation](https://www.weave.works/docs/net/latest/troubleshooting/)).
 

--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -65,7 +65,7 @@ credentials_dir: "{{ inventory_dir }}/credentials"
 # kube_webhook_authorization_url: https://...
 # kube_webhook_authorization_url_skip_tls_verify: false
 
-# Choose network plugin (cilium, calico, kube-ovn, weave or flannel. Use cni for generic cni plugin)
+# Choose network plugin (cilium, cilium-helm, calico, kube-ovn, weave or flannel. Use cni for generic cni plugin)
 # Can also be set to 'cloud', which lets the cloud provider setup appropriate routing
 kube_network_plugin: calico
 

--- a/roles/etcd/tasks/check_certs.yml
+++ b/roles/etcd/tasks/check_certs.yml
@@ -84,7 +84,7 @@
         {% if not loop.last %}{{ ',' }}{% endif %}
       {% endfor %}]
   when:
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally | default(false) | bool
+    - kube_network_plugin in ["calico", "flannel", "cilium", "cilium-helm"] or cilium_deploy_additionally | default(false) | bool
     - kube_network_plugin != "calico" or calico_datastore == "etcd"
     - force_etcd_cert_refresh or not item in etcdcert_master.files | map(attribute='path') | list
 

--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -55,7 +55,7 @@
   run_once: yes
   delegate_to: "{{ groups['etcd'][0] }}"
   when:
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally | default(false) | bool
+    - kube_network_plugin in ["calico", "flannel", "cilium", "cilium-helm"] or cilium_deploy_additionally | default(false) | bool
     - kube_network_plugin != "calico" or calico_datastore == "etcd"
     - gen_certs | default(false)
   notify: Set etcd_secret_changed
@@ -112,7 +112,7 @@
   when:
     - inventory_hostname in groups['etcd']
     - inventory_hostname != groups['etcd'][0]
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally | default(false) | bool
+    - kube_network_plugin in ["calico", "flannel", "cilium", "cilium-helm"] or cilium_deploy_additionally | default(false) | bool
     - kube_network_plugin != "calico" or calico_datastore == "etcd"
   notify: Set etcd_secret_changed
 
@@ -127,7 +127,7 @@
   when:
     - inventory_hostname in groups['etcd']
     - inventory_hostname != groups['etcd'][0]
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally | default(false) | bool
+    - kube_network_plugin in ["calico", "flannel", "cilium", "cilium-helm"] or cilium_deploy_additionally | default(false) | bool
     - kube_network_plugin != "calico" or calico_datastore == "etcd"
   loop_control:
     label: "{{ item.item }}"
@@ -141,7 +141,7 @@
 - name: Gen_certs | Generate etcd certs on nodes if needed
   include_tasks: gen_nodes_certs_script.yml
   when:
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally | default(false) | bool
+    - kube_network_plugin in ["calico", "flannel", "cilium", "cilium-helm"] or cilium_deploy_additionally | default(false) | bool
     - kube_network_plugin != "calico" or calico_datastore == "etcd"
     - inventory_hostname in groups['k8s_cluster'] and
         sync_certs | default(false) and inventory_hostname not in groups['etcd']

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -23,7 +23,7 @@
 - name: Trust etcd CA on nodes if needed
   include_tasks: upd_ca_trust.yml
   when:
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally | default(false) | bool
+    - kube_network_plugin in ["calico", "flannel", "cilium", "cilium-helm"] or cilium_deploy_additionally | default(false) | bool
     - kube_network_plugin != "calico" or calico_datastore == "etcd"
     - inventory_hostname in groups['k8s_cluster']
   tags:
@@ -35,7 +35,7 @@
   changed_when: false
   check_mode: no
   when:
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally | default(false) | bool
+    - kube_network_plugin in ["calico", "flannel", "cilium", "cilium-helm"] or cilium_deploy_additionally | default(false) | bool
     - kube_network_plugin != "calico" or calico_datastore == "etcd"
     - inventory_hostname in groups['k8s_cluster']
   tags:
@@ -46,7 +46,7 @@
   set_fact:
     etcd_client_cert_serial: "{{ etcd_client_cert_serial_result.stdout.split('=')[1] }}"
   when:
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally | default(false) | bool
+    - kube_network_plugin in ["calico", "flannel", "cilium", "cilium-helm"] or cilium_deploy_additionally | default(false) | bool
     - kube_network_plugin != "calico" or calico_datastore == "etcd"
     - inventory_hostname in groups['k8s_cluster']
   tags:

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -241,5 +241,5 @@
   when:
     - etcd_deployment_type == "kubeadm"
     - inventory_hostname not in groups['kube_control_plane']
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally | default(false) | bool
+    - kube_network_plugin in ["calico", "flannel", "cilium", "cilium-helm"] or cilium_deploy_additionally | default(false) | bool
     - kube_network_plugin != "calico" or calico_datastore == "etcd"

--- a/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
@@ -27,7 +27,7 @@
 
 - name: Stop if unknown network plugin
   assert:
-    that: kube_network_plugin in ['calico', 'flannel', 'weave', 'cloud', 'cilium', 'cni', 'kube-ovn', 'kube-router', 'macvlan', 'custom_cni']
+    that: kube_network_plugin in ['calico', 'flannel', 'weave', 'cloud', 'cilium', 'cilium-helm', 'cni', 'kube-ovn', 'kube-router', 'macvlan', 'custom_cni']
     msg: "{{ kube_network_plugin }} is not supported"
   when:
     - kube_network_plugin is defined
@@ -147,7 +147,7 @@
   assert:
     that: ansible_kernel.split('-')[0] is version('4.9.17', '>=')
   when:
-    - kube_network_plugin == 'cilium' or cilium_deploy_additionally | default(false) | bool
+    - kube_network_plugin in ['cilium', 'cilium-helm'] or cilium_deploy_additionally | default(false) | bool
     - not ignore_assert_errors
 
 - name: Stop if bad hostname

--- a/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
+++ b/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
@@ -77,11 +77,12 @@
     - "/etc/cni/net.d"
     - "/opt/cni/bin"
   when:
-    - kube_network_plugin in ["calico", "weave", "flannel", "cilium", "kube-ovn", "kube-router", "macvlan"]
+    - kube_network_plugin in ["calico", "weave", "flannel", "cilium", "cilium-helm", "kube-ovn", "kube-router", "macvlan"]
     - inventory_hostname in groups['k8s_cluster']
   tags:
     - network
     - cilium
+    - cilium-helm
     - calico
     - weave
     - kube-ovn

--- a/roles/kubespray-defaults/defaults/main/main.yml
+++ b/roles/kubespray-defaults/defaults/main/main.yml
@@ -38,6 +38,8 @@ kubeadm_init_phases_skip: >-
   {{ kubeadm_init_phases_skip_default + ["addon/kube-proxy"] }}
   {%- elif kube_network_plugin == 'cilium' and (cilium_kube_proxy_replacement is defined and cilium_kube_proxy_replacement == 'strict') -%}
   {{ kubeadm_init_phases_skip_default + ["addon/kube-proxy"] }}
+  {%- elif kube_network_plugin == 'cilium-helm' and (cilium_helm_values.kubeProxyReplacement | default(False)) -%}
+  {{ kubeadm_init_phases_skip_default + ["addon/kube-proxy"] }}
   {%- elif kube_network_plugin == 'calico' and (calico_bpf_enabled is defined and calico_bpf_enabled) -%}
   {{ kubeadm_init_phases_skip_default + ["addon/kube-proxy"] }}
   {%- elif kube_proxy_remove is defined and kube_proxy_remove -%}
@@ -181,7 +183,7 @@ kube_external_ca_mode: false
 # Cluster Loglevel configuration
 kube_log_level: 2
 
-# Choose network plugin (cilium, calico, kube-ovn, weave or flannel. Use cni for generic cni plugin)
+# Choose network plugin (cilium, cilium-helm, calico, kube-ovn, weave or flannel. Use cni for generic cni plugin)
 # Can also be set to 'cloud', which lets the cloud provider setup appropriate routing
 kube_network_plugin: calico
 kube_network_plugin_multus: false

--- a/roles/network_plugin/cilium-helm/defaults/main.yml
+++ b/roles/network_plugin/cilium-helm/defaults/main.yml
@@ -1,0 +1,40 @@
+---
+cilium_helm_namespace: kube-system
+
+cilium_helm_repository_name: cilium
+cilium_helm_repository_url: https://helm.cilium.io/
+cilium_helm_chart_ref: "{{ cilium_helm_repository_name }}/cilium"
+cilium_helm_chart_version: "{{ cilium_version[1:] }}"
+
+cilium_helm_default_values:
+  ipam:
+    operator:
+      # Cluster Pod CIDRs use the kube_pods_subnet value by default.
+      # If your node network is in the same range you will lose connectivity to other nodes.
+      # Defaults to kube_pods_subnet if not set.
+      clusterPoolIPv4PodCIDRList:
+        - "{{ kube_pods_subnet }}"
+
+      # When cilium_enable_ipv6 is used, you need to set the IPV6 value.  Defaults to kube_pods_subnet_ipv6 if not set.
+      clusterPoolIPv6PodCIDRList:
+        - "{{ kube_pods_subnet_ipv6 }}"
+
+      # When cilium IPAM uses the "Cluster Scope" mode, it will pre-allocate a segment of IP to each node,
+      # schedule the Pod to this node, and then allocate IP from here. cilium_pool_mask_size Specifies
+      # the size allocated from cluster Pod CIDR to node.ipam.podCIDRs
+      # Defaults to kube_network_node_prefix if not set.
+      clusterPoolIPv4MaskSize: "{{ kube_network_node_prefix }}"
+
+      # cilium_pool_mask_size Specifies the size allocated to node.ipam.podCIDRs from cluster Pod IPV6 CIDR
+      # Defaults to kube_network_node_prefix_ipv6 if not set.
+      clusterPoolIPv6MaskSize: "{{ kube_network_node_prefix_ipv6 }}"
+
+  k8sServiceHost: "{{ kube_apiserver_global_endpoint | urlsplit('hostname') }}"
+  k8sServicePort: "{{ kube_apiserver_global_endpoint | urlsplit('port') }}"
+
+  operator:
+    replicas: "{{ 1 if groups.k8s_cluster | length == 1 else 2 }}"
+
+# Fill values override here
+# See upstream https://docs.cilium.io/en/stable/helm-reference/
+cilium_helm_values: {}

--- a/roles/network_plugin/cilium-helm/tasks/install.yml
+++ b/roles/network_plugin/cilium-helm/tasks/install.yml
@@ -1,0 +1,22 @@
+---
+- name: Cilium Helm | Deploy helm chart
+  when:
+    - inventory_hostname == groups['kube_control_plane'][0]
+  include_role:
+    name: helm-apps
+    apply:
+      environment:
+        http_proxy: "{{ http_proxy | default('') }}"
+        https_proxy: "{{ https_proxy | default('') }}"
+  vars:
+    release_common_opts: {}
+    releases:
+      - name: cilium
+        namespace: "{{ cilium_helm_namespace }}"
+        chart_ref: "{{ cilium_helm_chart_ref }}"
+        chart_version: "{{ cilium_helm_chart_version }}"
+        wait: true
+        values: "{{ cilium_helm_default_values | combine(cilium_helm_values) }}"
+    repositories:
+      - name: "{{ cilium_helm_repository_name }}"
+        url: "{{ cilium_helm_repository_url }}"

--- a/roles/network_plugin/cilium-helm/tasks/main.yml
+++ b/roles/network_plugin/cilium-helm/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Cilium helm install
+  include_tasks: install.yml

--- a/roles/network_plugin/cilium-helm/tasks/reset.yml
+++ b/roles/network_plugin/cilium-helm/tasks/reset.yml
@@ -1,0 +1,5 @@
+---
+- name: Reset | Cleanup cilium
+  include_role:
+    name: "network_plugin/cilium"
+    tasks_from: reset

--- a/roles/network_plugin/meta/main.yml
+++ b/roles/network_plugin/meta/main.yml
@@ -7,6 +7,11 @@ dependencies:
     tags:
       - cilium
 
+  - role: network_plugin/cilium-helm
+    when: kube_network_plugin == 'cilium-helm'
+    tags:
+      - cilium-helm
+
   - role: network_plugin/calico
     when: kube_network_plugin == 'calico'
     tags:

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -406,7 +406,7 @@
     name: "network_plugin/{{ kube_network_plugin }}"
     tasks_from: reset
   when:
-    - kube_network_plugin in ['flannel', 'cilium', 'kube-router', 'calico']
+    - kube_network_plugin in ['flannel', 'cilium', 'cilium-helm', 'kube-router', 'calico']
   tags:
     - network
 


### PR DESCRIPTION
## PR Type
/kind feature

## What this PR Does / Why We Need It

* Adds support for `kube_network_plugin: "cilium-helm"`
* Enables the deployment of Cilium CNI using their official Helm Chart

## Which Issue(s) this PR Fixes
Potentially fixes #10938, #11047, #11110

## Special Notes for Your Reviewer
Following the presentation at KubeCon 2023, Cilium has expanded significantly, showcasing various features and technical integrations. As of version 1.16.0, Cilium maintains an extensive Helm values file encompassing 3524 lines. This large-scale project, unfortunately, poses a challenge for swift integration into community-driven projects like Kubespray. Therefore, I propose enabling the deployment of Cilium CNI using their official Helm Chart, allowing Kubespray to focus solely on compatibility. This approach aims to ease the burden on community contributors by eliminating the need to meticulously track Cilium's development trends.

Although Cilium CNI can currently be installed via custom_cni, this method does not leverage Kubespray functionalities such as reset or `kube_*` variables.

This PR supports the installation of Cilium CNI. However, deployment in offline environments is not yet supported and remains an outstanding task.

## Does this PR Introduce a User-Facing Change?
No, this new deployment method is activated only when `kube_network_plugin == "cilium-helm"`.

```release-note
Add support for Cilium Helm Chart deployment on `kube_network_plugin: "cilium-helm"`
```