### PR TITLE
Bump: OpenStack Cloud Controller Manager to v1.31.1

### DIFF
--- a/inventory/sample/group_vars/all/openstack.yml
+++ b/inventory/sample/group_vars/all/openstack.yml
@@ -41,9 +41,6 @@
 # external_openstack_application_credential_id:
 # external_openstack_application_credential_secret:
 
-## The tag of the external OpenStack Cloud Controller image
-# external_openstack_cloud_controller_image_tag: "v1.28.2"
-
 ## Tags for the Cinder CSI images
 ## registry.k8s.io/sig-storage/csi-attacher
 # cinder_csi_attacher_image_tag: "v4.4.2"

--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -279,8 +279,8 @@ kube_router_image_repo: "{{ docker_image_repo }}/cloudnativelabs/kube-router"
 kube_router_image_tag: "{{ kube_router_version }}"
 multus_image_repo: "{{ github_image_repo }}/k8snetworkplumbingwg/multus-cni"
 multus_image_tag: "{{ multus_version }}"
-external_openstack_cloud_controller_image_tag: "v1.30.0"
 external_openstack_cloud_controller_image_repo: "{{ kube_image_repo }}/provider-os/openstack-cloud-controller-manager"
+external_openstack_cloud_controller_image_tag: "v1.31.1"
 
 kube_vip_image_repo: "{{ github_image_repo }}/kube-vip/kube-vip"
 kube_vip_image_tag: v0.8.0

--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -279,8 +279,8 @@ kube_router_image_repo: "{{ docker_image_repo }}/cloudnativelabs/kube-router"
 kube_router_image_tag: "{{ kube_router_version }}"
 multus_image_repo: "{{ github_image_repo }}/k8snetworkplumbingwg/multus-cni"
 multus_image_tag: "{{ multus_version }}"
-external_openstack_cloud_controller_image_repo: "registry.k8s.io/provider-os/openstack-cloud-controller-manager"
 external_openstack_cloud_controller_image_tag: "v1.30.0"
+external_openstack_cloud_controller_image_repo: "{{ kube_image_repo }}/provider-os/openstack-cloud-controller-manager"
 
 kube_vip_image_repo: "{{ github_image_repo }}/kube-vip/kube-vip"
 kube_vip_image_tag: v0.8.0


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Update OCCM to the latest version v1.31, to align with the Kubernetes version

**Special notes for your reviewer**:

Waiting for Rockylinux9 CI fix.

**Does this PR introduce a user-facing change?**:

```release-note
Upgrade OpenStack Cloud Controller Manager to v1.31.1
```
