### PR TITLE
Remove leftover CI for ansible-core 2.11 (apparently)

### DIFF
--- a/tests/files/packet_ubuntu20-calico-all-in-one-ansible-2_11.yml
+++ b/tests/files/packet_ubuntu20-calico-all-in-one-ansible-2_11.yml
@@ -1,1 +1,0 @@
-packet_ubuntu20-calico-all-in-one.yml


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Remove symlink which does not appear to do anything different 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/label ci-short
