### PR TITLE
Feat: Gateway API early installation

### DIFF
--- a/playbooks/cluster.yml
+++ b/playbooks/cluster.yml
@@ -52,6 +52,11 @@
     - { role: kubernetes/kubeadm, tags: kubeadm}
     - { role: kubernetes/node-label, tags: node-label }
     - { role: kubernetes/node-taint, tags: node-taint }
+    - role: kubernetes-apps/gateway_api
+      when: gateway_api_enabled
+      tags: gateway_api
+      delegate_to: "{{ groups['kube_control_plane'][0] }}"
+      run_once: true
     - { role: network_plugin, tags: network }
 
 - name: Install Calico Route Reflector

--- a/roles/kubernetes-apps/meta/main.yml
+++ b/roles/kubernetes-apps/meta/main.yml
@@ -97,13 +97,6 @@ dependencies:
     tags:
       - container_engine_accelerator
 
-  - role: kubernetes-apps/gateway_api
-    when:
-      - gateway_api_enabled
-      - inventory_hostname == groups['kube_control_plane'][0]
-    tags:
-      - gateway_api
-
   - role: kubernetes-apps/kubelet-csr-approver
     when:
       - kubelet_csr_approver_enabled


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Since the Gateway API is just CRDs without any Pod, Deployment, etc., I think it can be brought forward before the CNI installation.

**Which issue(s) this PR fixes**:

Related #10814

**Does this PR introduce a user-facing change?**:

```release-note
Gateway API can be brought forward before the CNI installation.
```
