### PR TITLE
containerd: always use config_path

### DIFF
--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -93,9 +93,6 @@ containerd_limit_core: "infinity"
 containerd_limit_open_file_num: "infinity"
 containerd_limit_mem_lock: "infinity"
 
-# If enabled it will use config_path and config to be put in {{ containerd_cfg_dir }}/certs.d/
-containerd_use_config_path: false
-
 # OS distributions that already support containerd
 containerd_supported_distributions:
   - "CentOS"

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -115,7 +115,6 @@
   notify: Restart containerd
 
 - name: Containerd | Configure containerd registries
-  when: containerd_registries_mirrors is defined
   block:
     - name: Containerd | Create registry directories
       file:

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -69,19 +69,7 @@ oom_score = {{ containerd_oom_score }}
           runtime_type = "io.containerd.runsc.v1"
 {% endif %}
     [plugins."io.containerd.grpc.v1.cri".registry]
-{% if containerd_use_config_path is defined and containerd_use_config_path|bool %}
       config_path = "{{ containerd_cfg_dir }}/certs.d"
-{% else %}
-      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-{% for registry in containerd_registries_mirrors %}
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ registry.prefix }}"]
-          endpoint = {{ registry.mirrors | map(attribute='host') | unique | to_json }}
-{% endfor %}
-{% for mirror in containerd_registries_mirrors | map(attribute='mirrors') | flatten | selectattr('skip_verify', 'defined') | selectattr('skip_verify') | unique %}
-        [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ mirror.host | urlsplit('netloc') }}".tls]
-          insecure_skip_verify = true
-{% endfor %}
-{% endif %}
 {% for registry in containerd_registry_auth if registry['registry'] is defined %}
 {% if (registry['username'] is defined and registry['password'] is defined) or registry['auth'] is defined %}
       [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ registry['registry'] }}".auth]


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
config_path was introduced in containerd 1.5.0, and registry.mirrors is
deprecated.

There is no reason to keep the old alternative, so just always use
config_path, and consequently remove the option.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Ideally we would have first defaulted to config_path before removing the option, but I don't think there is a downside.
It's up for discussion though if I missed some shortcomings (in that case I will only default to true)

**Does this PR introduce a user-facing change?**:
```release-note
`containerd_use_config_path` is removed as kubespray now always use containerd `config_path` configuration.
```
