### PR TITLE
Include scripts and conf files in the ansible collection

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -22,3 +22,4 @@ dependencies:
 manifest:
   directives:
     - recursive-exclude tests **
+    - recursive-include roles **/files/*


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
We use shell scripts and conf files in some roles (notably, certificates
provisioning), so we need to include them in order for the collection to
work when using the configurations depending on those roles.

**Which issue(s) this PR fixes**:
Fixes #11706

**Does this PR introduce a user-facing change?**:
```release-note
Fix collection usage for calico and other configuration depending on .sh and .conf files in Kubespray 
```

/cherrypick release-2.26
