### PR TITLE
Directly list conntrack modules instead of using a variable

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -183,11 +183,6 @@ kube_proxy_ipvs_modules:
   - ip_vs_wlc
   - ip_vs_lc
 
-# Kubespray will use the first module of this list which it can successfully modprobe
-conntrack_modules:
-  - nf_conntrack
-  - nf_conntrack_ipv4
-
 # Set this option to "" (empty) to disable staticPodPath (See docs/operations/hardening.md)
 kubelet_static_pod_path: "{{ kube_manifest_dir }}"
 

--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -123,7 +123,9 @@
     persistent: present
   register: modprobe_conntrack_module
   ignore_errors: true  # noqa ignore-errors
-  loop: "{{ conntrack_modules }}"
+  loop:
+    - nf_conntrack
+    - nf_conntrack_ipv4
   when:
     - kube_proxy_mode == 'ipvs'
     - "(modprobe_conntrack_module|default({'rc': 1})).rc != 0"  # loop until first success


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The conntrack kernel modules have no reason to be something else than
those two options, so there is no reason to have a variable.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Technically a breaking change, but since there is only those two modules, overriding the variable isn't really a thing user should do.

**Does this PR introduce a user-facing change?**:
```release-note
action required
`conntrack_modules` is removed; the list of conntrack modules to try to load is instead hardcoded, since there is no reason to have any other values.
```
