### PR TITLE
Add Port-10250 to default kubeadm_ignore_preflight_errors

### DIFF
--- a/roles/kubernetes/kubeadm_common/defaults/main.yml
+++ b/roles/kubernetes/kubeadm_common/defaults/main.yml
@@ -20,4 +20,5 @@ kubeadm_patches: []
 # Patches are applied in the order they are specified.
 
 # List of errors to ignore during kubeadm preflight checks
-kubeadm_ignore_preflight_errors: []
+kubeadm_ignore_preflight_errors:
+- Port-10250


### PR DESCRIPTION
`kubelet` is [started](https://github.com/kubernetes-sigs/kubespray/blob/0e91000a04edabcaae0590e8bb87f10e2542627a/roles/kubernetes/node/tasks/kubelet.yml) before `kubeadm init` is run.

Since, https://github.com/kubernetes-sigs/kubespray/pull/11710, this leads to the following error:

```
W0116 14:54:04.224835   11902 utils.go:69] The recommended value for "clusterDNS" in "KubeletConfiguration" is: [10.233.0.10]; the provided value is: [169.254.25.10]
error execution phase preflight: [preflight] Some fatal errors occurred:
    [ERROR Port-10250]: Port 10250 is in use
[preflight] If you know what you are doing, you can make a check non-fatal with `--ignore-preflight-errors=...`
To see the stack trace of this error execute with --v=5 or highe
[init] Using Kubernetes version: v1.31.4
[preflight] Running pre-flight checks
```
