### PR TITLE
Bugfix/11936 - backup: "{{ leave_etc_backup_files }}"

### DIFF
--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -1,7 +1,8 @@
 ---
 # Set to true to allow pre-checks to fail and continue deployment
 ignore_assert_errors: false
-
+# Set to false to disable the backup parameter, set to true to accumulate backups of config files.
+leave_etc_backup_files: true
 nameservers: []
 cloud_resolver: []
 disable_host_nameservers: false

--- a/roles/kubernetes/preinstall/tasks/0063-networkmanager-dns.yml
+++ b/roles/kubernetes/preinstall/tasks/0063-networkmanager-dns.yml
@@ -6,7 +6,7 @@
     option: servers
     value: "{{ nameserverentries | join(',') }}"
     mode: '0600'
-    backup: true
+    backup: "{{ leave_etc_backup_files }}"
   when:
     - ('127.0.0.53' not in nameserverentries
        or systemd_resolved_enabled.rc != 0)
@@ -24,7 +24,7 @@
     option: searches
     value: "{{ (default_searchdomains | default([]) + searchdomains) | join(',') }}"
     mode: '0600'
-    backup: true
+    backup: "{{ leave_etc_backup_files }}"
   notify: Preinstall | update resolvconf for networkmanager
 
 - name: NetworkManager | Add DNS options to NM configuration
@@ -34,5 +34,5 @@
     option: options
     value: "ndots:{{ ndots }},timeout:{{ dns_timeout | default('2') }},attempts:{{ dns_attempts | default('2') }}"
     mode: '0600'
-    backup: true
+    backup: "{{ leave_etc_backup_files }}"
   notify: Preinstall | update resolvconf for networkmanager

--- a/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
+++ b/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
@@ -28,7 +28,7 @@
     line: "precedence ::ffff:0:0/96  100"
     state: present
     create: true
-    backup: true
+    backup: "{{ leave_etc_backup_files }}"
     mode: "0644"
   when:
     - disable_ipv6_dns

--- a/roles/kubernetes/preinstall/tasks/0090-etchosts.yml
+++ b/roles/kubernetes/preinstall/tasks/0090-etchosts.yml
@@ -25,7 +25,7 @@
     block: "{{ hostvars.localhost.etc_hosts_inventory_block }}"
     state: "{{ 'present' if populate_inventory_to_hosts_file else 'absent' }}"
     create: true
-    backup: true
+    backup: "{{ leave_etc_backup_files }}"
     unsafe_writes: true
     marker: "# Ansible inventory hosts {mark}"
     mode: "0644"
@@ -36,7 +36,7 @@
     regexp: ".*{{ apiserver_loadbalancer_domain_name }}$"
     line: "{{ loadbalancer_apiserver.address }} {{ apiserver_loadbalancer_domain_name }}"
     state: present
-    backup: true
+    backup: "{{ leave_etc_backup_files }}"
     unsafe_writes: true
   when:
     - populate_loadbalancer_apiserver_to_hosts_file
@@ -74,7 +74,7 @@
         line: "{{ item.key }} {{ item.value | join(' ') }}"
         regexp: "^{{ item.key }}.*$"
         state: present
-        backup: true
+        backup: "{{ leave_etc_backup_files }}"
         unsafe_writes: true
       loop: "{{ etc_hosts_localhosts_dict_target | default({}) | dict2items }}"
 

--- a/roles/kubernetes/preinstall/tasks/0100-dhclient-hooks.yml
+++ b/roles/kubernetes/preinstall/tasks/0100-dhclient-hooks.yml
@@ -10,7 +10,7 @@
     create: true
     state: present
     insertbefore: BOF
-    backup: true
+    backup: "{{ leave_etc_backup_files }}"
     marker: "# Ansible entries {mark}"
     mode: "0644"
   notify: Preinstall | propagate resolvconf to k8s components

--- a/roles/kubernetes/preinstall/tasks/0110-dhclient-hooks-undo.yml
+++ b/roles/kubernetes/preinstall/tasks/0110-dhclient-hooks-undo.yml
@@ -7,7 +7,7 @@
   blockinfile:
     path: "{{ dhclientconffile }}"
     state: absent
-    backup: true
+    backup: "{{ leave_etc_backup_files }}"
     marker: "# Ansible entries {mark}"
   notify: Preinstall | propagate resolvconf to k8s components
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
At the moment Kubespray always creates backups of the configuration files on the targets. This PR introduces a Boolean default variable `leave_etc_backup_files: true` that allows changing that behaviour. When `false`, there is no clutter in /etc/.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11936

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
 New Boolean default variable `leave_etc_backup_files: true`, set to `false` for uncluttered /etc directory on target nodes.
```
