### PR TITLE
Feat: revert calico default pool in CM calico-config

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-calico.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-calico.yml
@@ -25,8 +25,14 @@ calico_pool_blocksize: 26
 # add default ippool CIDR (must be inside kube_pods_subnet, defaults to kube_pods_subnet otherwise)
 # calico_pool_cidr: 1.2.3.4/5
 
+# add default ippool CIDR to CNI config
+# calico_cni_pool: true
+
 # Add default IPV6 IPPool CIDR. Must be inside kube_pods_subnet_ipv6. Defaults to kube_pods_subnet_ipv6 if not set.
 # calico_pool_cidr_ipv6: fd85:ee78:d8a6:8607::1:0000/112
+
+# Add default IPV6 IPPool CIDR to CNI config
+# calico_cni_pool_ipv6: true
 
 # Global as_num (/calico/bgp/v1/global/as_num)
 # global_as_num: "64512"

--- a/roles/network_plugin/calico/tasks/check.yml
+++ b/roles/network_plugin/calico/tasks/check.yml
@@ -163,7 +163,7 @@
   assert:
     that:
       - calico_pool_conf.spec.blockSize | int == calico_pool_blocksize | int
-      - calico_pool_conf.spec.cidr == (calico_pool_cidr | default(kube_pods_subnet))
+      - calico_pool_conf.spec.cidr == calico_pool_cidr
       - not calico_pool_conf.spec.ipipMode is defined or calico_pool_conf.spec.ipipMode == calico_ipip_mode
       - not calico_pool_conf.spec.vxlanMode is defined or calico_pool_conf.spec.vxlanMode == calico_vxlan_mode
     msg: "Your inventory doesn't match the current cluster configuration"
@@ -197,7 +197,7 @@
   assert:
     that:
       - calico_pool_conf.spec.blockSize | int == calico_pool_blocksize_ipv6 | int
-      - calico_pool_conf.spec.cidr == (calico_pool_cidr_ipv6 | default(kube_pods_subnet_ipv6))
+      - calico_pool_conf.spec.cidr == calico_pool_cidr_ipv6
       - not calico_pool_conf.spec.ipipMode is defined or calico_pool_conf.spec.ipipMode == calico_ipip_mode_ipv6
       - not calico_pool_conf.spec.vxlanMode is defined or calico_pool_conf.spec.vxlanMode == calico_vxlan_mode_ipv6
     msg: "Your ipv6 inventory doesn't match the current cluster configuration"

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -74,7 +74,7 @@
 - name: Calico | Check if calico network pool has already been configured
   # noqa risky-shell-pipe - grep will exit 1 if no match found
   shell: >
-    {{ bin_dir }}/calicoctl.sh get ippool | grep -w "{{ calico_pool_cidr | default(kube_pods_subnet) }}" | wc -l
+    {{ bin_dir }}/calicoctl.sh get ippool | grep -w "{{ calico_pool_cidr }}" | wc -l
   args:
     executable: /bin/bash
   register: calico_conf
@@ -99,7 +99,7 @@
 - name: Calico | Check if calico IPv6 network pool has already been configured
   # noqa risky-shell-pipe - grep will exit 1 if no match found
   shell: >
-    {{ bin_dir }}/calicoctl.sh get ippool | grep -w "{{ calico_pool_cidr_ipv6 | default(kube_pods_subnet_ipv6) }}" | wc -l
+    {{ bin_dir }}/calicoctl.sh get ippool | grep -w "{{ calico_pool_cidr_ipv6 }}" | wc -l
   args:
     executable: /bin/bash
   register: calico_conf_ipv6
