### PR TITLE
feat: add support for custom kubeadm image repository

### DIFF
--- a/roles/download/templates/kubeadm-images.yaml.j2
+++ b/roles/download/templates/kubeadm-images.yaml.j2
@@ -5,7 +5,7 @@ nodeRegistration:
 ---
 apiVersion: kubeadm.k8s.io/{{ kubeadm_config_api_version }}
 kind: ClusterConfiguration
-imageRepository: {{ kube_image_repo }}
+imageRepository: {{ kubeadm_image_repo }}
 kubernetesVersion: v{{ kube_version }}
 etcd:
 {% if etcd_deployment_type == "kubeadm" %}

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
@@ -103,7 +103,7 @@ controlPlaneEndpoint: "{{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.p
 controlPlaneEndpoint: "{{ main_ip | ansible.utils.ipwrap }}:{{ kube_apiserver_port }}"
 {% endif %}
 certificatesDir: {{ kube_cert_dir }}
-imageRepository: {{ kube_image_repo }}
+imageRepository: {{ kubeadm_image_repo }}
 apiServer:
   extraArgs:
     etcd-compaction-interval: "{{ kube_apiserver_etcd_compaction_interval }}"

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
@@ -122,7 +122,7 @@ controlPlaneEndpoint: "{{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.p
 controlPlaneEndpoint: "{{ main_ip | ansible.utils.ipwrap }}:{{ kube_apiserver_port }}"
 {% endif %}
 certificatesDir: {{ kube_cert_dir }}
-imageRepository: {{ kube_image_repo }}
+imageRepository: {{ kubeadm_image_repo }}
 apiServer:
   extraArgs:
   - name: etcd-compaction-interval

--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -88,6 +88,7 @@ docker_containerd_version: 1.6.32
 # gcr and kubernetes image repo define
 gcr_image_repo: "gcr.io"
 kube_image_repo: "registry.k8s.io"
+kubeadm_image_repo: "{{ kube_image_repo }}"
 
 # docker image repo define
 docker_image_repo: "docker.io"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

This PR adds support for `kubeadm_image_repo` variable to utilize custom kubernetes core images, such as `kube-apiserver` and `kube-proxy`.

Previously, to achieve this same functionality, we would have to use a variable called `kube_image_repo`. However, this would have affected the entire ecosystem, including `nodelocaldns`, `scheduler_plugins`, and `csi_attacher`. Instead, it is great for replacing `registry.k8s.io`, such as for air-gapped deployments.

However, it is not suitable for changing the image repository for Kubernetes itself. And it is unnecessary to change the repository for each image such as `kube_apiserver`, because these core services are shipped with the Kubernetes version (e.g. `v1.32.3`). Also, their existence is derived from `kubeadm`, so manual configuration is unnecessary. Therefore, the core of this PR is to add the ability to replace only the image repository used by `kubeadm`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add support for `kubeadm_image_repo` variable to change kubernetes core image repository (e.g. `kube-apiserver`, `kube-proxy`).
```
