### PR TITLE
download: Omit checksum if checksum is set to a default value of None

### DIFF
--- a/roles/download/tasks/download_file.yml
+++ b/roles/download/tasks/download_file.yml
@@ -62,7 +62,7 @@
       dest: "{{ file_path_cached if download_force_cache else download.dest }}"
       owner: "{{ omit if download_localhost else (download.owner | default(omit)) }}"
       mode: "{{ omit if download_localhost else (download.mode | default(omit)) }}"
-      checksum: "{{ download.checksum }}"
+      checksum: "{{ download.checksum if download.checksum else omit }}"
       validate_certs: "{{ download_validate_certs }}"
       url_username: "{{ download.username | default(omit) }}"
       url_password: "{{ download.password | default(omit) }}"


### PR DESCRIPTION
With 800c84dcc93fa98382064214645b45a68fd696e7, the use of different hashes were allowed. But, for many of the checksum variables, the default value of `None` is set. But `get_url` module of ansible expects checksum to be of string type. omitting the checksum field lets `get_url` to use "" as the default checksum.


**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
bug fix in download role

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
