### PR TITLE
calico: stop recording calico_kubelet_name

### DIFF
--- a/roles/network_plugin/calico/tasks/pre.yml
+++ b/roles/network_plugin/calico/tasks/pre.yml
@@ -20,17 +20,6 @@
     - "'plugins' in calico_cni_config"
     - "'etcd_endpoints' in calico_cni_config.plugins.0"
 
-- name: Calico | Get kubelet hostname
-  shell: >-
-    set -o pipefail && {{ kubectl }} get node -o custom-columns='NAME:.metadata.name,INTERNAL-IP:.status.addresses[?(@.type=="InternalIP")].address'
-    | egrep "{{ ansible_all_ipv4_addresses | join('$|') }}$" | cut -d" " -f1
-  args:
-    executable: /bin/bash
-  register: calico_kubelet_name
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
-  when:
-  - cloud_provider
-
 - name: Calico | Gather os specific variables
   include_vars: "{{ item }}"
   with_first_found:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The variable is not used anymore since 29ea790c30.
Besides, this tasks fails on dual stack installation.

**Which issue(s) this PR fixes**:
Fixes #11764

**Does this PR introduce a user-facing change?**:
```release-note
Fix calico dual stack installation when using `ip` and `ip6`.
```
