### PR TITLE
Refactor and expand download_hash.py

### DIFF
--- a/scripts/download_hash.py
+++ b/scripts/download_hash.py
@@ -172,7 +172,33 @@ def download_hash(only_downloads: [str]) -> None:
         yaml.dump(data, checksums_yml)
         print(f"\n\nUpdated {CHECKSUMS_YML}\n")
 
-parser = argparse.ArgumentParser(description=f"Add new patch versions hashes in {CHECKSUMS_YML}")
+parser = argparse.ArgumentParser(description=f"Add new patch versions hashes in {CHECKSUMS_YML}",
+                                 formatter_class=argparse.RawTextHelpFormatter,
+                                 epilog=f"""
+ This script only lookup new patch versions relative to those already existing
+ in the data in {CHECKSUMS_YML},
+ which means it won't add new major or minor versions.
+ In order to add one of these, edit {CHECKSUMS_YML}
+ by hand, adding the new versions with a patch number of 0 (or the lowest relevant patch versions)
+ ; then run this script.
+
+ Note that the script will try to add the versions on all
+ architecture keys already present for a given download target.
+
+ The '0' value for a version hash is treated as a missing hash, so the script will try to download it again.
+ To notify a non-existing version (yanked, or upstream does not have monotonically increasing versions numbers),
+ use the special value 'NONE'.
+
+ EXAMPLES:
+
+ crictl_checksums:
+      ...
+    amd64:
++     v1.30.0: 0
+      v1.29.0: d16a1ffb3938f5a19d5c8f45d363bd091ef89c0bc4d44ad16b933eede32fdcbb
+      v1.28.0: 8dc78774f7cbeaf787994d386eec663f0a3cf24de1ea4893598096cb39ef2508"""
+
+)
 parser.add_argument('binaries', nargs='*', choices=downloads.keys())
 
 args = parser.parse_args()

--- a/scripts/download_hash.py
+++ b/scripts/download_hash.py
@@ -98,6 +98,7 @@ def download_hash(only_downloads: [str]) -> None:
             }
 
     data, yaml = open_checksums_yaml()
+    s = requests.Session()
 
     for download, url in (downloads if only_downloads == []
                           else {k:downloads[k] for k in downloads.keys() & only_downloads}).items():
@@ -124,7 +125,7 @@ def download_hash(only_downloads: [str]) -> None:
                     # to find new versions
                     if version in versions and versions[version] != 0:
                         continue
