### PR TITLE
Use last patch versions by default for etcd/crio/crictl

### DIFF
--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -124,32 +124,10 @@ helm_version: "{{ (helm_archive_checksums['amd64'] | dict2items)[0].key }}"
 nerdctl_version: "{{ (nerdctl_archive_checksums['amd64'] | dict2items)[0].key }}"
 skopeo_version: "{{ (skopeo_binary_checksums['amd64'] | dict2items)[0].key }}"
 
-# Get kubernetes major version (i.e. 1.17.4 => 1.17)
-kube_major_version: "{{ (kube_version | split('.'))[:-1] | join('.') }}"
-
-pod_infra_supported_versions:
-  '1.33': '3.10'
-  '1.32': '3.10'
-  '1.31': '3.10'
 pod_infra_version: "{{ pod_infra_supported_versions[kube_major_version] }}"
-
-etcd_supported_versions:
-  '1.33': 3.5.21
-  '1.32': 3.5.16
-  '1.31': 3.5.16
 etcd_version: "{{ etcd_supported_versions[kube_major_version] }}"
-
-crictl_supported_versions:
-  '1.33': 1.33.0
-  '1.32': 1.32.0
-  '1.31': 1.31.1
-crictl_version: "{{ crictl_supported_versions[kube_major_version] }}"
-
-crio_supported_versions:
-  '1.33': 1.33.0
-  '1.32': 1.32.0
-  '1.31': 1.31.3
-crio_version: "{{ crio_supported_versions[kube_major_version] }}"
+crictl_version: "{{ (crictl_checksums['amd64'].keys() | select('version', kube_major_next_version, '<'))[0] }}"
+crio_version: "{{ (crio_archive_checksums['amd64'].keys() | select('version', kube_major_next_version, '<'))[0] }}"
 
 # Scheduler plugins doesn't build for K8s 1.29 yet
 scheduler_plugins_supported_versions:

--- a/roles/kubespray_defaults/vars/main/main.yml
+++ b/roles/kubespray_defaults/vars/main/main.yml
@@ -1,4 +1,20 @@
 ---
+# Internal version manipulation tooling
+
+# Get kubernetes major version (i.e. 1.17.4 => 1.17)
+kube_major_version: "{{ (kube_version | split('.'))[:-1] | join('.') }}"
+kube_next: "{{ ((kube_version | split('.'))[1] | int) + 1 }}"
+kube_major_next_version: "1.{{ kube_next }}"
+
+pod_infra_supported_versions:
+  '1.33': '3.10'
+  '1.32': '3.10'
+  '1.31': '3.10'
+
+etcd_supported_versions:
+  '1.33': "{{ (etcd_binary_checksums['amd64'].keys() | select('version', '3.6', '<'))[0] }}"
+  '1.32': "{{ (etcd_binary_checksums['amd64'].keys() | select('version', '3.6', '<'))[0] }}"
+  '1.31': "{{ (etcd_binary_checksums['amd64'].keys() | select('version', '3.6', '<'))[0] }}"
 # Kubespray constants
 
 kube_proxy_deployed: "{{ 'addon/kube-proxy' not in kubeadm_init_phases_skip }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This uses the same logic than the other versions, with simplications for
crictl and crio whose versionning scheme is tied to upstream kubernetes.

Also move some version variables in vars/ rather than defaults/, because
they are not used elsewhere and don't really make sense as modifiable by
the user.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
action required
drop support for cri-o on ubuntu20.
```
