### PR TITLE
Update quotation of parameter restarting the scheduler with crictl

### DIFF
--- a/roles/kubernetes/control-plane/handlers/main.yml
+++ b/roles/kubernetes/control-plane/handlers/main.yml
@@ -22,7 +22,7 @@
   listen: Control plane | Restart apiserver
 
 - name: Control plane | Remove apiserver container containerd/crio
-  shell: "set -o pipefail && {{ bin_dir }}/crictl pods --name kube-apiserver* -q | xargs -I% --no-run-if-empty bash -c '{{ bin_dir }}/crictl stopp % && {{ bin_dir }}/crictl rmp %'"
+  shell: "set -o pipefail && {{ bin_dir }}/crictl pods --name 'kube-apiserver*' -q | xargs -I% --no-run-if-empty bash -c '{{ bin_dir }}/crictl stopp % && {{ bin_dir }}/crictl rmp %'"
   args:
     executable: /bin/bash
   register: remove_apiserver_container
@@ -44,7 +44,7 @@
   listen: Control plane | Restart kube-scheduler
 
 - name: Control plane | Remove scheduler container containerd/crio
-  shell: "set -o pipefail && {{ bin_dir }}/crictl pods --name kube-scheduler* -q | xargs -I% --no-run-if-empty bash -c '{{ bin_dir }}/crictl stopp % && {{ bin_dir }}/crictl rmp %'"
+  shell: "set -o pipefail && {{ bin_dir }}/crictl pods --name 'kube-scheduler*' -q | xargs -I% --no-run-if-empty bash -c '{{ bin_dir }}/crictl stopp % && {{ bin_dir }}/crictl rmp %'"
   args:
     executable: /bin/bash
   register: remove_scheduler_container
@@ -66,7 +66,7 @@
   listen: Control plane | Restart kube-controller-manager
 
 - name: Control plane | Remove controller manager container containerd/crio
-  shell: "set -o pipefail && {{ bin_dir }}/crictl pods --name kube-controller-manager* -q | xargs -I% --no-run-if-empty bash -c '{{ bin_dir }}/crictl stopp % && {{ bin_dir }}/crictl rmp %'"
+  shell: "set -o pipefail && {{ bin_dir }}/crictl pods --name 'kube-controller-manager*' -q | xargs -I% --no-run-if-empty bash -c '{{ bin_dir }}/crictl stopp % && {{ bin_dir }}/crictl rmp %'"
   args:
     executable: /bin/bash
   register: remove_cm_container


### PR DESCRIPTION
Adding single quotes around parameters in crictl.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Otherwise I am running into problems. I was able to reproduce the problem with executing the same command with sudo as normal user. The issue in the ansible run shows as follows:

```sh
RUNNING HANDLER [kubernetes/control-plane : Master | Remove scheduler container containerd/crio] *******************************************
fatal: [my_master_node]: FAILED! => {"attempts": 10, "changed": true, "cmd": "set -o pipefail && /usr/local/bin/crictl pods --name kube-scheduler* -q | xargs -I% --no-run-if-empty bash -c '/usr/local/bin/crictl stopp % && /usr/local/bin/crictl rmp %'", "delta": "0:00:00.056335", "end": "2025-02-02 21:15:44.597865", "msg": "non-zero return code", "rc": 123, "start": "2025-02-02 21:15:44.541530", "stderr": "getting sandbox status of pod \"ATTEMPT\": rpc error: code = NotFound desc = an error occurred when try to find sandbox: not found\ngetting sandbox status of pod \"POD\": rpc error: code = NotFound desc = an error occurred when try to find sandbox: not found\ngetting sandbox status of pod \"NAMESPACE\": rpc error: code = NotFound desc = an error occurred when try to find sandbox: not found\ngetting sandbox status of pod \"STATE\": rpc error: code = NotFound desc = an error occurred when try to find sandbox: not found\ngetting sandbox status of pod \"CREATED\": rpc error: code = NotFound desc = an error occurred when try to find sandbox: not found\ngetting sandbox status of pod \"RUNTIME\": rpc error: code = NotFound desc = an error occurred when try to find sandbox: not found\ngetting sandbox status of pod \"NAME\": rpc error: code = NotFound desc = an error occurred when try to find sandbox: not found\ngetting sandbox status of pod \"ID\": rpc error: code = NotFound desc = an error occurred when try to find sandbox: not found", "stderr_lines": ["getting sandbox status of pod \"ATTEMPT\": rpc error: code = NotFound desc = an error occurred when try to find sandbox: not found", "getting sandbox status of pod \"POD\": rpc error: code = NotFound desc = an error occurred when try to find sandbox: not found", "getting sandbox status of pod \"NAMESPACE\": rpc error: code = NotFound desc = an error occurred when try to find sandbox: not found", "getting sandbox status of pod \"STATE\": rpc error: code = NotFound desc = an error occurred when try to find sandbox: not found", "getting sandbox status of pod \"CREATED\": rpc error: code = NotFound desc = an error occurred when try to find sandbox: not found", "getting sandbox status of pod \"RUNTIME\": rpc error: code = NotFound desc = an error occurred when try to find sandbox: not found", "getting sandbox status of pod \"NAME\": rpc error: code = NotFound desc = an error occurred when try to find sandbox: not found", "getting sandbox status of pod \"ID\": rpc error: code = NotFound desc = an error occurred when try to find sandbox: not found"], "stdout": "Stopped sandbox POD\nStopped sandbox ID\nStopped sandbox CREATED\nStopped sandbox STATE\nStopped sandbox NAME\nStopped sandbox NAMESPACE\nStopped sandbox ATTEMPT\nStopped sandbox RUNTIME", "stdout_lines": ["Stopped sandbox POD", "Stopped sandbox ID", "Stopped sandbox CREATED", "Stopped sandbox STATE", "Stopped sandbox NAME", "Stopped sandbox NAMESPACE", "Stopped sandbox ATTEMPT", "Stopped sandbox RUNTIME"]}
```

**Special notes for your reviewer**:

It might make sense to also add single quotes to other parts of this handlers file, but I wasn't able to test them directly.
