### PR TITLE
Remove leftover docs fragment about mitogen

### DIFF
--- a/docs/ansible/ansible.md
+++ b/docs/ansible/ansible.md
@@ -181,10 +181,6 @@ ansible-playbook -i inventory/sample/hosts.ini cluster.yml \
 
 Note: use `--tags` and `--skip-tags` wisely and only if you're 100% sure what you're doing.
 
-## Mitogen
-
-Mitogen support is deprecated, please see [mitogen related docs](/docs/advanced/mitogen.md) for usage and reasons for deprecation.
-
 ## Troubleshooting Ansible issues
 
 Having the wrong version of ansible, ansible collections or python dependencies can cause issue.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This was left behind from 1fb14b746 (docs: remove outdated mitogen
documentation. (#12619), 2025-10-14)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
