### PR TITLE
network: add ipv6 only global option

### DIFF
--- a/.gitlab-ci/vagrant.yml
+++ b/.gitlab-ci/vagrant.yml
@@ -36,6 +36,14 @@
       - .cache/pip
     policy: pull-push # TODO: change to "pull" when not on main
 
+vagrant_ubuntu24-calico-ipv6only-stack:
+  stage: deploy-extended
+  extends: .vagrant
+  rules:
+    - if: $PR_LABELS =~ /.*(ci-extended|ci-full).*/
+      when: on_success
+  allow_failure: false
+
 vagrant_ubuntu20-calico-dual-stack:
   stage: deploy-extended
   extends: .vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -210,13 +210,19 @@ Vagrant.configure("2") do |config|
       end
 
       ip = "#{$subnet}.#{i+100}"
+      ip6 = "#{$subnet_ipv6}::#{i+100}"
       node.vm.network :private_network,
         :ip => ip,
         :libvirt__guest_ipv6 => 'yes',
-        :libvirt__ipv6_address => "#{$subnet_ipv6}::#{i+100}",
+        :libvirt__ipv6_address => ip6,
         :libvirt__ipv6_prefix => "64",
         :libvirt__forward_mode => "none",
         :libvirt__dhcp_enabled => false
+
+      # libvirt__ipv6_address does not work as intended, the address is obtained with the desired prefix, but auto-generated(like fd3c:b398:698:756:5054:ff:fe48:c61e/64)
+      # add default route for detect ansible_default_ipv6
+      # TODO: fix libvirt__ipv6 or use $subnet in shell
+      config.vm.provision "shell", inline: "ip -6 r a fd3c:b398:698:756::/64 dev eth1;ip -6 r add default via fd3c:b398:0698:0756::1 dev eth1 || true"
 
       # Disable swap for each vm
       node.vm.provision "shell", inline: "swapoff -a"

--- a/contrib/terraform/terraform.py
+++ b/contrib/terraform/terraform.py
@@ -273,6 +273,7 @@ def openstack_host(resource, module_name):
         'access_ip_v4': raw_attrs['access_ip_v4'],
         'access_ip_v6': raw_attrs['access_ip_v6'],
         'access_ip': raw_attrs['access_ip_v4'],
+        'access_ip6': raw_attrs['access_ip_v6'],
         'ip': raw_attrs['network.0.fixed_ip_v4'],
         'flavor': parse_dict(raw_attrs, 'flavor',
                              sep='_'),

--- a/docs/ansible/vars.md
+++ b/docs/ansible/vars.md
@@ -38,11 +38,16 @@ Some variables of note include:
 * *access_ip* - IP to use from other hosts to connect to this host. Often required when deploying
   from a cloud, such as OpenStack or GCE and you have separate public/floating and private IPs.
   This would **usually** be the private ip.
+* *access_ip6* - IPv6 to use from other hosts to connect to this host.
 * *ansible_default_ipv4.address* - Not Kubespray-specific, but it is used if ip
   and access_ip are undefined
+* *ansible_default_ipv6.address* - Not Kubespray-specific, but it is used if ip
+  and access_ip6 are undefined
 * *ip6* - IPv6 address to use for binding services. (host var)
   If *enable_dual_stack_networks* is set to ``true`` and *ip6* is defined,
   kubelet's ``--node-ip`` and node's ``InternalIP`` will be the combination of *ip* and *ip6*.
+  If *enable_ipv6only_stack_networks* is set to ``true``,
+  kubelet's ``--node-ip`` and node's ``InternalIP`` will be use only *ip6*.
 * *loadbalancer_apiserver* - If defined, all hosts will connect to this
   address instead of localhost for kube_control_planes and kube_control_plane[0] for
   kube_nodes. See more details in the
