### PR TITLE
[release-2.25] fix: use super-admin.conf for kube-vip on first master when it exists (#11422 v2.25 backport)

### DIFF
--- a/roles/kubernetes/node/tasks/loadbalancer/kube-vip.yml
+++ b/roles/kubernetes/node/tasks/loadbalancer/kube-vip.yml
@@ -6,6 +6,32 @@
     - kube_proxy_mode == 'ipvs' and not kube_proxy_strict_arp
     - kube_vip_arp_enabled
 
+- name: Kube-vip | Check if super-admin.conf exists
+  stat:
+    path: "{{ kube_config_dir }}/super-admin.conf"
+  failed_when: false
+  changed_when: false
+  register: stat_kube_vip_super_admin
+
+- name: Kube-vip | Check if kubeadm has already run
+  stat:
+    path: "/var/lib/kubelet/config.yaml"
+    get_attributes: no
+    get_checksum: no
+    get_mime: no
+  register: kubeadm_already_run
+
+- name: Kube-vip | Set admin.conf
+  set_fact:
+    kube_vip_admin_conf: admin.conf
+
+- name: Kube-vip | Set admin.conf for first Control Plane
+  set_fact:
+    kube_vip_admin_conf: super-admin.conf
+  when:
+    - inventory_hostname == groups['kube_control_plane'] | first
+    - (stat_kube_vip_super_admin.stat.exists and stat_kube_vip_super_admin.stat.isreg) or (not kubeadm_already_run.stat.exists )
+
 - name: Kube-vip | Write static pod
   template:
     src: manifests/kube-vip.manifest.j2

--- a/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
@@ -119,6 +119,6 @@ spec:
   hostNetwork: true
   volumes:
   - hostPath:
-      path: /etc/kubernetes/admin.conf
+      path: /etc/kubernetes/{{kube_vip_admin_conf}}
     name: kubeconfig
 status: {}


### PR DESCRIPTION
(cherry picked from commit e43e08c7d1ea6a522c4bd648e1300cea82d7cf39)

**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #11229

**Special notes for your reviewer**:

Backport of https://github.com/kubernetes-sigs/kubespray/pull/11422 to v2.25

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added support for initial k8s v1.29+ installation with kube-vip enabled
```
