### PR TITLE
Fix `when` expr of conntrack module loading

### DIFF
--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -126,7 +126,7 @@
   loop: "{{ conntrack_modules }}"
   when:
     - kube_proxy_mode == 'ipvs'
-    - "(modprobe_conntrack_module|default({'rc': 1})).rc != 0"  # loop until first success
+    - modprobe_conntrack_module is not defined or modprobe_conntrack_module.failed is ansible.builtin.truthy  # loop until first success
   tags:
     - kube-proxy
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Retrying to load conntrack modules was bound to fail due to the way, the current `when` conditions were utilized. It was based on the assumption, that in case of success, the registered variable would have an `rc` attribute with the value `0`. Unfortunately, the `rc` attribute is only present in case of a failure, where it's value is >1.

The result of `community.general.modprobe` in case of success looks like this:
```
{
    "changed": false,
    "msg": "All items completed",
    "results": [
        {
            "ansible_loop_var": "item",
            "changed": false,
            "failed": false,
            "invocation": {
                "module_args": {
                    "name": "nf_conntrack",
                    "params": "",
                    "persistent": "present",
                    "state": "present"
                }
            },
            "item": "nf_conntrack",
            "name": "nf_conntrack",
            "params": "",
            "state": "present"
        }
    ],
    "skipped": false
}
```

While it looks like this in case of a failure:
```
{
    "changed": false,
    "failed": true,
    "msg": "One or more items failed",
    "results": [
        {
            "ansible_loop_var": "item",
            "attempts": 3,
            "changed": false,
            "failed": true,
            "invocation": {
                "module_args": {
                    "name": "nf_conntrack_doesnotexist",
                    "params": "",
                    "persistent": "present",
                    "state": "present"
                }
            },
            "item": "nf_conntrack_doesnotexist",
            "msg": "modprobe: FATAL: Module nf_conntrack_doesnotexist not found in directory /lib/modules/5.14.0-570.32.1.el9_6.x86_64\n",
            "name": "nf_conntrack_doesnotexist",
            "params": "",
            "rc": 1,
            "state": "present",
            "stderr": "modprobe: FATAL: Module nf_conntrack_doesnotexist not found in directory /lib/modules/5.14.0-570.32.1.el9_6.x86_64\n",
            "stderr_lines": [
                "modprobe: FATAL: Module nf_conntrack_doesnotexist not found in directory /lib/modules/5.14.0-570.32.1.el9_6.x86_64"
            ],
            "stdout": "",
            "stdout_lines": []
        }
    ],
    "skipped": false
}
```

By evaluating `failed` instead, this issue can be prevented.

**Which issue(s) this PR fixes**:
Fixes #11340

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
