### PR TITLE
Feat: offline installation registry support macOS

### DIFF
--- a/contrib/offline/manage-offline-container-images.sh
+++ b/contrib/offline/manage-offline-container-images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 OPTION=$1
 CURRENT_DIR=$(cd $(dirname $0); pwd)
@@ -118,6 +118,8 @@ function register_container_images() {
 		cp ${CURRENT_DIR}/registries.conf         ${TEMP_DIR}/registries.conf
 		sed -i s@"HOSTNAME"@"$(hostname)"@  ${TEMP_DIR}/registries.conf
 		sudo cp ${TEMP_DIR}/registries.conf   /etc/containers/registries.conf
+  elif [ "$(uname)" == "Darwin" ]; then
+    echo "This is a Mac, no configuration changes are required"
 	else
 		echo "runtime package(docker-ce, podman, nerctl, etc.) should be installed"
 		exit 1


### PR DESCRIPTION
My computer is a Mac, and I want to build the docker image service on the Mac and use it in the virtual machines. However, the current image script does not support Mac. So, I made a small adjustment.

```bash
# Create the images tgz file
export IMAGES_FROM_FILE=/PATH/TO/kubespray/contrib/offline/temp/images.list

./manage-offline-container-images.sh create



# Load the images

# Setup the registry service
docker run --restart=always -d -p 5000:5000 --name registry registry:latest

export DESTINATION_REGISTRY=localhost:5000  # If not set, unable to identify hostname

export IMAGE_TAR_FILE=/PATH/TO/kubespray/contrib/offline/container-images.tar.gz

# Registering images
./manage-offline-container-images.sh register
```





**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
registry support Mac


**Which issue(s) this PR fixes**:
No

**Special notes for your reviewer**:
No

**Does this PR introduce a user-facing change?**:
```release-note
Setting up a Docker image service for offline installation on a Mac
```