### PR TITLE
add var skip_assert_errors & var etcd-even-numbers to allow an even number of etcd nodes

### DIFF
--- a/docs/operations/nodes.md
+++ b/docs/operations/nodes.md
@@ -127,10 +127,10 @@ You need to make sure there are always an odd number of etcd nodes in the cluste
 
 ### 1) Add the new node running cluster.yml
 
-Update the inventory and run `cluster.yml` passing `--limit=etcd,kube_control_plane -e ignore_assert_errors=yes`.
+Update the inventory and run `cluster.yml` passing `--limit=etcd,kube_control_plane -e '{"skip_assert_errors": ["etcd-even-numbers"]}'`.
 If the node you want to add as an etcd node is already a worker or control plane node in your cluster, you have to remove him first using `remove-node.yml`.
 
-Run `upgrade-cluster.yml` also passing `--limit=etcd,kube_control_plane -e ignore_assert_errors=yes`. This is necessary to update all etcd configuration in the cluster.
+Run `upgrade-cluster.yml` also passing `--limit=etcd,kube_control_plane -e '{"skip_assert_errors": ["etcd-even-numbers"]}'`. This is necessary to update all etcd configuration in the cluster.
 
 At this point, you will have an even number of nodes.
 Everything should still be working, and you should only have problems if the cluster decides to elect a new etcd leader before you remove a node.

--- a/roles/kubespray_defaults/defaults/main/main.yml
+++ b/roles/kubespray_defaults/defaults/main/main.yml
@@ -93,6 +93,9 @@ kube_proxy_nodeport_addresses: >-
 # Set to true to allow pre-checks to fail and continue deployment
 ignore_assert_errors: false
 
+# List of pre-checks to skip
+skip_assert_errors: []
+
 # kube-vip
 kube_vip_enabled: false
 kube_vip_lb_fwdmethod: local

--- a/roles/validate_inventory/tasks/main.yml
+++ b/roles/validate_inventory/tasks/main.yml
@@ -58,6 +58,7 @@
     that: groups.get('etcd', groups.kube_control_plane) | length is not divisibleby 2
   run_once: true
   when:
+    - not 'etcd-even-numbers' in skip_assert_errors | default([])
     - not ignore_assert_errors
 
 # This assertion will fail on the safe side: One can indeed schedule more pods


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind flake

**What this PR does / why we need it**:
Currently the only way to add an even number of control-plane/etcd nodes to a cluster is to disable all assert checks by passing `ignore_assert_errors=yes`

It would be better just to skip the etcd even nodes assert check and leave all other asserts as they can catch useful problems.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12013

**Special notes for your reviewer**:
I've updated the docs to use the new `-e '{"skip_assert_errors": ["etcd-even-numbers"]}'` flag.  This isn't really a breaking change as  `ignore_assert_errors=yes` will still work.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
add var skip_assert_errors & var etcd-even-numbers to allow an even number of etcd nodes
```
