### PR TITLE
Fix: Correct permissions for downloaded artifacts

### DIFF
--- a/roles/download/tasks/download_file.yml
+++ b/roles/download/tasks/download_file.yml
@@ -22,8 +22,6 @@
   - name: Download_file | Create dest directory on node
     file:
       path: "{{ download.dest | dirname }}"
-      owner: "{{ download.owner | default(omit) }}"
-      mode: "0755"
       state: directory
       recurse: true
 
@@ -111,6 +109,7 @@
       owner: "{{ download.owner | default(omit) }}"
     when:
     - download_force_cache
+    - not download.unarchive | default(false)
 
   - name: "Download_file | Extract file archives"
     include_tasks: "extract_file.yml"

--- a/roles/download/tasks/extract_file.yml
+++ b/roles/download/tasks/extract_file.yml
@@ -4,7 +4,7 @@
     src: "{{ download.dest }}"
     dest: "{{ download.dest | dirname }}"
     owner: "{{ download.owner | default(omit) }}"
-    mode: "{{ download.mode | default(omit) }}"
+    mode: "{{ download.unarchive_mode | default(omit) }}"
     remote_src: true
     extra_opts: "{{ download.unarchive_extra_opts | default(omit) }}"
   when:

--- a/roles/etcdctl_etcdutl/tasks/main.yml
+++ b/roles/etcdctl_etcdutl/tasks/main.yml
@@ -20,13 +20,6 @@
     download: "{{ download_defaults | combine(downloads.etcd) }}"
   when: container_manager in ['crio', 'containerd']
 
-- name: Copy etcd binary
-  unarchive:
-    src: "{{ downloads.etcd.dest }}"
-    dest: "{{ local_release_dir }}/"
-    remote_src: true
-  when: container_manager in ['crio', 'containerd']
-
 - name: Copy etcdctl and etcdutl binary from download dir
   copy:
     src: "{{ local_release_dir }}/etcd-v{{ etcd_version }}-linux-{{ host_architecture }}/{{ item }}"

--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -413,9 +413,7 @@ downloads:
       {{ etcd_binary_checksum if (etcd_deployment_type == 'host')
       else etcd_digest_checksum | d(None) }}
     url: "{{ etcd_download_url }}"
-    unarchive: "{{ etcd_deployment_type == 'host' }}"
-    owner: "root"
-    mode: "0755"
+    unarchive: true
     groups:
       - etcd
 
@@ -426,8 +424,6 @@ downloads:
     checksum: "{{ cni_binary_checksum }}"
     url: "{{ cni_download_url }}"
     unarchive: false
-    owner: "root"
-    mode: "0755"
     groups:
       - k8s_cluster
 
@@ -438,7 +434,6 @@ downloads:
     checksum: "{{ kubeadm_binary_checksum }}"
     url: "{{ kubeadm_download_url }}"
     unarchive: false
-    owner: "root"
     mode: "0755"
     groups:
       - k8s_cluster
@@ -450,7 +445,6 @@ downloads:
     checksum: "{{ kubelet_binary_checksum }}"
     url: "{{ kubelet_download_url }}"
     unarchive: false
-    owner: "root"
     mode: "0755"
     groups:
       - k8s_cluster
@@ -462,7 +456,6 @@ downloads:
     checksum: "{{ kubectl_binary_checksum }}"
     url: "{{ kubectl_download_url }}"
     unarchive: false
-    owner: "root"
     mode: "0755"
     groups:
       - kube_control_plane
@@ -474,8 +467,6 @@ downloads:
     checksum: "{{ crictl_binary_checksum }}"
     url: "{{ crictl_download_url }}"
     unarchive: true
-    owner: "root"
-    mode: "0755"
     groups:
       - k8s_cluster
 
@@ -486,8 +477,6 @@ downloads:
     checksum: "{{ crio_archive_checksum }}"
     url: "{{ crio_download_url }}"
     unarchive: true
-    owner: "root"
-    mode: "0755"
     groups:
       - k8s_cluster
 
@@ -500,8 +489,6 @@ downloads:
     unarchive: true
     unarchive_extra_opts:
       - --strip=1
-    owner: "root"
-    mode: "0755"
     groups:
       - k8s_cluster
 
@@ -512,7 +499,6 @@ downloads:
     checksum: "{{ crun_binary_checksum }}"
     url: "{{ crun_download_url }}"
     unarchive: false
-    owner: "root"
     mode: "0755"
     groups:
       - k8s_cluster
@@ -524,8 +510,6 @@ downloads:
     checksum: "{{ youki_archive_checksum }}"
     url: "{{ youki_download_url }}"
     unarchive: true
-    owner: "root"
-    mode: "0755"
     groups:
       - k8s_cluster
 
