### PR TITLE
Do not assume systemd-resolved for resolv.conf

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -7,7 +7,7 @@ kubelet_address: "{{ main_ips | join(',') }}"
 kubelet_bind_address: "{{ main_ip | default('::') }}"
 
 # resolv.conf to base dns config
-kube_resolv_conf: "/etc/resolv.conf"
+kube_resolv_conf: "{{ '/run/systemd/resolve/resolv.conf' if 'systemd-resolved' in active_dns_services else '/etc/resolv.conf' }}"
 
 # Set to empty to avoid cgroup creation
 kubelet_enforce_node_allocatable: "\"\""

--- a/roles/kubernetes/node/vars/fedora.yml
+++ b/roles/kubernetes/node/vars/fedora.yml
@@ -1,2 +1,0 @@
----
-kube_resolv_conf: "/run/systemd/resolve/resolv.conf"

--- a/roles/kubernetes/node/vars/ubuntu-18.yml
+++ b/roles/kubernetes/node/vars/ubuntu-18.yml
@@ -1,2 +1,0 @@
----
-kube_resolv_conf: "/run/systemd/resolve/resolv.conf"

--- a/roles/kubernetes/node/vars/ubuntu-20.yml
+++ b/roles/kubernetes/node/vars/ubuntu-20.yml
@@ -1,2 +1,0 @@
----
-kube_resolv_conf: "/run/systemd/resolve/resolv.conf"

--- a/roles/kubernetes/node/vars/ubuntu-22.yml
+++ b/roles/kubernetes/node/vars/ubuntu-22.yml
@@ -1,2 +1,0 @@
----
-kube_resolv_conf: "/run/systemd/resolve/resolv.conf"

--- a/roles/kubernetes/node/vars/ubuntu-24.yml
+++ b/roles/kubernetes/node/vars/ubuntu-24.yml
@@ -1,2 +1,0 @@
----
-kube_resolv_conf: "/run/systemd/resolve/resolv.conf"

--- a/roles/kubernetes/preinstall/tasks/0020-set_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/0020-set_facts.yml
@@ -40,21 +40,17 @@
     src: /etc/resolv.conf
   register: resolvconf_slurp
 
-- name: NetworkManager | Check if host has NetworkManager
-  # noqa command-instead-of-module - Should we use service_facts for this?
-  command: systemctl is-active --quiet NetworkManager.service
-  register: networkmanager_enabled
-  failed_when: false
-  changed_when: false
-  check_mode: false
+- name: Register which network services are active
+  systemd:
+    name: "{{ item }}.service"
+  loop:
+    - NetworkManager
+    - systemd-resolved
+  register: network_services
 
-- name: Check systemd-resolved
-  # noqa command-instead-of-module - Should we use service_facts for this?
-  command: systemctl is-active systemd-resolved
-  register: systemd_resolved_enabled
-  failed_when: false
-  changed_when: false
-  check_mode: false
+- name: Save list of active network service
+  set_fact:
+    active_dns_services: "{{ network_services.results | selectattr('status.ActiveState', '==', 'active') | map(attribute='item') }}"
 
 - name: Set default dns if remove_default_searchdomains is false
   set_fact:

--- a/roles/kubernetes/preinstall/tasks/0063-networkmanager-dns.yml
+++ b/roles/kubernetes/preinstall/tasks/0063-networkmanager-dns.yml
@@ -9,7 +9,7 @@
     backup: "{{ leave_etc_backup_files }}"
   when:
     - ('127.0.0.53' not in nameserverentries
-       or systemd_resolved_enabled.rc != 0)
+       or 'systemd-resolved' not in active_dns_services)
   notify: Preinstall | update resolvconf for networkmanager
 
 - name: Set default dns if remove_default_searchdomains is false

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -29,8 +29,8 @@
   when:
     - dns_mode != 'none'
     - resolvconf_mode == 'host_resolvconf'
-    - systemd_resolved_enabled.rc != 0
-    - networkmanager_enabled.rc != 0
+    - ('systemd-resolved' not in active_dns_services )
+    - ('NetworkManager' not in active_dns_services )
   tags:
     - bootstrap_os
     - resolvconf
@@ -40,27 +40,26 @@
   when:
     - dns_mode != 'none'
     - resolvconf_mode == 'host_resolvconf'
-    - systemd_resolved_enabled.rc == 0
+    - ('systemd-resolved' in active_dns_services )
   tags:
     - bootstrap_os
     - resolvconf
 
-- name: Apply networkmanager unmanaged devices settings
-  import_tasks: 0062-networkmanager-unmanaged-devices.yml
-  when:
-    - networkmanager_enabled.rc == 0
+- name: NetworkManager | Apply settings
+  when: ('NetworkManager' in active_dns_services )
   tags:
     - bootstrap_os
+  block:
+    - name: Apply networkmanager unmanaged devices settings
+      import_tasks: 0062-networkmanager-unmanaged-devices.yml
 
-- name: Apply networkmanager DNS settings
-  import_tasks: 0063-networkmanager-dns.yml
-  when:
-    - dns_mode != 'none'
-    - resolvconf_mode == 'host_resolvconf'
-    - networkmanager_enabled.rc == 0
-  tags:
-    - bootstrap_os
-    - resolvconf
+    - name: Apply networkmanager DNS settings
+      import_tasks: 0063-networkmanager-dns.yml
+      when:
+        - dns_mode != 'none'
+        - resolvconf_mode == 'host_resolvconf'
+      tags:
+        - resolvconf
 
 - name: Apply system configurations
   import_tasks: 0080-system-configurations.yml


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
We currently assume on some distribution that systemd-resolved is used
and therefore we can use /run/systemd/resolve/resolv.conf to pass to the
kubelet configuration.

This breaks if the distribution is configured differently (use another
DNS service) and force us to special case.

Instead, detect if systemd-resolved is running dynamically and set
kube_resolv_conf default accordingly.


**Which issue(s) this PR fixes**:
Fixes #11810

**Special notes for your reviewer**:
I'm just wondering if this could cause breakage when systemd-resolved is running but /etc/resolv.conf does not point to its managed files and has other settings :thinking:
I'm not sure what we should do in that case (but I don't think hardcoding is the answer).


**Does this PR introduce a user-facing change?**:
```release-note
Use /run/systemd/resolve/resolv.conf for kubelet configuration only when systemd-resolved is active.
```
