### PR TITLE
Fixed syntax error in _bgp_config dict

### DIFF
--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -353,7 +353,7 @@
               {% if not calico_no_global_as_num | default(false) %}"asNumber": {{ global_as_num }},{% endif %}
               "nodeToNodeMeshEnabled": {{ nodeToNodeMeshEnabled | default('true') }} ,
               {% if calico_advertise_cluster_ips | default(false) %}
-              "serviceClusterIPs": >-
+              "serviceClusterIPs":
                 {%- if ipv4_stack and ipv6_stack-%}
                 [{"cidr": "{{ kube_service_addresses }}", "cidr": "{{ kube_service_addresses_ipv6 }}"}],
                 {%- elif ipv6_stack-%}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes a syntax error that made the `_bgp_config` an `AnsibleUnsafeText` instead of a `dict`.
```
TASK [network_plugin/calico : Calico | Process BGP Configuration]
fatal: [node1]: FAILED! => {"msg": "failed to combine variables, expected dicts but got a 'dict' and a 'AnsibleUnsafeText':
```

**Which issue(s) this PR fixes**:
Before the fix:
```
"_bgp_config": "{\n  \"kind\": \"BGPConfiguration\",\n  \"apiVersion\": \"projectcalico.org/v3\",\n  \"metadata\": {\n    \"name\": \"default\",\n  },\n  \"spec\": {\n    \"listenPort\": 179,\n    \"logSeverityScreen\": \"Info\",\n    \"asNumber\": 64512,    \"nodeToNodeMeshEnabled\": False ,\n        \"serviceClusterIPs\": >-[{\"cidr\": \"10.233.0.0/18\"}],    \"serviceLoadBalancerIPs\": [{'cidr': '172.16.8.0/24'}],    \"serviceExternalIPs\": []\n  }\n}\n"
```
After the fix:
```
"_bgp_config": {
    "apiVersion": "projectcalico.org/v3",
    "kind": "BGPConfiguration",
    "metadata": {
        "name": "default"
    },
    "spec": {
        "asNumber": 64512,
        "listenPort": 179,
        "logSeverityScreen": "Info",
        "nodeToNodeMeshEnabled": false,
        "serviceClusterIPs": [
            {
                "cidr": "10.233.0.0/18"
            }
        ],
        "serviceExternalIPs": [],
        "serviceLoadBalancerIPs": [
            {
                "cidr": "172.16.8.0/24"
            }
        ]
    }
}
```

**Special notes for your reviewer**:
The playbook finished without errors when I ran it locally after the fix

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixes a syntax error that made the '_bgp_config' an 'AnsibleUnsafeText' instead of a 'dict', which caused the "Calico | Process BGP Configuration" step to fail
```
