### PR TITLE
Changed to use first_kube_control_plane to parse kubeadm_certificate_key

### DIFF
--- a/roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml
@@ -24,11 +24,11 @@
 
 - name: Parse certificate key if not set
   set_fact:
-    kubeadm_certificate_key: "{{ hostvars[groups['kube_control_plane'][0]]['kubeadm_upload_cert'].stdout_lines[-1] | trim }}"
+    kubeadm_certificate_key: "{{ hostvars[first_kube_control_plane]['kubeadm_upload_cert'].stdout_lines[-1] | trim }}"
   run_once: true
   when:
-    - hostvars[groups['kube_control_plane'][0]]['kubeadm_upload_cert'] is defined
-    - hostvars[groups['kube_control_plane'][0]]['kubeadm_upload_cert'] is not skipped
+    - hostvars[first_kube_control_plane]['kubeadm_upload_cert'] is defined
+    - hostvars[first_kube_control_plane]['kubeadm_upload_cert'] is not skipped
 
 - name: Create kubeadm ControlPlane config
   template:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

When reordering controlplane nodes in `inventory.ini` and the first in the list is not the same as the first one when running `kubectl get nodes --selector=node-role.kubernetes.io/control-plane -o json` you'll get an error:

```
fatal: [some-name-k8s-control-plane-6]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'kubeadm_certificate_key' is undefined. 'kubeadm_certificate_key' is undefined"}
```

This is because the variable `first_kube_control_plane` is ultimately set [using kubectl](https://github.com/kubernetes-sigs/kubespray/blob/v2.25.0/roles/kubernetes/control-plane/tasks/define-first-kube-control.yml#L4) and this is the one that is used to [create the certificate](https://github.com/kubernetes-sigs/kubespray/blob/v2.25.0/roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml#L22).
However the one after is using `groups['kube_control_plane'][0]` which will depend on what node is first in `inventory.ini` hence why this error occurs.

This PR changes so the parsing also fetches the certificate from the `first_kube_control_plane`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10973

**Special notes for your reviewer**:

All credit to @nvalembois who had this patch in https://github.com/kubernetes-sigs/kubespray/issues/10973

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix a bug where `kubeadm_certificate_key` was not defined if control plane nodes were not in correct order 
```
