### PR TITLE
containerd: add After=dbus.service

### DIFF
--- a/roles/container-engine/containerd/templates/containerd.service.j2
+++ b/roles/container-engine/containerd/templates/containerd.service.j2
@@ -15,7 +15,7 @@
 [Unit]
 Description=containerd container runtime
 Documentation=https://containerd.io
-After=network.target local-fs.target
+After=network.target local-fs.target dbus.service
 
 [Service]
 ExecStartPre=-/sbin/modprobe overlay


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This is needed for shutdown ordering: while at startup, it's not a
problem that containerd start before dbus (the dbus socket already
exists) it needs to shutdown before dbus to do its cleanup (asking
systemd via dbus to cleanup cgroups).


**Which issue(s) this PR fixes**:
Fixes #11769

**Special notes for your reviewer**:
xref: https://github.com/containerd/containerd/pull/10798#issue-2573534164

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
