### PR TITLE
fix unquoted san cert causing issues with ips

### DIFF
--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
@@ -294,7 +294,7 @@ apiServer:
 {% endif %}
   certSANs:
 {% for san in apiserver_sans %}
-  - {{ san }}
+  - "{{ san }}"
 {% endfor %}
   timeoutForControlPlane: 5m0s
 controllerManager:

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
@@ -356,7 +356,7 @@ apiServer:
 {% endif %}
   certSANs:
 {% for san in apiserver_sans %}
-  - {{ san }}
+  - "{{ san }}"
 {% endfor %}
 controllerManager:
   extraArgs:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR resolves a bug where `kubeadm config validate` would fail during control plane setup, specifically when IP addresses were included as **Subject Alternative Names (SANs)** for the API server certificate. The issue arose because the Jinja2 template was rendering these IP addresses without quotes, causing them to be misinterpreted as numerical values by `kubeadm`'s Go YAML unmarshaler. This type mismatch would lead to a `json: cannot unmarshal number into Go struct field ... of type string` error during the validation step.

The fix involves explicitly **enclosing the `{{ san }}` variable in double quotes** within the `apiServer.certSANs` section of the `kubeadm-config.v1betaX.yaml.j2` template. This ensures that all SAN entries are correctly interpreted as strings, aligning this particular field's handling with how other similar list items (like `etcd.serverCertSANs` and `etcd.peerCertSANs`) are already properly quoted in the same template. This consistency resolves the validation error, allowing `kubeadm` to correctly process the configuration and generate the API server certificate with the specified SANs.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This change is applied to the `apiServer.certSANs` section within the `kubeadm-config.v1betaX.yaml.j2` template. It corrects an existing aberration, bringing the rendering behavior of `apiServer.certSANs` in line with other `certSANs` list types within the same file (e.g., those for `etcd`), which already correctly quote their elements. This is a targeted fix to ensure robust `kubeadm` configuration validation, especially when using IP addresses as API server SANs.

**Does this PR introduce a user-facing change?**:
```NONE```