### PR TITLE
docs(terraform): update command for destroying infrastructure in README

### DIFF
--- a/contrib/terraform/hetzner/README.md
+++ b/contrib/terraform/hetzner/README.md
@@ -102,7 +102,8 @@ Please read the instructions in both repos on how to install it.
 You can teardown your infrastructure using the following Terraform command:
 
 ```bash
-terraform destroy --var-file default.tfvars ../../contrib/terraform/hetzner
+cd ./kubespray
+terraform -chdir=./contrib/terraform/hetzner/ destroy --var-file=../../../inventory/$CLUSTER/default.tfvars
 ```
 
 ## Variables


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup
/kind documentation

**What this PR does / why we need it**:

This PR fixes and cleans up the Terraform destroy command documentation for the Hetzner Cloud setup. The previous instructions failed to correctly target the `default.tfvars` file from the inventory folder, and this caused confusion and incorrect behavior when attempting to destroy resources using Terraform.

The updated command explicitly specifies `--var-file=../../../inventory/$CLUSTER/default.tfvars`, ensuring that the correct variable file is loaded during the destroy operation. This change improves clarity and usability for users working with the Hetzner Cloud Terraform integration.

**Which issue(s) this PR fixes**:

Fixes #12110

**Special notes for your reviewer**:

This fix aligns Terraform destroy instructions with the recommended file structure used for clusters provisioned via Kubespray. It prevents unnecessary errors arising from missing the inventory file for variable inputs.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
