### PR TITLE
Remove deprecated key from kubeadmconfig/v1beta4

### DIFF
--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
@@ -344,7 +344,6 @@ apiServer:
 {% for san in apiserver_sans %}
   - "{{ san }}"
 {% endfor %}
-  timeoutForControlPlane: 5m0s
 controllerManager:
   extraArgs:
   - name: node-monitor-grace-period


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
timeoutForControlPlane has been removed from v1beta4, instead remplaced
by https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta4/#kubeadm-k8s-io-v1beta4-Timeouts
We have currently failing tests for this, but might be overshadowed by the --ignore-preflight-errors=all

The default for the new value are close enough that there is no need to
override them, IMO


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fix format of kubeadm-config v1beta4
```
