### PR TITLE
Upgrade molecule and molecule vagrant plugin in sync

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 -r ../requirements.txt
 distlib==0.3.9 # required for building collections
-molecule==24.12.0
-molecule-plugins[vagrant]==23.6.0
+molecule==25.1.0
+molecule-plugins[vagrant]==23.7.0
 pytest-testinfra==10.1.1
 python-vagrant==1.0.0


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Dependabot can't upgrade correctly molecule and molecule-plugins[vagrant], a molecule fonction has changed and molecule-plugins[vagrant] use the new one in it's new version (which does not exist on the version we have)

**Which issue(s) this PR fixes**:
Fixes #
Replace #11926 and #11925

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
