### PR TITLE
Bump version of community.general

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -14,7 +14,7 @@ documentation: https://kubespray.io
 license_file: LICENSE
 dependencies:
   ansible.utils: '>=2.5.0'
-  community.general: '>=3.0.0'
+  community.general: '>=7.0.0'
   ansible.netcommon: '>=5.3.0'
   ansible.posix: '>=1.5.4'
   community.docker: '>=3.11.0'


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
We use the persistent option of modprobe, which was introduced in 7.0.0

**Special notes for your reviewer**:
See ansible-collections/community.general#9144

**Does this PR introduce a user-facing change?**:
```release-note
Use correct version for community.general collection
```
