### PR TITLE
Etcd Certificates are not generated when adding nodes to an existing cluster with scale.yml

### DIFF
--- a/playbooks/cluster.yml
+++ b/playbooks/cluster.yml
@@ -17,6 +17,9 @@
     - { role: download, tags: download, when: "not skip_downloads" }
 
 - name: Install etcd
+  vars:
+    etcd_cluster_setup: true
+    etcd_events_cluster_setup: "{{ etcd_events_cluster_enabled }}"
   import_playbook: install_etcd.yml
 
 - name: Install Kubernetes nodes

--- a/playbooks/install_etcd.yml
+++ b/playbooks/install_etcd.yml
@@ -24,6 +24,5 @@
     - role: etcd
       tags: etcd
       vars:
-        etcd_cluster_setup: true
         etcd_events_cluster_setup: "{{ etcd_events_cluster_enabled }}"
       when: etcd_deployment_type != "kubeadm"

--- a/playbooks/install_etcd.yml
+++ b/playbooks/install_etcd.yml
@@ -23,6 +23,4 @@
     - { role: kubespray-defaults }
     - role: etcd
       tags: etcd
-      vars:
-        etcd_events_cluster_setup: "{{ etcd_events_cluster_enabled }}"
       when: etcd_deployment_type != "kubeadm"

--- a/playbooks/scale.yml
+++ b/playbooks/scale.yml
@@ -8,6 +8,7 @@
 - name: Install etcd
   vars:
     etcd_cluster_setup: false
+    etcd_events_cluster_setup: false
   import_playbook: install_etcd.yml
 
 - name: Download images to ansible host cache via first kube_control_plane node

--- a/playbooks/scale.yml
+++ b/playbooks/scale.yml
@@ -5,22 +5,8 @@
 - name: Gather facts
   import_playbook: facts.yml
 
-- name: Generate the etcd certificates beforehand
-  hosts: etcd:kube_control_plane
-  gather_facts: false
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
-  environment: "{{ proxy_disable_env }}"
-  roles:
-    - { role: kubespray-defaults }
-    - role: etcd
-      tags: etcd
-      vars:
-        etcd_cluster_setup: false
-        etcd_events_cluster_setup: false
-      when:
-        - etcd_deployment_type != "kubeadm"
-        - kube_network_plugin in ["calico", "flannel", "canal", "cilium"] or cilium_deploy_additionally | default(false) | bool
-        - kube_network_plugin != "calico" or calico_datastore == "etcd"
+- name: Install etcd
+  import_playbook: install_etcd.yml
 
 - name: Download images to ansible host cache via first kube_control_plane node
   hosts: kube_control_plane[0]

--- a/playbooks/scale.yml
+++ b/playbooks/scale.yml
@@ -6,6 +6,8 @@
   import_playbook: facts.yml
 
 - name: Install etcd
+  vars:
+    etcd_cluster_setup: false
   import_playbook: install_etcd.yml
 
 - name: Download images to ansible host cache via first kube_control_plane node

--- a/playbooks/upgrade_cluster.yml
+++ b/playbooks/upgrade_cluster.yml
@@ -36,6 +36,9 @@
     - { role: container-engine, tags: "container-engine", when: deploy_container_engine }
 
 - name: Install etcd
+  vars:
+    etcd_cluster_setup: true
+    etcd_events_cluster_setup: "{{ etcd_events_cluster_enabled }}"
   import_playbook: install_etcd.yml
 
 - name: Handle upgrades to control plane components first to maintain backwards compat.


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug


**What this PR does / why we need it**:
if will add new host or missing node etcd cert host to gen_node_certs_True group as part of check_certs and use to create certs using gen_certs task. 

**Which issue(s) this PR fixes**:
Fixes # - https://github.com/kubernetes-sigs/kubespray/issues/12117

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

```release-note
NONE
```
