### PR TITLE
Update the list of admission plugins which needs config

### DIFF
--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -122,15 +122,6 @@
     - item in kube_apiserver_admission_plugins_needs_configuration
   loop: "{{ kube_apiserver_enable_admission_plugins }}"
 
-- name: Kubeadm | Configure default cluster podnodeslector
-  template:
-    src: "podnodeselector.yaml.j2"
-    dest: "{{ kube_config_dir }}/admission-controls/podnodeselector.yaml"
-    mode: "0640"
-  when:
-    - kube_apiserver_admission_plugins_podnodeselector_default_node_selector is defined
-    - kube_apiserver_admission_plugins_podnodeselector_default_node_selector | length > 0
-
 - name: Kubeadm | Check apiserver.crt SANs
   vars:
     apiserver_ips: "{{ apiserver_sans | map('ansible.utils.ipaddr') | reject('equalto', False) | list }}"

--- a/roles/kubernetes/control-plane/vars/main.yaml
+++ b/roles/kubernetes/control-plane/vars/main.yaml
@@ -3,3 +3,4 @@
 kube_apiserver_admission_plugins_needs_configuration:
 - EventRateLimit
 - PodSecurity
+- PodNodeSelector

--- a/roles/kubernetes/control-plane/vars/main.yaml
+++ b/roles/kubernetes/control-plane/vars/main.yaml
@@ -1,3 +1,5 @@
 ---
 # list of admission plugins that needs to be configured
-kube_apiserver_admission_plugins_needs_configuration: [EventRateLimit, PodSecurity]
+kube_apiserver_admission_plugins_needs_configuration:
+- EventRateLimit
+- PodSecurity

--- a/roles/kubernetes/control-plane/vars/main.yaml
+++ b/roles/kubernetes/control-plane/vars/main.yaml
@@ -1,6 +1,8 @@
 ---
 # list of admission plugins that needs to be configured
+# https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/
 kube_apiserver_admission_plugins_needs_configuration:
 - EventRateLimit
+- ImagePolicyWebhook
 - PodSecurity
 - PodNodeSelector


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Basically a redo of #10733 which also add the other missing item (ImagePolicyWebhook)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10588

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
configuration can now be supplied to `ImagePolicyWebhook` and `PodNodeSelector` admission plugins
```

/label tide/merge-method-merge
