### PR TITLE
Bump ansible 9.8.0 to 10.3.0

### DIFF
--- a/docs/ansible/ansible.md
+++ b/docs/ansible/ansible.md
@@ -32,7 +32,7 @@ Based on the table below and the available python version for your ansible host 
 
 | Ansible Version | Python Version |
 |-----------------|----------------|
-| >= 2.16.4       | 3.10-3.12      |
+| >= 2.17.3       | 3.10-3.12      |
 
 ## Inventory
 

--- a/playbooks/ansible_version.yml
+++ b/playbooks/ansible_version.yml
@@ -5,8 +5,8 @@
   become: false
   run_once: true
   vars:
-    minimal_ansible_version: 2.16.4
-    maximal_ansible_version: 2.17.0
+    minimal_ansible_version: 2.17.3
+    maximal_ansible_version: 2.18.0
   tags: always
   tasks:
     - name: "Check {{ minimal_ansible_version }} <= Ansible version < {{ maximal_ansible_version }}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible==9.8.0
+ansible==10.3.0
 # Needed for jinja2 json_query templating
 jmespath==1.0.1
 # Needed for ansible.utils.validate module


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation
/kind feature

**What this PR does / why we need it**:

Manual upgrade because our CI would fail the `playbooks/ansible_version.yml` check, and ansible 9 will deprecated in Nov. 2024.

**Which issue(s) this PR fixes**:

Fixes #11519 
Related #11462

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Upgrade ansible 9.8.0 to 10.3.0 & ansible-core 2.16.x to 2.17.3
```
