### PR TITLE
Add kubelet registry parameters

### DIFF
--- a/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
@@ -134,3 +134,5 @@ tracing:
   samplingRatePerMillion: {{ kubelet_tracing_sampling_rate_per_million }}
 {% endif %}
 maxParallelImagePulls: {{ kubelet_max_parallel_image_pulls }}
+registryPullQPS: {{ kubelet_registry_pull_qps }}
+registryBurst: {{ kubelet_registry_burst }}

--- a/roles/kubespray-defaults/defaults/main/main.yml
+++ b/roles/kubespray-defaults/defaults/main/main.yml
@@ -721,6 +721,16 @@ host_os: >-
 # Sets the eventRecordQPS parameter in kubelet-config.yaml.
 # Setting it to 0 allows unlimited requests per second.
 kubelet_event_record_qps: 50
+# Sets the registryPullQPS parameter in kubelet-config.yaml.
+# registryPullQPS is the limit of registry pulls per second.
+# The value must not be a negative number. Setting it to 0 means no limit. Default: 5
+kubelet_registry_pull_qps: 5
+# Sets the registryBurst parameter in kubelet-config.yaml.
+# registryBurst is the maximum size of bursty pulls, temporarily allows pulls
+# to burst to this number, while still not exceeding registryPullQPS.
+# The value must not be a negative number.
+# Only used if registryPullQPS is greater than 0. Default: 10
+kubelet_registry_burst: 10
 
 proxy_env_defaults:
   http_proxy: "{{ http_proxy | default('') }}"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds kubelet config following parameters:

- registryPullQPS: the limit of registry pulls per second.
- registryBurst: the maximum size of bursty pulls.

**Which issue(s) this PR fixes**:

Fixes #11911

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Added registryPullQPS and registryBurst in kubelet configuration, see [kubelet configuration reference](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/).
```
