### PR TITLE
download: Only download dnsautoscaler image if needed

### DIFF
--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -897,7 +897,7 @@ downloads:
       - k8s_cluster
 
   dnsautoscaler:
-    enabled: "{{ dns_mode in ['coredns', 'coredns_dual'] }}"
+    enabled: "{{ dns_mode in ['coredns', 'coredns_dual'] and enable_dns_autoscaler }}"
     container: true
     repo: "{{ dnsautoscaler_image_repo }}"
     tag: "{{ dnsautoscaler_image_tag }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
dnsautoscaler should only be enabled when enable_dns_autoscaler is set to true. without this, it could be enabled without any manifest actually using it, which makes it a false signal.

**Does this PR introduce a user-facing change?**:
```release-note
None
```
