### PR TITLE
feat: containerd - support for HTTP headers.

### DIFF
--- a/docs/CRI/containerd.md
+++ b/docs/CRI/containerd.md
@@ -51,6 +51,19 @@ containerd_registries_mirrors:
     server: https://mirror.example.org
 ```
 
+contianerd supports registry authentication using custom HTTP headers. This can be set on [`header'](https://github.com/containerd/containerd/blob/main/docs/hosts.md#header-fields-in-the-toml-table-format) section:
+
+```yaml
+containerd_registries_mirrors:
+  - prefix: docker.io
+    mirrors:
+      - host: https://mirror.gcr.io
+        capabilities: ["pull", "resolve"]
+        skip_verify: false
+        header:
+          authorization: "Basic b3RsY="
+```
+
 The `containerd_registries` and `containerd_insecure_registries` configs are deprecated.
 
 ### Containerd Runtimes

--- a/roles/container-engine/containerd/templates/hosts.toml.j2
+++ b/roles/container-engine/containerd/templates/hosts.toml.j2
@@ -10,4 +10,10 @@ server = "{{ item.server | default("https://" + item.prefix) }}"
 {% if mirror.client is defined %}
   client = [{% for pair in mirror.client %}["{{ pair[0] }}", "{{ pair[1] }}"]{% if not loop.last %},{% endif %}{% endfor %}]
 {% endif %}
+{% if mirror.header is defined %}
+  [host."{{ mirror.host }}".header]
+{% for key, value in mirror.header.items() %}
+    {{ key }} = ["{{ ([ value ] | flatten ) | join('","') }}"]
+{% endfor %}
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
It is not possible to add headers to mirrors using containerd configuration template provided by Kubespray.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
A new field, `header`, has been added to the `containerd_registries_mirrors` configuration. This field allows you to set custom HTTP headers for authenticating registry mirrors.

While `header` is already supported by the containerd configuration itself, support was previously missing in Kubespray's provisioning of containerd. This limitation has now been addressed.

For more details, see the [containerd documentation on header fields](https://github.com/containerd/containerd/blob/main/docs/hosts.md#header-fields-in-the-toml-table-format).

```
