### PR TITLE
Cleanup NetworkManager dns.conf on Reset

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -300,6 +300,7 @@
     - /etc/etcd.env
     - /etc/calico
     - /etc/NetworkManager/conf.d/calico.conf
+    - /etc/NetworkManager/conf.d/dns.conf
     - /etc/NetworkManager/conf.d/k8s.conf
     - /etc/weave.env
     - /opt/cni


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

* Delete `/etc/NetworkManager/conf.d/dns.conf` on reset to ensure that there's no more k8s DNS.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

When initially deploying the cluster using Kubespray, nodelocaldns was enabled. After resetting and redeploying the cluster with nodelocaldns disabled, I noticed that the `/etc/resolv.conf` file still contained the nameserver address of nodelocaldns (nameserver 169.254.25.10). Since I was using NetworkManager, I discovered that it retained the legacy configuration from the previous cluster in the `/etc/NetworkManager/conf.d/dns.conf` file. To ensure DNS information is fully reset when resetting the cluster, I propose deleting this file.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Delete `/etc/NetworkManager/conf.d/dns.conf` on reset.
```
