### PR TITLE
fix: skip software-properties-common package on Debian 13 (Trixie)

### DIFF
--- a/roles/system_packages/tasks/main.yml
+++ b/roles/system_packages/tasks/main.yml
@@ -34,6 +34,18 @@
   tags:
     - bootstrap_os
 
+- name: Filter pkgs based on OS
+  set_fact:
+    pkgs_filtered: >-
+      {{
+        pkgs |
+        dict2items |
+        rejectattr('key', 'equalto', 'software-properties-common')
+        | items2dict
+        if (ansible_distribution == 'Debian' and ansible_distribution_major_version == '13')
+        else pkgs
+      }}
+
 - name: Manage packages
   package:
     name: "{{ item.packages | dict2items | selectattr('value', 'ansible.builtin.all') | map(attribute='key') }}"
@@ -47,7 +59,7 @@
   when: not (ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"] or is_fedora_coreos)
   loop:
     - { packages: "{{ pkgs_to_remove }}", state: "absent", action_label: "remove" }
-    - { packages: "{{ pkgs }}", state: "present", action_label: "install" }
+    - { packages: "{{ pkgs_filtered }}", state: "present", action_label: "install" }
   loop_control:
     label: "{{ item.action_label }}"
   tags:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!-- Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
-->
> /kind bug


**What this PR does / why we need it**:
When executing the Manage packages task in the system_packages role on Debian 13 Trixie, I get the error：

> "msg": "No package matching 'software-properties-common' is available."

This PR aims to filter and install software-properties-common on Debian 13 Trixie.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
<!--Fixes #-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
