### PR TITLE
feature: containerd_extra_runtime_args

### DIFF
--- a/docs/CRI/containerd.md
+++ b/docs/CRI/containerd.md
@@ -114,6 +114,16 @@ containerd_runc_runtime:
   ...
 ```
 
+The `containerd_extra_runtime_args` variable allows you to inject additional configuration options into the containerd CRI runtime plugin section (`[plugins."io.containerd.cri.v1.runtime"]`) without modifying Kubespray's core template files.
+
+This is useful for adding containerd runtime configuration options that aren't explicitly supported by Kubespray's default variables.
+
+```yaml
+containerd_extra_runtime_args: |
+  device_ownership_from_security_context = true
+  restrict_oom_score_adj = true
+```
+
 Config insecure-registry access to self hosted registries.
 
 ```yaml

--- a/docs/CRI/containerd.md
+++ b/docs/CRI/containerd.md
@@ -114,14 +114,13 @@ containerd_runc_runtime:
   ...
 ```
 
-The `containerd_extra_runtime_args` variable allows you to inject additional configuration options into the containerd CRI runtime plugin section (`[plugins."io.containerd.cri.v1.runtime"]`) without modifying Kubespray's core template files.
+The `containerd_extra_runtime_args` variable allows you to inject additional configuration options into the containerd CRI runtime plugin section (`[plugins."io.containerd.cri.v1.runtime"]`).
 
 This is useful for adding containerd runtime configuration options that aren't explicitly supported by Kubespray's default variables.
 
 ```yaml
 containerd_extra_runtime_args: |
   device_ownership_from_security_context = true
-  restrict_oom_score_adj = true
 ```
 
 Config insecure-registry access to self hosted registries.

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -36,6 +36,9 @@ oom_score = {{ containerd_oom_score }}
     enable_cdi = true
     cdi_spec_dirs = ["/etc/cdi", "/var/run/cdi"]
 {% endif %}
+{% if containerd_extra_runtime_args is defined %}
+    {{ containerd_extra_runtime_args }}
+{% endif %}
 
    [plugins."io.containerd.cri.v1.runtime".containerd]
      default_runtime_name = "{{ containerd_default_runtime }}"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds support for the `containerd_extra_runtime_args` variable, which allows users to inject additional runtime configuration options into the containerd CRI plugin section (`[plugins."io.containerd.cri.v1.runtime"]`).

This enhancement provides flexibility for users who need to configure containerd runtime options that aren't explicitly supported by Kubespray's existing variables, such as `device_ownership_from_security_context`  or other containerd CRI runtime settings.

**Special notes for your reviewer**:

- The variable is injected into the `[plugins."io.containerd.cri.v1.runtime"]` section of the containerd configuration
- Documentation has been added explaining the usage and providing examples
- The implementation follows the same pattern as existing `containerd_extra_args` variable

**Does this PR introduce a user-facing change?**:
- no

**release-note**
Add support for `containerd_extra_runtime_args` variable to allow injection of additional runtime configuration options into containerd CRI plugin section.
