### PR TITLE
Add privileged mode support for Cilium

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
@@ -12,6 +12,9 @@ cilium_l2announcements: false
 # Cilium agent health port
 # cilium_agent_health_port: "9879"
 
+# Enable privileged mode for Cilium
+# cilium_privileged: false
+
 # Identity allocation mode selects how identities are shared between cilium
 # nodes by setting how they are stored. The options are "crd" or "kvstore".
 # - "crd" stores identities in kubernetes as CRDs (custom resource definition).

--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -16,6 +16,9 @@ cilium_l2announcements: false
 # Cilium agent health port
 cilium_agent_health_port: "9879"
 
+# Enable privileged mode for Cilium
+cilium_privileged: false
+
 # Identity allocation mode selects how identities are shared between cilium
 # nodes by setting how they are stored. The options are "crd" or "kvstore".
 # - "crd" stores identities in kubernetes as CRDs (custom resource definition).

--- a/roles/network_plugin/cilium/templates/values.yaml.j2
+++ b/roles/network_plugin/cilium/templates/values.yaml.j2
@@ -34,6 +34,9 @@ dnsProxy:
   enableTransparentMode: {{ cilium_dns_proxy_enable_transparent_mode | to_json }}
 {% endif %}
 
+securityContext:
+  privileged: {{ cilium_privileged | to_json }}
+
 extraVolumes:
   {{ cilium_agent_extra_volumes | to_nice_yaml(indent=2) | indent(2) }}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds support for configuring Cilium to run in privileged mode through inventory variables.

This addresses permission issues encountered when running Cilium with `securityContext.privileged=false`, such as mount-cgroup container failures with "Permission denied" errors when copying files to `/hostbin/cilium-mount`.

Changes include:
- Added `securityContext.privileged` configuration to Cilium Helm values template
- Added `cilium_privileged` variable to inventory sample configuration  
- Added default value `cilium_privileged: false` to Cilium role defaults

This resolves issues like [cilium/cilium#23838](https://github.com/cilium/cilium/issues/23838) where Cilium mount-cgroup containers fail with permission denied errors without requiring `kube_owner` changes or other complex workarounds.

**Which issue(s) this PR fixes**:

Fixes #12276

**Special notes for your reviewer**:

- The default value is set to `false` to maintain security best practices
- Users need to explicitly enable privileged mode when required for their environment  
- This provides a clean solution for permission issues without modifying system-level settings
- No breaking changes - existing deployments will continue to work as before

**Does this PR introduce a user-facing change?**:

```release-note
Add support for configuring Cilium privileged mode via `cilium_privileged` inventory variable. Defaults to `false` for security. Set to `true` to resolve permission issues in restrictive environments.
```