### PR TITLE
Fix template syntax for cilium-values.yaml when encryption is enabled

### DIFF
--- a/roles/network_plugin/cilium/templates/values.yaml.j2
+++ b/roles/network_plugin/cilium/templates/values.yaml.j2
@@ -60,12 +60,11 @@ ipv6NativeRoutingCIDR: {{ cilium_native_routing_cidr_ipv6 }}
 
 encryption:
   enabled: {{ cilium_encryption_enabled }}
-  {% if cilium_encryption_enabled %}
+  {% if cilium_encryption_enabled -%}
   type: {{ cilium_encryption_type }}
-  {% if cilium_encryption_type == 'wireguard' %}
+  {% if cilium_encryption_type == 'wireguard' -%}
   nodeEncryption: {{ cilium_encryption_node_encryption }}
-  {% endif %}
-
+  {% endif -%}
   {% endif %}
 
 bandwidthManager:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Fixes this YAML syntax error in /etc/kubernetes/cilium-values.yaml that causes Cilium installation failing.

```
TASK [kubernetes_sigs.kubespray.network_plugin/cilium : Cilium | Install] *************************************************************************
fatal: [k8ststmaster-1]: FAILED! => {"changed": true, "cmd": ["/usr/local/bin/cilium", "install", "--version", "1.17.4", "-f", "/etc/kubernetes/cilium-values.yaml"], "delta": "0:00:00.104647", "end": "2025-05-21 15:04:12.720005", "msg": "non-zero return code", "rc": 1, "start": "2025-05-21 15:04:12.615358", "stderr": "\nError: Unable to install Cilium: failed to parse /etc/kubernetes/cilium-values.yaml: error converting YAML to JSON: yaml: line 62: mapping values are not allowed in this context", "stderr_lines": ["", "Error: Unable to install Cilium: failed to parse /etc/kubernetes/cilium-values.yaml: error converting YAML to JSON: yaml: line 62: mapping values are not allowed in this context"], "stdout": "", "stdout_lines": []}
```

**Which issue(s) this PR fixes**:

No existing issue found. The bug had been introduced last month, April 1st

**Special notes for your reviewer**:

Tested on my cluster.  Works fine.

Before my fix - this YAML syntax is wrong because of indentation : 
```yaml
encryption:
  enabled: True
    type: wireguard
    nodeEncryption: False
```

After my fix : 
```yaml
encryption:
  enabled: True
  type: wireguard
  nodeEncryption: False
```

**Does this PR introduce a user-facing change?**:

NONE

```release-note
Fix syntax in cilium-values.yaml when encryption is enabled, that made Cilium fail to install
```
