### PR TITLE
Move some approvers to emeritus

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,13 +1,9 @@
 aliases:
   kubespray-approvers:
-    - cristicalin
-    - floryut
-    - liupeng0518
-    - mzaian
-    - oomichi
-    - yankay
     - ant31
+    - mzaian
     - vannten
+    - yankay
   kubespray-reviewers:
     - cyclinder
     - erikjiang
@@ -19,8 +15,12 @@ aliases:
   kubespray-emeritus_approvers:
     - atoms
     - chadswen
+    - cristicalin
+    - floryut
+    - liupeng0518
     - luckysb
     - mattymo
     - miouge1
+    - oomichi
     - riverzhang
     - woopstar


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

Move some approvers to emeritus.
Mainly to have more helpful hints from Prow on who to assign after LGTM is given
Based on devstats + github kubespray activity from what I can see.

@floryut @oomichi @cristicalin @liupeng0518

Please respond if I've misread the metrics and you're in fact still active approvers :)
Thanks for all your work !


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Let's wait until the end of May to merge this.
/hold

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
