### PR TITLE
Ensure include_tasks is not skipped when task file does not exist

### DIFF
--- a/roles/bootstrap_os/tasks/main.yml
+++ b/roles/bootstrap_os/tasks/main.yml
@@ -28,6 +28,7 @@
     with_first_found:
     - <<: *search
       paths: []
+      skip: false
     loop_control:
       loop_var: included_tasks_file
 


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
Without this change, `include_tasks` can be silently skipped when the task file is not present in the `tasks` directory.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
