### PR TITLE
playbooks/remove_node.yml: prevent privilege escalation in localhost validation task

### DIFF
--- a/playbooks/remove_node.yml
+++ b/playbooks/remove_node.yml
@@ -1,6 +1,8 @@
 ---
 - name: Validate nodes for removal
   hosts: localhost
+  gather_facts: false
+  become: false
   tasks:
     - name: Assert that nodes are specified for removal
       assert:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Adds `become: false` and `gather_facts: false` to the localhost validation task in remove_node.yml.

Since we are forced to call the playbooks with `--become` and `--become-user`, without this patch Ansible tries to escalate privileges on localhost, which is:
- Unnecessary (validation task doesn't need elevated privileges)
- Not allowed in our security context and causes task failure

The `gather_facts: false` optimization is also added since no system facts are needed for this validation-only task.

**Which issue(s) this PR fixes**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
