### PR TITLE
Fix breakage when ignoring all kubeadm preflight errors

### DIFF
--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -91,13 +91,13 @@
     - not kubelet_conf.stat.exists
   vars:
     ignored:
-      - DirAvailable--etc-kubernetes-manifests
+      - "{{ 'DirAvailable--etc-kubernetes-manifests' if 'all' not in kubeadm_ignore_preflight_errors }}"
       - "{{ kubeadm_ignore_preflight_errors }}"
   command: >-
     timeout -k {{ kubeadm_join_timeout }} {{ kubeadm_join_timeout }}
     {{ bin_dir }}/kubeadm join
     --config {{ kube_config_dir }}/kubeadm-client.conf
-    --ignore-preflight-errors={{ ignored | flatten | join(',') }}
+    --ignore-preflight-errors={{ ignored | select | flatten | join(',') }}
     --skip-phases={{ kubeadm_join_phases_skip | join(',') }}
 
 - name: Update server field in kubelet kubeconfig

--- a/tests/files/ubuntu24-flannel-ha.yml
+++ b/tests/files/ubuntu24-flannel-ha.yml
@@ -9,3 +9,7 @@ etcd_deployment_type: kubeadm
 kubeadm_certificate_key: 3998c58db6497dd17d909394e62d515368c06ec617710d02edea31c06d741085
 skip_non_kubeadm_warning: true
 kube_asymmetric_encryption_algorithm: "RSA-4096"
+
+# This test the variable usage, it is not a prerequisite of the test itself
+kubeadm_ignore_preflight_errors:
+  - all


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
kubeadm errors out if 'all' is specified with specific checks, so check
that case when we add hardcoded checks.

Add a test to catch regression.

**Which issue(s) this PR fixes**:
Fixes #12605 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fix error when using `kubeadm_ignore_preflight_errors: ['all']`
```
