### PR TITLE
Fix: hide 'ansible managed' balises in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Note:
 
 ## Supported Components
 
-[//]: # BEGIN ANSIBLE MANAGED BLOCK
+<!-- BEGIN ANSIBLE MANAGED BLOCK -->
 
 - Core
   - [kubernetes](https://github.com/kubernetes/kubernetes) v1.32.0
@@ -134,7 +134,7 @@ Note:
   - [local-volume-provisioner](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner) v2.5.0
   - [node-feature-discovery](https://github.com/kubernetes-sigs/node-feature-discovery) v0.16.4
 
-[//]: # END ANSIBLE MANAGED BLOCK
+<!-- END ANSIBLE MANAGED BLOCK -->
 
 ## Container Runtime Notes
 

--- a/scripts/render_readme_version.yml
+++ b/scripts/render_readme_version.yml
@@ -17,6 +17,6 @@
     - ../roles/kubernetes-apps/argocd/defaults/main.yml
   - name: Render versions in README.md
     blockinfile:
-      marker: '[//]: # {mark} ANSIBLE MANAGED BLOCK'
+      marker: '<!-- {mark} ANSIBLE MANAGED BLOCK -->'
       block: "\n{{ lookup('ansible.builtin.template', 'readme_versions.md.j2') }}\n\n"
       path: ../README.md


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

```
[//]: -> apparently does not work for hiding on Github markdown
```
Use html comments instead.
Fixup of #11905

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
