### PR TITLE
Update cluster-role for cilium to prevent errors in agent startup

### DIFF
--- a/roles/network_plugin/cilium/templates/cilium/cr.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/cr.yml.j2
@@ -28,7 +28,6 @@ rules:
   - pods
   - endpoints
   - nodes
-  - secrets
   verbs:
   - get
   - list

--- a/roles/network_plugin/cilium/templates/cilium/cr.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/cr.yml.j2
@@ -33,6 +33,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
 {% if cilium_version | regex_replace('v') is version('1.12', '<') %}
 - apiGroups:
   - ""

--- a/roles/network_plugin/cilium/templates/cilium/cr.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/cr.yml.j2
@@ -28,6 +28,7 @@ rules:
   - pods
   - endpoints
   - nodes
+  - secrets
   verbs:
   - get
   - list
@@ -98,6 +99,9 @@ rules:
 {% if cilium_version | regex_replace('v') is version('1.12', '>=') %}
   - ciliumbgploadbalancerippools
   - ciliumbgppeeringpolicies
+{% if cilium_version | regex_replace('v') is version('1.13', '>=') %}
+  - ciliumloadbalancerippools
+{% endif %}
 {% endif %}
 {% if cilium_version | regex_replace('v') is version('1.11.5', '<') %}
   - ciliumnetworkpolicies/finalizers


### PR DESCRIPTION
ciliumloadbalancerippools permissions exists in the cilium helm chart for version 1.13.0 https://github.com/cilium/cilium/blob/v1.13.0/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml#L71

The agent also needs permissions to read/watch secrets for bgp auth secrets when using CiliumBGPPeeringPolicy with a secret.
Without the permissions for secrets, we see the following warns in the logs when cilium starts up on a node:
```
is forbidden: User \"system:serviceaccount:kube-system:cilium\" cannot list resource \"secrets\" in API group \"\" in the namespace \"kube-system\"" subsys=k8s
time="2024-08-20T14:18:16Z" level=warning msg="github.com/cilium/cilium/pkg/k8s/resource/resource.go:808: failed to list *v1.Secret: secrets is forbidden: User \"system:serviceaccount:kube-system:cilium\" cannot list resource \"secrets\" in API group \"\" in the namespace \"kube-system\"" subsys=klog
time="2024-08-20T14:18:16Z" level=error msg=k8sError error="github.com/cilium/cilium/pkg/k8s/resource/resource.go:808: Failed to watch *v1.Secret: failed to list *v1.Secret: secrets is forbidden: User \"system:serviceaccount:kube-system:cilium\" cannot list resource \"secrets\" in API group \"\" in the namespace \"kube-system\"" subsys=k8s
```

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Gives the cilium agent required permissions to watch loadbalancerippools and secrets

**Does this PR introduce a user-facing change?**:
NONE

**Release Note:**

```release-note
Fix Cilium agent permission can't read loadbalancerippools and secrets
```

** Cilium Config
```kubectl get cm cilium-config -n kube-system -o yaml
apiVersion: v1
data:
  agent-health-port: "9879"
  auto-direct-node-routes: "False"
  bgp-secrets-namespace: kube-system
  bpf-ct-global-any-max: "262144"
  bpf-ct-global-tcp-max: "524288"
  bpf-lb-acceleration: disabled
  bpf-lb-mode: dsr
  bpf-map-dynamic-size-ratio: "0.0025"
  cgroup-root: /run/cilium/cgroupv2
  clean-cilium-bpf-state: "false"
  clean-cilium-state: "false"
  cluster-name: default
  cluster-pool-ipv4-cidr: 10.Y.0.0/14
  cluster-pool-ipv4-mask-size: "25"
  cni-exclusive: "True"
  cni-log-file: /var/run/cilium/cilium-cni.log
  custom-cni-conf: "false"
  debug: "False"
  disable-cnp-status-updates: "True"
  enable-bgp-control-plane: "true"
  enable-bpf-clock-probe: "True"
  enable-bpf-masquerade: "False"
  enable-host-legacy-routing: "True"
  enable-hubble: "true"
  enable-ip-masq-agent: "False"
  enable-ipv4: "True"
  enable-ipv4-masquerade: "True"
  enable-ipv6: "False"
  enable-ipv6-masquerade: "True"
  enable-l2-announcements: "False"
  enable-metrics: "true"
  enable-remote-node-identity: "True"
  enable-well-known-identities: "False"
  etcd-config: |-
    ---
    endpoints:
      - https://10.X.0.36:2379
      - https://10.X.0.37:2379
      - https://10.X.0.38:2379
      - https://10.X.0.39:2379
      - https://10.X.0.40:2379

    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
    # and create a kubernetes secret by following the tutorial in
    # https://cilium.link/etcd-config
    ca-file: "/etc/cilium/certs/ca_cert.crt"

    # In case you want client to server authentication, uncomment the following
    # lines and create a kubernetes secret by following the tutorial in
    # https://cilium.link/etcd-config
    key-file: "/etc/cilium/certs/key.pem"
    cert-file: "/etc/cilium/certs/cert.crt"
  hubble-disable-tls: "false"
  hubble-listen-address: :4244
  hubble-metrics: dns drop tcp flow icmp http
  hubble-metrics-server: :9965
  hubble-tls-cert-file: /var/lib/cilium/tls/hubble/server.crt
  hubble-tls-client-ca-files: /var/lib/cilium/tls/hubble/client-ca.crt
  hubble-tls-key-file: /var/lib/cilium/tls/hubble/server.key
  identity-allocation-mode: kvstore
  ipam: cluster-pool
  ipv4-native-routing-cidr: 10.0.0.0/8
  kube-proxy-replacement: strict
  kvstore: etcd
  kvstore-opt: '{"etcd.config": "/var/lib/etcd-config/etcd.config"}'
  monitor-aggregation: medium
  monitor-aggregation-flags: all
  operator-api-serve-addr: 127.0.0.1:9234
  operator-prometheus-serve-addr: :9963
  preallocate-bpf-maps: "False"
  prometheus-serve-addr: :9962
  routing-mode: native
  sidecar-istio-proxy-image: cilium/istio_proxy
  write-cni-conf-when-ready: /host/etc/cni/net.d/05-cilium.conflist