### PR TITLE
Add option to skip network plugin installation

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
@@ -42,11 +42,20 @@
 
 - name: Stop if unknown network plugin
   assert:
-    that: kube_network_plugin in ['calico', 'flannel', 'weave', 'cloud', 'cilium', 'cni', 'kube-ovn', 'kube-router', 'macvlan', 'custom_cni']
+    that: kube_network_plugin in ['calico', 'flannel', 'weave', 'cloud', 'cilium', 'cni', 'kube-ovn', 'kube-router', 'macvlan', 'custom_cni', 'none']
     msg: "{{ kube_network_plugin }} is not supported"
   when:
     - kube_network_plugin is defined
     - not ignore_assert_errors
+- name: Warn the user if they are still using `etcd_kubeadm_enabled`
+  debug:
+    msg: >
+      "WARNING! => `kube_network_plugin` is set to `none`. The network configuration will be skipped.
+      The cluster won't be ready to use, we recommend to select one of the available plugins"
+  changed_when: true
+  when:
+    - kube_network_plugin is defined
+    - kube_network_plugin == 'none'
 
 - name: Stop if unsupported version of Kubernetes
   assert:

--- a/roles/network_plugin/meta/main.yml
+++ b/roles/network_plugin/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 dependencies:
   - role: network_plugin/cni
+    when: kube_network_plugin != 'none'
 
   - role: network_plugin/cilium
     when: kube_network_plugin == 'cilium' or cilium_deploy_additionally | default(false) | bool


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:


-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

We should be able to use other network plugin that the one proposed by Kubespray, or to manage them in a separate way. 

It can also be the way forward for weave users ([#11328](https://github.com/kubernetes-sigs/kubespray/issues/11328#issuecomment-2538623323)).

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Allow to skip network configuration by setting kube_network_plugin value to `none`  
```
