### PR TITLE
Move the CRI endpoint setting to kubelet config

### DIFF
--- a/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
@@ -26,6 +26,7 @@ staticPodPath: {{ kube_manifest_dir }}
 cgroupDriver: {{ kubelet_cgroup_driver | default('systemd') }}
 containerLogMaxFiles: {{ kubelet_logfiles_max_nr }}
 containerLogMaxSize: {{ kubelet_logfiles_max_size }}
+containerRuntimeEndpoint : {{ cri_socket }}
 maxPods: {{ kubelet_max_pods }}
 podPidsLimit: {{ kubelet_pod_pids_limit }}
 address: {{ kubelet_bind_address }}

--- a/roles/kubernetes/node/templates/kubelet.env.v1beta1.j2
+++ b/roles/kubernetes/node/templates/kubelet.env.v1beta1.j2
@@ -11,7 +11,6 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 --config={{ kube_config_dir }}/kubelet-config.yaml \
 --kubeconfig={{ kube_config_dir }}/kubelet.conf \
 {# end kubeadm specific settings #}
---container-runtime-endpoint={{ cri_socket }} \
 --runtime-cgroups={{ kubelet_runtime_cgroups }} \
 {% endset %}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
**What this PR does / why we need it**:
The `--container-runtime-endpoint` kubelet argument is deprecated in
favor of the config file alternative.


**Special notes for your reviewer**:
Re-creating #11489 which is stuck on CI bug

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