@@ -227,7 +227,7 @@
             },
             "spec": {
               "blockSize": {{ calico_pool_blocksize }},
-              "cidr": "{{ calico_pool_cidr | default(kube_pods_subnet) }}",
+              "cidr": "{{ calico_pool_cidr }}",
               "ipipMode": "{{ calico_ipip_mode }}",
               "vxlanMode": "{{ calico_vxlan_mode }}",
               "natOutgoing": {{ nat_outgoing | default(false) }}
@@ -278,7 +278,7 @@
             },
             "spec": {
               "blockSize": {{ calico_pool_blocksize_ipv6 }},
-              "cidr": "{{ calico_pool_cidr_ipv6 | default(kube_pods_subnet_ipv6) }}",
+              "cidr": "{{ calico_pool_cidr_ipv6 }}",
               "ipipMode": "{{ calico_ipip_mode_ipv6 }}",
               "vxlanMode": "{{ calico_vxlan_mode_ipv6 }}",
               "natOutgoing": {{ nat_outgoing_ipv6 | default(false) }}

--- a/roles/network_plugin/calico/templates/calico-config.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-config.yml.j2
@@ -57,9 +57,15 @@ data:
             "ipam": {
               "type": "calico-ipam",
             {% if ipv4_stack %}
+              {% if calico_cni_pool %}
+              "ipv4_pools": ["{{ calico_pool_cidr | default(kube_pods_subnet) }}"],
+              {% endif %}
               "assign_ipv4": "true"{{ ',' if (ipv6_stack and ipv4_stack) }}
             {% endif %}
             {% if ipv6_stack %}
+              {% if calico_cni_pool_ipv6 %}
+              "ipv6_pools": ["{{ calico_pool_cidr_ipv6 | default(kube_pods_subnet_ipv6) }}"],
+              {% endif %}
               "assign_ipv6": "true"
             {% endif %}
             },

--- a/roles/network_plugin/calico/templates/calico-config.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-config.yml.j2
@@ -58,13 +58,13 @@ data:
               "type": "calico-ipam",
             {% if ipv4_stack %}
               {% if calico_cni_pool %}
-              "ipv4_pools": ["{{ calico_pool_cidr | default(kube_pods_subnet) }}"],
+              "ipv4_pools": ["{{ calico_pool_cidr }}"],
               {% endif %}
               "assign_ipv4": "true"{{ ',' if (ipv6_stack and ipv4_stack) }}
             {% endif %}
             {% if ipv6_stack %}
               {% if calico_cni_pool_ipv6 %}
-              "ipv6_pools": ["{{ calico_pool_cidr_ipv6 | default(kube_pods_subnet_ipv6) }}"],
+              "ipv6_pools": ["{{ calico_pool_cidr_ipv6 }}"],
               {% endif %}
               "assign_ipv6": "true"
             {% endif %}

--- a/roles/network_plugin/calico/templates/calico-config.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-config.yml.j2
@@ -58,13 +58,13 @@ data:
               "type": "calico-ipam",
             {% if ipv4_stack %}
               {% if calico_cni_pool %}
-              "ipv4_pools": ["{{ calico_pool_cidr }}"],
+              "ipv4_pools": "{{ calico_pool_cidr }}",
               {% endif %}
-              "assign_ipv4": "true"{{ ',' if (ipv6_stack and ipv4_stack) }}
+              "assign_ipv4": "true"{{ ',' if ipv6_stack }}
             {% endif %}
             {% if ipv6_stack %}
               {% if calico_cni_pool_ipv6 %}
-              "ipv6_pools": ["{{ calico_pool_cidr_ipv6 }}"],
+              "ipv6_pools": "{{ calico_pool_cidr_ipv6 }}",
               {% endif %}
               "assign_ipv6": "true"
             {% endif %}

--- a/roles/network_plugin/calico/templates/calico-config.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-config.yml.j2
@@ -58,13 +58,13 @@ data:
               "type": "calico-ipam",
             {% if ipv4_stack %}
               {% if calico_cni_pool %}
-              "ipv4_pools": "{{ calico_pool_cidr }}",
+              "ipv4_pools": ["{{ calico_pool_cidr }}"],
               {% endif %}
-              "assign_ipv4": "true"{{ ',' if ipv6_stack }}
+              "assign_ipv4": "true"{{ ',' if (ipv6_stack and ipv4_stack) }}
             {% endif %}
             {% if ipv6_stack %}
               {% if calico_cni_pool_ipv6 %}
-              "ipv6_pools": "{{ calico_pool_cidr_ipv6 }}",
+              "ipv6_pools": ["{{ calico_pool_cidr_ipv6 }}"],
               {% endif %}
               "assign_ipv6": "true"
             {% endif %}

--- a/roles/network_plugin/calico_defaults/defaults/main.yml
+++ b/roles/network_plugin/calico_defaults/defaults/main.yml
@@ -14,6 +14,9 @@ calico_ipv4pool_ipip: "Off"
 calico_ipip_mode: Never  # valid values are 'Always', 'Never' and 'CrossSubnet'
 calico_vxlan_mode: Always  # valid values are 'Always', 'Never' and 'CrossSubnet'
 
+calico_cni_pool: true
+calico_cni_pool_ipv6: true
+
 # add default ippool blockSize
 calico_pool_blocksize: 26
 

--- a/roles/network_plugin/calico_defaults/defaults/main.yml
+++ b/roles/network_plugin/calico_defaults/defaults/main.yml
@@ -1,12 +1,12 @@
 ---
-# the default value of name
+# Calico default CNI name
 calico_cni_name: k8s-pod-network
 
 # Enables Internet connectivity from containers
 nat_outgoing: true
 nat_outgoing_ipv6: false
 
-# add default ippool name
+# Calico default ippool name
 calico_pool_name: "default-pool"
 calico_ipv4pool_ipip: "Off"
 
@@ -14,18 +14,21 @@ calico_ipv4pool_ipip: "Off"
 calico_ipip_mode: Never  # valid values are 'Always', 'Never' and 'CrossSubnet'
 calico_vxlan_mode: Always  # valid values are 'Always', 'Never' and 'CrossSubnet'
 
+# Enable/disable Calico CNI IP pool creation
 calico_cni_pool: true
 calico_cni_pool_ipv6: true
 
-# add default ippool blockSize
+# Calico default ippool cidr for IPv4 and IPv6
+calico_pool_cidr: "{{ kube_pods_subnet }}"
+calico_pool_cidr_ipv6: "{{ kube_pods_subnet_ipv6 }}"
+
+# Calico default ippool blockSize
 calico_pool_blocksize: 26
+calico_pool_blocksize_ipv6: 122
 
 # Calico doesn't support ipip tunneling for the IPv6.
 calico_ipip_mode_ipv6: Never
 calico_vxlan_mode_ipv6: Always
-
-# add default ipv6 ippool blockSize
-calico_pool_blocksize_ipv6: 122
 
 # Calico network backend can be 'bird', 'vxlan' and 'none'
 calico_network_backend: vxlan

--- a/roles/network_plugin/calico_defaults/defaults/main.yml
+++ b/roles/network_plugin/calico_defaults/defaults/main.yml
@@ -19,8 +19,8 @@ calico_cni_pool: true
 calico_cni_pool_ipv6: true
 
 # Calico default ippool cidr for IPv4 and IPv6
-calico_pool_cidr: "{{ kube_pods_subnet }}"
-calico_pool_cidr_ipv6: "{{ kube_pods_subnet_ipv6 }}"
+calico_pool_cidr: ["{{ kube_pods_subnet }}"]
+calico_pool_cidr_ipv6: ["{{ kube_pods_subnet_ipv6 }}"]
 
 # Calico default ippool blockSize
 calico_pool_blocksize: 26

--- a/roles/network_plugin/calico_defaults/defaults/main.yml
+++ b/roles/network_plugin/calico_defaults/defaults/main.yml
@@ -19,8 +19,8 @@ calico_cni_pool: true
 calico_cni_pool_ipv6: true
 
 # Calico default ippool cidr for IPv4 and IPv6
-calico_pool_cidr: ["{{ kube_pods_subnet }}"]
-calico_pool_cidr_ipv6: ["{{ kube_pods_subnet_ipv6 }}"]
+calico_pool_cidr: "{{ kube_pods_subnet }}"
+calico_pool_cidr_ipv6: "{{ kube_pods_subnet_ipv6 }}"
 
 # Calico default ippool blockSize
 calico_pool_blocksize: 26

--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -194,21 +194,22 @@ cilium_ipam_mode: cluster-pool
 
 # Cluster Pod CIDRs use the kube_pods_subnet value by default.
 # If your node network is in the same range you will lose connectivity to other nodes.
-# Defaults to kube_pods_subnet if not set.
-# cilium_pool_cidr: 10.233.64.0/18
+# exemple: cilium_pool_cidr: 10.233.64.0/18
+cilium_pool_cidr: "{{ kube_pods_subnet }}"
 
-# When cilium_enable_ipv6 is used, you need to set the IPV6 value.  Defaults to kube_pods_subnet_ipv6 if not set.
-# cilium_pool_cidr_ipv6: fd85:ee78:d8a6:8607::1:0000/112
+# When cilium_enable_ipv6 is used, you need to set the IPV6 value.
+# exemple: cilium_pool_cidr_ipv6: fd85:ee78:d8a6:8607::1:0000/112
+cilium_pool_cidr_ipv6: "{{ kube_pods_subnet_ipv6 }}"
 
 # When cilium IPAM uses the "Cluster Scope" mode, it will pre-allocate a segment of IP to each node,
 # schedule the Pod to this node, and then allocate IP from here. cilium_pool_mask_size Specifies
 # the size allocated from cluster Pod CIDR to node.ipam.podCIDRs
-# Defaults to kube_network_node_prefix if not set.
-# cilium_pool_mask_size: "24"
+# example: cilium_pool_mask_size: "24"
+cilium_pool_mask_size: "{{ kube_network_node_prefix }}"
 
 # cilium_pool_mask_size Specifies the size allocated to node.ipam.podCIDRs from cluster Pod IPV6 CIDR
-# Defaults to kube_network_node_prefix_ipv6 if not set.
-# cilium_pool_mask_size_ipv6: "120"
+# exemple: cilium_pool_mask_size_ipv6: "120"
+cilium_pool_mask_size_ipv6: "{{ kube_network_node_prefix_ipv6 }}"
 
 
 # Extra arguments for the Cilium agent

--- a/roles/network_plugin/cilium/templates/values.yaml.j2
+++ b/roles/network_plugin/cilium/templates/values.yaml.j2
@@ -122,12 +122,12 @@ ipam:
   mode: {{ cilium_ipam_mode }}
   operator:
     clusterPoolIPv4PodCIDRList:
-      - {{ cilium_pool_cidr | default(kube_pods_subnet) }}
-    clusterPoolIPv4MaskSize: {{ cilium_pool_mask_size | default(kube_network_node_prefix) }}
+      - {{ cilium_pool_cidr }}
+    clusterPoolIPv4MaskSize: {{ cilium_pool_mask_size }}
 
     clusterPoolIPv6PodCIDRList:
-      - {{ cilium_pool_cidr_ipv6 | default(kube_pods_subnet_ipv6) }}
-    clusterPoolIPv6MaskSize: {{ cilium_pool_mask_size_ipv6 | default(kube_network_node_prefix_ipv6) }}
+      - {{ cilium_pool_cidr_ipv6 }}
+    clusterPoolIPv6MaskSize: {{ cilium_pool_mask_size_ipv6 }}
 
 cgroup:
   autoMount:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This PR reverts the functionality of calico's default pool and make it configurable in the config map of calico.

**Special notes for your reviewer**:

This feature was removed on the version v2.23.0 with the removal of the config file and the usage of the config map instead. While this configuration of the default pool existed in the file it was absent in the config map.
Is there a proper way to defined the default IP pool that calico uses, instead of defining it in the config-map `calico-config.yml` ?

**Does this PR introduce a user-facing change?**:

```release-note
Reintroduced support for configuring Calico's default IP pool via the calico-config ConfigMap (fixing behavior removed in v2.23.0)
```
