### PR TITLE
Fix `'item' is undefined` error caused by indentation

### DIFF
--- a/roles/kubernetes/control-plane/tasks/main.yml
+++ b/roles/kubernetes/control-plane/tasks/main.yml
@@ -109,7 +109,7 @@
   file:
     path: "{{ kube_config_dir }}/apiserver-authorization-config-{{ item }}.yaml"
     state: absent
-    loop: "{{ ['v1alpha1', 'v1beta1', 'v1'] | reject('equalto', kube_apiserver_authorization_config_api_version) | list }}"
+  loop: "{{ ['v1alpha1', 'v1beta1', 'v1'] | reject('equalto', kube_apiserver_authorization_config_api_version) | list }}"
   when: kube_apiserver_use_authorization_config_file
 
 - name: Include kubelet client cert rotation fixes


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind bug

**What this PR does / why we need it**:
This fixes an AuthorizationConfiguration task error caused by [unintentional indentation](https://github.com/kubernetes-sigs/kubespray/pull/12058/commits/fed8aca2de7988f135a91f2637df96d6f6c25a5f) of the `loop` directive that was added by mistake when removing `from_json` per [comments](https://github.com/kubernetes-sigs/kubespray/pull/12058#discussion_r2007568785) on PR #12058.

```release-note
NONE
```
