### PR TITLE
feat(calico): add support for numAllowedLocalASNumbers on bgppeers per node definition

### DIFF
--- a/docs/CNI/calico.md
+++ b/docs/CNI/calico.md
@@ -89,8 +89,11 @@ node1 ansible_ssh_host=95.54.0.12 local_as=xxxxxx
 
 Peers can be defined using the `peers` variable (see docs/calico_peer_example examples).
 In order to define global peers, the `peers` variable can be defined in group_vars with the "scope" attribute of each global peer set to "global".
-In order to define peers on a per node basis, the `peers` variable must be defined in hostvars.
+In order to define peers on a per node basis, the `peers` variable must be defined in hostvars or group_vars with the "scope" attribute unset or set to "node".
+
 NB: Ansible's `hash_behaviour` is by default set to "replace", thus defining both global and per node peers would end up with having only per node peers. If having both global and per node peers defined was meant to happen, global peers would have to be defined in hostvars for each host (as well as per node peers)
+
+NB²: Peers definition at node scope can be customized with additional fields `filters`, `sourceAddress` and `numAllowedLocalASNumbers` (see <https://docs.tigera.io/calico/latest/reference/resources/bgppeer> for details)
 
 Since calico 3.4, Calico supports advertising Kubernetes service cluster IPs over BGP, just as it advertises pod IPs.
 This can be enabled by setting the following variable as follow in group_vars (k8s_cluster/k8s-net-calico.yml)

--- a/docs/calico_peer_example/new-york.yml
+++ b/docs/calico_peer_example/new-york.yml
@@ -2,9 +2,13 @@
 # peers:
 #   - router_id: "10.99.0.34"
 #     as: "65xxx"
+#     filters: []
+#     numallowedlocalasnumbers: 0
 #     sourceaddress: "None"
 #   - router_id: "10.99.0.35"
 #     as: "65xxx"
+#     filters: []
+#     numallowedlocalasnumbers: 0
 #     sourceaddress: "None"
 
 # loadbalancer_apiserver:

--- a/docs/calico_peer_example/paris.yml
+++ b/docs/calico_peer_example/paris.yml
@@ -2,9 +2,13 @@
 # peers:
 #   - router_id: "10.99.0.2"
 #     as: "65xxx"
+#     filters: []
+#     numallowedlocalasnumbers: 0
 #     sourceaddress: "None"
 #   - router_id: "10.99.0.3"
 #     as: "65xxx"
+#     filters: []
+#     numallowedlocalasnumbers: 0
 #     sourceaddress: "None"
 
 # loadbalancer_apiserver:

--- a/roles/network_plugin/calico/tasks/peer_with_router.yml
+++ b/roles/network_plugin/calico/tasks/peer_with_router.yml
@@ -100,6 +100,9 @@
         {% if calico_version is version('v3.26.0', '>=') and (item.filters | default([]) | length > 0) %}
         "filters": {{ item.filters }},
         {% endif %}
+        {% if calico_version is version('v3.23.0', '>=') and (item.numallowedlocalasnumbers | default(0) > 0) %}
+        "numAllowedLocalASNumbers": {{ item.numallowedlocalasnumbers }},
+        {% endif %}
         "sourceAddress": "{{ item.sourceaddress | default('UseNodeIP') }}"
       }}
   register: output


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
When using eBGP peering, routes from other nodes using the same ASN as local are not received if numAllowedLocalASNumbers is nil/0 (the default).
This is a problem with IP adresses taken from other nodes' IPAMblocks (with strictAffinity disabled)

**Which issue(s) this PR fixes**:
None that I know of

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
feat(calico): add support for numAllowedLocalASNumbers on bgppeers per node definition
```
