### PR TITLE
Fix path in vagrant.md documentation

### DIFF
--- a/docs/developers/vagrant.md
+++ b/docs/developers/vagrant.md
@@ -88,7 +88,7 @@ $ pip install -r requirements.txt
 $ vagrant up
 
 # Access the cluster
-$ export INV=.vagrant/provisionners/ansible/inventory
+$ export INV=.vagrant/provisioners/ansible/inventory
 $ export KUBECONFIG=${INV}/artifacts/admin.conf
 # make the kubectl binary available
 $ export PATH=$PATH:$PWD/$INV/artifacts


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This PR fixes a typo in the `docs/developers/vagrant.md` documentation example section.

The current path `.vagrant/provisionners/ansible/inventory` is incorrect.
The correct path should be `.vagrant/provisioners/ansible/inventory`.

**Which issue(s) this PR fixes**:
It doesn't related with any issue.

**Does this PR introduce a user-facing change?**:
It doesn't related with any issue.

```release-note
```