### PR TITLE
Feat: add `dns_autoscaler_affinity` and remove in-place values

### DIFF
--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -65,6 +65,7 @@ dns_autoscaler_cpu_requests: 20m
 dns_autoscaler_memory_requests: 10Mi
 dns_autoscaler_deployment_nodeselector: "kubernetes.io/os: linux"
 # dns_autoscaler_extra_tolerations: [{effect: NoSchedule, operator: "Exists"}]
+dns_autoscaler_affinity: {}
 
 # etcd metrics
 # etcd_metrics_service_labels:

--- a/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
@@ -48,21 +48,7 @@ spec:
         {{ dns_autoscaler_extra_tolerations | list | to_nice_yaml(indent=2) | indent(8) }}
 {% endif %}
       affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - topologyKey: "kubernetes.io/hostname"
-            labelSelector:
-              matchLabels:
-                k8s-app: dns-autoscaler{{ coredns_ordinal_suffix }}
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            preference:
-              matchExpressions:
-              - key: node-role.kubernetes.io/control-plane
-                operator: In
-                values:
-                - ""
+        {{ dns_autoscaler_affinity | to_nice_yaml(indent=2) | indent(8) }}
       containers:
       - name: autoscaler
         image: "{{ dnsautoscaler_image_repo }}:{{ dnsautoscaler_image_tag }}"

--- a/tests/files/ubuntu22-calico-all-in-one-upgrade.yml
+++ b/tests/files/ubuntu22-calico-all-in-one-upgrade.yml
@@ -11,6 +11,9 @@ auto_renew_certificates: true
 kube_proxy_mode: iptables
 enable_nodelocaldns: false
 
+# Single node don't need the DNS autoscaler
+enable_dns_autoscaler: false
+
 containerd_registries_mirrors:
   - prefix: docker.io
     mirrors:


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

Upstream has removed affinity and fixed the upgrade failing test (ubuntu22-calico-all-in-one-upgrade).

- https://github.com/kubernetes-sigs/cluster-proportional-autoscaler/blob/ccf8617916aebe4f5d985ae36993c0551a6a4d32/charts/cluster-proportional-autoscaler/values.yaml#L1
- https://github.com/coredns/helm/blob/1921572adca00de6a8bae2485ddfae0d3d1db0a7/charts/coredns/values.yaml#L358

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Add `dns_autoscaler_affinity` and remove in-place values.
```
