### PR TITLE
Fix the format of the list of images extracted from kubeadm

### DIFF
--- a/roles/download/tasks/prep_kubeadm_images.yml
+++ b/roles/download/tasks/prep_kubeadm_images.yml
@@ -44,7 +44,8 @@
         container: true
         repo: "{{ item | regex_replace('^(.*):.*$', '\\1') }}"
         tag: "{{ item | regex_replace('^.*:(.*)$', '\\1') }}"
-        groups: k8s_cluster
+        groups:
+          - k8s_cluster
   loop: "{{ kubeadm_images_list | flatten(levels=1) }}"
   register: kubeadm_images_cooked
   run_once: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The download role expect 'groups' be a list, in order to properly filter
images.


**Which issue(s) this PR fixes**:
Fixes #11740


**Does this PR introduce a user-facing change?**:
```release-note
Kubeadm images (kube-controller-manager,kube-scheduler,kube-apiserver,kube-proxy) are properly downloaded, including when using the download cache.
```
