### PR TITLE
update containerd.options key name

### DIFF
--- a/docs/CRI/containerd.md
+++ b/docs/CRI/containerd.md
@@ -68,8 +68,8 @@ containerd_runc_runtime:
   engine: ""
   root: ""
   options:
-    systemdCgroup: "false"
-    binaryName: /usr/local/bin/my-runc
+    SystemdCgroup: "false"
+    BinaryName: /usr/local/bin/my-runc
   base_runtime_spec: cri-base.json
 ```
 

--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -17,8 +17,8 @@ containerd_runc_runtime:
   root: ""
   base_runtime_spec: cri-base.json
   options:
-    systemdCgroup: "{{ containerd_use_systemd_cgroup | ternary('true', 'false') }}"
-    binaryName: "{{ bin_dir }}/runc"
+    SystemdCgroup: "{{ containerd_use_systemd_cgroup | ternary('true', 'false') }}"
+    BinaryName: "{{ bin_dir }}/runc"
 
 containerd_additional_runtimes: []
 # Example for Kata Containers as additional runtime:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
This PR fixes an issue where the `BinaryName` field in containerd's runtime configuration was incorrectly using lowercase `binaryName`. This inconsistency caused problems with GPU-Operator installation, as it resulted in duplicate configuration entries (`BinaryName` and `binaryName`) in the containerd config.toml file. (https://github.com/NVIDIA/gpu-operator/issues/1374#issuecomment-2829150654)

The following is the output of  `containerd config default` . The default configuration uses uppercase.

````
...
    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
      BinaryName = ""
      CriuImagePath = ""
      CriuPath = ""
      CriuWorkPath = ""
      IoGid = 0
      IoUid = 0
      NoNewKeyring = false
      NoPivotRoot = false
      Root = ""
      ShimCgroup = ""
      SystemdCgroup = false
...
````



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12167

**Special notes for your reviewer**:

- The change aligns with containerd's official configuration format where the field is defined as `BinaryName`.
- This fix ensures compatibility with GPU-Operator's expectations of the containerd configuration.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
