### PR TITLE
Add vagrant boxes caching to CI

### DIFF
--- a/.gitlab-ci/molecule.yml
+++ b/.gitlab-ci/molecule.yml
@@ -29,6 +29,10 @@
     when: always
     paths:
     - molecule_logs/
+  cache:
+    key: vagrant_boxes
+    paths:
+    - ~/vagrant.d/boxes/
 
 # CI template for periodic CI jobs
 # Enabled when PERIODIC_CI_ENABLED var is set

--- a/.gitlab-ci/vagrant.yml
+++ b/.gitlab-ci/vagrant.yml
@@ -27,6 +27,10 @@
     - ./tests/scripts/vagrant_clean.sh
   script:
     - ./tests/scripts/testcases_run.sh
+  cache:
+    key: vagrant_boxes
+    paths:
+    - ~/vagrant.d/boxes/
 
 vagrant_ubuntu20-calico-dual-stack:
   stage: deploy-extended


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
We're hitting 429 responses when running lots of jobs, presumably
because we are downloading lots of boxes again and again.
This should cache them instead.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
/ok-to-test
