### PR TITLE
Do not pick the control plane/etcd we are removing

### DIFF
--- a/roles/remove-node/post-remove/tasks/main.yml
+++ b/roles/remove-node/post-remove/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: Remove-node | Delete node
   command: "{{ kubectl }} delete node {{ kube_override_hostname | default(inventory_hostname) }}"
-  delegate_to: "{{ groups['kube_control_plane'] | first }}"
+  delegate_to: "{{ groups['kube_control_plane'] | community.general.lists_difference(node) | first }}"
   when:
-    - groups['kube_control_plane'] | length > 0
+    - groups['kube_control_plane'] | community.general.lists_difference(node) | length > 0
     # ignore servers that are not nodes
     - ('k8s_cluster' in group_names) and kube_override_hostname | default(inventory_hostname) in nodes.stdout_lines
   retries: "{{ delete_node_retries }}"

--- a/roles/remove-node/remove-etcd-node/tasks/main.yml
+++ b/roles/remove-node/remove-etcd-node/tasks/main.yml
@@ -16,7 +16,7 @@
     ETCDCTL_KEY: "{{ kube_cert_dir + '/etcd/server.key' if etcd_deployment_type == 'kubeadm' else etcd_cert_dir + '/admin-' + groups['etcd'] | first + '-key.pem' }}"
     ETCDCTL_CACERT: "{{ kube_cert_dir + '/etcd/ca.crt' if etcd_deployment_type == 'kubeadm' else etcd_cert_dir + '/ca.pem' }}"
     ETCDCTL_ENDPOINTS: "https://127.0.0.1:2379"
-  delegate_to: "{{ groups['etcd'] | first }}"
+  delegate_to: "{{ groups['etcd'] | community.general.lists_difference(node) | first }}"
   block:
   - name: Lookup members infos
     command: "{{ bin_dir }}/etcdctl member list"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When removing the first control plane or etcd node kubespray will try to run the removal operations on the node you are removing. There's a special section in the [docs](https://github.com/kubernetes-sigs/kubespray/blob/4dbfd42f1dfdcc8c10d6765bdd66b1a9f7acdde5/docs/operations/nodes.md#replacing-a-first-control-plane-node) stating you should re-arrange the nodes in the inventory before attempting to remove the first node.

This can be avoided by removing the node we are about to remove from the list using the difference filter.
This is particularly useful when someone is utilizing dynamic inventory plugins where's the no way to influence the order of the nodes in the resulting inventory.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

**Special notes for your reviewer**:
I used the `community.general.lists_difference` filter instead of the builtin `difference` filter because the latter doesn't not [guarantee the items order](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/difference_filter.html#:~:text=Items%20in%20the%20resulting%20list%20are%20returned%20in%20arbitrary%20order.). I think we can use the builtin filter as well.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Do not pick the control plane/etcd node we are removing
```
