### PR TITLE
Feature: configure crio default capabilities

### DIFF
--- a/docs/CRI/cri-o.md
+++ b/docs/CRI/cri-o.md
@@ -79,6 +79,26 @@ The `allowed_annotations` configures `crio.conf` accordingly.
 The `crio_remap_enable` configures the `/etc/subuid` and `/etc/subgid` files to add an entry for the **containers** user.
 By default, 16M uids and gids are reserved for user namespaces (256 pods * 65536 uids/gids) at the end of the uid/gid space.
 
+The `crio_default_capabilities` configure the default containers capabilities for the crio.
+Defaults capabilties are:
+
+```yaml
+crio_default_capabilities:
+  - CHOWN
+  - DAC_OVERRIDE
+  - FSETID
+  - FOWNER
+  - NET_RAW
+  - SETGID
+  - SETUID
+  - SETPCAP
+  - NET_BIND_SERVICE
+  - SYS_CHROOT
+  - KILL
+```
+
+You can add MKNOD to the list for a rancher deployment
+
 ## Optional : NRI
 
 [Node Resource Interface](https://github.com/containerd/nri) (NRI) is disabled by default for the CRI-O. If you

--- a/roles/container-engine/cri-o/defaults/main.yml
+++ b/roles/container-engine/cri-o/defaults/main.yml
@@ -99,3 +99,17 @@ crio_man_files:
 
 # If set to true, it will enable the CRIU support in cri-o
 crio_criu_support_enabled: false
+
+# Configure default_capabilities in crio.conf
+crio_default_capabilities:
+  - CHOWN
+  - DAC_OVERRIDE
+  - FSETID
+  - FOWNER
+  - NET_RAW
+  - SETGID
+  - SETUID
+  - SETPCAP
+  - NET_BIND_SERVICE
+  - SYS_CHROOT
+  - KILL

--- a/roles/container-engine/cri-o/templates/crio.conf.j2
+++ b/roles/container-engine/cri-o/templates/crio.conf.j2
@@ -155,17 +155,9 @@ cgroup_manager = "{{ crio_cgroup_manager }}"
 # only the capabilities defined in the containers json file by the user/kube
 # will be added.
 default_capabilities = [
-	"CHOWN",
-	"DAC_OVERRIDE",
-	"FSETID",
-	"FOWNER",
-	"NET_RAW",
-	"SETGID",
-	"SETUID",
-	"SETPCAP",
-	"NET_BIND_SERVICE",
-	"SYS_CHROOT",
-	"KILL",
+{%- for item in crio_default_capabilities %}
+        "{{ item }}",
+{%- endfor %}
 ]
 
 # List of default sysctls. If it is empty or commented out, only the sysctls


### PR DESCRIPTION
What type of PR is this?

/kind bug


What this PR does / why we need it:

This PR update crio default_capabilties  to allow rancher to start  https://github.com/rancher/rancher/issues/41043


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

NONE

```release-note
Upate default crio capabilities to allow rancher to start
```
