### PR TITLE
[Bug] use kube-vip-iptables image when kube_vip_lb_fwdmethod is masquerade

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s_cluster/addons.yml
@@ -238,6 +238,7 @@ kube_vip_enabled: false
 # kube_vip_cp_detect: false
 # kube_vip_leasename: plndr-cp-lock
 # kube_vip_enable_node_labeling: false
+# kube_vip_lb_fwdmethod: local
 
 # Node Feature Discovery
 node_feature_discovery_enabled: false

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -83,7 +83,6 @@ kube_vip_bgppeers:
 kube_vip_address:
 kube_vip_enableServicesElection: false
 kube_vip_lb_enable: false
-kube_vip_lb_fwdmethod: local
 kube_vip_leasename: plndr-cp-lock
 kube_vip_svc_leasename: plndr-svcs-lock
 kube_vip_leaseduration: 5

--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -281,7 +281,7 @@ multus_image_tag: "v{{ multus_version }}"
 external_openstack_cloud_controller_image_repo: "{{ kube_image_repo }}/provider-os/openstack-cloud-controller-manager"
 external_openstack_cloud_controller_image_tag: "v1.32.0"
 
-kube_vip_image_repo: "{{ github_image_repo }}/kube-vip/kube-vip"
+kube_vip_image_repo: "{{ github_image_repo }}/kube-vip/kube-vip{{ '-iptables' if kube_vip_lb_fwdmethod == 'masquerade' else '' }}"
 kube_vip_image_tag: v0.8.9
 nginx_image_repo: "{{ docker_image_repo }}/library/nginx"
 nginx_image_tag: 1.27.4-alpine

--- a/roles/kubespray-defaults/defaults/main/main.yml
+++ b/roles/kubespray-defaults/defaults/main/main.yml
@@ -80,7 +80,9 @@ kube_proxy_nodeport_addresses: >-
 # Set to true to allow pre-checks to fail and continue deployment
 ignore_assert_errors: false
 
+# kube-vip
 kube_vip_enabled: false
+kube_vip_lb_fwdmethod: local
 
 # nginx-proxy configure
 nginx_config_dir: "/etc/nginx"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
* kube-vip maintains two images `ghcr.io/kube-vip/kube-vip` and `ghcr.io/kube-vip/kube-vip-iptables` https://github.com/kube-vip/kube-vip/pkgs/container/kube-vip-iptables, which needs to be selected based on `lb_fwdmethod` flag in kube-vip manifest yml. 
If `lb_fwdmethod` is `masquerade`, then `kube-vip-iptables` image needs to be used
* In Kubespray, this kube-vip manifest flag is mapped to or is picked from `kube_vip_lb_fwdmethod` variable
* But currently, in Kubepsray, the image for kube-vip is fixed to  `ghcr.io/kube-vip/kube-vip` irrespective of `lb_fwdmethod` or `kube_vip_lb_fwdmethod`, which causes kube-vip to not work as expected
* The following error can be observed in kube-vip pod logs
```
time="2025-02-28T15:52:37Z" level=info msg="Node [vm1-private] is assuming leadership of the cluster"
time="2025-02-28T15:52:37Z" level=fatal msg="could not add iptables rules for masquerade: could not ge
t iptables version: run cmd 'iptables --version' wtith error: exec: \"iptables\": executable file not
found in $PATH"
```

**Which issue(s) this PR fixes**:
Fixes #
* Though I could not find issues in Kubespray that this PR fixes, I am adding the following links to issues from kube-vip where this issue has been discussed and closed with this solution
[kube-vip issue 1065](https://github.com/kube-vip/kube-vip/issues/1065) 
[kube-vip issue 874](https://github.com/kube-vip/kube-vip/issues/874)
* Unfortunately, kube-vip documentation does not cover this well enough (also being discussed in one of the above issue)
* For reference, I see an old PR #11838 which, I believe, was not merged. I have tried to incorporate the feedback from the same in this PR

**Special notes for your reviewer**:
* add a new variable `kube_vip_iptables_image_repo` in `roles\kubespray-defaults\defaults\main\download.yml` for `kube-vip-iptables` image of kube-vip
* changes made in `roles\kubernetes\node\templates\manifests\kube-vip.manifest.j2` to use `ghcr.io/kube-vip/kube-vip-iptables` instead of  `ghcr.io/kube-vip/kube-vip` if `kube_vip_lb_fwdmethod` is `masquerade`
* I am following [kube-vip issue 1065](https://github.com/kube-vip/kube-vip/issues/1065) to make sure `kube-vip-iptables` image is only required for `kube_vip_lb_fwdmethod==masquerade`. If required for any other mode, I will update.

**Does this PR introduce a user-facing change?**:
* only one change
* `kube_vip_lb_fwdmethod` defined with defaults in `roles\kubernetes\node\defaults\main.yml` but not in `inventory\sample\group_vars\k8s_cluster\addons.yml`
* adding `kube_vip_lb_fwdmethod` in `inventory\sample\group_vars\k8s_cluster\addons.yml` as it is frequently used by kube-vip users
* It is only added as a comment/hint so that folks don't need to search for it in code, and are aware
* It is added with already existing kube-vip related settings, which are expected to be updated by users

```release-note
Fixed kube-vip to use `kube-vip/kube-vip-iptables` image instead of `kube-vip/kube-vip` when `lb_fwdmethod` or `kube_vip_lb_fwdmethod` is set to `masquerade`
```