### PR TITLE
fix: A timeout occurs when running the offline deployment script using Podman.

### DIFF
--- a/contrib/offline/manage-offline-container-images.sh
+++ b/contrib/offline/manage-offline-container-images.sh
@@ -36,7 +36,7 @@ function create_container_image_tar() {
 	mkdir  ${IMAGE_DIR}
 	cd     ${IMAGE_DIR}
 
-	sudo ${runtime} pull registry:latest
+	sudo --preserve-env=http_proxy,https_proxy,no_proxy ${runtime} pull registry:latest
 	sudo ${runtime} save -o registry-latest.tar registry:latest
 
 	while read -r image
@@ -45,7 +45,7 @@ function create_container_image_tar() {
 		set +e
 		for step in $(seq 1 ${RETRY_COUNT})
 		do
-			sudo ${runtime} pull ${image}
+			sudo --preserve-env=http_proxy,https_proxy,no_proxy ${runtime} pull ${image}
 			if [ $? -eq 0 ]; then
 				break
 			fi

--- a/contrib/offline/manage-offline-files.sh
+++ b/contrib/offline/manage-offline-files.sh
@@ -41,7 +41,7 @@ fi
 
 sudo "${runtime}" container inspect nginx >/dev/null 2>&1
 if [ $? -ne 0 ]; then
-    sudo "${runtime}" run \
+    sudo --preserve-env=http_proxy,https_proxy,no_proxy "${runtime}" run \
         --restart=always -d -p ${NGINX_PORT}:80 \
         --volume "${OFFLINE_FILES_DIR}":/usr/share/nginx/html/download \
         --volume "${CURRENT_DIR}"/nginx.conf:/etc/nginx/nginx.conf \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:

When trying to create an Nginx container as a file server, the container fails to start due to a timeout when using `manage-offline-files.sh`.
```
Trying to pull docker.io/library/nginx:alpine...
WARN[0065] Failed, retrying in 1s ... (1/3). Error: initializing source docker://nginx:alpine: pinging container registry registry-1.docker.io: Get "https://registry-1.docker.io/v2/": dial tcp 54.198.86.24:443: i/o timeout 
WARN[0126] Failed, retrying in 1s ... (2/3). Error: initializing source docker://nginx:alpine: pinging container registry registry-1.docker.io: Get "https://registry-1.docker.io/v2/": dial tcp 54.198.86.24:443: i/o timeout 
WARN[0187] Failed, retrying in 1s ... (3/3). Error: initializing source docker://nginx:alpine: pinging container registry registry-1.docker.io: Get "https://registry-1.docker.io/v2/": dial tcp 54.227.20.253:443: i/o timeout 
Error: initializing source docker://nginx:alpine: pinging container registry registry-1.docker.io: Get "https://registry-1.docker.io/v2/": dial tcp 54.236.113.205:443: i/o timeout
```

When I checked the script file(`manage-offline-files.sh`), I found git run was executed with sudo.

* manage-offline-files.sh
```
"${runtime}" container inspect nginx >/dev/null 2>&1
if [ $? -ne 0 ]; then
    sudo "${runtime}" run \
        --restart=always -d -p ${NGINX_PORT}:80 \
        --volume "${OFFLINE_FILES_DIR}":/usr/share/nginx/html/download \
        --volume "${CURRENT_DIR}"/nginx.conf:/etc/nginx/nginx.conf \
        --name nginx nginx:alpine
fi
```

When acquiring an image with Podman, it goes through a proxy, but sudo is attached, so the environment variables are not inherited and resulting in a timeout.

Therefore, adding the -E option to the run pull command in the script.

* manage-offline-files.sh
* manage-offline-container-images.sh

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11866 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix: A timeout occurs when running the offline deployment script using Podman.
```
