### PR TITLE
Docs: bump version to 2.29.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Ensure you have installed Docker then
 ```ShellSession
 docker run --rm -it --mount type=bind,source="$(pwd)"/inventory/sample,dst=/inventory \
   --mount type=bind,source="${HOME}"/.ssh/id_rsa,dst=/root/.ssh/id_rsa \
-  quay.io/kubespray/kubespray:v2.28.0 bash
+  quay.io/kubespray/kubespray:v2.29.0 bash
 # Inside the container you may now run the kubespray playbooks:
 ansible-playbook -i /inventory/inventory.ini --private-key /root/.ssh/id_rsa cluster.yml
 ```

--- a/docs/ansible/ansible.md
+++ b/docs/ansible/ansible.md
@@ -200,11 +200,11 @@ You will then need to use [bind mounts](https://docs.docker.com/storage/bind-mou
 to access the inventory and SSH key in the container, like this:
 
 ```ShellSession
-git checkout v2.28.0
-docker pull quay.io/kubespray/kubespray:v2.28.0
+git checkout v2.29.0
+docker pull quay.io/kubespray/kubespray:v2.29.0
 docker run --rm -it --mount type=bind,source="$(pwd)"/inventory/sample,dst=/inventory \
   --mount type=bind,source="${HOME}"/.ssh/id_rsa,dst=/root/.ssh/id_rsa \
-  quay.io/kubespray/kubespray:v2.28.0 bash
+  quay.io/kubespray/kubespray:v2.29.0 bash
 # Inside the container you may now run the kubespray playbooks:
 ansible-playbook -i /inventory/inventory.ini --private-key /root/.ssh/id_rsa cluster.yml
 ```


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Related #12550

Start the release cut 2.29.0.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
