### PR TITLE
Do not choke if the `download_file` task is invoked without a checksum

### DIFF
--- a/roles/download/tasks/download_file.yml
+++ b/roles/download/tasks/download_file.yml
@@ -62,7 +62,7 @@
       dest: "{{ file_path_cached if download_force_cache else download.dest }}"
       owner: "{{ omit if download_localhost else (download.owner | default(omit)) }}"
       mode: "{{ omit if download_localhost else (download.mode | default(omit)) }}"
-      checksum: "{{ download.checksum }}"
+      checksum: "{{ download.checksum | default(omit) }}"
       validate_certs: "{{ download_validate_certs }}"
       url_username: "{{ download.username | default(omit) }}"
       url_password: "{{ download.password | default(omit) }}"


### PR DESCRIPTION
Previously (before 800c84dcc93fa98382064214645b45a68fd696e7), `download_file` tasks were invoked with a `sha256` (not a `checksum` parameter) and if not provided, downloads were done without verifying checksums.

That patch changed things (`sha256` -> `checksums`), but it seems like unintentionally also made `checksum` required (no more `omit` fallbacks). At least some invocations of `download_file` do not provide a `checksum`, as reported here (for the ArgoCD addon): https://github.com/kubernetes-sigs/kubespray/issues/12223

The failure behavior is also appaling, because the download task (which references `checksum`) has `no_log` enabled by default (via the `unsafe_show_logs` variable, defaulting to `false`), so users would see a failing download, but could not easily figure out that it's actually an "undefined variable" error.

While checksum support for ArgoCD is being added in https://github.com/kubernetes-sigs/kubespray/pull/12266 it's probably better to restore the ability to invoke `download_file` without `checksum`, so that:

- any other current no-`checksum` callers (like ArgoCD) would be instantly made to work again
- any future calls without `checksum` would work, and not choke silently (due to `no_log`)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind bug

**Which issue(s) this PR fixes**:
Fixes #12223

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
