### PR TITLE
fix: do not mount hubble-ui tls volume when cilium_hubble_tls_generate is false

### DIFF
--- a/roles/network_plugin/cilium/templates/hubble/deploy.yml.j2
+++ b/roles/network_plugin/cilium/templates/hubble/deploy.yml.j2
@@ -168,10 +168,12 @@ spec:
               value: "hubble-relay:80"
             {% endif %}
 
+          {% if cilium_hubble_tls_generate -%}
           volumeMounts:
             - name: tls
               mountPath: /var/lib/hubble-ui/certs
               readOnly: true
+          {%- endif %}
           ports:
             - containerPort: 8090
               name: grpc
@@ -182,6 +184,7 @@ spec:
             defaultMode: 420
             name: hubble-ui-nginx
           name: hubble-ui-nginx-conf
+        {% if cilium_hubble_tls_generate -%}
         - projected:
             sources:
             - secret:
@@ -194,6 +197,7 @@ spec:
                   - key: tls.key
                     path: client.key
           name: tls
+        {%- endif %}
         - emptyDir: {}
           name: tmp-dir
 {% endif %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix hubble-ui deployment to not renders tls volume when the `cilium_hubble_tls_generate` option not configured.

Like hubble relay, add conditionals to the volume parts of the hubble-ui deployment template.
c.f. https://github.com/atobaum/kubespray/blob/298f0a05d54df77764a1c257be62bef500f928ac/roles/network_plugin/cilium/templates/hubble/deploy.yml.j2#L64-L105

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12144

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix hubble-ui deployment to not renders tls volume when the `cilium_hubble_tls_generate` option not configured.
```
