### PR TITLE
Add `manual` option to the `external_cloud_provider` variable

### DIFF
--- a/inventory/sample/group_vars/all/all.yml
+++ b/inventory/sample/group_vars/all/all.yml
@@ -45,9 +45,11 @@ loadbalancer_apiserver_healthcheck_port: 8081
 ## If set the possible values only 'external' after K8s v1.31.
 # cloud_provider:
 
-## When cloud_provider is set to 'external', you can set the cloud controller to deploy
-## Supported cloud controllers are: 'openstack', 'vsphere', 'huaweicloud' and 'hcloud'
-## When openstack or vsphere are used make sure to source in the required fields
+# External Cloud Controller Manager (Formerly known as cloud provider)
+# cloud_provider must be "external", otherwise this setting is invalid.
+# Supported external cloud controllers are: 'openstack', 'vsphere', 'oci', 'huaweicloud', 'hcloud' and 'manual'
+# 'manual' does not install the cloud controller manager used by Kubespray.
+# If you fill in a value other than the above, the check will fail.
 # external_cloud_provider:
 
 ## Set these proxy values in order to update package manager and docker daemon to use proxies and custom CA for https_proxy if needed

--- a/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
@@ -185,7 +185,7 @@
 
 - name: Check external_cloud_provider value
   assert:
-    that: external_cloud_provider in ['hcloud', 'huaweicloud', 'oci', 'openstack', 'vsphere']
+    that: external_cloud_provider in ['hcloud', 'huaweicloud', 'oci', 'openstack', 'vsphere', 'manual']
   when:
     - cloud_provider == 'external'
     - not ignore_assert_errors

--- a/roles/kubespray-defaults/defaults/main/main.yml
+++ b/roles/kubespray-defaults/defaults/main/main.yml
@@ -285,7 +285,8 @@ kubelet_shutdown_grace_period_critical_pods: 20s
 cloud_provider: ""
 # External Cloud Controller Manager (Formerly known as cloud provider)
 # cloud_provider must be "external", otherwise this setting is invalid.
-# Supported external cloud controllers are: 'openstack', 'vsphere', 'oci', 'huaweicloud' and 'hcloud'
+# Supported external cloud controllers are: 'openstack', 'vsphere', 'oci', 'huaweicloud', 'hcloud' and 'manual'
+# 'manual' does not install the cloud controller manager used by Kubespray.
 # If you fill in a value other than the above, the check will fail.
 external_cloud_provider: ""
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Let users install the cloud controller manager themselves after installing Kubernetes via Kubespray.

**Which issue(s) this PR fixes**:

Fixes #11878

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
The `external_cloud_provider` support `manual` option lets users install the cloud controller manager themselves.
```
