### PR TITLE
Update containerd `containerd_max_container_log_line_size` default value to 16384

### DIFF
--- a/docs/developers/ci-setup.md
+++ b/docs/developers/ci-setup.md
@@ -90,7 +90,7 @@ containerd_registries_mirrors:
         capabilities: ["pull", "resolve"]
         skip_verify: false
 
-containerd_max_container_log_line_size: -1
+containerd_max_container_log_line_size: 16384
 
 crio_registries_mirrors:
   - prefix: docker.io

--- a/inventory/sample/group_vars/all/containerd.yml
+++ b/inventory/sample/group_vars/all/containerd.yml
@@ -38,7 +38,7 @@
 #       capabilities: ["pull", "resolve"]
 #       skip_verify: false
 
-# containerd_max_container_log_line_size: -1
+# containerd_max_container_log_line_size: 16384
 
 # containerd_registry_auth:
 #   - registry: 10.0.0.2:5000

--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -59,7 +59,7 @@ containerd_registries_mirrors:
         capabilities: ["pull", "resolve"]
         skip_verify: false
 
-containerd_max_container_log_line_size: -1
+containerd_max_container_log_line_size: 16384
 
 # If enabled it will allow non root users to use port numbers <1024
 containerd_enable_unprivileged_ports: false

--- a/tests/common/_docker_hub_registry_mirror.yml
+++ b/tests/common/_docker_hub_registry_mirror.yml
@@ -15,7 +15,7 @@ containerd_registries_mirrors:
         capabilities: ["pull", "resolve"]
         skip_verify: false
 
-containerd_max_container_log_line_size: -1
+containerd_max_container_log_line_size: 16384
 
 crio_registries:
   - prefix: docker.io


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind feature


**What this PR does / why we need it**:
update containerd `max_container_log_line_size` default value to 16384. 

See https://github.com/containerd/containerd/blob/main/docs/cri/config.md

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[need notice] update containerd `max_container_log_line_size` default value to 16384
```
