### PR TITLE
Make cri-dockerd log level configurable

### DIFF
--- a/roles/container-engine/cri-dockerd/defaults/main.yml
+++ b/roles/container-engine/cri-dockerd/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Default is "info" (like if not provided). Possible values are any log level string parseable by logrus
+cri_dockerd_log_level: "info"

--- a/roles/container-engine/cri-dockerd/templates/cri-dockerd.service.j2
+++ b/roles/container-engine/cri-dockerd/templates/cri-dockerd.service.j2
@@ -7,7 +7,7 @@ Requires=cri-dockerd.socket
 
 [Service]
 Type=notify
-ExecStart={{ bin_dir }}/cri-dockerd --container-runtime-endpoint {{ cri_socket }} --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin --network-plugin=cni --pod-cidr={{ kube_pods_subnet }} --pod-infra-container-image={{ pod_infra_image_repo }}:{{ pod_infra_version }} {% if enable_dual_stack_networks %}--ipv6-dual-stack=True{% endif %}
+ExecStart={{ bin_dir }}/cri-dockerd --container-runtime-endpoint {{ cri_socket }} --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin --network-plugin=cni --pod-cidr={{ kube_pods_subnet }} --pod-infra-container-image={{ pod_infra_image_repo }}:{{ pod_infra_version }} --log-level {{ cri_dockerd_log_level }} {% if enable_dual_stack_networks %}--ipv6-dual-stack=True{% endif %}
 
 ExecReload=/bin/kill -s HUP $MAINPID
 TimeoutSec=0


### PR DESCRIPTION
**What type of PR is this?**
 /kind feature

**What this PR does / why we need it**:
cri-dockerd does log by default at the "info" level which may generate lots of log lines.
This PR makes the log level configurable, leaving the current behaviour unchanged by setting the "info" as the default for the corresponding Ansible variable.

**Which issue(s) this PR fixes**:
None that I know of

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Make cri-dockerd log level configurable
```