### PR TITLE
CI: Run vagrant validate on master as well

### DIFF
--- a/.gitlab-ci/lint.yml
+++ b/.gitlab-ci/lint.yml
@@ -23,4 +23,3 @@ vagrant-validate:
     VAGRANT_VERSION: 2.3.7
   script:
   - ./tests/scripts/vagrant-validate.sh
-  except: ['triggers', 'master']


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Not really a reason not to, and this actually breaks daily-ci because
some jobs depends on this one so the whole pipeline is invalid if it's
not created.


**Which issue(s) this PR fixes**:
Fixes #

https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/pipelines/1870217160

**Special notes for your reviewer**:
/label ci-short


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
