### PR TITLE
Allow for configuring etcd progress notify interval

### DIFF
--- a/inventory/sample/group_vars/etcd.yml
+++ b/inventory/sample/group_vars/etcd.yml
@@ -33,3 +33,6 @@
 # etcd_experimental_distributed_tracing_sample_rate: 100
 # etcd_experimental_distributed_tracing_address: "localhost:4317"
 # etcd_experimental_distributed_tracing_service_name: etcd
+
+## The interval for etcd watch progress notify events
+# etcd_experimental_watch_progress_notify_interval: 5s

--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -125,3 +125,6 @@ etcd_experimental_enable_distributed_tracing: false
 etcd_experimental_distributed_tracing_sample_rate: 100
 etcd_experimental_distributed_tracing_address: "localhost:4317"
 etcd_experimental_distributed_tracing_service_name: etcd
+
+# The interval for etcd watch progress notify events
+etcd_experimental_watch_progress_notify_interval: 5s

--- a/roles/etcd/templates/etcd.env.j2
+++ b/roles/etcd/templates/etcd.env.j2
@@ -76,3 +76,5 @@ ETCD_EXPERIMENTAL_DISTRIBUTED_TRACING_ADDRESS={{ etcd_experimental_distributed_t
 ETCD_EXPERIMENTAL_DISTRIBUTED_TRACING_SERVICE_NAME={{ etcd_experimental_distributed_tracing_service_name }}
 ETCD_EXPERIMENTAL_DISTRIBUTED_TRACING_INSTANCE_ID={{ etcd_member_name }}
 {% endif %}
+
+ETCD_EXPERIMENTAL_WATCH_PROGRESS_NOTIFY_INTERVAL={{ etcd_experimental_watch_progress_notify_interval }}


### PR DESCRIPTION

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Allow for configuring etcd progress notify interval and default set to 5s

like gce and kubeadm
https://github.com/kubernetes/kubernetes/blob/v1.31.0/cluster/gce/config-default.sh#L527-L528
https://github.com/kubernetes/kubernetes/pull/111383

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Allow for configuring etcd progress notify interval and default set to 5s
```
