### PR TITLE
Revert "apiserver: fix incorrect path to admission plugins config files (#11779)"

### DIFF
--- a/roles/kubernetes/control-plane/templates/admission-controls.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/admission-controls.yaml.j2
@@ -4,6 +4,6 @@ plugins:
 {% for plugin in kube_apiserver_enable_admission_plugins %}
 {% if plugin in kube_apiserver_admission_plugins_needs_configuration %}
 - name: {{ plugin }}
-  path: {{ kube_config_dir }}/admission-controls/{{ item | lower }}.yaml.yaml
+  path: {{ kube_config_dir }}/{{ plugin | lower }}.yaml
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The reverted PR was not necessary at all
https://github.com/kubernetes-sigs/kubespray/pull/11779#discussion_r1889461748

**Which issue(s) this PR fixes**:
Fixes #11733

**Special notes for your reviewer**:
/cc @chadswen
I'll add a testcase for hardening which exercise this config instead. (in a follow-up PR).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cherrypick release-2.26
/cherrypick release-2.25
