### PR TITLE
Publish ingress-nginx service address if manual address not specified and not using host network

### DIFF
--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/defaults/main.yml
@@ -6,6 +6,7 @@ ingress_nginx_service_nodeport_http: ""
 ingress_nginx_service_nodeport_https: ""
 ingress_nginx_service_annotations: {}
 ingress_publish_status_address: ""
+ingress_nginx_publish_service: "{{ ingress_nginx_namespace }}/ingress-nginx"
 ingress_nginx_nodeselector:
   kubernetes.io/os: "linux"
 ingress_nginx_tolerations: []

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
@@ -79,11 +79,12 @@ spec:
 {% if ingress_nginx_without_class %}
             - --watch-ingress-without-class=true
 {% endif %}
-{% if ingress_nginx_host_network %}
-            - --report-node-internal-ip-address
-{% endif %}
 {% if ingress_publish_status_address != "" %}
             - --publish-status-address={{ ingress_publish_status_address }}
+{% elif ingress_nginx_host_network %}
+            - --report-node-internal-ip-address
+{% elif ingress_nginx_publish_service != "" %}
+            - --publish-service={{ ingress_nginx_publish_service }}
 {% endif %}
 {% for extra_arg in ingress_nginx_extra_args %}
             - {{ extra_arg }}


### PR DESCRIPTION
…ed and not using host network

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Advertises the correct service address if no manual address if defined and not using host networking

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Automatically publish ingress-nginx service address if manual address is not specified and ingress-nginx is not using host network
```
