### PR TITLE
calico: don't set calico-node cpu limits by default

### DIFF
--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -352,7 +352,9 @@ spec:
             privileged: true
           resources:
             limits:
+{% if calico_node_cpu_limit != "0" %}
               cpu: {{ calico_node_cpu_limit }}
+{% endif %}
               memory: {{ calico_node_memory_limit }}
             requests:
               cpu: {{ calico_node_cpu_requests }}

--- a/roles/network_plugin/calico_defaults/defaults/main.yml
+++ b/roles/network_plugin/calico_defaults/defaults/main.yml
@@ -58,7 +58,7 @@ calico_felix_floating_ips: Disabled
 
 # Limits for apps
 calico_node_memory_limit: 500M
-calico_node_cpu_limit: 300m
+calico_node_cpu_limit: "0"
 calico_node_memory_requests: 64M
 calico_node_cpu_requests: 150m
 calico_felix_chaininsertmode: Insert


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Upstream calico isn't doing that, and:
- this can cause throttling
- the cpu needed by calico is very cluster / workload dependent
- missing cpu limits will not starve other pods (unlike missing memory
  requests), because the kernel scheduler will still gives priority to
  other process in pods not exceeding their requests

See the slack thread for further details: https://kubernetes.slack.com/archives/C2V9WJSJD/p1737468771207299


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
calico-node pods no longer have a cpu limit by default
```
