### PR TITLE
Fix duplicate dict key warning in bootstrap_os task includes

### DIFF
--- a/roles/bootstrap_os/tasks/main.yml
+++ b/roles/bootstrap_os/tasks/main.yml
@@ -10,24 +10,24 @@
   vars:
     os_release_dict: "{{ os_release.stdout_lines | select('regex', '^.+=.*$') | map('regex_replace', '\"', '') |
                          map('split', '=') | community.general.dict }}"
+    search_files: &search_files
+      files:
+      - "{{ os_release_dict['ID'] }}-{{ os_release_dict['VARIANT_ID'] }}.yml"
+      - "{{ os_release_dict['ID'] }}.yml"
   block:
   - name: Include vars
     include_vars: "{{ item }}"
     tags:
     - facts
     with_first_found:
-    - &search
-      files:
-      - "{{ os_release_dict['ID'] }}-{{ os_release_dict['VARIANT_ID'] }}.yml"
-      - "{{ os_release_dict['ID'] }}.yml"
+    - <<: *search_files
       paths:
       - vars/
       skip: true
   - name: Include tasks
     include_tasks: "{{ included_tasks_file }}"
     with_first_found:
-    - <<: *search
-      paths: []
+    - <<: *search_files
     loop_control:
       loop_var: included_tasks_file
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
During playbook execution, the following warning was being logged:

```
[WARNING]: While constructing a mapping from .../roles/bootstrap_os/tasks/main.yml, line 29, column 7, found a duplicate dict key (paths). Using last defined value only.
```

This was caused by using a single, broad YAML anchor for both `include_vars` and `include_tasks`. The anchor defined a `paths` key that was correct for `include_vars` but was immediately overridden for `include_tasks`, leading to the redundant definition.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
