### PR TITLE
Ensure apt cache is updated before dist-upgrade

### DIFF
--- a/roles/upgrade/system-upgrade/tasks/apt.yml
+++ b/roles/upgrade/system-upgrade/tasks/apt.yml
@@ -1,6 +1,7 @@
 ---
 - name: APT Dist-Upgrade
   apt:
+    update_cache: true
     upgrade: dist
     autoremove: true
     dpkg_options: force-confold,force-confdef


### PR DESCRIPTION
This change updates the `APT Dist-Upgrade` task to update apt cache before performing a `dist` upgrade.  
Ensuring the package cache is refreshed prevents outdated package index issues during upgrades.

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Without updating the APT cache, a dist-upgrade might fail or skip updates if the package index is stale.  

**Does this PR introduce a user-facing change?**:
```release-note
Make APT updates its package cache before `dist-upgrade`
```
