### PR TITLE
Remove `shell` module usage from CI testcases

### DIFF
--- a/tests/testcases/030_check-network.yml
+++ b/tests/testcases/030_check-network.yml
@@ -20,29 +20,29 @@
     when:
     - kubelet_rotate_server_certificates | default(false)
     - kubelet_csr_approver_enabled | default(kubelet_rotate_server_certificates | default(false))
+    vars:
+      csrs: "{{ csr_json.stdout | from_json }}"
     block:
 
     - name: Get certificate signing requests
-      command: "{{ bin_dir }}/kubectl get csr"
-      register: get_csr
+      command: "{{ bin_dir }}/kubectl get csr -o jsonpath-as-json={.items[*]}"
+      register: csr_json
       changed_when: false
 
     - debug:  # noqa name[missing]
-        msg: "{{ get_csr.stdout.split('\n') }}"
+        var: csrs
 
     - name: Check there are csrs
       assert:
-        that: get_csr.stdout_lines | length > 0
+        that: csrs | length > 0
         fail_msg: kubelet_rotate_server_certificates is {{ kubelet_rotate_server_certificates }} but no csr's found
-
-    - name: Get Denied/Pending certificate signing requests
-      shell: "set -o pipefail && {{ bin_dir }}/kubectl get csr | grep -e Denied -e Pending || true"
-      register: get_csr_denied_pending
-      changed_when: false
 
     - name: Check there are Denied/Pending csrs
       assert:
-        that: get_csr_denied_pending.stdout_lines | length == 0
+        that:
+        - csrs | rejectattr('status') | length == 0 # Pending == no status
+        - csrs | map(attribute='status.conditions') | flatten | selectattr('type', 'equalto', 'Denied') | length == 0 # Denied
+
         fail_msg: kubelet_csr_approver is enabled but CSRs are not approved
 
   - name: Approve kubelet serving certificates
@@ -76,10 +76,9 @@
     changed_when: false
 
   - name: Run 2 agnhost pods in test ns
-    shell:
-      cmd: |
-        set -o pipefail
-        cat <<EOF | {{ bin_dir }}/kubectl apply -f -
+    command:
+      cmd: "{{ bin_dir }}/kubectl apply -f -"
+      stdin: |
         apiVersion: v1
         kind: Pod
         metadata:
@@ -98,8 +97,6 @@
               runAsNonRoot: true
               seccompProfile:
                 type: RuntimeDefault
-        EOF
-      executable: /bin/bash
     changed_when: false
     loop:
     - agnhost1

--- a/tests/testcases/030_check-network.yml
+++ b/tests/testcases/030_check-network.yml
@@ -75,16 +75,6 @@
     command: "{{ bin_dir }}/kubectl create namespace test"
     changed_when: false
 
-  - name: Wait for API token of test namespace
-    shell: "set -o pipefail && {{ bin_dir }}/kubectl describe serviceaccounts default --namespace test | grep Tokens | awk '{print $2}'"
-    args:
-      executable: /bin/bash
-    changed_when: false
-    register: default_token
-    until: default_token.stdout | length > 0
-    retries: 5
-    delay: 5
-
   - name: Run 2 agnhost pods in test ns
     shell:
       cmd: |

--- a/tests/testcases/040_check-network-adv.yml
+++ b/tests/testcases/040_check-network-adv.yml
@@ -3,12 +3,15 @@
   hosts: kube_node
   tasks:
     - name: Test tunl0 routes
-      shell: "set -o pipefail && ! /sbin/ip ro | grep '/{{ calico_pool_blocksize }} | default(26) via' | grep -v tunl0"
-      args:
-        executable: /bin/bash
+      command: "/sbin/ip route"
+      register: routes
+      failed_when: routes.stdout_lines
+        | select('contains', '/' ~ calico_pool_blocksize|d(26))
+        | select('contains', 'tunl0') | length == 0
       when:
         - (calico_ipip_mode is defined and calico_ipip_mode != 'Never' or cloud_provider is defined)
         - kube_network_plugin | default('calico') == 'calico'
+
 
 - name: Advanced testcases for network
   hosts: k8s_cluster
