### PR TITLE
docs(operations): remove outdated instructions on refreshing facts cache for nodes

### DIFF
--- a/docs/operations/nodes.md
+++ b/docs/operations/nodes.md
@@ -64,8 +64,6 @@ This should be the easiest.
 
 You can use `--limit=NODE_NAME` to limit Kubespray to avoid disturbing other nodes in the cluster.
 
-Before using `--limit` run playbook `facts.yml` without the limit to refresh facts cache for all nodes.
-
 ### 3) Remove an old node with remove-node.yml
 
 With the old node still in the inventory, run `remove-node.yml`. You need to pass `-e node=NODE_NAME` to the playbook to limit the execution to the node being removed.


### PR DESCRIPTION

**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #12100 

**Special notes for your reviewer**:

The current documentation advises users to run `facts.yml` separately to refresh the facts cache before using the `--limit` option with `scale.yml`. However, this step is unnecessary because `scale.yml` already includes `facts.yml` as part of its execution.

Specifically:
- In `scale.yml`, line 5 explicitly imports `facts.yml`  [Gather facts](https://github.com/kubernetes-sigs/kubespray/blob/f9ebd45c749647c0e8fdd55ea58d0fb0b6612d08/playbooks/scale.yml#L5) :
  ```yaml
  - name: Gather facts
    import_playbook: facts.yml  

This ensures that the facts cache is refreshed for all nodes automatically when running scale.yml, even if the --limit option is used.

By removing this redundant step from the documentation, we can simplify the instructions and prevent confusion for users, ensuring the documentation reflects the actual behavior of scale.yml.

**Does this PR introduce a user-facing change?**:

```release-note
None
```
