### PR TITLE
CRI-O: Fix for handling of container runtime switching

### DIFF
--- a/roles/container-engine/cri-o/defaults/main.yml
+++ b/roles/container-engine/cri-o/defaults/main.yml
@@ -4,6 +4,7 @@ crio_cgroup_manager: "{{ kubelet_cgroup_driver | default('systemd') }}"
 crio_conmon: "{{ bin_dir }}/conmon"
 crio_default_runtime: "crun"
 crio_libexec_dir: "/usr/libexec/crio"
+crio_runtime_switch: false
 crio_enable_metrics: false
 crio_log_level: "info"
 crio_metrics_port: "9090"

--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -55,6 +55,46 @@
   when:
     - youki_enabled
 
+- name: Cri-o | Stop kubelet service if running
+  service:
+    name: kubelet
+    state: stopped
+  when:
+    - crio_runtime_switch
+    - ansible_facts.services['kubelet.service'] is defined and ansible_facts.services['kubelet.service'].state == 'running'
+
+- name: Cri-o | Get all pods
+  ansible.builtin.command: "{{ bin_dir }}/crictl pods -o json"
+  changed_when: false
+  register: crio_pods
+  when:
+    - crio_runtime_switch
+    - ansible_facts.services['crio.service'] is defined
+
+- name: Cri-o | Stop and remove pods not on host network
+  ansible.builtin.command: "{{ bin_dir }}/crictl rmp -f {{ item.id }}"
+  loop: "{{ (crio_pods.stdout | from_json).items | default([]) | selectattr('metadata.namespace', 'ne', 'NODE') }}"
+  changed_when: true
+  when:
+    - crio_runtime_switch
+    - ansible_facts.services['crio.service'] is defined
+    - crio_pods.stdout is defined
+
+- name: Cri-o | Stop and remove all remaining pods
+  ansible.builtin.command: "{{ bin_dir }}/crictl rmp -fa"
+  changed_when: true
+  when:
+    - crio_runtime_switch
+    - ansible_facts.services['crio.service'] is defined
+
+- name: Cri-o | stop crio service if running
+  service:
+    name: crio
+    state: stopped
+  when:
+    - crio_runtime_switch
+    - ansible_facts.services['crio.service'] is defined and ansible_facts.services['crio.service'].state == 'running'
+
 - name: Cri-o | make sure needed folders exist in the system
   with_items:
     - /etc/crio
@@ -250,3 +290,16 @@
   changed_when: false
   retries: 5
   delay: "{{ retry_stagger | random + 3 }}"
+
+# The kubelet service status can be 'not-found' if something depends on it.
+# This check prevents failures when the service is in this indeterminate state,
+# which can occur when adding new nodes to a cluster.
+# See: https://superuser.com/questions/1755211/cleaning-debugging-services/1755215#1755215
+
+- name: Cri-o | ensure kubelet service is started if present and stopped
+  service:
+    name: kubelet
+    state: started
+  when:
+    - crio_runtime_switch
+    - ansible_facts.services['kubelet.service'] is defined and ansible_facts.services['kubelet.service']['status'] != 'not-found'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

This PR stops the kubelet service if running, stops running containers, and then stops the crio service before changing the runtime (e.g., runc to crun). After making the changes, it starts the crio and kubelet services.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kubespray/issues/11907

**Special notes for your reviewer**:

Kubernetes has changed the default runtime for CRI-O from runc to crun starting with version 1.31. This change has caused upgrade failures because CRI-O cannot handle a real-time runtime switch. As mentioned in https://github.com/cri-o/cri-o/issues/8705#issuecomment-2456818791, when switching runtimes, we need to ensure that the kubelet service and running containers are stopped before making the change.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Introduce `crio_runtime_switch` boolean to allow users to switch the crio runtime by removing pods and stopping crio and kubelet during upgrade ; otherwise crio has problems when trying to work with pods created with the old runtime.
```
