### PR TITLE
Feat: add nftable mode in calico

### DIFF
--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -275,6 +275,8 @@ spec:
             # Enable or disable usage report
             - name: FELIX_USAGEREPORTINGENABLED
               value: "{{ calico_usage_reporting }}"
+            - name: FELIX_NFTABLESMODE
+              value: "{{ calico_nftable_mode }}"
             # Set MTU for tunnel device used if ipip is enabled
 {% if calico_mtu is defined %}
             # Set MTU for tunnel device used if ipip is enabled

--- a/roles/network_plugin/calico_defaults/defaults/main.yml
+++ b/roles/network_plugin/calico_defaults/defaults/main.yml
@@ -101,6 +101,10 @@ calico_iptables_lock_timeout_secs: 10
 # Choose Calico iptables backend: "Legacy", "Auto" or "NFT" (FELIX_IPTABLESBACKEND)
 calico_iptables_backend: "Auto"
 
+# Calico NFTable Mode Support
+# Valid option: Disabled (default), Enabled (when kube_proxy_mode is set "nftable")
+calico_nftable_mode: "{{ 'Enabled' if kube_proxy_mode == 'nftable' else 'Disabled' }}"
+
 # Calico Wireguard support
 calico_wireguard_enabled: false
 calico_wireguard_packages: []


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Calico supports nftable when `kube_proxy_mode` is set to `nftable`.

**Which issue(s) this PR fixes**:

Fixes #12198

**Does this PR introduce a user-facing change?**:

```release-note
Calico supports nftable mode
```
