### PR TITLE
Upgrade kube-router

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Note:
   - [cilium](https://github.com/cilium/cilium) 1.15.9
   - [flannel](https://github.com/flannel-io/flannel) 0.22.0
   - [kube-ovn](https://github.com/alauda/kube-ovn) 1.12.21
-  - [kube-router](https://github.com/cloudnativelabs/kube-router) 2.0.0
+  - [kube-router](https://github.com/cloudnativelabs/kube-router) 2.1.1
   - [multus](https://github.com/k8snetworkplumbingwg/multus-cni) 4.1.0
   - [weave](https://github.com/rajch/weave) 2.8.7
   - [kube-vip](https://github.com/kube-vip/kube-vip) 0.8.0

--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -119,7 +119,7 @@ cilium_enable_hubble: false
 
 kube_ovn_version: "1.12.21"
 kube_ovn_dpdk_version: "19.11-v{{ kube_ovn_version }}"
-kube_router_version: "2.0.0"
+kube_router_version: "2.1.1"
 multus_version: "4.1.0"
 helm_version: "{{ (helm_archive_checksums['amd64'] | dict2items)[0].key }}"
 nerdctl_version: "{{ (nerdctl_archive_checksums['amd64'] | dict2items)[0].key }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
- This happens to fix the fact that kube-router is broken when using the
  service proxy: https://github.com/cloudnativelabs/kube-router/issues/1558

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Related to #12037 (fix the remaining error case)

**Does this PR introduce a user-facing change?**:

```release-note
Upgrade kube-router to 2.1.1
```
