### PR TITLE
Fix CI by exclude the `.ansible` in `.ansible-lint` &  remove `ctr image pull` workaround

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -37,5 +37,6 @@ exclude_paths:
   - tests/files/custom_cni/cilium.yaml
   - venv
   - .github
+  - .ansible
 mock_modules:
   - gluster.gluster.gluster_volume

--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -57,8 +57,7 @@ download_retries: 4
 docker_image_pull_command: "{{ docker_bin_dir }}/docker pull"
 docker_image_info_command: "{{ docker_bin_dir }}/docker images -q | xargs -i {{ '{{' }} docker_bin_dir }}/docker inspect -f {% raw %}'{{ '{{' }} if .RepoTags }}{{ '{{' }} join .RepoTags \",\" }}{{ '{{' }} end }}{{ '{{' }} if .RepoDigests }},{{ '{{' }} join .RepoDigests \",\" }}{{ '{{' }} end }}' {% endraw %} {} | tr '\n' ','"
 nerdctl_image_info_command: "{{ bin_dir }}/nerdctl -n k8s.io images --format '{% raw %}{{ .Repository }}:{{ .Tag }}{% endraw %}' 2>/dev/null | grep -v ^:$ | tr '\n' ','"
-# Using the ctr instead of nerdctl to workdaround the https://github.com/kubernetes-sigs/kubespray/issues/10670
-nerdctl_image_pull_command: "{{ bin_dir }}/ctr -n k8s.io images pull{% if containerd_registries_mirrors is defined %} --hosts-dir {{ containerd_cfg_dir }}/certs.d{%- endif -%}"
+nerdctl_image_pull_command: "{{ bin_dir }}/nerdctl -n k8s.io pull --quiet"
 crictl_image_info_command: "{{ bin_dir }}/crictl images --verbose | awk -F ': ' '/RepoTags|RepoDigests/ {print $2}' | tr '\n' ','"
 crictl_image_pull_command: "{{ bin_dir }}/crictl pull"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

There are 2 errors in CI 
1. The CI fails like: https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/9057272199 .
```
.ansible/collections/ansible_collections/gluster/gluster/plugins/modules/gluster_volume.py:14: load-failure: Failed to load or parse file.
.ansible/collections/ansible_collections/gluster/gluster/plugins/modules/gluster_volume.py:14: yaml[document-start]: Missing document start "---"
```
The  `.ansible` is auto-generated, so skip it.

Fix CI by excluding the `.ansible` in `.ansible-lint`

2. The CI fails like https://github.com/kubernetes-sigs/kubespray/runs/36766855903.
It's just after the https://github.com/kubernetes-sigs/kubespray/pull/11913, And I submit an issue at https://github.com/containerd/nerdctl/issues/3866. 

I think there are 3 solutions: 
1. Update the nerdctl when it fixes the issue.
But the issue just occurs when the image is pulled by the ctr, so I'm not sure it's a bug and will be fixed.

2. Remove `ctr image pull` workaround for nerdctl
The https://github.com/containerd/nerdctl/issues/2357 , https://github.com/kubernetes-sigs/kubespray/issues/10670 have been fixed.
So remove the workaround

3. Using the other way to download images.
I'm not sure switch tools can work better. :-) 

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix CI by exclude the `.ansible` in `.ansible-lint`
Remove `ctr image pull` workaround for nerdctl
```
