### PR TITLE
fix: Use crun in the cri-o distribution and don't use crun role from …

### DIFF
--- a/roles/container-engine/cri-o/defaults/main.yml
+++ b/roles/container-engine/cri-o/defaults/main.yml
@@ -44,7 +44,7 @@ crio_root: "/var/lib/containers/storage"
 # The crio_runtimes variable defines a list of OCI compatible runtimes.
 crio_runtimes:
   - name: crun
-    path: "{{ crio_runtime_bin_dir }}/crun"
+    path: "{{ crio_runtime_bin_dir }}/crun"  # Use crun in cri-o distributions, don't use 'crun' role
     type: oci
     root: /run/crun
 

--- a/roles/container-engine/cri-o/meta/main.yml
+++ b/roles/container-engine/cri-o/meta/main.yml
@@ -1,5 +1,4 @@
 ---
 dependencies:
-  - role: container-engine/crun
   - role: container-engine/crictl
   - role: container-engine/skopeo


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The cri-o distribution uses a crun binary included in the cri-o distribution, and it does not use crun role anymore.

**Which issue(s) this PR fixes**:
Fixes #12250

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
