### PR TITLE
Update load balancers versions to Nginx 1.28.0, Haproxy 3.1.7

### DIFF
--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -279,9 +279,9 @@ external_openstack_cloud_controller_image_tag: "v1.32.0"
 kube_vip_image_repo: "{{ github_image_repo }}/kube-vip/kube-vip{{ '-iptables' if kube_vip_lb_fwdmethod == 'masquerade' else '' }}"
 kube_vip_image_tag: v0.8.9
 nginx_image_repo: "{{ docker_image_repo }}/library/nginx"
-nginx_image_tag: 1.27.4-alpine
+nginx_image_tag: 1.28.0-alpine
 haproxy_image_repo: "{{ docker_image_repo }}/library/haproxy"
-haproxy_image_tag: 3.1.3-alpine
+haproxy_image_tag: 3.1.7-alpine
 
 # Coredns version should be supported by corefile-migration (or at least work with)
 # bundle with kubeadm; if not 'basic' upgrade can sometimes fail


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

**Does this PR introduce a user-facing change?**:
NONE
```release-note
Update load balancers versions to Nginx 1.28.0, Haproxy 3.1.7
```
