### PR TITLE
Cleanup of preinstall assertions

### DIFF
--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Generate etcd certs
   include_tasks: "gen_certs_script.yml"
   when:
-    - cert_management | d('script') == "script"
+    - cert_management == "script"
   tags:
     - etcd-secrets
 

--- a/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
@@ -61,18 +61,15 @@
     msg: "The current release of Kubespray only support newer version of Kubernetes than {{ kube_version_min_required }} - You are trying to apply {{ kube_version }}"
   when: not ignore_assert_errors
 
-# simplify this items-list when   https://github.com/ansible/ansible/issues/15753  is resolved
 - name: "Stop if known booleans are set as strings (Use JSON format on CLI: -e \"{'key': true }\")"
   assert:
-    that: item.value | type_debug == 'bool'
-    msg: "{{ item.value }} isn't a bool"
+    that:
+      - download_run_once | type_debug == 'bool'
+      - deploy_netchecker | type_debug == 'bool'
+      - download_always_pull | type_debug == 'bool'
+      - helm_enabled | type_debug == 'bool'
+      - openstack_lbaas_enabled | type_debug == 'bool'
   run_once: true
-  with_items:
-    - { name: download_run_once, value: "{{ download_run_once }}" }
-    - { name: deploy_netchecker, value: "{{ deploy_netchecker }}" }
-    - { name: download_always_pull, value: "{{ download_always_pull }}" }
-    - { name: helm_enabled, value: "{{ helm_enabled }}" }
-    - { name: openstack_lbaas_enabled, value: "{{ openstack_lbaas_enabled }}" }
   when: not ignore_assert_errors
 
 - name: Stop if even number of etcd hosts

--- a/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
@@ -22,12 +22,11 @@
 
 - name: Stop if etcd group is empty in external etcd mode
   assert:
-    that: groups.get('etcd')
+    that: groups.get('etcd') or etcd_deployment_type == 'kubeadm'
     fail_msg: "Group 'etcd' cannot be empty in external etcd mode"
   run_once: true
   when:
     - not ignore_assert_errors
-    - etcd_deployment_type != "kubeadm"
 
 - name: Stop if non systemd OS type
   assert:

--- a/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
@@ -74,10 +74,10 @@
 
 - name: Stop if even number of etcd hosts
   assert:
-    that: groups.etcd | length is not divisibleby 2
+    that: groups.get('etcd', groups.kube_control_plane) | length is not divisibleby 2
+  run_once: true
   when:
     - not ignore_assert_errors
-    - inventory_hostname in groups.get('etcd',[])
 
 - name: Stop if memory is too small for control plane nodes
   assert:

--- a/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
@@ -273,14 +273,6 @@
     - containerd_version not in ['latest', 'edge', 'stable']
     - container_manager == 'containerd'
 
-- name: Stop if using deprecated containerd_config variable
-  assert:
-    that: containerd_config is not defined
-    msg: "Variable containerd_config is now deprecated. See https://github.com/kubernetes-sigs/kubespray/blob/master/inventory/sample/group_vars/all/containerd.yml for details."
-  when:
-    - containerd_config is defined
-    - not ignore_assert_errors
-
 - name: Stop if auto_renew_certificates is enabled when certificates are managed externally (kube_external_ca_mode is true)
   assert:
     that: not auto_renew_certificates

--- a/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
@@ -112,8 +112,7 @@
   when:
     - not ignore_assert_errors
     - ('k8s_cluster' in group_names)
-    - kube_network_node_prefix is defined
-    - kube_network_plugin != 'calico'
+    - kube_network_plugin not in ['calico', 'none']
 
 - name: Stop if ip var does not match local ips
   assert:

--- a/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
@@ -231,25 +231,14 @@
     - not disable_host_nameservers
     - dns_mode in ['coredns', 'coredns_dual']
 
-# TODO: Clean this task up when we drop backward compatibility support for `etcd_kubeadm_enabled`
-- name: Stop if etcd deployment type is not host or kubeadm when container_manager != docker and etcd_kubeadm_enabled is not defined
+# TODO: Clean this task up after 2.28 is released
+- name: Stop if etcd_kubeadm_enabled is defined
   run_once: true
