### PR TITLE
fix(cilium): add dynamic api server endpoint configuration

### DIFF
--- a/roles/network_plugin/cilium/templates/values.yaml.j2
+++ b/roles/network_plugin/cilium/templates/values.yaml.j2
@@ -7,8 +7,8 @@ image:
   repository: {{ cilium_image_repo }}
   tag: {{ cilium_image_tag }}
 
-k8sServiceHost: "auto"
-k8sServicePort: "auto"
+k8sServiceHost: "{{ kube_apiserver_global_endpoint | urlsplit('hostname') }}"
+k8sServicePort: "{{ kube_apiserver_global_endpoint | urlsplit('port') }}"
 
 ipv4:
   enabled: {{ cilium_enable_ipv4 | to_json }}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This pull request automatically configures Cilium's API server endpoint for high availability (HA) clusters. It patches the `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` environment variables in both cilium-operator Deployment and cilium DaemonSet to match the cluster's load balancer configuration.

In HA clusters with multiple control planes, Cilium pods would hardcode the first control plane IP, causing complete network failure when that node shuts down. Even when users configured `cilium_config_extra_vars` with the correct endpoint, the environment variables injected at pod creation time were not updated.

After Cilium installation/upgrade, the playbook now automatically:
1. Detects the appropriate API server endpoint based on cluster configuration
2. Patches both cilium-operator and cilium agent pods with correct environment variables
3. Waits for rollout to complete, ensuring cluster stability

Configuration priority:
1. Explicit override: User-defined `cilium_config_extra_vars.k8sServiceHost` (highest priority)
2. External load balancer: `loadbalancer_apiserver` if defined
3. Local load balancer: `127.0.0.1` (default for HA clusters with nginx-proxy)

This makes HA Cilium clusters work correctly out-of-the-box without manual intervention.

**Which issue(s) this PR fixes**:
Fixes #12623

**Special notes for your reviewer**:

[Playbook log on Gist](https://gist.github.com/r3m8/421ae6276decc9b01cb60df444d6d70c)

**Does this PR introduce a user-facing change?**:

```release-note
Action Required: Cilium `k8sServiceHost` and `k8sServicePort` are now derived from `kube_apiserver_global_endpoint` instead of being auto-detected, so users must ensure this endpoint is correctly set and reachable from all nodes.
```