### PR TITLE
Let calico install its own CNI plugin

### DIFF
--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -447,7 +447,7 @@ downloads:
       - etcd
 
   cni:
-    enabled: true
+    enabled: "{{ kube_network_plugin != 'calico' }}"
     file: true
     version: "{{ cni_version }}"
     dest: "{{ local_release_dir }}/cni-plugins-linux-{{ image_arch }}-{{ cni_version }}.tgz"

--- a/roles/network_plugin/cni/defaults/main.yml
+++ b/roles/network_plugin/cni/defaults/main.yml
@@ -1,2 +1,0 @@
----
-cni_bin_owner: "{{ kube_owner }}"

--- a/roles/network_plugin/cni/tasks/main.yml
+++ b/roles/network_plugin/cni/tasks/main.yml
@@ -4,7 +4,7 @@
     path: /opt/cni/bin
     state: directory
     mode: "0755"
-    owner: "{{ cni_bin_owner }}"
+    owner: "{{ kube_owner }}"
     recurse: true
 
 - name: CNI | Copy cni plugins
@@ -12,5 +12,5 @@
     src: "{{ downloads.cni.dest }}"
     dest: "/opt/cni/bin"
     mode: "0755"
-    owner: "{{ cni_bin_owner }}"
+    owner: "{{ kube_owner }}"
     remote_src: true

--- a/roles/network_plugin/cni/tasks/main.yml
+++ b/roles/network_plugin/cni/tasks/main.yml
@@ -5,7 +5,6 @@
     state: directory
     mode: "0755"
     owner: "{{ kube_owner }}"
-    recurse: true
 
 - name: CNI | Copy cni plugins
   unarchive:

--- a/roles/network_plugin/meta/main.yml
+++ b/roles/network_plugin/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 dependencies:
   - role: network_plugin/cni
+    when: kube_network_plugin != 'calico'
 
   - role: network_plugin/cilium
     when: kube_network_plugin == 'cilium' or cilium_deploy_additionally | default(false) | bool


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
- Revert "Support overriding cni directory owner (#10929)"
- Don't set use recurse for cni directory
- Don't install cni when using calico


**Which issue(s) this PR fixes**:
Fixes #11747

**Does this PR introduce a user-facing change?**:

```release-note
action required
The workaround variable `cni_bin_owner` is removed since the underlying issue with calico is fixed.
```

/label tide/merge-method-merge
