### PR TITLE
fix: create groups from legacy inventory even with limit flag set

### DIFF
--- a/playbooks/boilerplate.yml
+++ b/playbooks/boilerplate.yml
@@ -7,31 +7,37 @@
 # - to reduce inventory boilerplate (defining parent groups / empty groups)
 
 - name: Add kube-master nodes to kube_control_plane
-  hosts: kube-master
-  gather_facts: false
+  hosts: all
+  gather_facts: true
   tags: always
   tasks:
     - name: Add nodes to kube_control_plane group
-      group_by:
-        key: 'kube_control_plane'
+      add_host:
+        name: "{{ item }}"
+        groups: 'kube_control_plane'
+      with_items: "{{ groups['kube-master'] | default([]) }}"
 
 - name: Add kube-node nodes to kube_node
-  hosts: kube-node
+  hosts: all
   gather_facts: false
   tags: always
   tasks:
     - name: Add nodes to kube_node group
-      group_by:
-        key: 'kube_node'
+      add_host:
+        name: "{{ item }}"
+        groups: 'kube_node'
+      with_items: "{{ groups['kube-node'] | default([]) }}"
 
 - name: Add calico-rr nodes to calico_rr
-  hosts: calico-rr
+  hosts: all
   gather_facts: false
   tags: always
   tasks:
     - name: Add nodes to calico_rr group
-      group_by:
-        key: 'calico_rr'
+      add_host:
+        name: "{{ item }}"
+        groups: 'calico_rr'
+      with_items: "{{ groups['calico-rr'] | default([]) }}"
 
 - name: Define k8s_cluster group
   hosts: kube_node:kube_control_plane:calico_rr
@@ -43,13 +49,15 @@
         key: 'k8s_cluster'
 
 - name: Add no-floating nodes to no_floating
-  hosts: no-floating
+  hosts: all
   gather_facts: false
   tags: always
   tasks:
-    - name: Add nodes to no-floating group
-      group_by:
-        key: 'no_floating'
+    - name: Add nodes to no_floating group
+      add_host:
+        name: "{{ item }}"
+        groups: 'no_floating'
+      with_items: "{{ groups['no-floating'] | default([]) }}"
 
 - name: Install bastion ssh config
   hosts: bastion[0]

--- a/playbooks/boilerplate.yml
+++ b/playbooks/boilerplate.yml
@@ -8,7 +8,7 @@
 
 - name: Add kube-master nodes to kube_control_plane
   hosts: all
-  gather_facts: true
+  gather_facts: false
   tags: always
   tasks:
     - name: Add nodes to kube_control_plane group

--- a/playbooks/boilerplate.yml
+++ b/playbooks/boilerplate.yml
@@ -40,13 +40,15 @@
       with_items: "{{ groups['calico-rr'] | default([]) }}"
 
 - name: Define k8s_cluster group
-  hosts: kube_node:kube_control_plane:calico_rr
+  hosts: all
   gather_facts: false
   tags: always
   tasks:
     - name: Add nodes to k8s_cluster group
-      group_by:
-        key: 'k8s_cluster'
+      add_host:
+        name: "{{ item }}"
+        groups: 'k8s_cluster'
+      with_items: "{{ (groups['kube_node'] | default([])) | union(groups['kube_control_plane'] | default([])) | union(groups['calico_rr'] | default([])) }}"
 
 - name: Add no-floating nodes to no_floating
   hosts: all


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
/kind bug

**What this PR does / why we need it**:

When using the legacy inventory with the kube-master and kube-node groups the boilerplate.yml playbook is supposed to add them to the kube_control_plane and kube_node group respectively. 
The problem is that if you follow the docs and run the scale.yml playbook with the limit flag set to the new worker node (mentioned [here](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/operations/nodes.md#2-run-scaleyml)) then it won't add the nodes from the kube-master group to the kube_control_plane group because it doesn't match any hosts.
Consequently the task "Stop if kube_control_plane group is empty" in roles/kubernetes/preinstall/tasks/0040-verify-settings.yml will fail.
The fix uses the add_host module instead which runs on all hosts and will always add the hosts from the legacy groups to the new groups, even if the limit flag is set.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
I haven't created an issue for this bug since the information in the bug template isn't relevant and I couldn't get vagrant to work easily, but let me know if it's needed and I can create one.
This bug should happen on any Kubespray version with the updated groups and the fix worked in our CI environment where we're using the legacy group names.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
