### PR TITLE
Disable blank issue option in Github UI

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,5 @@
 ---
+blank_issues_enabled: false
 contact_links:
   - name: Support Request
     url: https://kubernetes.slack.com/channels/kubespray


### PR DESCRIPTION
**What this PR does / why we need it**:
We're still getting bug reports circumventing the bug report template
and omitting informations.

Blank issue (aka, not using the form templates) can still be created
using the gh cli, the API, etc. This only disable the possibility in the
Web UI.

**Special notes for your reviewer**:
Personnaly, I'd rather get no issues than unactionnable ones.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/label ci-short
