### PR TITLE
fix: GatewayAPI installation, condition not satisfied when role called with delegate_to and run_once

### DIFF
--- a/roles/kubernetes-apps/gateway_api/tasks/main.yml
+++ b/roles/kubernetes-apps/gateway_api/tasks/main.yml
@@ -11,8 +11,6 @@
     owner: root
     group: root
     mode: "0755"
-  when:
-    - inventory_hostname == groups['kube_control_plane'][0]
 
 - name: Gateway API | Copy YAML from download dir
   copy:
@@ -20,8 +18,6 @@
     dest: "{{ kube_config_dir }}/addons/gateway_api/{{ gateway_api_channel }}-install.yaml"
     mode: "0644"
     remote_src: true
-  when:
-    - "inventory_hostname == groups['kube_control_plane'][0]"
 
 - name: Gateway API | Install Gateway API
   kube:
@@ -29,5 +25,3 @@
     kubectl: "{{ bin_dir }}/kubectl"
     filename: "{{ kube_config_dir }}/addons/gateway_api/{{ gateway_api_channel }}-install.yaml"
     state: latest
-  when:
-    - "inventory_hostname == groups['kube_control_plane'][0]"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
GatewayAPI is not installed even when `gateway_api_enabled` is set to true

Following is the Root Cause:
* When `gateway_api_enabled` is set to true, GatewayAPI is installed using role `kubernetes-apps/gateway_api`
* Since Kubespray 2.28.0, the role is called with 
`delegate_to: "{{ groups['kube_control_plane'][0] }}"` i.e. first control plane node
`run_once: true` i.e., select `first host available` out of the nodes mentioned in `hosts` of the ansible task in which the role is called, and execute the role on that node
* the task `Invoke kubeadm and install a CNI`, in which role `kubernetes-apps/gateway_api` is called, has `hosts: k8s_cluster` (which has control plane+working nodes)
* When using `run_once`, `first host available` is selected (not necessarily the first control plane node) and the ansible variable `inventory_hostname` is set to that node
(In my case, it was the first worker node, though I did not explore in depth how exactly `k8s_cluster` is formed)
* Hence, the following condition is not met, and GatewayAPI is not installed even when `gateway_api_enabled` is set to true as the tasks were skipped
```
when:
  - inventory_hostname == groups['kube_control_plane'][0]
```

**Which issue(s) this PR fixes**:
I did not open any issue for this, nor could I find any open ones
I saw comments to the same effect in PR #12189 

**Special notes for your reviewer**:
* from https://docs.ansible.com/ansible/latest/reference_appendices/playbooks_keywords.html
`delegate_to`: Host to execute task instead of the target (inventory_hostname). Connection vars from the delegated host will also be used for the task.
`run_once`: Boolean that will bypass the host loop, forcing the task to attempt to execute on the first host available and afterward apply any results and facts to all active hosts in the same batch.
* Since, while calling the role, `delegate_to` already ensures that the first control plane node executes the task, irrespective of where the role runs (selected by `run_once`, different from delegate_to, an Ansible nuance it seems)
We do not need the `when` condition anyway

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
