### PR TITLE
Add extra requirements.txt ref to the Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ then run the following steps:
 cp -rfp inventory/sample inventory/mycluster
 
 # Update Ansible inventory file with inventory builder
+# Basides root ``requirements.txt`` , ``inventory builder`` requires some extra Python Packages: ``contrib/inventory_builder/requirements.txt``
 declare -a IPS=(10.10.1.3 10.10.1.4 10.10.1.5)
 CONFIG_FILE=inventory/mycluster/hosts.yaml python3 contrib/inventory_builder/inventory.py ${IPS[@]}
 

--- a/docs/getting_started/setting-up-your-first-cluster.md
+++ b/docs/getting_started/setting-up-your-first-cluster.md
@@ -205,6 +205,10 @@ playbook:
 ```ShellSession
 pip install -r requirements.txt
 ```
+Extra Python Packages are required if you want to use ``inventory builder``:
+```ShellSession
+pip install -r contrib/inventory_builder/requirements.txt
+```
 
 Copy ``inventory/sample`` as ``inventory/mycluster``:
 


### PR DESCRIPTION
 
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Two scripts within the project, `inventory.py` and `download_hash.py`, rely on `YAML parsing` functionalities. Without the `ruamel.yaml` library referenced in requirements.txt, users on **freshly installed systems** or **Python environments** will encounter a `ModuleNotFoundError` when trying to execute the command:
```
CONFIG_FILE=inventory/mycluster/hosts.yaml python3 contrib/inventory_builder/inventory.py ${IPS[@]}
```
This error occurs because the ruamel.yaml library is not installed by default.
This should be indicated in `Installation docs` to provide more clarity.

**Which issue(s) this PR fixes**:
[Fixes https://github.com/kubernetes-sigs/kubespray/issues/4331](https://github.com/kubernetes-sigs/kubespray/pull/11465#issuecomment-2324210183)

**Does this PR introduce a user-facing change?**
```
NONE
```
 