### PR TITLE
Drop explicit k8s_cluster group in CI inventory

### DIFF
--- a/tests/cloud_playbooks/roles/packet-ci/tasks/main.yml
+++ b/tests/cloud_playbooks/roles/packet-ci/tasks/main.yml
@@ -4,11 +4,8 @@
 
 - name: Start vms for CI job
   vars:
-    # Workaround for compatibility when testing upgrades with old == before e9d406ed088d4291ef1d9018c170a4deed2bf928
-    # TODO: drop after 2.27.0
-    legacy_groups: "{{ (['kube_control_plane', 'kube_node', 'calico_rr'] | intersect(item) | length > 0) | ternary(['k8s_cluster'], []) }}"
     tvars:
-      kubespray_groups: "{{ item + legacy_groups }}"
+      kubespray_groups: "{{ item }}"
   kubernetes.core.k8s:
     definition: "{{ lookup('template', 'vm.yml.j2', template_vars=tvars) }}"
   loop: "{{ scenarios[mode | d('default')] }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This removes compatibility with releases below 2.27.0, now that it has
been released and that we're testing upgrades against it.

Functional revert of b5464af now that 2.27.0 is released.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
