### PR TITLE
Add myself (tico88612) as approver

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,6 +2,7 @@ aliases:
   kubespray-approvers:
     - ant31
     - mzaian
+    - tico88612
     - vannten
     - yankay
   kubespray-reviewers:


### PR DESCRIPTION
I'm delighted to have been involved with Kubespray for 1 year (starting on Apr. 25, 2024), during which time I have also assisted with releases, application updates, and related tasks. I will continue to contribute to and review pull requests for the foreseeable future.

/cc @yankay @ant31 @mzaian @VannTen 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
