### PR TITLE
[release-2.28] Upgrade cilium from 1.17.7 to 1.17.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Note:
 - Network Plugin
   - [cni-plugins](https://github.com/containernetworking/plugins) 1.4.1
   - [calico](https://github.com/projectcalico/calico) 3.29.6
-  - [cilium](https://github.com/cilium/cilium) 1.17.7
+  - [cilium](https://github.com/cilium/cilium) 1.17.8
   - [flannel](https://github.com/flannel-io/flannel) 0.22.0
   - [kube-ovn](https://github.com/alauda/kube-ovn) 1.12.21
   - [kube-router](https://github.com/cloudnativelabs/kube-router) 2.1.1

--- a/docs/CNI/cilium.md
+++ b/docs/CNI/cilium.md
@@ -237,7 +237,7 @@ cilium_operator_extra_volume_mounts:
 ## Choose Cilium version
 
 ```yml
-cilium_version: "1.17.7"
+cilium_version: "1.17.8"
 ```
 
 ## Add variable to config

--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -114,7 +114,7 @@ flannel_cni_version: 1.1.2
 weave_version: 2.8.7
 cni_version: "{{ (cni_binary_checksums['amd64'] | dict2items)[0].key }}"
 
-cilium_version: "1.17.7"
+cilium_version: "1.17.8"
 cilium_cli_version: "{{ (ciliumcli_binary_checksums['amd64'] | dict2items)[0].key }}"
 cilium_enable_hubble: false
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
