### PR TITLE
[ingress-nginx] expose custom tcp and udp ports in ingress-nginx-controller

### DIFF
--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
@@ -125,6 +125,26 @@ spec:
 {% if not ingress_nginx_host_network %}
               hostPort: {{ ingress_nginx_metrics_port }}
 {% endif %}
+{% if ingress_nginx_configmap_tcp_services %}
+{% for port in ingress_nginx_configmap_tcp_services.keys() %}
+            - name: tcp-port-{{ port }}
+              containerPort: {{ port }}
+              protocol: TCP
+{% if not ingress_nginx_host_network %}
+              hostPort: {{ port }}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% if ingress_nginx_configmap_udp_services %}
+{% for port in ingress_nginx_configmap_udp_services.keys() %}
+            - name: udp-port-{{ port }}
+              containerPort: {{ port }}
+              protocol: UDP
+{% if not ingress_nginx_host_network %}
+              hostPort: {{ port }}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% if ingress_nginx_webhook_enabled %}
             - name: webhook
               containerPort: 8443


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The PR adds missing container port mappings for custom TCP and UDP services so they are exposed by the ingress-nginx-controller container.

Prior to these changes, users may have defined custom TCP/UDP ports to be handled by ingress-nginx but they will have no effect because they are not exposed from the container.

**Which issue(s) this PR fixes**:

No existing issue found.

**Special notes for your reviewer**:

None.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
