### PR TITLE
Multus configuration add namespace isolation

### DIFF
--- a/docs/CNI/multus.md
+++ b/docs/CNI/multus.md
@@ -17,6 +17,12 @@ kube_network_plugin_multus: true
 
 will install Multus and Calico and configure Multus to use Calico as the primary network plugin.
 
+Namespace isolation enables a mode where Multus only allows pods to access custom resources (the `NetworkAttachmentDefinitions`) within the namespace where that pod resides. To enable namespace isolation:
+
+```yml
+multus_namespace_isolation: true
+```
+
 ### Cilium compatibility
 
 If you are using `cilium` as the primary CNI you'll have to set `cilium_cni_exclusive` to `false` to avoid cillium reverting multus config.

--- a/roles/network_plugin/multus/defaults/main.yml
+++ b/roles/network_plugin/multus/defaults/main.yml
@@ -7,3 +7,4 @@ multus_cni_conf_dir: "{{ ('/host', multus_cni_conf_dir_host) | join }}"
 multus_cni_bin_dir: "{{ ('/host', multus_cni_bin_dir_host) | join }}"
 multus_cni_run_dir: "{{ ('/host', multus_cni_run_dir_host) | join }}"
 multus_kubeconfig_file_host: "{{ (multus_cni_conf_dir_host, '/multus.d/multus.kubeconfig') | join }}"
+multus_namespace_isolation: false

--- a/roles/network_plugin/multus/templates/multus-daemonset.yml.j2
+++ b/roles/network_plugin/multus/templates/multus-daemonset.yml.j2
@@ -61,6 +61,7 @@ spec:
         - "--cni-bin-dir={{ multus_cni_bin_dir }}"
         - "--multus-conf-file={{ multus_conf_file }}"
         - "--multus-kubeconfig-file-host={{ multus_kubeconfig_file_host }}"
+        - "--namespace-isolation={{ multus_namespace_isolation | string | lower }}"
         resources:
           requests:
             cpu: "100m"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:

Add the support of network isolation configuration in Multus.

**Which issue(s) this PR fixes**:
Fixes #11594

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE

```release-note
Add the support of network isolation configuration in Multus.
```
