### PR TITLE
Add timestamp to kaniko builds

### DIFF
--- a/.gitlab-ci/build.yml
+++ b/.gitlab-ci/build.yml
@@ -25,6 +25,7 @@
                        --label 'git-branch'=$CI_COMMIT_REF_SLUG
                        --label 'git-tag=$CI_COMMIT_TAG'
                        --destination $PIPELINE_IMAGE
+                       --log-timestamp=true
 
 pipeline-image:
   extends: .build-container


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
The build steps at the start of CI takes about 2 minutes; now that we
have greatly reduced the overall duration, this is not an insignificant
impact.

Add timestamps to the build process to see measure which steps of the
image build take the most time.


**Special notes for your reviewer**:
/label ci-short

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
