### PR TITLE
Remove no_log in CI tests

### DIFF
--- a/tests/testcases/015_check-nodes-ready.yml
+++ b/tests/testcases/015_check-nodes-ready.yml
@@ -20,7 +20,6 @@
     command: "{{ bin_dir }}/kubectl get nodes"
     changed_when: false
     register: get_nodes
-    no_log: true
 
   - debug:  # noqa name[missing]
       msg: "{{ get_nodes.stdout.split('\n') }}"

--- a/tests/testcases/020_check-pods-running.yml
+++ b/tests/testcases/020_check-pods-running.yml
@@ -20,7 +20,6 @@
     command: "{{ bin_dir }}/kubectl get pods --all-namespaces -owide"
     changed_when: false
     register: get_pods
-    no_log: true
 
   - debug:  # noqa name[missing]
       msg: "{{ get_pods.stdout.split('\n') }}"
@@ -37,13 +36,11 @@
     retries: 30
     delay: 10
     failed_when: false
-    no_log: true
 
   - name: Check kubectl output
     command: "{{ bin_dir }}/kubectl get pods --all-namespaces -owide"
     changed_when: false
     register: get_pods
-    no_log: true
 
   - debug:  # noqa name[missing]
       msg: "{{ get_pods.stdout.split('\n') }}"

--- a/tests/testcases/030_check-network.yml
+++ b/tests/testcases/030_check-network.yml
@@ -117,13 +117,11 @@
     retries: 18
     delay: 10
     failed_when: false
-    no_log: true
 
   - name: Get pod names
     command: "{{ bin_dir }}/kubectl get pods -n test -o json"
     changed_when: false
     register: pods
-    no_log: true
 
   - debug:  # noqa name[missing]
       msg: "{{ pods.stdout.split('\n') }}"
@@ -135,20 +133,17 @@
     changed_when: false
     register: hostnet_pods
     ignore_errors: true  # noqa ignore-errors
-    no_log: true
 
   - name: Get running pods
     command: "{{ bin_dir }}/kubectl get pods -n test -o
             jsonpath='{range .items[?(.status.phase==\"Running\")]}{.metadata.name} {.status.podIP} {.status.containerStatuses} {end}'"
     changed_when: false
     register: running_pods
-    no_log: true
 
   - name: Check kubectl output
     command: "{{ bin_dir }}/kubectl get pods --all-namespaces -owide"
     changed_when: false
     register: get_pods
-    no_log: true
 
   - debug:  # noqa name[missing]
       msg: "{{ get_pods.stdout.split('\n') }}"

--- a/tests/testcases/040_check-network-adv.yml
+++ b/tests/testcases/040_check-network-adv.yml
@@ -49,7 +49,6 @@
       command: "{{ bin_dir }}/kubectl -n {{ netcheck_namespace }} describe pod -l app={{ item }}"
       run_once: true
       delegate_to: "{{ groups['kube_control_plane'][0] }}"
-      no_log: false
       with_items:
         - netchecker-agent
         - netchecker-agent-hostnet
@@ -72,7 +71,6 @@
         agents.content[0] == '{' and
         agents.content | from_json | length >= groups['k8s_cluster'] | intersect(ansible_play_hosts) | length * 2
       failed_when: false
-      no_log: false
 
     - name: Check netchecker status
       uri:
@@ -86,7 +84,6 @@
       delay: "{{ agent_report_interval }}"
       until: connectivity_check.content | length > 0 and
         connectivity_check.content[0] == '{'
-      no_log: false
       failed_when: false
       when:
         - agents.content != '{}'
@@ -97,7 +94,6 @@
 
     - name: Get kube-proxy logs
       command: "{{ bin_dir }}/kubectl -n kube-system logs -l k8s-app=kube-proxy"
-      no_log: false
       when:
         - inventory_hostname == groups['kube_control_plane'][0]
         - not connectivity_check is success
@@ -107,7 +103,6 @@
       when:
         - inventory_hostname == groups['kube_control_plane'][0]
         - not connectivity_check is success
-      no_log: false
       with_items:
         - kube-router
         - flannel

--- a/tests/testcases/roles/cluster-dump/tasks/main.yml
+++ b/tests/testcases/roles/cluster-dump/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 - name: Generate dump folder
   command: "{{ bin_dir }}/kubectl cluster-info dump --all-namespaces --output-directory /tmp/cluster-dump"
-  no_log: true
   when: inventory_hostname in groups['kube_control_plane']
 
 - name: Compress directory cluster-dump


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
We always want to see the logs in the CI.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/label ci-short
