### PR TITLE
CI: remove IDEMPOT_CHECK

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,6 @@ variables:
   GCE_PREEMPTIBLE: "false"
   ANSIBLE_KEEP_REMOTE_FILES: "1"
   ANSIBLE_CONFIG: ./tests/ansible.cfg
-  IDEMPOT_CHECK: "false"
   RESET_CHECK: "false"
   REMOVE_NODE_CHECK: "false"
   UPGRADE_TEST: "false"

--- a/tests/scripts/testcases_run.sh
+++ b/tests/scripts/testcases_run.sh
@@ -120,29 +120,6 @@ fi
 ## Kubernetes conformance tests
 run_playbook tests/testcases/100_check-k8s-conformance.yml
 
-if [ "${IDEMPOT_CHECK}" = "true" ]; then
-  ## Idempotency checks 1/5 (repeat deployment)
-  run_playbook cluster.yml
-
-  ## Idempotency checks 2/5 (Advanced DNS checks)
-  if [[ ! ( "$CI_JOB_NAME" =~ "hardening" ) ]]; then
-      run_playbook tests/testcases/040_check-network-adv.yml
-  fi
-
-  if [ "${RESET_CHECK}" = "true" ]; then
-    ## Idempotency checks 3/5 (reset deployment)
-    run_playbook reset.yml -e reset_confirmation=yes
-
-    ## Idempotency checks 4/5 (redeploy after reset)
-    run_playbook cluster.yml
-
-    ## Idempotency checks 5/5 (Advanced DNS checks)
-    if [[ ! ( "$CI_JOB_NAME" =~ "hardening" ) ]]; then
-        run_playbook tests/testcases/040_check-network-adv.yml
-    fi
-  fi
-fi
-
 # Test node removal procedure
 if [ "${REMOVE_NODE_CHECK}" = "true" ]; then
   run_playbook remove-node.yml -e skip_confirmation=yes -e node=${REMOVE_NODE_NAME}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
There is no test with IDEMPOT_CHECK=true since commit 7b78e6872 (disable
idempotency tests (#1872), 2017-10-26)

Remove the related infra from our CI scripts.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/label ci-short
