### PR TITLE
Change failure condition for image container download

### DIFF
--- a/roles/download/tasks/download_container.yml
+++ b/roles/download/tasks/download_container.yml
@@ -74,7 +74,6 @@
       delegate_to: "{{ download_delegate }}"
       delegate_facts: false
       register: container_save_status
-      failed_when: container_save_status.stderr
       run_once: true
       become: "{{ user_can_become_root | default(false) or not download_localhost }}"
       when:


### PR DESCRIPTION
When installing with `download_run_once`, nerdctl will log to stderr and cause a failure even if the image was saved successfully.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
When installing with `download_run_once`, nerdctl will log to stderr and cause a failure even if the image was saved successfully.

```
fatal: [whitemist-node-0]: FAILED! => {"changed": true, "cmd": "/usr/local/bin/nerdctl -n [k8s.io](http://k8s.io/) image save -o /tmp/releases/images/registry.k8s.io_coredns_coredns_v1.11.3.tar [registry.k8s.io/coredns/coredns:v1.11.3](http://registry.k8s.io/coredns/coredns:v1.11.3)", "delta": "0:00:00.902071", "end": "2025-06-18 15:42:45.980235", "failed_when_result": true, "msg": "", "rc": 0, "start": "2025-06-18 15:42:45.078164", "stderr": "time=\"2025-06-18T15:42:45Z\" level=info msg=\"host will try HTTPS first since it is configured for HTTP with a TLS configuration, consider changing host to HTTPS or removing unused TLS configuration\" host=\"10.100.12.195:8080\"\ntime=\"2025-06-18T15:42:45Z\" level=info msg=\"host will try HTTPS first since it is configured for HTTP with a TLS configuration, consider changing host to HTTPS or removing unused TLS configuration\" host=\"10.100.12.195:8080\"\[nregistry.k8s.io/coredns/coredns:v1.11.3:](http://nregistry.k8s.io/coredns/coredns:v1.11.3) resolving      |\u001b[32m\u001b[0m--------------------------------------| \nelapsed: 0.1 s                           total:   0.0 B (0.0 B/s)                                         \[nregistry.k8s.io/coredns/coredns:v1.11.3:](http://nregistry.k8s.io/coredns/coredns:v1.11.3)                                          resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nindex-sha256:9caabbf6238b189a65d0d6e6ac138de60d6a1c419e5a341fbbb7c78382559c6e:    exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:f0b8c589314ed010a0c326e987a52b50801f0145ac9b75423af1b5c66dbd6d50: exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:d095569ed07d46f67b8d67f2fd1456c4ab693f33c70d3d31e8ad0148cd1052ee:    exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:c8022d07192eddbb2a548ba83be5e412f7ba863bbba158d133c9653bb8a47768:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/130.0 B   \nlayer-sha256:5318d93a3a6582d0351c833fa3cf04ab41352b2e6c77c9ec3d330581eb267683:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/327.0 B   \nlayer-sha256:b40161cd83fc5d470d6abe50e87aa288481b6b89137012881d74187cfbf9f502:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/382.0 B   \nlayer-sha256:2ae710cd8bfef4545fa3a6dc274d6b7a991ca379cdaa3cdf460d5cb5840a3c88:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/19.8 KiB  \nlayer-sha256:307c1adadb60e6e9b8aca553ec620d77fedc112737cc54e9ee73ac165e7f3cbc:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/119.2 KiB \nlayer-sha256:f9d565286af529b228717cf8bb117abb80fe7f5433c2d1087c70759fd97ad98e:    exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:d462aa3453675bb1f9a271a72cc72a53e628521a7d0e94b720bd07f9ca4962dc:    waiting        |\u001b[32m\u001b[0m--------------------------------------| \nlayer-sha256:0f8b424aa0b96c1c388a5fd4d90735604459256336853082afb61733438872b5:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/75.0 B \nconfig-sha256:c69fa2e9cbf5f42dc48af631e956d3f95724c13f91596bc567591790e5e36db6:   exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:d858cbc252ade14879807ff8dbc3043a26bbdb92087da98cda831ee040b172b3:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/173.0 B \nlayer-sha256:d557676654e572af3e3173c90e7874644207fda32cd87e9d3d66b5d7b98a7b21:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/193.0 B \nlayer-sha256:1069fc2daed1aceff7232f4b8ab21200dd3d8b04f61be9da86977a34a105dfdc:    waiting        |\u001b[32m\u001b[0m--------------------------------------| \nlayer-sha256:804c8aba2cc61168600515a6831474978d0ea8faddd8a66f99cc9f2bbd576105:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/82.0 KiB \nelapsed: 0.2 s                                                                    total:   0.0 B (0.0 B/s)                                         \[nregistry.k8s.io/coredns/coredns:v1.11.3:](http://nregistry.k8s.io/coredns/coredns:v1.11.3)                                          resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nindex-sha256:9caabbf6238b189a65d0d6e6ac138de60d6a1c419e5a341fbbb7c78382559c6e:    exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:f0b8c589314ed010a0c326e987a52b50801f0145ac9b75423af1b5c66dbd6d50: exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:d095569ed07d46f67b8d67f2fd1456c4ab693f33c70d3d31e8ad0148cd1052ee:    exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:c8022d07192eddbb2a548ba83be5e412f7ba863bbba158d133c9653bb8a47768:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:5318d93a3a6582d0351c833fa3cf04ab41352b2e6c77c9ec3d330581eb267683:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:b40161cd83fc5d470d6abe50e87aa288481b6b89137012881d74187cfbf9f502:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:2ae710cd8bfef4545fa3a6dc274d6b7a991ca379cdaa3cdf460d5cb5840a3c88:    downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| 19.8 KiB/19.8 KiB \nlayer-sha256:307c1adadb60e6e9b8aca553ec620d77fedc112737cc54e9ee73ac165e7f3cbc:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:f9d565286af529b228717cf8bb117abb80fe7f5433c2d1087c70759fd97ad98e:    exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:d462aa3453675bb1f9a271a72cc72a53e628521a7d0e94b720bd07f9ca4962dc:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/619.3 KiB \nlayer-sha256:0f8b424aa0b96c1c388a5fd4d90735604459256336853082afb61733438872b5:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nconfig-sha256:c69fa2e9cbf5f42dc48af631e956d3f95724c13f91596bc567591790e5e36db6:   exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:d858cbc252ade14879807ff8dbc3043a26bbdb92087da98cda831ee040b172b3:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:d557676654e572af3e3173c90e7874644207fda32cd87e9d3d66b5d7b98a7b21:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:1069fc2daed1aceff7232f4b8ab21200dd3d8b04f61be9da86977a34a105dfdc:    waiting        |\u001b[32m\u001b[0m--------------------------------------| \nlayer-sha256:804c8aba2cc61168600515a6831474978d0ea8faddd8a66f99cc9f2bbd576105:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nelapsed: 0.3 s                                                                    total:  222.4  (726.6 KiB/s)                                     \[nregistry.k8s.io/coredns/coredns:v1.11.3:](http://nregistry.k8s.io/coredns/coredns:v1.11.3)                                          resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nindex-sha256:9caabbf6238b189a65d0d6e6ac138de60d6a1c419e5a341fbbb7c78382559c6e:    exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:f0b8c589314ed010a0c326e987a52b50801f0145ac9b75423af1b5c66dbd6d50: exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:d095569ed07d46f67b8d67f2fd1456c4ab693f33c70d3d31e8ad0148cd1052ee:    exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:c8022d07192eddbb2a548ba83be5e412f7ba863bbba158d133c9653bb8a47768:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:5318d93a3a6582d0351c833fa3cf04ab41352b2e6c77c9ec3d330581eb267683:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:b40161cd83fc5d470d6abe50e87aa288481b6b89137012881d74187cfbf9f502:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:2ae710cd8bfef4545fa3a6dc274d6b7a991ca379cdaa3cdf460d5cb5840a3c88:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:307c1adadb60e6e9b8aca553ec620d77fedc112737cc54e9ee73ac165e7f3cbc:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:f9d565286af529b228717cf8bb117abb80fe7f5433c2d1087c70759fd97ad98e:    exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:d462aa3453675bb1f9a271a72cc72a53e628521a7d0e94b720bd07f9ca4962dc:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:0f8b424aa0b96c1c388a5fd4d90735604459256336853082afb61733438872b5:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nconfig-sha256:c69fa2e9cbf5f42dc48af631e956d3f95724c13f91596bc567591790e5e36db6:   exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:d858cbc252ade14879807ff8dbc3043a26bbdb92087da98cda831ee040b172b3:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:d557676654e572af3e3173c90e7874644207fda32cd87e9d3d66b5d7b98a7b21:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:1069fc2daed1aceff7232f4b8ab21200dd3d8b04f61be9da86977a34a105dfdc:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:804c8aba2cc61168600515a6831474978d0ea8faddd8a66f99cc9f2bbd576105:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nelapsed: 0.4 s                                                                    total:  222.4  (555.8 KiB/s)                                     ", "stderr_lines": ["time=\"2025-06-18T15:42:45Z\" level=info msg=\"host will try HTTPS first since it is configured for HTTP with a TLS configuration, consider changing host to HTTPS or removing unused TLS configuration\" host=\"10.100.12.195:8080\"", "time=\"2025-06-18T15:42:45Z\" level=info msg=\"host will try HTTPS first since it is configured for HTTP with a TLS configuration, consider changing host to HTTPS or removing unused TLS configuration\" host=\"10.100.12.195:8080\"", "[registry.k8s.io/coredns/coredns:v1.11.3:](http://registry.k8s.io/coredns/coredns:v1.11.3) resolving      |\u001b[32m\u001b[0m--------------------------------------| ", "elapsed: 0.1 s                           total:   0.0 B (0.0 B/s)                                         ", "[registry.k8s.io/coredns/coredns:v1.11.3:](http://registry.k8s.io/coredns/coredns:v1.11.3)                                          resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "index-sha256:9caabbf6238b189a65d0d6e6ac138de60d6a1c419e5a341fbbb7c78382559c6e:    exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:f0b8c589314ed010a0c326e987a52b50801f0145ac9b75423af1b5c66dbd6d50: exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:d095569ed07d46f67b8d67f2fd1456c4ab693f33c70d3d31e8ad0148cd1052ee:    exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:c8022d07192eddbb2a548ba83be5e412f7ba863bbba158d133c9653bb8a47768:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/130.0 B   ", "layer-sha256:5318d93a3a6582d0351c833fa3cf04ab41352b2e6c77c9ec3d330581eb267683:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/327.0 B   ", "layer-sha256:b40161cd83fc5d470d6abe50e87aa288481b6b89137012881d74187cfbf9f502:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/382.0 B   ", "layer-sha256:2ae710cd8bfef4545fa3a6dc274d6b7a991ca379cdaa3cdf460d5cb5840a3c88:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/19.8 KiB  ", "layer-sha256:307c1adadb60e6e9b8aca553ec620d77fedc112737cc54e9ee73ac165e7f3cbc:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/119.2 KiB ", "layer-sha256:f9d565286af529b228717cf8bb117abb80fe7f5433c2d1087c70759fd97ad98e:    exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:d462aa3453675bb1f9a271a72cc72a53e628521a7d0e94b720bd07f9ca4962dc:    waiting        |\u001b[32m\u001b[0m--------------------------------------| ", "layer-sha256:0f8b424aa0b96c1c388a5fd4d90735604459256336853082afb61733438872b5:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/75.0 B ", "config-sha256:c69fa2e9cbf5f42dc48af631e956d3f95724c13f91596bc567591790e5e36db6:   exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:d858cbc252ade14879807ff8dbc3043a26bbdb92087da98cda831ee040b172b3:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/173.0 B ", "layer-sha256:d557676654e572af3e3173c90e7874644207fda32cd87e9d3d66b5d7b98a7b21:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/193.0 B ", "layer-sha256:1069fc2daed1aceff7232f4b8ab21200dd3d8b04f61be9da86977a34a105dfdc:    waiting        |\u001b[32m\u001b[0m--------------------------------------| ", "layer-sha256:804c8aba2cc61168600515a6831474978d0ea8faddd8a66f99cc9f2bbd576105:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/82.0 KiB ", "elapsed: 0.2 s                                                                    total:   0.0 B (0.0 B/s)                                         ", "[registry.k8s.io/coredns/coredns:v1.11.3:](http://registry.k8s.io/coredns/coredns:v1.11.3)                                          resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "index-sha256:9caabbf6238b189a65d0d6e6ac138de60d6a1c419e5a341fbbb7c78382559c6e:    exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:f0b8c589314ed010a0c326e987a52b50801f0145ac9b75423af1b5c66dbd6d50: exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:d095569ed07d46f67b8d67f2fd1456c4ab693f33c70d3d31e8ad0148cd1052ee:    exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:c8022d07192eddbb2a548ba83be5e412f7ba863bbba158d133c9653bb8a47768:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:5318d93a3a6582d0351c833fa3cf04ab41352b2e6c77c9ec3d330581eb267683:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:b40161cd83fc5d470d6abe50e87aa288481b6b89137012881d74187cfbf9f502:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:2ae710cd8bfef4545fa3a6dc274d6b7a991ca379cdaa3cdf460d5cb5840a3c88:    downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| 19.8 KiB/19.8 KiB ", "layer-sha256:307c1adadb60e6e9b8aca553ec620d77fedc112737cc54e9ee73ac165e7f3cbc:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:f9d565286af529b228717cf8bb117abb80fe7f5433c2d1087c70759fd97ad98e:    exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:d462aa3453675bb1f9a271a72cc72a53e628521a7d0e94b720bd07f9ca4962dc:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/619.3 KiB ", "layer-sha256:0f8b424aa0b96c1c388a5fd4d90735604459256336853082afb61733438872b5:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "config-sha256:c69fa2e9cbf5f42dc48af631e956d3f95724c13f91596bc567591790e5e36db6:   exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:d858cbc252ade14879807ff8dbc3043a26bbdb92087da98cda831ee040b172b3:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:d557676654e572af3e3173c90e7874644207fda32cd87e9d3d66b5d7b98a7b21:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:1069fc2daed1aceff7232f4b8ab21200dd3d8b04f61be9da86977a34a105dfdc:    waiting        |\u001b[32m\u001b[0m--------------------------------------| ", "layer-sha256:804c8aba2cc61168600515a6831474978d0ea8faddd8a66f99cc9f2bbd576105:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "elapsed: 0.3 s      
                                                              total:  222.4  (726.6 KiB/s)                                     ", "[registry.k8s.io/coredns/coredns:v1.11.3:](http://registry.k8s.io/coredns/coredns:v1.11.3)                                          resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "index-sha256:9caabbf6238b189a65d0d6e6ac138de60d6a1c419e5a341fbbb7c78382559c6e:    exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:f0b8c589314ed010a0c326e987a52b50801f0145ac9b75423af1b5c66dbd6d50: exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:d095569ed07d46f67b8d67f2fd1456c4ab693f33c70d3d31e8ad0148cd1052ee:    exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:c8022d07192eddbb2a548ba83be5e412f7ba863bbba158d133c9653bb8a47768:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:5318d93a3a6582d0351c833fa3cf04ab41352b2e6c77c9ec3d330581eb267683:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:b40161cd83fc5d470d6abe50e87aa288481b6b89137012881d74187cfbf9f502:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:2ae710cd8bfef4545fa3a6dc274d6b7a991ca379cdaa3cdf460d5cb5840a3c88:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:307c1adadb60e6e9b8aca553ec620d77fedc112737cc54e9ee73ac165e7f3cbc:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:f9d565286af529b228717cf8bb117abb80fe7f5433c2d1087c70759fd97ad98e:    exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:d462aa3453675bb1f9a271a72cc72a53e628521a7d0e94b720bd07f9ca4962dc:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:0f8b424aa0b96c1c388a5fd4d90735604459256336853082afb61733438872b5:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "config-sha256:c69fa2e9cbf5f42dc48af631e956d3f95724c13f91596bc567591790e5e36db6:   exists         |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:d858cbc252ade14879807ff8dbc3043a26bbdb92087da98cda831ee040b172b3:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:d557676654e572af3e3173c90e7874644207fda32cd87e9d3d66b5d7b98a7b21:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:1069fc2daed1aceff7232f4b8ab21200dd3d8b04f61be9da86977a34a105dfdc:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:804c8aba2cc61168600515a6831474978d0ea8faddd8a66f99cc9f2bbd576105:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "elapsed: 0.4 s                                                                    total:  222.4  (555.8 KiB/s)                                     "], "stdout": "", "stdout_lines": []}
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix broken failure condition when downloading images with `nerdctl` and `download_run_one`
```