-  when: etcd_kubeadm_enabled is defined
-  block:
-    - name: Warn the user if they are still using `etcd_kubeadm_enabled`
-      debug:
-        msg: >
-          "WARNING! => `etcd_kubeadm_enabled` is deprecated and will be removed in a future release.
-          You can set `etcd_deployment_type` to `kubeadm` instead of setting `etcd_kubeadm_enabled` to `true`."
-      changed_when: true
-
-    - name: Stop if `etcd_kubeadm_enabled` is defined and `etcd_deployment_type` is not `kubeadm` or `host`
-      assert:
-        that: etcd_deployment_type == 'kubeadm'
-        msg: >
-          It is not possible to use `etcd_kubeadm_enabled` when `etcd_deployment_type` is set to {{ etcd_deployment_type }}.
-          Unset the `etcd_kubeadm_enabled` variable and set `etcd_deployment_type` to desired deployment type (`host`, `kubeadm`, `docker`) instead."
-      when: etcd_kubeadm_enabled
+  assert:
+    that: etcd_kubeadm_enabled is not defined
+    msg: |
+      `etcd_kubeadm_enabled` is removed.
+       You can set `etcd_deployment_type` to `kubeadm` instead of setting `etcd_kubeadm_enabled` to `true`."
 
 - name: Stop if download_localhost is enabled but download_run_once is not
   assert:

--- a/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
@@ -281,14 +281,6 @@
     - kube_external_ca_mode
     - not ignore_assert_errors
 
-- name: Stop if using deprecated comma separated list for admission plugins
-  assert:
-    that: "',' not in kube_apiserver_enable_admission_plugins[0]"
-    msg: "Comma-separated list for kube_apiserver_enable_admission_plugins is now deprecated, use separate list items for each plugin."
-  when:
-    - kube_apiserver_enable_admission_plugins is defined
-    - kube_apiserver_enable_admission_plugins | length > 0
-
 - name: Verify that the packages list is sorted
   vars:
     pkgs_lists: "{{ pkgs.keys() | list }}"

--- a/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
@@ -39,13 +39,6 @@
     msg: "{{ ansible_distribution }} is not a known OS"
   when: not ignore_assert_errors
 
