### PR TITLE
Add `kubeadm_auto_ignore_kernel_check` option for kernel version compatibility

### DIFF
--- a/docs/operations/kernel-requirements.md
+++ b/docs/operations/kernel-requirements.md
@@ -2,12 +2,30 @@
 
 For Kubernetes >=1.32.0, the recommended kernel LTS version from the 4.x series is 4.19. Any 5.x or 6.x versions are also supported. For cgroups v2 support, the minimum version is 4.15 and the recommended version is 5.8+. Refer to [this link](https://github.com/kubernetes/kubernetes/blob/v1.32.0/vendor/k8s.io/system-validators/validators/types_unix.go#L33). For more information, see [kernel version requirements](https://kubernetes.io/docs/reference/node/kernel-version-requirements).
 
-If the OS kernel version is lower than required, add the following configuration to ignore the kubeadm preflight errors:
+## Handling Lower Kernel Versions
+
+If the OS kernel version is lower than required, you have two options:
+
+### Option 1: Manually ignore preflight errors
+
+Add the following configuration to ignore the kubeadm preflight errors:
 
 ```yaml
 kubeadm_ignore_preflight_errors:
   - SystemVerification
 ```
+
+### Option 2: Automatically ignore kernel version check
+
+Enable the automatic kernel check bypass option:
+
+```yaml
+kubeadm_auto_ignore_kernel_check: true
+```
+
+When this option is enabled, Kubespray will automatically add SystemVerification to the kubeadm_ignore_preflight_errors list if it detects that:
+* The kernel version is lower than 4.19
+* Kubernetes version is 1.32.0 or higher
 
 The Kernel Version Matrixs:
 

--- a/roles/kubernetes/control-plane/defaults/main/main.yml
+++ b/roles/kubernetes/control-plane/defaults/main/main.yml
@@ -255,3 +255,6 @@ kubeadm_image_pull_serial: true
 # can be one of RSA-2048(default), RSA-3072, RSA-4096, ECDSA-P256
 # ref: https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta4/#kubeadm-k8s-io-v1beta4-ClusterConfiguration
 kube_asymmetric_encryption_algorithm: "RSA-2048"
+
+# Auto ignore kernel version check for kubeadm when OS kernel < 4.19 and Kubernetes >= 1.32.0
+kubeadm_auto_ignore_kernel_check: false

--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -23,6 +23,14 @@
   when:
     - kubeadm_already_run.stat.exists
 
+- name: Check kernel version and add SystemVerification to kubeadm_ignore_preflight_errors if needed
+  set_fact:
+    kubeadm_ignore_preflight_errors: "{{ kubeadm_ignore_preflight_errors | default([]) + ['SystemVerification'] }}"
+  when:
+    - kubeadm_auto_ignore_kernel_check | bool
+    - ansible_kernel is version_compare('4.19', '<')
+    - kube_version is version_compare('1.32.0', '>=')
+
 - name: Kubeadm | aggregate all SANs
   set_fact:
     apiserver_sans: "{{ (sans_base + groups['kube_control_plane'] + sans_lb + sans_lb_ip + sans_supp + sans_access_ip + sans_ip + sans_address + sans_override + sans_hostname + sans_fqdn + sans_kube_vip_address) | unique }}"

--- a/tests/files/almalinux8-calico.yml
+++ b/tests/files/almalinux8-calico.yml
@@ -4,5 +4,4 @@ cloud_image: almalinux-8
 vm_memory: 3072
 
 # Workaround for RHEL8: kernel version 4.18 is lower than Kubernetes system verification.
-kubeadm_ignore_preflight_errors:
-  - SystemVerification
+kubeadm_auto_ignore_kernel_check: true

--- a/tests/files/amazon-linux-2-all-in-one.yml
+++ b/tests/files/amazon-linux-2-all-in-one.yml
@@ -4,5 +4,4 @@ cloud_image: amazon-linux-2
 mode: all-in-one
 
 # Workaround for RHEL8: kernel version 4.18 is lower than Kubernetes system verification.
-kubeadm_ignore_preflight_errors:
-  - SystemVerification
+kubeadm_auto_ignore_kernel_check: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This PR adds a new option `kubeadm_auto_ignore_kernel_check` to automatically handle kernel version compatibility issues when running Kubernetes 1.32.0+ on kernels older than 4.19.

When enabled, this option automatically adds `SystemVerification` to the kubeadm preflight error ignore list if:
- Kernel version is < 4.19
- Kubernetes version is >= 1.32.0

Documentation has been updated to include this new option.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add `kubeadm_auto_ignore_kernel_check` option for kernel version compatibility
```
