### PR TITLE
CI: Put pre-commit cache under CI_PROJECT_DIR

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -38,5 +38,6 @@ exclude_paths:
   - venv
   - .github
   - .ansible
+  - .cache
 mock_modules:
   - gluster.gluster.gluster_volume

--- a/.gitlab-ci/lint.yml
+++ b/.gitlab-ci/lint.yml
@@ -3,15 +3,16 @@ pre-commit:
   stage: test
   tags:
   - ffci
-  image: 'ghcr.io/pre-commit-ci/runner-image@sha256:aaf2c7b38b22286f2d381c11673bec571c28f61dd086d11b43a1c9444a813cef'
+  image: 'ghcr.io/pre-commit-ci/runner-image@sha256:fe01a6ec51b298412990b88627c3973b1146c7304f930f469bafa29ba60bcde9'
   variables:
-    PRE_COMMIT_HOME: /pre-commit-cache
+    PRE_COMMIT_HOME: ${CI_PROJECT_DIR}/.cache/pre-commit
   script:
   - pre-commit run --all-files --show-diff-on-failure
   cache:
-    key: pre-commit-all
+    key: pre-commit-2
     paths:
-    - /pre-commit-cache
+    - ${PRE_COMMIT_HOME}
+    when: 'always'
   needs: []
 
 vagrant-validate:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         files: "\\.sh$"
 
   - repo: https://github.com/ansible/ansible-lint
-    rev: v25.1.0
+    rev: v25.1.1
     hooks:
       - id: ansible-lint
         additional_dependencies:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Apparently gitlab-runner can't cache stuff outside of the project
directory.

Put the cache under CI_PROJECT_DIR to make it work.

Also update the pre-commit image while we're at it.

Link: https://gitlab.com/gitlab-org/gitlab/-/issues/14151

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/label ci-short

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
