### PR TITLE
Update pre-commit and put ansible-lint at the end

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.35.1
+    rev: v1.37.0
     hooks:
       - id: yamllint
         args: [--strict]
@@ -101,7 +101,7 @@ repos:
         exclude: "^.github|(^docs/_sidebar\\.md$)"
 
   - repo: https://github.com/ansible/ansible-lint
-    rev: v25.1.1
+    rev: v25.4.0
     hooks:
       - id: ansible-lint
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,15 +28,6 @@ repos:
         exclude: "^.git"
         files: "\\.sh$"
 
-  - repo: https://github.com/ansible/ansible-lint
-    rev: v25.1.1
-    hooks:
-      - id: ansible-lint
-        additional_dependencies:
-          - jmespath==1.0.1
-          - netaddr==1.3.0
-          - distlib
-
   - repo: https://github.com/golangci/misspell
     rev: v0.6.0
     hooks:
@@ -108,3 +99,12 @@ repos:
     hooks:
       - id: markdownlint
         exclude: "^.github|(^docs/_sidebar\\.md$)"
+
+  - repo: https://github.com/ansible/ansible-lint
+    rev: v25.1.1
+    hooks:
+      - id: ansible-lint
+        additional_dependencies:
+          - jmespath==1.0.1
+          - netaddr==1.3.0
+          - distlib


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
pre-commit: move ansible-lint at the end

Ansible-lint is the most expensive hook we have.

Run it at the end to fail faster if any of the others hooks have
something to say.

Also autoupdate our hooks.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
