### PR TITLE
Fix incorrect syntax for secondary nodelocaldns manifest

### DIFF
--- a/roles/kubernetes-apps/ansible/vars/main.yml
+++ b/roles/kubernetes-apps/ansible/vars/main.yml
@@ -19,4 +19,4 @@ nodelocaldns_manifests:
 - nodelocaldns-config.yml.j2
 - nodelocaldns-daemonset.yml.j2
 - nodelocaldns-sa.yml.j2
-- "{{ nodelocaldns-second-daemonset.yml.j2 if enable_nodelocaldns_secondary else [] }}"
+- "{{ 'nodelocaldns-second-daemonset.yml.j2' if enable_nodelocaldns_secondary else [] }}"

--- a/roles/kubernetes-apps/ansible/vars/main.yml
+++ b/roles/kubernetes-apps/ansible/vars/main.yml
@@ -13,7 +13,7 @@ coredns_manifests:
 - coredns-sa.yml.j2
 - coredns-svc.yml.j2
 - "{{ dns_autoscaler_manifests if enable_dns_autoscaler else [] }}"
-- "{{ coredns-poddisruptionbudget.yml.j2 if coredns_pod_disruption_budget else [] }}"
+- "{{ 'coredns-poddisruptionbudget.yml.j2' if coredns_pod_disruption_budget else [] }}"
 
 nodelocaldns_manifests:
 - nodelocaldns-config.yml.j2


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
This PR fixes a rendering bug in the Kubernetes apps role caused by missing quoting in Jinja2 template expressions. In v2.27.0 the file names for the nodelocaldns secondary daemonset and the CoreDNS PodDisruptionBudget were not quoted, so they were interpreted as undefined variables rather than literal strings. This resulted in malformed manifests and deployment errors. By explicitly quoting these file names, the templates render correctly and the resources are created as expected, resolving the observable bug reported in #11951.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/kubespray/issues/11951

**Special notes for your reviewer**:
Can we please release a patch asap? v2.27.1

**Does this PR introduce a user-facing change?**:

```release-note
Fix coredns deployment with `coredns_pod_disruption_budget: true` or `enable_nodelocaldns_secondary`
```
