### PR TITLE
Fix calico-node template and remove flexvol-driver initContainer

### DIFF
--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -103,7 +103,6 @@ github_image_repo: "ghcr.io"
 calico_version: "v3.28.1"
 calico_ctl_version: "{{ calico_version }}"
 calico_cni_version: "{{ calico_version }}"
-calico_flexvol_version: "{{ calico_version }}"
 calico_policy_version: "{{ calico_version }}"
 calico_typha_version: "{{ calico_version }}"
 calico_apiserver_version: "{{ calico_version }}"
@@ -238,8 +237,6 @@ calico_node_image_repo: "{{ quay_image_repo }}/calico/node"
 calico_node_image_tag: "{{ calico_version }}"
 calico_cni_image_repo: "{{ quay_image_repo }}/calico/cni"
 calico_cni_image_tag: "{{ calico_cni_version }}"
-calico_flexvol_image_repo: "{{ quay_image_repo }}/calico/pod2daemon-flexvol"
-calico_flexvol_image_tag: "{{ calico_flexvol_version }}"
 calico_policy_image_repo: "{{ quay_image_repo }}/calico/kube-controllers"
 calico_policy_image_tag: "{{ calico_policy_version }}"
 calico_typha_image_repo: "{{ quay_image_repo }}/calico/typha"
@@ -790,15 +787,6 @@ downloads:
     repo: "{{ calico_cni_image_repo }}"
     tag: "{{ calico_cni_image_tag }}"
     sha256: "{{ calico_cni_digest_checksum | default(None) }}"
-    groups:
-      - k8s_cluster
-
-  calico_flexvol:
-    enabled: "{{ kube_network_plugin == 'calico' }}"
-    container: true
-    repo: "{{ calico_flexvol_image_repo }}"
-    tag: "{{ calico_flexvol_image_tag }}"
-    sha256: "{{ calico_flexvol_digest_checksum | default(None) }}"
     groups:
       - k8s_cluster
 

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -13,6 +13,10 @@ spec:
   selector:
     matchLabels:
       k8s-app: calico-node
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       labels:
@@ -30,10 +34,16 @@ spec:
         {{ calico_ds_nodeselector }}
       priorityClassName: system-node-critical
       hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: calico-node
       tolerations:
-      - operator: Exists
+        # Make sure calico-node gets scheduled on all nodes.
+        - effect: NoSchedule
+          operator: Exists
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
@@ -90,9 +100,11 @@ spec:
             # Name of the CNI config file to create.
             - name: CNI_CONF_NAME
               value: "10-calico.conflist"
-            # Install CNI binaries
-            - name: UPDATE_CNI_BINARIES
-              value: "true"
+{% if calico_mtu is defined %}
+            # CNI MTU Config variable
+            - name: CNI_MTU
+              value: "{{ calico_veth_mtu | default(calico_mtu) }}"
+{% endif %}
             # Prevents the container from sleeping forever.
             - name: SLEEP
               value: "false"
@@ -117,14 +129,29 @@ spec:
               name: cni-bin-dir
           securityContext:
             privileged: true
-        # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
-        # to communicate with Felix over the Policy Sync API.
-        - name: flexvol-driver
-          image: {{ calico_flexvol_image_repo }}:{{ calico_flexvol_image_tag }}
+        # This init container mounts the necessary filesystems needed by the BPF data plane
+        # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
+        # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
+        - name: "mount-bpffs"
+          image: {{ calico_node_image_repo }}:{{ calico_node_image_tag }}
           imagePullPolicy: {{ k8s_image_pull_policy }}
+          command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
-            - name: flexvol-driver-host
-              mountPath: /host/driver
+            - mountPath: /sys/fs
+              name: sys-fs
+              # Bidirectional is required to ensure that the new mount we make at /sys/fs/bpf propagates to the host
+              # so that it outlives the init container.
+              mountPropagation: Bidirectional
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              # Bidirectional is required to ensure that the new mount we make at /run/calico/cgroup propagates to the host
+              # so that it outlives the init container.
+              mountPropagation: Bidirectional
+            # Mount /proc/ from host which usually is an init program at /nodeproc. It's needed by mountns binary,
+            # executed by calico-node, to mount root cgroup2 fs at /run/calico/cgroup to attach CTLB programs correctly.
+            - mountPath: /nodeproc
+              name: nodeproc
+              readOnly: true
           securityContext:
             privileged: true
       containers:
