### PR TITLE
Fix pretty-printing of coredns and nodelocaldns configmaps

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -73,7 +73,9 @@ data:
           max_concurrent 1000
 {% if dns_upstream_forward_extra_opts is defined %}
 {% for optname, optvalue in dns_upstream_forward_extra_opts.items() %}
-          {{ optname }} {{ optvalue }}
+          {{ (optname ~ ' ' ~ optvalue) | trim }}
+          {# do not add a trailing space when optvalue == ''
+             workaround for: https://github.com/kubernetes/kubernetes/issues/36222 #}
 {% endfor %}
 {% endif %}
         }

--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2
@@ -82,7 +82,9 @@ data:
         bind {{ nodelocaldns_ip }}
         forward . {{ upstreamForwardTarget }}{% if dns_upstream_forward_extra_opts is defined %} {
 {% for optname, optvalue in dns_upstream_forward_extra_opts.items() %}
-          {{ optname }} {{ optvalue }}
+          {{ (optname ~ ' ' ~ optvalue) | trim }}
+          {# do not add a trailing space when optvalue == ''
+             workaround for: https://github.com/kubernetes/kubernetes/issues/36222 #}
 {% endfor %}
         }{% endif %}
 
@@ -164,7 +166,9 @@ data:
         bind {{ nodelocaldns_ip }}
         forward . {{ upstreamForwardTarget }}{% if dns_upstream_forward_extra_opts is defined %} {
 {% for optname, optvalue in dns_upstream_forward_extra_opts.items() %}
-          {{ optname }} {{ optvalue }}
+          {{ (optname ~ ' ' ~ optvalue) | trim }}
+          {# do not add a trailing space when optvalue == ''
+             workaround for: https://github.com/kubernetes/kubernetes/issues/36222 #}
 {% endfor %}
         }{% endif %}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When using
```
dns_upstream_forward_extra_opts:
  prefer_udp: "" # the option as no value so use empty string to just
                 # put the key
```

This is rendered in the dns configmap as ($ for end-of-line)

...
  prefer_udp $
...

Note the trailing space.
This triggers https://github.com/kubernetes/kubernetes/issues/36222,
which makes the configmap hardly readable when editing them manually or
simply putting them in a yaml file for inspection.

Trim the concatenation of option + value to get rid of any trailing
space.
Example of kubectl edit on such a configmap:

```
  Corefile: ".:53 {\n    errors {\n    }\n    health {\n        lameduck 5s\n    }\n
    \   rewrite name suffix <redacted> cluster.local answer auto\n    ready\n    kubernetes
    cluster.local in-addr.arpa ip6.arpa {\n      pods insecure\n      fallthrough
    in-addr.arpa ip6.arpa\n    }\n    prometheus :9153\n    forward . <redacted>
    <redacted> {\n      prefer_udp\n      max_concurrent 1000\n      prefer_udp
    \n    }\n    cache 30\n\n    loop\n    reload\n    loadbalance\n}\n"
```


**Special notes for your reviewer**:
This is pretty minor, but pretty annoying !

**Does this PR introduce a user-facing change?**:
```release-note
Fix pretty-printing (in kubectl) of nodelocaldns and coredns configmap when using `dns_upstream_forward_extra_opts` with an empty value option.
```
