### PR TITLE
Make kubespray authoritative on node taints

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -64,6 +64,8 @@
   * [Ingress Nginx](/docs/ingress/ingress_nginx.md)
   * [Kube-vip](/docs/ingress/kube-vip.md)
   * [Metallb](/docs/ingress/metallb.md)
+* Manage Your Inventory
+  * [Dedicated Node Groups](/docs/manage_your_inventory/dedicated_node_groups.md)
 * Operating Systems
   * [Amazonlinux](/docs/operating_systems/amazonlinux.md)
   * [Bootstrap-os](/docs/operating_systems/bootstrap-os.md)

--- a/docs/manage_your_inventory/dedicated_node_groups.md
+++ b/docs/manage_your_inventory/dedicated_node_groups.md
@@ -1,0 +1,20 @@
+# Dedicated node groups
+
+To reserved some nodes for particular workload (for instances, reserved GPU node for workload using them), you should
+define an Ansible group for theses nodes (statically or dynamically) and set taints and labels for these those in your inventory,
+using [Ansible group variable](https://docs.ansible.com/ansible/latest/inventory_guide/intro_inventory.html#assigning-a-variable-to-many-machines-group-variables).
+
+See below for concrete examples.
+
+## Nvidia GPU
+
+When using the Nvidia GPU support in kubespray, the nodes should have the following variables set:
+
+```yaml
+node_taints:
+- key: nvidia.com/gpu
+  effect: NoSchedule
+  ... (any other node taints)
+```
+
+TODO: add the same for labels once

--- a/roles/kubernetes/node-taint/defaults/main.yml
+++ b/roles/kubernetes/node-taint/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+# node_taints:
+# - key: example.com/some_key
+#   value: some_value
+#   effect: NoSchedule
+# - key: example.com/other_key
+#   effect: NoExecute
+# The structure is identical to the kubernetes API object
+# https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodespec-v1-core (taints field)
+node_taints: []

--- a/roles/kubernetes/node-taint/tasks/main.yml
+++ b/roles/kubernetes/node-taint/tasks/main.yml
@@ -1,35 +1,29 @@
 ---
-- name: Set role and inventory node taint to empty list
-  set_fact:
-    role_node_taints: []
-    inventory_node_taints: []
-
-- name: Node taint for nvidia GPU nodes
-  set_fact:
-    role_node_taints: "{{ role_node_taints + ['nvidia.com/gpu=:NoSchedule'] }}"
-  when:
-    - nvidia_gpu_nodes is defined
-    - nvidia_accelerator_enabled | bool
-    - inventory_hostname in nvidia_gpu_nodes
-
-- name: Populate inventory node taint
-  set_fact:
-    inventory_node_taints: "{{ inventory_node_taints + ['%s' | format(item)] }}"
-  loop: "{{ node_taints | d([]) }}"
-  when:
-    - node_taints is defined
-    - node_taints is not string
-    - node_taints is not mapping
-    - node_taints is iterable
-- debug:  # noqa name[missing]
-    var: role_node_taints
-- debug:  # noqa name[missing]
-    var: inventory_node_taints
-
-- name: Set taint to node
-  command: >-
-      {{ kubectl }} taint node {{ kube_override_hostname | default(inventory_hostname) }} {{ (role_node_taints + inventory_node_taints) | join(' ') }} --overwrite=true
+- name: Get current node taints
+  command: "{{ kubectl }} get node {{ kube_override_hostname }} -o jsonpath-as-json={.spec.taints[]}"
+  register: current_taints
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
-  changed_when: false
-  when:
-    - (role_node_taints + inventory_node_taints) | length > 0
+
+- name: Set node taints
+  command: "{{ kubectl }} patch node {{ kube_override_hostname }} --type json -p '{{ patch | to_json }}'"
+  register: patch_cmd_result
+  changed_when: patch_cmd_result.stdout == "patched"
+  # https://github.com/kubernetes/kubernetes/blob/2691a29eacb6cc0d115eb773fb86825b9929f63d/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go#L353-L358
+  vars:
+    patch:
+    - op: replace
+      path: /spec/taints
+      value: "{{ _node_taints + reserved_taints }}"
+    # Preserve kubernetes reserved taints only
+    reserved_taints: "{{ current_taints.stdout | from_json | selectattr('key', 'match', '([-a-z0-9]+.)*(kubernetes|k8s)\\.io/.*') }}"
+    # Compatibility layer for taints as string (instead of {key: "", value:, effect} dict)
+    # TODO: remove after release 2.27.0
+    _node_taints: "{{ _parsed_taints if ((node_taints | select('string')) != []) else node_taints }}"
+    _parsed_taints: "{{ node_taints
+        | map('ansible.builtin.regex_search',
+                  '(([-a-z09.]+/)?[-0-9a-z._]+)=([-a-z0-9._]+)?:(NoSchedule|PreferNoSchedule|NoExecute)',
+                  '\\1', '\\3', '\\4')
+        | map('zip', ['key', 'value', 'effect'])
+        | map('map', 'reverse')
+        | map('community.general.dict') }}"
+  delegate_to: "{{ groups['kube_control_plane'][0] }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Currently, we only add/modify taints to nodes (not remove). This mean is
users remove taints from their kubespray inventories, they also have to
remove them manually from their clusters.

Switch to replacing the entire taints array by patching 'spec.taints';
we do preserve Kubernetes reserved taints
(https://kubernetes.io/docs/reference/labels-annotations-taints/).

The string from for providing the annotations is more complicated to
manipulate, in kubespray or in users inventory.

Deprecate the string form in favor of reusing the structure of the
Kubernetes API. We keep a compatibily layer which parse the string
on-the-fly, which we should remove in the N+1 release (N=next relase)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Kinda follow-up to #10705 @maxime1907 would love to hear your thoughts

Regarding the nvidia bits. Setting a boolean is marginally easier, but why not just ask users to have the nvidia taints in their group_vars for their nvidia nodes and just scrap those variables ? => and just add that to documentation ? Wdyt ?

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
action required
Using `node_taints` as a string array is deprecated. See roles/kubernetes/node-taint/defaults/main.yml for the new format. 
Kubespray will now be authoritative on node taints, which means taints not defined in kubespray will be removed (except kubernetes.io/k8s.io prefixed taints)
The variable `nvidia_gpu_nodes` is not used anymore to set node taints. Instead, directly [set them in your inventory](docs/manage_your_inventory/dedicated_node_groups.md)
```
