### PR TITLE
Refactor control plane upgrades with reconfiguration support

### DIFF
--- a/roles/kubernetes/control-plane/defaults/main/main.yml
+++ b/roles/kubernetes/control-plane/defaults/main/main.yml
@@ -248,6 +248,9 @@ kube_apiserver_tracing_sampling_rate_per_million: 100
 # Enable kubeadm file discovery if anonymous access has been removed
 kubeadm_use_file_discovery: "{{ remove_anonymous_access }}"
 
+# imagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel. Default: true
+kubeadm_image_pull_serial: true
+
 # Supported asymmetric encryption algorithm types for the cluster's keys and certificates.
 # can be one of RSA-2048(default), RSA-3072, RSA-4096, ECDSA-P256
 # ref: https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta4/#kubeadm-k8s-io-v1beta4-ClusterConfiguration

--- a/roles/kubernetes/control-plane/tasks/check-api.yml
+++ b/roles/kubernetes/control-plane/tasks/check-api.yml
@@ -1,0 +1,10 @@
+---
+- name: Kubeadm | Check api is up
+  uri:
+    url: "https://{{ ip | default(fallback_ip) }}:{{ kube_apiserver_port }}/healthz"
+    validate_certs: false
+  when: ('kube_control_plane' in group_names)
+  register: _result
+  retries: 60
+  delay: 5
+  until: _result.status == 200

--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -229,7 +229,7 @@
 - name: Kubeadm | Join other control plane nodes
   include_tasks: kubeadm-secondary.yml
 
-- name: Kubeadm | upgrade kubernetes cluster
+- name: Kubeadm | upgrade kubernetes cluster to {{ kube_version }}
   include_tasks: kubeadm-upgrade.yml
   when:
     - upgrade_cluster_setup

--- a/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
@@ -40,15 +40,25 @@
   environment:
     PATH: "{{ bin_dir }}:{{ ansible_env.PATH }}"
 
-# kubeadm upgrade no longer reconciles ClusterConfiguration changes, this must be done separately after upgrade to ensure the latest config is applied
-- name: Update kubeadm configmap after upgrade
-  command: "{{ bin_dir }}/kubeadm init phase upload-config kubeadm --config {{ kube_config_dir }}/kubeadm-config.yaml"
+# kubeadm upgrade no longer reconciles ClusterConfiguration and KubeProxyConfiguration changes, this must be done separately after upgrade to ensure the latest config is applied
+- name: Update kubeadm and kubelet configmaps after upgrade
+  command: "{{ bin_dir }}/kubeadm init phase upload-config all --config {{ kube_config_dir }}/kubeadm-config.yaml"
   register: kubeadm_upload_config
   # Retry is because upload config sometimes fails
   retries: 3
   until: kubeadm_upload_config.rc == 0
   when:
   - inventory_hostname == first_kube_control_plane
+
+- name: Update kube-proxy configmap after upgrade
+  command: "{{ bin_dir }}/kubeadm init phase addon kube-proxy --config {{ kube_config_dir }}/kubeadm-config.yaml"
+  register: kube_proxy_upload_config
+  # Retry is because upload config sometimes fails
+  retries: 3
+  until: kube_proxy_upload_config.rc == 0
+  when:
+  - inventory_hostname == first_kube_control_plane
+  - ('addon/kube-proxy' not in kubeadm_init_phases_skip)
 
 - name: Rewrite kubeadm managed etcd static pod manifests with updated configmap
   command: "{{ bin_dir }}/kubeadm init phase control-plane all --config {{ kube_config_dir }}/kubeadm-config.yaml"

--- a/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
@@ -1,55 +1,65 @@
 ---
-- name: Kubeadm | Check api is up
-  uri:
-    url: "https://{{ main_ip | ansible.utils.ipwrap }}:{{ kube_apiserver_port }}/healthz"
-    validate_certs: false
-  when: ('kube_control_plane' in group_names)
-  register: _result
-  retries: 60
-  delay: 5
-  until: _result.status == 200
+- name: Ensure kube-apiserver is up before upgrade
+  import_tasks: check-api.yml
 
