### PR TITLE
docs: add some complete samples for node_labels and dynamic vars render by inventory group

### DIFF
--- a/docs/ansible/vars.md
+++ b/docs/ansible/vars.md
@@ -258,6 +258,13 @@ node_labels:
   label2_name: label2_value
 ```
 
+  Example of `node_labels` definition in `inventory.ini` format:
+
+```toml
+[sample_inventory_group:vars]
+node_labels={"label1_name":"label1_value", "label2_name":"label2_value"}
+```
+
 * *node_taints* - Taints applied to nodes via `kubectl taint node`.
   For example, taints can be set in the inventory as variables or more widely in group_vars.
   *node_taints* has to be defined as a list of strings in format `key=value:effect`, e.g.:

--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -315,8 +315,9 @@ persistent_volumes_enabled: false
 ## Important: if you use Ubuntu then you should set in all.yml 'docker_storage_options: -s overlay2'
 ## Array with nvida_gpu_nodes, leave empty or comment if you don't want to install drivers.
 ## Labels and taints won't be set to nodes if they are not in the array.
-# nvidia_gpu_nodes:
-#   - kube-gpu-001
+## Dynamic render gpu node list via ansible inventory group.
+# nvidia_gpu_nodes: "{{ groups['nvidia_gpu_nodes'] | list }}"
+
 # nvidia_driver_version: "384.111"
 ## flavor can be tesla or gtx
 # nvidia_gpu_flavor: gtx

--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -8,6 +8,9 @@ containerd_systemd_dir: "/etc/systemd/system/containerd.service.d"
 containerd_oom_score: 0
 
 containerd_default_runtime: "runc"
+# Also you can dynamic set container runtime by ansible inventory group
+# containerd_default_runtime: "{{ 'nvidia' if inventory_hostname in groups['nvidia_gpu_nodes'] else 'runc' }}"
+
 containerd_snapshotter: "overlayfs"
 
 containerd_runc_runtime:
@@ -26,6 +29,15 @@ containerd_additional_runtimes: []
 #    type: "io.containerd.kata.v2"
 #    engine: ""
 #    root: ""
+
+# Example for Nvidia as additional runtime:
+# containerd_additional_runtimes:
+#   - name: nvidia
+#     type: "io.containerd.runc.v2"
+#     engine: ""
+#     root: ""
+#     options:
+#       BinaryName: "/usr/bin/nvidia-container-runtime"
 
 containerd_base_runtime_spec_rlimit_nofile: 65535
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

1. Add example for `node_labels` var defination to label or taint nodes
2. Add example for dynamic render `containerd_default_runtime` var by inventory group
3. Add example for `containerd_additional_runtimes` of nvidia
4. Add example for dynamic render `nvidia_gpu_nodes` var by inventory group'

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

- sample for `node_labels`defination
- sample for dynamic set `containerd_default_runtime` 
- sample for dynamic set `nvidia_gpu_nodes` var

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
