### PR TITLE
Skip kube-proxy addon phase during kubeadm upgrade if disabled

### DIFF
--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -170,6 +170,7 @@
     - apiserver_sans_ip_check.changed or apiserver_sans_host_check.changed
     - not kube_external_ca_mode
 
+  # TODO: Remove --skip-phases from command when v1beta4 UpgradeConfiguration supports skipPhases
 - name: Kubeadm | Initialize first control plane node
   when: inventory_hostname == first_kube_control_plane and not kubeadm_already_run.stat.exists
   vars:

--- a/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
@@ -3,6 +3,7 @@
   import_tasks: check-api.yml
 
   # kubeadm-config.v1beta4 with UpgradeConfiguration requires some values that were previously allowed as args to be specified in the config file
+  # TODO: Remove --skip-phases from command when v1beta4 UpgradeConfiguration supports skipPhases
 - name: Kubeadm | Upgrade first control plane node
   command: >-
     timeout -k 600s 600s
@@ -16,13 +17,15 @@
     --force
     {%- else %}
     --config={{ kube_config_dir }}/kubeadm-config.yaml
-    {%- endif -%}
+    {%- endif %}
+    --skip-phases={{ kubeadm_init_phases_skip | join(',') }}
   register: kubeadm_upgrade
   when: inventory_hostname == first_kube_control_plane
   failed_when: kubeadm_upgrade.rc != 0 and "field is immutable" not in kubeadm_upgrade.stderr
   environment:
     PATH: "{{ bin_dir }}:{{ ansible_env.PATH }}"
 
+  # TODO: Remove --skip-phases from command when v1beta4 UpgradeConfiguration supports skipPhases
 - name: Kubeadm | Upgrade other control plane nodes
   command: >-
     {{ bin_dir }}/kubeadm upgrade node
@@ -33,7 +36,8 @@
     {% if kubeadm_patches | length > 0 %}--patches={{ kubeadm_patches_dir }}{% endif %}
     {%- else %}
     --config={{ kube_config_dir }}/kubeadm-config.yaml
-    {%- endif -%}
+    {%- endif %}
+    --skip-phases={{ kubeadm_init_phases_skip | join(',') }}
   register: kubeadm_upgrade
   when: inventory_hostname != first_kube_control_plane
   failed_when: kubeadm_upgrade.rc != 0 and "field is immutable" not in kubeadm_upgrade.stderr

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
@@ -496,6 +496,12 @@ apply:
 {% endif %}
   imagePullPolicy: {{ k8s_image_pull_policy }}
   imagePullSerial: {{ kubeadm_image_pull_serial | lower }}
+{% for skip_phase in kubeadm_init_phases_skip %}
+{% if loop.first %}
+  skipPhases:
+{% endif %}
+  - "{{ skip_phase }}"
+{% endfor %}
 node:
   certificateRenewal: {{ kubeadm_upgrade_auto_cert_renewal | lower }}
   etcdUpgrade: {{ (etcd_deployment_type == "kubeadm") | lower }}
@@ -511,6 +517,12 @@ node:
 {% endif %}
   imagePullPolicy: {{ k8s_image_pull_policy }}
   imagePullSerial: {{ kubeadm_image_pull_serial | lower }}
+{% for skip_phase in kubeadm_init_phases_skip %}
+{% if loop.first %}
+  skipPhases:
+{% endif %}
+  - "{{ skip_phase }}"
+{% endfor %}
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

v2.28.0 tag introduced a bug that deploys `kube-proxy` when it should be disabled.
It can be explicitly disabled via `kube_proxy_remove: true` in group variables or if CNI like `kube-router` is used.
Kubespray automatically calculates the list of disabled addons into `kubeadm_init_phases_skip` variable. This variable should be applied during upgrade procedure in the `kubernetes/control-plane` role which substantially changed in v2.28.0.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12303 

**Special notes for your reviewer**:

Checked command options for [kubeadm upgrade apply](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-upgrade/#cmd-upgrade-apply) and [kubeadm upgrade node](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-upgrade/#cmd-upgrade-node)
Tested on environment specified in #12303 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
