### PR TITLE
Fix calico-kube-controllers etcd mode networkpolicy RBAC

### DIFF
--- a/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-cr.yml.j2
+++ b/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-cr.yml.j2
@@ -6,19 +6,26 @@ metadata:
   namespace: kube-system
 rules:
 {% if calico_datastore == "etcd"  %}
-  - apiGroups:
-    - ""
-    - extensions
+  # Pods are monitored for changing labels.
+  # The node controller monitors Kubernetes nodes.
+  # Namespace and serviceaccount labels are used for policy.
+  - apiGroups: [""]
     resources:
       - pods
-      - namespaces
-      - networkpolicies
       - nodes
+      - namespaces
       - serviceaccounts
     verbs:
       - watch
       - list
       - get
+  # Watch for changes to Kubernetes NetworkPolicies.
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - networkpolicies
+    verbs:
+      - watch
+      - list
 {% elif calico_datastore == "kdd" %}
   # Nodes are watched to monitor for deletions.
   - apiGroups: [""]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The ClusterRole for calico-kube-controllers grants the NetworkPolicy watch/list in the incorrect apiGroup when running calico in etcd datastore mode.

This syncs the correct rules for etcd mode, referencing the [calico helm chart upstream](https://github.com/projectcalico/calico/blob/1501b4709441b277b4c733451545ca2e26b49593/charts/calico/templates/calico-kube-controllers-rbac.yaml#L22-L28). 

/ok-to-test

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
