### PR TITLE
fix etcd-events member not removed after remove node

### DIFF
--- a/roles/remove-node/remove-etcd-node/tasks/main.yml
+++ b/roles/remove-node/remove-etcd-node/tasks/main.yml
@@ -1,22 +1,39 @@
 ---
-- name: Lookup node IP in kubernetes
-  command: >
-    {{ kubectl }} get nodes {{ node }}
-    -o jsonpath-as-json='{.status.addresses[?(@.type=="InternalIP")].address}'
-  register: k8s_node_ips
-  changed_when: false
-  when:
-  - groups['kube_control_plane'] | length > 0
-  delegate_to: "{{ groups['kube_control_plane'] | first }}"
-
-- name: Remove etcd member from cluster
+- name: Remove member from etcd cluster
   environment:
     ETCDCTL_API: "3"
-    ETCDCTL_CERT: "{{ kube_cert_dir + '/etcd/server.crt' if etcd_deployment_type == 'kubeadm' else etcd_cert_dir + '/admin-' + groups['etcd'] | first + '.pem' }}"
-    ETCDCTL_KEY: "{{ kube_cert_dir + '/etcd/server.key' if etcd_deployment_type == 'kubeadm' else etcd_cert_dir + '/admin-' + groups['etcd'] | first + '-key.pem' }}"
-    ETCDCTL_CACERT: "{{ kube_cert_dir + '/etcd/ca.crt' if etcd_deployment_type == 'kubeadm' else etcd_cert_dir + '/ca.pem' }}"
+    ETCDCTL_CERT: "{{ etcd_cert_dir }}/admin-{{ groups['etcd'] | first }}.pem"
+    ETCDCTL_KEY: "{{ etcd_cert_dir }}/admin-{{ groups['etcd'] | first }}-key.pem"
+    ETCDCTL_CACERT: "{{ etcd_cert_dir }}/ca.pem"
     ETCDCTL_ENDPOINTS: "https://127.0.0.1:2379"
   delegate_to: "{{ groups['etcd'] | first }}"
+  block:
+    - name: Lookup members infos
+      command: "{{ bin_dir }}/etcdctl member list"
+      register: etcd_members
+      changed_when: false
+      check_mode: false
+      tags:
+        - facts
+    - name: Remove member from cluster
+      command:
+        argv:
+          - "{{ bin_dir }}/etcdctl"
+          - member
+          - remove
+          - "{{ ((etcd_members.stdout_lines | select('contains', '//' + main_access_ip + ':'))[0] | split(','))[0] }}"
+      register: etcd_removal_output
+      changed_when: "'Removed member' in etcd_removal_output.stdout"
+
+- name: Remove member from etcd-events cluster
+  environment:
+    ETCDCTL_API: "3"
+    ETCDCTL_CERT: "{{ etcd_cert_dir }}/admin-{{ groups['etcd'] | first }}.pem"
+    ETCDCTL_KEY: "{{ etcd_cert_dir }}/admin-{{ groups['etcd'] | first }}-key.pem"
+    ETCDCTL_CACERT: "{{ etcd_cert_dir }}/ca.pem"
+    ETCDCTL_ENDPOINTS: "https://127.0.0.1:2383"
+  delegate_to: "{{ groups['etcd'] | first }}"
+  when: etcd_events_cluster_setup
   block:
   - name: Lookup members infos
     command: "{{ bin_dir }}/etcdctl member list"
@@ -26,18 +43,11 @@
     tags:
     - facts
   - name: Remove member from cluster
-    vars:
-      node_ip: >-
-        {%- if not ipv4_stack -%}
-        {{ ip6 if ip6 is defined else (access_ip6 if access_ip6 is defined else (k8s_node_ips.stdout | from_json)[0]) | ansible.utils.ipwrap }}
-        {%- else -%}
-        {{ ip if ip is defined else (access_ip if access_ip is defined else (k8s_node_ips.stdout | from_json)[0]) | ansible.utils.ipwrap }}
-        {%- endif -%}
     command:
       argv:
       - "{{ bin_dir }}/etcdctl"
       - member
       - remove
-      - "{{ ((etcd_members.stdout_lines | select('contains', '//' + node_ip + ':'))[0] | split(','))[0] }}"
+      - "{{ ((etcd_members.stdout_lines | select('contains', '//' + main_access_ip + ':'))[0] | split(','))[0] }}"
     register: etcd_removal_output
     changed_when: "'Removed member' in etcd_removal_output.stdout"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

We need to ensure that when the etcd node is deleted, the member is also removed from the etcd-events cluster.


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix the issue where the member was not removed from the etcd-events cluster during etcd node removal.
```
