### PR TITLE
Add external_openstack_lbaas_classes: list to define load balancer classes

### DIFF
--- a/docs/cloud_controllers/openstack.md
+++ b/docs/cloud_controllers/openstack.md
@@ -81,6 +81,13 @@ The cloud provider is configured to have Octavia by default in Kubespray.
   external_openstack_lbaas_monitor_max_retries: 1
   external_openstack_lbaas_monitor_timeout: 3s
   external_openstack_lbaas_internal_lb: false
+  external_openstack_lbaas_classes:
+    - name: my-class
+      network_id: "Neutron network ID to create LBaaS VIP"
+      subnet_id: "Neutron subnet ID to create LBaaS VIP"
+      floating_network_id: "Neutron network ID to get floating IP from"
+      floating_subnet_id: "Neutron subnet ID to get floating IP from"
+      member_subnet_id: "Neutron subnet ID on which to create the members of the load balancer"
 
   ```
 

--- a/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
+++ b/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-config.j2
@@ -78,6 +78,34 @@ ingress-hostname-suffix={{ external_openstack_ingress_hostname_suffix | string |
 max-shared-lb={{ external_openstack_max_shared_lb }}
 {% endif %}
 
+{% if external_openstack_lbaas_classes is defined %}
+{% for lb_class in external_openstack_lbaas_classes %}
+[LoadBalancerClass "{{ lb_class.name }}"]
+{% if 'floating_network_id' in lb_class %}
+floating-network-id={{ lb_class.floating_network_id }}
+{% endif %}
+{% if 'floating_subnet_id' in lb_class %}
+floating-subnet-id={{ lb_class.floating_subnet_id }}
+{% endif %}
+{% if 'floating_subnet' in lb_class %}
+floating-subnet={{ lb_class.floating_subnet }}
+{% endif %}
+{% if 'floating_subnet_tags' in lb_class %}
+floating-subnet-tags={{ lb_class.floating_subnet_tags }}
+{% endif %}
+{% if 'network_id' in lb_class %}
+network-id={{ lb_class.network_id }}
+{% endif %}
+{% if 'subnet_id' in lb_class %}
+subnet-id={{ lb_class.subnet_id }}
+{% endif %}
+{% if 'member_subnet_id' in lb_class %}
+member-subnet-id={{ lb_class.member_subnet_id }}
+{% endif %}
+
+{% endfor %}
+{% endif %}
+
 [Networking]
 ipv6-support-disabled={{ external_openstack_network_ipv6_disabled | string | lower }}
 {% for network_name in external_openstack_network_internal_networks %}


### PR DESCRIPTION
**What type of PR is this?**
 /kind feature

**What this PR does / why we need it**:
It allows to use the load balancer classes as defined in the [openstack-cloud-controller-manager documentation](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#load-balancer).

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:

```release-note
Add external_openstack_lbaas_classes: list to define load balancer classes
```
