### PR TITLE
[WIP] Fix terraform outdated resource to `openstack_blockstorage_volume_v3`

### DIFF
--- a/.gitlab-ci/terraform.yml
+++ b/.gitlab-ci/terraform.yml
@@ -164,7 +164,7 @@ tf-elastx_cleanup:
 
 tf-elastx_ubuntu20-calico:
   extends: .terraform_apply
-  stage: deploy-part1
+  stage: test
   when: on_success
   allow_failure: true
   variables:

--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -1078,7 +1078,7 @@ resource "openstack_networking_floatingip_associate_v2" "k8s_nodes" {
   port_id               = openstack_networking_port_v2.k8s_nodes_port[each.key].id
 }
 
-resource "openstack_blockstorage_volume_v2" "glusterfs_volume" {
+resource "openstack_blockstorage_volume_v3" "glusterfs_volume" {
   name        = "${var.cluster_name}-glusterfs_volume-${count.index + 1}"
   count       = var.gfs_root_volume_size_in_gb == 0 ? var.number_of_gfs_nodes_no_floating_ip : 0
   description = "Non-ephemeral volume for GlusterFS"
@@ -1088,5 +1088,5 @@ resource "openstack_blockstorage_volume_v2" "glusterfs_volume" {
 resource "openstack_compute_volume_attach_v2" "glusterfs_volume" {
   count       = var.gfs_root_volume_size_in_gb == 0 ? var.number_of_gfs_nodes_no_floating_ip : 0
   instance_id = element(openstack_compute_instance_v2.glusterfs_node_no_floating_ip.*.id, count.index)
-  volume_id   = element(openstack_blockstorage_volume_v2.glusterfs_volume.*.id, count.index)
+  volume_id   = element(openstack_blockstorage_volume_v3.glusterfs_volume.*.id, count.index)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

I guess this job failed because `openstack_blockstorage_volume_v2` is outdated.

EDIT:
I think this message is main reason:
`ERROR! No inventory was parsed, please check your configuration and options.`

**Which issue(s) this PR fixes**:

Fixes #11837 

**Special notes for your reviewer**:

Remove the `[WIP]` commit after getting the `approved` label.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