@@ -84,6 +89,8 @@ following default cluster parameters:
   [Calico IP block sizes](https://docs.projectcalico.org/reference/resources/ippool#block-sizes)).
 
 * *enable_dual_stack_networks* - Setting this to true will provision both IPv4 and IPv6 networking for pods and services.
+
+* *enable_ipv6only_stack_networks* - Setting this to true will provision IPv6 only networking for pods and services.
 
 * *kube_service_addresses_ipv6* - Subnet for cluster IPv6 IPs (default is ``fd85:ee78:d8a6:8607::1000/116``). Must not overlap with ``kube_pods_subnet_ipv6``.
 
@@ -155,6 +162,7 @@ and ``kube_pods_subnet``, for example from the ``172.18.0.0/16``.
 ## Enabling Dual Stack (IPV4 + IPV6) networking
 
 If *enable_dual_stack_networks* is set to ``true``, Dual Stack networking will be enabled in the cluster. This will use the default IPv4 and IPv6 subnets specified in the defaults file in the ``kubespray-defaults`` role, unless overridden of course. The default config will give you room for up to 256 nodes with 126 pods per node, and up to 4096 services.
+Also you can use *enable_ipv6only_stack_networks* for ipv6 only networking.
 
 ## DNS variables
 

--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -100,24 +100,27 @@ kube_network_node_prefix: 24
 # Configure Dual Stack networking (i.e. both IPv4 and IPv6)
 enable_dual_stack_networks: false
 
+# Configure IPv6 only
+enable_ipv6only_stack_networks: false
+
 # Kubernetes internal network for IPv6 services, unused block of space.
-# This is only used if enable_dual_stack_networks is set to true
+# This is used if enable_dual_stack_networks or enable_ipv6only_stack_networks is set to true
 # This provides 4096 IPv6 IPs
 kube_service_addresses_ipv6: fd85:ee78:d8a6:8607::1000/116
 
 # Internal network. When used, it will assign IPv6 addresses from this range to individual pods.
 # This network must not already be in your network infrastructure!
-# This is only used if enable_dual_stack_networks is set to true.
+# This is used if enable_dual_stack_networks or enable_ipv6only_stack_networks is set to true
 # This provides room for 256 nodes with 254 pods per node.
 kube_pods_subnet_ipv6: fd85:ee78:d8a6:8607::1:0000/112
 
 # IPv6 subnet size allocated to each for pods.
-# This is only used if enable_dual_stack_networks is set to true
+# This is used if enable_dual_stack_networks or enable_ipv6only_stack_networks is set to true
 # This provides room for 254 pods per node.
 kube_network_node_prefix_ipv6: 120
 
 # The port the API Server will be listening on.
-kube_apiserver_ip: "{{ kube_service_addresses | ansible.utils.ipaddr('net') | ansible.utils.ipaddr(1) | ansible.utils.ipaddr('address') }}"
+kube_apiserver_ip: "{{ (kube_service_addresses_ipv6 if enable_ipv6only_stack_networks else kube_service_addresses) | ansible.utils.ipaddr('net') | ansible.utils.ipaddr(1) | ansible.utils.ipaddr('address') }}"
 kube_apiserver_port: 6443  # (https)
 
 # Kube-proxy proxyMode configuration.
@@ -215,8 +218,8 @@ resolvconf_mode: host_resolvconf
 # Deploy netchecker app to verify DNS resolve as an HTTP service
 deploy_netchecker: false
 # Ip address of the kubernetes skydns service
-skydns_server: "{{ kube_service_addresses | ansible.utils.ipaddr('net') | ansible.utils.ipaddr(3) | ansible.utils.ipaddr('address') }}"
-skydns_server_secondary: "{{ kube_service_addresses | ansible.utils.ipaddr('net') | ansible.utils.ipaddr(4) | ansible.utils.ipaddr('address') }}"
+skydns_server: "{{ (kube_service_addresses_ipv6 if enable_ipv6only_stack_networks else kube_service_addresses) | ansible.utils.ipaddr('net') | ansible.utils.ipaddr(3) | ansible.utils.ipaddr('address') }}"
+skydns_server_secondary: "{{ (kube_service_addresses_ipv6 if enable_ipv6only_stack_networks else kube_service_addresses) | ansible.utils.ipaddr('net') | ansible.utils.ipaddr(4) | ansible.utils.ipaddr('address') }}"
 dns_domain: "{{ cluster_name }}"
 
 ## Container runtime

--- a/roles/container-engine/cri-dockerd/templates/cri-dockerd.service.j2
+++ b/roles/container-engine/cri-dockerd/templates/cri-dockerd.service.j2
@@ -7,7 +7,7 @@ Requires=cri-dockerd.socket
 
 [Service]
 Type=notify
-ExecStart={{ bin_dir }}/cri-dockerd --container-runtime-endpoint {{ cri_socket }} --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin --network-plugin=cni --pod-cidr={{ kube_pods_subnet }} --pod-infra-container-image={{ pod_infra_image_repo }}:{{ pod_infra_version }} --log-level {{ cri_dockerd_log_level }} {% if enable_dual_stack_networks %}--ipv6-dual-stack=True{% endif %}
+ExecStart={{ bin_dir }}/cri-dockerd --container-runtime-endpoint {{ cri_socket }} --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin --network-plugin=cni --pod-cidr={{ kube_pods_subnet_range }} --pod-infra-container-image={{ pod_infra_image_repo }}:{{ pod_infra_version }} --log-level {{ cri_dockerd_log_level }} {% if enable_dual_stack_networks %}--ipv6-dual-stack=True{% endif %}
 
 ExecReload=/bin/kill -s HUP $MAINPID
 TimeoutSec=0

--- a/roles/etcd/tasks/configure.yml
+++ b/roles/etcd/tasks/configure.yml
@@ -145,7 +145,8 @@
     ETCDCTL_ENDPOINTS: "{{ etcd_events_access_addresses }}"
 
 - name: Configure | Check if member is in etcd cluster
-  shell: "{{ bin_dir }}/etcdctl member list | grep -w -q {{ etcd_access_address }}"
+  # remove ipv6 square brackets
+  shell: "{{ bin_dir }}/etcdctl member list | grep -w -q {{ etcd_access_address | replace('[', '') | replace(']', '') }}"
   register: etcd_member_in_cluster
   ignore_errors: true  # noqa ignore-errors
   changed_when: false
@@ -163,7 +164,8 @@
     ETCDCTL_ENDPOINTS: "{{ etcd_access_addresses }}"
 
 - name: Configure | Check if member is in etcd-events cluster
-  shell: "{{ bin_dir }}/etcdctl member list | grep -w -q {{ etcd_access_address }}"
+  # remove ipv6 square brackets
+  shell: "{{ bin_dir }}/etcdctl member list | grep -w -q {{ etcd_access_address | replace('[', '') | replace(']', '') }}"
   register: etcd_events_member_in_cluster
   ignore_errors: true  # noqa ignore-errors
   changed_when: false

--- a/roles/etcd/templates/openssl.conf.j2
+++ b/roles/etcd/templates/openssl.conf.j2
@@ -39,10 +39,10 @@ DNS.{{ counter["dns"] }} = {{ apiserver_loadbalancer_domain_name }}{{ increment(
 DNS.{{ counter["dns"] }} = {{ etcd_alt_name }}{{ increment(counter, 'dns') }}
 {% endfor %}
 {% for host in groups['etcd'] %}
-{% if hostvars[host]['access_ip'] is defined  %}
-IP.{{ counter["ip"] }} = {{ hostvars[host]['access_ip'] }}{{ increment(counter, 'ip') }}
+{% if hostvars[host]['access_ip' + default_net_mode] is defined  %}
+IP.{{ counter["ip"] }} = {{ hostvars[host]['access_ip' + default_net_mode] }}{{ increment(counter, 'ip') }}
 {% endif %}
-IP.{{ counter["ip"] }} = {{ hostvars[host]['ip'] | default(hostvars[host]['fallback_ip']) }}{{ increment(counter, 'ip') }}
+IP.{{ counter["ip"] }} = {{ hostvars[host]['ip' + default_net_mode] | default(hostvars[host]['fallback_ip' + default_net_mode]) }}{{ increment(counter, 'ip') }}
 {% endfor %}
 {% for cert_alt_ip in etcd_cert_alt_ips %}
 IP.{{ counter["ip"] }} = {{ cert_alt_ip }}{{ increment(counter, 'ip') }}

--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -71,7 +71,7 @@
     user_certs: "{{ admin_kubeconfig['users'][0]['user'] }}"
     username: "kubernetes-admin-{{ cluster_name }}"
     context: "kubernetes-admin-{{ cluster_name }}@{{ cluster_name }}"
-    override_cluster_name: "{{ {'clusters': [{'cluster': (cluster_infos | combine({'server': 'https://' + external_apiserver_address + ':' + (external_apiserver_port | string)})), 'name': cluster_name}]} }}"
+    override_cluster_name: "{{ {'clusters': [{'cluster': (cluster_infos | combine({'server': 'https://' + (external_apiserver_address | ansible.utils.ipwrap) + ':' + (external_apiserver_port | string)})), 'name': cluster_name}]} }}"
     override_context: "{{ {'contexts': [{'context': {'user': username, 'cluster': cluster_name}, 'name': context}], 'current-context': context} }}"
     override_user: "{{ {'users': [{'name': username, 'user': user_certs}]} }}"
   when: kubeconfig_localhost

--- a/roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml
@@ -43,8 +43,8 @@
 
 - name: Wait for k8s apiserver
   wait_for:
-    host: "{{ kubeadm_discovery_address.split(':')[0] }}"
-    port: "{{ kubeadm_discovery_address.split(':')[1] }}"
+    host: "{{ kubeadm_discovery_address | regex_replace('\\]?:\\d+$', '') | regex_replace('^\\[', '') }}"
+    port: "{{ kubeadm_discovery_address.split(':')[-1] }}"
     timeout: 180
 
 

--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -35,6 +35,7 @@
       - "{{ kube_apiserver_ip }}"
       - "localhost"
       - "127.0.0.1"
+      - "::1"
     sans_lb: "{{ [apiserver_loadbalancer_domain_name] if apiserver_loadbalancer_domain_name is defined else [] }}"
     sans_lb_ip: "{{ [loadbalancer_apiserver.address] if loadbalancer_apiserver is defined and loadbalancer_apiserver.address is defined else [] }}"
     sans_supp: "{{ supplementary_addresses_in_ssl_keys if supplementary_addresses_in_ssl_keys is defined else [] }}"

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
@@ -94,9 +94,9 @@ dns:
   imageTag: {{ coredns_image_tag }}
 networking:
   dnsDomain: {{ dns_domain }}
-  serviceSubnet: "{{ kube_service_addresses }}{{ ',' + kube_service_addresses_ipv6 if enable_dual_stack_networks else '' }}"
+  serviceSubnet: "{{ kube_service_addresses_range }}"
 {% if kube_network_plugin is defined and kube_network_plugin not in ["kube-ovn"] %}
-  podSubnet: "{{ kube_pods_subnet }}{{ ',' + kube_pods_subnet_ipv6 if enable_dual_stack_networks else '' }}"
+  podSubnet: "{{ kube_pods_subnet_range }}"
 {% endif %}
 {% if kubeadm_feature_gates %}
 featureGates:
@@ -108,7 +108,7 @@ kubernetesVersion: {{ kube_version }}
 {% if kubeadm_config_api_fqdn is defined %}
 controlPlaneEndpoint: {{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
 {% else %}
-controlPlaneEndpoint: {{ ip | default(fallback_ip) }}:{{ kube_apiserver_port }}
+controlPlaneEndpoint: "{{ lookup('ansible.builtin.vars', 'ip' + default_net_mode, default=hostvars[inventory_hostname]['fallback_ip' + default_net_mode]) | ansible.utils.ipwrap }}:{{ kube_apiserver_port }}"
 {% endif %}
 certificatesDir: {{ kube_cert_dir }}
 imageRepository: {{ kube_image_repo }}
@@ -147,7 +147,7 @@ apiServer:
     etcd-servers-overrides: "/events#{{ etcd_events_access_addresses_semicolon }}"
 {% endif %}
     service-node-port-range: {{ kube_apiserver_node_port_range }}
-    service-cluster-ip-range: "{{ kube_service_addresses }}{{ ',' + kube_service_addresses_ipv6 if enable_dual_stack_networks else '' }}"
+    service-cluster-ip-range: "{{ kube_service_addresses_range }}"
     kubelet-preferred-address-types: "{{ kubelet_preferred_address_types }}"
     profiling: "{{ kube_profiling }}"
     request-timeout: "{{ kube_apiserver_request_timeout }}"
@@ -294,7 +294,7 @@ apiServer:
 {% endif %}
   certSANs:
 {% for san in apiserver_sans %}
-  - "{{ san }}"
+  - {{ san }}
 {% endfor %}
   timeoutForControlPlane: 5m0s
 controllerManager:
@@ -302,18 +302,18 @@ controllerManager:
     node-monitor-grace-period: {{ kube_controller_node_monitor_grace_period }}
     node-monitor-period: {{ kube_controller_node_monitor_period }}
 {% if kube_network_plugin is defined and kube_network_plugin not in ["kube-ovn"] %}
-    cluster-cidr: "{{ kube_pods_subnet }}{{ ',' + kube_pods_subnet_ipv6 if enable_dual_stack_networks else '' }}"
+    cluster-cidr: "{{ kube_pods_subnet_range }}"
 {% endif %}
-    service-cluster-ip-range: "{{ kube_service_addresses }}{{ ',' + kube_service_addresses_ipv6 if enable_dual_stack_networks else '' }}"
+    service-cluster-ip-range: "{{ kube_service_addresses_range }}"
 {% if kube_network_plugin is defined and kube_network_plugin == "calico" and not calico_ipam_host_local %}
     allocate-node-cidrs: "false"
-{% else %}
-{% if enable_dual_stack_networks %}
+{% elif enable_ipv6only_stack_networks %}
+    node-cidr-mask-size-ipv6: "{{ kube_network_node_prefix_ipv6 }}"
+{% elif enable_dual_stack_networks %}
     node-cidr-mask-size-ipv4: "{{ kube_network_node_prefix }}"
     node-cidr-mask-size-ipv6: "{{ kube_network_node_prefix_ipv6 }}"
 {% else %}
     node-cidr-mask-size: "{{ kube_network_node_prefix }}"
-{% endif %}
 {% endif %}
     profiling: "{{ kube_profiling }}"
     terminated-pod-gc-threshold: "{{ kube_controller_terminated_pod_gc_threshold }}"
@@ -392,7 +392,7 @@ clientConnection:
   kubeconfig: {{ kube_proxy_client_kubeconfig }}
   qps: {{ kube_proxy_client_qps }}
 {% if kube_network_plugin is defined and kube_network_plugin not in ["kube-ovn"] %}
-clusterCIDR: "{{ kube_pods_subnet }}{{ ',' + kube_pods_subnet_ipv6 if enable_dual_stack_networks else '' }}"
+clusterCIDR: "{{ kube_pods_subnet_range }}"
 {% endif %}
 configSyncPeriod: {{ kube_proxy_config_sync_period }}
 conntrack:

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
@@ -106,9 +106,9 @@ dns:
   imageTag: {{ coredns_image_tag }}
 networking:
   dnsDomain: {{ dns_domain }}
-  serviceSubnet: "{{ kube_service_addresses }}{{ ',' + kube_service_addresses_ipv6 if enable_dual_stack_networks else '' }}"
+  serviceSubnet: "{{ kube_service_addresses_range }}"
 {% if kube_network_plugin is defined and kube_network_plugin not in ["kube-ovn"] %}
-  podSubnet: "{{ kube_pods_subnet }}{{ ',' + kube_pods_subnet_ipv6 if enable_dual_stack_networks else '' }}"
+  podSubnet: "{{ kube_pods_subnet_range }}"
 {% endif %}
 {% if kubeadm_feature_gates %}
 featureGates:
@@ -120,7 +120,7 @@ kubernetesVersion: {{ kube_version }}
 {% if kubeadm_config_api_fqdn is defined %}
 controlPlaneEndpoint: {{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
 {% else %}
-controlPlaneEndpoint: {{ ip | default(fallback_ip) }}:{{ kube_apiserver_port }}
+controlPlaneEndpoint: "{{ lookup('ansible.builtin.vars', 'ip' + default_net_mode, default=hostvars[inventory_hostname]['fallback_ip' + default_net_mode]) | ansible.utils.ipwrap }}:{{ kube_apiserver_port }}"
 {% endif %}
 certificatesDir: {{ kube_cert_dir }}
 imageRepository: {{ kube_image_repo }}
@@ -174,7 +174,7 @@ apiServer:
   - name: service-node-port-range
     value: "{{ kube_apiserver_node_port_range }}"
   - name: service-cluster-ip-range
-    value: "{{ kube_service_addresses }}{{ ',' + kube_service_addresses_ipv6 if enable_dual_stack_networks else '' }}"
+    value: "{{ kube_service_addresses_range }}"
   - name: kubelet-preferred-address-types
     value: "{{ kubelet_preferred_address_types }}"
   - name: profiling
@@ -351,7 +351,7 @@ apiServer:
 {% endif %}
   certSANs:
 {% for san in apiserver_sans %}
-  - "{{ san }}"
+  - {{ san }}
 {% endfor %}
 controllerManager:
   extraArgs:
@@ -361,15 +361,17 @@ controllerManager:
     value: "{{ kube_controller_node_monitor_period }}"
 {% if kube_network_plugin is defined and kube_network_plugin not in ["kube-ovn"] %}
   - name: cluster-cidr
-    value: "{{ kube_pods_subnet }}{{ ',' + kube_pods_subnet_ipv6 if enable_dual_stack_networks else '' }}"
+    value: "{{ kube_pods_subnet_range }}"
 {% endif %}
   - name: service-cluster-ip-range
-    value: "{{ kube_service_addresses }}{{ ',' + kube_service_addresses_ipv6 if enable_dual_stack_networks else '' }}"
+    value: "{{ kube_service_addresses_range }}"
 {% if kube_network_plugin is defined and kube_network_plugin == "calico" and not calico_ipam_host_local %}
   - name: allocate-node-cidrs
     value: "false"
-{% else %}
-{% if enable_dual_stack_networks %}
+{% elif enable_ipv6only_stack_networks %}
+  - name: node-cidr-mask-size-ipv6
+    value: "{{ kube_network_node_prefix_ipv6 }}"
+{% elif enable_dual_stack_networks %}
   - name: node-cidr-mask-size-ipv4
     value: "{{ kube_network_node_prefix }}"
   - name: node-cidr-mask-size-ipv6
@@ -377,7 +379,6 @@ controllerManager:
 {% else %}
   - name: node-cidr-mask-size
     value: "{{ kube_network_node_prefix }}"
-{% endif %}
 {% endif %}
   - name: profiling
     value: "{{ kube_profiling }}"
@@ -488,7 +489,7 @@ clientConnection:
   kubeconfig: {{ kube_proxy_client_kubeconfig }}
   qps: {{ kube_proxy_client_qps }}
 {% if kube_network_plugin is defined and kube_network_plugin not in ["kube-ovn"] %}
-clusterCIDR: "{{ kube_pods_subnet }}{{ ',' + kube_pods_subnet_ipv6 if enable_dual_stack_networks else '' }}"
+clusterCIDR: "{{ kube_pods_subnet_range }}"
 {% endif %}
 configSyncPeriod: {{ kube_proxy_config_sync_period }}
 conntrack:

--- a/roles/kubernetes/control-plane/templates/kubeadm-controlplane.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-controlplane.yaml.j2
@@ -7,9 +7,9 @@ discovery:
 {% else %}
   bootstrapToken:
 {% if kubeadm_config_api_fqdn is defined %}
-    apiServerEndpoint: {{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
+    apiServerEndpoint: "{{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}"
 {% else %}
-    apiServerEndpoint: {{ kubeadm_discovery_address }}
+    apiServerEndpoint: "{{ kubeadm_discovery_address }}"
 {% endif %}
     token: {{ kubeadm_token }}
     unsafeSkipCAVerification: true

--- a/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.j2
+++ b/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.j2
@@ -8,9 +8,9 @@ discovery:
 {% else %}
   bootstrapToken:
 {% if kubeadm_config_api_fqdn is defined %}
-    apiServerEndpoint: {{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
+    apiServerEndpoint: "{{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}"
 {% else %}
-    apiServerEndpoint: {{ kubeadm_discovery_address }}
+    apiServerEndpoint: "{{ kubeadm_discovery_address }}"
 {% endif %}
     token: {{ kubeadm_token }}
 {% if ca_cert_content is defined %}

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
 # advertised host IP for kubelet. This affects network plugin config. Take caution
-kubelet_address: "{{ ip | default(fallback_ip) }}{{ (',' + ip6) if enable_dual_stack_networks and ip6 is defined else '' }}"
+kubelet_address: "{{ [ip | default(fallback_ip) if not enable_ipv6only_stack_networks, ip6 | default(fallback_ip6) if (enable_dual_stack_networks or enable_ipv6only_stack_networks)] | reject('match', '^$') | join(',') }}{{ '' }}"
 
 # bind address for kubelet. Set to 0.0.0.0 to listen on all interfaces
-kubelet_bind_address: "{{ ip | default('0.0.0.0') }}"
+kubelet_bind_address: "{{ (ip6 if enable_ipv6only_stack_networks else ip) | default('0.0.0.0') }}"
 
 # resolv.conf to base dns config
 kube_resolv_conf: "/etc/resolv.conf"
@@ -29,7 +29,7 @@ kubelet_systemd_wants_dependencies: []
 # List of secure IPs for kubelet
 kube_node_addresses: >-
   {%- for host in (groups['k8s_cluster'] | union(groups['etcd'])) -%}
-    {{ hostvars[host]['ip'] | default(hostvars[host]['fallback_ip']) }}{{ ' ' if not loop.last else '' }}
+    {{ hostvars[host]['ip' + default_net_mode] | default(hostvars[host]['fallback_ip' + default_net_mode]) | ansible.utils.ipwrap }}{{ ' ' if not loop.last else '' }}
   {%- endfor -%}
 kubelet_secure_addresses: "localhost link-local {{ kube_pods_subnet }} {{ kube_node_addresses }}"
 

--- a/roles/kubernetes/node/templates/loadbalancer/haproxy.cfg.j2
+++ b/roles/kubernetes/node/templates/loadbalancer/haproxy.cfg.j2
@@ -22,7 +22,7 @@ defaults
 {% if loadbalancer_apiserver_healthcheck_port is defined -%}
 frontend healthz
   bind 0.0.0.0:{{ loadbalancer_apiserver_healthcheck_port }}
-  {% if enable_dual_stack_networks -%}
+  {% if enable_dual_stack_networks or enable_ipv6only_stack_networks -%}
   bind :::{{ loadbalancer_apiserver_healthcheck_port }}
   {% endif -%}
   mode http
@@ -31,7 +31,7 @@ frontend healthz
 
 frontend kube_api_frontend
   bind 127.0.0.1:{{ loadbalancer_apiserver_port|default(kube_apiserver_port) }}
-  {% if enable_dual_stack_networks -%}
+  {% if enable_dual_stack_networks or enable_ipv6only_stack_networks -%}
   bind [::1]:{{ loadbalancer_apiserver_port|default(kube_apiserver_port) }};
   {% endif -%}
   mode tcp

--- a/roles/kubernetes/node/templates/loadbalancer/nginx.conf.j2
+++ b/roles/kubernetes/node/templates/loadbalancer/nginx.conf.j2
@@ -20,7 +20,7 @@ stream {
 
   server {
     listen        127.0.0.1:{{ loadbalancer_apiserver_port|default(kube_apiserver_port) }};
-    {% if enable_dual_stack_networks -%}
+    {% if enable_dual_stack_networks or enable_ipv6only_stack_networks -%}
     listen        [::1]:{{ loadbalancer_apiserver_port|default(kube_apiserver_port) }};
     {% endif -%}
     proxy_pass    kube_apiserver;
@@ -44,7 +44,7 @@ http {
   {% if loadbalancer_apiserver_healthcheck_port is defined -%}
   server {
     listen {{ loadbalancer_apiserver_healthcheck_port }};
-    {% if enable_dual_stack_networks -%}
+    {% if enable_dual_stack_networks or enable_ipv6only_stack_networks -%}
     listen [::]:{{ loadbalancer_apiserver_healthcheck_port }};
     {% endif -%}
     location /healthz {

--- a/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
+++ b/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
@@ -84,7 +84,7 @@
     value: "1"
     state: present
     reload: true
-  when: enable_dual_stack_networks | bool
+  when: (enable_dual_stack_networks or enable_ipv6only_stack_networks) | bool
 
 - name: Check if we need to set fs.may_detach_mounts
   stat:

--- a/roles/kubernetes/preinstall/tasks/0090-etchosts.yml
+++ b/roles/kubernetes/preinstall/tasks/0090-etchosts.yml
@@ -3,8 +3,13 @@
   set_fact:
     etc_hosts_inventory_block: |-
       {% for item in (groups['k8s_cluster'] + groups['etcd'] | default([]) + groups['calico_rr'] | default([])) | unique -%}
-      {% if 'access_ip' in hostvars[item] or 'ip' in hostvars[item] or 'ansible_default_ipv4' in hostvars[item] -%}
+      {% if 'access_ip' in hostvars[item] or 'ip' in hostvars[item] or hostvars[item]['ansible_default_ipv4'] -%}
       {{ hostvars[item]['access_ip'] | default(hostvars[item]['ip'] | default(hostvars[item]['ansible_default_ipv4']['address'])) }}
+      {%- if ('ansible_hostname' in hostvars[item] and item != hostvars[item]['ansible_hostname']) %} {{ hostvars[item]['ansible_hostname'] }}.{{ dns_domain }} {{ hostvars[item]['ansible_hostname'] }} {% else %} {{ item }}.{{ dns_domain }} {{ item }} {% endif %}
+
+      {% endif %}
+      {% if ('access_ip6' in hostvars[item] or 'ip6' in hostvars[item] or hostvars[item]['ansible_default_ipv6']) and (enable_ipv6only_stack_networks or enable_dual_stack_networks) -%}
+      {{ hostvars[item]['access_ip6'] | default(hostvars[item]['ip6'] | default(hostvars[item]['ansible_default_ipv6']['address'])) }}
       {%- if ('ansible_hostname' in hostvars[item] and item != hostvars[item]['ansible_hostname']) %} {{ hostvars[item]['ansible_hostname'] }}.{{ dns_domain }} {{ hostvars[item]['ansible_hostname'] }} {% else %} {{ item }}.{{ dns_domain }} {{ item }} {% endif %}
 
       {% endif %}

--- a/roles/kubespray-defaults/defaults/main/main.yml
+++ b/roles/kubespray-defaults/defaults/main/main.yml
@@ -135,8 +135,8 @@ resolvconf_mode: host_resolvconf
 # Deploy netchecker app to verify DNS resolve as an HTTP service
 deploy_netchecker: false
 # Ip address of the kubernetes DNS service (called skydns for historical reasons)
-skydns_server: "{{ kube_service_addresses | ansible.utils.ipaddr('net') | ansible.utils.ipaddr(3) | ansible.utils.ipaddr('address') }}"
-skydns_server_secondary: "{{ kube_service_addresses | ansible.utils.ipaddr('net') | ansible.utils.ipaddr(4) | ansible.utils.ipaddr('address') }}"
+skydns_server: "{{ (kube_service_addresses_ipv6 if enable_ipv6only_stack_networks else kube_service_addresses) | ansible.utils.ipaddr('net') | ansible.utils.ipaddr(3) | ansible.utils.ipaddr('address') }}"
+skydns_server_secondary: "{{ (kube_service_addresses_ipv6 if enable_ipv6only_stack_networks else kube_service_addresses) | ansible.utils.ipaddr('net') | ansible.utils.ipaddr(4) | ansible.utils.ipaddr('address') }}"
 dns_domain: "{{ cluster_name }}"
 docker_dns_search_domains:
 - 'default.svc.{{ dns_domain }}'
@@ -232,6 +232,9 @@ kube_network_node_prefix: 24
 # Configure Dual Stack networking (i.e. both IPv4 and IPv6)
 enable_dual_stack_networks: false
 
+# Configure only IPv6 networking
+enable_ipv6only_stack_networks: false
+
 # Kubernetes internal network for IPv6 services, unused block of space.
 # This is only used if enable_dual_stack_networks is set to true
 # This provides 4096 IPv6 IPs
@@ -248,11 +251,37 @@ kube_pods_subnet_ipv6: fd85:ee78:d8a6:8607::1:0000/112
 # This provides room for 254 pods per node.
 kube_network_node_prefix_ipv6: 120
 
+# Configure all of service addresses in one variable.
+# Merge all of different stack.
+kube_service_addresses_range: >-
+  {%- if enable_ipv6only_stack_networks -%}
+  {{ kube_service_addresses_ipv6 }}
+  {%- elif enable_dual_stack_networks -%}
+  {{ kube_service_addresses }},{{ kube_service_addresses_ipv6 }}
+  {%- else -%}
+  {{ kube_service_addresses }}
+  {%- endif -%}
+
+# Configure all of pods subnets in one variable.
+# Merge all of different stack.
+kube_pods_subnet_range: >-
+  {%- if enable_ipv6only_stack_networks -%}
+  {{ kube_pods_subnet_ipv6 }}
+  {%- elif enable_dual_stack_networks -%}
+  {{ kube_pods_subnet }},{{ kube_pods_subnet_ipv6 }}
+  {%- else -%}
+  {{ kube_pods_subnet }}
+  {%- endif -%}
+
+# Configure variable with default stack for ip.
+# IPv6 get more priority only with enable_ipv6only_stack_networks options.
+default_net_mode: "{{ '6' if enable_ipv6only_stack_networks else '' }}"
+
 # The virtual cluster IP, real host IPs and ports the API Server will be
 # listening on.
 # NOTE: loadbalancer_apiserver_localhost somewhat alters the final API enpdoint
 # access IP value (automatically evaluated below)
-kube_apiserver_ip: "{{ kube_service_addresses | ansible.utils.ipaddr('net') | ansible.utils.ipaddr(1) | ansible.utils.ipaddr('address') }}"
+kube_apiserver_ip: "{{ (kube_service_addresses_ipv6 if enable_ipv6only_stack_networks else kube_service_addresses) | ansible.utils.ipaddr('net') | ansible.utils.ipaddr(1) | ansible.utils.ipaddr('address') }}"
 
 # NOTE: If you specific address/interface and use loadbalancer_apiserver_localhost
 # loadbalancer_apiserver_localhost (nginx/haproxy) will deploy on control plane nodes on 127.0.0.1:{{ loadbalancer_apiserver_port | default(kube_apiserver_port) }} too.
@@ -609,9 +638,9 @@ ssl_ca_dirs: |-
 
 # Vars for pointing to kubernetes api endpoints
 kube_apiserver_count: "{{ groups['kube_control_plane'] | length }}"
-kube_apiserver_address: "{{ ip | default(hostvars[inventory_hostname]['fallback_ip']) }}"
-kube_apiserver_access_address: "{{ access_ip | default(kube_apiserver_address) }}"
-first_kube_control_plane_address: "{{ hostvars[groups['kube_control_plane'][0]]['access_ip'] | default(hostvars[groups['kube_control_plane'][0]]['ip'] | default(hostvars[groups['kube_control_plane'][0]]['fallback_ip'])) }}"
+kube_apiserver_address: "{{ lookup('ansible.builtin.vars', 'ip' + default_net_mode, default=hostvars[inventory_hostname]['fallback_ip' + default_net_mode]) }}"
+kube_apiserver_access_address: "{{ lookup('ansible.builtin.vars', 'access_ip' + default_net_mode, default=kube_apiserver_address) }}"
+first_kube_control_plane_address: "{{ hostvars[groups['kube_control_plane'][0]]['access_ip' + default_net_mode] | default(hostvars[groups['kube_control_plane'][0]]['ip' + default_net_mode] | default(hostvars[groups['kube_control_plane'][0]]['fallback_ip' + default_net_mode])) | ansible.utils.ipwrap }}"
 loadbalancer_apiserver_localhost: "{{ loadbalancer_apiserver is not defined }}"
 loadbalancer_apiserver_type: "nginx"
 # applied if only external loadbalancer_apiserver is defined, otherwise ignored
@@ -630,7 +659,7 @@ kube_apiserver_endpoint: |-
   {%- elif ('kube_control_plane' not in group_names) and loadbalancer_apiserver_localhost -%}
       https://localhost:{{ loadbalancer_apiserver_port | default(kube_apiserver_port) }}
   {%- elif 'kube_control_plane' in group_names -%}
-      https://{{ kube_apiserver_bind_address | regex_replace('0\.0\.0\.0', '127.0.0.1') }}:{{ kube_apiserver_port }}
+      https://{{ kube_apiserver_bind_address | regex_replace('0\.0\.0\.0', '127.0.0.1') | ansible.utils.ipwrap }}:{{ kube_apiserver_port }}
   {%- else -%}
       https://{{ first_kube_control_plane_address }}:{{ kube_apiserver_port }}
   {%- endif %}
@@ -644,26 +673,26 @@ etcd_events_cluster_enabled: false
 etcd_hosts: "{{ groups['etcd'] | default(groups['kube_control_plane']) }}"
 
 # Vars for pointing to etcd endpoints
-etcd_address: "{{ ip | default(fallback_ip) }}"
-etcd_access_address: "{{ access_ip | default(etcd_address) }}"
-etcd_events_access_address: "{{ access_ip | default(etcd_address) }}"
+etcd_address: "{{ (ip6 | default(fallback_ip6) | ansible.utils.ipwrap) if enable_ipv6only_stack_networks else (ip | default(fallback_ip)) }}"
+etcd_access_address: "{{ (access_ip6 if enable_ipv6only_stack_networks else access_ip) | default(etcd_address) | ansible.utils.ipwrap }}"
+etcd_events_access_address: "{{ (access_ip6 if enable_ipv6only_stack_networks else access_ip) | default(etcd_address) | ansible.utils.ipwrap }}"
 etcd_peer_url: "https://{{ etcd_access_address }}:2380"
 etcd_client_url: "https://{{ etcd_access_address }}:2379"
 etcd_events_peer_url: "https://{{ etcd_events_access_address }}:2382"
 etcd_events_client_url: "https://{{ etcd_events_access_address }}:2383"
 etcd_access_addresses: |-
   {% for item in etcd_hosts -%}
-    https://{{ hostvars[item]['etcd_access_address'] | default(hostvars[item]['ip'] | default(hostvars[item]['fallback_ip'])) }}:2379{% if not loop.last %},{% endif %}
+    https://{{ hostvars[item]['etcd_access_address'] | default(hostvars[item]['ip' + default_net_mode] | default(hostvars[item]['fallback_ip' + default_net_mode])) | ansible.utils.ipwrap }}:2379{% if not loop.last %},{% endif %}
   {%- endfor %}
 etcd_events_access_addresses_list: |-
   [
   {% for item in etcd_hosts -%}
-    'https://{{ hostvars[item]['etcd_events_access_address'] | default(hostvars[item]['ip'] | default(hostvars[item]['fallback_ip'])) }}:2383'{% if not loop.last %},{% endif %}
+    'https://{{ hostvars[item]['etcd_events_access_address'] | default(hostvars[item]['ip' + default_net_mode] | default(hostvars[item]['fallback_ip' + default_net_mode])) | ansible.utils.ipwrap }}:2383'{% if not loop.last %},{% endif %}
   {%- endfor %}
   ]
 etcd_metrics_addresses: |-
   {% for item in etcd_hosts -%}
-    https://{{ hostvars[item]['etcd_access_address'] | default(hostvars[item]['ip'] | default(hostvars[item]['fallback_ip'])) }}:{{ etcd_metrics_port | default(2381) }}{% if not loop.last %},{% endif %}
+    https://{{ hostvars[item]['etcd_access_address'] | default(hostvars[item]['ip' + default_net_mode] | default(hostvars[item]['fallback_ip' + default_net_mode])) }}:{{ etcd_metrics_port | default(2381) | ansible.utils.ipwrap }}{% if not loop.last %},{% endif %}
   {%- endfor %}
 etcd_events_access_addresses: "{{ etcd_events_access_addresses_list | join(',') }}"
 etcd_events_access_addresses_semicolon: "{{ etcd_events_access_addresses_list | join(';') }}"
@@ -674,11 +703,11 @@ etcd_member_name: |-
   {% endfor %}
 etcd_peer_addresses: |-
   {% for item in groups['etcd'] -%}
-    {{ hostvars[item].etcd_member_name | default("etcd" + loop.index | string) }}=https://{{ hostvars[item].etcd_access_address | default(hostvars[item].ip | default(hostvars[item]['fallback_ip'])) }}:2380{% if not loop.last %},{% endif %}
+    {{ hostvars[item].etcd_member_name | default("etcd" + loop.index | string) }}=https://{{ hostvars[item].etcd_access_address | default(hostvars[item]['ip' + default_net_mode] | default(hostvars[item]['fallback_ip' + default_net_mode])) | ansible.utils.ipwrap }}:2380{% if not loop.last %},{% endif %}
   {%- endfor %}
 etcd_events_peer_addresses: |-
   {% for item in groups['etcd'] -%}
-    {{ hostvars[item].etcd_member_name | default("etcd" + loop.index | string) }}-events=https://{{ hostvars[item].etcd_events_access_address | default(hostvars[item].ip | default(hostvars[item]['fallback_ip'])) }}:2382{% if not loop.last %},{% endif %}
+    {{ hostvars[item].etcd_member_name | default("etcd" + loop.index | string) }}-events=https://{{ hostvars[item].etcd_events_access_address | default(hostvars[item]['ip' + default_net_mode] | default(hostvars[item]['fallback_ip' + default_net_mode])) | ansible.utils.ipwrap }}:2382{% if not loop.last %},{% endif %}
   {%- endfor %}
 
 etcd_heartbeat_interval: "250"

--- a/roles/kubespray-defaults/tasks/main.yaml
+++ b/roles/kubespray-defaults/tasks/main.yaml
@@ -16,7 +16,17 @@
     - name: Set fallback_ip
       set_fact:
         fallback_ip: "{{ ansible_default_ipv4.address | d('127.0.0.1') }}"
-      when: fallback_ip is not defined
+      when: fallback_ip6 is not defined
+    - name: Gather ansible_default_ipv6
+      setup:
+        gather_subset: '!all,network'
+        filter: "ansible_default_ipv6"
+      when: ansible_default_ipv6 is not defined
+      ignore_unreachable: true
+    - name: Set fallback_ip6
+      set_fact:
+        fallback_ip6: "{{ ansible_default_ipv6.address | d('::1') }}"
+      when: fallback_ip6 is not defined
 
     - name: Set no_proxy
       import_tasks: no_proxy.yml

--- a/roles/kubespray-defaults/tasks/no_proxy.yml
+++ b/roles/kubespray-defaults/tasks/no_proxy.yml
@@ -23,7 +23,7 @@
       {%- if additional_no_proxy is defined -%}
       {{ additional_no_proxy }},
       {%- endif -%}
-      127.0.0.1,localhost,{{ kube_service_addresses }},{{ kube_pods_subnet }},svc,svc.{{ dns_domain }}
+      127.0.0.1,::1,localhost,{{ kube_service_addresses_range }},{{ kube_pods_subnet }},svc,svc.{{ dns_domain }}
   delegate_to: localhost
   connection: local
   delegate_facts: true

--- a/roles/network_plugin/calico/tasks/check.yml
+++ b/roles/network_plugin/calico/tasks/check.yml
@@ -192,6 +192,6 @@
       - "calico_ipip_mode_ipv6 in ['Never']"
     msg: "Calico doesn't support ipip tunneling for the IPv6"
   when:
-    - enable_dual_stack_networks
+    - (enable_dual_stack_networks or enable_ipv6only_stack_networks)
   run_once: true
   delegate_to: "{{ groups['kube_control_plane'][0] }}"

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -107,7 +107,7 @@
   changed_when: false
   when:
     - inventory_hostname == groups['kube_control_plane'][0]
-    - enable_dual_stack_networks
+    - (enable_dual_stack_networks or enable_ipv6only_stack_networks)
 
 - name: Calico | Ensure that calico_pool_cidr_ipv6 is within kube_pods_subnet_ipv6 when defined
   assert:
@@ -117,7 +117,7 @@
     - inventory_hostname == groups['kube_control_plane'][0]
     - calico_conf_ipv6.stdout is defined and calico_conf_ipv6.stdout == "0"
     - calico_pool_cidr_ipv6 is defined
-    - enable_dual_stack_networks
+    - (enable_dual_stack_networks or enable_ipv6only_stack_networks)
 
 - name: Calico | kdd specific configuration
   when:
@@ -256,7 +256,7 @@
 - name: Calico | Configure Calico IPv6 Pool
   when:
     - inventory_hostname == groups['kube_control_plane'][0]
-    - enable_dual_stack_networks | bool
+    - (enable_dual_stack_networks or enable_ipv6only_stack_networks) | bool
   block:
     - name: Calico | Get existing calico ipv6 network pool
       command: "{{ bin_dir }}/calicoctl.sh get ippool {{ calico_pool_name }}-ipv6 -o json"
@@ -350,7 +350,7 @@
               {% if not calico_no_global_as_num | default(false) %}"asNumber": {{ global_as_num }},{% endif %}
               "nodeToNodeMeshEnabled": {{ nodeToNodeMeshEnabled | default('true') }} ,
               {% if calico_advertise_cluster_ips | default(false) %}
-              "serviceClusterIPs": [{"cidr": "{{ kube_service_addresses }}" } {{ ',{"cidr":"' + kube_service_addresses_ipv6 + '"}' if enable_dual_stack_networks else '' }}],{% endif %}
+              "serviceClusterIPs": [{% for cidr in kube_service_addresses_range.split(",") %}{{ "," if not loop.first }}{"cidr": "{{ cidr }}"}{% endfor %}],{% endif %}
               {% if calico_advertise_service_loadbalancer_ips | length > 0  %}"serviceLoadBalancerIPs": {{ _service_loadbalancer_ips }},{% endif %}
               "serviceExternalIPs": {{ _service_external_ips | default([]) }}
             }

--- a/roles/network_plugin/calico/templates/calico-config.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-config.yml.j2
@@ -56,10 +56,14 @@ data:
             {% else %}
             "ipam": {
               "type": "calico-ipam",
-              {%   if enable_dual_stack_networks %}
+              {% if enable_ipv6only_stack_networks %}
+              "assign_ipv6": "true"
+              {% elif enable_dual_stack_networks %}
               "assign_ipv6": "true",
-              {%   endif %}
+              {% endif %}
+              {% if not enable_ipv6only_stack_networks %}
               "assign_ipv4": "true"
+              {% endif %}
             },
           {% endif %}
           {% if calico_allow_ip_forwarding %}

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -259,13 +259,15 @@ spec:
             # no effect. This should fall within `--cluster-cidr`.
             # - name: CALICO_IPV4POOL_CIDR
             #   value: "192.168.0.0/16"
+{% if not enable_ipv6only_stack_networks %}
             - name: CALICO_IPV4POOL_IPIP
               value: "{{ calico_ipv4pool_ipip }}"
+{% endif %}
             # Enable or Disable VXLAN on the default IP pool.
             - name: CALICO_IPV4POOL_VXLAN
               value: "Never"
             - name: FELIX_IPV6SUPPORT
-              value: "{{ enable_dual_stack_networks | default(false) }}"
+              value: "{{ (enable_dual_stack_networks or enable_ipv6only_stack_networks) | default(false) }}"
             # Set Felix logging to "info"
             - name: FELIX_LOGSEVERITYSCREEN
               value: "{{ calico_loglevel }}"
@@ -308,19 +310,27 @@ spec:
             - name: IP_AUTODETECTION_METHOD
               value: "can-reach=$(NODEIP)"
 {% endif %}
-            - name: IP
-              value: "autodetect"
-{% if calico_ip6_auto_method is defined and enable_dual_stack_networks %}
+{% if calico_ip6_auto_method is defined and (enable_dual_stack_networks or enable_ipv6only_stack_networks) %}
             - name: IP6_AUTODETECTION_METHOD
               value: "{{ calico_ip6_auto_method }}"
+{% endif %}
+{% if enable_ipv6only_stack_networks %}
+            - name: IP6
+              value: "autodetect"
+            - name: IP
+              value: none
+{% elif enable_dual_stack_networks %}
+            - name: IP6
+              value: "autodetect"
+            - name: IP
+              value: "autodetect"
+{% else %}
+            - name: IP
+              value: "autodetect"
 {% endif %}
 {% if calico_felix_mtu_iface_pattern is defined %}
             - name: FELIX_MTUIFACEPATTERN
               value: "{{ calico_felix_mtu_iface_pattern }}"
-{% endif %}
-{% if enable_dual_stack_networks %}
-            - name: IP6
-              value: autodetect
 {% endif %}
 {% if calico_use_default_route_src_ipaddr | default(false) %}
             - name: FELIX_DEVICEROUTESOURCEADDRESS

--- a/roles/network_plugin/calico_defaults/defaults/main.yml
+++ b/roles/network_plugin/calico_defaults/defaults/main.yml
@@ -22,7 +22,7 @@ calico_pool_blocksize: 26
 
 # Calico doesn't support ipip tunneling for the IPv6.
 calico_ipip_mode_ipv6: Never
-calico_vxlan_mode_ipv6: Never
+calico_vxlan_mode_ipv6: Always
 
 # add default ipv6 ippool blockSize
 calico_pool_blocksize_ipv6: 122

--- a/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
+++ b/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
@@ -30,12 +30,14 @@ data:
     }
   net-conf.json: |
     {
+{% if not enable_ipv6only_stack_networks %}
       "Network": "{{ kube_pods_subnet }}",
       "EnableIPv4": true,
-{%   if enable_dual_stack_networks %}
+{% endif %}
+{% if enable_dual_stack_networks or enable_ipv6only_stack_networks %}
       "EnableIPv6": true,
       "IPv6Network": "{{ kube_pods_subnet_ipv6 }}",
-{%   endif %}
+{% endif %}
       "Backend": {
         "Type": "{{ flannel_backend_type }}"{% if flannel_backend_type == "vxlan" %},
         "VNI": {{ flannel_vxlan_vni }},

--- a/roles/network_plugin/kube-ovn/templates/cni-kube-ovn.yml.j2
+++ b/roles/network_plugin/kube-ovn/templates/cni-kube-ovn.yml.j2
@@ -240,14 +240,14 @@ spec:
           imagePullPolicy: {{ k8s_image_pull_policy }}
           args:
           - /kube-ovn/start-controller.sh
-          - --default-cidr={{ kube_pods_subnet }}{% if enable_dual_stack_networks %},{{ kube_ovn_pool_cidr_ipv6 | default(kube_pods_subnet_ipv6) }}{% endif %}{{ '' }}
+          - --default-cidr={{ kube_pods_subnet_range }}
           - --default-gateway={% if kube_ovn_default_gateway is defined %}{{ kube_ovn_default_gateway }}{% endif %}{{ '' }}
           - --default-gateway-check={{ kube_ovn_default_gateway_check | string }}
           - --default-logical-gateway={{ kube_ovn_default_logical_gateway | string }}
           - --default-u2o-interconnection={{ kube_ovn_u2o_interconnection }}
           - --default-exclude-ips={% if kube_ovn_default_exclude_ips is defined %}{{ kube_ovn_default_exclude_ips }}{% endif %}{{ '' }}
-          - --node-switch-cidr={{ kube_ovn_node_switch_cidr }}{% if enable_dual_stack_networks %},{{ kube_ovn_node_switch_cidr_ipv6 }}{% endif %}{{ '' }}
-          - --service-cluster-ip-range={{ kube_service_addresses }}{% if enable_dual_stack_networks %},{{ kube_service_addresses_ipv6 }}{% endif %}{{ '' }}
+          - --node-switch-cidr={{ [kube_ovn_node_switch_cidr if not enable_ipv6only_stack_networks, kube_ovn_node_switch_cidr_ipv6 if (enable_dual_stack_networks or enable_ipv6only_stack_networks)] | reject('match', '^$') | join(',') }}{{ '' }}
+          - --service-cluster-ip-range={{ kube_service_addresses_range }}
           - --network-type={{ kube_ovn_network_type }}
           - --default-interface-name={{ kube_ovn_default_interface_name | default('') }}
           - --default-vlan-id={{ kube_ovn_default_vlan_id }}
@@ -403,7 +403,7 @@ spec:
         args:
           - --enable-mirror={{ kube_ovn_traffic_mirror | lower }}
           - --encap-checksum={{ kube_ovn_encap_checksum | lower }}
-          - --service-cluster-ip-range={{ kube_service_addresses }}{% if enable_dual_stack_networks %},{{ kube_service_addresses_ipv6 }}{% endif %}{{ '' }}
+          - --service-cluster-ip-range={{ kube_service_addresses_range }}
           - --iface={{ kube_ovn_iface | default('') }}
           - --dpdk-tunnel-iface={{ kube_ovn_dpdk_tunnel_iface }}
           - --network-type={{ kube_ovn_network_type }}
@@ -588,7 +588,7 @@ spec:
           command:
           - /kube-ovn/kube-ovn-pinger
           args:
-          - --external-address={{ kube_ovn_external_address }}{% if enable_dual_stack_networks %},{{ kube_ovn_external_address_ipv6 }}{% endif %}{{ '' }}
+          - --external-address={{ [kube_ovn_external_address if not enable_ipv6only_stack_networks, kube_ovn_external_address_ipv6 if (enable_dual_stack_networks or enable_ipv6only_stack_networks)] | reject('match', '^$') | join(',') }}{{ '' }}
           - --external-dns={{ kube_ovn_external_dns }}
           - --logtostderr=false
           - --alsologtostderr=true
@@ -837,7 +837,7 @@ spec:
     - name: metrics
       port: 10661
   type: ClusterIP
-{% if enable_dual_stack_networks %}
+{% if enable_dual_stack_networks or enable_ipv6only_stack_networks %}
   ipFamilyPolicy: PreferDualStack
 {% endif %}
   selector:
@@ -852,7 +852,7 @@ metadata:
   labels:
     app: kube-ovn-pinger
 spec:
-{% if enable_dual_stack_networks %}
+{% if enable_dual_stack_networks or enable_ipv6only_stack_networks %}
   ipFamilyPolicy: PreferDualStack
 {% endif %}
   selector:
@@ -869,7 +869,7 @@ metadata:
   labels:
     app: kube-ovn-controller
 spec:
-{% if enable_dual_stack_networks %}
+{% if enable_dual_stack_networks or enable_ipv6only_stack_networks %}
   ipFamilyPolicy: PreferDualStack
 {% endif %}
   selector:
@@ -886,7 +886,7 @@ metadata:
   labels:
     app: kube-ovn-cni
 spec:
-{% if enable_dual_stack_networks %}
+{% if enable_dual_stack_networks or enable_ipv6only_stack_networks %}
   ipFamilyPolicy: PreferDualStack
 {% endif %}
   selector:

--- a/roles/network_plugin/kube-ovn/templates/cni-ovn.yml.j2
+++ b/roles/network_plugin/kube-ovn/templates/cni-ovn.yml.j2
@@ -260,7 +260,7 @@ spec:
       port: 6641
       targetPort: 6641
   type: ClusterIP
-{% if enable_dual_stack_networks %}
+{% if enable_dual_stack_networks or enable_ipv6only_stack_networks %}
   ipFamilyPolicy: PreferDualStack
 {% endif %}
   selector:
@@ -280,7 +280,7 @@ spec:
       port: 6642
       targetPort: 6642
   type: ClusterIP
-{% if enable_dual_stack_networks %}
+{% if enable_dual_stack_networks or enable_ipv6only_stack_networks %}
   ipFamilyPolicy: PreferDualStack
 {% endif %}
   selector:
@@ -300,7 +300,7 @@ spec:
       port: 6643
       targetPort: 6643
   type: ClusterIP
-{% if enable_dual_stack_networks %}
+{% if enable_dual_stack_networks or enable_ipv6only_stack_networks %}
   ipFamilyPolicy: PreferDualStack
 {% endif %}
   selector:

--- a/roles/remove-node/remove-etcd-node/tasks/main.yml
+++ b/roles/remove-node/remove-etcd-node/tasks/main.yml
@@ -9,6 +9,8 @@
   - groups['kube_control_plane'] | length > 0
   - ip is not defined
   - access_ip is not defined
+  - ip6 is not defined
+  - access_ip6 is not defined
   delegate_to: "{{ groups['kube_control_plane'] | first }}"
 
 - name: Remove etcd member from cluster
@@ -29,7 +31,7 @@
     - facts
   - name: Remove member from cluster
     vars:
-      node_ip: "{{ ip if ip is defined else (access_ip if access_ip is defined else (k8s_node_ips.stdout | from_json)[0]) }}"
+      node_ip: "{{ hostvars[item]['ip' + default_net_mode] | default(hostvars[item]['access_ip' + default_net_mode]) | default((k8s_node_ips.stdout | from_json)[0]) | ansible.utils.ipwrap }}"
     command:
       argv:
       - "{{ bin_dir }}/etcdctl"

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -203,7 +203,7 @@
     - nat
     - mangle
     - raw
-  when: flush_iptables | bool and enable_dual_stack_networks
+  when: flush_iptables | bool and (enable_dual_stack_networks or enable_ipv6only_stack_networks)
   tags:
     - ip6tables
 

--- a/tests/files/vagrant_ubuntu24-calico-ipv6only-stack.rb
+++ b/tests/files/vagrant_ubuntu24-calico-ipv6only-stack.rb
@@ -1,0 +1,9 @@
+$os = "ubuntu2404"
+
+$vm_cpus = 2
+$libvirt_volume_cache = "unsafe"
+
+# Checking for box update can trigger API rate limiting
+# https://www.vagrantup.com/docs/vagrant-cloud/request-limits.html
+$box_check_update = false
+$network_plugin = "calico"

--- a/tests/files/vagrant_ubuntu24-calico-ipv6only-stack.yml
+++ b/tests/files/vagrant_ubuntu24-calico-ipv6only-stack.yml
@@ -1,0 +1,11 @@
+---
+# Instance settings
+cloud_image: ubuntu-2404
+mode: default
+
+# Kubespray settings
+enable_ipv6only_stack_networks: true
+kube_network_plugin: calico
+etcd_deployment_type: kubeadm
+kube_proxy_mode: iptables
+enable_nodelocaldns: false

--- a/tests/testcases/030_check-network.yml
+++ b/tests/testcases/030_check-network.yml
@@ -7,7 +7,7 @@
     # TODO: source those from kubespray-defaults instead.
     # Needs kubespray-defaults to be decoupled from no-proxy stuff
     bin_dir: "/usr/local/bin"
-    kube_pods_subnet: 10.233.64.0/18
+    kube_pods_subnet: "{{ 'fd85:ee78:d8a6:8607::1:0000/112' if (enable_ipv6only_stack_networks | default(false)) else '10.233.64.0/18' }}"
 
   tasks:
 
@@ -115,7 +115,7 @@
               | length == 2
 
     - name: Curl between pods is working
-      command: "{{ bin_dir }}/kubectl -n test exec {{ item[0].metadata.name }} -- curl {{ item[1].status.podIP }}:8080"
+      command: "{{ bin_dir }}/kubectl -n test exec {{ item[0].metadata.name }} -- curl {{ item[1].status.podIP | ansible.utils.ipwrap}}:8080"
       with_nested:
       - "{{ pods }}"
       - "{{ pods }}"

--- a/tests/testcases/040_check-network-adv.yml
+++ b/tests/testcases/040_check-network-adv.yml
@@ -51,7 +51,7 @@
       block:
         - name: Get netchecker agents
           uri:
-            url: "http://{{ ansible_default_ipv4.address }}:{{ netchecker_port }}/api/v1/agents/"
+            url: "http://{{ (ansible_default_ipv6.address if (enable_ipv6only_stack_networks | default(false)) else ansible_default_ipv4.address) | ansible.utils.ipwrap }}:{{ netchecker_port }}/api/v1/agents/"
             return_content: true
             headers:
               Accept: application/json
@@ -64,7 +64,7 @@
 
         - name: Check netchecker status
           uri:
-            url: "http://{{ ansible_default_ipv4.address }}:{{ netchecker_port }}/api/v1/connectivity_check"
+            url: "http://{{ (ansible_default_ipv6.address if (enable_ipv6only_stack_networks | default(false)) else ansible_default_ipv4.address) | ansible.utils.ipwrap }}:{{ netchecker_port }}/api/v1/connectivity_check"
             return_content: true
             headers:
               Accept: application/json


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Support ipv6 only clusters

**Which issue(s) this PR fixes**:
Fixes #5649

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Add support for ipv6 only cluster via "enable_ipv6only_stack_networks"
```
