### PR TITLE
Add a new crio_root variable in order to store CRI-O data on somethin…

### DIFF
--- a/roles/container-engine/cri-o/defaults/main.yml
+++ b/roles/container-engine/cri-o/defaults/main.yml
@@ -39,6 +39,8 @@ crio_stream_port: "10010"
 
 crio_required_version: "{{ kube_version | regex_replace('^v(?P<major>\\d+).(?P<minor>\\d+).(?P<patch>\\d+)$', '\\g<major>.\\g<minor>') }}"
 
+crio_root: "/var/lib/containers/storage"
+
 # The crio_runtimes variable defines a list of OCI compatible runtimes.
 crio_runtimes:
   - name: crun

--- a/roles/container-engine/cri-o/templates/crio.conf.j2
+++ b/roles/container-engine/cri-o/templates/crio.conf.j2
@@ -17,7 +17,7 @@
 
 # Path to the "root directory". CRI-O stores all of its data, including
 # containers images, in this directory.
-root = "/var/lib/containers/storage"
+root = "{{ crio_root }}"
 
 # Path to the "run directory". CRI-O stores all of its state in this directory.
 # Read from /etc/containers/storage.conf first so unnecessary here


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
This change give the opportunity to change the CRI-O storage location.

**Which issue(s) this PR fixes**:
https://github.com/kubernetes-sigs/kubespray/issues/11686

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Add a new CRI-O `crio_root` variable
```
