### PR TITLE
Run CI without the sample inventory

### DIFF
--- a/.gitlab-ci/lint.yml
+++ b/.gitlab-ci/lint.yml
@@ -7,7 +7,7 @@ pre-commit:
   variables:
     PRE_COMMIT_HOME: /pre-commit-cache
   script:
-  - pre-commit run --all-files
+  - pre-commit run --all-files --show-diff-on-failure
   cache:
     key: pre-commit-all
     paths:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,8 +58,7 @@ $subnet ||= "172.18.8"
 $subnet_ipv6 ||= "fd3c:b398:0698:0756"
 $os ||= "ubuntu2004"
 $network_plugin ||= "flannel"
-$inventory ||= "inventory/sample"
-$inventories ||= [$inventory]
+$inventories ||= []
 # Setting multi_networking to true will install Multus: https://github.com/k8snetworkplumbingwg/multus-cni
 $multi_networking ||= "False"
 $download_run_once ||= "True"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -9,19 +9,22 @@ create-tf:
 delete-tf:
 	./scripts/delete-tf.sh
 
-create-packet: init-packet
+$(INVENTORY_DIR):
+	mkdir $@
+
+create-packet: init-packet | $(INVENTORY_DIR)
 	ansible-playbook cloud_playbooks/create-packet.yml -c local \
 	-e @"files/${CI_JOB_NAME}.yml" \
 	-e test_name="$(subst .,-,$(CI_PIPELINE_ID)-$(CI_JOB_ID))" \
 	-e branch="$(CI_COMMIT_BRANCH)" \
 	-e pipeline_id="$(CI_PIPELINE_ID)" \
-	-e inventory_path=$(INVENTORY_DIR)
+	-e inventory_path=$|
 
 delete-packet: ;
 
-create-vagrant:
+create-vagrant: | $(INVENTORY_DIR)
 	vagrant up
-	cp $(CI_PROJECT_DIR)/.vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory $(INVENTORY_DIR)
+	cp $(CI_PROJECT_DIR)/.vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory $|
 
 delete-vagrant:
 	vagrant destroy -f

--- a/tests/scripts/testcases_run.sh
+++ b/tests/scripts/testcases_run.sh
@@ -26,7 +26,7 @@ fi
 export ANSIBLE_REMOTE_USER=$SSH_USER
 export ANSIBLE_BECOME=true
 export ANSIBLE_BECOME_USER=root
-export ANSIBLE_INVENTORY=${CI_PROJECT_DIR}/inventory/sample/
+export ANSIBLE_INVENTORY=/tmp/inventory/
 
 make -C tests INVENTORY_DIR=${ANSIBLE_INVENTORY} create-${CI_PLATFORM} -s
 

--- a/tests/testcases/030_check-network.yml
+++ b/tests/testcases/030_check-network.yml
@@ -4,7 +4,10 @@
   vars:
     test_image_repo: registry.k8s.io/e2e-test-images/agnhost
     test_image_tag: "2.40"
+    # TODO: source those from kubespray-defaults instead.
+    # Needs kubespray-defaults to be decoupled from no-proxy stuff
     bin_dir: "/usr/local/bin"
+    kube_pods_subnet: 10.233.64.0/18
 
   tasks:
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Our CI should not depend on the sample inventory, it causes problems when making default changes and we miss updating it (which happens all the time). 
This is taken from #11897 because this is (IMO) less controversial with a more evident value.

**Special notes for your reviewer**:
@ant31 I think those parts were not a problem, right ?

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
