### PR TITLE
Stop cleaning up containerd packages

### DIFF
--- a/roles/container-engine/containerd-common/defaults/main.yml
+++ b/roles/container-engine/containerd-common/defaults/main.yml
@@ -3,15 +3,3 @@
 # manager controlled installs to direct download ones.
 containerd_package: 'containerd.io'
 yum_repo_dir: /etc/yum.repos.d
-
-# Keep minimal repo information around for cleanup
-containerd_repo_info:
-  repos:
-
-# Ubuntu docker-ce repo
-containerd_ubuntu_repo_base_url: "https://download.docker.com/linux/ubuntu"
-containerd_ubuntu_repo_component: "stable"
-
-# Debian docker-ce repo
-containerd_debian_repo_base_url: "https://download.docker.com/linux/debian"
-containerd_debian_repo_component: "stable"

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -1,31 +1,4 @@
 ---
-- name: Fail containerd setup if distribution is not supported
-  fail:
-    msg: "{{ ansible_distribution }} is not supported by containerd."
-  when:
-    - not (allow_unsupported_distribution_setup | default(false)) and (ansible_distribution not in containerd_supported_distributions)
-
-- name: Containerd | Remove any package manager controlled containerd package
-  package:
-    name: "{{ containerd_package }}"
-    state: absent
-  when:
-    - not (is_ostree or (ansible_distribution == "Flatcar Container Linux by Kinvolk") or (ansible_distribution == "Flatcar"))
-
-- name: Containerd | Remove containerd repository
-  file:
-    path: "{{ yum_repo_dir }}/containerd.repo"
-    state: absent
-  when:
-    - ansible_os_family in ['RedHat']
-
-- name: Containerd | Remove containerd repository
-  apt_repository:
-    repo: "{{ item }}"
-    state: absent
-  with_items: "{{ containerd_repo_info.repos }}"
-  when: ansible_pkg_mgr == 'apt'
-
 - name: Containerd | Download containerd
   include_tasks: "../../../download/tasks/download_file.yml"
   vars:
@@ -40,21 +13,6 @@
     extra_opts:
       - --strip-components=1
   notify: Restart containerd
-
-- name: Containerd | Remove orphaned binary
-  file:
-    path: "/usr/bin/{{ item }}"
-    state: absent
-  when:
-    - containerd_bin_dir != "/usr/bin"
-    - not (is_ostree or (ansible_distribution == "Flatcar Container Linux by Kinvolk") or (ansible_distribution == "Flatcar"))
-  ignore_errors: true  # noqa ignore-errors
-  with_items:
-    - containerd
-    - containerd-shim
-    - containerd-shim-runc-v1
-    - containerd-shim-runc-v2
-    - ctr
 
 - name: Containerd | Generate systemd service for containerd
   template:

--- a/roles/container-engine/containerd/tasks/reset.yml
+++ b/roles/container-engine/containerd/tasks/reset.yml
@@ -1,22 +1,4 @@
 ---
-- name: Containerd | Remove containerd repository for RedHat os family
-  file:
-    path: "{{ yum_repo_dir }}/containerd.repo"
-    state: absent
-  when:
-    - ansible_os_family in ['RedHat']
-  tags:
-    - reset_containerd
-
-- name: Containerd | Remove containerd repository for Debian os family
-  apt_repository:
-    repo: "{{ item }}"
-    state: absent
-  with_items: "{{ containerd_repo_info.repos }}"
-  when: ansible_pkg_mgr == 'apt'
-  tags:
-    - reset_containerd
-
 - name: Containerd | Stop containerd service
   service:
     name: containerd

--- a/roles/container-engine/containerd/vars/debian.yml
+++ b/roles/container-engine/containerd/vars/debian.yml
@@ -1,7 +1,0 @@
----
-containerd_repo_info:
-  repos:
-    - >
-      deb {{ containerd_debian_repo_base_url }}
-      {{ ansible_distribution_release | lower }}
-      {{ containerd_debian_repo_component }}

--- a/roles/container-engine/containerd/vars/ubuntu.yml
+++ b/roles/container-engine/containerd/vars/ubuntu.yml
@@ -1,7 +1,0 @@
----
-containerd_repo_info:
-  repos:
-    - >
-      deb {{ containerd_ubuntu_repo_base_url }}
-      {{ ansible_distribution_release | lower }}
-      {{ containerd_ubuntu_repo_component }}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The switch to not use system packages for containerd packages happened
multiples releases ago ; there should not be any up-to-date installation
of kubespray needing that cleanup.

Remove those steps and variables only used by them.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
