### PR TITLE
Add Auto-Labeling of Issues Based on OS Selection

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -36,11 +36,35 @@ body:
     attributes:
       value: '### Environment'
 
-  - type: textarea
+  - type: dropdown
     id: os
     attributes:
       label: OS
-      placeholder: 'printf "$(uname -srm)\n$(cat /etc/os-release)\n"'
+      options:
+        - 'RHEL 9'
+        - 'RHEL 8'
+        - 'Fedora 40'
+        - 'Ubuntu 24'
+        - 'Ubuntu 22'
+        - 'Ubuntu 20'
+        - 'Debian 12'
+        - 'Debian 11'
+        - 'Flatcar Container Linux'
+        - 'openSUSE Leap'
+        - 'openSUSE Tumbleweed'
+        - 'Oracle Linux 9'
+        - 'Oracle Linux 8'
+        - 'AlmaLinux 9'
+        - 'AlmaLinux 8'
+        - 'Rocky Linux 9'
+        - 'Rocky Linux 8'
+        - 'Amazon Linux 2'
+        - 'Kylin Linux Advanced Server V10'
+        - 'UOS Linux 20'
+        - 'openEuler 24'
+        - 'openEuler 22'
+        - 'openEuler 20'
+        - 'Other|Unsupported'
     validations:
       required: true
 

--- a/.github/workflows/auto-label-os.yml
+++ b/.github/workflows/auto-label-os.yml
@@ -1,0 +1,32 @@
+name: Issue labeler
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  label-component:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Parse issue form
+        uses: stefanbuck/github-issue-parser@v3
+        id: issue-parser
+        with:
+          template-path: .github/ISSUE_TEMPLATE/bug-report.yaml
+
+      - name: Set labels based on OS field
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v2
+        with:
+          issue-form: ${{ steps.issue-parser.outputs.jsonString }}
+          section: os
+          block-list: |
+            None
+            Other
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

 /kind feature


**What this PR does / why we need it**:

This PR introduces an automatic labeling mechanism based on the operating system (OS) specified in bug reports.

The primary objective is to capture and label the user's OS when an issue is raised. This enables aggregation and analysis of user data, helping us better understand the distribution of OS usage among our users.

**Which issue(s) this PR fixes**: 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11873

**Special notes for your reviewer**: 

The OS field in the bug-report issue form has been converted into a dropdown menu for consistency and ease of selection. The list of supported OS options has been sourced from [Kubespray's preinstall defaults](https://github.com/kubernetes-sigs/kubespray/blob/1f186ed451894a55d0336c9736df7d147b2c3a55/roles/kubernetes/preinstall/defaults/main.yml#L117-L137).

A GitHub Action workflow for advanced issue labeling has been introduced. This workflow auto-assigns an OS label based on the OS selected in the bug report.

The implementation leverages the [Advanced Issue Labeler GitHub Action](https://github.com/marketplace/actions/advanced-issue-labeler), as described in the #11873 issue.

Your review and feedback on the OS dropdown implementation and the GitHub Action integration would be greatly appreciated!

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
