### PR TITLE
Fix: kubeadm secondary use file discovery validation

### DIFF
--- a/roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml
@@ -30,17 +30,6 @@
     - hostvars[first_kube_control_plane]['kubeadm_upload_cert'] is defined
     - hostvars[first_kube_control_plane]['kubeadm_upload_cert'] is not skipped
 
-- name: Create kubeadm ControlPlane config
-  template:
-    src: "kubeadm-controlplane.yaml.j2"
-    dest: "{{ kube_config_dir }}/kubeadm-controlplane.yaml"
-    mode: "0640"
-    backup: true
-    validate: "{{ kubeadm_config_validate_enabled | ternary(bin_dir + '/kubeadm config validate --config %s', omit) }}"
-  when:
-    - inventory_hostname != first_kube_control_plane
-    - not kubeadm_already_run.stat.exists
-
 - name: Wait for k8s apiserver
   wait_for:
     host: "{{ kubeadm_discovery_address | regex_replace('\\]?:\\d+$', '') | regex_replace('^\\[', '') }}"
@@ -83,6 +72,17 @@
     - inventory_hostname != first_kube_control_plane
     - kubeadm_use_file_discovery
     - kubeadm_already_run is not defined or not kubeadm_already_run.stat.exists
+
+- name: Create kubeadm ControlPlane config
+  template:
+    src: "kubeadm-controlplane.yaml.j2"
+    dest: "{{ kube_config_dir }}/kubeadm-controlplane.yaml"
+    mode: "0640"
+    backup: true
+    validate: "{{ kubeadm_config_validate_enabled | ternary(bin_dir + '/kubeadm config validate --config %s', omit) }}"
+  when:
+    - inventory_hostname != first_kube_control_plane
+    - not kubeadm_already_run.stat.exists
 
 - name: Joining control plane node to the cluster.
   command: >-


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The validation step is moved to the end to avoid the loss of files that may lead to verification failure.

**Which issue(s) this PR fixes**:

Fixes #11835

**Special notes for your reviewer**:

I hope someone who has encountered this problem can help me review it.

**Does this PR introduce a user-facing change?**:

```release-note
Fix: kubeadm secondary nodes use file discovery validation failed
```
