### PR TITLE
Fix(system_packages): Avoid version compare error

### DIFF
--- a/roles/system_packages/vars/main.yml
+++ b/roles/system_packages/vars/main.yml
@@ -94,14 +94,12 @@ pkgs:
     - "{{ ansible_os_family == 'Debian' }}"
     - "{{ ansible_distribution_major_version == '10' }}"
   python-cryptography:
-    - "{{ ansible_os_family == 'Suse' }}"
-    - "{{ ansible_distribution_version is version('15.4', '<') }}"
+    - "{{ ansible_os_family == 'Suse' and ansible_distribution_version is version('15.4', '<') }}"
   python3-apt:
     - "{{ ansible_os_family == 'Debian' }}"
     - "{{ ansible_distribution_major_version != '10' }}"
   python3-cryptography:
-    - "{{ ansible_os_family == 'Suse' }}"
-    - "{{ ansible_distribution_version is version('15.4', '>=') }}"
+    - "{{ ansible_os_family == 'Suse' and ansible_distribution_version is version('15.4', '>=') }}"
   python3-libselinux:
     - "{{ ansible_distribution in ['RedHat', 'CentOS'] }}"
   rsync: []


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
When running the system_packages role on an OS like Kylin V11, the playbook fails with the error: 

```
Error was a <class ''ansible.errors.AnsibleFilterError''>, original message: 
Version comparison failed: ''<'' not supported between instances of ''str'' and ''int''
```

This happens because ansible_distribution_version can be a non-numeric string (e.g., V11), which the version filter cannot parse for comparison.

This commit fixes the issue by using short-circuit evaluation. The version comparison for python-cryptography now only runs when ansible_os_family is 'Suse', preventing the error on other systems.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
