### PR TITLE
feat: Add cilium_install_extra_flags

### DIFF
--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -355,3 +355,6 @@ cilium_certgen_args:
 
 cilium_enable_host_firewall: false
 cilium_policy_audit_mode: false
+
+# Cilium extra install flags
+cilium_install_extra_flags: ""

--- a/roles/network_plugin/cilium/tasks/apply.yml
+++ b/roles/network_plugin/cilium/tasks/apply.yml
@@ -11,7 +11,7 @@
     cilium_action: "{{ 'install' if ('release: not found' in cilium_release_info.stderr | default('') or 'release: not found' in cilium_release_info.stdout | default('')) else 'upgrade' }}"
 
 - name: Cilium | Install
-  command: "{{ bin_dir }}/cilium {{ cilium_action }} --version {{ cilium_version }} -f {{ kube_config_dir }}/cilium-values.yaml"
+  command: "{{ bin_dir }}/cilium {{ cilium_action }} --version {{ cilium_version }} -f {{ kube_config_dir }}/cilium-values.yaml {{ cilium_install_extra_flags }}"
   when: inventory_hostname == groups['kube_control_plane'][0]
 
 - name: Cilium | Wait for pods to run


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add `cilium_install_extra_flags` variable for `cilium install` command.

This enables to use such as `--chart-directory` or `--repository` option to enable offline installation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Add cilium_install_extra_flags variable
```
