### PR TITLE
Adjust preinstall check task name since we allow an empty kube_node group

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
@@ -1,5 +1,5 @@
 ---
-- name: Stop if either kube_control_plane or kube_node group is empty
+- name: Stop if kube_control_plane group is empty
   assert:
     that: groups.get( 'kube_control_plane' )
   run_once: true


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Follow-up of #11248

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
