### PR TITLE
Move cilium_deploy_additionnaly to kubespray-default

### DIFF
--- a/roles/etcd/tasks/check_certs.yml
+++ b/roles/etcd/tasks/check_certs.yml
@@ -84,7 +84,7 @@
         {% if not loop.last %}{{ ',' }}{% endif %}
       {% endfor %}]
   when:
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally | default(false) | bool
+    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally
     - kube_network_plugin != "calico" or calico_datastore == "etcd"
     - force_etcd_cert_refresh or not item in etcdcert_master.files | map(attribute='path') | list
 

--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -54,7 +54,7 @@
   run_once: true
   delegate_to: "{{ groups['etcd'][0] }}"
   when:
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally | default(false) | bool
+    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally
     - kube_network_plugin != "calico" or calico_datastore == "etcd"
     - gen_certs | default(false)
   notify: Set etcd_secret_changed
@@ -111,7 +111,7 @@
   when:
     - ('etcd' in group_names)
     - inventory_hostname != groups['etcd'][0]
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally | default(false) | bool
+    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally
     - kube_network_plugin != "calico" or calico_datastore == "etcd"
   notify: Set etcd_secret_changed
 
@@ -126,7 +126,7 @@
   when:
     - ('etcd' in group_names)
     - inventory_hostname != groups['etcd'][0]
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally | default(false) | bool
+    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally
     - kube_network_plugin != "calico" or calico_datastore == "etcd"
   loop_control:
     label: "{{ item.item }}"
@@ -140,7 +140,7 @@
 - name: Gen_certs | Generate etcd certs on nodes if needed
   include_tasks: gen_nodes_certs_script.yml
   when:
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally | default(false) | bool
+    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally
     - kube_network_plugin != "calico" or calico_datastore == "etcd"
     - ('k8s_cluster' in group_names) and
         sync_certs | default(false) and inventory_hostname not in groups['etcd']

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -23,7 +23,7 @@
 - name: Trust etcd CA on nodes if needed
   include_tasks: upd_ca_trust.yml
   when:
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally | default(false) | bool
+    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally
     - kube_network_plugin != "calico" or calico_datastore == "etcd"
     - ('k8s_cluster' in group_names)
   tags:
@@ -35,7 +35,7 @@
   changed_when: false
   check_mode: false
   when:
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally | default(false) | bool
+    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally
     - kube_network_plugin != "calico" or calico_datastore == "etcd"
     - ('k8s_cluster' in group_names)
   tags:
@@ -47,7 +47,7 @@
   set_fact:
     etcd_client_cert_serial: "{{ etcd_client_cert_serial_result.stdout.split('=')[1] }}"
   when:
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally | default(false) | bool
+    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally
     - kube_network_plugin != "calico" or calico_datastore == "etcd"
     - ('k8s_cluster' in group_names)
   tags:

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -201,5 +201,5 @@
   when:
     - etcd_deployment_type == "kubeadm"
     - inventory_hostname not in groups['kube_control_plane']
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally | default(false) | bool
+    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally
     - kube_network_plugin != "calico" or calico_datastore == "etcd"

--- a/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
@@ -204,7 +204,7 @@
   assert:
     that: ansible_kernel.split('-')[0] is version('4.9.17', '>=')
   when:
-    - kube_network_plugin == 'cilium' or cilium_deploy_additionally | default(false) | bool
+    - kube_network_plugin == 'cilium' or cilium_deploy_additionally
     - not ignore_assert_errors
 
 - name: Stop if kernel version is too low for nftables

--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -632,7 +632,7 @@ downloads:
       - kube_control_plane
 
   cilium:
-    enabled: "{{ kube_network_plugin == 'cilium' or cilium_deploy_additionally | default(false) | bool }}"
+    enabled: "{{ kube_network_plugin == 'cilium' or cilium_deploy_additionally }}"
     container: true
     repo: "{{ cilium_image_repo }}"
     tag: "{{ cilium_image_tag }}"
@@ -641,7 +641,7 @@ downloads:
       - k8s_cluster
 
   cilium_operator:
-    enabled: "{{ kube_network_plugin == 'cilium' or cilium_deploy_additionally | default(false) | bool }}"
+    enabled: "{{ kube_network_plugin == 'cilium' or cilium_deploy_additionally }}"
     container: true
     repo: "{{ cilium_operator_image_repo }}"
     tag: "{{ cilium_operator_image_tag }}"
@@ -695,7 +695,7 @@ downloads:
       - k8s_cluster
 
   ciliumcli:
-    enabled: "{{ kube_network_plugin == 'cilium' or cilium_deploy_additionally | default(false) | bool }}"
+    enabled: "{{ kube_network_plugin == 'cilium' or cilium_deploy_additionally }}"
     file: true
     dest: "{{ local_release_dir }}/cilium-{{ cilium_cli_version }}-{{ image_arch }}.tar.gz"
     checksum: "{{ ciliumcli_binary_checksum }}"

--- a/roles/kubespray-defaults/defaults/main/main.yml
+++ b/roles/kubespray-defaults/defaults/main/main.yml
@@ -204,6 +204,12 @@ kube_log_level: 2
 kube_network_plugin: calico
 kube_network_plugin_multus: false
 
+## Network plugin options with dependencies across the whole playbook
+
+# Deploy cilium even if kube_network_plugin is not cilium.
+# This enables to deploy cilium alongside another CNI to replace kube-proxy.
+cilium_deploy_additionally: false
+
 # Determines if calico_rr group exists
 peer_with_calico_rr: "{{ 'calico_rr' in groups and groups['calico_rr'] | length > 0 }}"
 

--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -69,10 +69,6 @@ cilium_tofqdns_enable_poller: false
 # `cilium_enable_legacy_services` is deprecated in 1.6, removed in 1.9
 cilium_enable_legacy_services: false
 
-# Deploy cilium even if kube_network_plugin is not cilium.
-# This enables to deploy cilium alongside another CNI to replace kube-proxy.
-cilium_deploy_additionally: false
-
 # Auto direct nodes routes can be used to advertise pods routes in your cluster
 # without any tunelling (with `cilium_tunnel_mode` sets to `disabled`).
 # This works only if you have a L2 connectivity between all your nodes.

--- a/roles/network_plugin/cilium/tasks/check.yml
+++ b/roles/network_plugin/cilium/tasks/check.yml
@@ -18,13 +18,13 @@
   when:
     - cilium_ipsec_enabled is defined
     - cilium_ipsec_enabled
-    - kube_network_plugin == 'cilium' or cilium_deploy_additionally | default(false) | bool
+    - kube_network_plugin == 'cilium' or cilium_deploy_additionally
 
 - name: Stop if kernel version is too low for Cilium Wireguard encryption
   assert:
     that: ansible_kernel.split('-')[0] is version('5.6.0', '>=')
   when:
-    - kube_network_plugin == 'cilium' or cilium_deploy_additionally | default(false) | bool
+    - kube_network_plugin == 'cilium' or cilium_deploy_additionally
     - cilium_encryption_enabled
     - cilium_encryption_type == "wireguard"
     - not ignore_assert_errors

--- a/roles/network_plugin/meta/main.yml
+++ b/roles/network_plugin/meta/main.yml
@@ -4,7 +4,7 @@ dependencies:
     when: kube_network_plugin != 'none'
 
   - role: network_plugin/cilium
-    when: kube_network_plugin == 'cilium' or cilium_deploy_additionally | default(false) | bool
+    when: kube_network_plugin == 'cilium' or cilium_deploy_additionally
     tags:
       - cilium
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Instead of using default(false) all over the place, use
kubespray-defaults

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
