### PR TITLE
fix(etcd): Update TLS cipher‑suite list and document insecure algorithms

### DIFF
--- a/roles/etcd_defaults/defaults/main.yml
+++ b/roles/etcd_defaults/defaults/main.yml
@@ -90,28 +90,39 @@ etcd_retries: 4
 
 ## Support tls cipher suites.
 # etcd_tls_cipher_suites: {}
-#   - TLS_RSA_WITH_RC4_128_SHA
-#   - TLS_RSA_WITH_3DES_EDE_CBC_SHA
+# Recommended AEAD suites (TLS 1.2 or newer, provide Perfect Forward Secrecy):
+#   - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+#   - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+#   - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+#   - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+#   - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+#   - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+#
+# Legacy AEAD suites without PFS (RSA key exchange):
+#   - TLS_RSA_WITH_AES_128_GCM_SHA256
+#   - TLS_RSA_WITH_AES_256_GCM_SHA384
+#
+# Legacy AES‑CBC suites without PFS (susceptible to BEAST/Lucky13 timing attacks).
+# Enable only for backward compatibility with very old clients:
 #   - TLS_RSA_WITH_AES_128_CBC_SHA
 #   - TLS_RSA_WITH_AES_256_CBC_SHA
 #   - TLS_RSA_WITH_AES_128_CBC_SHA256
-#   - TLS_RSA_WITH_AES_128_GCM_SHA256
-#   - TLS_RSA_WITH_AES_256_GCM_SHA384
-#   - TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
 #   - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
 #   - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
-#   - TLS_ECDHE_RSA_WITH_RC4_128_SHA
-#   - TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
 #   - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
 #   - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
 #   - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
 #   - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
-#   - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-#   - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-#   - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-#   - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-#   - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
-#   - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+#
+# Insecure suites – do not enable:
+#   * RC4: prohibited by RFC 7465 because of severe statistical biases.
+#   * 3DES‑CBC: 64‑bit block cipher vulnerable to the SWEET32 collision attack
+#     (CVE‑2016‑2183) after roughly 32 GiB of data.
+#   - TLS_RSA_WITH_RC4_128_SHA
+#   - TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
+#   - TLS_ECDHE_RSA_WITH_RC4_128_SHA
+#   - TLS_RSA_WITH_3DES_EDE_CBC_SHA
+#   - TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
 
 # ETCD 3.5.x issue
 # https://groups.google.com/a/kubernetes.io/g/dev/c/B7gJs88XtQc/m/rSgNOzV2BwAJ?utm_medium=email&utm_source=footer


### PR DESCRIPTION
<html><head></head><body><h3>PR Description —&nbsp;Document and Re‑order <strong><code>etcd_tls_cipher_suites</code></strong> Defaults</h3>
<h4>What does this PR change?</h4>
<ul>
<li>
<p>Re‑writes the commented example in <code>roles/etcd_defaults/defaults/main.yml</code></p>
<ul>
<li>
<p>Groups cipher suites into <strong>Recommended</strong>, <strong>Legacy (no PFS)</strong> and <strong>Insecure</strong>.</p>
</li>
</ul>
</li>
<li>
<p>Removes no suites at runtime – the variable is still empty by default, so etcd keeps Go’s secure default list.</p>
<ul>
<li>
<p>The change is <strong>documentation‑only</strong> unless an operator explicitly sets <code>etcd_tls_cipher_suites</code>.</p>
</li>
</ul>
</li>
</ul>
<h4>Why is it needed?</h4>
<p>Cluster operators sometimes copy the commented list verbatim to “lock down” TLS.<br>
The previous order mixed modern AEAD suites with legacy RC4/3DES, making it easy to choose insecure options by mistake.</p>

Cipher family | Risk | References
-- | -- | --
RC4 | Statistical biases; prohibited by RFC 7465 | RFC 7465
3DES‑CBC | 64‑bit blocks → SWEET32 collision after ≈ 32 GiB | CVE‑2016‑2183
AES‑CBC + RSA | No Perfect Forward Secrecy; susceptible to BEAST / Lucky13 timing attacks | CVE‑2011‑3389, CVE‑2013‑0169


<p>The new comments:</p>
<ul>
<li>
<p>Highlight <em>safe</em> AEAD‑with‑ECDHE suites (GCM / ChaCha20).</p>
</li>
<li>
<p>Move AES‑CBC and RSA‑GCM to a “legacy” bucket, clearly flagged “no PFS”.</p>
</li>
<li>
<p>Mark RC4 and 3DES as <strong>“do not enable”</strong> with a short rationale.</p>
</li>
</ul>
<h4>Benefits</h4>
<ul>
<li>
<p>Reduces chance of deploying etcd with weak encryption.</p>
</li>
<li>
<p>Acts as living guidance for newcomers who rely on Kubespray defaults.</p>
</li>
<li>
<p>No behavioural change for existing clusters.</p>
</li>
</ul>