### PR TITLE
Don't run upgrade-patch jobs on forks

### DIFF
--- a/.github/workflows/upgrade-patch-versions-schedule.yml
+++ b/.github/workflows/upgrade-patch-versions-schedule.yml
@@ -8,6 +8,7 @@ on:
 permissions: {}
 jobs:
   get-releases-branches:
+    if: github.repository == 'kubernetes-sigs/kubespray'
     runs-on: ubuntu-latest
     outputs:
       branches: ${{ steps.get-branches.outputs.data }}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
With the current github-workflow setup, workflows are triggered on every
forked repository (which is quite wasteful).

Add a condition to only run on the main repository.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
