### PR TITLE
improve ntp package conflict handling

### DIFF
--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -55,17 +55,6 @@ minimal_node_memory_mb: 1024
 minimal_master_memory_mb: 1500
 
 ## NTP Settings
-# Start the ntpd or chrony service and enable it at system boot.
-ntp_enabled: false
-# The package to install which provides NTP functionality.
-# The default is ntp for most platforms, or chrony on RHEL/CentOS 7 and later.
-# The ntp_package can be one of ['ntp', 'ntpsec', 'chrony']
-ntp_package: >-
-      {% if ansible_os_family == "RedHat" -%}
-      chrony
-      {%- else -%}
-      ntp
-      {%- endif -%}
 
 # Manage the NTP configuration file.
 ntp_manage_config: false

--- a/roles/kubernetes/preinstall/tasks/0081-ntp-configurations.yml
+++ b/roles/kubernetes/preinstall/tasks/0081-ntp-configurations.yml
@@ -1,12 +1,4 @@
 ---
-- name: Ensure NTP package
-  package:
-    name:
-      - "{{ ntp_package }}"
-    state: present
-  when:
-    - not is_fedora_coreos
-    - not ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
 
 - name: Disable systemd-timesyncd
   service:

--- a/roles/kubespray_defaults/defaults/main/main.yml
+++ b/roles/kubespray_defaults/defaults/main/main.yml
@@ -770,3 +770,20 @@ system_upgrade_reboot: on-upgrade  # never, always
 
 # Enables or disables the scheduler plugins.
 scheduler_plugins_enabled: false
+
+## NTP Settings
+# Start the ntpd or chrony service and enable it at system boot.
+ntp_enabled: false
+
+# TODO: Refactor NTP package selection to integrate with the general package installation system
+# instead of using a separate variable approach
+
+# The package to install which provides NTP functionality.
+# The default is ntp for most platforms, or chrony on RHEL/CentOS 7 and later.
+# The ntp_package can be one of ['ntp', 'ntpsec', 'chrony']
+ntp_package: >-
+      {% if ansible_os_family == "RedHat" -%}
+      chrony
+      {%- else -%}
+      ntp
+      {%- endif -%}

--- a/roles/system_packages/tasks/main.yml
+++ b/roles/system_packages/tasks/main.yml
@@ -65,14 +65,19 @@
   tags:
     - bootstrap-os
 
-- name: Install packages requirements
+- name: Manage packages
   package:
-    name: "{{ pkgs | dict2items | selectattr('value', 'ansible.builtin.all') | map(attribute='key') }}"
-    state: present
+    name: "{{ item.packages | dict2items | selectattr('value', 'ansible.builtin.all') | map(attribute='key') }}"
+    state: "{{ item.state }}"
   register: pkgs_task_result
   until: pkgs_task_result is succeeded
   retries: "{{ pkg_install_retries }}"
   delay: "{{ retry_stagger | random + 3 }}"
   when: not (ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"] or is_fedora_coreos)
+  loop:
+    - { packages: "{{ pkgs_to_remove }}", state: "absent", action_label: "remove" }
+    - { packages: "{{ pkgs }}", state: "present", action_label: "install" }
+  loop_control:
+    label: "{{ item.action_label }}"
   tags:
     - bootstrap-os

--- a/roles/system_packages/vars/main.yml
+++ b/roles/system_packages/vars/main.yml
@@ -1,4 +1,9 @@
 ---
+pkgs_to_remove:
+  systemd-timesyncd:
+    - "{{ ntp_enabled }}"
+    - "{{ ntp_package == 'ntp' }}"
+    - "{{ ansible_os_family == 'Debian' }}"
 pkgs:
   apparmor:
     - "{{ ansible_os_family == 'Debian' }}"
@@ -9,6 +14,9 @@ pkgs:
     - "{{ ansible_distribution_major_version == '10' }}"
     - "{{ 'k8s_cluster' in group_names }}"
   bash-completion: []
+  chrony:
+    - "{{ ntp_enabled }}"
+    - "{{ ntp_package == 'chrony' }}"
   conntrack:
     - "{{ ansible_os_family in ['Debian', 'RedHat'] }}"
     - "{{ ansible_distribution != 'openEuler' }}"
@@ -70,6 +78,12 @@ pkgs:
     - "{{ 'k8s_cluster' in group_names }}"
   nss:
     - "{{ ansible_os_family == 'RedHat' }}"
+  ntp:
+    - "{{ ntp_enabled }}"
+    - "{{ ntp_package == 'ntp' }}"
+  ntpsec:
+    - "{{ ntp_enabled }}"
+    - "{{ ntp_package == 'ntpsec' }}"
   openssl: []
   python-apt:
     - "{{ ansible_os_family == 'Debian' }}"

--- a/scripts/assert-sorted-checksums.yml
+++ b/scripts/assert-sorted-checksums.yml
@@ -40,12 +40,15 @@
     include_vars: ../roles/system_packages/vars/main.yml
 
   - name: Verify that the packages list is sorted
+    loop:
+    - pkgs_to_remove
+    - pkgs
     vars:
-      pkgs_lists: "{{ pkgs.keys() | list }}"
+      pkgs_lists: "{{ lookup('vars', item).keys() | list }}"
       ansible_distribution: irrelevant
       ansible_distribution_major_version: irrelevant
       ansible_distribution_minor_version: irrelevant
       ansible_os_family: irrelevant
     assert:
       that: "pkgs_lists | sort == pkgs_lists"
-      fail_msg: "pkgs is not sorted: {{ pkgs_lists | ansible.utils.fact_diff(pkgs_lists | sort) }}"
+      fail_msg: "{{ item }} is not sorted: {{ pkgs_lists | ansible.utils.fact_diff(pkgs_lists | sort) }}"

--- a/tests/files/almalinux9-calico.yml
+++ b/tests/files/almalinux9-calico.yml
@@ -14,6 +14,7 @@ kube_proxy_mode: nftables
 
 # NTP mangement
 ntp_enabled: true
+ntp_package: chrony
 ntp_timezone: Etc/UTC
 ntp_manage_config: true
 ntp_tinker_panic: true

--- a/tests/files/debian12-cilium.yml
+++ b/tests/files/debian12-cilium.yml
@@ -4,3 +4,7 @@ cloud_image: debian-12
 
 # Kubespray settings
 kube_network_plugin: cilium
+
+# ntp settings
+ntp_enabled: true
+ntp_package: ntp

--- a/tests/files/ubuntu24-calico-etcd-datastore.yml
+++ b/tests/files/ubuntu24-calico-etcd-datastore.yml
@@ -44,3 +44,7 @@ kubeadm_patches:
           example.com/test: "false"
         labels:
           example.com/prod_level: "prep"
+
+# ntp settings
+ntp_enabled: true
+ntp_package: ntpsec


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:

This PR improves NTP package management by:

1. Moving NTP package installation logic from kubernetes/preinstall role to system_packages role
2. Adding package removal task before installation in system_packages role
3. Adding systemd-timesyncd to the removal list to handle conflicts with NTP package
4. Adding test cases for NTP package management

This change resolves the conflict between systemd-timesyncd and NTP packages, 
ensuring proper time synchronization configuration on Debian-based systems.

Related to: https://github.com/kubernetes-sigs/kubespray/pull/11665

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
improve ntp package conflict handling
```
