### PR TITLE
Add github workflow to auto update hashes daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,9 @@ updates:
         patterns:
           - molecule
           - molecule-plugins*
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels:
+      - release-note-none
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/upgrade-patch-versions-schedule.yml
+++ b/.github/workflows/upgrade-patch-versions-schedule.yml
@@ -1,0 +1,54 @@
+name: Upgrade Kubespray components with new patches versions - all branches
+
+on:
+  schedule:
+  - cron: '22 2 * * *' # every day, 02:22 UTC
+  workflow_dispatch:
+
+permissions: {}
+jobs:
+  get-releases-branches:
+    runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ steps.get-branches.outputs.data }}
+    steps:
+    - uses: octokit/graphql-action@v2.3.2
+      id: get-branches
+      with:
+        query: |
+          query get_release_branches($owner:String!, $name:String!) {
+            repository(owner:$owner, name:$name) {
+              refs(refPrefix: "refs/heads/",
+                   first: 0, # TODO increment once we have release branch with the new checksums format
+                   query: "release-",
+                   orderBy: {
+                     field: ALPHABETICAL,
+                     direction: DESC
+                   }) {
+                     nodes {
+                       name
+                     }
+              }
+            }
+          }
+        variables: |
+          owner: ${{ github.repository_owner }}
+          name: ${{ github.event.repository.name }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  update-versions:
+    needs: get-releases-branches
+    strategy:
+      fail-fast: false
+      matrix:
+        branch:
+          - name: ${{ github.event.repository.default_branch }}
+          -  ${{ fromJSON(needs.get-releases-branches.outputs.branches).repository.refs.nodes }}
+    uses: ./.github/workflows/upgrade-patch-versions.yml
+    permissions:
+      contents: write
+      pull-requests: write
+    name: Update patch updates on ${{ matrix.branch.name }}
+    with:
+      branch: ${{ matrix.branch.name }}

--- a/.github/workflows/upgrade-patch-versions.yml
+++ b/.github/workflows/upgrade-patch-versions.yml
@@ -1,0 +1,44 @@
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: Which branch to update with new patch versions
+        default: master
+        required: true
+        type: string
+
+jobs:
+  update-patch-versions:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.branch }}
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+        cache: 'pip'
+    - run: pip install scripts/component_hash_update pre-commit
+    - run: update-hashes
+      env:
+        API_KEY: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/cache@v4
+      with:
+        key: pre-commit-hook-propagate
+        path: |
+          ~/.cache/pre-commit
+    - run: pre-commit run --all-files propagate-ansible-variables
+      continue-on-error: true
+    - uses: peter-evans/create-pull-request@v7
+      with:
+        commit-message: Patch versions updates
+        title: Patch versions updates - ${{ inputs.branch }}
+        labels: bot
+        branch: ${{ inputs.branch }}-patch-updates
+        sign-commits: true
+        body: |
+          /kind feature
+
+          ```release-note
+          NONE
+          ```


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Use the component_hash_update to update all relevant branches (which is now only master, but will be release-branch > release-2.27)

See https://github.com/VannTen/kubespray/actions for examples runs.

**Which issue(s) this PR fixes**:
Fixes #10681 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
