### PR TITLE
Only consider host in 'k8s_cluster' when checking if ip is a cached fact

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
@@ -2,7 +2,7 @@
 - name: Stop if any host not in '--limit' does not have a fact cache
   vars:
     uncached_hosts: "{{ hostvars | dict2items | selectattr('value.ansible_default_ipv4', 'undefined') | map(attribute='key') }}"
-    excluded_hosts: "{{ hostvars.keys() | difference(query('inventory_hostnames', ansible_limit)) }}"
+    excluded_hosts: "{{ groups['k8s_cluster'] | difference(query('inventory_hostnames', ansible_limit)) }}"
   assert:
     that: uncached_hosts | intersect(excluded_hosts) == []
     fail_msg: |


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This avoids spurious failure with 'localhost'.

It should also be more correct the inventory contains uncached hosts
which are not in `k8s_cluster` and therefore should not be Kubespray
business.

(We still use hostvars for uncached hosts, because it's easier to select
on `ansible_default_ipv4` that way and does not change the end result)


**Which issue(s) this PR fixes**:
Fixes #11815

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fix spurious failure with 'localhost' when using `scale.yml --limit <some nodes>`
```
