### PR TITLE
Generate the correct facts for dynamic groups when using playbooks/facts.yml

### DIFF
--- a/playbooks/facts.yml
+++ b/playbooks/facts.yml
@@ -8,6 +8,30 @@
   roles:
     - { role: bootstrap_os, tags: bootstrap_os}
 
+- name: Inventory setup and validation
+  hosts: all
+  gather_facts: false
+  tags: always
+  tasks:
+    - name: debug groups
+      debug:
+        msg: "Groups: {{ groups.keys() | list }}"
+    - name: Update dynamic inventory
+      block:
+      - name: Include dynamic groups
+        import_role:
+          name: dynamic_groups
+
+      - name: Validate inventory
+        import_role:
+          name: validate_inventory
+
+      when: not ('k8s_cluster' in groups and
+            'no_floating' in groups and
+            'calico_rr' in groups and
+            'kube_node' in groups and
+            'kube_control_plane' in groups)
+
 - name: Gather facts
   hosts: k8s_cluster:etcd:calico_rr
   gather_facts: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Run the boilerplate components when playbooks/facts.yml is used. This way the groups are correct.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12418

**Special notes for your reviewer**:
Since dynamic groups is a supported uption, facts, needs to be aware of correct group like k8s_cluster, kube_node, kube_control_plane

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
