### PR TITLE
Add support for ntpsec

### DIFF
--- a/docs/advanced/ntp.md
+++ b/docs/advanced/ntp.md
@@ -53,5 +53,4 @@ When using Ubuntu 24.04 or a distribution that already has `systemd-timesyncd` i
 
 ```ShellSession
 ntp_package: ntpsec
-ntp_driftfile: /var/lib/ntpsec/ntp.drift
 ```

--- a/docs/advanced/ntp.md
+++ b/docs/advanced/ntp.md
@@ -48,3 +48,10 @@ Force sync time immediately by NTP after the ntp installed, which is useful in n
 ```ShellSession
 ntp_force_sync_immediately: true
 ```
+
+When using Ubuntu 24.04 or a distribution that already has `systemd-timesyncd` installed, use the `ntpsec` package.
+
+```ShellSession
+ntp_package: ntpsec
+ntp_driftfile: /var/lib/ntpsec/ntp.drift
+```

--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -64,7 +64,7 @@ ping_access_ip: true
 ntp_enabled: false
 # The package to install which provides NTP functionality.
 # The default is ntp for most platforms, or chrony on RHEL/CentOS 7 and later.
-# The ntp_package can be one of ['ntp', 'chrony']
+# The ntp_package can be one of ['ntp', 'ntpsec', 'chrony']
 ntp_package: >-
       {% if ansible_os_family == "RedHat" -%}
       chrony
@@ -95,6 +95,7 @@ ntp_filter_interface: false
 #   - listen xxx
 # The NTP driftfile path
 # Only takes effect when ntp_manage_config is true.
+# For ntpsec use '/var/lib/ntpsec/ntp.drift'
 ntp_driftfile: /var/lib/ntp/ntp.drift
 # Enable tinker panic is useful when running NTP in a VM environment.
 # Only takes effect when ntp_manage_config is true.

--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -95,9 +95,13 @@ ntp_filter_interface: false
 #   - listen xxx
 # The NTP driftfile path
 # Only takes effect when ntp_manage_config is true.
-# For ntpsec use '/var/lib/ntpsec/ntp.drift'
-ntp_driftfile: /var/lib/ntp/ntp.drift
-# Enable tinker panic is useful when running NTP in a VM environment.
+# Default value is `/var/lib/ntp/ntp.drift`, for ntpsec use '/var/lib/ntpsec/ntp.drift'
+ntp_driftfile: >-
+      {% if ntp_package == "ntpsec" -%}
+      /var/lib/ntpsec/ntp.drift
+      {%- else -%}
+      /var/lib/ntp/ntp.drift
+      {%- endif -%}
 # Only takes effect when ntp_manage_config is true.
 ntp_tinker_panic: false
 

--- a/roles/kubernetes/preinstall/tasks/0081-ntp-configurations.yml
+++ b/roles/kubernetes/preinstall/tasks/0081-ntp-configurations.yml
@@ -21,6 +21,8 @@
     ntp_config_file: >-
       {% if ntp_package == "ntp" -%}
       /etc/ntp.conf
+      {%- elif ntp_package == "ntpsec" -%}
+      /etc/ntpsec/ntp.conf
       {%- elif ansible_os_family in ['RedHat', 'Suse'] -%}
       /etc/chrony.conf
       {%- else -%}
@@ -56,10 +58,10 @@
   # noqa: jinja[spacing]
   command: >-
       timeout -k 60s 60s
-      {% if ntp_package == "ntp" -%}
-      ntpd -gq
-      {%- else -%}
+      {% if ntp_package == "chrony" -%}
       chronyd -q
+      {%- else -%}
+      ntpd -gq
       {%- endif -%}
   when:
     - ntp_force_sync_immediately


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

Adds support for `ntpsec`, required for using ntp when running on Ubuntu 24.04 or when `systemd-timesyncd` is already installed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added support for using ntpsec
```
