### PR TITLE
Revert "Update cluster-proportional-autoscaler to v1.9.0"

### DIFF
--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -299,7 +299,7 @@ nodelocaldns_version: "1.25.0"
 nodelocaldns_image_repo: "{{ kube_image_repo }}/dns/k8s-dns-node-cache"
 nodelocaldns_image_tag: "{{ nodelocaldns_version }}"
 
-dnsautoscaler_version: 1.9.0
+dnsautoscaler_version: 1.8.8
 dnsautoscaler_image_repo: "{{ kube_image_repo }}/cpa/cluster-proportional-autoscaler"
 dnsautoscaler_image_tag: "v{{ dnsautoscaler_version }}"
 


### PR DESCRIPTION
Reverts kubernetes-sigs/kubespray#11982

Break our CI (ubuntu22-calico-all-in-one-upgrade) currently.

```release-note
NONE
```