### PR TITLE
Add possibility to use any values from Cilium 

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
@@ -384,3 +384,7 @@ cilium_l2announcements: false
 #       resourceNames:
 #       - toto
 # cilium_clusterrole_rules_operator_extra_vars: []
+
+# Cilium extra values, use any values from cilium Helm Chart
+# ref: https://docs.cilium.io/en/stable/helm-reference/
+# cilium_extra_values: {}

--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -362,3 +362,7 @@ cilium_policy_audit_mode: false
 
 # Cilium extra install flags
 cilium_install_extra_flags: ""
+
+# Cilium extra values, use any values from cilium Helm Chart
+# ref: https://docs.cilium.io/en/stable/helm-reference/
+cilium_extra_values: {}

--- a/roles/network_plugin/cilium/tasks/apply.yml
+++ b/roles/network_plugin/cilium/tasks/apply.yml
@@ -12,7 +12,7 @@
 
 - name: Cilium | Install
   environment: "{{ proxy_env }}"
-  command: "{{ bin_dir }}/cilium {{ cilium_action }} --version {{ cilium_version }} -f {{ kube_config_dir }}/cilium-values.yaml {{ cilium_install_extra_flags }}"
+  command: "{{ bin_dir }}/cilium {{ cilium_action }} --version {{ cilium_version }} -f {{ kube_config_dir }}/cilium-values.yaml -f {{ kube_config_dir }}/cilium-extra-values.yaml {{ cilium_install_extra_flags }}"
   when: inventory_hostname == groups['kube_control_plane'][0]
 
 - name: Cilium | Wait for pods to run

--- a/roles/network_plugin/cilium/tasks/install.yml
+++ b/roles/network_plugin/cilium/tasks/install.yml
@@ -45,6 +45,14 @@
   when:
     - inventory_hostname == groups['kube_control_plane'][0]
 
+- name: Cilium | Copy extra values
+  copy:
+    content: "{{ cilium_extra_values | to_nice_yaml(indent=2) }}"
+    dest: "{{ kube_config_dir }}/cilium-extra-values.yaml"
+    mode: "0644"
+  when:
+    - inventory_hostname == groups['kube_control_plane'][0]
+
 - name: Cilium | Copy Ciliumcli binary from download dir
   copy:
     src: "{{ local_release_dir }}/cilium"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
Add possibility to use any values from Cilium [Helm Chart](https://docs.cilium.io/en/stable/helm-reference/l) . 

This allow to activate service Topology on LoadBalancer for Cilium and any other feature not supported by Kubespray. 

For service Topology on LoadBalancer, this enable usage of Hints in EndpointSlices for traffic distribution and topology aware routing.  Ref: https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/#traffic-distribution-and-topology-aware-hints

**Which issue(s) this PR fixes**:
Fixes #12019

**Special notes for your reviewer**:
pre-commit was blocking me on `roles/kubernetes/client/tasks/main.yml:68: jinja[invalid][/] ... Unrecognized type <<class 'ansible.template.native_helpers.AnsibleUndefined'>> for ipwrap filter <value>`. It appears that `external_apiserver_port` is undefined. 

Not sure if it was the right thing to do but I skipped it with  `# noqa` 


**Does this PR introduce a user-facing change?**:
```release-note
Add the possibility to use any values from Cilium Helm Chart
```
