### PR TITLE
docs(cilium): update documentation for unprivileged agent configuration

### DIFF
--- a/docs/CNI/cilium.md
+++ b/docs/CNI/cilium.md
@@ -1,5 +1,13 @@
 # Cilium
 
+## Unprivileged agent configuration
+
+By default, Cilium is installed with `securityContext.privileged: false`. You need to set the `kube_owner` variable to `root` in the inventory:
+
+```yml
+kube_owner: root
+```
+
 ## IP Address Management (IPAM)
 
 IP Address Management (IPAM) is responsible for the allocation and management of IP addresses used by network endpoints (container and others) managed by Cilium. The default mode is "Cluster Scope".

--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -22,7 +22,8 @@ local_release_dir: "/tmp/releases"
 # Random shifts for retrying failed ops like pushing/downloading
 retry_stagger: 5
 
-# This is the user that owns tha cluster installation.
+# This is the user that owns the cluster installation.
+# Note: cilium needs to set kube_owner to root https://kubespray.io/#/docs/CNI/cilium?id=unprivileged-agent-configuration
 kube_owner: kube
 
 # This is the group that the cert creation scripts chgrp the


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This PR fixes Cilium installation failures when running with unprivileged mode by ensuring `/opt/cni/bin` has `root:root` ownership instead of inheriting from `kube_owner`.

Kubespray sets CNI bin directory ownership to `kube_owner`, which causes Cilium agent to crash when `securityContext.privileged: false` ([Helm's default setting](https://docs.cilium.io/en/stable/helm-reference)). This misalignment between Kubespray's defaults and Cilium's expected configuration **breaks all Kubespray fresh installations with Cilium CNI** without custom extra helm value `securityContext.priviledged: true`.

Changes:
- Added `cilium_enable_unprivileged_agent` variable (default: `true`) to control this behavior
- Created dedicated task to set `/opt/cni/bin` ownership to `root:root`

Fixes issues related to [cilium/cilium#23838](https://github.com/cilium/cilium/issues/23838) where unprivileged mode fails due to CNI directory permission mismatches.

**Which issue(s) this PR fixes**:

Old one, fixes #10499 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(cilium): prevent installation failure with unprivileged agent
```