### PR TITLE
Set Calico CNI API server endpoint when using localhost load balancers

### DIFF
--- a/roles/kubespray_defaults/defaults/main/main.yml
+++ b/roles/kubespray_defaults/defaults/main/main.yml
@@ -646,8 +646,8 @@ apiserver_loadbalancer_domain_name: "lb-apiserver.kubernetes.local"
 kube_apiserver_global_endpoint: |-
   {% if loadbalancer_apiserver is defined -%}
       https://{{ apiserver_loadbalancer_domain_name }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
-  {%- elif loadbalancer_apiserver_localhost and (loadbalancer_apiserver_port is not defined or loadbalancer_apiserver_port == kube_apiserver_port) -%}
-      https://localhost:{{ kube_apiserver_port }}
+  {%- elif loadbalancer_apiserver_localhost -%}
+      https://localhost:{{ loadbalancer_apiserver_port | default(kube_apiserver_port) }}
   {%- else -%}
       https://{{ first_kube_control_plane_address | ansible.utils.ipwrap }}:{{ kube_apiserver_port }}
   {%- endif %}

--- a/roles/network_plugin/calico/templates/kubernetes-services-endpoint.yml.j2
+++ b/roles/network_plugin/calico/templates/kubernetes-services-endpoint.yml.j2
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   name: kubernetes-services-endpoint
 data:
-{% if calico_bpf_enabled %}
+{% if calico_bpf_enabled or loadbalancer_apiserver_localhost %}
   KUBERNETES_SERVICE_HOST: "{{ kube_apiserver_global_endpoint | urlsplit('hostname') }}"
   KUBERNETES_SERVICE_PORT: "{{ kube_apiserver_global_endpoint | urlsplit('port') }}"
 {% endif %}


### PR DESCRIPTION
When loadbalancer_apiserver_localhost is enabled, Calico CNI fails to reach the API server during pod creation because the kubernetes-services-endpoint ConfigMap is not populated, which causes CNI to default to the service IP which won't work

This change populates the ConfigMap with 127.0.0.1 when localhost load balancers are enabled, allowing CNI to use the local nginx proxy that's already running on each node.

This fix ensures CNI always has a reachable API server endpoint by:

1. Using localhost:6443 when loadbalancer_apiserver_localhost=true
2. Using kube_apiserver_global_endpoint for eBPF mode (existing behavior)
3. Leaving ConfigMap empty otherwise (existing behavior)

Fixes kubernetes-sigs/kubespray#12597

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Fixes an issue where Kubespray deployments fail when using Calico in vxlan mode, without eBPF, but with localhost load balancers

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12597 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

Deployments using Calico in vxlan mode without eBPF but with localhost load balancers will now work. 
```
