### PR TITLE
Fix: Using the `./manage-offline-container-images.sh register` command does not create a new container but registers the image in the existing container registry.

### DIFF
--- a/contrib/offline/manage-offline-container-images.sh
+++ b/contrib/offline/manage-offline-container-images.sh
@@ -127,7 +127,7 @@ function register_container_images() {
 
 	tar -zxvf ${IMAGE_TAR_FILE}
 
-	if [ "${create_registry}" ]; then
+	if ${create_registry}; then
 		sudo ${runtime} load -i ${IMAGE_DIR}/registry-latest.tar
 		set +e
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Since I have already created a container registry, I would like to register the image there. However, when I try to register the image using the command below, a new container named 'registry' is created, and the image is registered there instead.
```
# export DESTINATION_REGISTRY=192.168.122.155:5000 #Specify an existing container registry
# ./manage-offline-container-images.sh register
```

* check containers
```
# podman ps -a
CONTAINER ID  IMAGE                              COMMAND               CREATED             STATUS       PORTS                   NAMES
d90b84b7c726  docker.io/library/registry:2.8.2   /etc/docker/regis...  15 hours ago        Up 15 hours  0.0.0.0:5000->5000/tcp  docker-distribution
b2ab51819745  docker.io/library/nginx:alpine     nginx -g daemon o...  15 hours ago        Up 15 hours  0.0.0.0:8080->80/tcp    nginx
61997afcca9e  docker.io/library/registry:latest  /etc/docker/regis...  About a minute ago  Created      0.0.0.0:5000->5000/tcp  registry
```

When I checked the script file (`manage-offline-container-images.sh`), it seemed that the container registry was being created using the following steps.

```
if [ "${create_registry}" ]; then
		sudo ${runtime} load -i ${IMAGE_DIR}/registry-latest.tar
		set +e

		sudo ${runtime} container inspect registry >/dev/null 2>&1
		if [ $? -ne 0 ]; then
			sudo ${runtime} run --restart=always -d -p "${REGISTRY_PORT}":"${REGISTRY_PORT}" --name registry registry:latest
		fi
		set -e
	fi
```

The `create_registry` above is determined by the following.

```
function register_container_images() {
	create_registry=false
	REGISTRY_PORT=${REGISTRY_PORT:-"5000"}

	if [ -z "${DESTINATION_REGISTRY}" ]; then
		echo "DESTINATION_REGISTRY not set, will create local registry"
		create_registry=true
		DESTINATION_REGISTRY="$(hostname):${REGISTRY_PORT}"
	fi
	echo "Images will be pushed to ${DESTINATION_REGISTRY}"
```

Originally, if a registry already exists and you want to push the image there, you need to set the registry address in `REGISTRY_PORT`. I understand that if `REGISTRY_PORT` is not set, it means a container registry is created in the local registry and the image is pushed there.

Based on the above settings, it is correct to not execute the procedure if `create_registry` is `false`, but to execute it if it is `true`. However, as shown in `if [ "${create_registry}" ]; then`, the procedure is designed to create a registry if the `create_registry` variable is set, meaning a local registry is created regardless of whether a push destination container registry is specified or not.

To fix the issue, the following changes are necessary.

```
if ${create_registry}; then
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11867 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix: Using the ./manage-offline-container-images.sh register command does not create a new container but registers the image in the existing container registry.
```
