### PR TITLE
openstack : add the external_openstack_lbaas_member_subnet_id variable

### DIFF
--- a/docs/cloud_controllers/openstack.md
+++ b/docs/cloud_controllers/openstack.md
@@ -73,6 +73,7 @@ The cloud provider is configured to have Octavia by default in Kubespray.
   external_openstack_lbaas_method: ROUND_ROBIN
   external_openstack_lbaas_provider: amphora
   external_openstack_lbaas_subnet_id: "Neutron subnet ID to create LBaaS VIP"
+  external_openstack_lbaas_member_subnet_id: "Neutron subnet ID on which to create the members of the load balancer"
   external_openstack_lbaas_network_id: "Neutron network ID to create LBaaS VIP"
   external_openstack_lbaas_manage_security_groups: false
   external_openstack_lbaas_create_monitor: false

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/defaults/main.yml
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/defaults/main.yml
@@ -24,3 +24,5 @@ external_openstack_cloud_controller_extra_args: {}
 external_openstack_cloud_controller_image_tag: "v1.32.0"
 external_openstack_cloud_controller_bind_address: 127.0.0.1
 external_openstack_cloud_controller_dns_policy: ClusterFirst
+
+external_openstack_lbaas_member_subnet_id: "{{ external_openstack_lbaas_subnet_id }}"

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
@@ -45,6 +45,7 @@ lb-provider={{ external_openstack_lbaas_provider }}
 {% endif %}
 {% if external_openstack_lbaas_subnet_id is defined %}
 subnet-id={{ external_openstack_lbaas_subnet_id }}
+member-subnet-id={{ external_openstack_lbaas_member_subnet_id }}
 {% endif %}
 {% if external_openstack_lbaas_network_id is defined %}
 network-id={{ external_openstack_lbaas_network_id }}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
It adds the variable `external_openstack_lbaas_member_subnet_id` which is used to define `member-subnet-id` in the file `roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2`

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Add external_openstack_lbaas_member_subnet_id: str  (not set by default), to define a specific `member-subnet-id` for the openstack load balancers
```
