### PR TITLE
Remove kubeadm_version and use kube_version instead

### DIFF
--- a/inventory/sample/group_vars/all/offline.yml
+++ b/inventory/sample/group_vars/all/offline.yml
@@ -18,7 +18,7 @@
 # quay_image_repo: "{{ registry_host }}"
 
 ## Kubernetes components
-# kubeadm_download_url: "{{ files_repo }}/dl.k8s.io/release/{{ kubeadm_version }}/bin/linux/{{ image_arch }}/kubeadm"
+# kubeadm_download_url: "{{ files_repo }}/dl.k8s.io/release/{{ kube_version }}/bin/linux/{{ image_arch }}/kubeadm"
 # kubectl_download_url: "{{ files_repo }}/dl.k8s.io/release/{{ kube_version }}/bin/linux/{{ image_arch }}/kubectl"
 # kubelet_download_url: "{{ files_repo }}/dl.k8s.io/release/{{ kube_version }}/bin/linux/{{ image_arch }}/kubelet"
 

--- a/roles/download/tasks/prep_kubeadm_images.yml
+++ b/roles/download/tasks/prep_kubeadm_images.yml
@@ -1,11 +1,4 @@
 ---
-- name: Prep_kubeadm_images | Check kubeadm version matches kubernetes version
-  fail:
-    msg: "Kubeadm version {{ kubeadm_version }} do not matches kubernetes {{ kube_version }}"
-  when:
-    - not skip_downloads | default(false)
-    - not kubeadm_version == downloads.kubeadm.version
-
 - name: Prep_kubeadm_images | Download kubeadm binary
   include_tasks: "download_file.yml"
   vars:

--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -74,7 +74,6 @@ image_info_command_on_localhost: "{{ lookup('vars', image_command_tool_on_localh
 image_arch: "{{ host_architecture | default('amd64') }}"
 
 # Versions
-kubeadm_version: "{{ kube_version }}"
 crun_version: 1.14.4
 runc_version: v1.1.13
 kata_containers_version: 3.1.3
@@ -173,7 +172,7 @@ get_helm_url: https://get.helm.sh
 # Download URLs
 kubelet_download_url: "{{ dl_k8s_io_url }}/release/{{ kube_version }}/bin/linux/{{ image_arch }}/kubelet"
 kubectl_download_url: "{{ dl_k8s_io_url }}/release/{{ kube_version }}/bin/linux/{{ image_arch }}/kubectl"
-kubeadm_download_url: "{{ dl_k8s_io_url }}/release/{{ kubeadm_version }}/bin/linux/{{ image_arch }}/kubeadm"
+kubeadm_download_url: "{{ dl_k8s_io_url }}/release/{{ kube_version }}/bin/linux/{{ image_arch }}/kubeadm"
 etcd_download_url: "{{ github_url }}/etcd-io/etcd/releases/download/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-{{ image_arch }}.tar.gz"
 cni_download_url: "{{ github_url }}/containernetworking/plugins/releases/download/{{ cni_version }}/cni-plugins-linux-{{ image_arch }}-{{ cni_version }}.tgz"
 calicoctl_download_url: "{{ github_url }}/projectcalico/calico/releases/download/{{ calico_ctl_version }}/calicoctl-linux-{{ image_arch }}"
@@ -200,7 +199,7 @@ etcd_binary_checksum: "{{ etcd_binary_checksums[image_arch][etcd_version] }}"
 cni_binary_checksum: "{{ cni_binary_checksums[image_arch][cni_version] }}"
 kubelet_binary_checksum: "{{ kubelet_checksums[image_arch][kube_version] }}"
 kubectl_binary_checksum: "{{ kubectl_checksums[image_arch][kube_version] }}"
-kubeadm_binary_checksum: "{{ kubeadm_checksums[image_arch][kubeadm_version] }}"
+kubeadm_binary_checksum: "{{ kubeadm_checksums[image_arch][kube_version] }}"
 yq_binary_checksum: "{{ yq_checksums[image_arch][yq_version] }}"
 calicoctl_binary_checksum: "{{ calicoctl_binary_checksums[image_arch][calico_ctl_version] }}"
 calico_crds_archive_checksum: "{{ calico_crds_archive_checksums[calico_version] }}"
@@ -466,8 +465,8 @@ downloads:
   kubeadm:
     enabled: true
     file: true
-    version: "{{ kubeadm_version }}"
-    dest: "{{ local_release_dir }}/kubeadm-{{ kubeadm_version }}-{{ image_arch }}"
+    version: "{{ kube_version }}"
+    dest: "{{ local_release_dir }}/kubeadm-{{ kube_version }}-{{ image_arch }}"
     sha256: "{{ kubeadm_binary_checksum }}"
     url: "{{ kubeadm_download_url }}"
     unarchive: false


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
see https://github.com/kubernetes-sigs/kubespray/pull/11065#issuecomment-2312467819

**Does this PR introduce a user-facing change?**:
```release-note
Remove the `kubeadm_version` which is always equal to `kube_version`
```
