### PR TITLE
WIP fix: redeploy coredns and nodelocaldns when its config changed

### DIFF
--- a/roles/kubernetes-apps/ansible/tasks/main.yml
+++ b/roles/kubernetes-apps/ansible/tasks/main.yml
@@ -11,6 +11,17 @@
   delay: 1
   when: inventory_hostname == groups['kube_control_plane'][0]
 
+- name: Kubernetes Apps | Calculate CoreDNS Config Checksum
+  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  run_once: true
+  set_fact:
+    coredns_config_checksum: "{{ lookup('template', coredns_config_manifest) | checksum }}"
+  tags:
+    - coredns
+  when:
+    - dns_mode in ['coredns', 'coredns_dual']
+    - deploy_coredns
+
 - name: Kubernetes Apps | CoreDNS
   command:
     cmd: "{{ kubectl_apply_stdin }}"
@@ -41,6 +52,30 @@
   when:
     - dns_mode == 'coredns_dual'
     - deploy_coredns
+
+- name: Kubernetes Apps | Calculate NodelocalDNS Config Checksum
+  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  run_once: true
+  set_fact:
+    nodelocaldns_config_checksum: "{{ lookup('template', nodelocaldns_config_manifest) | checksum }}"
+  when:
+    - enable_nodelocaldns
+  tags:
+    - nodelocaldns
+    - coredns
+  vars:
+    forwardTarget: >-
+      {%- if secondaryclusterIP is defined and dns_mode == 'coredns_dual' -%}
+      {{ primaryClusterIP }} {{ secondaryclusterIP }}
+      {%- else -%}
+      {{ primaryClusterIP }}
+      {%- endif -%}
+    upstreamForwardTarget: >-
+      {%- if upstream_dns_servers | length > 0 -%}
+      {{ upstream_dns_servers | join(' ') }}
+      {%- else -%}
+      /etc/resolv.conf
+      {%- endif -%}
 
 - name: Kubernetes Apps | nodelocalDNS
   command:

--- a/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
@@ -23,6 +23,7 @@ spec:
         k8s-app: kube-dns{{ coredns_ordinal_suffix }}
       annotations:
         createdby: 'kubespray'
+        checksum/config: "{{ coredns_config_checksum }}"
     spec:
       securityContext:
         seccompProfile:

--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-daemonset.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-daemonset.yml.j2
@@ -17,6 +17,7 @@ spec:
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '{{ nodelocaldns_prometheus_port }}'
+        checksum/config: "{{ nodelocaldns_config_checksum }}"
     spec:
       nodeSelector:
         {{ nodelocaldns_ds_nodeselector }}

--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-second-daemonset.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-second-daemonset.yml.j2
@@ -17,6 +17,7 @@ spec:
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '{{ nodelocaldns_secondary_prometheus_port }}'
+        checksum/config: "{{ nodelocaldns_config_checksum }}"
     spec:
       nodeSelector:
         {{ nodelocaldns_ds_nodeselector }}

--- a/roles/kubernetes-apps/ansible/vars/main.yml
+++ b/roles/kubernetes-apps/ansible/vars/main.yml
@@ -5,6 +5,8 @@ dns_autoscaler_manifests:
 - dns-autoscaler-clusterrole.yml.j2
 - dns-autoscaler-clusterrolebinding.yml.j2
 
+coredns_config_manifest: coredns-config.yml.j2
+
 coredns_manifests:
 - coredns-clusterrole.yml.j2
 - coredns-clusterrolebinding.yml.j2
@@ -14,6 +16,8 @@ coredns_manifests:
 - coredns-svc.yml.j2
 - "{{ dns_autoscaler_manifests if enable_dns_autoscaler else [] }}"
 - "{{ 'coredns-poddisruptionbudget.yml.j2' if coredns_pod_disruption_budget else [] }}"
+
+nodelocaldns_config_manifest: nodelocaldns-config.yml.j2
 
 nodelocaldns_manifests:
 - nodelocaldns-config.yml.j2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Redeploy coredns and nodelocaldns when their configuration changes.
To do this,
1. Add tasks to get the checksum of the configmaps
2. Add pod annotations(`checksum/config`) denoting calculated checksum to the coredns and nodelocaldns.

**Which issue(s) this PR fixes**:
Fixes #12400

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Redeploy coredns and nodelocaldns when their configurations change.
```
