### PR TITLE
set kubelet_status_update_frequency to 120s

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -58,7 +58,7 @@ system_pid_reserved: 1000
 eviction_hard: {}
 eviction_hard_control_plane: {}
 
-kubelet_status_update_frequency: 10s
+kubelet_status_update_frequency: 120s
 
 # kube-vip
 kube_vip_version: 0.8.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

The default setting out of the box for this is 5 minutes. As far as I can tell this is what EKS, AKS, and ACK all use. On our metal clusters we were seeing _a lot_ more GC activity causing memory contention and higher CPU usage. It was eventually traced to how often the Node Conditions were updating. You can see when we rolled out this change to this cluster in the screenshot below.

On a ~300 node cluster updating this setting to 120s brought Prometheus' Bytes allocated and freed per second from 1Gi down to ~450Mi and the CPU time from ~7 seconds down to ~3 seconds. It also brought GC cycles per minute from ~8 down to ~3.3.

![Screenshot 2025-04-03 at 1 24 12 PM](https://github.com/user-attachments/assets/ff62a79e-3e44-463b-a266-bef0320a6ef3)

I recognize that updating this setting is called out in the Large Deployment docs, but I think 10s is a bit low for most cases. Even on our small clusters this was causing a noticeable difference with Prometheus.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Updated kubelet_status_update_frequency from 10s to 120s. Useful for larger clusters.
```
