### PR TITLE
Remove versions from inventory sample

### DIFF
--- a/inventory/sample/group_vars/all/oci.yml
+++ b/inventory/sample/group_vars/all/oci.yml
@@ -43,7 +43,6 @@
 #   ocid1.subnet.oc1.phx.aaaaaaaahuxrgvs65iwdz7ekwgg3l5gyah7ww5klkwjcso74u3e4i64hvtvq: ocid1.securitylist.oc1.iad.aaaaaaaaqti5jsfvyw6ejahh7r4okb2xbtuiuguswhs746mtahn72r7adt7q
 ## If oci_use_instance_principals is true, you do not need to set the region, tenancy, user, key, passphrase, or fingerprint
 # oci_use_instance_principals: false
-# oci_cloud_controller_version: 0.6.0
 ## If you would like to control OCI query rate limits for the controller
 # oci_rate_limit:
 #   rate_limit_qps_read:

--- a/inventory/sample/group_vars/all/openstack.yml
+++ b/inventory/sample/group_vars/all/openstack.yml
@@ -1,5 +1,4 @@
 ## When OpenStack is used, Cinder version can be explicitly specified if autodetection fails (Fixed in 1.9: https://github.com/kubernetes/kubernetes/issues/50461)
-# openstack_blockstorage_version: "v1/v2/auto (default)"
 # openstack_blockstorage_ignore_volume_az: yes
 ## When OpenStack is used, if LBaaSv2 is available you can enable it with the following 2 variables.
 # openstack_lbaas_enabled: True

--- a/inventory/sample/group_vars/all/vsphere.yml
+++ b/inventory/sample/group_vars/all/vsphere.yml
@@ -7,26 +7,6 @@
 # external_vsphere_datacenter: "DATACENTER_name"
 # external_vsphere_kubernetes_cluster_id: "kubernetes-cluster-id"
 
-## Vsphere version where located VMs
-# external_vsphere_version: "6.7u3"
-
-## Tags for the external vSphere Cloud Provider images
-## registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere
-# external_vsphere_cloud_controller_image_tag: "v1.31.0"
-## registry.k8s.io/csi-vsphere/syncer
-# vsphere_syncer_image_tag: "v3.3.1"
-## registry.k8s.io/sig-storage/csi-attacher
-# vsphere_csi_attacher_image_tag: "v3.4.0"
-## registry.k8s.io/csi-vsphere/driver
-# vsphere_csi_controller: "v3.3.1"
-## registry.k8s.io/sig-storage/livenessprobe
-# vsphere_csi_liveness_probe_image_tag: "v2.6.0"
-## registry.k8s.io/sig-storage/csi-provisioner
-# vsphere_csi_provisioner_image_tag: "v3.1.0"
-## registry.k8s.io/sig-storage/csi-resizer
-## makes sense only for vSphere version >=7.0
-# vsphere_csi_resizer_tag: "v1.3.0"
-
 ## To use vSphere CSI plugin to provision volumes set this value to true
 # vsphere_csi_enabled: true
 # vsphere_csi_controller_replicas: 1

--- a/inventory/sample/group_vars/k8s_cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s_cluster/addons.yml
@@ -148,7 +148,6 @@ cert_manager_enabled: false
 metallb_enabled: false
 metallb_speaker_enabled: "{{ metallb_enabled }}"
 metallb_namespace: "metallb-system"
-# metallb_version: 0.13.9
 # metallb_protocol: "layer2"
 # metallb_port: "7472"
 # metallb_memberlist_port: "7946"
@@ -210,7 +209,6 @@ metallb_namespace: "metallb-system"
 #             - pool2
 
 argocd_enabled: false
-# argocd_version: 2.14.5
 # argocd_namespace: argocd
 # Default password:
 #   - https://argo-cd.readthedocs.io/en/stable/getting_started/#4-login-using-the-cli

--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -16,9 +16,6 @@ kube_token_dir: "{{ kube_config_dir }}/tokens"
 
 kube_api_anonymous_auth: true
 
-## Change this to use another Kubernetes version, e.g. a current beta release
-kube_version: 1.32.4
-
 # Where the binaries will be downloaded.
 # Note: ensure that you've enough disk space (about 1G)
 local_release_dir: "/tmp/releases"

--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
@@ -1,6 +1,4 @@
 ---
-# cilium_version: "1.15.9"
-
 # Log-level
 # cilium_debug: false
 

--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-custom-cni.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-custom-cni.yml
@@ -45,7 +45,7 @@
 # custom_cni_chart_repository_name: cilium
 # custom_cni_chart_repository_url: https://helm.cilium.io
 # custom_cni_chart_ref: cilium/cilium
-# custom_cni_chart_version: 1.14.3
+# custom_cni_chart_version: <chart version> (e.g.: 1.14.3)
 # custom_cni_chart_values:
 #   cluster:
 #     name: "cilium-demo"

--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-kube-router.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-kube-router.yml
@@ -1,11 +1,5 @@
 # See roles/network_plugin/kube-router/defaults/main.yml
 
-# Kube router version
-# Default to v2
-# kube_router_version: "2.0.0"
-# Uncomment to use v1 (Deprecated)
-# kube_router_version: "1.6.0"
-
 # Enables Pod Networking -- Advertises and learns the routes to Pods via iBGP
 # kube_router_run_router: true
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The recommended usage of kubespray is to use the default versions.
So putting them in inventory/sample is not really very helpful, and
causes:
- churn (keeping the inventory/sample up to date)
- support issues (mismatch between defaults and sample_

Remove all concrecte versions from the inventory/sample.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
