### PR TITLE
fix: crio restart handler

### DIFF
--- a/roles/container-engine/validate-container-engine/tasks/main.yml
+++ b/roles/container-engine/validate-container-engine/tasks/main.yml
@@ -151,3 +151,4 @@
       import_role:
         name: container-engine/cri-o
         tasks_from: reset
+        handlers_from: reset


### PR DESCRIPTION
crio restart handler `when` clause is overwritten by an unrelated import_role. we set the import_role to load handlers from an empty file to avoid this

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

cri-o does not restart because import_role overwrites the when conditional of the handler

same fix was made for containerd here: https://github.com/kubernetes-sigs/kubespray/pull/9322

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix: cri-o is now properly restarted when there is a material change, such as a change in the binary version.
```
