### PR TITLE
Timeout on RHEL subscription check

### DIFF
--- a/roles/bootstrap-os/defaults/main.yml
+++ b/roles/bootstrap-os/defaults/main.yml
@@ -2,6 +2,8 @@
 ## CentOS/RHEL/AlmaLinux specific variables
 # Use the fastestmirror yum plugin
 centos_fastestmirror_enabled: false
+# Timeout (in seconds) for checking RHEL subscription status
+rh_subscription_check_timeout: 180
 
 ## Flatcar Container Linux specific variables
 # Disable locksmithd or leave it in its current state

--- a/roles/bootstrap-os/tasks/rhel.yml
+++ b/roles/bootstrap-os/tasks/rhel.yml
@@ -28,6 +28,7 @@
   register: rh_subscription_status
   changed_when: "rh_subscription_status.rc != 0"
   ignore_errors: true  # noqa ignore-errors
+  timeout: "{{ rh_subscription_check_timeout }}"
   become: true
 
 - name: RHEL subscription Organization ID/Activation Key registration


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
subscription-manager status can in some circumstances just never
terminates, with nothing indicating the problem from the Ansible
playbook log.
This makes it difficult to find the hosts misbehaving.

Add a timeout to the subscription checks (defaulting to 3 minutes). This
should be more than enough for normal circumstances while allowing
easier troubleshooting, as the hosts will be FAILED instead of the
playbook just waiting indefinitely.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This could arguably be considered an action required change, but I don't think of it being a problem (subscription-manager status taking more than 3 minutes to complete in normal circumstances) often enough to warrant a specific notice. Wdty ?


**Does this PR introduce a user-facing change?**:
```release-note
For RHEL hosts, checking for subscription status timeout after `rh_subscription_check_timeout` (default to 3 minutes)
```
