### PR TITLE
coredns: set deploy replicas when dns autoscaler is disabled

### DIFF
--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -29,6 +29,8 @@ coredns_default_zone_cache_block: |
   cache 30
 
 coredns_pod_disruption_budget: false
+# when enable_dns_autoscaler is false, coredns_replicas is used to set the number of replicas
+coredns_replicas: 2
 # value for coredns pdb
 coredns_pod_disruption_budget_max_unavailable: "30%"
 deploy_coredns: true

--- a/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
@@ -9,6 +9,9 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/name: "coredns{{ coredns_ordinal_suffix }}"
 spec:
+{% if not enable_dns_autoscaler %}
+  replicas: {{ coredns_replicas }}
+{% endif %}
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Allow setting deployment replicas through `coredns_replicas` when `enable_dns_autoscaler` is set to false.

**Does this PR introduce a user-facing change?**:
```release-note
Introduced `coredns_replicas` to alter coredns deployment replicas when `enable_dns_autoscaler` is set to false.
```
