### PR TITLE
Cleanup OWNERS files in each folders

### DIFF
--- a/contrib/terraform/OWNERS
+++ b/contrib/terraform/OWNERS
@@ -1,3 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-approvers:
-  - miouge1

--- a/logo/OWNERS
+++ b/logo/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-  - thomeced

--- a/roles/container-engine/kata-containers/OWNERS
+++ b/roles/container-engine/kata-containers/OWNERS
@@ -1,6 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-  - pasqualet
-reviewers:
-  - pasqualet

--- a/roles/kubernetes-apps/csi_driver/OWNERS
+++ b/roles/kubernetes-apps/csi_driver/OWNERS
@@ -1,6 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-reviewers:
-  - alijahnas
-  - luckySB

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/OWNERS
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/OWNERS
@@ -1,6 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-reviewers:
-  - alijahnas
-  - luckySB

--- a/roles/kubernetes-apps/ingress_controller/alb_ingress_controller/OWNERS
+++ b/roles/kubernetes-apps/ingress_controller/alb_ingress_controller/OWNERS
@@ -1,6 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-  - kubespray-approvers
-reviewers:
-  - kubespray-reviewers

--- a/roles/kubernetes-apps/metallb/OWNERS
+++ b/roles/kubernetes-apps/metallb/OWNERS
@@ -1,5 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-reviewers:
-  - oomichi

--- a/roles/kubernetes-apps/network_plugin/kube-router/OWNERS
+++ b/roles/kubernetes-apps/network_plugin/kube-router/OWNERS
@@ -1,6 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-  - bozzo
-reviewers:
-  - bozzo

--- a/roles/kubernetes-apps/persistent_volumes/aws-ebs-csi/OWNERS
+++ b/roles/kubernetes-apps/persistent_volumes/aws-ebs-csi/OWNERS
@@ -1,5 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-  - alijahnas
-reviewers:

--- a/roles/network_plugin/kube-ovn/OWNERS
+++ b/roles/network_plugin/kube-ovn/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-emeritus_approvers:
-- oilbeater

--- a/roles/network_plugin/kube-router/OWNERS
+++ b/roles/network_plugin/kube-router/OWNERS
@@ -1,6 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-  - bozzo
-reviewers:
-  - bozzo

--- a/roles/network_plugin/macvlan/OWNERS
+++ b/roles/network_plugin/macvlan/OWNERS
@@ -1,6 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-  - simon
-reviewers:
-  - simon

--- a/roles/recover_control_plane/OWNERS
+++ b/roles/recover_control_plane/OWNERS
@@ -1,8 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - qvicksilver
   - yujunz
 reviewers:
-  - qvicksilver
   - yujunz

--- a/roles/recover_control_plane/OWNERS
+++ b/roles/recover_control_plane/OWNERS
@@ -1,6 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-  - yujunz
-reviewers:
-  - yujunz

--- a/test-infra/image-builder/OWNERS
+++ b/test-infra/image-builder/OWNERS
@@ -1,8 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - woopstar
+  - yankay
   - ant31
 reviewers:
-  - woopstar
+  - yankay
   - ant31


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

https://github.com/kubernetes-sigs/kubespray/issues/5432#issuecomment-2579885754
https://github.com/kubernetes-sigs/kubespray/issues/5432#issuecomment-2589879715

The OWNERS file in the folder may not suit the current situation, and some users are no longer k-sigs members. Open this PR to clean it up.

We are very grateful to those who have contributed to this project and welcome back anytime.

**Special notes for your reviewer**:

The `test-infra/` specialization (with quay.io upload permission) will be retained and replaced with the currently active member.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