-- name: Kubeadm | Upgrade first control plane node
-  command: >-
-    timeout -k 600s 600s
-    {{ bin_dir }}/kubeadm
-    upgrade apply -y v{{ kube_version }}
-    --certificate-renewal={{ kubeadm_upgrade_auto_cert_renewal }}
-    --ignore-preflight-errors={{ kubeadm_ignore_preflight_errors | join(',') }}
-    --allow-experimental-upgrades
-    --etcd-upgrade={{ (etcd_deployment_type == "kubeadm") | lower }}
-    {% if kubeadm_patches | length > 0 %}--patches={{ kubeadm_patches_dir }}{% endif %}
-    --force
-  register: kubeadm_upgrade
-  # Retry is because upload config sometimes fails
-  retries: 3
-  until: kubeadm_upgrade.rc == 0
-  when: inventory_hostname == first_kube_control_plane
-  failed_when: kubeadm_upgrade.rc != 0 and "field is immutable" not in kubeadm_upgrade.stderr
+- name: Kubeadm | Upgrade control plane nodes
+  vars:
+    # kubeadm upgrade apply on v1.30 will always fail if --config is used during upgrade, but newer versions support --config if using UpgradeConfiguration
+    # kubeadm-config.v1beta4 with UpgradeConfiguration requires some values that were previously allowed as args to be specified in the config file
+    kubeadm_upgrade_apply_command: >-
+      timeout -k 600s 600s
+      {{ bin_dir }}/kubeadm upgrade apply -y {{ kube_version }}
+      {%- if kube_major_version != 'v1.30' %}
+      --config={{ kube_config_dir }}/kubeadm-config.yaml
+      {%- endif -%}
+      {%- if kubeadm_config_api_version == 'v1beta3' %}
+      --certificate-renewal={{ kubeadm_upgrade_auto_cert_renewal }}
+      --ignore-preflight-errors={{ kubeadm_ignore_preflight_errors | join(',') }}
+      --allow-experimental-upgrades
+      --etcd-upgrade={{ (etcd_deployment_type == "kubeadm") | lower }}
+      {% if kubeadm_patches | length > 0 %}--patches={{ kubeadm_patches_dir }}{% endif %}
+      --force
+      {%- endif -%}
   environment:
     PATH: "{{ bin_dir }}:{{ ansible_env.PATH }}"
-  notify: Control plane | restart kubelet
+  block:
+  - name: Kubeadm | Upgrade first control plane node
+    command: "{{ kubeadm_upgrade_apply_command }}"
+    register: kubeadm_upgrade
+    when: inventory_hostname == first_kube_control_plane
+    failed_when: kubeadm_upgrade.rc != 0 and "field is immutable" not in kubeadm_upgrade.stderr
 
-- name: Kubeadm | Upgrade other control plane nodes
-  command: >-
-    timeout -k 600s 600s
-    {{ bin_dir }}/kubeadm
-    upgrade apply -y v{{ kube_version }}
-    --certificate-renewal={{ kubeadm_upgrade_auto_cert_renewal }}
-    --ignore-preflight-errors={{ kubeadm_ignore_preflight_errors | join(',') }}
-    --allow-experimental-upgrades
-    --etcd-upgrade={{ (etcd_deployment_type == "kubeadm") | lower }}
-    {% if kubeadm_patches | length > 0 %}--patches={{ kubeadm_patches_dir }}{% endif %}
-    --force
-  register: kubeadm_upgrade
+  - name: Kubeadm | Upgrade other control plane nodes
+    command: "{{ kubeadm_upgrade_apply_command }}"
+    register: kubeadm_upgrade
+    when: inventory_hostname != first_kube_control_plane
+    failed_when: kubeadm_upgrade.rc != 0 and "field is immutable" not in kubeadm_upgrade.stderr
+
+# kubeadm upgrade apply will no longer reconcile ClusterConfiguration changes, this must be done separately after upgrade to ensure the latest config is applied
+- name: Update kubeadm configmap after upgrade
+  command: "{{ bin_dir }}/kubeadm init phase upload-config kubeadm --config {{ kube_config_dir }}/kubeadm-config.yaml"
+  register: kubeadm_upload_config
   # Retry is because upload config sometimes fails
   retries: 3
-  until: kubeadm_upgrade.rc == 0
-  when: inventory_hostname != first_kube_control_plane
-  failed_when: kubeadm_upgrade.rc != 0 and "field is immutable" not in kubeadm_upgrade.stderr
-  environment:
-    PATH: "{{ bin_dir }}:{{ ansible_env.PATH }}"
+  until: kubeadm_upload_config.rc == 0
+  when:
+  - inventory_hostname == first_kube_control_plane
+
+- name: Rewrite kubeadm managed etcd static pod manifests with updated configmap
+  command: "{{ bin_dir }}/kubeadm init phase control-plane all --config {{ kube_config_dir }}/kubeadm-config.yaml"
+  when:
+  - etcd_deployment_type == "kubeadm"
   notify: Control plane | restart kubelet
