### PR TITLE
Feat: add Cilium LB IP Pool configuration to support ranges

### DIFF
--- a/docs/CNI/cilium.md
+++ b/docs/CNI/cilium.md
@@ -54,6 +54,10 @@ cilium_loadbalancer_ip_pools:
   - name: "blue-pool"
     cidrs:
       - "10.0.10.0/24"
+    ranges:
+      - start: "20.0.20.100"
+        stop: "20.0.20.200"
+      - start: "1.2.3.4"
 ```
 
 For further information, check [LB IPAM documentation](https://docs.cilium.io/en/stable/network/lb-ipam/)

--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
@@ -255,6 +255,10 @@ cilium_l2announcements: false
 #   - name: "blue-pool"
 #     cidrs:
 #       - "10.0.10.0/24"
+#     ranges:
+#       - start: "20.0.20.100"
+#         stop: "20.0.20.200"
+#       - start: "1.2.3.4"
 
 # -- Configure BGP Instances (New bgpv2 API v1.16+)
 # cilium_bgp_cluster_configs:

--- a/roles/network_plugin/cilium/templates/cilium/cilium-loadbalancer-ip-pool.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/cilium-loadbalancer-ip-pool.yml.j2
@@ -6,7 +6,11 @@ metadata:
   name: "{{ cilium_loadbalancer_ip_pool.name }}"
 spec:
   blocks:
-{% for cblock in cilium_loadbalancer_ip_pool.cidrs %}
+{% for cblock in cilium_loadbalancer_ip_pool.cidrs | default([]) %}
   - cidr: "{{ cblock }}"
+{% endfor %}
+{% for rblock in cilium_loadbalancer_ip_pool.ranges | default([]) %}
+  - start: "{{ rblock.start }}"
+    stop: "{{ rblock.stop | default(rblock.start) }}"
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation
/kind feature

**What this PR does / why we need it**:
This PR will support Cilium LB IP Pool configuration for `ranges` which is `start-stop` and `start`.
Details on #12036

**Which issue(s) this PR fixes**:
Fixes #12036

**Special notes for your reviewer**:
Reference: [Cilium Docs - LB IPAM Pools](https://docs.cilium.io/en/stable/network/lb-ipam/#lb-ipam-pools)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add support for `ranges:` (start‑stop or single start) as an additional way to define Cilium LoadBalancer IP pools, alongside the existing `cidrs:` field.
```
