### PR TITLE
Reduce pre-commit hooks dependencies

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -37,3 +37,5 @@ exclude_paths:
   - tests/files/custom_cni/cilium.yaml
   - venv
   - .github
+mock_modules:
+  - gluster.gluster.gluster_volume

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,6 @@ repos:
     hooks:
       - id: ansible-lint
         additional_dependencies:
-          - ansible==9.8.0
           - jsonschema==4.22.0
           - jmespath==1.0.1
           - netaddr==1.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -35,7 +35,7 @@ repos:
         files: "\\.sh$"
 
   - repo: https://github.com/ansible/ansible-lint
-    rev: v24.5.0
+    rev: v24.9.2
     hooks:
       - id: ansible-lint
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,14 +52,6 @@ repos:
 
   - repo: local
     hooks:
-      - id: ansible-syntax-check
-        name: ansible-syntax-check
-        entry: env ANSIBLE_INVENTORY=inventory/local-tests.cfg ANSIBLE_REMOTE_USER=root ANSIBLE_BECOME="true" ANSIBLE_BECOME_USER=root ANSIBLE_VERBOSITY="3" ansible-playbook --syntax-check
-        language: python
-        files: "^cluster.yml|^upgrade-cluster.yml|^reset.yml|^extra_playbooks/upgrade-only-k8s.yml"
-        additional_dependencies:
-          - ansible==9.5.1
-
       - id: tox-inventory-builder
         name: tox-inventory-builder
         entry: bash -c "cd contrib/inventory_builder && tox"

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,3 +1,0 @@
----
-collections:
-  - name: gluster.gluster


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Reduce pre-commit dependencies, and in particular, don't install ansible for ansible-lint (== rely on ansible-core).
This should help catche missing collections requirements in galaxy.yml

See commits for details

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
