### PR TITLE
Fix: change the EOL Debian backports to archive

### DIFF
--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -60,16 +60,17 @@
   environment: "{{ proxy_env }}"
   when: ansible_pkg_mgr == 'apt'
 
-# ref to https://github.com/kubernetes-sigs/kubespray/issues/11086
-- name: Remove the archived debian apt repository
-  lineinfile:
-    path: /etc/apt/sources.list
-    regexp: 'buster-backports'
-    state: absent
+# ref to https://github.com/kubernetes-sigs/kubespray/issues/11086 & 12424
+- name: Convert -backports sources to archive.debian.org for bullseye and older
+  replace:
+    path: "{{ item }}"
+    regexp: '^(deb(?:-src)?\s+)(?:https?://)?(?:[^ ]+debian\.org)?([^ ]*/debian)(\s+{{ ansible_distribution_release }}-backports\b.*)'
+    replace: '\1http://archive.debian.org/debian\3'
     backup: true
+  loop: "{{ query('fileglob', '/etc/apt/sources.list') }}"
   when:
     - ansible_os_family == 'Debian'
-    - ansible_distribution_release == "buster"
+    - ansible_distribution_release in ['bullseye', 'buster']
 
 - name: Ensure docker-ce repository is enabled
   apt_repository:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Change the EOL Debian (current like Bullseye, Buster...) backports apt package link to `archive.debian.org`.

**Which issue(s) this PR fixes**:

Fixes #12424
Related #11086

**Special notes for your reviewer**:

This only affects `container_manager: docker` user.

**Does this PR introduce a user-facing change?**:

```release-note
Change the EOL Debian backports apt package to archive.debian.org
```
