### PR TITLE
 cilium 1.17: fix etcd trusted-ca-file config var

### DIFF
--- a/roles/network_plugin/cilium/templates/cilium/config.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/config.yml.j2
@@ -20,7 +20,11 @@ data:
     # In case you want to use TLS in etcd, uncomment the 'ca-file' line
     # and create a kubernetes secret by following the tutorial in
     # https://cilium.link/etcd-config
+{% if cilium_version | regex_replace('v') is version('1.17.0', '>=') %}
+    trusted-ca-file: "{{ cilium_cert_dir }}/ca_cert.crt"
+{% else %}
     ca-file: "{{ cilium_cert_dir }}/ca_cert.crt"
+{% endif %}
 
     # In case you want client to server authentication, uncomment the following
     # lines and create a kubernetes secret by following the tutorial in


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
kind feature
> /kind flake

**What this PR does / why we need it**:
Add support for cilium 1.17

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11968

**Special notes for your reviewer**:
cilium 1.17 has changed `ca-file` -> ` trusted-ca-file` in the cilium config
https://github.com/kubernetes-sigs/kubespray/blob/a60ec1dbde6400af8c4090a333dacce7d818ba64/roles/network_plugin/cilium/templates/cilium/config.yml.j2#L23

cilium 1.17 docs:
https://docs.cilium.io/en/v1.17/network/kubernetes/configuration/

so if you're using cilium in kvstore mode, the cilium agents cannot connect to the etcd server.



**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix cilium network plugin config issue deploying cilium 1.17
```
