### PR TITLE
Cleanup assert after 2.28

### DIFF
--- a/roles/validate_inventory/tasks/main.yml
+++ b/roles/validate_inventory/tasks/main.yml
@@ -2,59 +2,6 @@
 # This should only contains check of the inventory itself, nothing depending on facts
 # Checks depending on current state (of the nodes or the cluster)
 # should be in roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
-- name: Stop if some versions have a 'v' left at the start
-  # TODO: drop this task after 2.28.0 is released
-  # The 'not defined' tests are exception for applications which version in not defined
-  # in kubespray_defaults, only in their own roles.
-  assert:
-    msg: |
-      All version string used in kubespray have been normalized to not use a leading 'v'.
-      This check will be dropped in the next minor release.
-    that:
-      - argocd_version is not defined or not argocd_version.startswith('v')
-      - not aws_ebs_csi_plugin_version.startswith('v')
-      - not azure_csi_plugin_version.startswith('v')
-      - not calico_version.startswith('v')
-      - not calico_apiserver_version.startswith('v')
-      - not calico_ctl_version.startswith('v')
-      - not calico_typha_version.startswith('v')
-      - not cert_manager_version.startswith('v')
-      - not cilium_cli_version.startswith('v')
-      - not cilium_version.startswith('v')
-      - not cinder_csi_plugin_version.startswith('v')
-      - not cni_version.startswith('v')
-      - not dnsautoscaler_version.startswith('v')
-      - not flannel_cni_version.startswith('v')
-      - not flannel_version.startswith('v')
-      - gateway_api_version is not defined or not gateway_api_version.startswith('v')
-      - not gcp_pd_csi_plugin_version.startswith('v')
-      - not helm_version.startswith('v')
-      - not kube_ovn_version.startswith('v')
-      - not kube_router_version.startswith('v')
-      - not kube_version.startswith('v')
-      - kube_vip_version is not defined or not kube_vip_version.startswith('v')
-      - not local_path_provisioner_version.startswith('v')
-      - not local_volume_provisioner_version.startswith('v')
-      - not metallb_version.startswith('v')
-      - not metrics_server_version.startswith('v')
-      - not multus_version.startswith('v')
-      - not netcheck_version.startswith('v')
-      - not runc_version.startswith('v')
-      - not skopeo_version.startswith('v')
-      - not yq_version.startswith('v')
-
-- name: Stop if some derived versions have a 'v' left at the start
-  # TODO: drop this task after 2.28.0 is released
-  # The 'not defined' tests are exception for applications which version in not defined
-  # in kubespray_defaults, only in their own roles.
-  assert:
-    msg: |
-      All version string used in kubespray have been normalized to not use a leading 'v'.
-      This check will be dropped in the next minor release.
-    that:
-      - not etcd_version.startswith('v')
-      - not pod_infra_version.startswith('v')
-
 - name: Stop if kube_control_plane group is empty
   assert:
     that: groups.get( 'kube_control_plane' )
@@ -224,15 +171,6 @@
     msg: "WARNING! => `enable_dual_stack_networks` deprecation. Please switch to using ipv4_stack and ipv6_stack."
   when:
     - enable_dual_stack_networks is defined
-
-# TODO: Clean this task up after 2.28 is released
-- name: Stop if etcd_kubeadm_enabled is defined
-  run_once: true
-  assert:
-    that: etcd_kubeadm_enabled is not defined
-    msg: |
-      `etcd_kubeadm_enabled` is removed.
-       You can set `etcd_deployment_type` to `kubeadm` instead of setting `etcd_kubeadm_enabled` to `true`."
 
 - name: Stop if download_localhost is enabled but download_run_once is not
   assert:


### PR DESCRIPTION
Users should have used 2.28 and adapted their inventories now.
**What type of PR is this?**
/kind cleanup
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
