### PR TITLE
Fix sample inventory kube_version to 1.31.3

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -17,7 +17,7 @@ kube_token_dir: "{{ kube_config_dir }}/tokens"
 kube_api_anonymous_auth: true
 
 ## Change this to use another Kubernetes version, e.g. a current beta release
-kube_version: v1.31.1
+kube_version: v1.31.3
 
 # Where the binaries will be downloaded.
 # Note: ensure that you've enough disk space (about 1G)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Fix sample inventory `kube_version` to 1.31.3, but maybe we can remove this in sample inventory?

**Which issue(s) this PR fixes**:

Follow-up #11737

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