-                    hash_file = requests.get(downloads[download].format(
+                    hash_file = s.get(downloads[download].format(
                         version = version,
                         os = "linux",
                         arch = arch

--- a/scripts/download_hash.py
+++ b/scripts/download_hash.py
@@ -45,6 +45,21 @@ downloads = {
     "skopeo_binary": "https://github.com/lework/skopeo-binary/releases/download/{version}/skopeo-{os}-{arch}.sha256",
     "yq": "https://github.com/mikefarah/yq/releases/download/{version}/checksums-bsd", # see https://github.com/mikefarah/yq/pull/1691 for why we use this url
 }
+# TODO: downloads not supported
+# youki: no checkusms in releases
+# kata: no checksums in releases
+# gvisor: sha512 checksums
+# crun : PGP signatures
+# cri_dockerd: no checksums or signatures
+# helm_archive: PGP signatures
+# krew_archive: different yaml structure
+# calico_crds_archive: different yaml structure
+
+# TODO:
+# noarch support -> k8s manifests, helm charts
+# different checksum format (needs download role changes)
+# different verification methods (gpg, cosign) ( needs download role changes) (or verify the sig in this script and only use the checksum in the playbook)
+# perf improvements (async)
 
 def download_hash(only_downloads: [str]) -> None:
     # Handle file with multiples hashes, with various formats.

--- a/scripts/download_hash.py
+++ b/scripts/download_hash.py
@@ -30,11 +30,16 @@ def version_compare(version):
     return Version(version.removeprefix("v"))
 
 downloads = {
+    "ciliumcli_binary": "https://github.com/cilium/cilium-cli/releases/download/{version}/cilium-{os}-{arch}.tar.gz.sha256sum",
+    "cni_binary": "https://github.com/containernetworking/plugins/releases/download/{version}/cni-plugins-{os}-{arch}-{version}.tgz.sha256",
     "containerd_archive": "https://github.com/containerd/containerd/releases/download/v{version}/containerd-{version}-{os}-{arch}.tar.gz.sha256sum",
+    "crictl": "https://github.com/kubernetes-sigs/cri-tools/releases/download/{version}/critest-{version}-{os}-{arch}.tar.gz.sha256",
+    "crio_archive": "https://storage.googleapis.com/cri-o/artifacts/cri-o.{arch}.{version}.tar.gz.sha256sum",
     "kubeadm": "https://dl.k8s.io/release/{version}/bin/linux/{arch}/kubeadm.sha256",
     "kubectl": "https://dl.k8s.io/release/{version}/bin/linux/{arch}/kubectl.sha256",
     "kubelet": "https://dl.k8s.io/release/{version}/bin/linux/{arch}/kubelet.sha256",
     "runc": "https://github.com/opencontainers/runc/releases/download/{version}/runc.sha256sum",
+    "skopeo_binary": "https://github.com/lework/skopeo-binary/releases/download/{version}/skopeo-{os}-{arch}.sha256",
 }
 
 def download_hash(only_downloads: [str]) -> None:

--- a/scripts/download_hash.py
+++ b/scripts/download_hash.py
@@ -52,6 +52,18 @@ def download_hash(only_downloads: [str]) -> None:
     for download, url in (downloads if only_downloads == []
                           else {k:downloads[k] for k in downloads.keys() & only_downloads}).items():
         checksum_name = f"{download}_checksums"
+        # Propagate new patch versions to all architectures
+        for arch in data[checksum_name].values():
+            for arch2 in data[checksum_name].values():
+                arch.update({
+                    v:("NONE" if arch2[v] == "NONE" else 0)
+                    for v in (set(arch2.keys()) - set(arch.keys()))
+                    if v.split('.')[2] == '0'})
+                    # this is necessary to make the script indempotent,
+                    # by only adding a vX.X.0 version (=minor release) in each arch
+                    # and letting the rest of the script populate the potential
+                    # patch versions
+
         for arch, versions in data[checksum_name].items():
             for minor, patches in groupby(versions.copy().keys(), lambda v : '.'.join(v.split('.')[:-1])):
                 for version in (f"{minor}.{patch}" for patch in


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This reworks the Python version of the download script making it much more
powerful and versatile and supporting most of the components we download.

It's intended to be the first step in completely replacing download_hash.sh.
It's missing some things for that (see 86855be6) that I will address in later PRs.

It has the following advantages over download_hash.sh in particular:

- which versions and which archs to download for each components is driven by the current content of the `downloads` variable, which allow to avoid lots of '0' value.
- It only downloads hashs; I intend to keep it that way unless absolutely necessary, as downloading the binary locally is super wasteful.
  This means it will have to handle different hash format, and crypto signing, certainly (gpg + cosign for k8s binaries).
  I've also started asking upstream project which don't provide any of these if they would kindly do so (that's just youki for now)
- it's faster. It's not (yet) a fair comparison (because some components are not handled), but this is a result for a full run of both on a clean current version of master:

$ time python download_hash.py

...

real	1m26.888s
user	0m0.827s
sys	0m0.058s

$ time python download_hash.sh

...

real	14m32.278s
user	0m41.258s
sys	0m29.733s

**Special notes for your reviewer**:
My python code is pretty functional (in the Haskell sense, lambdas and
comprehensions all other the place), you've been warned ^.

I didn't mark this as draft because it does not affect end-users, but there is still things I'm unsure about:
1. Handling '0' / 'NONE' (see the help text for the current semantics)
2. Is the documentation clear enough for using it easily ?

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/label tide/merge-method-merge
/cc @MrFreezeex
/cc @mzaian
