### PR TITLE
Fix cilium_policy_audit_mode variable

### DIFF
--- a/roles/network_plugin/cilium/templates/values.yaml.j2
+++ b/roles/network_plugin/cilium/templates/values.yaml.j2
@@ -158,6 +158,8 @@ enableIPv6Masquerade: {{ cilium_enable_ipv6_masquerade | to_json }}
 hostFirewall:
   enabled: {{ cilium_enable_host_firewall | to_json }}
 
+policyAuditMode: {{ cilium_policy_audit_mode | to_json }}
+
 certgen:
   image:
     repository: {{ cilium_hubble_certgen_image_repo }}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
PR #12101 introduced a regression where cilium deployment no longer respected the `cilium_policy_audit_mode` variable.
This PR restores the correct behavior by explicitly adding the missing `policyAuditMode` setting to the helm values file. 

**Special notes for your reviewer**:
Please backport it to the `release-2.28` branch.

**Does this PR introduce a user-facing change?**:
```release-note
Fix cilium_policy_audit_mode variable
```
