### PR TITLE
Cilium: Pass cluster DNS to hubble.peerService in values.yaml.j2

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
@@ -175,6 +175,10 @@ cilium_l2announcements: false
 ### Buffer size of the channel to receive monitor events.
 # cilium_hubble_event_queue_size: 50
 
+# Override the DNS suffix that Hubble-Relay uses to resolve its peer service.
+# It defaults to the inventory's `dns_domain`.
+# cilium_hubble_peer_service_cluster_domain: "{{ dns_domain }}"
+
 # IP address management mode for v1.9+.
 # https://docs.cilium.io/en/v1.9/concepts/networking/ipam/
 # cilium_ipam_mode: kubernetes

--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -176,6 +176,10 @@ cilium_hubble_export_dynamic_config_content:
     excludeFilters: []
     filePath: "/var/run/cilium/hubble/events.log"
 
+# Override the DNS suffix that Hubble-Relay uses to resolve its peer service.
+# It defaults to the inventory's `dns_domain`.
+cilium_hubble_peer_service_cluster_domain: "{{ dns_domain }}"
+
 ### Capacity of Hubble events buffer. The provided value must be one less than an integer power of two and no larger than 65535
 ### (ie: 1, 3, ..., 2047, 4095, ..., 65535) (default 4095)
 # cilium_hubble_event_buffer_capacity: 4095

--- a/roles/network_plugin/cilium/templates/values.yaml.j2
+++ b/roles/network_plugin/cilium/templates/values.yaml.j2
@@ -83,6 +83,8 @@ ipMasqAgent:
 {% endif %}
 
 hubble:
+  peerService:
+    clusterDomain: {{ dns_domain }}
   enabled: {{ cilium_enable_hubble | to_json }}
   relay:
     enabled: {{ cilium_enable_hubble | to_json }}

--- a/roles/network_plugin/cilium/templates/values.yaml.j2
+++ b/roles/network_plugin/cilium/templates/values.yaml.j2
@@ -84,7 +84,7 @@ ipMasqAgent:
 
 hubble:
   peerService:
-    clusterDomain: {{ dns_domain }}
+    clusterDomain: {{ cilium_hubble_peer_service_cluster_domain }}
   enabled: {{ cilium_enable_hubble | to_json }}
   relay:
     enabled: {{ cilium_enable_hubble | to_json }}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes a regression in Hubble-Relay peer discovery for clusters that use a non-default cluster name (other than `cluster.local`). 

After the refactor in commit 6fe64323 that removed old Cilium template-based installation and moved to Helm-based deployment, the cluster DNS domain configuration (`dns_domain`) is no longer being passed to the Cilium Helm values. This causes Hubble-Relay to fail when attempting to resolve peer services, resulting in connection timeouts with "name resolver error: produced zero addresses".

The fix ensures that the actual `dns_domain` inventory setting is properly injected into the Cilium Helm values under `hubble.peerService.clusterDomain`, allowing Hubble-Relay to correctly resolve peer service FQDNs.

**Which issue(s) this PR fixes**:
<!--
This regression was introduced by the refactor in commit 6fe64323dbf7b3b04c4a8c36440c1ece405ddf82
Related upstream issue: https://github.com/cilium/cilium/issues/20130
-->
Fixes #

**Special notes for your reviewer**:

This is a regression fix for functionality that worked in Kubespray v2.27.0 but broke in v2.28.0. The issue manifests as Hubble-Relay logging repeated connection timeout errors when trying to discover peers in clusters with custom DNS domains.

The fix is minimal and surgical - it only adds the missing `clusterDomain` configuration to the Hubble peer service settings in the Helm values template.

**Does this PR introduce a user-facing change?**:
```release-note
Fix Hubble-Relay peer discovery in clusters using non-default cluster name by properly configuring clusterDomain in Cilium Helm values
```