### PR TITLE
Add version pinning for AWS tf provider to fix CI

### DIFF
--- a/contrib/terraform/aws/create-infrastructure.tf
+++ b/contrib/terraform/aws/create-infrastructure.tf
@@ -1,5 +1,11 @@
 terraform {
   required_version = ">= 0.12.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
 }
 
 provider "aws" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
hashicorp/aws version `v6.0.0` was [released](https://www.hashicorp.com/en/blog/terraform-aws-provider-6-0-now-generally-available) yesterday with breaking changes. 

CI was not using provider version pinning for aws, so the `terraform_validate: [aws]` test is now picking up `hashicorp/aws` tf provider version `v6.0.0` instead of `v5.100.0` and fails with this error:

```bash
$ tofu -chdir="contrib/terraform/$PROVIDER" validate
╷
│ Error: Unsupported argument
│ 
│   on modules/vpc/main.tf line 15, in resource "aws_eip" "cluster-nat-eip":
│   15:   vpc   = true
│ 
│ An argument named "vpc" is not expected here.
╵
```

This change adds version pinning for 5.x

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