@@ -205,10 +232,7 @@ spec:
                   key: calico_backend
             # Cluster type to identify the deployment type
             - name: CLUSTER_TYPE
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: cluster_type
+              value: "k8s,bgp"
             # Set noderef for node controller.
             - name: CALICO_K8S_NODE_REF
               valueFrom:
@@ -230,12 +254,16 @@ spec:
               value: "{{ calico_iptables_backend }}"
             - name: FELIX_IPTABLESLOCKTIMEOUTSECS
               value: "{{ calico_iptables_lock_timeout_secs }}"
-# should be set in etcd before deployment
-#            # Configure the IP Pool from which Pod IPs will be chosen.
-#            - name: CALICO_IPV4POOL_CIDR
-#              value: "{{ calico_pool_cidr | default(kube_pods_subnet) }}"
+            # The default IPv4 pool to create on startup if none exists. Pod IPs will be
+            # chosen from this range. Changing this value after installation will have
+            # no effect. This should fall within `--cluster-cidr`.
+            # - name: CALICO_IPV4POOL_CIDR
+            #   value: "192.168.0.0/16"
             - name: CALICO_IPV4POOL_IPIP
               value: "{{ calico_ipv4pool_ipip }}"
+            # Enable or Disable VXLAN on the default IP pool.
+            - name: CALICO_IPV4POOL_VXLAN
+              value: "Never"
             - name: FELIX_IPV6SUPPORT
               value: "{{ enable_dual_stack_networks | default(false) }}"
             # Set Felix logging to "info"
@@ -391,15 +419,10 @@ spec:
 {% endif %}
             - name: policysync
               mountPath: /var/run/nodeagent
-{% if calico_bpf_enabled %}
             # For eBPF mode, we need to be able to mount the BPF filesystem at /sys/fs/bpf so we mount in the
             # parent directory.
-            - name: sysfs
-              mountPath: /sys/fs/
-              # Bidirectional means that, if we mount the BPF filesystem at /sys/fs/bpf it will propagate to the host.
-              # If the host is known to mount that filesystem already then Bidirectional can be omitted.
-              mountPropagation: Bidirectional
-{% endif %}
+            - name: bpffs
+              mountPath: /sys/fs/bpf
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -456,12 +479,18 @@ spec:
           hostPath:
             path: "/etc/kubernetes/ssl/"
 {% endif %}
-{% if calico_bpf_enabled %}
-        - name: sysfs
+        - name: sys-fs
           hostPath:
             path: /sys/fs/
             type: DirectoryOrCreate
-{% endif %}
+        - name: bpffs
+          hostPath:
+            path: /sys/fs/bpf
+            type: Directory
+        # mount /proc at /nodeproc to be used by mount-bpffs initContainer to mount root cgroup2 fs.
+        - name: nodeproc
+          hostPath:
+            path: /proc
         # Used to access CNI logs.
         - name: cni-log-dir
           hostPath:
@@ -471,12 +500,3 @@ spec:
           hostPath:
             type: DirectoryOrCreate
             path: /var/run/nodeagent
-        # Used to install Flex Volume Driver
-        - name: flexvol-driver-host
-          hostPath:
-            type: DirectoryOrCreate
-            path: "{{ kubelet_flexvolumes_plugins_dir | default('/usr/libexec/kubernetes/kubelet-plugins/volume/exec') }}/nodeagent~uds"
-  updateStrategy:
-    rollingUpdate:
-      maxUnavailable: {{ serial | default('20%') }}
-    type: RollingUpdate


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

update calico-nopde template and remove flexvol-driver initContainer, for calico has abandon it. 

See https://github.com/projectcalico/calico/blob/v3.28.1/manifests/calico.yaml#L4757

The calico-node.yml template file has not been updated and it should follow calico version(currently v3.28.1).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
link https://github.com/projectcalico/calico/issues/9338

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update calico-nopde template and remove flexvol-driver initContainer
```
