### PR TITLE
fix: Enable NRI for containerd and disable plugin when nri_enabled is false

### DIFF
--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -76,10 +76,8 @@ oom_score = {{ containerd_oom_score }}
   [plugins."io.containerd.cri.v1.images".registry]
     config_path = "{{ containerd_cfg_dir }}/certs.d"
 
-{% if nri_enabled %}
   [plugins."io.containerd.nri.v1.nri"]
-    disable = false
-{% endif %}
+    disable = {{ 'false' if nri_enabled else 'true' }}
 
 {% if containerd_tracing_enabled %}
   [plugins."io.containerd.tracing.processor.v1.otlp"]

--- a/roles/kubespray-defaults/defaults/main/main.yml
+++ b/roles/kubespray-defaults/defaults/main/main.yml
@@ -307,7 +307,7 @@ deploy_container_engine: "{{ 'k8s_cluster' in group_names or etcd_deployment_typ
 container_manager: containerd
 
 # Enable Node Resource Interface plugin for containerd
-nri_enabled: {{ container_manager == 'containerd' }}
+nri_enabled: "{{ container_manager == 'containerd' }}"
 
 # Enable Kata Containers as additional container runtime
 # When enabled, it requires `container_manager` different than Docker

--- a/roles/kubespray-defaults/defaults/main/main.yml
+++ b/roles/kubespray-defaults/defaults/main/main.yml
@@ -306,9 +306,8 @@ deploy_container_engine: "{{ 'k8s_cluster' in group_names or etcd_deployment_typ
 # Container for runtime
 container_manager: containerd
 
-# Enable Node Resource Interface in containerd or CRI-O. Requires crio_version >= v1.26.0
-# or containerd_version >= 1.7.0.
-nri_enabled: false
+# Enable the Node Resource Interface plugin for containerd
+nri_enabled: {{ container_manager == 'containerd' }}
 
 # Enable Kata Containers as additional container runtime
 # When enabled, it requires `container_manager` different than Docker

--- a/roles/kubespray-defaults/defaults/main/main.yml
+++ b/roles/kubespray-defaults/defaults/main/main.yml
@@ -306,7 +306,7 @@ deploy_container_engine: "{{ 'k8s_cluster' in group_names or etcd_deployment_typ
 # Container for runtime
 container_manager: containerd
 
-# Enable the Node Resource Interface plugin for containerd
+# Enable Node Resource Interface plugin for containerd
 nri_enabled: {{ container_manager == 'containerd' }}
 
 # Enable Kata Containers as additional container runtime


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This PR updates the `nri_enabled` configuration in Kubespray to:
- Automatically enable the Node Resource Interface (NRI) plugin when `container_manager == 'containerd'`
- Disable the NRI plugin (and fully deactivate it per Containerd documentation) for all other container runtimes (e.g., CRI-O)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12118

**Special notes for your reviewer**:

This is my first open-source contribution, so there may be areas that need improvement; thank you in advance for your review.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Enable NRI by default on containerd (following containerd defaults)
```
