### PR TITLE
etcd: throttle restart for availability

### DIFF
--- a/roles/etcd/handlers/main.yml
+++ b/roles/etcd/handlers/main.yml
@@ -15,13 +15,19 @@
     state: restarted
   when: ('etcd' in group_names)
   listen: Restart etcd
+  throttle: "{{ groups['etcd'] | length // 2 }}"
+  # Etcd cluster MUST have an odd number of members
+  # Truncated integer division by 2 will always return (majority - 1) which
+  # means the cluster will keep quorum and stay available
 
 - name: Reload etcd-events
   service:
     name: etcd-events
     state: restarted
+  # TODO: this seems odd. etcd-events should be a different group possibly ?
   when: ('etcd' in group_names)
   listen: Restart etcd-events
+  throttle: "{{ groups['etcd'] | length // 2 }}"
 
 - name: Wait for etcd up
   uri:

--- a/roles/etcd/handlers/main.yml
+++ b/roles/etcd/handlers/main.yml
@@ -2,31 +2,24 @@
 - name: Backup etcd
   import_tasks: backup.yml
 
-- name: Etcd | reload systemd
+- name: Restart etcd
   systemd_service:
-    daemon_reload: true
-  listen:
-    - Restart etcd
-    - Restart etcd-events
-
-- name: Reload etcd
-  service:
     name: etcd
     state: restarted
+    daemon_reload: true
   when: ('etcd' in group_names)
-  listen: Restart etcd
   throttle: "{{ groups['etcd'] | length // 2 }}"
   # Etcd cluster MUST have an odd number of members
   # Truncated integer division by 2 will always return (majority - 1) which
   # means the cluster will keep quorum and stay available
 
-- name: Reload etcd-events
-  service:
+- name: Restart etcd-events
+  systemd_service:
     name: etcd-events
     state: restarted
+    daemon_reload: true
   # TODO: this seems odd. etcd-events should be a different group possibly ?
   when: ('etcd' in group_names)
-  listen: Restart etcd-events
   throttle: "{{ groups['etcd'] | length // 2 }}"
 
 - name: Wait for etcd up


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
During upgrade, etcd member are restarted all at once.
This can impact the availability of the etcd cluster and subsequently of
the Kubernetes cluster.

Limit the concurrent restart so that the etcd cluster can keep quorum.


**Which issue(s) this PR fixes**:
Fixes #11645

**Does this PR introduce a user-facing change?**:
```release-note
HA etcd cluster keeps quorum during upgrades.
```
