### PR TITLE
Add ruamel.yaml to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ jmespath==1.0.1
 jsonschema==4.23.0
 # Needed for ansible.utils.ipaddr
 netaddr==1.3.0
+# Needed for YAML parsing in inventory.py and download_hash.py
+ruamel.yaml==0.18.6


### PR DESCRIPTION
 
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Two scripts within the project, `inventory.py` and `download_hash.py`, rely on `YAML parsing` functionalities. Without the `ruamel.yaml` library referenced in requirements.txt, users on **freshly installed systems** or **Python environments** will encounter a `ModuleNotFoundError` when trying to execute the command:
```
CONFIG_FILE=inventory/mycluster/hosts.yaml python3 contrib/inventory_builder/inventory.py ${IPS[@]}
```
This error occurs because the ruamel.yaml library is not installed by default.
**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/kubespray/issues/4331

**Does this PR introduce a user-facing change?**
```
NONE
```
 