### PR TITLE
fix: ensure CoreDNS is kept disabled on kubeadm upgrade

### DIFF
--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
@@ -102,6 +102,9 @@ etcd:
 {% endfor %}
 {% endif %}
 dns:
+{% if 'addon/coredns' in kubeadm_init_phases_skip  %}
+  disabled: true
+{% endif %}
   imageRepository: {{ coredns_image_repo | regex_replace('/coredns(?!/coredns).*$', '') }}
   imageTag: {{ coredns_image_tag }}
 networking:


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

With https://github.com/kubernetes/kubernetes/pull/129429 integrated in k8s 1.32, `kubeadm upgrade node` now honors `dns.disabled` from [ClusterConfiguration](https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta4/#kubeadm-k8s-io-v1beta4-DNS).

Without this, kubeadm will override coredns configs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix: prevent kubeadm to override coredns configuration/deployment on upgrade
```
