### PR TITLE
Fix calico CNI timeouts in reset role

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -8,8 +8,6 @@
     - kubelet.service
     - cri-dockerd.service
     - cri-dockerd.socket
-    - etcd.service
-    - etcd-events.service
   failed_when: false
   tags:
     - services
@@ -27,8 +25,6 @@
     - crio.service.d/http-proxy.conf
     - k8s-certs-renew.service
     - k8s-certs-renew.timer
-    - etcd.service
-    - etcd-events.service
   register: services_removed
   tags:
     - services
@@ -154,9 +150,39 @@
       file:
         path: /etc/systemd/system/containerd.service
         state: absent
-      register: services_removed
+      register: services_removed_containerd
       tags:
         - services
+
+- name: Reset | stop etcd services
+  service:
+    name: "{{ item }}"
+    state: stopped
+    enabled: false
+  with_items:
+    - etcd.service
+    - etcd-events.service
+  failed_when: false
+  tags:
+    - services
+
+- name: Reset | remove etcd services
+  file:
+    path: "/etc/systemd/system/{{ item }}"
+    state: absent
+  with_items:
+    - etcd.service
+    - etcd-events.service
+  register: services_removed_etcd
+  tags:
+    - services
+    - containerd
+    - crio
+
+- name: Reset | systemctl daemon-reload  # noqa no-handler
+  systemd_service:
+    daemon_reload: true
+  when: services_removed_etcd.changed or services_removed_containerd.changed
 
 - name: Reset | gather mounted kubelet dirs
   shell: set -o pipefail && mount | grep /var/lib/kubelet/ | awk '{print $3}' | tac

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -135,54 +135,36 @@
       ignore_errors: true  # noqa ignore-errors
       changed_when: true
 
-- name: Reset | remove containerd
-  when: container_manager == 'containerd'
-  block:
-    - name: Reset | stop containerd service
-      service:
-        name: containerd
-        state: stopped
-      failed_when: false
-      tags:
-        - services
-
-    - name: Reset | remove containerd service
-      file:
-        path: /etc/systemd/system/containerd.service
-        state: absent
-      register: services_removed_containerd
-      tags:
-        - services
-
-- name: Reset | stop etcd services
+- name: Reset | stop containerd and etcd services
   service:
     name: "{{ item }}"
     state: stopped
     enabled: false
   with_items:
+    - containerd.service
     - etcd.service
     - etcd-events.service
   failed_when: false
   tags:
     - services
 
-- name: Reset | remove etcd services
+- name: Reset | remove containerd and etcd services
   file:
     path: "/etc/systemd/system/{{ item }}"
     state: absent
   with_items:
+    - containerd.service
     - etcd.service
     - etcd-events.service
-  register: services_removed_etcd
+  register: services_removed_secondary
   tags:
     - services
     - containerd
-    - crio
 
 - name: Reset | systemctl daemon-reload  # noqa no-handler
   systemd_service:
     daemon_reload: true
-  when: services_removed_etcd.changed or services_removed_containerd.changed
+  when: services_removed_secondary.changed
 
 - name: Reset | gather mounted kubelet dirs
   shell: set -o pipefail && mount | grep /var/lib/kubelet/ | awk '{print $3}' | tac


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
### Problem
Kubespray's `reset` role currently sequences the removal of etcd before all of the pods, containers, and CNI interfaces are removed with `crictl`. The calico CNI plugin [depends on etcd and kube-apiserver](https://docs.tigera.io/calico/latest/reference/configure-cni-plugins#kubernetes-specific) for many of its operations.

When `crictl` attempts to stop and remove pods after etcd was removed in a cluster targeted by the `reset.yml` playbook, the `crictl` removal tasks will fail across every cluster node, and after reaching their max timeout the looped tasks fail again repeatedly on every stop and remove task loop iteration, adding many wasted minutes to the playbook execution as the timeouts will never succeed.

Error example:
```
FAILED - RETRYING: [nodename]: Reset | stop all cri pods (5 retries left).
...
FAILED - RETRYING: [nodename]: Reset | force remove all cri pods (5 retries left).
...
TASK [reset : Reset | force remove all cri pods] *******************************
fatal: [nodename]: FAILED! => changed=true 
  cmd: ip netns list | cut -d' ' -f 1 | xargs -n1 ip netns delete && /usr/local/bin/crictl rmp -a -f
  stderr: |-
    E0611 18:09:54.337357   35161 log.go:32] "RemovePodSandbox from runtime service failed" err="rpc error: code = Unknown desc = failed to forcibly stop sandbox \"<id>\": failed to destroy network for sandbox \"<id>\": plugin type=\"calico\" failed (delete): netplugin failed with no error message: signal: killed" podSandboxID="<id>"
    removing the pod sandbox "<id>": rpc error: code = Unknown desc = failed to forcibly stop sandbox "<id>": failed to destroy network for sandbox "<id>": plugin type="calico" failed (delete): netplugin failed with no error message: signal: killed
...
...ignoring
...
```

Introduced by PR #10902
Related: 
- https://github.com/containerd/containerd/issues/6565
- #7177


### Solution
This change fixes the issue by resequencing the etcd teardown tasks after container and container engine removal, which ensures successful removal without timeouts for the tasks that depend on kube-apiserver and/or etcd availability. Cluster deletes via `reset.yml` take less than a minute instead of 10+ minutes based on my testing with a 4 node cluster as it no longer has to wait for any looping timeouts.

An additional `daemon-reload` task was also added to reload as needed after the second batch of removed services (containerd and etcd).

**Which issue(s) this PR fixes**:
Fixes #12054


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fixed a looping timeout bug when deleting an entire cluster
```