+
+- name: Rewrite kubernetes control plane static pod manifests with updated configmap
+  command: "{{ bin_dir }}/kubeadm init phase control-plane all --config {{ kube_config_dir }}/kubeadm-config.yaml"
+  notify: Control plane | restart kubelet
+
+- name: Flush kubelet handlers
+  meta: flush_handlers
+
+- name: Ensure kube-apiserver is up after upgrade and control plane configuration updates
+  import_tasks: check-api.yml
 
 - name: Kubeadm | Remove binding to anonymous user
   command: "{{ kubectl }} -n kube-public delete rolebinding kubeadm:bootstrap-signer-clusterinfo --ignore-not-found"
@@ -60,8 +70,8 @@
     path: "{{ item }}"
     state: absent
   with_items:
-    - /root/.kube/cache
-    - /root/.kube/http-cache
+  - /root/.kube/cache
+  - /root/.kube/http-cache
 
 # FIXME: https://github.com/kubernetes/kubeadm/issues/1318
 - name: Kubeadm | scale down coredns replicas to 0 if not using coredns dns_mode
@@ -75,6 +85,6 @@
   until: scale_down_coredns is succeeded
   run_once: true
   when:
-    - kubeadm_scale_down_coredns_enabled
-    - dns_mode not in ['coredns', 'coredns_dual']
+  - kubeadm_scale_down_coredns_enabled
+  - dns_mode not in ['coredns', 'coredns_dual']
   changed_when: false

--- a/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
@@ -2,40 +2,45 @@
 - name: Ensure kube-apiserver is up before upgrade
   import_tasks: check-api.yml
 
-- name: Kubeadm | Upgrade control plane nodes
-  vars:
-    # kubeadm upgrade apply on v1.30 will always fail if --config is used during upgrade, but newer versions support --config if using UpgradeConfiguration
-    # kubeadm-config.v1beta4 with UpgradeConfiguration requires some values that were previously allowed as args to be specified in the config file
-    kubeadm_upgrade_apply_command: >-
-      timeout -k 600s 600s
-      {{ bin_dir }}/kubeadm upgrade apply -y {{ kube_version }}
-      {%- if kube_major_version != 'v1.30' %}
-      --config={{ kube_config_dir }}/kubeadm-config.yaml
-      {%- endif -%}
-      {%- if kubeadm_config_api_version == 'v1beta3' %}
-      --certificate-renewal={{ kubeadm_upgrade_auto_cert_renewal }}
-      --ignore-preflight-errors={{ kubeadm_ignore_preflight_errors | join(',') }}
-      --allow-experimental-upgrades
-      --etcd-upgrade={{ (etcd_deployment_type == "kubeadm") | lower }}
-      {% if kubeadm_patches | length > 0 %}--patches={{ kubeadm_patches_dir }}{% endif %}
-      --force
-      {%- endif -%}
+  # kubeadm-config.v1beta4 with UpgradeConfiguration requires some values that were previously allowed as args to be specified in the config file
+- name: Kubeadm | Upgrade first control plane node
+  command: >-
+    timeout -k 600s 600s
+    {{ bin_dir }}/kubeadm upgrade apply -y {{ kube_version }}
+    {%- if kubeadm_config_api_version == 'v1beta3' %}
+    --certificate-renewal={{ kubeadm_upgrade_auto_cert_renewal }}
+    --ignore-preflight-errors={{ kubeadm_ignore_preflight_errors | join(',') }}
+    --allow-experimental-upgrades
+    --etcd-upgrade={{ (etcd_deployment_type == "kubeadm") | lower }}
+    {% if kubeadm_patches | length > 0 %}--patches={{ kubeadm_patches_dir }}{% endif %}
+    --force
+    {%- else %}
+    --config={{ kube_config_dir }}/kubeadm-config.yaml
+    {%- endif -%}
+  register: kubeadm_upgrade
+  when: inventory_hostname == first_kube_control_plane
+  failed_when: kubeadm_upgrade.rc != 0 and "field is immutable" not in kubeadm_upgrade.stderr
   environment:
     PATH: "{{ bin_dir }}:{{ ansible_env.PATH }}"
-  block:
-  - name: Kubeadm | Upgrade first control plane node
-    command: "{{ kubeadm_upgrade_apply_command }}"
-    register: kubeadm_upgrade
-    when: inventory_hostname == first_kube_control_plane
-    failed_when: kubeadm_upgrade.rc != 0 and "field is immutable" not in kubeadm_upgrade.stderr
 
