### PR TITLE
Fix: cannot stop & remove all cri containers via remove_node.yml

### DIFF
--- a/playbooks/remove_node.yml
+++ b/playbooks/remove_node.yml
@@ -27,6 +27,10 @@
   hosts: "{{ node | default('kube_node') }}"
   gather_facts: false
   environment: "{{ proxy_disable_env }}"
+  pre_tasks:
+    - name: Gather information about installed services
+      service_facts:
+      when: reset_nodes | default(True) | bool
   roles:
     - { role: kubespray-defaults, when: reset_nodes | default(True) | bool }
     - { role: remove-node/pre-remove, tags: pre-remove }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

If you use remove_node.yml, deleting the node does not stop the container, and the container will continue to exist on the host.

**Which issue(s) this PR fixes**:

Fixes #11627 

**Special notes for your reviewer**:

I have compared the `remove_node.yml` and `reset.yml` diffs, and before adding these changes, `ansible_facts.services["containerd.service"]` would fail to check for triggering the container stop and delete behaviors.

**Does this PR introduce a user-facing change?**:

```release-note
Fix: cannot stop & remove all cri containers via remove_node.yml
```
