### PR TITLE
Bump: pause container upgrade to 3.10

### DIFF
--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -131,7 +131,7 @@ skopeo_version: "v1.16.1"
 kube_major_version: "{{ kube_version | regex_replace('^v([0-9])+\\.([0-9]+)\\.[0-9]+', 'v\\1.\\2') }}"
 
 pod_infra_supported_versions:
-  v1.31: "3.9"
+  v1.31: "3.10"
   v1.30: "3.9"
   v1.29: "3.9"
 pod_infra_version: "{{ pod_infra_supported_versions[kube_major_version] }}"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Upgrade pause container to 3.10

**Special notes for your reviewer**:

Although this version doesn't affect Linux-based much, we want to keep it the same version as Kubernetes.

- https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md
- https://github.com/kubernetes/kubernetes/pull/125112

**Does this PR introduce a user-facing change?**:

```release-note
Upgrade pause container to 3.10
```
