### PR TITLE
[release-2.28] Fix automated cherrypick failure in UpgradeConfiguration.node

### DIFF
--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
@@ -502,7 +502,7 @@ apply:
 {% endif %}
   imagePullPolicy: {{ k8s_image_pull_policy }}
   imagePullSerial: {{ kubeadm_image_pull_serial | lower }}
-{% for skip_phase in kubeadm_upgrade_node_phases_skip %}
+{% for skip_phase in kubeadm_init_phases_skip %}
 {% if loop.first %}
   skipPhases:
 {% endif %}
@@ -523,7 +523,7 @@ node:
 {% endif %}
   imagePullPolicy: {{ k8s_image_pull_policy }}
   imagePullSerial: {{ kubeadm_image_pull_serial | lower }}
-{% for skip_phase in kubeadm_init_phases_skip %}
+{% for skip_phase in kubeadm_upgrade_node_phases_skip %}
 {% if loop.first %}
   skipPhases:
 {% endif %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
Fixes an issue caused the cherrypick bot introduced in PR #12384. The cherrypick bot applied the `kubeadm_upgrade_node_phases_skip` fix for upgrades with multiple CP nodes in the `release-2.28` branch to `kubeadm.k8s.io/v1beta4.UpgradeConfiguration.apply` instead of `kubeadm.k8s.io/v1beta4.UpgradeConfiguration.node` for whatever reason.

Note that this only affects the `release-2.28` branch. The fix was merged into `master` without issue via #12367.

I did not investigate why the cherrypick failed to patch the correct yaml object. I have not seen this with similar cherrypicks. Perhaps it is thrown off by jinja2 templated yaml.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12515 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix skip phases issue in UpgradeConfiguration.node caused by automated cherrypick
```
