### PR TITLE
fix(kubeadm): Conditionally add --skip-phases flag for v1.32.0+

### DIFF
--- a/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
@@ -18,7 +18,9 @@
     {%- else %}
     --config={{ kube_config_dir }}/kubeadm-config.yaml
     {%- endif %}
+    {%- if kube_version is version('1.32.0', '>=') %}
     --skip-phases={{ kubeadm_init_phases_skip | join(',') }}
+    {%- endif %}
   register: kubeadm_upgrade
   when: inventory_hostname == first_kube_control_plane
   failed_when: kubeadm_upgrade.rc != 0 and "field is immutable" not in kubeadm_upgrade.stderr
@@ -37,7 +39,9 @@
     {%- else %}
     --config={{ kube_config_dir }}/kubeadm-config.yaml
     {%- endif %}
+    {%- if kube_version is version('1.32.0', '>=') %}
     --skip-phases={{ kubeadm_init_phases_skip | join(',') }}
+    {%- endif %}
   register: kubeadm_upgrade
   when: inventory_hostname != first_kube_control_plane
   failed_when: kubeadm_upgrade.rc != 0 and "field is immutable" not in kubeadm_upgrade.stderr


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 
/kind bug

**What this PR does / why we need it**:

The `--skip-phases` command-line flag for `kubeadm upgrade apply` was introduced in Kubernetes v1.32.0. Applying this flag to older kubeadm versions that do not support it causes the upgrade to fail with an "unknown flag" error.

```
root@node1:~# kubeadm version -o json
{
  "clientVersion": {
    "major": "1",
    "minor": "31",
    "gitVersion": "v1.31.6",
    "gitCommit": "6b3560758b37680cb713dfc71da03c04cadd657c",
    "gitTreeState": "clean",
    "buildDate": "2025-02-12T21:31:09Z",
    "goVersion": "go1.22.12",
    "compiler": "gc",
    "platform": "linux/amd64"
  }
}
root@node1:~# kubeadm upgrade apply --config=/etc/kubernetes/kubeadm-config.yaml --skip-phases=addon/coredns
unknown flag: --skip-phases
To see the stack trace of this error execute with --v=5 or higher
```

This patch makes the addition of the `--skip-phases` flag conditional on the `kube_version`. It uses a version comparison to ensure the flag is only passed to kubeadm versions `v1.32.0` and newer.

This provides backward compatibility for older Kubernetes versions while enabling the feature for supported versions, thus preventing upgrade failures.

Related #12306

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix(kubeadm): Conditionally add --skip-phases flag for v1.32.0+
```
