### PR TITLE
vagrant: allow to config vagrant with separate etcd

### DIFF
--- a/tests/files/vagrant_fedora39-kube-router.rb
+++ b/tests/files/vagrant_fedora39-kube-router.rb
@@ -2,7 +2,7 @@ $num_instances = 2
 $vm_memory ||= 2048
 $os = "fedora39"
 
-$kube_master_instances = 1
+$control_plane_instances = 1
 $etcd_instances = 1
 
 # For CI we are not worried about data persistence across reboot

--- a/tests/files/vagrant_ubuntu20-kube-router-sep.rb
+++ b/tests/files/vagrant_ubuntu20-kube-router-sep.rb
@@ -2,7 +2,7 @@ $num_instances = 2
 $vm_memory ||= 2048
 $os = "ubuntu2004"
 
-$kube_master_instances = 1
+$control_plane_instances = 1
 $etcd_instances = 1
 
 # For CI we are not worried about data persistence across reboot


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
(but only for devs)

**What this PR does / why we need it**:
This should help test separate etcd configuration locally more easily.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Note that I took the occasion to rename master to control_plane in Vagrantfile

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
