### PR TITLE
auto-update: use a branch prefix rather than suffix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,5 +16,6 @@ updates:
     directory: "/"
     labels:
       - release-note-none
+      - ci-short
     schedule:
       interval: "weekly"

--- a/.github/workflows/upgrade-patch-versions.yml
+++ b/.github/workflows/upgrade-patch-versions.yml
@@ -34,7 +34,7 @@ jobs:
         commit-message: Patch versions updates
         title: Patch versions updates - ${{ inputs.branch }}
         labels: bot
-        branch: ${{ inputs.branch }}-patch-updates
+        branch: component_hash_update/${{ inputs.branch }}
         sign-commits: true
         body: |
           /kind feature


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This is more in-line with dependabot and similar auto-updaters.

Reduce ci coverage on github action updating (it does not change
kubespray code, no need for testing).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
