### PR TITLE
Add conditional python3-libdnf5 install for Fedora 41+ bootstrap

### DIFF
--- a/roles/bootstrap_os/tasks/fedora.yml
+++ b/roles/bootstrap_os/tasks/fedora.yml
@@ -28,3 +28,11 @@
   become: true
   when:
     - need_bootstrap.rc != 0
+
+- name: Install python3-libdnf5 on Fedora > 41
+  raw: >
+    dnf install --assumeyes python3-libdnf5
+  become: true
+  when:
+    - need_bootstrap.rc != 0
+    - ansible_distribution_major_version | int > 41


### PR DESCRIPTION
Fedora 41+ systems use dnf5 as the default package manager, which requires python3-libdnf5 for Ansible compatibility. 

This PR adds a conditional task to install python3-libdnf5 during bootstrap when:
ansible_distribution_major_version > 41

This ensures compatibility with newer Fedora releases while preserving behavior for older versions. The change is scoped, non-invasive, and aligns with the existing bootstrap logic in roles/bootstrap_os/tasks/fedora.yml.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
Ensures Ansible compatibility with Fedora 41+ systems by installing python3-libdnf5, which is required for interacting with the dnf5 package manager. Without this, bootstrap tasks may fail on newer Fedora hosts.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #

**Special notes for your reviewer**:

- The task is added after the existing need_bootstrap check
- Scoped only to Fedora systems with major version > 41
- Uses raw module to match existing bootstrap style

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fedora 41+ systems now install python3-libdnf5 during bootstrap to support dnf5-based package management. This ensures Ansible compatibility with newer Fedora releases.
```
