### PR TITLE
Remove systemd version + ostree check for docker TasksMax

### DIFF
--- a/roles/container-engine/docker/tasks/systemd.yml
+++ b/roles/container-engine/docker/tasks/systemd.yml
@@ -13,16 +13,6 @@
   notify: Restart docker
   when: http_proxy is defined or https_proxy is defined
 
-- name: Get systemd version
-  # noqa command-instead-of-module - systemctl is called intentionally here
-  shell: set -o pipefail && systemctl --version | head -n 1 | cut -d " " -f 2
-  args:
-    executable: /bin/bash
-  register: systemd_version
-  when: not is_ostree
-  changed_when: false
-  check_mode: false
-
 - name: Write docker.service systemd file
   template:
     src: docker.service.j2

--- a/roles/container-engine/docker/templates/docker.service.j2
+++ b/roles/container-engine/docker/templates/docker.service.j2
@@ -31,9 +31,7 @@ ExecStart={{ docker_bin_dir }}/dockerd \
           $DOCKER_OPTS \
           $DOCKER_STORAGE_OPTIONS \
           $DOCKER_DNS_OPTIONS
-{% if not is_ostree and systemd_version.stdout|int >= 226 %}
 TasksMax=infinity
-{% endif %}
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LimitCORE=infinity


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
systemd ignores unknown keys (with a warning) so version checking is not
necessary.
There is no rationale for excluding it from ostree systems either.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Use TasksMask=infinity on ostree systems for docker systemd service
```
