### PR TITLE
[CI] Add a CI job to test cluster upgrading, and fix bug of testcases_run.sh

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -88,6 +88,11 @@ packet_ubuntu20-crio:
 packet_ubuntu22-calico-all-in-one:
   extends: .packet_pr
 
+packet_ubuntu22-calico-all-in-one-upgrade:
+  extends: .packet_pr
+  variables:
+    UPGRADE_TEST: graceful
+
 packet_ubuntu24-calico-etcd-datastore:
   extends: .packet_pr
 

--- a/tests/files/packet_ubuntu22-calico-all-in-one-upgrade.yml
+++ b/tests/files/packet_ubuntu22-calico-all-in-one-upgrade.yml
@@ -1,0 +1,24 @@
+---
+# Instance settings
+cloud_image: ubuntu-2204
+mode: all-in-one
+vm_memory: 1600
+
+# Kubespray settings
+auto_renew_certificates: true
+
+# Currently ipvs not available on KVM: https://packages.ubuntu.com/search?suite=focal&arch=amd64&mode=exactfilename&searchon=contents&keywords=ip_vs_sh.ko
+kube_proxy_mode: iptables
+enable_nodelocaldns: false
+
+containerd_registries_mirrors:
+  - prefix: docker.io
+    mirrors:
+      - host: https://mirror.gcr.io
+        capabilities: ["pull", "resolve"]
+        skip_verify: false
+  - prefix: 172.19.16.11:5000
+    mirrors:
+      - host: http://172.19.16.11:5000
+        capabilities: ["pull", "resolve", "push"]
+        skip_verify: true


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This adds a  packet_ubuntu22-calico-all-in-one-upgrade job to test cluster upgrading. This is needed to test #11352

Also this fixes a bug in testcases_run.sh which does not checkout the latest (target) commit before upgrading.
(Partially revert the #11173)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11173

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
