### PR TITLE
Add support for enabling Cilium Egress Gateway in values.yaml.j2

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
@@ -49,6 +49,8 @@ cilium_l2announcements: false
 # cilium_enable_prometheus: false
 # Enable if you want to make use of hostPort mappings
 # cilium_enable_portmap: false
+# Enable Egress Gateway support in Cilium. Ref: https://docs.cilium.io/en/stable/network/egress-gateway/
+# cilium_egress_gateway_enabled: false
 # Monitor aggregation level (none/low/medium/maximum)
 # cilium_monitor_aggregation: medium
 # The monitor aggregation flags determine which TCP flags which, upon the

--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -56,6 +56,8 @@ cilium_loadbalancer_ip_pools: []
 cilium_enable_prometheus: false
 # Enable if you want to make use of hostPort mappings
 cilium_enable_portmap: false
+# Enable Egress Gateway support in Cilium. Ref: https://docs.cilium.io/en/stable/network/egress-gateway/
+cilium_egress_gateway_enabled: false
 # Monitor aggregation level (none/low/medium/maximum)
 cilium_monitor_aggregation: medium
 # Kube Proxy Replacement mode (true/false)

--- a/roles/network_plugin/cilium/templates/values.yaml.j2
+++ b/roles/network_plugin/cilium/templates/values.yaml.j2
@@ -113,6 +113,9 @@ hubble:
 gatewayAPI:
   enabled: {{ cilium_gateway_api_enabled | to_json }}
 
+egressGateway:
+  enabled: {{ cilium_egress_gateway_enabled | to_json }}
+
 ipam:
   mode: {{ cilium_ipam_mode }}
   operator:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This PR adds support for enabling the [Cilium Egress Gateway](https://docs.cilium.io/en/stable/network/egress-gateway/) via Kubespray by introducing a new inventory variable `cilium_egress_gateway_enabled`.

Previously, users had to manually modify the Cilium `values.yaml.j2` Helm template to enable this feature. With this PR, the feature can now be toggled cleanly using inventory variables.

**Which issue(s) this PR fixes**:
Fixes #12363

**Special notes for your reviewer**:
- The new variable `cilium_egress_gateway_enabled` is `false` by default to preserve current behavior.
- Placement of the `egressGateway:` block in `values.yaml.j2` matches the structure of Cilium's upstream Helm chart.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added support for enabling the Cilium Egress Gateway via the new variable `cilium_egress_gateway_enabled`.
```
