### PR TITLE
Fix: kubelet-csr-approver moves to regular application installation

### DIFF
--- a/playbooks/cluster.yml
+++ b/playbooks/cluster.yml
@@ -50,7 +50,6 @@
     - { role: kubernetes/node-label, tags: node-label }
     - { role: kubernetes/node-taint, tags: node-taint }
     - { role: network_plugin, tags: network }
-    - { role: kubernetes-apps/kubelet-csr-approver, tags: kubelet-csr-approver }
 
 - name: Install Calico Route Reflector
   hosts: calico_rr

--- a/roles/kubernetes-apps/meta/main.yml
+++ b/roles/kubernetes-apps/meta/main.yml
@@ -104,6 +104,13 @@ dependencies:
     tags:
       - gateway_api
 
+  - role: kubernetes-apps/kubelet-csr-approver
+    when:
+      - kubelet_csr_approver_enabled
+      - inventory_hostname == groups['kube_control_plane'][0]
+    tags:
+      - kubelet-csr-approver
+
   - role: kubernetes-apps/metallb
     when:
       - metallb_enabled


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This commit fixed the process to ensure that CCM is installed first to avoid the chicken-and-egg problem.

**Which issue(s) this PR fixes**:

Fixes #12059

**Does this PR introduce a user-facing change?**:

```release-note
kubelet-csr-approver moves to regular application installation
```
