### PR TITLE
Remove --auth-anonymous if kube_api_anonymous_auth is undefined

### DIFF
--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
@@ -109,7 +109,10 @@ apiServer:
     etcd-compaction-interval: "{{ kube_apiserver_etcd_compaction_interval }}"
     default-not-ready-toleration-seconds: "{{ kube_apiserver_pod_eviction_not_ready_timeout_seconds }}"
     default-unreachable-toleration-seconds: "{{ kube_apiserver_pod_eviction_unreachable_timeout_seconds }}"
+{% if kube_api_anonymous_auth is defined %}
+{# TODO: rework once suppport for structured auth lands #}
     anonymous-auth: "{{ kube_api_anonymous_auth }}"
+{% endif %}
 {% if kube_apiserver_use_authorization_config_file %}
     authorization-config: "{{ kube_config_dir }}/apiserver-authorization-config-{{ kube_apiserver_authorization_config_api_version }}.yaml"
 {% else %}

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
@@ -131,8 +131,11 @@ apiServer:
     value: "{{ kube_apiserver_pod_eviction_not_ready_timeout_seconds }}"
   - name: default-unreachable-toleration-seconds
     value: "{{ kube_apiserver_pod_eviction_unreachable_timeout_seconds }}"
+{% if kube_api_anonymous_auth is defined %}
+{# TODO: rework once suppport for structured auth lands #}
   - name: anonymous-auth
     value: "{{ kube_api_anonymous_auth }}"
+{% endif %}
 {% if kube_apiserver_use_authorization_config_file %}
   - name: authorization-config
     value: "{{ kube_config_dir }}/apiserver-authorization-config-{{ kube_apiserver_authorization_config_api_version }}.yaml"

--- a/roles/kubespray_defaults/defaults/main/main.yml
+++ b/roles/kubespray_defaults/defaults/main/main.yml
@@ -11,6 +11,7 @@ ping_access_ip: true
 
 # Setting this value to false will fail
 # For details, read this comment https://github.com/kubernetes-sigs/kubespray/pull/11016#issuecomment-2004985001
+# if kube_api_anonymous_auth: "{{ undef() }}", remove --anonymous-auth argument
 kube_api_anonymous_auth: true
 
 # Default value, but will be set to true automatically if detected


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it:**

This PR introduces changes to address the incompatibility between the `kube_api_anonymous_auth` flag and the `--authentication-config` argument in **kubeadm**. The current implementation adds `--anonymous-auth=true|false` based on the value of `kube_api_anonymous_auth`, which is not compatible with the `--authentication-config` configuration file, when the config file includes a configuration for anonymous authentication.

This PR modifies the behavior to remove the `--anonymous-auth` flag when `kube_api_anonymous_auth` is `"{{ undef() }}"`, ensuring compatibility without conflicting configurations.

**Which issue(s) this PR fixes:**

Additionally, if **kube-apiserver** uses `--anonynous-auth=true|false` and `--authorization-config` with a configuration like the following:

```yaml
apiVersion: apiserver.config.k8s.io/v1beta1
kind: AuthenticationConfiguration
anonymous:
  enabled: true
  conditions:
    - path: /livez
    - path: /readyz
    - path: /healthz
    - path: /api/v1/namespaces/kube-public/configmaps/cluster-info
jwt:
  - issuer:
      url: https://false.url/realms/myrealm
      audiences:
        - verylongaud
    claimMappings:
      username:
        claim: email
        prefix: "oidc:"
      groups:
        claim: groups
        prefix: "oidc:"
    userValidationRules:
      - expression: "!user.username.startsWith('system:')"
        message: "username cannot use reserved system: prefix"
      - expression: "user.groups.all(group, !group.startsWith('system:'))"
        message: 'groups cannot be used with reserved system: prefix'
```

An error log message will exist in **kube-apiserver**:

```
E0628 08:00:07.762676       1 run.go:72] "command failed" err="anonymous: Forbidden: --anonynous-auth flag cannot be set when anonymous 
field is configured in authentication configuration file"
```

As describe in the [KEP-4633](https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/4633-anonymous-auth-configurable-endpoints/README.md#story-2) and in [documentation](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration).

**Special notes for your reviewer:**

Maybe this issue was introduced by #12307. It would be nice to port the fix to older versions.

**Does this PR introduce a user-facing change?**:

```release-note
Remove --auth-anonymous if kube_api_anonymous_auth is undefined.
```
