### PR TITLE
Making 28.3 the new docker default

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Note:
 - Core
   - [kubernetes](https://github.com/kubernetes/kubernetes) 1.33.4
   - [etcd](https://github.com/etcd-io/etcd) 3.5.22
-  - [docker](https://www.docker.com/) 28.0
+  - [docker](https://www.docker.com/) 28.3
   - [containerd](https://containerd.io/) 2.1.4
   - [cri-o](http://cri-o.io/) 1.33.3 (experimental: see [CRI-O Note](docs/CRI/cri-o.md). Only on fedora, ubuntu and centos based OS)
 - Network Plugin

--- a/roles/container-engine/docker/defaults/main.yml
+++ b/roles/container-engine/docker/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-docker_version: '28.0'
+docker_version: '28.3'
 docker_cli_version: "{{ docker_version }}"
 
 docker_package_info:

--- a/roles/container-engine/docker/vars/debian.yml
+++ b/roles/container-engine/docker/vars/debian.yml
@@ -34,8 +34,10 @@ containerd_versioned_pkg:
   '1.7.23': "{{ containerd_package }}=1.7.23-1"
   '1.7.24': "{{ containerd_package }}=1.7.24-1"
   '1.7.25': "{{ containerd_package }}=1.7.25-1"
-  'stable': "{{ containerd_package }}=1.7.25-1"
-  'edge': "{{ containerd_package }}=1.7.25-1"
+  '1.7.26': "{{ containerd_package }}=1.7.26-1"
+  '1.7.27': "{{ containerd_package }}=1.7.27-1"
+  'stable': "{{ containerd_package }}=1.7.27-1"
+  'edge': "{{ containerd_package }}=1.7.27-1"
 
 # https://download.docker.com/linux/debian/
 docker_versioned_pkg:
@@ -53,10 +55,13 @@ docker_versioned_pkg:
   '27.2': docker-ce=5:27.2.1-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
   '27.3': docker-ce=5:27.3.1-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
   '27.4': docker-ce=5:27.4.1-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
-  '27.5': docker-ce=5:27.5.4-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
-  '28.0': docker-ce=5:28.0.2-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
-  'stable': docker-ce=5:28.0.2-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
-  'edge': docker-ce=5:28.0.2-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
+  '27.5': docker-ce=5:27.5.1-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
+  '28.0': docker-ce=5:28.0.4-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
+  '28.1': docker-ce=5:28.1.1-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
+  '28.2': docker-ce=5:28.2.2-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
+  '28.3': docker-ce=5:28.3.3-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
+  'stable': docker-ce=5:28.3.3-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
+  'edge': docker-ce=5:28.3.3-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
@@ -73,10 +78,13 @@ docker_cli_versioned_pkg:
   '27.2': docker-ce-cli=5:27.2.1-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
   '27.3': docker-ce-cli=5:27.3.1-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
   '27.4': docker-ce-cli=5:27.4.1-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
-  '27.5': docker-ce-cli=5:27.5.4-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
-  '28.0': docker-ce-cli=5:28.0.2-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
-  'stable': docker-ce-cli=5:28.0.2-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
-  'edge': docker-ce-cli=5:28.0.2-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
+  '27.5': docker-ce-cli=5:27.5.1-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
+  '28.0': docker-ce-cli=5:28.0.4-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
+  '28.1': docker-ce-cli=5:28.1.1-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
+  '28.2': docker-ce-cli=5:28.2.2-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
+  '28.3': docker-ce-cli=5:28.3.3-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
+  'stable': docker-ce-cli=5:28.3.3-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
+  'edge': docker-ce-cli=5:28.3.3-1~debian.{{ ansible_distribution_major_version }}~{{ ansible_distribution_release | lower }}
 
 docker_package_info:
   pkgs:

--- a/roles/container-engine/docker/vars/fedora.yml
+++ b/roles/container-engine/docker/vars/fedora.yml
@@ -34,8 +34,10 @@ containerd_versioned_pkg:
   '1.7.23': "{{ containerd_package }}-1.7.23-3.1.fc{{ ansible_distribution_major_version }}"
   '1.7.24': "{{ containerd_package }}-1.7.24-3.1.fc{{ ansible_distribution_major_version }}"
   '1.7.25': "{{ containerd_package }}-1.7.25-3.1.fc{{ ansible_distribution_major_version }}"
-  'stable': "{{ containerd_package }}-1.7.25-3.1.fc{{ ansible_distribution_major_version }}"
-  'edge': "{{ containerd_package }}-1.7.25-3.1.fc{{ ansible_distribution_major_version }}"
+  '1.7.26': "{{ containerd_package }}-1.7.26-3.1.fc{{ ansible_distribution_major_version }}"
+  '1.7.27': "{{ containerd_package }}-1.7.27-3.1.fc{{ ansible_distribution_major_version }}"
+  'stable': "{{ containerd_package }}-1.7.27-3.1.fc{{ ansible_distribution_major_version }}"
+  'edge': "{{ containerd_package }}-1.7.27-3.1.fc{{ ansible_distribution_major_version }}"
 
 # https://docs.docker.com/install/linux/docker-ce/fedora/
 # https://download.docker.com/linux/fedora/<fedora-version>/x86_64/stable/Packages/
@@ -53,9 +55,13 @@ docker_versioned_pkg:
   '27.3': docker-ce-3:27.3.1-1.fc{{ ansible_distribution_major_version }}
   '27.4': docker-ce-3:27.4.1-1.fc{{ ansible_distribution_major_version }}
   '27.5': docker-ce-3:27.5.1-1.fc{{ ansible_distribution_major_version }}
-  '28.0': docker-ce-3:28.0.2-1.fc{{ ansible_distribution_major_version }}
-  'stable': docker-ce-3:28.0.2-1.fc{{ ansible_distribution_major_version }}
-  'edge': docker-ce-3:28.0.2-1.fc{{ ansible_distribution_major_version }}
+  '28.0': docker-ce-3:28.0.4-1.fc{{ ansible_distribution_major_version }}
+  '28.1': docker-ce-3:28.1.1-1.fc{{ ansible_distribution_major_version }}
+  '28.2': docker-ce-3:28.2.2-1.fc{{ ansible_distribution_major_version }}
+  '28.3': docker-ce-3:28.3.3-1.fc{{ ansible_distribution_major_version }}
+  'stable': docker-ce-3:28.3.3-1.fc{{ ansible_distribution_major_version }}
+  'edge': docker-ce-3:28.3.3-1.fc{{ ansible_distribution_major_version }}
+
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
@@ -71,9 +77,12 @@ docker_cli_versioned_pkg:
   '27.3': docker-ce-cli-1:27.3.1-1.fc{{ ansible_distribution_major_version }}
   '27.4': docker-ce-cli-1:27.4.1-1.fc{{ ansible_distribution_major_version }}
   '27.5': docker-ce-cli-1:27.5.1-1.fc{{ ansible_distribution_major_version }}
-  '28.0': docker-ce-cli-1:28.0.2-1.fc{{ ansible_distribution_major_version }}
-  'stable': docker-ce-cli-1:28.0.2-1.fc{{ ansible_distribution_major_version }}
-  'edge': docker-ce-cli-1:28.0.2-1.fc{{ ansible_distribution_major_version }}
+  '28.0': docker-ce-cli-1:28.0.4-1.fc{{ ansible_distribution_major_version }}
+  '28.1': docker-ce-cli-1:28.1.1-1.fc{{ ansible_distribution_major_version }}
+  '28.2': docker-ce-cli-1:28.2.2-1.fc{{ ansible_distribution_major_version }}
+  '28.3': docker-ce-cli-1:28.3.3-1.fc{{ ansible_distribution_major_version }}
+  'stable': docker-ce-cli-1:28.3.3-1.fc{{ ansible_distribution_major_version }}
+  'edge': docker-ce-cli-1:28.3.3-1.fc{{ ansible_distribution_major_version }}
 
 docker_package_info:
   enablerepo: "docker-ce"

--- a/roles/container-engine/docker/vars/redhat.yml
+++ b/roles/container-engine/docker/vars/redhat.yml
@@ -34,8 +34,10 @@ containerd_versioned_pkg:
   '1.7.23': "{{ containerd_package }}-1.7.23-3.1.el{{ ansible_distribution_major_version }}"
   '1.7.24': "{{ containerd_package }}-1.7.24-3.1.el{{ ansible_distribution_major_version }}"
   '1.7.25': "{{ containerd_package }}-1.7.25-3.1.el{{ ansible_distribution_major_version }}"
-  'stable': "{{ containerd_package }}-1.7.25-3.1.el{{ ansible_distribution_major_version }}"
-  'edge': "{{ containerd_package }}-1.7.25-3.1.el{{ ansible_distribution_major_version }}"
+  '1.7.26': "{{ containerd_package }}-1.7.26-3.1.el{{ ansible_distribution_major_version }}"
+  '1.7.27': "{{ containerd_package }}-1.7.27-3.1.el{{ ansible_distribution_major_version }}"
+  'stable': "{{ containerd_package }}-1.7.27-3.1.el{{ ansible_distribution_major_version }}"
+  'edge': "{{ containerd_package }}-1.7.27-3.1.el{{ ansible_distribution_major_version }}"
 
 # https://docs.docker.com/engine/installation/linux/rhel/#install-from-a-package
 # https://download.docker.com/linux/rhel/<rhel_version>>/x86_64/stable/Packages/
@@ -44,39 +46,45 @@ docker_versioned_pkg:
   'latest': docker-ce
   '18.09': docker-ce-3:18.09.9-3.el7
   '19.03': docker-ce-3:19.03.15-3.el{{ ansible_distribution_major_version }}
-  '20.10': docker-ce-3:20.10.20-3.el{{ ansible_distribution_major_version }}
+  '20.10': docker-ce-3:20.10.24-3.el{{ ansible_distribution_major_version }}
   '23.0': docker-ce-3:23.0.6-1.el{{ ansible_distribution_major_version }}
   '24.0': docker-ce-3:24.0.9-1.el{{ ansible_distribution_major_version }}
   '26.0': docker-ce-3:26.0.2-1.el{{ ansible_distribution_major_version }}
   '26.1': docker-ce-3:26.1.4-1.el{{ ansible_distribution_major_version }}
   '27.0': docker-ce-3:27.0.3-1.el{{ ansible_distribution_major_version }}
-  '27.1': docker-ce-3:27.1.3-1.el{{ ansible_distribution_major_version }}
-  '27.2': docker-ce-3:27.2.3-1.el{{ ansible_distribution_major_version }}
-  '27.3': docker-ce-3:27.3.3-1.el{{ ansible_distribution_major_version }}
-  '27.4': docker-ce-3:27.4.3-1.el{{ ansible_distribution_major_version }}
-  '27.5': docker-ce-3:27.5.3-1.el{{ ansible_distribution_major_version }}
-  '28.0': docker-ce-3:28.0.2-1.el{{ ansible_distribution_major_version }}
-  'stable': docker-ce-3:28.0.2-1.el{{ ansible_distribution_major_version }}
-  'edge': docker-ce-3:28.0.2-1.el{{ ansible_distribution_major_version }}
+  '27.1': docker-ce-3:27.1.2-1.el{{ ansible_distribution_major_version }}
+  '27.2': docker-ce-3:27.2.1-1.el{{ ansible_distribution_major_version }}
+  '27.3': docker-ce-3:27.3.1-1.el{{ ansible_distribution_major_version }}
+  '27.4': docker-ce-3:27.4.1-1.el{{ ansible_distribution_major_version }}
+  '27.5': docker-ce-3:27.5.1-1.el{{ ansible_distribution_major_version }}
+  '28.0': docker-ce-3:28.0.4-1.el{{ ansible_distribution_major_version }}
+  '28.1': docker-ce-3:28.1.1-1.el{{ ansible_distribution_major_version }}
+  '28.2': docker-ce-3:28.2.2-1.el{{ ansible_distribution_major_version }}
+  '28.3': docker-ce-3:28.3.3-1.el{{ ansible_distribution_major_version }}
+  'stable': docker-ce-3:28.3.3-1.el{{ ansible_distribution_major_version }}
+  'edge': docker-ce-3:28.3.3-1.el{{ ansible_distribution_major_version }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
   '18.09': docker-ce-cli-1:18.09.9-3.el7
   '19.03': docker-ce-cli-1:19.03.15-3.el{{ ansible_distribution_major_version }}
-  '20.10': docker-ce-cli-1:20.10.20-3.el{{ ansible_distribution_major_version }}
+  '20.10': docker-ce-cli-1:20.10.24-3.el{{ ansible_distribution_major_version }}
   '23.0': docker-ce-cli-1:23.0.6-1.el{{ ansible_distribution_major_version }}
   '24.0': docker-ce-cli-1:24.0.9-1.el{{ ansible_distribution_major_version }}
   '26.0': docker-ce-cli-1:26.0.2-1.el{{ ansible_distribution_major_version }}
   '26.1': docker-ce-cli-1:26.1.4-1.el{{ ansible_distribution_major_version }}
   '27.0': docker-ce-cli-1:27.0.3-1.el{{ ansible_distribution_major_version }}
-  '27.1': docker-ce-cli-1:27.1.3-1.el{{ ansible_distribution_major_version }}
-  '27.2': docker-ce-cli-1:27.2.3-1.el{{ ansible_distribution_major_version }}
-  '27.3': docker-ce-cli-1:27.3.3-1.el{{ ansible_distribution_major_version }}
-  '27.4': docker-ce-cli-1:27.4.3-1.el{{ ansible_distribution_major_version }}
-  '27.5': docker-ce-cli-1:27.5.3-1.el{{ ansible_distribution_major_version }}
-  '28.0': docker-ce-cli-1:28.0.2-1.el{{ ansible_distribution_major_version }}
-  'stable': docker-ce-cli-1:28.0.2-1.el{{ ansible_distribution_major_version }}
-  'edge': docker-ce-cli-1:28.0.2-1.el{{ ansible_distribution_major_version }}
+  '27.1': docker-ce-cli-1:27.1.2-1.el{{ ansible_distribution_major_version }}
+  '27.2': docker-ce-cli-1:27.2.1-1.el{{ ansible_distribution_major_version }}
+  '27.3': docker-ce-cli-1:27.3.1-1.el{{ ansible_distribution_major_version }}
+  '27.4': docker-ce-cli-1:27.4.1-1.el{{ ansible_distribution_major_version }}
+  '27.5': docker-ce-cli-1:27.5.1-1.el{{ ansible_distribution_major_version }}
+  '28.0': docker-ce-cli-1:28.0.4-1.el{{ ansible_distribution_major_version }}
+  '28.1': docker-ce-cli-1:28.1.1-1.el{{ ansible_distribution_major_version }}
+  '28.2': docker-ce-cli-1:28.2.2-1.el{{ ansible_distribution_major_version }}
+  '28.3': docker-ce-cli-1:28.3.3-1.el{{ ansible_distribution_major_version }}
+  'stable': docker-ce-cli-1:28.3.3-1.el{{ ansible_distribution_major_version }}
+  'edge': docker-ce-cli-1:28.3.3-1.el{{ ansible_distribution_major_version }}
 
 docker_package_info:
   enablerepo: "docker-ce"

--- a/roles/container-engine/docker/vars/ubuntu.yml
+++ b/roles/container-engine/docker/vars/ubuntu.yml
@@ -27,8 +27,10 @@ containerd_versioned_pkg:
   '1.7.23': "{{ containerd_package }}=1.7.23-1"
   '1.7.24': "{{ containerd_package }}=1.7.24-1"
   '1.7.25': "{{ containerd_package }}=1.7.25-1"
-  'stable': "{{ containerd_package }}=1.7.25-1"
-  'edge': "{{ containerd_package }}=1.7.25-1"
+  '1.7.26': "{{ containerd_package }}=1.7.26-1"
+  '1.7.27': "{{ containerd_package }}=1.7.27-1"
+  'stable': "{{ containerd_package }}=1.7.27-1"
+  'edge': "{{ containerd_package }}=1.7.27-1"
 
 # https://download.docker.com/linux/ubuntu/
 docker_versioned_pkg:
@@ -46,9 +48,10 @@ docker_versioned_pkg:
   '27.3': docker-ce=5:27.3.1-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
   '27.4': docker-ce=5:27.4.1-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
   '27.5': docker-ce=5:27.5.4-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
-  '28.0': docker-ce=5:28.0.2-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
-  'stable': docker-ce=5:28.0.2-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
-  'edge': docker-ce=5:28.0.2-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
+  '28.0': docker-ce=5:28.0.4-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
+  '28.1': docker-ce=5:28.1.1-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
+  '28.2': docker-ce=5:28.2.2-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
+  '28.3': docker-ce=5:28.3.3-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
 
 docker_cli_versioned_pkg:
   'latest': docker-ce-cli
@@ -65,9 +68,12 @@ docker_cli_versioned_pkg:
   '27.3': docker-ce-cli=5:27.3.1-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
   '27.4': docker-ce-cli=5:27.4.1-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
   '27.5': docker-ce-cli=5:27.5.4-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
-  '28.0': docker-ce-cli=5:28.0.2-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
-  'stable': docker-ce-cli=5:28.0.2-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
-  'edge': docker-ce-cli=5:28.0.2-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
+  '28.0': docker-ce-cli=5:28.0.4-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
+  '28.1': docker-ce-cli=5:28.1.1-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
+  '28.2': docker-ce-cli=5:28.2.2-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
+  '28.3': docker-ce-cli=5:28.3.3-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
+  'stable': docker-ce-cli=5:28.3.3-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
+  'edge': docker-ce-cli=5:28.3.3-1~ubuntu.{{ ansible_distribution_version }}~{{ ansible_distribution_release | lower }}
 
 docker_package_info:
   pkgs:


### PR DESCRIPTION

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
This PR will make docker 28.3 the default one

**Which issue(s) this PR fixes**:
Fixes #12485

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
