### PR TITLE
Feat: cilium routing mode setting

### DIFF
--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -43,6 +43,9 @@ cilium_cpu_limit: 500m
 cilium_memory_requests: 64M
 cilium_cpu_requests: 100m
 
+# Enable native-routing mode or tunneling mode.
+cilium_routing_mode: tunnel
+
 # Overlay Network Mode
 cilium_tunnel_mode: vxlan
 

--- a/roles/network_plugin/cilium/templates/values.yaml.j2
+++ b/roles/network_plugin/cilium/templates/values.yaml.j2
@@ -25,6 +25,8 @@ healthPort: {{ cilium_agent_health_port }}
 
 identityAllocationMode: {{ cilium_identity_allocation_mode }}
 
+routingMode: {{ cilium_routing_mode }}
+
 tunnelProtocol: {{ cilium_tunnel_mode }}
 
 loadbalancer:


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Some users want independent variables and hope to be able to configure them like `tunnelProtocol`.

**Which issue(s) this PR fixes**:

Fixes #12541

**Does this PR introduce a user-facing change?**:

```release-note
Add cilium_routing_mode independent variable for Cilium routingMode
```
