### PR TITLE
CI: replace kaniko with buildkit

### DIFF
--- a/.gitlab-ci/build.yml
+++ b/.gitlab-ci/build.yml
@@ -7,23 +7,24 @@ pipeline-image:
   tags:
     - ffci
   stage: build
-  image:
-    name: gcr.io/kaniko-project/executor:debug
-    entrypoint: ['']
+  image: moby/buildkit:rootless
   variables:
-    GODEBUG: "http2client=0"
+    BUILDKITD_FLAGS: --oci-worker-no-process-sandbox
+    CACHE_IMAGE: $CI_REGISTRY_IMAGE/pipeline:cache
   # TODO: remove the override
   # currently rebase.sh depends on bash (not available in the kaniko image)
   # once we have a simpler rebase (which should be easy if the target branch ref is available as variable
   # we'll be able to rebase here as well hopefully
-  before_script: []
+  before_script:
+    - mkdir -p ~/.docker
+    - echo "{\"auths\":{\"$CI_REGISTRY\":{\"auth\":\"$(echo -n ${CI_REGISTRY_USER}:${CI_REGISTRY_PASSWORD} | base64)\"}}}" > ~/.docker/config.json
   script:
-    - echo "{\"auths\":{\"$CI_REGISTRY\":{\"auth\":\"$(echo -n ${CI_REGISTRY_USER}:${CI_REGISTRY_PASSWORD} | base64)\"}}}" > /kaniko/.docker/config.json
-    - /kaniko/executor --cache=true
-                       --cache-dir=image-cache
-                       --context $CI_PROJECT_DIR
-                       --dockerfile $CI_PROJECT_DIR/pipeline.Dockerfile
-                       --label 'git-branch'=$CI_COMMIT_REF_SLUG
-                       --label 'git-tag=$CI_COMMIT_TAG'
-                       --destination $PIPELINE_IMAGE
-                       --log-timestamp=true
+    - |
+      buildctl-daemonless.sh build \
+        --frontend dockerfile.v0 \
+        --local context=$CI_PROJECT_DIR \
+        --local dockerfile=$CI_PROJECT_DIR \
+        --opt filename=pipeline.Dockerfile \
+        --export-cache type=registry,ref=$CACHE_IMAGE \
+        --import-cache type=registry,ref=$CACHE_IMAGE \
+        --output type=image,name=$PIPELINE_IMAGE,push=true


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The Kaniko project was deprecated; we should remove it.

**Which issue(s) this PR fixes**:

Fixes #12304 

**Special notes for your reviewer**:

PR #11292 seems to have tried, but ultimately failed. Let's give it another chance.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
