### PR TITLE
Fix: nodelocaldns capabilities usage

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-daemonset.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-daemonset.yml.j2
@@ -59,7 +59,9 @@ spec:
           name: metrics
           protocol: TCP
         securityContext:
-          privileged: true
+          capabilities:
+            add:
+            - NET_ADMIN
 {% if nodelocaldns_bind_metrics_host_ip %}
         env:
           - name: MY_HOST_IP

--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-second-daemonset.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-second-daemonset.yml.j2
@@ -44,7 +44,9 @@ spec:
           name: metrics
           protocol: TCP
         securityContext:
-          privileged: true
+          capabilities:
+            add:
+            - NET_ADMIN
 {% if nodelocaldns_bind_metrics_host_ip %}
         env:
           - name: MY_HOST_IP


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Remove the nodelocaldns privileged container.

**Which issue(s) this PR fixes**:

Fixes #12396

**Does this PR introduce a user-facing change?**:

```release-note
Nodelocaldns capabilities only use NET_ADMIN, not privileged
```
