### PR TITLE
Make control plane health check retries configurable

### DIFF
--- a/roles/kubernetes/control-plane/defaults/main/main.yml
+++ b/roles/kubernetes/control-plane/defaults/main/main.yml
@@ -31,6 +31,9 @@ kube_etcd_key_file: node-{{ inventory_hostname }}-key.pem
 # CLI/web clients.
 kube_controller_manager_bind_address: "::"
 
+## Control plane health check settings
+control_plane_health_retries: 60  # Default retries for apiserver, scheduler, controller-manager health checks
+
 # Leader election lease durations and timeouts for controller-manager
 kube_controller_manager_leader_elect_lease_duration: 15s
 kube_controller_manager_leader_elect_renew_deadline: 10s

--- a/roles/kubernetes/control-plane/handlers/main.yml
+++ b/roles/kubernetes/control-plane/handlers/main.yml
@@ -84,7 +84,7 @@
     validate_certs: false
   register: scheduler_result
   until: scheduler_result.status == 200
-  retries: 60
+  retries: "{{ control_plane_health_retries }}"
   delay: 1
   listen:
     - Control plane | restart kubelet
@@ -98,7 +98,7 @@
     validate_certs: false
   register: controller_manager_result
   until: controller_manager_result.status == 200
-  retries: 60
+  retries: "{{ control_plane_health_retries }}"
   delay: 1
   listen:
     - Control plane | restart kubelet
@@ -110,7 +110,7 @@
     validate_certs: false
   register: result
   until: result.status == 200
-  retries: 60
+  retries: "{{ control_plane_health_retries }}"
   delay: 1
   listen:
     - Control plane | restart kubelet


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds a `control_plane_health_retries` variable to control retries for control-plane health checks (apiserver, scheduler, controller-manager), defaulting to 60 but overridable for different environments.

**Which issue(s) this PR fixes**:
Fixes: #12448
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Control plane health check retries for apiserver, scheduler, and controller-manager are now configurable via `control_plane_health_retries` (default: 60).
```
