### PR TITLE
Simplify collection of SubjectAlternativeNames for apiserver

### DIFF
--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -25,9 +25,9 @@
 
 - name: Kubeadm | aggregate all SANs
   set_fact:
-    apiserver_sans: "{{ (sans_base + groups['kube_control_plane'] + sans_lb + sans_lb_ip + sans_supp + sans_access_ip + sans_ip + sans_ipv4_address + sans_ipv6_address + sans_override + sans_hostname + sans_fqdn + sans_kube_vip_address) | unique }}"
+    apiserver_sans: "{{ _apiserver_sans | flatten | select | unique }}"
   vars:
-    sans_base:
+    _apiserver_sans:
       - "kubernetes"
       - "kubernetes.default"
       - "kubernetes.default.svc"
@@ -36,17 +36,17 @@
       - "localhost"
       - "127.0.0.1"
       - "::1"
-    sans_lb: "{{ [apiserver_loadbalancer_domain_name] if apiserver_loadbalancer_domain_name is defined else [] }}"
-    sans_lb_ip: "{{ [loadbalancer_apiserver.address] if loadbalancer_apiserver is defined and loadbalancer_apiserver.address is defined else [] }}"
-    sans_supp: "{{ supplementary_addresses_in_ssl_keys if supplementary_addresses_in_ssl_keys is defined else [] }}"
-    sans_access_ip: "{{ groups['kube_control_plane'] | map('extract', hostvars, 'main_access_ip') | list | select('defined') | list }}"
-    sans_ip: "{{ groups['kube_control_plane'] | map('extract', hostvars, 'main_ip') | list | select('defined') | list }}"
-    sans_ipv4_address: "{{ groups['kube_control_plane'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | list | select('defined') | list }}"
-    sans_ipv6_address: "{{ groups['kube_control_plane'] | map('extract', hostvars, ['ansible_default_ipv6', 'address']) | list | select('defined') | list }}"
-    sans_override: "{{ [kube_override_hostname] if kube_override_hostname else [] }}"
-    sans_hostname: "{{ groups['kube_control_plane'] | map('extract', hostvars, ['ansible_hostname']) | list | select('defined') | list }}"
-    sans_fqdn: "{{ groups['kube_control_plane'] | map('extract', hostvars, ['ansible_fqdn']) | list | select('defined') | list }}"
-    sans_kube_vip_address: "{{ [kube_vip_address] if kube_vip_address is defined and kube_vip_address else [] }}"
+      - "{{ apiserver_loadbalancer_domain_name }}"
+      - "{{ loadbalancer_apiserver.address | d('') }}"
+      - "{{ supplementary_addresses_in_ssl_keys | d([]) }}"
+      - "{{ groups['kube_control_plane'] | map('extract', hostvars, 'main_access_ip') }}"
+      - "{{ groups['kube_control_plane'] | map('extract', hostvars, 'main_ip') }}"
+      - "{{ groups['kube_control_plane'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | select('defined') }}"
+      - "{{ groups['kube_control_plane'] | map('extract', hostvars, ['ansible_default_ipv6', 'address']) | select('defined') }}"
+      - "{{ groups['kube_control_plane'] | map('extract', hostvars, 'ansible_hostname') }}"
+      - "{{ groups['kube_control_plane'] | map('extract', hostvars, 'ansible_fqdn') }}"
+      - "{{ kube_override_hostname }}"
+      - "{{ kube_vip_address }}"
   tags: facts
 
 - name: Create audit-policy directory

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -80,7 +80,6 @@ kube_vip_bgp_peeraddress:
 kube_vip_bgp_peerpass:
 kube_vip_bgp_peeras: 65000
 kube_vip_bgppeers:
-kube_vip_address:
 kube_vip_enableServicesElection: false
 kube_vip_lb_enable: false
 kube_vip_leasename: plndr-cp-lock

--- a/roles/kubespray_defaults/defaults/main/main.yml
+++ b/roles/kubespray_defaults/defaults/main/main.yml
@@ -96,6 +96,7 @@ ignore_assert_errors: false
 # kube-vip
 kube_vip_enabled: false
 kube_vip_lb_fwdmethod: local
+kube_vip_address:
 
 # nginx-proxy configure
 nginx_config_dir: "/etc/nginx"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Remove a bunch of intermediate variables, which fixes a
"'UndefinedMarker' concatenation" error in ansible-lint v25.8.1.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Related: #12484
I'm not completely sure this works so just putting this as draft for now

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
