### PR TITLE
Add iproute(2) package checking

### DIFF
--- a/roles/bootstrap-os/tasks/amzn.yml
+++ b/roles/bootstrap-os/tasks/amzn.yml
@@ -14,3 +14,14 @@
     enabled: true
     repo_gpgcheck: false
   when: epel_enabled
+
+# iproute is required for networking related facts gathering
+# See https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_vars_facts.html#package-requirements-for-fact-gathering
+# Note: It is not recommended way, but since the tasks execution order, put it here is the simplest way so far. We can move it to a proper place later.
+# TODO: move this to roles/kubernetes/preinstall/vars/main.yml -> pkgs variables
+# Currently not possible because the collect the network facts before that step, needs reordering of the exec flow.
+- name: Ensure iproute is installed
+  package:
+    name: iproute
+    state: present
+  become: true

--- a/roles/bootstrap-os/tasks/centos.yml
+++ b/roles/bootstrap-os/tasks/centos.yml
@@ -116,3 +116,14 @@
     name: "{{ ((ansible_distribution_major_version | int) < 8) | ternary('libselinux-python', 'python3-libselinux') }}"
     state: present
   become: true
+
+# iproute is required for networking related facts gathering
+# See https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_vars_facts.html#package-requirements-for-fact-gathering
+# Note: It is not recommended way, but since the tasks execution order, put it here is the simplest way so far. We can move it to a proper place later.
+# TODO: move this to roles/kubernetes/preinstall/vars/main.yml -> pkgs variables
+# Currently not possible because the collect the network facts before that step, needs reordering of the exec flow.
+- name: Ensure iproute is installed
+  package:
+    name: iproute
+    state: present
+  become: true

--- a/roles/bootstrap-os/tasks/clear-linux-os.yml
+++ b/roles/bootstrap-os/tasks/clear-linux-os.yml
@@ -14,3 +14,14 @@
     daemon_reload: true
     state: started
   become: true
+
+# iproute2 is required for networking related facts gathering
+# See https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_vars_facts.html#package-requirements-for-fact-gathering
+# Note: It is not recommended way, but since the tasks execution order, put it here is the simplest way so far. We can move it to a proper place later.
+# TODO: move this to roles/kubernetes/preinstall/vars/main.yml -> pkgs variables
+# Currently not possible because the collect the network facts before that step, needs reordering of the exec flow.
+- name: Ensure iproute2 is installed
+  package:
+    name: iproute2
+    state: present
+  become: true

--- a/roles/bootstrap-os/tasks/debian.yml
+++ b/roles/bootstrap-os/tasks/debian.yml
@@ -62,3 +62,14 @@
     - '"changed its" in bootstrap_update_apt_result.stdout'
     - '"value from" in bootstrap_update_apt_result.stdout'
   ignore_errors: true
+
+# iproute2 is required for networking related facts gathering
+# See https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_vars_facts.html#package-requirements-for-fact-gathering
+# Note: It is not recommended way, but since the tasks execution order, put it here is the simplest way so far. We can move it to a proper place later.
+# TODO: move this to roles/kubernetes/preinstall/vars/main.yml -> pkgs variables
+# Currently not possible because the collect the network facts before that step, needs reordering of the exec flow.
+- name: Ensure iproute2 is installed
+  package:
+    name: iproute2
+    state: present
+  become: true

--- a/roles/bootstrap-os/tasks/fedora.yml
+++ b/roles/bootstrap-os/tasks/fedora.yml
@@ -28,3 +28,14 @@
   become: true
   when:
     - need_bootstrap.rc != 0
+
+# iproute is required for networking related facts gathering
+# See https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_vars_facts.html#package-requirements-for-fact-gathering
+# Note: It is not recommended way, but since the tasks execution order, put it here is the simplest way so far. We can move it to a proper place later.
+# TODO: move this to roles/kubernetes/preinstall/vars/main.yml -> pkgs variables
+# Currently not possible because the collect the network facts before that step, needs reordering of the exec flow.
+- name: Ensure iproute is installed
+  package:
+    name: iproute
+    state: present
+  become: true

--- a/roles/bootstrap-os/tasks/opensuse.yml
+++ b/roles/bootstrap-os/tasks/opensuse.yml
@@ -83,3 +83,15 @@
       - apparmor-parser
     state: present
   become: true
+
+# iproute2 is required for networking related facts gathering
+# See https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_vars_facts.html#package-requirements-for-fact-gathering
+# Note: It is not recommended way, but since the tasks execution order, put it here is the simplest way so far. We can move it to a proper place later.
+# TODO: move this to roles/kubernetes/preinstall/vars/main.yml -> pkgs variables
+# Currently not possible because the collect the network facts before that step, needs reordering of the exec flow.
+- name: Ensure iproute2 is installed
+  community.general.zypper:
+    name: iproute2
+    state: present
+    update_cache: true
+  become: true

--- a/roles/bootstrap-os/tasks/rhel.yml
+++ b/roles/bootstrap-os/tasks/rhel.yml
@@ -100,3 +100,14 @@
     name: "{{ ((ansible_distribution_major_version | int) < 8) | ternary('libselinux-python', 'python3-libselinux') }}"
     state: present
   become: true
+
+# iproute is required for networking related facts gathering
+# See https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_vars_facts.html#package-requirements-for-fact-gathering
+# Note: It is not recommended way, but since the tasks execution order, put it here is the simplest way so far. We can move it to a proper place later.
+# TODO: move this to roles/kubernetes/preinstall/vars/main.yml -> pkgs variables
+# Currently not possible because the collect the network facts before that step, needs reordering of the exec flow.
+- name: Ensure iproute is installed
+  package:
+    name: iproute
+    state: present
+  become: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
From [ansible doc](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_vars_facts.html#package-requirements-for-fact-gathering) and https://github.com/kubernetes-sigs/kubespray/issues/11679, it is necessary to check `ip` utilities to avoid getting invaild facts.

iproute:
- amazon: https://docs.aws.amazon.com/linux/al2023/release-notes/all-packages-AL2023.6.html
- rhel: https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/package_manifest/repositories#BaseOS-repository
- fedora: https://packages.fedoraproject.org/pkgs/iproute/iproute/
- openEuler: https://repo.openeuler.org/openEuler-22.03-LTS/OS/x86_64/Packages/iproute-5.15.0-3.oe2203.x86_64.rpm
- CentOS: https://vault.centos.org/centos/7/os/x86_64/Packages/iproute-4.11.0-30.el7.x86_64.rpm

iproute2:
- opensuse: https://download.opensuse.org/tumbleweed/repo/oss/x86_64/iproute2-6.10-1.1.x86_64.rpm
- debian: https://packages.debian.org/bookworm/iproute2
- ubuntu: https://packages.ubuntu.com/noble/iproute2
- clearlinux: https://github.com/clearlinux-pkgs/iproute2


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11679 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
iproute is installed before gathering facts (needed for getting `ansible_default_ipv4`)
```
