### PR TITLE
feat: add trigger to restart kube-apiserver when config files change

### DIFF
--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -234,12 +234,17 @@
 - name: Kubeadm | Join other control plane nodes
   include_tasks: kubeadm-secondary.yml
 
+- name: Kubeadm | upgrade kubernetes cluster to {{ kube_version }}
+  include_tasks: kubeadm-upgrade.yml
+  when:
+    - upgrade_cluster_setup
+    - kubeadm_already_run.stat.exists
+
 - name: Kubeadm | Trigger restart kube-apiserver
   debug:
     msg: Detected changes in kube-apiserver config files
   changed_when: true
   when:
-    - not upgrade_cluster_setup
     - kubeadm_already_run.stat.exists
     - >
       apiserver_audit_policy_update.changed or
@@ -248,12 +253,6 @@
       apiserver_admission_control_config_update.changed or
       apiserver_admission_control_plugin_config_update.changed
   notify: Control plane | Restart apiserver
-
-- name: Kubeadm | upgrade kubernetes cluster to {{ kube_version }}
-  include_tasks: kubeadm-upgrade.yml
-  when:
-    - upgrade_cluster_setup
-    - kubeadm_already_run.stat.exists
 
 # FIXME(mattymo): from docs: If you don't want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file.
 - name: Kubeadm | Remove taint for control plane node with node role

--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -60,6 +60,7 @@
     src: apiserver-audit-policy.yaml.j2
     dest: "{{ audit_policy_file }}"
     mode: "0640"
+  register: apiserver_audit_policy_update
   when: kubernetes_audit or kubernetes_audit_webhook
 
 - name: Write api audit webhook config yaml
@@ -67,6 +68,7 @@
     src: apiserver-audit-webhook-config.yaml.j2
     dest: "{{ audit_webhook_config_file }}"
     mode: "0640"
+  register: apiserver_audit_webhook_config_update
   when: kubernetes_audit_webhook
 
 - name: Create apiserver tracing config directory
@@ -81,6 +83,7 @@
     src: apiserver-tracing.yaml.j2
     dest: "{{ kube_config_dir }}/tracing/apiserver-tracing.yaml"
     mode: "0640"
+  register: apiserver_tracing_config_update
   when: kube_apiserver_tracing
 
 # Nginx LB(default), If kubeadm_config_api_fqdn is defined, use other LB by kubeadm controlPlaneEndpoint.
@@ -108,6 +111,7 @@
     src: "admission-controls.yaml.j2"
     dest: "{{ kube_config_dir }}/admission-controls/admission-controls.yaml"
     mode: "0640"
+  register: apiserver_admission_control_config_update
   when: kube_apiserver_admission_control_config_file
 
 - name: Kubeadm | Push admission control config files
@@ -115,6 +119,7 @@
     src: "{{ item | lower }}.yaml.j2"
     dest: "{{ kube_config_dir }}/admission-controls/{{ item | lower }}.yaml"
     mode: "0640"
+  register: apiserver_admission_control_plugin_config_update
   when:
     - kube_apiserver_admission_control_config_file
     - item in kube_apiserver_admission_plugins_needs_configuration
@@ -228,6 +233,21 @@
 
 - name: Kubeadm | Join other control plane nodes
   include_tasks: kubeadm-secondary.yml
+
+- name: Kubeadm | Trigger restart kube-apiserver
+  debug:
+    msg: Detected changes in kube-apiserver config files
+  changed_when: true
+  when:
+    - not upgrade_cluster_setup
+    - kubeadm_already_run.stat.exists
+    - >
+      apiserver_audit_policy_update.changed or
+      apiserver_audit_webhook_config_update.changed or
+      apiserver_tracing_config_update.changed or
+      apiserver_admission_control_config_update.changed or
+      apiserver_admission_control_plugin_config_update.changed
+  notify: Control plane | Restart apiserver
 
 - name: Kubeadm | upgrade kubernetes cluster to {{ kube_version }}
   include_tasks: kubeadm-upgrade.yml

--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -60,16 +60,16 @@
     src: apiserver-audit-policy.yaml.j2
     dest: "{{ audit_policy_file }}"
     mode: "0640"
-  register: apiserver_audit_policy_update
   when: kubernetes_audit or kubernetes_audit_webhook
+  notify: Control plane | Restart apiserver
 
 - name: Write api audit webhook config yaml
   template:
     src: apiserver-audit-webhook-config.yaml.j2
     dest: "{{ audit_webhook_config_file }}"
     mode: "0640"
-  register: apiserver_audit_webhook_config_update
   when: kubernetes_audit_webhook
+  notify: Control plane | Restart apiserver
 
 - name: Create apiserver tracing config directory
   file:
@@ -83,8 +83,8 @@
     src: apiserver-tracing.yaml.j2
     dest: "{{ kube_config_dir }}/tracing/apiserver-tracing.yaml"
     mode: "0640"
-  register: apiserver_tracing_config_update
   when: kube_apiserver_tracing
+  notify: Control plane | Restart apiserver
 
 # Nginx LB(default), If kubeadm_config_api_fqdn is defined, use other LB by kubeadm controlPlaneEndpoint.
 - name: Set kubeadm_config_api_fqdn define
@@ -111,19 +111,19 @@
     src: "admission-controls.yaml.j2"
     dest: "{{ kube_config_dir }}/admission-controls/admission-controls.yaml"
     mode: "0640"
-  register: apiserver_admission_control_config_update
   when: kube_apiserver_admission_control_config_file
+  notify: Control plane | Restart apiserver
 
 - name: Kubeadm | Push admission control config files
   template:
     src: "{{ item | lower }}.yaml.j2"
     dest: "{{ kube_config_dir }}/admission-controls/{{ item | lower }}.yaml"
     mode: "0640"
-  register: apiserver_admission_control_plugin_config_update
   when:
     - kube_apiserver_admission_control_config_file
     - item in kube_apiserver_admission_plugins_needs_configuration
   loop: "{{ kube_apiserver_enable_admission_plugins }}"
+  notify: Control plane | Restart apiserver
 
 - name: Kubeadm | Check apiserver.crt SANs
   vars:
@@ -239,20 +239,6 @@
   when:
     - upgrade_cluster_setup
     - kubeadm_already_run.stat.exists
-
-- name: Kubeadm | Trigger restart kube-apiserver
-  debug:
-    msg: Detected changes in kube-apiserver config files
-  changed_when: true
-  when:
-    - kubeadm_already_run.stat.exists
-    - >
-      apiserver_audit_policy_update.changed or
-      apiserver_audit_webhook_config_update.changed or
-      apiserver_tracing_config_update.changed or
-      apiserver_admission_control_config_update.changed or
-      apiserver_admission_control_plugin_config_update.changed
-  notify: Control plane | Restart apiserver
 
 # FIXME(mattymo): from docs: If you don't want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file.
 - name: Kubeadm | Remove taint for control plane node with node role


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

When the kube-apiserver config files change, some users may not realize that they need to manually restart the kube-apiserver because the manifest itself remains unchanged and kubelet does not automatically restart the Pod.

With this PR, even if the manifest is not modified, the kube-apiserver will be restarted whenever related config files change.

For example, if `audit_policy_custom_rules` is modified and `ansible-playbook upgrade-cluster.yml --tags master` is run, the kube-apiserver will be automatically restarted to apply the updated audit policies.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
None
```