@@ -32,24 +35,14 @@
         name: cluster-dump
 
     - name: Wait for netchecker server
-      shell: "set -o pipefail && {{ bin_dir }}/kubectl get pods -o wide --namespace {{ netcheck_namespace }} | grep ^netchecker-server"
-      args:
-        executable: /bin/bash
-      register: ncs_pod
-      until: ncs_pod.stdout.find('Running') != -1
+      command: "{{ bin_dir }}/kubectl get pods --field-selector=status.phase==Running -o jsonpath-as-json={.items[*].metadata.name} --namespace {{ netcheck_namespace }}"
+      register: pods_json
+      until:
+        - pods_json.stdout | from_json | select('match', 'netchecker-server.*') | length == 1
+        - (pods_json.stdout | from_json | select('match', 'netchecker-agent.*') | length)
+          >= (groups['k8s_cluster'] | intersect(ansible_play_hosts) | length * 2)
       retries: 3
       delay: 10
-      when: inventory_hostname == groups['kube_control_plane'][0]
-
-    - name: Wait for netchecker agents
-      shell: "set -o pipefail && {{ bin_dir }}/kubectl get pods -o wide --namespace {{ netcheck_namespace }} | grep '^netchecker-agent-.*Running'"
-      args:
-        executable: /bin/bash
-      register: nca_pod
-      until: nca_pod.stdout_lines | length >= groups['k8s_cluster'] | intersect(ansible_play_hosts) | length * 2
-      retries: 3
-      delay: 10
-      failed_when: false
       when: inventory_hostname == groups['kube_control_plane'][0]
 
     - name: Get netchecker pods
@@ -60,7 +53,7 @@
       with_items:
         - netchecker-agent
         - netchecker-agent-hostnet
-      when: not nca_pod is success
+      when: not pods_json is success
 
     - debug:  # noqa name[missing]
         var: nca_pod.stdout_lines
@@ -99,7 +92,7 @@
         - agents.content != '{}'
 
     - debug:  # noqa name[missing]
-        var: ncs_pod
+        var: pods_json
       run_once: true
 
     - name: Get kube-proxy logs
@@ -169,14 +162,9 @@
       run_once: true
 
     - name: Create macvlan network conf
-      # We cannot use only shell: below because Ansible will render the text
-      # with leading spaces, which means the shell will never find the string
-      # EOF at the beginning of a line. We can avoid Ansible's unhelpful
-      # heuristics by using the cmd parameter like this:
-      shell:
-        cmd: |
-          set -o pipefail
-          cat <<EOF | {{ bin_dir }}/kubectl create -f -
+      command:
+        cmd: "{{ bin_dir }}/kubectl create -f -"
+        stdin: |
           apiVersion: "k8s.cni.cncf.io/v1"
           kind: NetworkAttachmentDefinition
           metadata:
@@ -198,21 +186,7 @@
               "gateway": "192.168.1.1"
             }
           }'
-          EOF
-        executable: /bin/bash
-      when:
-        - inventory_hostname == groups['kube_control_plane'][0]
-        - kube_network_plugin_multus | default(false) | bool
-
-    - name: Annotate pod with macvlan network
-      # We cannot use only shell: below because Ansible will render the text
-      # with leading spaces, which means the shell will never find the string
-      # EOF at the beginning of a line. We can avoid Ansible's unhelpful
-      # heuristics by using the cmd parameter like this:
-      shell:
-        cmd: |
-          set -o pipefail
-          cat <<EOF | {{ bin_dir }}/kubectl create -f -
+          ---
           apiVersion: v1
           kind: Pod
           metadata:
@@ -224,8 +198,6 @@
             - name: samplepod
               command: ["/bin/bash", "-c", "sleep 2000000000000"]
               image: dougbtv/centos-network
-          EOF
-        executable: /bin/bash
       when:
         - inventory_hostname == groups['kube_control_plane'][0]
         - kube_network_plugin_multus | default(false) | bool


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Cleanup of the the test/testcases/030-040.

**Special notes for your reviewer**:
This is motivated by the test failures in #11530 (specifically: https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/8143741647)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/label ci-full
/label tide/merge-method-merge
