### PR TITLE
docs: remove obsolete cgroups variables

### DIFF
--- a/docs/operations/cgroups.md
+++ b/docs/operations/cgroups.md
@@ -30,11 +30,6 @@ kube_memory_reserved: 256Mi
 kube_cpu_reserved: 100m
 # kube_ephemeral_storage_reserved: 2Gi
 # kube_pid_reserved: "1000"
-# Reservation for master hosts
-kube_master_memory_reserved: 512Mi
-kube_master_cpu_reserved: 200m
-# kube_master_ephemeral_storage_reserved: 2Gi
-# kube_master_pid_reserved: "1000"
 
 # Set to true to reserve resources for system daemons
 system_reserved: true
@@ -44,11 +39,6 @@ system_memory_reserved: 512Mi
 system_cpu_reserved: 500m
 # system_ephemeral_storage_reserved: 2Gi
 # system_pid_reserved: "1000"
-# Reservation for master hosts
-system_master_memory_reserved: 256Mi
-system_master_cpu_reserved: 250m
-# system_master_ephemeral_storage_reserved: 2Gi
-# system_master_pid_reserved: "1000"
 ```
 
 After the setup, the cgroups hierarchy is as follows:


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Those variables are removed since 1bc61c9f3 (Simplify kubelet-config
template, 2023-11-23), removing them from docs as well.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/label ci-short

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
