### PR TITLE
Use in inventory variables rather than patch files for kubeadm_patches

### DIFF
--- a/docs/ansible/vars.md
+++ b/docs/ansible/vars.md
@@ -337,6 +337,13 @@ in the form of dicts of key-value pairs of configuration parameters that will be
 * *kube_kubeadm_controller_extra_args*
 * *kube_kubeadm_scheduler_extra_args*
 
+### Kubeadm patches
+
+When extra flags are not sufficient and there is a need to further customize kubernetes components,
+[kubeadm patches](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/control-plane-flags/#patches)
+can be used.
+You should use the [`kubeadm_patches` variable](../../roles/kubernetes/kubeadm_common/defaults/main.yml) for that purpose.
+
 ## App variables
 
 * *helm_version* - Only supports v3.x. Existing v2 installs (with Tiller) will not be modified and need to be removed manually.

--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -366,11 +366,25 @@ auto_renew_certificates: false
 # First Monday of each month
 # auto_renew_certificates_systemd_calendar: "Mon *-*-1,2,3,4,5,6,7 03:{{ groups['kube_control_plane'].index(inventory_hostname) }}0:00"
 
-# kubeadm patches path
-kubeadm_patches:
-  enabled: false
-  source_dir: "{{ inventory_dir }}/patches"
-  dest_dir: "{{ kube_config_dir }}/patches"
+kubeadm_patches_dir: "{{ kube_config_dir }}/patches"
+kubeadm_patches: []
+# See https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/control-plane-flags/#patches
+# Correspondance with this link
+# patchtype = type
+# target = target
+# suffix -> managed automatically
+# extension -> always "yaml"
+# kubeadm_patches:
+# - target: kube-apiserver|kube-controller-manager|kube-scheduler|etcd|kubeletconfiguration
+#   type: strategic(default)|json|merge
+#   patch:
+#    metadata:
+#      annotations:
+#        example.com/test: "true"
+#      labels:
+#        example.com/prod_level: "{{ prod_level }}"
+# - ...
+# Patches are applied in the order they are specified.
 
 # Set to true to remove the role binding to anonymous users created by kubeadm
 remove_anonymous_access: false

--- a/inventory/sample/patches/kube-controller-manager+merge.yaml
+++ b/inventory/sample/patches/kube-controller-manager+merge.yaml
@@ -1,8 +1,0 @@
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: kube-controller-manager
-  annotations:
-    prometheus.io/scrape: 'true'
-    prometheus.io/port: '10257'

--- a/inventory/sample/patches/kube-scheduler+merge.yaml
+++ b/inventory/sample/patches/kube-scheduler+merge.yaml
@@ -1,8 +1,0 @@
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: kube-scheduler
-  annotations:
-    prometheus.io/scrape: 'true'
-    prometheus.io/port: '10259'

--- a/roles/kubernetes/control-plane/meta/main.yml
+++ b/roles/kubernetes/control-plane/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
+  - role: kubernetes/kubeadm_common
   - role: kubernetes/tokens
     when: kube_token_auth
     tags:

--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -176,21 +176,6 @@
     - apiserver_sans_ip_check.changed or apiserver_sans_host_check.changed
     - not kube_external_ca_mode
 
-- name: Kubeadm | Create directory to store kubeadm patches
-  file:
-    path: "{{ kubeadm_patches.dest_dir }}"
-    state: directory
-    mode: "0640"
-  when: kubeadm_patches is defined and kubeadm_patches.enabled
-
-- name: Kubeadm | Copy kubeadm patches from inventory files
-  copy:
-    src: "{{ kubeadm_patches.source_dir }}/"
-    dest: "{{ kubeadm_patches.dest_dir }}"
-    owner: "root"
-    mode: "0644"
-  when: kubeadm_patches is defined and kubeadm_patches.enabled
-
 - name: Kubeadm | Initialize first control plane node
   command: >-
     timeout -k {{ kubeadm_init_timeout }} {{ kubeadm_init_timeout }}

--- a/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
@@ -18,7 +18,7 @@
     --ignore-preflight-errors=all
     --allow-experimental-upgrades
     --etcd-upgrade={{ (etcd_deployment_type == "kubeadm") | bool | lower }}
-    {% if kubeadm_patches is defined and kubeadm_patches.enabled %}--patches={{ kubeadm_patches.dest_dir }}{% endif %}
+    {% if kubeadm_patches | length > 0 %}--patches={{ kubeadm_patches_dir }}{% endif %}
     --force
   register: kubeadm_upgrade
   # Retry is because upload config sometimes fails
@@ -39,7 +39,7 @@
     --ignore-preflight-errors=all
     --allow-experimental-upgrades
     --etcd-upgrade={{ (etcd_deployment_type == "kubeadm") | bool | lower }}
-    {% if kubeadm_patches is defined and kubeadm_patches.enabled %}--patches={{ kubeadm_patches.dest_dir }}{% endif %}
+    {% if kubeadm_patches | length > 0 %}--patches={{ kubeadm_patches_dir }}{% endif %}
     --force
   register: kubeadm_upgrade
   # Retry is because upload config sometimes fails

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
@@ -28,9 +28,9 @@ nodeRegistration:
   kubeletExtraArgs:
     cloud-provider: external
 {% endif %}
-{% if kubeadm_patches is defined and kubeadm_patches.enabled %}
+{% if kubeadm_patches | length > 0 %}
 patches:
-  directory: {{ kubeadm_patches.dest_dir }}
+  directory: {{ kubeadm_patches_dir }}
 {% endif %}
 ---
 apiVersion: kubeadm.k8s.io/v1beta3

--- a/roles/kubernetes/control-plane/templates/kubeadm-controlplane.v1beta3.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-controlplane.v1beta3.yaml.j2
@@ -31,7 +31,7 @@ nodeRegistration:
 {% else %}
   taints: []
 {% endif %}
-{% if kubeadm_patches is defined and kubeadm_patches.enabled %}
+{% if kubeadm_patches | length > 0 %}
 patches:
-  directory: {{ kubeadm_patches.dest_dir }}
+  directory: {{ kubeadm_patches_dir }}
 {% endif %}

--- a/roles/kubernetes/kubeadm/meta/main.yml
+++ b/roles/kubernetes/kubeadm/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: kubernetes/kubeadm_common

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -83,21 +83,6 @@
     mode: "0640"
   when: ('kube_control_plane' not in group_names)
 
-- name: Kubeadm | Create directory to store kubeadm patches
-  file:
-    path: "{{ kubeadm_patches.dest_dir }}"
-    state: directory
-    mode: "0640"
-  when: kubeadm_patches is defined and kubeadm_patches.enabled
-
-- name: Kubeadm | Copy kubeadm patches from inventory files
-  copy:
-    src: "{{ kubeadm_patches.source_dir }}/"
-    dest: "{{ kubeadm_patches.dest_dir }}"
-    owner: "root"
-    mode: "0644"
-  when: kubeadm_patches is defined and kubeadm_patches.enabled
-
 - name: Join to cluster if needed
   environment:
     PATH: "{{ bin_dir }}:{{ ansible_env.PATH }}:/sbin"

--- a/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1beta3.j2
+++ b/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.v1beta3.j2
@@ -38,7 +38,7 @@ nodeRegistration:
   - effect: NoSchedule
     key: node-role.kubernetes.io/calico-rr
 {% endif %}
-{% if kubeadm_patches is defined and kubeadm_patches.enabled %}
+{% if kubeadm_patches | length > 0 %}
 patches:
-  directory: {{ kubeadm_patches.dest_dir }}
+  directory: {{ kubeadm_patches_dir }}
 {% endif %}

--- a/roles/kubernetes/kubeadm_common/defaults/main.yml
+++ b/roles/kubernetes/kubeadm_common/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+kubeadm_patches_dir: "{{ kube_config_dir }}/patches"
+kubeadm_patches: []
+# kubeadm_patches:
+# - target: kube-apiserver|kube-controller-manager|kube-scheduler|etcd|kubeletconfiguration
+#   type: strategic(default)|json|merge
+#   patch:
+#    metadata:
+#      annotations:
+#        example.com/test: "true"
+#      labels:
+#        example.com/prod_level: "{{ prod_level }}"
+# - ...
+# Patches are applied in the order they are specified.

--- a/roles/kubernetes/kubeadm_common/defaults/main.yml
+++ b/roles/kubernetes/kubeadm_common/defaults/main.yml
@@ -1,6 +1,12 @@
 ---
 kubeadm_patches_dir: "{{ kube_config_dir }}/patches"
 kubeadm_patches: []
+# See https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/control-plane-flags/#patches
+# Correspondance with this link
+# patchtype = type
+# target = target
+# suffix -> managed automatically
+# extension -> always "yaml"
 # kubeadm_patches:
 # - target: kube-apiserver|kube-controller-manager|kube-scheduler|etcd|kubeletconfiguration
 #   type: strategic(default)|json|merge

--- a/roles/kubernetes/kubeadm_common/tasks/main.yml
+++ b/roles/kubernetes/kubeadm_common/tasks/main.yml
@@ -1,15 +1,17 @@
 ---
 - name: Kubeadm | Create directory to store kubeadm patches
   file:
-    path: "{{ kubeadm_patches.dest_dir }}"
+    path: "{{ kubeadm_patches_dir }}"
     state: directory
     mode: "0640"
-  when: kubeadm_patches is defined and kubeadm_patches.enabled
+  when: kubeadm_patches | length > 0
 
 - name: Kubeadm | Copy kubeadm patches from inventory files
   copy:
-    src: "{{ kubeadm_patches.source_dir }}/"
-    dest: "{{ kubeadm_patches.dest_dir }}"
+    content: "{{ item.patch | to_yaml }}"
+    dest: "{{ kubeadm_patches_dir }}/{{ item.target }}{{ suffix }}+{{ item.type | d('strategic') }}.yaml"
     owner: "root"
     mode: "0644"
-  when: kubeadm_patches is defined and kubeadm_patches.enabled
+  loop: "{{ kubeadm_patches }}"
+  loop_control:
+    index_var: suffix

--- a/roles/kubernetes/kubeadm_common/tasks/main.yml
+++ b/roles/kubernetes/kubeadm_common/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Kubeadm | Create directory to store kubeadm patches
+  file:
+    path: "{{ kubeadm_patches.dest_dir }}"
+    state: directory
+    mode: "0640"
+  when: kubeadm_patches is defined and kubeadm_patches.enabled
+
+- name: Kubeadm | Copy kubeadm patches from inventory files
+  copy:
+    src: "{{ kubeadm_patches.source_dir }}/"
+    dest: "{{ kubeadm_patches.dest_dir }}"
+    owner: "root"
+    mode: "0644"
+  when: kubeadm_patches is defined and kubeadm_patches.enabled

--- a/tests/files/packet_ubuntu24-calico-etcd-datastore.yml
+++ b/tests/files/packet_ubuntu24-calico-etcd-datastore.yml
@@ -27,3 +27,20 @@ containerd_registries_mirrors:
         skip_verify: true
 
 calico_datastore: "etcd"
+
+# Test kubeadm patches
+kubeadm_patches:
+  - target: kube-apiserver
+    patch:
+      metadata:
+        annotations:
+          example.com/test: "true"
+        labels:
+          example.com/prod_level: "prep"
+  - target: kube-controller-manager
+    patch:
+      metadata:
+        annotations:
+          example.com/test: "false"
+        labels:
+          example.com/prod_level: "prep"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Specifying one directory for kubeadm patches is not ideal:

1. It does oes not allow working with multiples inventories easily
2. No ansible templating of the patch.
3. Ansible path searching can sometimes be confusing

Instead, provide the patch directly in a variable, and add some quality
of life to handle components targeting and patch ordering more
explicitly (`target` and `type` which are translated to the kubeadm
scheme which is based on the file name)

**Special notes for your reviewer**:
I also added a new 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
action required
Change `kubeadm_patches` format to use an array of inline patch instead of patch files.
See [the example](roles/kubernetes/kubeadm_common/defaults/main.yml) for new format.
```

/label tide/merge-method-merge
