### PR TITLE
CI: remove ci-not-authorized job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,36 +55,8 @@ before_script:
   extends: .job
   needs:
     - pipeline-image
-    - ci-not-authorized
     - pre-commit            # lint
     - vagrant-validate      # lint
-
-# For failfast, at least 1 job must be defined in .gitlab-ci.yml
-# Premoderated with manual actions
-ci-not-authorized:
-  stage: build
-  before_script: []
-  after_script: []
-  rules:
-    # LGTM or ok-to-test labels
-    - if: $PR_LABELS =~ /.*,(lgtm|approved|ok-to-test).*|^(lgtm|approved|ok-to-test).*/i
-      variables:
-        CI_OK_TO_TEST: '0'
-      when: always
-    - if: $CI_PIPELINE_SOURCE == "schedule" || $CI_PIPELINE_SOURCE == "trigger"
-      variables:
-        CI_OK_TO_TEST: '0'
-    - if: $CI_COMMIT_BRANCH == "master"
-      variables:
-        CI_OK_TO_TEST: '0'
-    - when: always
-      variables:
-        CI_OK_TO_TEST: '1'
-  script:
-    - exit $CI_OK_TO_TEST
-  tags:
-    - ffci
-  needs: []
 
 include:
   - .gitlab-ci/build.yml

--- a/.gitlab-ci/kubevirt.yml
+++ b/.gitlab-ci/kubevirt.yml
@@ -12,7 +12,6 @@
     - ffci
   needs:
     - pipeline-image
-    - ci-not-authorized
 
 # TODO: generate testcases matrixes from the files in tests/files/
 # this is needed to avoid the need for PR rebasing when a job was added or removed in the target branch

--- a/.gitlab-ci/molecule.yml
+++ b/.gitlab-ci/molecule.yml
@@ -12,7 +12,6 @@
   image: $PIPELINE_IMAGE
   needs:
   - pipeline-image
-  # - ci-not-authorized
   script:
   - ./tests/scripts/molecule_run.sh
   after_script:

--- a/.gitlab-ci/terraform.yml
+++ b/.gitlab-ci/terraform.yml
@@ -3,7 +3,6 @@
 .terraform_install:
   extends: .job
   needs:
-    - ci-not-authorized
     - pipeline-image
   variables:
     TF_VAR_public_key_path: "${ANSIBLE_PRIVATE_KEY_FILE}.pub"

--- a/.gitlab-ci/vagrant.yml
+++ b/.gitlab-ci/vagrant.yml
@@ -1,8 +1,6 @@
 ---
 vagrant:
   extends: .job-moderated
-  needs:
-    - ci-not-authorized
   variables:
     CI_PLATFORM: "vagrant"
     SSH_USER: "vagrant"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This is now handled directly at the failfast-ci level (== integration
Github <-> Gitlab).
The whole pipeline will not be triggered unless:
- The author is a maintainer
- The PR has the /ok-to-test label

ref: https://github.com/kubernetes-sigs/kubespray/pull/12218#issuecomment-2886256630

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
