### PR TITLE
[CVE] Upgrade cryptography to version 44.0.1 on requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ansible==9.13.0
 # Needed for community.crypto module
-cryptography==44.0.0
+cryptography==44.0.1
 # Needed for jinja2 json_query templating
 jmespath==1.0.1
 # Needed for ansible.utils.ipaddr


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This pull request addresses a security vulnerability identified in the `cryptography` package defined in `framework/requirements.txt`.
It was found that the version of `cryptography` (v42.0.0-44.0.0) is vulnerable due to a statically linked OpenSSL version that contains a security issue. The issue can lead to potential exploitation in certain environments. This update ensures the cryptography package is upgraded to a secure version that does not rely on vulnerable OpenSSL versions.

**Which issue(s) this PR fixes**:

[Fix] Vulnerable OpenSSL included in cryptography wheels

**Special notes for your reviewer**:

The vulnerability in the cryptography package is linked to a statically bundled OpenSSL version, which has been patched in newer releases of `cryptography`. The CVE details can be found here: [OpenSSL Security Advisory](https://openssl-library.org/news/secadv/20250211.txt).

**Does this PR introduce a user-facing change?**:

NONE
