### PR TITLE
kubeadm: control imageRepository with dedicated var

### DIFF
--- a/roles/download/templates/kubeadm-images.yaml.j2
+++ b/roles/download/templates/kubeadm-images.yaml.j2
@@ -5,7 +5,7 @@ nodeRegistration:
 ---
 apiVersion: kubeadm.k8s.io/{{ kubeadm_config_api_version }}
 kind: ClusterConfiguration
-imageRepository: {{ kube_image_repo }}
+imageRepository: {{ kubeadm_image_repo }}
 kubernetesVersion: v{{ kube_version }}
 etcd:
 {% if etcd_deployment_type == "kubeadm" %}

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
@@ -103,7 +103,7 @@ controlPlaneEndpoint: "{{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.p
 controlPlaneEndpoint: "{{ main_ip | ansible.utils.ipwrap }}:{{ kube_apiserver_port }}"
 {% endif %}
 certificatesDir: {{ kube_cert_dir }}
-imageRepository: {{ kube_image_repo }}
+imageRepository: {{ kubeadm_image_repo }}
 apiServer:
   extraArgs:
     etcd-compaction-interval: "{{ kube_apiserver_etcd_compaction_interval }}"

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
@@ -122,7 +122,7 @@ controlPlaneEndpoint: "{{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.p
 controlPlaneEndpoint: "{{ main_ip | ansible.utils.ipwrap }}:{{ kube_apiserver_port }}"
 {% endif %}
 certificatesDir: {{ kube_cert_dir }}
-imageRepository: {{ kube_image_repo }}
+imageRepository: {{ kubeadm_image_repo }}
 apiServer:
   extraArgs:
   - name: etcd-compaction-interval

--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -88,6 +88,7 @@ docker_containerd_version: 1.6.32
 # gcr and kubernetes image repo define
 gcr_image_repo: "gcr.io"
 kube_image_repo: "registry.k8s.io"
+kubeadm_image_repo: "{{ kube_image_repo }}"
 
 # docker image repo define
 docker_image_repo: "docker.io"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Introduce `kubeadm_image_repo` to independently control the image repository used by kubeadm. This allows referencing custom Kubernetes builds without affecting other components that rely on `kube_image_repo`, such as CoreDNS, which should be managed by their own variables.

**Does this PR introduce a user-facing change?**:
```release-note
Introduce `kubeadm_image_repo` to independently control the image repository used by kubeadm.
```
