### PR TITLE
apiserver: fix incorrect path to admission plugins config files

### DIFF
--- a/roles/kubernetes/control-plane/templates/admission-controls.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/admission-controls.yaml.j2
@@ -4,6 +4,6 @@ plugins:
 {% for plugin in kube_apiserver_enable_admission_plugins %}
 {% if plugin in kube_apiserver_admission_plugins_needs_configuration %}
 - name: {{ plugin }}
-  path: {{ kube_config_dir }}/{{ plugin | lower }}.yaml
+  path: {{ kube_config_dir }}/admission-controls/{{ item | lower }}.yaml.yaml
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Which issue(s) this PR fixes**:
Fixes #11733

**Does this PR introduce a user-facing change?**:
```release-note
Fix usage of admission plugins configuration.
```
