### PR TITLE
dependabot: add group for molecule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,8 @@ updates:
     labels:
       - dependencies
       - release-note-none
+    groups:
+      molecule:
+        patterns:
+          - molecule
+          - molecule-plugins*


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
Add a new dependabot to group molecule dependencies together
**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
For instance the latest version of the vagrant plugin (https://github.com/kubernetes-sigs/kubespray/pull/11926) requires the latest version of molecule, grouping those two could provide a simpler experience handling molecule related upgrades.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
