### PR TITLE
Add option to [not] install coredns via Kubespray

### DIFF
--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -20,7 +20,7 @@ coredns_default_zone_cache_block: |
 coredns_pod_disruption_budget: false
 # value for coredns pdb
 coredns_pod_disruption_budget_max_unavailable: "30%"
-
+deploy_coredns: true
 # coredns_additional_configs adds any extra configuration to coredns
 # coredns_additional_configs: |
 #   whoami

--- a/roles/kubernetes-apps/ansible/tasks/main.yml
+++ b/roles/kubernetes-apps/ansible/tasks/main.yml
@@ -22,7 +22,9 @@
     - coredns
   vars:
     clusterIP: "{{ skydns_server }}"
-  when: dns_mode in ['coredns', 'coredns_dual']
+  when:
+    - dns_mode in ['coredns', 'coredns_dual']
+    - deploy_coredns
 
 - name: Kubernetes Apps | CoreDNS Secondary
   command:
@@ -38,6 +40,7 @@
     coredns_ordinal_suffix: "-secondary"
   when:
     - dns_mode == 'coredns_dual'
+    - deploy_coredns
 
 - name: Kubernetes Apps | nodelocalDNS
   command:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

We're managing the deployment of coredns without kubespray (gitops). 
We still want most of the configuration executed by kubespray when the variable dns_mode=coredns is set as coredns will sitll be used. 

```release-note
Add deploy_coredns: bool  (true by default), to let kubespray deploy or not coredns in kube-system
```
