### PR TITLE
fix: When running `./manage-offline-container-images.sh register` using Podman, retrieving the image ID fails and the script stops.

### DIFF
--- a/contrib/offline/manage-offline-container-images.sh
+++ b/contrib/offline/manage-offline-container-images.sh
@@ -146,7 +146,11 @@ function register_container_images() {
 		if [ "${org_image}" == "ID:" ]; then
 		  org_image=$(echo "${load_image}"  | awk '{print $4}')
 		fi
-		image_id=$(sudo ${runtime} image inspect ${org_image} | grep "\"Id\":" | awk -F: '{print $3}'| sed s/'\",'//)
+		if [ "${runtime}" == "podman" ]; then
+		  image_id=$(sudo -E "${runtime}" image inspect "${org_image}" | grep "\"Id\":" | awk -F: '{print $2}'| sed 's/[",]//g')
+		else
+		  image_id=$(sudo -E "${runtime}" image inspect "${org_image}" | grep "\"Id\":" | awk -F: '{print $3}'| sed s/'\",'//)
+		fi
 		if [ -z "${file_name}" ]; then
 			echo "Failed to get file_name for line ${line}"
 			exit 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

When I run `./manage-offline-container-images.sh register to register` an image in the container registry using Podman, the following error occurs and the script stops.
```
Getting image source signatures
Copying blob b972131a1dcc skipped: already exists
Copying blob 011b303988d2 skipped: already exists
Copying blob a4be933f3ee0 skipped: already exists
Copying config 3fe402881a done   |
Writing manifest to image destination
Failed to get image_id for file docker.io-mirantis-k8s-netchecker-server-v1.2.2.tar
```

I checked the error contents, it seems that the acquisition of image_id has failed.

* The relevant part of the script (manage-offline-container-images.sh)
```
image_id=$(${runtime} image inspect ${org_image} | grep "\"Id\":" | awk -F: '{print $3}'| sed s/'\",'//)
```

In offline deployment, we can use Docker, Podman, and nerdctl as container runtimes.
The method for outputting the image ID is the same for Docker and nerdctl, but Podman uses a different method, so the method to obtain the ID needs to be modified separately for Podman and the others.

* Podman
```
# podman image inspect <image>
          "Id": "XXX",
```
* Docker
```
# docker image inspect <image>
        "Id": "sha256:XXX",
```
* nerdctl
```
# nerdctl image inspect <image>
        "Id": "sha256:XXX",
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11865 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix: When running `./manage-offline-container-images.sh register` with using Podman, getting the image_id fails and the script is interrupted.
```
