### PR TITLE
CI: cleanup dependencies, pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         files: "\\.sh$"
 
   - repo: https://github.com/ansible/ansible-lint
-    rev: v24.12.2
+    rev: v25.1.0
     hooks:
       - id: ansible-lint
         additional_dependencies:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,8 +1,6 @@
 -r ../requirements.txt
-ansible-lint==24.12.2
-distlib==0.3.9
+distlib==0.3.9 # required for building collections
 molecule==24.12.0
 molecule-plugins[vagrant]==23.6.0
 pytest-testinfra==10.1.1
 python-vagrant==1.0.0
-yamllint==1.35.1


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
ansible-lint and yamllint are run as pre-commit hooks, which are
installed by pre-commit directly. So there is no need to put them in
tests/requirements.txt.

So remove them and make it leaner.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
