### PR TITLE
fix crio restart while switching runtime

### DIFF
--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -55,6 +55,25 @@
   when:
     - youki_enabled
 
+- name: Cri-o | Stop kubelet service if running
+  service:
+    name: kubelet
+    state: stopped
+  when: ansible_facts.services["kubelet.service"] is defined and ansible_facts.services["kubelet.service"].state == 'running'
+
+- name: Cri-o | Stop all the running containers
+  ansible.builtin.shell: |
+    for container in $({{ bin_dir }}/crictl ps -q); do
+      {{ bin_dir }}/crictl stop $container
+    done
+  when: ansible_facts.services["crio.service"] is defined
+
+- name: Cri-o | stop crio service if running
+  service:
+    name: crio
+    state: stopped
+  when: ansible_facts.services["crio.service"] is defined and ansible_facts.services["crio.service"].state == 'running'
+
 - name: Cri-o | make sure needed folders exist in the system
   with_items:
     - /etc/crio
@@ -87,7 +106,6 @@
     remote_src: true
   with_items:
     - "{{ crio_bin_files }}"
-  notify: Restart crio
 
 - name: Cri-o | create directory for libexec
   file:
@@ -104,7 +122,6 @@
     remote_src: true
   with_items:
     - "{{ crio_libexec_files }}"
-  notify: Restart crio
 
 - name: Cri-o | copy service file
   copy:
@@ -112,7 +129,6 @@
     dest: /etc/systemd/system/crio.service
     mode: "0755"
     remote_src: true
-  notify: Restart crio
 
 - name: Cri-o | configure crio to use kube reserved cgroups
   ansible.builtin.copy:
@@ -133,7 +149,6 @@
     dest: /etc/systemd/system/crio.service
     regexp: "/usr/local/bin/crio"
     replace: "{{ bin_dir }}/crio"
-  notify: Restart crio
 
 - name: Cri-o | copy default policy
   copy:
@@ -141,7 +156,6 @@
     dest: /etc/containers/policy.json
     mode: "0755"
     remote_src: true
-  notify: Restart crio
 
 - name: Cri-o | copy mounts.conf
   copy:
@@ -150,7 +164,6 @@
     mode: "0644"
   when:
     - ansible_os_family == 'RedHat'
-  notify: Restart crio
 
 - name: Cri-o | create directory for oci hooks
   file:
@@ -196,21 +209,18 @@
     dest: "/etc/containers/registries.conf.d/10-{{ item.prefix | default(item.location) | regex_replace(':|/', '_') }}.conf"
     mode: "0644"
   loop: "{{ crio_registries }}"
-  notify: Restart crio
 
 - name: Cri-o | configure unqualified registry settings
   template:
     src: unqualified.conf.j2
     dest: "/etc/containers/registries.conf.d/01-unqualified.conf"
     mode: "0644"
-  notify: Restart crio
 
 - name: Cri-o | write cri-o proxy drop-in
   template:
     src: http-proxy.conf.j2
     dest: /etc/systemd/system/crio.service.d/http-proxy.conf
     mode: "0644"
-  notify: Restart crio
   when: http_proxy is defined or https_proxy is defined
 
 - name: Cri-o | configure the uid/gid space for user namespaces
@@ -235,14 +245,6 @@
     state: started
   register: service_start
 
-- name: Cri-o | trigger service restart only when needed
-  service:
-    name: crio
-    state: restarted
-  when:
-    - config_install.changed or reg_auth_install.changed
-    - not service_start.changed
-
 - name: Cri-o | verify that crio is running
   command: "{{ bin_dir }}/{{ crio_status_command }} info"
   register: get_crio_info
@@ -250,3 +252,9 @@
   changed_when: false
   retries: 5
   delay: "{{ retry_stagger | random + 3 }}"
+
+- name: Cri-o | ensure kubelet service is started if present and stopped
+  service:
+    name: kubelet
+    state: started
+  when: ansible_facts.services["kubelet.service"] is defined


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

This PR stops the kubelet service if running, stops running containers, and then stops the crio service before changing the runtime (e.g., runc to crun). After making the changes, it starts the crio and kubelet services.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes-sigs/kubespray/issues/11907

**Special notes for your reviewer**:

Kubernetes has changed the default runtime for CRI-O from runc to crun starting with version 1.31. This change has caused upgrade failures because CRI-O cannot handle a real-time runtime switch. As mentioned in https://github.com/cri-o/cri-o/issues/8705#issuecomment-2456818791, when switching runtimes, we need to ensure that the kubelet service and running containers are stopped before making the change.

**Does this PR introduce a user-facing change?**: N/A
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