-- name: Stop if unknown network plugin
-  assert:
-    that: kube_network_plugin in ['calico', 'flannel', 'weave', 'cloud', 'cilium', 'cni', 'kube-ovn', 'kube-router', 'macvlan', 'custom_cni', 'none']
-    msg: "{{ kube_network_plugin }} is not supported"
-  when:
-    - not ignore_assert_errors
-
 - name: Warn if `kube_network_plugin` is `none
   debug:
     msg: |
@@ -215,62 +208,28 @@
   when: kube_network_plugin != 'calico'
   run_once: true
 
-- name: Stop if unknown dns mode
+- name: Stop if unsupported options selected
   assert:
-    that: dns_mode in ['coredns', 'coredns_dual', 'manual', 'none']
-    msg: "dns_mode can only be 'coredns', 'coredns_dual', 'manual' or 'none'"
-  when: dns_mode is defined
+    that:
+      - kube_network_plugin in ['calico', 'flannel', 'weave', 'cloud', 'cilium', 'cni', 'kube-ovn', 'kube-router', 'macvlan', 'custom_cni', 'none']
+      - dns_mode in ['coredns', 'coredns_dual', 'manual', 'none']
+      - kube_proxy_mode in ['iptables', 'ipvs']
+      - cert_management in ['script', 'none']
+      - resolvconf_mode in ['docker_dns', 'host_resolvconf', 'none']
+      - etcd_deployment_type in ['host', 'docker', 'kubeadm']
+      - etcd_deployment_type in ['host', 'kubeadm'] or container_manager == 'docker'
+      - container_manager in ['docker', 'crio', 'containerd']
+    msg: The selected choice is not supported
   run_once: true
 
 - name: Stop if /etc/resolv.conf has no configured nameservers
   assert:
     that: configured_nameservers | length>0
-    fail_msg: "nameserver should not empty in /etc/resolv.conf"
+    fail_msg: "nameserver should not be empty in /etc/resolv.conf"
   when:
     - upstream_dns_servers | length == 0
     - not disable_host_nameservers
     - dns_mode in ['coredns', 'coredns_dual']
-
-- name: Stop if unknown kube proxy mode
-  assert:
-    that: kube_proxy_mode in ['iptables', 'ipvs']
-    msg: "kube_proxy_mode can only be 'iptables' or 'ipvs'"
-  when: kube_proxy_mode is defined
-  run_once: true
-
-- name: Stop if unknown cert_management
-  assert:
-    that: cert_management | d('script') in ['script', 'none']
-    msg: "cert_management can only be 'script' or 'none'"
-  run_once: true
-
-- name: Stop if unknown resolvconf_mode
-  assert:
-    that: resolvconf_mode in ['docker_dns', 'host_resolvconf', 'none']
-    msg: "resolvconf_mode can only be 'docker_dns', 'host_resolvconf' or 'none'"
-  when: resolvconf_mode is defined
-  run_once: true
-
-- name: Stop if etcd deployment type is not host, docker or kubeadm
-  assert:
-    that: etcd_deployment_type in ['host', 'docker', 'kubeadm']
-    msg: "The etcd deployment type, 'etcd_deployment_type', must be host, docker or kubeadm"
-  when:
-    - inventory_hostname in groups.get('etcd',[])
-
-- name: Stop if container manager is not docker, crio or containerd
-  assert:
-    that: container_manager in ['docker', 'crio', 'containerd']
-    msg: "The container manager, 'container_manager', must be docker, crio or containerd"
-  run_once: true
-
-- name: Stop if etcd deployment type is not host or kubeadm when container_manager != docker
-  assert:
-    that: etcd_deployment_type in ['host', 'kubeadm']
-    msg: "The etcd deployment type, 'etcd_deployment_type', must be host or kubeadm when container_manager is not docker"
-  when:
-    - inventory_hostname in groups.get('etcd',[])
-    - container_manager != 'docker'
 
 # TODO: Clean this task up when we drop backward compatibility support for `etcd_kubeadm_enabled`
 - name: Stop if etcd deployment type is not host or kubeadm when container_manager != docker and etcd_kubeadm_enabled is not defined

--- a/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
@@ -45,16 +45,14 @@
     that: kube_network_plugin in ['calico', 'flannel', 'weave', 'cloud', 'cilium', 'cni', 'kube-ovn', 'kube-router', 'macvlan', 'custom_cni', 'none']
     msg: "{{ kube_network_plugin }} is not supported"
   when:
-    - kube_network_plugin is defined
     - not ignore_assert_errors
-- name: Warn the user if they are still using `etcd_kubeadm_enabled`
+
+- name: Warn if `kube_network_plugin` is `none
   debug:
-    msg: >
+    msg: |
       "WARNING! => `kube_network_plugin` is set to `none`. The network configuration will be skipped.
       The cluster won't be ready to use, we recommend to select one of the available plugins"
-  changed_when: true
   when:
-    - kube_network_plugin is defined
     - kube_network_plugin == 'none'
 
 - name: Stop if unsupported version of Kubernetes

--- a/roles/kubespray-defaults/tasks/main.yaml
+++ b/roles/kubespray-defaults/tasks/main.yaml
@@ -23,12 +23,3 @@
       when:
         - http_proxy is defined or https_proxy is defined
         - no_proxy is not defined
-
-# TODO: Clean this task up when we drop backward compatibility support for `etcd_kubeadm_enabled`
-- name: Set `etcd_deployment_type` to "kubeadm" if `etcd_kubeadm_enabled` is true
-  set_fact:
-    etcd_deployment_type: kubeadm
-  when:
-    - etcd_kubeadm_enabled is defined and etcd_kubeadm_enabled
-  tags:
-    - always


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

- Various cleanup in kubernetes/preinstall/task/0040-verify-settings.yml
- Drop old assert for removed stuff which should be out of users inventories by now
- Drop compatibility with `etcd_kubeadm_enabled` (which was deprecated) and assert it's not defined for one release

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
action required
`etdc_kubeadm_enabled` (was deprecated) is removed. You should remove it from your inventory
```
