### PR TITLE
crio: add option pull_progress_timeout

### DIFF
--- a/roles/container-engine/cri-o/defaults/main.yml
+++ b/roles/container-engine/cri-o/defaults/main.yml
@@ -31,6 +31,8 @@ crio_registry_auth: []
 crio_seccomp_profile: ""
 crio_selinux: "{{ (preinstall_selinux_state == 'enforcing') | lower }}"
 crio_signature_policy: "{% if ansible_os_family == 'ClearLinux' %}/usr/share/defaults/crio/policy.json{% endif %}"
+# Override the default pull progress timeout
+#crio_pull_progress_timeout: "60s"
 
 # Override system default for storage driver
 # crio_storage_driver: "overlay"

--- a/roles/container-engine/cri-o/templates/crio.conf.j2
+++ b/roles/container-engine/cri-o/templates/crio.conf.j2
@@ -348,6 +348,14 @@ signature_policy = "{{ crio_signature_policy }}"
 # ignore; the latter will ignore volumes entirely.
 image_volumes = "mkdir"
 
+{% if crio_pull_progress_timeout is defined %}
+# The timeout for an image pull to make progress until the pull operation gets
+# canceled. This value will be also used for calculating the pull progress interval
+# to pull_progress_timeout / 10. Can be set to 0 to disable the timeout as well as
+# the progress output.
+pull_progress_timeout = "{{ crio_pull_progress_timeout }}"
+{% endif %}
+
 # The crio.network table containers settings pertaining to the management of
 # CNI plugins.
 [crio.network]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature

> /kind flake

**What this PR does / why we need it**:
pulling large container images can fail with error:
```bash
pulling image: rpc error: code = Canceled desc = copying system image from manifest list: copying config: context canceled
```

releated crio issues:
https://github.com/cri-o/cri-o/issues/8760
https://github.com/cri-o/cri-o/issues/8764

A PR was opened in crio 1.32 & backported to crio 1.30, 1.31:
https://github.com/cri-o/cri-o/pull/8765
to add option `pull_progress_timeout `

This PR adds the option to the crio.conf so it can be set if needed (and leave it disabled by default)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12554

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
crio: add option pull_progress_timeout
```
