### PR TITLE
Feat: CoreDNS upgrade to v1.11.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [kube-vip](https://github.com/kube-vip/kube-vip) v0.8.0
 - Application
   - [cert-manager](https://github.com/jetstack/cert-manager) v1.14.7
-  - [coredns](https://github.com/coredns/coredns) v1.11.1
+  - [coredns](https://github.com/coredns/coredns) v1.11.3
   - [ingress-nginx](https://github.com/kubernetes/ingress-nginx) v1.11.2
   - [krew](https://github.com/kubernetes-sigs/krew) v0.4.4
   - [argocd](https://argoproj.github.io/) v2.11.0

--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -295,7 +295,7 @@ haproxy_image_tag: 2.8.2-alpine
 # Coredns version should be supported by corefile-migration (or at least work with)
 # bundle with kubeadm; if not 'basic' upgrade can sometimes fail
 
-coredns_version: "{{ 'v1.11.1' if (kube_version is version('v1.29.0', '>=')) else 'v1.10.1' }}"
+coredns_version: "{{ 'v1.11.3' if (kube_version is version('v1.30.0', '>=')) else 'v1.11.1' }}"
 coredns_image_is_namespaced: "{{ (coredns_version is version('v1.7.1', '>=')) }}"
 
 coredns_image_repo: "{{ kube_image_repo }}{{ '/coredns/coredns' if (coredns_image_is_namespaced | bool) else '/coredns' }}"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

CoreDNS upgrade to v1.11.3 and Kubernetes v1.31 already support it.

**Which issue(s) this PR fixes**:

Fixes #11639

**Special notes for your reviewer**:

https://github.com/kubernetes/kubernetes/pull/126796

**Does this PR introduce a user-facing change?**:

```release-note
Upgrade CoreDNS version to v1.11.3
```
