### PR TITLE
Ensure correct `AuthorizationConfiguration` API version during upgrades

### DIFF
--- a/roles/kubernetes/control-plane/tasks/main.yml
+++ b/roles/kubernetes/control-plane/tasks/main.yml
@@ -109,7 +109,7 @@
   file:
     path: "{{ kube_config_dir }}/apiserver-authorization-config-{{ item }}.yaml"
     state: absent
-  loop: "{{ '[\"v1alpha1\", \"v1beta1\", \"v1\"]' | from_json | reject('equalto', kube_apiserver_authorization_config_api_version) | list }}"
+    loop: "{{ ['v1alpha1', 'v1beta1', 'v1'] | reject('equalto', kube_apiserver_authorization_config_api_version) | list }}"
   when: kube_apiserver_use_authorization_config_file
 
 - name: Include kubelet client cert rotation fixes

--- a/roles/kubernetes/control-plane/tasks/main.yml
+++ b/roles/kubernetes/control-plane/tasks/main.yml
@@ -21,11 +21,11 @@
 - name: Create structured AuthorizationConfiguration file
   copy:
     content: "{{ authz_config | to_nice_yaml(indent=2, sort_keys=false) }}"
-    dest: "{{ kube_config_dir }}/apiserver-authorization-config.yaml"
+    dest: "{{ kube_config_dir }}/apiserver-authorization-config-{{ kube_apiserver_authorization_config_api_version }}.yaml"
     mode: "0640"
   vars:
     authz_config:
-      apiVersion: apiserver.config.k8s.io/{{ 'v1alpha1' if kube_version is version('1.30.0', '<') else 'v1beta1' if kube_version is version('1.32.0', '<') else 'v1' }}
+      apiVersion: apiserver.config.k8s.io/{{ kube_apiserver_authorization_config_api_version }}
       kind: AuthorizationConfiguration
       authorizers: "{{ kube_apiserver_authorization_config_authorizers }}"
   when: kube_apiserver_use_authorization_config_file
@@ -104,6 +104,13 @@
 
 - name: Include kubeadm secondary server apiserver fixes
   include_tasks: kubeadm-fix-apiserver.yml
+
+- name: Cleanup unused AuthorizationConfiguration file versions
+  file:
+    path: "{{ kube_config_dir }}/apiserver-authorization-config-{{ item }}.yaml"
+    state: absent
+  loop: "{{ '[\"v1alpha1\", \"v1beta1\", \"v1\"]' | from_json | reject('equalto', kube_apiserver_authorization_config_api_version) | list }}"
+  when: kube_apiserver_use_authorization_config_file
 
 - name: Include kubelet client cert rotation fixes
   include_tasks: kubelet-fix-client-cert-rotation.yml

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
@@ -127,7 +127,7 @@ apiServer:
     anonymous-auth: "{{ kube_api_anonymous_auth }}"
 {% endif %}
 {% if kube_apiserver_use_authorization_config_file %}
-    authorization-config: "{{ kube_config_dir }}/apiserver-authorization-config.yaml"
+    authorization-config: "{{ kube_config_dir }}/apiserver-authorization-config-{{ kube_apiserver_authorization_config_api_version }}.yaml"
 {% else %}
     authorization-mode: {{ authorization_modes | join(',') }}
 {% endif %}
@@ -249,8 +249,8 @@ apiServer:
 {% endif %}
 {% if kube_apiserver_use_authorization_config_file %}
   - name: authorization-config
-    hostPath: {{ kube_config_dir }}/apiserver-authorization-config.yaml
-    mountPath: {{ kube_config_dir }}/apiserver-authorization-config.yaml
+    hostPath: {{ kube_config_dir }}/apiserver-authorization-config-{{ kube_apiserver_authorization_config_api_version }}.yaml
+    mountPath: {{ kube_config_dir }}/apiserver-authorization-config-{{ kube_apiserver_authorization_config_api_version }}.yaml
 {% endif %}
 {% if kubernetes_audit or kubernetes_audit_webhook %}
   - name: {{ audit_policy_name }}

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
@@ -144,7 +144,7 @@ apiServer:
 {% endif %}
 {% if kube_apiserver_use_authorization_config_file %}
   - name: authorization-config
-    value: "{{ kube_config_dir }}/apiserver-authorization-config.yaml"
+    value: "{{ kube_config_dir }}/apiserver-authorization-config-{{ kube_apiserver_authorization_config_api_version }}.yaml"
 {% else %}
   - name: authorization-mode
     value: "{{ authorization_modes | join(',') }}"
@@ -306,8 +306,8 @@ apiServer:
 {% endif %}
 {% if kube_apiserver_use_authorization_config_file %}
   - name: authorization-config
-    hostPath: {{ kube_config_dir }}/apiserver-authorization-config.yaml
-    mountPath: {{ kube_config_dir }}/apiserver-authorization-config.yaml
+    hostPath: {{ kube_config_dir }}/apiserver-authorization-config-{{ kube_apiserver_authorization_config_api_version }}.yaml
+    mountPath: {{ kube_config_dir }}/apiserver-authorization-config-{{ kube_apiserver_authorization_config_api_version }}.yaml
 {% endif %}
 {% if kubernetes_audit or kubernetes_audit_webhook %}
   - name: {{ audit_policy_name }}

--- a/roles/kubespray-defaults/defaults/main/main.yml
+++ b/roles/kubespray-defaults/defaults/main/main.yml
@@ -506,6 +506,7 @@ authorization_modes: ['Node', 'RBAC']
 ## Examples: https://kubernetes.io/blog/2024/04/26/multi-webhook-and-modular-authorization-made-much-easier/
 ## KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3221-structured-authorization-configuration
 kube_apiserver_use_authorization_config_file: false
+kube_apiserver_authorization_config_api_version: "{{ 'v1alpha1' if kube_version is version('1.30.0', '<') else 'v1beta1' if kube_version is version('1.32.0', '<') else 'v1' }}"
 kube_apiserver_authorization_config_authorizers:
 - type: Node
   name: node


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes an issue where the wrong `AuthorizationConfiguration` API version could be used by kube-apiserver prematurely during upgrades.

The `kubernets/control-plane` role writes configuration for the target version before control plane pods are upgraded.

However, since the `AuthorizationConfiguration` file is reconciled continuously, this leads to a race condition where a new configuration version can be reconciled before kube-apiserver is upgraded to the compatible version.

This solution ensures the correct configuration is available throughout the process by writing each api version to a different file path. Unused file versions are cleaned up post-upgrade for better hygiene.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
