### PR TITLE
Add ResourceQuota plugin configuration

### DIFF
--- a/roles/kubernetes/control-plane/defaults/main/main.yml
+++ b/roles/kubernetes/control-plane/defaults/main/main.yml
@@ -107,6 +107,7 @@ kube_apiserver_admission_control_config_file: false
 #   cache_size: <cache_size_value>
 kube_apiserver_admission_event_rate_limits: {}
 
+## PodSecurityAdmission plugin configuration
 kube_pod_security_use_default: false
 kube_pod_security_default_enforce: baseline
 kube_pod_security_default_enforce_version: "{{ kube_major_version }}"
@@ -118,6 +119,16 @@ kube_pod_security_exemptions_usernames: []
 kube_pod_security_exemptions_runtime_class_names: []
 kube_pod_security_exemptions_namespaces:
   - kube-system
+
+## ResourceQuota plugin configuration
+## Resources that ResourceQuota should limit by default if no quota exists
+## Example below enforces quota on all storage classes
+# kube_resource_quota_limited_resources:
+# - apiGroup: ""
+#   resource: persistentvolumeclaims
+#   matchContains:
+#   - .storageclass.storage.k8s.io/requests.storage
+kube_resource_quota_limited_resources: []
 
 # 1.10+ list of disabled admission plugins
 kube_apiserver_disable_admission_plugins: []

--- a/roles/kubernetes/control-plane/templates/resourcequota.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/resourcequota.yaml.j2
@@ -1,0 +1,8 @@
+apiVersion: apiserver.config.k8s.io/v1
+kind: ResourceQuotaConfiguration
+{% if kube_resource_quota_limited_resources | d(false) -%}
+limitedResources:
+{{ kube_resource_quota_limited_resources | to_nice_yaml(indent=2, sort_keys=false) }}
+{% else %}
+# No limitedResources configured. If limitedResources are required, please set kube_resource_quota_limited_resources.
+{%- endif %}

--- a/roles/kubernetes/control-plane/vars/main.yaml
+++ b/roles/kubernetes/control-plane/vars/main.yaml
@@ -6,3 +6,4 @@ kube_apiserver_admission_plugins_needs_configuration:
 - ImagePolicyWebhook
 - PodSecurity
 - PodNodeSelector
+- ResourceQuota


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
This enables [configuration](https://kubernetes.io/docs/concepts/policy/resource-quotas/#limit-priority-class-consumption-by-default) of the [ResourceQuota AdmissionController plugin](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#resourcequota). 

The configuration file will be empty by default when no limitedResources are set.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add ResourceQuota AdmissionController plugin Configuration
```
