### PR TITLE
remove nameless extraArgs entry

### DIFF
--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
@@ -85,8 +85,6 @@ etcd:
     - name: {{ key }}
       value: "{{ value }}"
 {% endfor %}
-    - name:
-      value:
     serverCertSANs:
 {% for san in etcd_cert_alt_names %}
       - "{{ san }}"

--- a/roles/kubernetes/kubeadm/tasks/kubeadm_etcd_node.yml
+++ b/roles/kubernetes/kubeadm/tasks/kubeadm_etcd_node.yml
@@ -6,7 +6,7 @@
 
 - name: Create kubeadm cert controlplane config
   template:
-    src: "kubeadm-client.conf.{{ kubeadmConfig_api_version }}.j2"
+    src: "kubeadm-client.conf.j2"
     dest: "{{ kube_config_dir }}/kubeadm-cert-controlplane.conf"
     mode: "0640"
   vars:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Remove empty entry in `extraArgs` for kubeadm config v1beta4, as it causes upload-certs to fail with the following error:
```
etcd.local.extraArgs: Invalid value: "index 5": argument has no name
```
Also, the same PR, which introduced the above bug renamed the `kubeadm-client.conf` template, but left behind a reference to the old name, which I fixed as well.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

I haven't opened an issue for this - it was easier to just fix it.
Fixes #

**Special notes for your reviewer**:

The bug was introduced with the file recently: https://github.com/kubernetes-sigs/kubespray/pull/11674

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
remove invalid extraArgs entry and update template file reference
```
