### PR TITLE
Fix Ansible example values for OpenStack controller

### DIFF
--- a/docs/cloud_controllers/openstack.md
+++ b/docs/cloud_controllers/openstack.md
@@ -76,9 +76,9 @@ The cloud provider is configured to have Octavia by default in Kubespray.
   external_openstack_lbaas_network_id: "Neutron network ID to create LBaaS VIP"
   external_openstack_lbaas_manage_security_groups: false
   external_openstack_lbaas_create_monitor: false
-  external_openstack_lbaas_monitor_delay: 5
+  external_openstack_lbaas_monitor_delay: 5s
   external_openstack_lbaas_monitor_max_retries: 1
-  external_openstack_lbaas_monitor_timeout: 3
+  external_openstack_lbaas_monitor_timeout: 3s
   external_openstack_lbaas_internal_lb: false
 
   ```


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

Bad example variable values id doc for OpenStack controller. Should be a duration instead of an it.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
