### PR TITLE
Make the etcd metrics port name unique to the etcd host name

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/etcd_metrics-endpoints.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/etcd_metrics-endpoints.yml.j2
@@ -14,7 +14,7 @@ subsets:
           kind: Node
           name: {{ etcd_host }}
     ports:
-      - name: http-metrics
+      - name: http-metrics-{{ etcd_host }}
         port: {{ etcd_metrics_address | urlsplit('port') }}
         protocol: TCP
 {% endfor %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR makes it so etcd metrics endpoint port names are unique, to avoid `PrometheusDuplicateTimestamps` when deploying the `kube-prometheus-stack` helm chart

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/kubespray/issues/12033

**Special notes for your reviewer**:
As mentioned in the issue, I am not exactly sure if this is the best solution to the problem. The port name is not necessarily wrong as is, as `http-metrics` are indeed served on it. There is probably a valid argument that this is not an issue with `kubespray` at all, and rather an issue with `kube-prometheus-stack` or its upstream application.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
