### PR TITLE
Update load balancers Versions Nginx 1.25.2-alpine, Haproxy 3.0.5-alpine

### DIFF
--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -288,9 +288,9 @@ external_openstack_cloud_controller_image_tag: "v1.30.0"
 kube_vip_image_repo: "{{ github_image_repo }}/kube-vip/kube-vip"
 kube_vip_image_tag: v0.8.0
 nginx_image_repo: "{{ docker_image_repo }}/library/nginx"
-nginx_image_tag: 1.25.2-alpine
+nginx_image_tag: 1.27.1-alpine
 haproxy_image_repo: "{{ docker_image_repo }}/library/haproxy"
-haproxy_image_tag: 2.8.2-alpine
+haproxy_image_tag: 3.0.5-alpine
 
 # Coredns version should be supported by corefile-migration (or at least work with)
 # bundle with kubeadm; if not 'basic' upgrade can sometimes fail


### PR DESCRIPTION
What type of PR is this?

/kind feature

What this PR does / why we need it:

Update load balancer Versions to resolve the CVE issue.

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

Upgrade the load balancer ( nginx and haproxy ) image version to Nginx 1.25.2-alpine, Haproxy 3.0.5-alpine