### PR TITLE
Replace deprecated MAINTAINER with OCI-compliant LABEL in Dockerfile

### DIFF
--- a/test-infra/image-builder/roles/kubevirt-images/templates/Dockerfile
+++ b/test-infra/image-builder/roles/kubevirt-images/templates/Dockerfile
@@ -1,6 +1,7 @@
 FROM kubevirt/registry-disk-v1alpha
 
 ARG cloud_image
-MAINTAINER "The Kubespray Project" <kubespray@googlegroups.com>
+
+LABEL org.opencontainers.image.authors="The Kubespray Project <kubespray@googlegroups.com>"
 
 COPY $cloud_image /disk


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The Dockerfile currently uses the deprecated `MAINTAINER` instruction, which is no longer recommended in Docker best practices. This PR replaces it with the standardized `LABEL` instruction using the `org.opencontainers.image.authors` key, which follows the Open Container Initiative (OCI) image specification for metadata.

This change improves compatibility and future-proofs the Dockerfile according to current Docker guidelines.

**Which issue(s) this PR fixes**:
Fixed #12357

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
