### PR TITLE
fix double pop of access_ip

### DIFF
--- a/contrib/terraform/terraform.py
+++ b/contrib/terraform/terraform.py
@@ -368,7 +368,7 @@ def iter_host_ips(hosts, ips):
                 'ansible_host': ip,
             })
 
-        if 'use_access_ip' in host[1]['metadata'] and host[1]['metadata']['use_access_ip'] == "0":
+        if 'use_access_ip' in host[1]['metadata'] and host[1]['metadata']['use_access_ip'] == "0" and 'access_ip' in host[1]:
                 host[1].pop('access_ip')
 
         yield host


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/kubespray/issues/11426
Caused by https://github.com/kubernetes-sigs/kubespray/pull/9869
Replaces https://github.com/kubernetes-sigs/kubespray/pull/11427

**Special notes for your reviewer**:
The original implementation was done for a scenario with fixed (non-floating) public IPs, but by duplicating the popping logic it violated the assumption that access_ip can be safely popped if use_access_ip=0 . See linked issues.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
