### PR TITLE
Make containerd RLIMIT_NOFILE configurable via inventory

### DIFF
--- a/docs/CRI/containerd.md
+++ b/docs/CRI/containerd.md
@@ -81,38 +81,19 @@ Default runtime can be changed by setting `containerd_default_runtime`.
 #### Base runtime specs and limiting number of open files
 
 `base_runtime_spec` key in a runtime dictionary is used to explicitly
-specify a runtime spec json file. `runc` runtime has it set to `cri-base.json`,
-which is generated with `ctr oci spec > /etc/containerd/cri-base.json` and
-updated to include a custom setting for maximum number of file descriptors per
-container.
+specify a runtime spec JSON file. The default `runc` runtime uses `cri-base.json`, generated with `ctr oci spec`, and patched by Kubespray to include a file descriptor limit (`RLIMIT_NOFILE`).
 
-You can change maximum number of file descriptors per container for the default
-`runc` runtime by setting the `containerd_base_runtime_spec_rlimit_nofile`
-variable.
+##### RLIMIT_NOFILE Configuration
 
-You can tune many more [settings][runtime-spec] by supplying your own file name and content with `containerd_base_runtime_specs`:
+To change the maximum number of open file descriptors (`RLIMIT_NOFILE`) per container for the default `runc` runtime, set the following variable in your inventory:
 
 ```yaml
-containerd_base_runtime_specs:
-  cri-spec-custom.json: |
-    {
-      "ociVersion": "1.1.0",
-      "process": {
-        "user": {
-          "uid": 0,
-    ...
+containerd_base_runtime_spec_rlimit_nofile: 102400
 ```
 
-The files in this dict will be placed in containerd config directory,
-`/etc/containerd` by default. The files can then be referenced by filename in a
-runtime:
-
-```yaml
-containerd_runc_runtime:
-  name: runc
-  base_runtime_spec: cri-spec-custom.json
-  ...
-```
+- **Default value:** `65535`
+- **Default location:** `inventory/group_vars/all/containerd.yml`
+- This variable is used to dynamically patch the base runtime spec unless you manually override `containerd_default_base_runtime_spec_patch`.
 
 Config insecure-registry access to self hosted registries.
 

--- a/inventory/sample/group_vars/all/containerd.yml
+++ b/inventory/sample/group_vars/all/containerd.yml
@@ -57,3 +57,6 @@
 #   - registry: 10.0.0.2:5000
 #     username: user
 #     password: pass
+
+# Set the RLIMIT_NOFILE value for the base containerd runtime spec (default is 65535)
+containerd_base_runtime_spec_rlimit_nofile: 65535

--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -29,12 +29,12 @@ containerd_additional_runtimes: []
 
 containerd_base_runtime_spec_rlimit_nofile: 65535
 
-containerd_default_base_runtime_spec_patch:
-  process:
-    rlimits:
-      - type: RLIMIT_NOFILE
-        hard: "{{ containerd_base_runtime_spec_rlimit_nofile }}"
-        soft: "{{ containerd_base_runtime_spec_rlimit_nofile }}"
+# containerd_default_base_runtime_spec_patch:
+#   process:
+#     rlimits:
+#       - type: RLIMIT_NOFILE
+#         hard: "{{ containerd_base_runtime_spec_rlimit_nofile }}"
+#         soft: "{{ containerd_base_runtime_spec_rlimit_nofile }}"
 
 # Can help reduce disk usage
 # https://github.com/containerd/containerd/discussions/6295

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -97,6 +97,22 @@
   set_fact:
     containerd_default_base_runtime_spec: "{{ ctr_oci_spec.stdout | from_json }}"
 
+- name: Containerd | Generate rlimit patch from base_runtime_spec_rlimit_nofile
+  set_fact:
+    containerd_default_base_runtime_spec_patch:
+      process:
+        rlimits:
+          - type: RLIMIT_NOFILE
+            hard: "{{ containerd_base_runtime_spec_rlimit_nofile }}"
+            soft: "{{ containerd_base_runtime_spec_rlimit_nofile }}"
+  when: containerd_default_base_runtime_spec_patch is not defined
+
+- name: Containerd | Construct base_runtime_specs dictionary
+  set_fact:
+    containerd_base_runtime_specs:
+      "runtime-spec.json": "{{ containerd_default_base_runtime_spec_patch }}"
+  when: containerd_base_runtime_specs is not defined
+
 - name: Containerd | Write base_runtime_specs
   copy:
     content: "{{ item.value }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> 
/kind feature
> /kind flake

**What this PR does / why we need it**:
To eliminate manual edits during cluster upgrades by making the RLIMIT_NOFILE (max open file descriptors) for Containerd runtime spec configurable via inventory, rather than hardcoded in role defaults.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
