### PR TITLE
Add singleProcessOOMKill option to kubelet

### DIFF
--- a/docs/ansible/vars.md
+++ b/docs/ansible/vars.md
@@ -320,6 +320,8 @@ node_taints:
   In a nutshell, this option removes the rolebinding after the init phase of the first control plane node and then configures kubeadm to use file discovery for the join phase of other nodes.
   This option does not remove the anonymous authentication feature of the API server.
 
+* *kubelet_single_process_oom_kill* - if `true`, will prevent the `memory.oom.group` flag from being set for container cgroups in cgroups v2. This causes processes in the container to be OOM killed individually instead of as a group. It means that if `true`, the behavior aligns with the behavior of cgroups v1. The default value is determined automatically when you don't specify. On non-linux such as windows, only `null` / `absent` is allowed. On cgroup v1 linux, only `null` / `absent` and `true` are allowed. On cgroup v2 linux, `null` / `absent`, `true` and `false` are allowed. The default value is `false`.
+
 ### Custom flags for Kube Components
 
 For all kube components, custom flags can be passed in. This allows for edge cases where users need changes to the default deployment that may not be applicable to all deployments.

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -196,3 +196,9 @@ kubelet_tracing_sampling_rate_per_million: 100
 
 # The maximum number of image pulls in parallel. Set it to a integer great than 1 to enable image pulling in parallel.
 kubelet_max_parallel_image_pulls: 1
+
+# Set kubelet singleProcessOOMKill option, If true, This causes processes in the container to be OOM killed individually instead of as a group.
+# On non-linux such as windows, only null / absent is allowed.
+# On cgroup v1 linux, only null / absent and true are allowed.
+# On cgroup v2 linux, null / absent, true and false are allowed. The default value is false.
+kubelet_single_process_oom_kill: null

--- a/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
@@ -134,3 +134,6 @@ tracing:
   samplingRatePerMillion: {{ kubelet_tracing_sampling_rate_per_million }}
 {% endif %}
 maxParallelImagePulls: {{ kubelet_max_parallel_image_pulls }}
+{% if kube_version is version('1.32.0', '>=') and kubelet_single_process_oom_kill != none %}
+singleProcessOOMKill: {{ kubelet_single_process_oom_kill }}
+{% endif %}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds support for the `singleProcessOOMKill` option in the kubelet configuration via the kubelet_single_process_oom_kill variable. This option was introduced in Kubernetes v1.32 and, when set to `true`, causes OOM kills to be applied to individual processes rather than to the whole container cgroup.

- more detail on [link](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)

**Which issue(s) this PR fixes**:
Fixes #12362

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Add support for the singleProcessOOMKill kubelet option (Kubernetes v1.32+) via the kubelet_single_process_oom_kill variable.
```