### PR TITLE
Add header configuration in containerd hosts.toml

### DIFF
--- a/inventory/sample/group_vars/all/containerd.yml
+++ b/inventory/sample/group_vars/all/containerd.yml
@@ -50,6 +50,8 @@
 #     - host: https://registry-1.docker.io
 #       capabilities: ["pull", "resolve"]
 #       skip_verify: false
+#       header:
+#         Authorization: "Basic XXX"
 
 # containerd_max_container_log_line_size: 16384
 

--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -64,7 +64,8 @@ containerd_registries_mirrors:
         skip_verify: false
 #        ca: ["/etc/certs/mirror.pem"]
 #        client: [["/etc/certs/client.pem", ""],["/etc/certs/client.cert", "/etc/certs/client.key"]]
-
+#        header:
+#          Authorization: "Basic XXX"
 containerd_max_container_log_line_size: 16384
 
 # If enabled it will allow non root users to use port numbers <1024

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -73,6 +73,8 @@
   notify: Restart containerd
 
 - name: Containerd | Configure containerd registries
+  # mirror configuration can contain sensitive information on headers configuration
+  no_log: "{{ not (unsafe_show_logs | bool) }}"
   block:
     - name: Containerd | Create registry directories
       file:

--- a/roles/container-engine/containerd/templates/hosts.toml.j2
+++ b/roles/container-engine/containerd/templates/hosts.toml.j2
@@ -10,4 +10,10 @@ server = "{{ item.server | default("https://" + item.prefix) }}"
 {% if mirror.client is defined %}
   client = [{% for pair in mirror.client %}["{{ pair[0] }}", "{{ pair[1] }}"]{% if not loop.last %},{% endif %}{% endfor %}]
 {% endif %}
+{% if mirror.header is defined %}
+  [host."{{ mirror.host }}".header]
+{% for key, value in mirror.header.items() %}
+    {{ key }} = ["{{ ([ value ] | flatten ) | join('","') }}"]
+{% endfor %}
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This PR adds support for custom header configuration in containerd `hosts.toml` for registry mirrors. It allows users to specify headers (such as Authorization) for containerd registry mirrors via inventory and role variables. This is needed because the previous method (`containerd_registry_auth`) is deprecated for containerd 2.x, and there was no way to add custom headers for registry mirrors.

The implementation is based on the solution discussed in https://github.com/kubernetes-sigs/kubespray/issues/11877 and addresses the need described in https://github.com/kubernetes-sigs/kubespray/issues/12296.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12296

**Special notes for your reviewer**:

- The code and approach are based on the workaround and discussion from issue #11877.
- This change is required for containerd 2.x+ users who need to configure private registry authentication via headers.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Support for custom header configuration in containerd registry mirrors via inventory and role variables. Users can now specify headers (e.g., Authorization) for registry mirrors in `hosts.toml`.
```

---

Similar code found with 2 license types