### PR TITLE
Parameterize kubelet root directory (/var/lib/kubelet)

### DIFF
--- a/.gitlab-ci/packet.yml
+++ b/.gitlab-ci/packet.yml
@@ -80,6 +80,9 @@ packet_ubuntu20-crio:
 packet_ubuntu22-calico-all-in-one:
   extends: .packet_pr
 
+packet_debian12-kubelet_root:
+  extends: .packet_pr
+
 packet_ubuntu22-calico-all-in-one-upgrade:
   extends: .packet_pr
   variables:

--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -148,3 +148,4 @@ systemd_resolved_disable_stub_listener: "{{ ansible_os_family in ['Flatcar', 'Fl
 # Used to disable File Access Policy Daemon service.
 # If service is enabled, the CNI plugin installation will fail
 disable_fapolicyd: true
+kubelet_root_dir: /var/lib/kubelet

--- a/roles/kubernetes/preinstall/tasks/0200-kubeletroot.yml
+++ b/roles/kubernetes/preinstall/tasks/0200-kubeletroot.yml
@@ -1,0 +1,36 @@
+# mount bind the kubelet root to the default location.
+# many csi and software in the ecosystem have this location hardcoded
+
+- name: "Make sure /var/lib/kubelet exists"
+  ansible.builtin.file:
+    path: "/var/lib/kubelet"
+    state: directory
+    mode: '0750'
+  when:
+    - kubelet_root_dir != '/var/lib/kubelet'
+
+- name: "Make sure kubelet_root_dir exists"
+  ansible.builtin.file:
+    path: "{{kubelet_root_dir}}"
+    state: directory
+    mode: '0750'
+  when:
+    - kubelet_root_dir != '/var/lib/kubelet'
+    
+- name: "Synchronize old /var/lib/kubelet to new location before mounting"
+  command: "rsync -avh --ignore-existing /var/lib/kubelet/ {{kubelet_root_dir}}"
+  changed_when: false
+  when:
+    - kubelet_root_dir != '/var/lib/kubelet'
+
+
+- name: "Mount bind kubelet-root to /var/lib/kubelet and add it to fstab"
+  ansible.posix.mount:
+    path: /var/lib/kubelet
+    src: "{{kubelet_root_dir}}"
+    opts: bind,nofail
+    state: mounted
+    boot: true
+    fstype: none
+  when:
+    - kubelet_root_dir != '/var/lib/kubelet'

--- a/roles/kubernetes/preinstall/tasks/0200-kubeletroot.yml
+++ b/roles/kubernetes/preinstall/tasks/0200-kubeletroot.yml
@@ -1,3 +1,4 @@
+---
 # mount bind the kubelet root to the default location.
 # many csi and software in the ecosystem have this location hardcoded
 
@@ -16,10 +17,16 @@
     mode: '0750'
   when:
     - kubelet_root_dir != '/var/lib/kubelet'
-    
+
 - name: "Synchronize old /var/lib/kubelet to new location before mounting"
-  command: "rsync -avh --ignore-existing /var/lib/kubelet/ {{kubelet_root_dir}}"
-  changed_when: false
+  ansible.posix.synchronize:
+    src: /var/lib/kubelet/
+    dest: "{{kubelet_root_dir}}"
+    archive: true
+    rsync_opts:
+      - "--ignore-existing"
+    set_remote_user: false
+  delegate_to: "{{inventory_hostname}}"
   when:
     - kubelet_root_dir != '/var/lib/kubelet'
 

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -139,7 +139,8 @@
     - not ignore_assert_errors
 
 
-- import_tasks: 0200_kubeletroot.yaml
+- name: Configure alternative kubelet root
+  import_tasks: 0200-kubeletroot.yml
   tags:
     - bootstrap-os
     - kubelet-root

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -137,3 +137,11 @@
   when:
     - kube_network_plugin == 'calico'
     - not ignore_assert_errors
+
+
+- import_tasks: 0200_kubeletroot.yaml
+  tags:
+    - bootstrap-os
+    - kubelet-root
+  when:
+    - kubelet_root_dir != '/var/lib/kubelet'

--- a/roles/kubespray-defaults/defaults/main/main.yml
+++ b/roles/kubespray-defaults/defaults/main/main.yml
@@ -569,6 +569,7 @@ kubelet_rotate_server_certificates: false
 # If set to true, kubelet errors if any of kernel tunables is different than kubelet defaults
 kubelet_protect_kernel_defaults: true
 
+kubelet_root_dir: /var/lib/kubelet
 # Set additional sysctl variables to modify Linux kernel variables, for example:
 # additional_sysctl:
 #  - { name: kernel.pid_max, value: 131072 }

--- a/tests/files/packet_debian12-kubelet_root.yml
+++ b/tests/files/packet_debian12-kubelet_root.yml
@@ -1,0 +1,8 @@
+---
+# Instance settings
+cloud_image: debian-12
+mode: default
+
+# Kubespray settings
+
+kubelet_root_dir: /data/kubelet


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:

In some situation, users wants to use a different directory than the default "/var/lib/kubelet'. 
It was previously possible by setting the `kubelet_custom_flags` but many roles were still hardcoded to "/var/lib/kubelet".

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7087

**Special notes for your reviewer**:

Not sure the best way to handle users that were using the `kubelet_custom_flags`. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add new variable: `kubelet_root_dir`  to change the kubelet root default "/var/lib/kubelet" to a custom directory
```
