### PR TITLE
Fix indentation issue in Cilium values file and ensure booleans are lowercase

### DIFF
--- a/roles/network_plugin/cilium/templates/values.yaml.j2
+++ b/roles/network_plugin/cilium/templates/values.yaml.j2
@@ -1,6 +1,7 @@
+#jinja2: trim_blocks: True, lstrip_blocks: True
 MTU: {{ cilium_mtu }}
 debug:
-  enabled: {{ cilium_debug }}
+  enabled: {{ cilium_debug | to_json }}
 
 image:
   repository: {{ cilium_image_repo }}
@@ -10,12 +11,12 @@ k8sServiceHost: "auto"
 k8sServicePort: "auto"
 
 ipv4:
-  enabled: {{ cilium_enable_ipv4 }}
+  enabled: {{ cilium_enable_ipv4 | to_json }}
 ipv6:
-  enabled: {{ cilium_enable_ipv6 }}
+  enabled: {{ cilium_enable_ipv6 | to_json }}
 
 l2announcements:
-  enabled: {{ cilium_l2announcements }}
+  enabled: {{ cilium_l2announcements | to_json }}
 
 healthPort: {{ cilium_agent_health_port }}
 
@@ -26,11 +27,11 @@ tunnelProtocol: {{ cilium_tunnel_mode }}
 loadbalancer:
   mode: {{ cilium_loadbalancer_mode }}
 
-kubeProxyReplacement: {{ cilium_kube_proxy_replacement }}
+kubeProxyReplacement: {{ cilium_kube_proxy_replacement | to_json }}
 
 {% if cilium_dns_proxy_enable_transparent_mode is defined %}
 dnsProxy:
-  enableTransparentMode: {{ cilium_dns_proxy_enable_transparent_mode }}
+  enableTransparentMode: {{ cilium_dns_proxy_enable_transparent_mode | to_json }}
 {% endif %}
 
 extraVolumes:
@@ -43,54 +44,53 @@ extraArgs:
   {{ cilium_agent_extra_args | to_nice_yaml(indent=2) | indent(2) }}
 
 bpf:
-  masquerade: {{ cilium_enable_bpf_masquerade }}
-  hostLegacyRouting: {{ cilium_enable_host_legacy_routing }}
+  masquerade: {{ cilium_enable_bpf_masquerade | to_json }}
+  hostLegacyRouting: {{ cilium_enable_host_legacy_routing | to_json }}
   monitorAggregation: {{ cilium_monitor_aggregation }}
-  preallocateMaps: {{ cilium_preallocate_bpf_maps }}
+  preallocateMaps: {{ cilium_preallocate_bpf_maps | to_json }}
   mapDynamicSizeRatio: {{ cilium_bpf_map_dynamic_size_ratio }}
 
 cni:
-  exclusive: {{ cilium_cni_exclusive }}
+  exclusive: {{ cilium_cni_exclusive | to_json }}
   logFile: {{ cilium_cni_log_file }}
 
-autoDirectNodeRoutes: {{ cilium_auto_direct_node_routes }}
+autoDirectNodeRoutes: {{ cilium_auto_direct_node_routes | to_json }}
 
 ipv4NativeRoutingCIDR: {{ cilium_native_routing_cidr }}
 ipv6NativeRoutingCIDR: {{ cilium_native_routing_cidr_ipv6 }}
 
 encryption:
-  enabled: {{ cilium_encryption_enabled }}
-  {% if cilium_encryption_enabled %}
+  enabled: {{ cilium_encryption_enabled | to_json }}
+{% if cilium_encryption_enabled %}
   type: {{ cilium_encryption_type }}
-  {% if cilium_encryption_type == 'wireguard' %}
-  nodeEncryption: {{ cilium_encryption_node_encryption }}
-  {% endif %}
-
-  {% endif %}
+{% if cilium_encryption_type == 'wireguard' %}
+  nodeEncryption: {{ cilium_encryption_node_encryption | to_json }}
+{% endif %}
+{% endif %}
 
 bandwidthManager:
-  enabled: {{ cilium_enable_bandwidth_manager }}
-  bbr: {{ cilium_enable_bandwidth_manager_bbr }}
+  enabled: {{ cilium_enable_bandwidth_manager | to_json }}
+  bbr: {{ cilium_enable_bandwidth_manager_bbr | to_json }}
 
 ipMasqAgent:
-  enabled: {{ cilium_ip_masq_agent_enable }}
-  {% if cilium_ip_masq_agent_enable %}
+  enabled: {{ cilium_ip_masq_agent_enable | to_json }}
+{% if cilium_ip_masq_agent_enable %}
   config:
     nonMasqueradeCIDRs: {{ cilium_non_masquerade_cidrs }}
