### PR TITLE
bootstrap_os: fix ansible warning

### DIFF
--- a/roles/bootstrap_os/tasks/main.yml
+++ b/roles/bootstrap_os/tasks/main.yml
@@ -7,29 +7,29 @@
   check_mode: false
 
 - name: Include distro specifics vars and tasks
+  block:
+    - name: Include vars
+      include_vars: "{{ item }}"
+      tags:
+        - facts
+      with_first_found:
+        - files: "{{ search_files }}"
+          paths:
+            - vars/
+          skip: true
+    - name: Include tasks
+      include_tasks: "{{ included_tasks_file }}"
+      with_first_found:
+        - files: "{{ search_files }}"
+          skip: true
+      loop_control:
+        loop_var: included_tasks_file
   vars:
     os_release_dict: "{{ os_release.stdout_lines | select('regex', '^.+=.*$') | map('regex_replace', '\"', '') |
                          map('split', '=') | community.general.dict }}"
-  block:
-  - name: Include vars
-    include_vars: "{{ item }}"
-    tags:
-    - facts
-    with_first_found:
-    - &search
-      files:
+    search_files:
       - "{{ os_release_dict['ID'] }}-{{ os_release_dict['VARIANT_ID'] }}.yml"
       - "{{ os_release_dict['ID'] }}.yml"
-      paths:
-      - vars/
-      skip: true
-  - name: Include tasks
-    include_tasks: "{{ included_tasks_file }}"
-    with_first_found:
-    - <<: *search
-      paths: []
-    loop_control:
-      loop_var: included_tasks_file
 
 - name: Install system packages
   import_role:


### PR DESCRIPTION

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

#10983 provided a nice cleanup/refactoring, but also causes every kubespray play to produce an ansible warning:
```
$ ansible-playbook -b --become-user=root kubespray/upgrade-cluster.yml
[WARNING]: While constructing a mapping from kubespray/roles/bootstrap-os/tasks/main.yml, line 29, column 7,
found a duplicate dict key (paths). Using last defined value only.
```

This fixes the warning, and also uses standard YAML indentation.

**Special notes for your reviewer**:
'files' is deduplicated with a regular ansible variable instead of using the less common YAML functionality of aliases and anchors.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
