### PR TITLE
Add preflight network resource support for custom_cni

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-custom-cni.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-custom-cni.yml
@@ -49,3 +49,15 @@
 # custom_cni_chart_values:
 #   cluster:
 #     name: "cilium-demo"
+
+## Preflight - Deploy network files prior to CNI
+## It can be used when preparatory work such as deploying CRDs is required
+## prior to CNI distribution, as if the `kubectl create -f` method (present)
+## or `kubectl apply -f` (latest) was used with it.
+#
+## List of Kubernetes network resource files
+## Example:
+# custom_cni_preflight_templates:
+#   - path: https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+#     namespace: "kube-system"  # default: "kube-system"
+#     state: present  # options: [latest, present, absent]

--- a/roles/kubernetes-apps/network_plugin/custom_cni/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/custom_cni/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Custom CNI | Preflight | Start Resources
+  kube:
+    namespace: "{{ item.namespace | default('kube-system') }}"
+    kubectl: "{{ bin_dir }}/kubectl"
+    filename: "{{ item.path }}"
+    state: "{{ item.state }}"
+    wait: true
+  loop: "{{ custom_cni_preflight_templates }}"
+  delegate_to: "{{ groups['kube_control_plane'] | first }}"
+  run_once: true

--- a/roles/network_plugin/custom_cni/defaults/main.yml
+++ b/roles/network_plugin/custom_cni/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
 
+custom_cni_preflight_templates: []
+
 custom_cni_manifests: []
 
 custom_cni_chart_namespace: kube-system

--- a/roles/network_plugin/custom_cni/meta/main.yml
+++ b/roles/network_plugin/custom_cni/meta/main.yml
@@ -1,5 +1,13 @@
 ---
 dependencies:
+  - role: kubernetes-apps/network_plugin/custom_cni
+    when:
+      - inventory_hostname == groups['kube_control_plane'][0]
+      - custom_cni_chart_release_name | length > 0
+    environment:
+      http_proxy: "{{ http_proxy | default('') }}"
+      https_proxy: "{{ https_proxy | default('') }}"
+
   - role: helm-apps
     when:
       - inventory_hostname == groups['kube_control_plane'][0]


### PR DESCRIPTION
## PR Type
/kind feature

## What this PR Does / Why We Need It

* Enables the deployment of network resources such as CRDs prior to CNI

## Which Issue(s) this PR Fixes
Fixes #

## Special Notes for Your Reviewer

I want to enable the serviceMonitor option when installing Cilium CNI as custom_cni. However, I couldn't find a way to deploy the ServiceMonitor CRD prior to CNI installation. So I want to add a feature to deploy the prerequisite resources that should be deployed before the CNI during the custom_cni deployment process.

Additionally, I have prepared a new PR to enable pre-deployment of Ansible Roles if the pre-deployment feature for resources is merged in any form (custom_cni, generic, ...). This was necessary because while deploying Cilium CNI, I encountered an issue where the deployment of hubble-relay failed due to CoreDNS not being active when the peer service was enabled on cilium-agent. This PR aims to address that problem.

## Does this PR Introduce a User-Facing Change?
No, this new method is managed by new variable `custom_cni_preflight_templates`.

```release-note
Add preflight network resource support for custom_cni: `custom_cni_preflight_templates`
```