### PR TITLE
Fix: When the cluster config lb-apiserver.kubernetes.local, new worker nodes need to add the/etc/hosts configuration

### DIFF
--- a/playbooks/scale.yml
+++ b/playbooks/scale.yml
@@ -5,6 +5,15 @@
 - name: Gather facts
   import_playbook: facts.yml
 
+- name: Target only new nodes to config /etc/hosts
+  hosts: kube_node
+  gather_facts: False
+  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
+  roles:
+    - { role: kubespray-defaults }
+    - { role: kubernetes/preinstall, tags: etchosts }
+
 - name: Generate the etcd certificates beforehand
   hosts: etcd:kube_control_plane
   gather_facts: false


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
When the cluster config lb-apiserver.kubernetes.local, new worker nodes without adding in the/etc/hosts VIP configuration, cluster nodes will fail.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12136 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None  
```release-note
None 
```
