### PR TITLE
feat: Support certificate validity period config in kubeadm v1beta4

### DIFF
--- a/roles/kubernetes/control-plane/defaults/main/main.yml
+++ b/roles/kubernetes/control-plane/defaults/main/main.yml
@@ -255,3 +255,9 @@ kubeadm_image_pull_serial: true
 # can be one of RSA-2048(default), RSA-3072, RSA-4096, ECDSA-P256
 # ref: https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta4/#kubeadm-k8s-io-v1beta4-ClusterConfiguration
 kube_asymmetric_encryption_algorithm: "RSA-2048"
+
+# certificates validity period configuration
+# non-CA certificate validity period, default 1 year (365d × 24h = 8760h)
+kube_cert_validity_period: 8760h
+# CA certificate validity period, default 10 years (365d × 24h × 10 = 87600h)
+kube_ca_cert_validity_period: 87600h

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
@@ -40,6 +40,8 @@ apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
 clusterName: {{ cluster_name }}
 encryptionAlgorithm: {{ kube_asymmetric_encryption_algorithm }}
+certificateValidityPeriod: {{ kube_cert_validity_period }}
+caCertificateValidityPeriod: {{ kube_ca_cert_validity_period }}
 etcd:
 {% if etcd_deployment_type != "kubeadm" %}
   external:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add support for configuring certificate validity periods with kubeadm v1beta4 API.

Kubernetes 1.31 introduced [two new fields](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/#choosing-cert-validity-period) in kubeadm's ClusterConfiguration:
* certificateValidityPeriod: For standard certificates (default: 8760h/1y)
* caCertificateValidityPeriod: For CA certificates (default: 87600h/10y)

This PR adds default values for these parameters to allow users to customize certificate expiration periods, reducing certificate renewal frequency.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
feat: Support certificate validity period config in kubeadm v1beta4
```
