### PR TITLE
chore(requirements): bump ruamel.yaml to 0.18.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ jmespath==1.0.1
 jsonschema==4.23.0
 # Needed for ansible.utils.ipaddr
 netaddr==1.3.0
+# Needed for contrib/inventory_builder/inventory.py
+ruamel.yaml==0.18.6


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Updates ruamel.yaml package to version 0.18.6 in requirements.txt. This package is required for the inventory builder functionality.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
This is a routine dependency update to maintain compatibility with the inventory builder.

**Does this PR introduce a user-facing change?**: