### PR TITLE
Fix: Set iptables/ip6tables default policies to ACCEPT and remove user chains during reset

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -188,6 +188,18 @@
   tags:
     - mounts
 
+- name: Set IPv4 iptables default policies to ACCEPT
+  iptables:
+    chain: "{{ item }}"
+    policy: ACCEPT
+  with_items:
+    - INPUT
+    - FORWARD
+    - OUTPUT
+  when: flush_iptables | bool and ipv4_stack
+  tags:
+    - iptables
+
 - name: Flush iptables
   iptables:
     table: "{{ item }}"
@@ -201,6 +213,25 @@
   tags:
     - iptables
 
+- name: Delete IPv4 user-defined chains # noqa command-instead-of-module
+  command: iptables -X
+  when: flush_iptables | bool and ipv4_stack
+  tags:
+    - iptables
+
+- name: Set IPv6 ip6tables default policies to ACCEPT
+  iptables:
+    chain: "{{ item }}"
+    policy: ACCEPT
+    ip_version: ipv6
+  with_items:
+    - INPUT
+    - FORWARD
+    - OUTPUT
+  when: flush_iptables | bool and ipv6_stack
+  tags:
+    - ip6tables
+
 - name: Flush ip6tables
   iptables:
     table: "{{ item }}"
@@ -211,6 +242,12 @@
     - nat
     - mangle
     - raw
+  when: flush_iptables | bool and ipv6_stack
+  tags:
+    - ip6tables
+
+- name: Delete IPv6 user-defined chains # noqa command-instead-of-module
+  command: ip6tables -X
   when: flush_iptables | bool and ipv6_stack
   tags:
     - ip6tables


### PR DESCRIPTION
### What this PR does / why we need it

`reset.yml` currently flushes `iptables`/`ip6tables` tables but does **not** change built-in chain default policies. On hosts where `INPUT`/`FORWARD`/`OUTPUT` default to `DROP`, running reset with `flush_iptables: true` can sever access (including SSH) even though rules were flushed.
This PR explicitly sets built-in chain policies to **ACCEPT** (IPv4 & IPv6) before flushing and removes user-defined chains afterward to ensure a clean, predictable baseline during reset.

### Changes in this PR

* **IPv4:** set default policies (`INPUT`, `FORWARD`, `OUTPUT`) to `ACCEPT` using `ansible.builtin.iptables`; flush tables; delete user-defined chains via `iptables -X`.
* **IPv6:** same behavior using `ansible.builtin.iptables` with `ip_version: ipv6`, plus `ip6tables -X`.
* All tasks are gated by `flush_iptables | bool` and the relevant stack (`ipv4_stack` / `ipv6_stack`).

### Risk / compatibility

* **No effect unless** `flush_iptables: true`.
* During reset, opening policies to `ACCEPT` prevents accidental lockouts; stricter policies can be re-applied after redeploy.

### Special notes for your reviewer

* Uses `ansible.builtin.iptables`’s `policy` and `flush` (and `ip_version` for v6) for idempotence; chain deletion relies on `iptables -X` / `ip6tables -X` to drop user-defined chains.
* If `ansible-lint` flags `command-instead-of-module`, I can add `# noqa` to those two tasks or switch to a discovery+module delete loop on request.
* Scope is limited to the reset role; no unrelated whitespace churn.

### Test plan

1. On a test node, set built-in default policies to `DROP` (IPv4 & IPv6) and create a few user chains.
2. Run `reset.yml` with `flush_iptables: true` (or `--tags iptables,ip6tables`).
3. Verify:

   * Built-in chain policies are `ACCEPT` (v4 & v6).
   * `filter`, `nat`, `mangle`, `raw` tables are flushed (existing behavior preserved).
   * User-defined chains are removed.
   * SSH session remains intact throughout reset.

### What type of PR is this?

/kind bug

### Does this PR introduce a user-facing change?

```release-note
[reset] When `flush_iptables: true`, set IPv4/IPv6 default policies (INPUT/FORWARD/OUTPUT) to ACCEPT before flushing and delete user-defined chains to ensure a clean, non-locking reset.
```
