### PR TITLE
CI: remove retry from jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,7 +55,6 @@ before_script:
 
 .testcases: &testcases
   extends: .job-moderated
-  retry: 1
   interruptible: true
   before_script:
     - update-alternatives --install /usr/bin/python python /usr/bin/python3 1


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Since e8ee42280 (CI: remove deletion tasks of 'packet' VMs, 2024-09-13),
our tests appears to not be flakey anymore.
The current retry slow down the testing feedback on pull request.

Since it's not needed anymore, don't retry and fail fast.

If it appears that we in fact still have flaky tests, we can revert this quite easily.

/label ci-extended
(for more flakiness exposure)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
