### PR TITLE
[release-2.28] Fix: constant etcd_supported_version to dynamic

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Note:
 
 - Core
   - [kubernetes](https://github.com/kubernetes/kubernetes) 1.32.8
-  - [etcd](https://github.com/etcd-io/etcd) 3.5.16
+  - [etcd](https://github.com/etcd-io/etcd) 3.5.22
   - [docker](https://www.docker.com/) 28.0
   - [containerd](https://containerd.io/) 2.0.6
   - [cri-o](http://cri-o.io/) 1.32.0 (experimental: see [CRI-O Note](docs/CRI/cri-o.md). Only on fedora, ubuntu and centos based OS)

--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -136,9 +136,9 @@ pod_infra_supported_versions:
 pod_infra_version: "{{ pod_infra_supported_versions[kube_major_version] }}"
 
 etcd_supported_versions:
-  '1.32': 3.5.16
-  '1.31': 3.5.16
-  '1.30': 3.5.16
+  '1.32': "{{ (etcd_binary_checksums['amd64'].keys() | select('version', '3.6', '<'))[0] }}"
+  '1.31': "{{ (etcd_binary_checksums['amd64'].keys() | select('version', '3.6', '<'))[0] }}"
+  '1.30': "{{ (etcd_binary_checksums['amd64'].keys() | select('version', '3.6', '<'))[0] }}"
 etcd_version: "{{ etcd_supported_versions[kube_major_version] }}"
 
 crictl_supported_versions:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`release-2.28`'s etcd version is constant; maybe we should let them auto-update.

**Which issue(s) this PR fixes**:

Fixes #12496

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