-  - name: Kubeadm | Upgrade other control plane nodes
-    command: "{{ kubeadm_upgrade_apply_command }}"
-    register: kubeadm_upgrade
-    when: inventory_hostname != first_kube_control_plane
-    failed_when: kubeadm_upgrade.rc != 0 and "field is immutable" not in kubeadm_upgrade.stderr
+- name: Kubeadm | Upgrade other control plane nodes
+  command: >-
+    {{ bin_dir }}/kubeadm upgrade node
+    {%- if kubeadm_config_api_version == 'v1beta3' %}
+    --certificate-renewal={{ kubeadm_upgrade_auto_cert_renewal }}
+    --ignore-preflight-errors={{ kubeadm_ignore_preflight_errors | join(',') }}
+    --etcd-upgrade={{ (etcd_deployment_type == "kubeadm") | lower }}
+    {% if kubeadm_patches | length > 0 %}--patches={{ kubeadm_patches_dir }}{% endif %}
+    {%- else %}
+    --config={{ kube_config_dir }}/kubeadm-config.yaml
+    {%- endif -%}
+  register: kubeadm_upgrade
+  when: inventory_hostname != first_kube_control_plane
+  failed_when: kubeadm_upgrade.rc != 0 and "field is immutable" not in kubeadm_upgrade.stderr
+  environment:
+    PATH: "{{ bin_dir }}:{{ ansible_env.PATH }}"
 
-# kubeadm upgrade apply will no longer reconcile ClusterConfiguration changes, this must be done separately after upgrade to ensure the latest config is applied
+# kubeadm upgrade no longer reconciles ClusterConfiguration changes, this must be done separately after upgrade to ensure the latest config is applied
 - name: Update kubeadm configmap after upgrade
   command: "{{ bin_dir }}/kubeadm init phase upload-config kubeadm --config {{ kube_config_dir }}/kubeadm-config.yaml"
   register: kubeadm_upload_config

--- a/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
@@ -61,7 +61,7 @@
   - ('addon/kube-proxy' not in kubeadm_init_phases_skip)
 
 - name: Rewrite kubeadm managed etcd static pod manifests with updated configmap
-  command: "{{ bin_dir }}/kubeadm init phase control-plane all --config {{ kube_config_dir }}/kubeadm-config.yaml"
+  command: "{{ bin_dir }}/kubeadm init phase etcd local --config {{ kube_config_dir }}/kubeadm-config.yaml"
   when:
   - etcd_deployment_type == "kubeadm"
   notify: Control plane | restart kubelet

--- a/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
@@ -6,7 +6,7 @@
 - name: Kubeadm | Upgrade first control plane node
   command: >-
     timeout -k 600s 600s
-    {{ bin_dir }}/kubeadm upgrade apply -y {{ kube_version }}
+    {{ bin_dir }}/kubeadm upgrade apply -y v{{ kube_version }}
     {%- if kubeadm_config_api_version == 'v1beta3' %}
     --certificate-renewal={{ kubeadm_upgrade_auto_cert_renewal }}
     --ignore-preflight-errors={{ kubeadm_ignore_preflight_errors | join(',') }}

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
@@ -480,7 +480,7 @@ scheduler:
 apiVersion: kubeadm.k8s.io/v1beta4
 kind: UpgradeConfiguration
 apply:
-  kubernetesVersion: {{ kube_version }}
+  kubernetesVersion: v{{ kube_version }}
   allowExperimentalUpgrades: true
   certificateRenewal: {{ kubeadm_upgrade_auto_cert_renewal | lower }}
   etcdUpgrade: {{ (etcd_deployment_type == "kubeadm") | lower }}

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
@@ -477,6 +477,28 @@ scheduler:
 {% endfor %}
 {% endif %}
 ---
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: UpgradeConfiguration
+apply:
+  kubernetesVersion: {{ kube_version }}
+  allowExperimentalUpgrades: true
+  allowRCUpgrades: true
+  certificateRenewal: {{ kubeadm_upgrade_auto_cert_renewal | lower }}
+  etcdUpgrade: {{ (etcd_deployment_type == "kubeadm") | lower }}
+  forceUpgrade: true
+{% if kubeadm_ignore_preflight_errors | length > 0 %}
+  ignorePreflightErrors:
+{% for ignore_error in kubeadm_ignore_preflight_errors %}
+  - "{{ ignore_error }}"
+{% endfor %}
+{% endif %}
+{% if kubeadm_patches | length > 0 %}
+  patches:
+    directory: {{ kubeadm_patches_dir }}
+{% endif %}
+  imagePullPolicy: {{ k8s_image_pull_policy }}
+  imagePullSerial: {{ kubeadm_image_pull_serial | lower }}
+---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 bindAddress: "{{ kube_proxy_bind_address }}"

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
@@ -29,6 +29,8 @@ nodeRegistration:
   - name: cloud-provider
     value: external
 {% endif %}
