### PR TITLE
Remove jsonschema from dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 ansible==9.12.0
 # Needed for jinja2 json_query templating
 jmespath==1.0.1
-# Needed for ansible.utils.validate module
-jsonschema==4.23.0
 # Needed for ansible.utils.ipaddr
 netaddr==1.3.0


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
8ff4ad2d8 (preinstall: simplify OS packages selection, 2024-11-04)
removed all usages of ansible.utils.validate (not that many), so the
dependencies is no longer necessary.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
