### PR TITLE
Ensure metrics port exists for nodelocaldns/nodelocaldns-second daemonsets

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-daemonset.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-daemonset.yml.j2
@@ -47,7 +47,7 @@ spec:
         - coredns
 {% if enable_nodelocaldns_secondary %}
         - -skipteardown
-{% else %}
+{% endif %}
         ports:
         - containerPort: 53
           name: dns
@@ -55,10 +55,9 @@ spec:
         - containerPort: 53
           name: dns-tcp
           protocol: TCP
-        - containerPort: 9253
+        - containerPort: {{ nodelocaldns_prometheus_port }}
           name: metrics
           protocol: TCP
-{% endif %}
         securityContext:
           privileged: true
 {% if nodelocaldns_bind_metrics_host_ip %}

--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-second-daemonset.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-second-daemonset.yml.j2
@@ -39,6 +39,10 @@ spec:
             cpu: {{ nodelocaldns_cpu_requests }}
             memory: {{ nodelocaldns_memory_requests }}
         args: [ "-localip", "{{ nodelocaldns_ip }}", "-conf", "/etc/coredns/Corefile", "-upstreamsvc", "coredns", "-skipteardown" ]
+        ports:
+        - containerPort: {{ nodelocaldns_secondary_prometheus_port }}
+          name: metrics
+          protocol: TCP
         securityContext:
           privileged: true
 {% if nodelocaldns_bind_metrics_host_ip %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Allows a prometheus PodMonitor to scrape metrics endpoint when `enable_nodelocaldns_secondary` is enabled.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11980 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Ensure metrics port exists for nodelocaldns/nodelocaldns-second daemonsets
```
