### PR TITLE
fix: Missed verb for hostendpoints

### DIFF
--- a/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-cr.yml.j2
+++ b/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-cr.yml.j2
@@ -79,6 +79,7 @@ rules:
       - create
       - update
       - delete
+      - watch
   # Needs access to update clusterinformations.
   - apiGroups: ["crd.projectcalico.org"]
     resources:


### PR DESCRIPTION
/kind bug

After installing latest kubespray from master-branch:

```
2025-09-15 16:06:39.984 [INFO][13] kube-controllers/watchercache.go 226: Full resync is required ListRoot=".../v3/pc.org/hostendpoints"
2025-09-15 16:06:39.991 [WARNING][13] kube-controllers/watchercache.go 355: Failed to create watcher; will retry. ListRoot=".../v3/pc.org/hostendpoints" error=connection is unauthorized: hostendpoints.crd.projectcalico.org is forbidden: User "system:serviceaccount:kube-system:calico-kube-controllers" cannot watch resource "hostendpoints" in API group "crd.projectcalico.org" at the cluster scope errorsWithoutProgress=1 performFullResync=false

```

Fix is trivial and [original chart ](https://github.com/projectcalico/calico/blob/master/charts/calico/templates/calico-kube-controllers-rbac.yaml#L132) contain this rule.