### PR TITLE
Fix: Change "empty" definition for PodSecurity Admission configuration

### DIFF
--- a/roles/kubernetes/control-plane/templates/podsecurity.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/podsecurity.yaml.j2
@@ -1,6 +1,6 @@
-{% if kube_pod_security_use_default %}
 apiVersion: pod-security.admission.config.k8s.io/v1
 kind: PodSecurityConfiguration
+{% if kube_pod_security_use_default %}
 defaults:
   enforce: "{{ kube_pod_security_default_enforce }}"
   enforce-version: "{{ kube_pod_security_default_enforce_version }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes a bug where `kube-apiserver` fails to start if the PodSecurity configuration file doesn't have the `apiVersion` and `kind` keys.

Error log:
```
E0731 20:30:53.254052       1 run.go:72] "command failed" err=<
        failed to apply admission: couldn't init admission plugin "PodSecurity": Object 'Kind' is missing in '# This file is intentinally left empty as kube_pod_security_use_default=False
        '
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix invalid PodSecurity admission configuration when `kube_pod_security_use_default: false`
```
