### PR TITLE
Fix: render tcp and udp service ports as integers in Ingress NGINX te…

### DIFF
--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/ds-ingress-nginx-controller.yml.j2
@@ -129,20 +129,20 @@ spec:
 {% if ingress_nginx_configmap_tcp_services %}
 {% for port in ingress_nginx_configmap_tcp_services.keys() %}
             - name: tcp-port-{{ port }}
-              containerPort: "{{ port | int }}"
+              containerPort: {{ port | int }}
               protocol: TCP
 {% if not ingress_nginx_host_network %}
-              hostPort: "{{ port | int }}"
+              hostPort: {{ port | int }}
 {% endif %}
 {% endfor %}
 {% endif %}
 {% if ingress_nginx_configmap_udp_services %}
 {% for port in ingress_nginx_configmap_udp_services.keys() %}
             - name: udp-port-{{ port }}
-              containerPort: "{{ port | int }}"
+              containerPort: {{ port | int }}
               protocol: UDP
 {% if not ingress_nginx_host_network %}
-              hostPort: "{{ port | int }}"
+              hostPort: {{ port | int }}
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/svc-ingress-nginx.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/ingress_nginx/templates/svc-ingress-nginx.yml.j2
@@ -31,16 +31,16 @@ spec:
 {% if ingress_nginx_configmap_tcp_services %}
 {% for port in ingress_nginx_configmap_tcp_services.keys() %}
     - name: tcp-port-{{ port }}
-      port: "{{ port | int }}"
-      targetPort: "{{ port | int }}"
+      port: {{ port | int }}
+      targetPort: {{ port | int }}
       protocol: TCP
 {% endfor %}
 {% endif %}
 {% if ingress_nginx_configmap_udp_services %}
 {% for port in ingress_nginx_configmap_udp_services.keys() %}
     - name: udp-port-{{ port }}
-      port: "{{ port | int }}"
-      targetPort: "{{ port | int }}"
+      port: {{ port | int }}
+      targetPort: {{ port | int }}
       protocol: UDP
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes a bug in the `ingress_nginx` templates where `ingress_nginx_configmap_tcp_services` and `ingress_nginx_configmap_udp_services` entries are rendered with string keys (e.g. `"9000"`) instead of integer keys (e.g. `9000`). 

According to the [NGINX ingress controller documentation](https://kubernetes.github.io/ingress-nginx/user-guide/exposing-tcp-udp-services/), port numbers in these configmaps must be integers. Rendering them as strings causes the ingress controller to ignore these entries silently, preventing users from exporting TCP or UDP services via the LoadBalancer service.

**Which issue(s) this PR fixes**:
N/A (not tracked in a GitHub issue)

**Special notes for your reviewer**:
- Updated `ds-ingress-nginx-controller.yml.j2` and `svc-ingress-nginx.yml.j2` to ensure that the port keys in the `tcp-services` and `udp-services` configmaps are rendered as integers using Jinja2’s `int` filter.
- This fix is necessary to enable functionality like exposing PostgreSQL, Redis, or other TCP-based services through the ingress controller.

**Does this PR introduce a user-facing change?**:
```release-note
Fix ingress-nginx DaemonSet and Service templates rendering TCP/UDP ports as strings, which prevented correct export of TCP/UDP services via NGINX ingress controller.
```
