### PR TITLE
fix: Swap roles kubespray-defaults & bootstrap-os

### DIFF
--- a/docs/operating_systems/bootstrap-os.md
+++ b/docs/operating_systems/bootstrap-os.md
@@ -40,10 +40,6 @@ Variables are listed with their default values, if applicable.
 * `centos_fastestmirror_enabled: false`
   Whether the [fastestmirror](https://wiki.centos.org/PackageManagement/Yum/FastestMirror) yum plugin should be enabled.
 
-## Dependencies
-
-The `kubespray-defaults` role is expected to be run before this role.
-
 ## Example Playbook
 
 Remember to disable fact gathering since Python might not be present on hosts.

--- a/playbooks/facts.yml
+++ b/playbooks/facts.yml
@@ -10,8 +10,8 @@
     # fail. bootstrap-os fixes this on these systems, so in later plays it can be enabled.
     ansible_ssh_pipelining: false
   roles:
-    - { role: kubespray-defaults }
     - { role: bootstrap-os, tags: bootstrap-os}
+    - { role: kubespray-defaults }
 
 - name: Gather facts
   hosts: k8s_cluster:etcd:calico_rr

--- a/roles/kubespray-defaults/tasks/main.yaml
+++ b/roles/kubespray-defaults/tasks/main.yaml
@@ -1,10 +1,5 @@
 ---
 - name: Set facts variables
-  # do not run gather facts when bootstrap-os in roles
-  when: >
-        ansible_play_role_names |
-        intersect(['bootstrap-os', 'kubernetes_sigs.kubespray.bootstrap-os']) |
-        length == 0
   tags:
     - always
   block:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

When using a Flatcar distribution, Python is not installed by default. This is taken care of by the bootstrap-os role. 
We need to have Python to successfully execute the kubespray-defaults role.

This PR makes sure role bootstrap-os executes before role kubespray-defaults. The facts that are set by kubespray-defaults are not used by bootstrap-os, but some variables defined in kubespray-defaults/defaults/main might (the [doc](https://github.com/kubernetes-sigs/kubespray/blob/ce9ba9a8bfe4ccd5eac0f603f032e721192537a3/docs/operating_systems/bootstrap-os.md#dependencies) hints at this, but I did not manage to find any var that are used). If that is the case, we might need to split kubespray-defaults into two roles, one role that only sets vars, then we run bootstrap-os to install Python, and then execute the second role to set the facts (this needs Python).


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Make sure kubespray-defaults can be executed successfully by executing bootstrap-os first
```
