### PR TITLE
Change semantics of kubelet resources reservation

### DIFF
--- a/docs/operations/cgroups.md
+++ b/docs/operations/cgroups.md
@@ -1,63 +1,52 @@
 # cgroups
 
-To avoid resource contention between containers and host daemons in Kubernetes, the kubelet components can use cgroups to limit resource usage.
+To avoid resource contention between containers and host daemons in Kubernetes,
+the kubelet components can use cgroups to limit resource usage.
 
-## Enforcing Node Allocatable
+## Node Allocatable
 
-You can use `kubelet_enforce_node_allocatable` to set node allocatable enforcement.
+Node Allocatable is calculated by subtracting from the node capacity:
 
-```yaml
-# A comma separated list of levels of node allocatable enforcement to be enforced by kubelet.
-kubelet_enforce_node_allocatable: "pods"
-# kubelet_enforce_node_allocatable: "pods,kube-reserved"
-# kubelet_enforce_node_allocatable: "pods,kube-reserved,system-reserved"
-```
+- kube-reserved reservations
+- system-reserved reservations
+- hard eviction thresholds
 
-Note that to enforce kube-reserved or system-reserved, `kube_reserved_cgroups` or `system_reserved_cgroups` needs to be specified respectively.
-
-Here is an example:
+You can set those reservations:
 
 ```yaml
-kubelet_enforce_node_allocatable: "pods,kube-reserved,system-reserved"
-
-# Set kube_reserved to true to run kubelet and container-engine daemons in a dedicated cgroup.
-# This is required if you want to enforce limits on the resource usage of these daemons.
-# It is not required if you just want to make resource reservations (kube_memory_reserved, kube_cpu_reserved, etc.)
-kube_reserved: true
-kube_reserved_cgroups_for_service_slice: kube.slice
-kube_reserved_cgroups: "/{{ kube_reserved_cgroups_for_service_slice }}"
 kube_memory_reserved: 256Mi
 kube_cpu_reserved: 100m
-# kube_ephemeral_storage_reserved: 2Gi
-# kube_pid_reserved: "1000"
+kube_ephemeral_storage_reserved: 2Gi
+kube_pid_reserved: "1000"
 
-# Set to true to reserve resources for system daemons
-system_reserved: true
-system_reserved_cgroups_for_service_slice: system.slice
-system_reserved_cgroups: "/{{ system_reserved_cgroups_for_service_slice }}"
+# System daemons (sshd, network manager, ...)
 system_memory_reserved: 512Mi
 system_cpu_reserved: 500m
-# system_ephemeral_storage_reserved: 2Gi
-# system_pid_reserved: "1000"
+system_ephemeral_storage_reserved: 2Gi
+system_pid_reserved: "1000"
 ```
 
-After the setup, the cgroups hierarchy is as follows:
+By default, the kubelet will enforce Node Allocatable for pods, which means
+pods will be evicted when resource usage excess Allocatable.
 
