### PR TITLE
Fix: missing directory when run with download_run_once

### DIFF
--- a/roles/download/tasks/prep_download.yml
+++ b/roles/download/tasks/prep_download.yml
@@ -84,7 +84,6 @@
   delegate_facts: false
   run_once: true
   become: false
-  when:
-    - download_force_cache
+  when: download_force_cache or download_run_once
   tags:
     - localhost


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #12274

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
