### PR TITLE
Fix dynamic groups definition when using --limit

### DIFF
--- a/playbooks/boilerplate.yml
+++ b/playbooks/boilerplate.yml
@@ -6,50 +6,29 @@
 # - to ensure we keep compatibility with old style group names
 # - to reduce inventory boilerplate (defining parent groups / empty groups)
 
-- name: Add kube-master nodes to kube_control_plane
-  hosts: kube-master
+- name: Define groups for legacy less structured inventories
+  hosts: all
   gather_facts: false
   tags: always
   tasks:
-    - name: Add nodes to kube_control_plane group
+    - name: Match needed groups by their old names or definition
+      vars:
+        group_mappings:
+          kube_control_plane:
+            - kube-master
+          kube_node:
+            - kube-node
+          calico_rr:
+            - calico-rr
+          no_floating:
+            - no-floating
+          k8s_cluster:
+            - kube_node
+            - kube_control_plane
+            - calico_rr
       group_by:
-        key: 'kube_control_plane'
-
-- name: Add kube-node nodes to kube_node
-  hosts: kube-node
-  gather_facts: false
-  tags: always
-  tasks:
-    - name: Add nodes to kube_node group
-      group_by:
-        key: 'kube_node'
-
-- name: Add calico-rr nodes to calico_rr
-  hosts: calico-rr
-  gather_facts: false
-  tags: always
-  tasks:
-    - name: Add nodes to calico_rr group
-      group_by:
-        key: 'calico_rr'
-
-- name: Define k8s_cluster group
-  hosts: kube_node:kube_control_plane:calico_rr
-  gather_facts: false
-  tags: always
-  tasks:
-    - name: Add nodes to k8s_cluster group
-      group_by:
-        key: 'k8s_cluster'
-
-- name: Add no-floating nodes to no_floating
-  hosts: no-floating
-  gather_facts: false
-  tags: always
-  tasks:
-    - name: Add nodes to no-floating group
-      group_by:
-        key: 'no_floating'
+        key: "{{ (group_names | intersect(item.value) | length > 0) | ternary(item.key, '_all') }}"
+      loop: "{{ group_mappings | dict2items }}"
 
 - name: Install bastion ssh config
   hosts: bastion[0]


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Using the hosts directive at the play level prevent those tasks from
being run when using --limit and the group in question is not part of
the limit.

Instead, run on all hosts, and for each group, partition between that
group and '_' (generic group name which is not used; using an empty
string as the group is not supported by ansible.builtin.group_by)


**Special notes for your reviewer**:
This is an alternative take to #11506 which avoids the problem mentionned in [this review](https://github.com/kubernetes-sigs/kubespray/pull/11506/files#r1773145407)
@Adrian-St does this fix your issue ?

**Does this PR introduce a user-facing change?**:
```release-note
Fix the usage of --limit when using legacy groups
```