-```bash
-/ (Cgroups Root)
-├── kubepods.slice
-│   ├── ...
-│   ├── kubepods-besteffort.slice
-│   ├── kubepods-burstable.slice
-│   └── ...
-├── kube.slice
-│   ├── ...
-│   ├── {{container_manager}}.service
-│   ├── kubelet.service
-│   └── ...
-├── system.slice
-│   └── ...
-└── ...
+You can optionnaly enforce the reservations for kube-reserved and
+system-reserved, but proceed with caution (see [the kubernetes
+guidelines](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#general-guidelines)).
+Note that to enforce kube-reserved or system-reserved, `kube_reserved_cgroups`
+or `system_reserved_cgroups` needs to be specified respectively.
+
+```yaml
+enforce_allocatable_pods: true # default
+enforce_allocatable_kube_reserved: true
+enforce_allocatable_system_reserved: true
+
+# This is required if you want to enforce limits on the resource usage of these daemons.
+# It is not required if you just want to make resource reservations (kube_memory_reserved, kube_cpu_reserved, etc.)
+kube_reserved_cgroups_for_service_slice: kube.slice
+kube_reserved_cgroups: "/{{ kube_reserved_cgroups_for_service_slice }}"
+
+system_reserved_cgroups_for_service_slice: system.slice
+system_reserved_cgroups: "/{{ system_reserved_cgroups_for_service_slice }}"
 ```
 
 You can learn more in the [official kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/).

--- a/docs/operations/cgroups.md
+++ b/docs/operations/cgroups.md
@@ -42,6 +42,8 @@ enforce_allocatable_system_reserved: true
 
 # This is required if you want to enforce limits on the resource usage of these daemons.
 # It is not required if you just want to make resource reservations (kube_memory_reserved, kube_cpu_reserved, etc.)
+# DEPRECATED: those settings are deprecated and will be removed in an upcoming release
+# It will no longer be a requirement to enforce resources limits on kube / system daemons
 kube_reserved_cgroups_for_service_slice: kube.slice
 kube_reserved_cgroups: "/{{ kube_reserved_cgroups_for_service_slice }}"
 

--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -241,9 +241,8 @@ default_kubelet_config_dir: "{{ kube_config_dir }}/dynamic_kubelet_dir"
 # Download kubectl onto the host that runs Ansible in {{ bin_dir }}
 # kubectl_localhost: false
 
-# A comma separated list of levels of node allocatable enforcement to be enforced by kubelet.
-# Acceptable options are 'pods', 'system-reserved', 'kube-reserved' and ''. Default is "".
-# kubelet_enforce_node_allocatable: pods
+## Reserving compute resources
+# https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
 
 ## Set runtime and kubelet cgroups when using systemd as cgroup driver (default)
 # kubelet_runtime_cgroups: "/{{ kube_service_cgroups }}/{{ container_manager }}.service"
@@ -253,10 +252,8 @@ default_kubelet_config_dir: "{{ kube_config_dir }}/dynamic_kubelet_dir"
 # kubelet_runtime_cgroups_cgroupfs: "/system.slice/{{ container_manager }}.service"
 # kubelet_kubelet_cgroups_cgroupfs: "/system.slice/kubelet.service"
 
-# Whether to run kubelet and container-engine daemons in a dedicated cgroup.
-# kube_reserved: false
+# Optionally reserve resources for kube daemons.
 ## Uncomment to override default values
-## The following two items need to be set when kube_reserved is true
 # kube_reserved_cgroups_for_service_slice: kube.slice
 # kube_reserved_cgroups: "/{{ kube_reserved_cgroups_for_service_slice }}"
 # kube_memory_reserved: 256Mi
@@ -265,14 +262,26 @@ default_kubelet_config_dir: "{{ kube_config_dir }}/dynamic_kubelet_dir"
 # kube_pid_reserved: "1000"
 
 ## Optionally reserve resources for OS system daemons.
-# system_reserved: true
 ## Uncomment to override default values
-## The following two items need to be set when system_reserved is true
 # system_reserved_cgroups_for_service_slice: system.slice
 # system_reserved_cgroups: "/{{ system_reserved_cgroups_for_service_slice }}"
 # system_memory_reserved: 512Mi
 # system_cpu_reserved: 500m
 # system_ephemeral_storage_reserved: 2Gi
+# system_pid_reserved: "1000"
+#
+# Make the kubelet enforce with cgroups the limits of Pods
+# enforce_allocatable_pods: true
+
+# Enforce kube_*_reserved as limits
+# WARNING: this limits the resources the kubelet and the container engine can
+# use which can cause instability on your nodes
+# enforce_allocatable_kube_reserved: false
+
+# Enforce system_*_reserved as limits
+# WARNING: this limits the resources system daemons can use which can lock you
+# out of your nodes (by OOMkilling sshd for instance)
+# enforce_allocatable_system_reserved: false
 
 ## Eviction Thresholds to avoid system OOMs
 # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#eviction-thresholds

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -9,9 +9,6 @@ kubelet_bind_address: "{{ main_ip | default('::') }}"
 # resolv.conf to base dns config
 kube_resolv_conf: "/etc/resolv.conf"
 
-# Set to empty to avoid cgroup creation
-kubelet_enforce_node_allocatable: "\"\""
-
 # Set runtime and kubelet cgroups when using systemd as cgroup driver (default)
 kube_service_cgroups: "{% if kube_reserved %}{{ kube_reserved_cgroups_for_service_slice }}{% else %}system.slice{% endif %}"
 kubelet_runtime_cgroups: "/{{ kube_service_cgroups }}/{{ container_manager }}.service"
@@ -35,23 +32,37 @@ kube_node_addresses: >-
   {%- endfor -%}
 kubelet_secure_addresses: "localhost link-local {{ kube_pods_subnets | regex_replace(',', ' ') }} {{ kube_node_addresses }}"
 
-# Reserve this space for kube resources
-# Whether to run kubelet and container-engine daemons in a dedicated cgroup. (Not required for resource reservations).
-kube_reserved: false
 kube_reserved_cgroups: "/{{ kube_reserved_cgroups_for_service_slice }}"
+## Reserving compute resources
+# https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
+
+# Resource reservations for kube daemons
 kube_memory_reserved: "256Mi"
 kube_cpu_reserved: "100m"
 kube_ephemeral_storage_reserved: "500Mi"
-kube_pid_reserved: "1000"
+kube_pid_reserved: 1000
 
-# Set to true to reserve resources for system daemons
-system_reserved: false
 system_reserved_cgroups_for_service_slice: system.slice
 system_reserved_cgroups: "/{{ system_reserved_cgroups_for_service_slice }}"
+
+# Resource reservations for system daemons
 system_memory_reserved: "512Mi"
 system_cpu_reserved: "500m"
 system_ephemeral_storage_reserved: "500Mi"
 system_pid_reserved: 1000
+
+# Make the kubelet enforce with cgroups the limits of Pods
+enforce_allocatable_pods: true
+
+# Enforce kube_*_reserved as limits
+# WARNING: this limits the resources the kubelet and the container engine can
+# use which can cause instability on your nodes
+enforce_allocatable_kube_reserved: false
+
+# Enforce system_*_reserved as limits
+# WARNING: this limits the resources system daemons can use which can lock you
+# out of your nodes (by OOMkilling sshd for instance)
+enforce_allocatable_system_reserved: false
 
 ## Eviction Thresholds to avoid system OOMs
 # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#eviction-thresholds

--- a/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
@@ -15,13 +15,10 @@ authorization:
 {% else %}
   mode: AlwaysAllow
 {% endif %}
-{% if kubelet_enforce_node_allocatable is defined and kubelet_enforce_node_allocatable != "\"\"" %}
-{% set kubelet_enforce_node_allocatable_list = kubelet_enforce_node_allocatable.split(",") %}
 enforceNodeAllocatable:
-{% for item in kubelet_enforce_node_allocatable_list %}
+{% for item in enforce_node_allocatable | d(['none']) %}
 - {{ item }}
 {% endfor %}
-{% endif %}
 staticPodPath: "{{ kubelet_static_pod_path }}"
 cgroupDriver: {{ kubelet_cgroup_driver | default('systemd') }}
 containerLogMaxFiles: {{ kubelet_logfiles_max_nr }}
@@ -62,9 +59,7 @@ clusterDNS:
 {% endfor %}
 {# Node reserved CPU/memory #}
 {% for scope in "kube", "system" %}
-{% if lookup('ansible.builtin.vars', scope + "_reserved") | bool %}
 {{ scope }}ReservedCgroup: {{ lookup('ansible.builtin.vars', scope + '_reserved_cgroups') }}
-{% endif %}
 {{ scope }}Reserved:
 {% for resource in "cpu", "memory", "ephemeral-storage", "pid" %}
   {{ resource }}: "{{ lookup('ansible.builtin.vars', scope + '_' ~ (resource | replace('-', '_')) + '_reserved') }}"

--- a/roles/kubernetes/node/vars/main.yml
+++ b/roles/kubernetes/node/vars/main.yml
@@ -1,0 +1,6 @@
+---
+enforce_node_allocatable_stub:
+  pods: "{{ enforce_allocatable_pods }}"
+  kube-reserved: "{{ enforce_allocatable_kube_reserved }}"
+  system-reserved: "{{ enforce_allocatable_system_reserved }}"
+enforce_node_allocatable: "{{ enforce_node_allocatable_stub | dict2items | selectattr('value') | map(attribute='key') }}"

--- a/tests/files/almalinux9-crio.yml
+++ b/tests/files/almalinux9-crio.yml
@@ -5,3 +5,6 @@ cloud_image: almalinux-9
 # Kubespray settings
 container_manager: crio
 auto_renew_certificates: true
+
+enforce_allocatable_kube_reserved: true
+enforce_allocatable_system_reserved: true

--- a/tests/files/amazon-linux-2-all-in-one.yml
+++ b/tests/files/amazon-linux-2-all-in-one.yml
@@ -6,3 +6,6 @@ mode: all-in-one
 # Workaround for RHEL8: kernel version 4.18 is lower than Kubernetes system verification.
 kubeadm_ignore_preflight_errors:
   - SystemVerification
+
+enforce_allocatable_kube_reserved: true
+enforce_allocatable_system_reserved: true

--- a/tests/files/ubuntu22-crio.yml
+++ b/tests/files/ubuntu22-crio.yml
@@ -7,3 +7,6 @@ container_manager: crio
 
 download_localhost: false
 download_run_once: true
+
+enforce_allocatable_kube_reserved: true
+enforce_allocatable_system_reserved: true

--- a/tests/files/ubuntu24-calico-all-in-one.yml
+++ b/tests/files/ubuntu24-calico-all-in-one.yml
@@ -23,5 +23,5 @@ containerd_registries_mirrors:
         capabilities: ["pull", "resolve", "push"]
         skip_verify: true
 
-kube_reserved: true
-system_reserved: true
+enforce_allocatable_kube_reserved: true
+enforce_allocatable_system_reserved: true


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This is extracted from #10714, with only the parts related to Node Allocatable.
This clarify the API change the API for users which happened in #10643 (see #12438):
Dinstinguish between:
1. reserving resources for kube / system daemon -> this impacts the calculation of Allocatable
2. enforcing those limits -> this translate the limits in cgroups terms on the node

The current variables (kube_reserved / system_reserved) were used, before #10643, to enable 1 and activate 2.
#10643 decoupled 1 and 2, but those variable and the documentation are still quite confusing. This PR align instead the variables with upstream Kubernetes terminology (`enforce_node_allocatable_*`).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12438

**Special notes for your reviewer**:
@rptaylor would appreciate your thoughts on this
@tico88612 I wonder if we should revert the change in #10643 which set resources unconditionnaly, and reapply them on master only, thoughts ?

**Does this PR introduce a user-facing change?**:
```release-note
action-required
`kube_reserved` is renamed to `enforce_allocatable_kube_reserved`
`system_reserved` is renamed to `enforce_allocatable_system_reserved`
```
