### PR TITLE
Always copy cert generation scripts to first etcd

### DIFF
--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -35,7 +35,6 @@
     mode: "0700"
   run_once: true
   when:
-    - gen_certs | default(false)
     - inventory_hostname == groups['etcd'][0]
 
 - name: Gen_certs | run cert generation script for etcd and kube control plane nodes


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
If we don't, existing installation would not pick up fixes to that script, such as #9974 (we we're just bitten by this while upgrading in 2.24.3, despite this being merged since 2.22)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Always copy cert generation script to first etcd to pick up fixes on existing clusters
```
