### PR TITLE
Check separately for 'v'-prefixed versions for ones which are derived

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
@@ -22,7 +22,6 @@
       - not cinder_csi_plugin_version.startswith('v')
       - not cni_version.startswith('v')
       - not dnsautoscaler_version.startswith('v')
-      - not etcd_version.startswith('v')
       - not flannel_cni_version.startswith('v')
       - not flannel_version.startswith('v')
       - gateway_api_version is not defined or not gateway_api_version.startswith('v')
@@ -38,11 +37,22 @@
       - not metrics_server_version.startswith('v')
       - not multus_version.startswith('v')
       - not netcheck_version.startswith('v')
-      - not pod_infra_version.startswith('v')
       - not rbd_provisioner_version.startswith('v')
       - not runc_version.startswith('v')
       - not skopeo_version.startswith('v')
       - not yq_version.startswith('v')
+
+- name: Stop if some derived versions have a 'v' left at the start
+  # TODO: drop this task after 2.28.0 is released
+  # The 'not defined' tests are exception for applications which version in not defined
+  # in kubespray-defaults, only in their own roles.
+  assert:
+    msg: |
+      All version string used in kubespray have been normalized to not use a leading 'v'.
+      This check will be dropped in the next minor release.
+    that:
+      - not etcd_version.startswith('v')
+      - not pod_infra_version.startswith('v')
 
 - name: Stop if any host not in '--limit' does not have a fact cache
   vars:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The versions which are by default derived from `kube_version` can break
the assert if kube_version start with `v`, because they use the start of
`kube_version` as dict key.
By putting them in their own assert, the first assert should trigger on
`kube_version`, with a more explicit error.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Should avoid confusion like #12056 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