@@ -536,7 +520,6 @@ downloads:
     checksum: "{{ runc_binary_checksum }}"
     url: "{{ runc_download_url }}"
     unarchive: false
-    owner: "root"
     mode: "0755"
     groups:
       - k8s_cluster
@@ -548,7 +531,6 @@ downloads:
     checksum: "{{ kata_containers_binary_checksum }}"
     url: "{{ kata_containers_download_url }}"
     unarchive: false
-    owner: "root"
     mode: "0755"
     groups:
       - k8s_cluster
@@ -560,8 +542,6 @@ downloads:
     checksum: "{{ containerd_checksum }}"
     url: "{{ containerd_download_url }}"
     unarchive: false
-    owner: "root"
-    mode: "0755"
     groups:
       - k8s_cluster
 
@@ -572,7 +552,6 @@ downloads:
     checksum: "{{ gvisor_runsc_binary_checksum }}"
     url: "{{ gvisor_runsc_download_url }}"
     unarchive: false
-    owner: "root"
     mode: 755
     groups:
       - k8s_cluster
@@ -584,7 +563,6 @@ downloads:
     checksum: "{{ gvisor_containerd_shim_binary_checksum }}"
     url: "{{ gvisor_containerd_shim_runsc_download_url }}"
     unarchive: false
-    owner: "root"
     mode: 755
     groups:
       - k8s_cluster
@@ -596,8 +574,6 @@ downloads:
     checksum: "{{ nerdctl_archive_checksum }}"
     url: "{{ nerdctl_download_url }}"
     unarchive: true
-    owner: "root"
-    mode: "0755"
     groups:
       - k8s_cluster
 
@@ -608,7 +584,6 @@ downloads:
     checksum: "{{ skopeo_binary_checksum }}"
     url: "{{ skopeo_download_url }}"
     unarchive: false
-    owner: "root"
     mode: "0755"
     groups:
       - kube_control_plane
@@ -683,8 +658,6 @@ downloads:
     checksum: "{{ ciliumcli_binary_checksum }}"
     url: "{{ ciliumcli_download_url }}"
     unarchive: true
-    owner: "root"
-    mode: "0755"
     groups:
       - k8s_cluster
 
@@ -722,7 +695,6 @@ downloads:
     checksum: "{{ calicoctl_binary_checksum }}"
     url: "{{ calicoctl_download_url }}"
     unarchive: false
-    owner: "root"
     mode: "0755"
     groups:
       - k8s_cluster
@@ -783,8 +755,6 @@ downloads:
       - "{{ '--strip=6' if (calico_version is version('3.22.3', '<')) else '--strip=3' }}"
       - "--wildcards"
       - "{{ '*/_includes/charts/calico/crds/kdd/' if (calico_version is version('3.22.3', '<')) else '*/libcalico-go/config/crd/' }}"
-    owner: "root"
-    mode: "0755"
     groups:
       - kube_control_plane
 
@@ -876,8 +846,6 @@ downloads:
     checksum: "{{ helm_archive_checksum }}"
     url: "{{ helm_download_url }}"
     unarchive: true
-    owner: "root"
-    mode: "0755"
     groups:
       - kube_control_plane
 
@@ -969,7 +937,6 @@ downloads:
     dest: "{{ local_release_dir }}/gateway-api-{{ gateway_api_channel }}-install.yaml"
     checksum: "{{ lookup('vars', 'gateway_api_' + gateway_api_channel + '_crds_checksums').no_arch[gateway_api_version] }}"
     url: "{{ gateway_api_crds_download_url }}"
-    owner: "root"
     mode: "0755"
     groups:
       - kube_control_plane
@@ -1090,7 +1057,6 @@ downloads:
     checksum: "{{ yq_binary_checksum }}"
     url: "{{ yq_download_url }}"
     unarchive: false
-    owner: "root"
     mode: "0755"
     groups:
       - kube_control_plane
@@ -1103,7 +1069,6 @@ downloads:
     checksum: "{{ argocd_install_checksum }}"
     url: "{{ argocd_install_url }}"
     unarchive: false
-    owner: "root"
     mode: "0644"
     groups:
       - kube_control_plane
@@ -1118,4 +1083,5 @@ download_defaults:
   url: None
   unarchive: false
   owner: "{{ kube_owner }}"
-  mode: None
+  mode: "0644"
+  unarchive_mode: "0755"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes incorrect 0755 (executable) permissions on downloaded archives.

* A new download_defaults dictionary now sets a safe 0644 mode for archives. Hardcoded permissions were removed from individual items to allow proper inheritance.
* The owner and mode parameters were removed from the directory creation task. This prevents it from recursively applying incorrect permissions to files already in the destination directory during subsequent loop iterations.

These changes ensure archives receive the correct 0644 permissions, while extracted binaries are correctly set to 0755.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12403

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
