### PR TITLE
Allow overriding vsphere-csi-controller config options

### DIFF
--- a/docs/CSI/vsphere-csi.md
+++ b/docs/CSI/vsphere-csi.md
@@ -38,6 +38,7 @@ You need to source the vSphere credentials you use to deploy your machines that 
 | vsphere_csi_aggressive_node_unreachable_timeout | FALSE    | int     |                 | 300                     | Timeout till node will be drained when it in an unreachable state                                                           |
 | vsphere_csi_aggressive_node_not_ready_timeout   | FALSE    | int     |                 | 300                     | Timeout till node will be drained when it in not-ready state                                                                |
 | vsphere_csi_namespace                           | TRUE     | string  |                 | "kube-system"           | vSphere CSI namespace to use; kube-system for backward compatibility, should be change to vmware-system-csi on the long run |
+| vsphere_csi_controller_config_override          | FALSE   | dict     |                 | {}                      | key/value pairs to override any values in internal-feature-states.csi.vsphere.vmware.com configmap |
 
 ## Usage example
 

--- a/roles/kubernetes-apps/csi_driver/vsphere/defaults/main.yml
+++ b/roles/kubernetes-apps/csi_driver/vsphere/defaults/main.yml
@@ -27,9 +27,11 @@ vsphere_csi_aggressive_node_not_ready_timeout: 300
 
 vsphere_csi_node_affinity: {}
 
-# https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/docs/book/features/volume_snapshot.md#how-to-enable-volume-snapshot--restore-feature-in-vsphere-csi-
-# according to the above link , we can controler the block-volume-snapshot parameter
-vsphere_csi_block_volume_snapshot: false
+# key/value pairs to override any values in internal-feature-states.csi.vsphere.vmware.com configmap
+# example:
+# vsphere_csi_controller_config_override:
+#   block-volume-snapshot: "false"
+vsphere_csi_controller_config_override: {}
 
 external_vsphere_user: "{{ lookup('env', 'VSPHERE_USER') }}"
 external_vsphere_password: "{{ lookup('env', 'VSPHERE_PASSWORD') }}"

--- a/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-controller-config.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/vsphere/templates/vsphere-csi-controller-config.yml.j2
@@ -1,28 +1,29 @@
+{%- set default_config = {
+  "csi-auth-check": "true" if external_vsphere_version >= "7.0" else "false",
+  "online-volume-extend": "true",
+  "trigger-csi-fullsync": "false",
+  "async-query-volume": "true",
+  "block-volume-snapshot": "true",
+  "csi-windows-support": "false",
+  "list-volumes": "true",
+  "pv-to-backingdiskobjectid-mapping": "false",
+  "cnsmgr-suspend-create-volume": "true",
+  "topology-preferential-datastores": "true",
+  "max-pvscsi-targets-per-vm": "true",
+  "multi-vcenter-csi-topology": "true",
+  "csi-internal-generated-cluster-id": "true",
+  "listview-tasks": "true",
+  "improved-csi-idempotency": "true",
+  "improved-volume-topology": "true",
+  "use-csinode-id": "true",
+  "list-volumes": "false"
+} -%}
+{%- set merged = default_config | ansible.builtin.combine(vsphere_csi_controller_config_override) -%}
 apiVersion: v1
 data:
-{% if external_vsphere_version >= "7.0" %}
-  "csi-auth-check": "true"
-{% else %}
-  "csi-auth-check": "false"
-{% endif %}
-  "csi-auth-check": "true"
-  "online-volume-extend": "true"
-  "trigger-csi-fullsync": "false"
-  "async-query-volume": "true"
-  "block-volume-snapshot": "true"
-  "csi-windows-support": "false"
-  "list-volumes": "true"
-  "pv-to-backingdiskobjectid-mapping": "false"
-  "cnsmgr-suspend-create-volume": "true"
-  "topology-preferential-datastores": "true"
-  "max-pvscsi-targets-per-vm": "true"
-  "multi-vcenter-csi-topology": "true"
-  "csi-internal-generated-cluster-id": "true"
-  "listview-tasks": "true"
-  "improved-csi-idempotency": "true"
-  "improved-volume-topology": "true"
-  "use-csinode-id": "true"
-  "list-volumes": "false"
+{% for key, value in merged.items() %}
+  "{{ key }}": "{{ value | string }}"
+{% endfor %}
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR Introduces a new variable named `vsphere_csi_controller_config_override` to allow users to override the values in the vsphere-csi-controller ConfigMap. The default values from the vanilla chart are preserved and using `combine` we override any values that the user selects. Also, using the override method, the user is able to add additional variables not present in the vanilla chart (e.g if the chart hasn't been updated).

In our case we need to override `topology-preferential-datastores` setting. I've seen, in the past, we were able to override the `block-volume-snapshot` using the `vsphere_csi_block_volume_snapshot` variable. This was broken in https://github.com/kubernetes-sigs/kubespray/commit/bc5e33791f9ef53d40fbcf1997727a624310517f#diff-50e8ea2fb43e82b373fae7c006b5af6a37248e36d195bff2bd99b0d9cae420f7L14 hence I removed the variable. I can bring it back if we consider this a breaking change.

Also removed the duplicate `csi-auth-check` definition.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
I think this approach is better than adding single variables for each setting in the ConfigMap.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
action required 
`vsphere_csi_block_volume_snapshot` has been removed. Use `vsphere_csi_controller_config_override` to override the `block-volume-snapshot` setting.
```
