### PR TITLE
`kubeadm config validate` flag for debugging and development

### DIFF
--- a/roles/download/tasks/prep_kubeadm_images.yml
+++ b/roles/download/tasks/prep_kubeadm_images.yml
@@ -19,7 +19,7 @@
     src: "kubeadm-images.yaml.j2"
     dest: "{{ kube_config_dir }}/kubeadm-images.yaml"
     mode: "0644"
-    validate: "{{ bin_dir }}/kubeadm config validate --config %s"
+    validate: "{{ kubeadm_config_validate_enabled | ternary(bin_dir + '/kubeadm config validate --config %s', omit) }}"
   when:
     - not skip_kubeadm_images | default(false)
 

--- a/roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml
@@ -36,7 +36,7 @@
     dest: "{{ kube_config_dir }}/kubeadm-controlplane.yaml"
     mode: "0640"
     backup: true
-    validate: "{{ bin_dir }}/kubeadm config validate --config %s"
+    validate: "{{ kubeadm_config_validate_enabled | ternary(bin_dir + '/kubeadm config validate --config %s', omit) }}"
   when:
     - inventory_hostname != first_kube_control_plane
     - not kubeadm_already_run.stat.exists

--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -94,7 +94,7 @@
     src: "kubeadm-config.{{ kubeadm_config_api_version }}.yaml.j2"
     dest: "{{ kube_config_dir }}/kubeadm-config.yaml"
     mode: "0640"
-    validate: "{{ bin_dir }}/kubeadm config validate --config %s"
+    validate: "{{ kubeadm_config_validate_enabled | ternary(bin_dir + '/kubeadm config validate --config %s', omit) }}"
 
 - name: Kubeadm | Create directory to store admission control configurations
   file:

--- a/roles/kubernetes/kubeadm/tasks/kubeadm_etcd_node.yml
+++ b/roles/kubernetes/kubeadm/tasks/kubeadm_etcd_node.yml
@@ -9,7 +9,7 @@
     src: "kubeadm-client.conf.j2"
     dest: "{{ kube_config_dir }}/kubeadm-cert-controlplane.conf"
     mode: "0640"
-    validate: "{{ bin_dir }}/kubeadm config validate --config %s"
+    validate: "{{ kubeadm_config_validate_enabled | ternary(bin_dir + '/kubeadm config validate --config %s', omit) }}"
   vars:
     kubeadm_cert_controlplane: true
 

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -75,7 +75,7 @@
     dest: "{{ kube_config_dir }}/kubeadm-client.conf"
     backup: true
     mode: "0640"
-    validate: "{{ bin_dir }}/kubeadm config validate --config %s"
+    validate: "{{ kubeadm_config_validate_enabled | ternary(bin_dir + '/kubeadm config validate --config %s', omit) }}"
   when: ('kube_control_plane' not in group_names)
 
 - name: Join to cluster if needed

--- a/roles/kubespray-defaults/defaults/main/main.yml
+++ b/roles/kubespray-defaults/defaults/main/main.yml
@@ -30,6 +30,10 @@ kube_proxy_mode: ipvs
 # If kube_version is v1.31 or higher, it will be v1beta4, otherwise it will be v1beta3.
 kubeadm_config_api_version: "{{ 'v1beta4' if kube_version is version('v1.31.0', '>=') else 'v1beta3' }}"
 
+# Debugging option for the kubeadm config validate command
+# Set to false only for development and testing scenarios where validation is expected to fail (pre-release Kubernetes versions, etc.)
+kubeadm_config_validate_enabled: true
+
 ## The timeout for init first control-plane
 kubeadm_init_timeout: 300s
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This adds a new flag with default `kubeadm_config_validate_enabled: true` to use when debugging features and enhancements affected by the `kubeadm config validate` command.

This new flag should be set to `false` only for development and testing scenarios where validation is expected to fail (pre-release Kubernetes versions, etc).

While working with development and test versions of Kubernetes and Kubespray, I found this option very useful.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