+  imagePullPolicy: {{ k8s_image_pull_policy }}
+  imagePullSerial: {{ kubeadm_image_pull_serial | lower }}
 {% if kubeadm_patches | length > 0 %}
 patches:
   directory: {{ kubeadm_patches_dir }}

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
@@ -482,10 +482,24 @@ kind: UpgradeConfiguration
 apply:
   kubernetesVersion: {{ kube_version }}
   allowExperimentalUpgrades: true
-  allowRCUpgrades: true
   certificateRenewal: {{ kubeadm_upgrade_auto_cert_renewal | lower }}
   etcdUpgrade: {{ (etcd_deployment_type == "kubeadm") | lower }}
   forceUpgrade: true
+{% if kubeadm_ignore_preflight_errors | length > 0 %}
+  ignorePreflightErrors:
+{% for ignore_error in kubeadm_ignore_preflight_errors %}
+  - "{{ ignore_error }}"
+{% endfor %}
+{% endif %}
+{% if kubeadm_patches | length > 0 %}
+  patches:
+    directory: {{ kubeadm_patches_dir }}
+{% endif %}
+  imagePullPolicy: {{ k8s_image_pull_policy }}
+  imagePullSerial: {{ kubeadm_image_pull_serial | lower }}
+node:
+  certificateRenewal: {{ kubeadm_upgrade_auto_cert_renewal | lower }}
+  etcdUpgrade: {{ (etcd_deployment_type == "kubeadm") | lower }}
 {% if kubeadm_ignore_preflight_errors | length > 0 %}
   ignorePreflightErrors:
 {% for ignore_error in kubeadm_ignore_preflight_errors %}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Adds revised support for:
- The previously removed `--config` argument for `kubeadm upgrade apply`
- Changes to `ClusterConfiguration` as part of the `upgrade-cluster.yml` playbook lifecycle (Fixes #11552)
- kubeadm-config `v1beta4` `UpgradeConfiguration` for the `kubeadm upgrade apply` command: [UpgradeConfiguration v1beta4](https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta4/#kubeadm-k8s-io-v1beta4-UpgradeConfiguration).

#### kubeadm upgrade apply --config support
PR #11352 removed the --config flag from all usages of `kubeadm upgrade apply` to address the upgrade issues with kubeadm v1.30 identified in #11350.

This PR enables support for the scenarios in which `--config` can and should still be used with `kubeadm upgrade apply`, with some version specific handling that still avoid kubeadm v1.30's upgrade failures.

#### Control plane reconfiguration during upgrade
Before PR #11352, kubespray upgrades depended on `kubeadm upgrade apply --config=...` to make ClusterConfiguration changes during a cluster upgrade. However, this reconfiguration was deprecated from `kubeadm upgrade apply` some time ago, and is [no longer supported](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/#additional-information) by the `kubeadm upgrade apply` command.

To ensure `ClusterConfiguration` changes are still applied during upgrades in a supportable way, the new solution in this PR reconfigures `ClusterConfiguration` separately with distinct `kubeadm init phase upload-config kubeadm --config=...` and control plane static pod rewrite tasks that run immediately after a successful upgrade. See [this comment from @vannten](https://github.com/kubernetes-sigs/kubespray/pull/11871#issuecomment-2582051300) for more discussion on why the expectation is to fix reconfiguration as part of the upgrade lifecycle, as well as issue #11552. This approach is in line with kubeadm's [recommendations for cluster reconfiguration](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure/).

#### kubeadm-config v1beta4 `UpgradeApplyConfiguration` support
Additionally, kubeadm v1.31 added back support for `--config` while introducing support for `UpgradeConfiguration` in the kubeadm-config file, which is required to fully implement upgrades with `kubeadm.k8s.io/v1beta4`. UpgradeConfiguration was not added in kubespray's initial v1beta4 implementation (PR #11674), but it is required to use `--config` correctly during kubeadm upgrades with v1beta4.

This PR uses UpgradeConfiguration for v1beta4 kubeadm upgrades, while still retaining support for v1beta3.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11552

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add support for control plane reconfiguration on upgrades 
Add support for kubeadm-config v1beta4 `UpgradeConfiguration.apply` and `UpgradeConfiguration.node`
Use `kubeadm upgrade node` during secondary control plane node upgrades
```
