### PR TITLE
Fix: When creating a list of files and images with ./generate_list.sh, included ingress-nginx/kube-webhook-certgen image in the list. 

### DIFF
--- a/contrib/offline/manage-offline-container-images.sh
+++ b/contrib/offline/manage-offline-container-images.sh
@@ -125,7 +125,7 @@ function register_container_images() {
 
 	tar -zxvf ${IMAGE_TAR_FILE}
 
-	if [ "${create_registry}" ]; then
+	if ${create_registry}; then
 		sudo ${runtime} load -i ${IMAGE_DIR}/registry-latest.tar
 		set +e
 

--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -1049,6 +1049,14 @@ downloads:
     groups:
       - kube_node
 
+  ingress_nginx_kube_webhook_certgen:
+    repo: "{{ ingress_nginx_kube_webhook_certgen_image_repo }}"
+    tag: "{{ ingress_nginx_kube_webhook_certgen_image_tag }}"
+    sha256: "{{ ingress_nginx_kube_webhook_certgen_digest_checksum | default(None) }}"
+    groups:
+      - kube_node
+    when: ingress_nginx_webhook_enabled
+
   cert_manager_controller:
     enabled: "{{ cert_manager_enabled }}"
     container: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When list of files, images and local repogitry was created with ./generate_list.sh, ./manage-offline-files.sh and createing Kubernetes Cluster In offline construction with `ingress_nginx_webhook_enabled: true`, `ingress-nginx-admission-*` Pod of the Job created when is ImagePullBackOff and does not become READY.

* kubectl describe po -n ingress-nginx ingress-nginx-admission-*
```
Events:
  Type     Reason     Age                  From               Message
  ----     ------     ----                 ----               -------
  Normal   Scheduled  2m16s                default-scheduler  Successfully assigned ingress-nginx/ingress-nginx-admission-patch-5hcxf to worker2
  Normal   Pulling    53s (x4 over 2m16s)  kubelet            Pulling image "192.168.122.155:5000/ingress-nginx/kube-webhook-certgen:v1.4.1"
  Warning  Failed     53s (x4 over 2m16s)  kubelet            Failed to pull image "192.168.122.155:5000/ingress-nginx/kube-webhook-certgen:v1.4.1": rpc error: code = NotFound desc = failed to pull and unpack image "192.168.122.155:5000/ingress-nginx/kube-webhook-certgen:v1.4.1": failed to resolve reference "192.168.122.155:5000/ingress-nginx/kube-webhook-certgen:v1.4.1": 192.168.122.155:5000/ingress-nginx/kube-webhook-certgen:v1.4.1: not found
  Warning  Failed     53s (x4 over 2m16s)  kubelet            Error: ErrImagePull
  Warning  Failed     38s (x6 over 2m16s)  kubelet            Error: ImagePullBackOff
  Normal   BackOff    23s (x7 over 2m16s)  kubelet            Back-off pulling image "192.168.122.155:5000/ingress-nginx/kube-webhook-certgen:v1.4.1"
```

`./generate_list.sh` creates an image list based on the `downloads:` section of `/roles/kubespray-defaults/defaults/main/download.yml`.
```
#!/bin/bash
set -eo pipefail

CURRENT_DIR=$(cd $(dirname $0); pwd)
TEMP_DIR="${CURRENT_DIR}/temp"
REPO_ROOT_DIR="${CURRENT_DIR%/contrib/offline}"

: ${DOWNLOAD_YML:="roles/kubespray-defaults/defaults/main/download.yml"}

mkdir -p ${TEMP_DIR}

# generate all download files url template
grep 'download_url:' ${REPO_ROOT_DIR}/${DOWNLOAD_YML} \
    | sed 's/^.*_url: //g;s/\"//g' > ${TEMP_DIR}/files.list.template

# generate all images list template
sed -n '/^downloads:/,/download_defaults:/p' ${REPO_ROOT_DIR}/${DOWNLOAD_YML} \
    | sed -n "s/repo: //p;s/tag: //p" | tr -d ' ' \
    | sed 'N;s#\n# #g' | tr ' ' ':' | sed 's/\"//g' > ${TEMP_DIR}/images.list.template
```

So, add the following to download.yml, `registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.1` was added to the image list, and the above phenomenon was resolved.

* vi /root/k8s-upgrade/kubespray-2.25.0/roles/kubespray-defaults/defaults/main/download.yml
```
downloads:
  ingress_nginx_kube_webhook_certgen:
    repo: "{{ ingress_nginx_kube_webhook_certgen_image_repo }}"
    tag: "{{ ingress_nginx_kube_webhook_certgen_image_tag }}"
    sha256: "{{ ingress_nginx_kube_webhook_certgen_digest_checksum | default(None) }}"
    groups:
      - kube_node
    when: ingress_nginx_webhook_enabled
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11591

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix: When creating a list of files and images with ./generate_list.sh, `ingress-nginx/kube-webhook-certgen:v1.4.1` is also included in the list.
```