-    masqLinkLocal: {{ cilium_masq_link_local }}
-    masqLinkLocalIPv6: {{ cilium_masq_link_local_ipv6 }}
+    masqLinkLocal: {{ cilium_masq_link_local | to_json }}
+    masqLinkLocalIPv6: {{ cilium_masq_link_local_ipv6 | to_json }}
   # cilium_ip_masq_resync_interval
-  {% endif %}
+{% endif %}
 
 hubble:
-  enabled: {{ cilium_enable_hubble }}
+  enabled: {{ cilium_enable_hubble | to_json }}
   relay:
-    enabled: {{ cilium_enable_hubble }}
+    enabled: {{ cilium_enable_hubble | to_json }}
     image:
       repository: {{ cilium_hubble_relay_image_repo }}
       tag: {{ cilium_hubble_relay_image_tag }}
   ui:
-    enabled: {{ cilium_enable_hubble_ui }}
+    enabled: {{ cilium_enable_hubble_ui | to_json }}
     backend:
       image:
         repository: {{ cilium_hubble_ui_backend_image_repo }}
@@ -100,18 +100,18 @@ hubble:
         repository: {{ cilium_hubble_ui_image_repo }}
         tag: {{ cilium_hubble_ui_image_tag }}
   metrics:
-    enabled: {{ cilium_hubble_metrics }}
+    enabled: {{ cilium_hubble_metrics | to_json }}
   export:
     fileMaxBackups: {{ cilium_hubble_export_file_max_backups }}
     fileMaxSizeMb: {{ cilium_hubble_export_file_max_size_mb }}
     dynamic:
-      enabled: {{ cilium_hubble_export_dynamic_enabled }}
+      enabled: {{ cilium_hubble_export_dynamic_enabled | to_json }}
       config:
         content:
           {{ cilium_hubble_export_dynamic_config_content | to_nice_yaml(indent=10) | indent(10) }}
 
 gatewayAPI:
-  enabled: {{ cilium_gateway_api_enabled }}
+  enabled: {{ cilium_gateway_api_enabled | to_json }}
 
 ipam:
   mode: {{ cilium_ipam_mode }}
@@ -126,7 +126,7 @@ ipam:
 
 cgroup:
   autoMount:
-    enabled: {{ cilium_cgroup_auto_mount }}
+    enabled: {{ cilium_cgroup_auto_mount | to_json }}
   hostRoot: {{ cilium_cgroup_host_root }}
 
 operator:
@@ -147,11 +147,11 @@ cluster:
   id: {{ cilium_cluster_id }}
   name: {{ cilium_cluster_name }}
 
-enableIPv4Masquerade: {{ cilium_enable_ipv4_masquerade }}
-enableIPv6Masquerade: {{ cilium_enable_ipv6_masquerade }}
+enableIPv4Masquerade: {{ cilium_enable_ipv4_masquerade | to_json }}
+enableIPv6Masquerade: {{ cilium_enable_ipv6_masquerade | to_json }}
 
 hostFirewall:
-  enabled: {{ cilium_enable_host_firewall }}
+  enabled: {{ cilium_enable_host_firewall | to_json }}
 
 certgen:
   image:


### PR DESCRIPTION
This patch fixes the indentation in the `encryption` section. Previously configuration like this:

```yml
cilium_encryption_enabled: true
cilium_encryption_type: wireguard
```

Would template to a `values.yaml` file with indentation that looks like this:

```yml
encryption:
  enabled: True
    type: wireguard
    nodeEncryption: False
```

instead of this:

```yml
encryption:
  enabled: true
  type: wireguard
  nodeEncryption: false
```

This syntax issue causes an error during Cilium installation.

This patch also makes all boolean values in this template file to go through the `to_json` filter. Since values like `True` and `False` are not compliant with the YAML v1.2 spec, avoiding them is preferable.

`to_json` may be used for all other values in this template to ensure we end up with a valid YAML document in all cases (even when various strings include special characters), but this was left for another future patch.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

https://github.com/kubernetes-sigs/kubespray/pull/12101 (part of Kubespray v2.28.0) completely reworked the Cilium installation method, so people who were enabling encryption for Cilium (via `cilium_encryption_enabled: true` ..) would encounter errors during the `cilium install` command executed by the Kubespray playbook.


**Which issue(s) this PR fixes**:

No open issues about this yet, as far as I see.

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:
```release-note
Fix Cilium installation issues (caused by templating syntax errors) when certain non-default features (encryption, etc.) are enabled
```
