### PR TITLE
Simplify group_by logic by moving conditional to when clause

### DIFF
--- a/roles/dynamic_groups/tasks/main.yml
+++ b/roles/dynamic_groups/tasks/main.yml
@@ -15,5 +15,6 @@
         - kube_control_plane
         - calico_rr
   group_by:
-    key: "{{ (group_names | intersect(item.value) | length > 0) | ternary(item.key, '_all') }}"
+    key: "{{ item.key }}"
+  when: group_names | intersect(item.value) | length > 0
   loop: "{{ group_mappings | dict2items }}"


### PR DESCRIPTION
This PR refactors the Ansible task that maps old inventory groups to new ones.  
Previously, the `group_by` key relied on a `ternary` expression to decide whether to assign the group or `_all`.  
This has been simplified by moving the condition into a `when` clause, allowing `group_by` to always use `item.key` directly.


**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
- Makes the task easier to understand.
- Keeps `group_by` focused solely on assigning the group key.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
