### PR TITLE
Adds `nodelocaldns_additional_configs` to facilitate additional CoreDNS config options

### DIFF
--- a/docs/advanced/dns-stack.md
+++ b/docs/advanced/dns-stack.md
@@ -64,6 +64,10 @@ Custom options to be added to the kubernetes coredns plugin.
 
 Extra domains to be forwarded to the kubernetes coredns plugin.
 
+### coredns_additional_configs
+
+Extra configuration to be added to CoreDNS configuration
+
 ### coredns_rewrite_block
 
 [Rewrite](https://coredns.io/plugins/rewrite/) plugin block to perform internal message rewriting.
@@ -289,6 +293,10 @@ nodelocaldns_external_zones:
 ### dns_etchosts (nodelocaldns)
 
 See [dns_etchosts](#dns_etchosts-coredns) above.
+
+### nodelocaldns_additional_configs
+
+Extra configuration to be added to CoreDNS configuration
 
 ### Nodelocal DNS HA
 

--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -55,6 +55,11 @@ nodelocaldns_ds_nodeselector: "kubernetes.io/os: linux"
 nodelocaldns_prometheus_port: 9253
 nodelocaldns_secondary_prometheus_port: 9255
 
+# nodelocaldns_additional_configs adds any extra configuration to coredns
+# nodelocaldns_additional_configs: |
+#   whoami
+#   local
+
 # Limits for dns-autoscaler
 dns_autoscaler_cpu_requests: 20m
 dns_autoscaler_memory_requests: 10Mi

--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2
@@ -75,6 +75,9 @@ data:
         prometheus {% if nodelocaldns_bind_metrics_host_ip %}{$MY_HOST_IP}{% endif %}:{{ nodelocaldns_prometheus_port }}
     }
     .:53 {
+{% if nodelocaldns_additional_configs is defined %}
+        {{ nodelocaldns_additional_configs | indent(width=8, first=False) }}
+{% endif %}
         errors
         cache 30
         reload
@@ -157,6 +160,9 @@ data:
         prometheus {% if nodelocaldns_bind_metrics_host_ip %}{$MY_HOST_IP}{% endif %}:{{ nodelocaldns_secondary_prometheus_port }}
     }
     .:53 {
+{% if nodelocaldns_additional_configs is defined %}
+        {{ nodelocaldns_additional_configs | indent(width=8, first=False) }}
+{% endif %}
         errors
         cache 30
         reload


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds an extra variable `nodelocaldns_additional_configs` to allow additional config to be added to the node-local DNS CoreDNS config, just as can be done with normal CoreDNS config with variable `coredns_additional_configs`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

**Special notes for your reviewer**:

Could we simply reuse the existing variable `coredns_additional_configs` here instead of adding a new variable?

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Adds `nodelocaldns_additional_configs` variable
```
