### PR TITLE
fix(calico): Add missed rbac verb watch for hostendpoints

### DIFF
--- a/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-cr.yml.j2
+++ b/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-cr.yml.j2
@@ -79,6 +79,7 @@ rules:
       - create
       - update
       - delete
+      - watch
   # Needs access to update clusterinformations.
   - apiGroups: ["crd.projectcalico.org"]
     resources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes/adds Calico RBAC watch verb permission for hostedendpoints. This RBAC exists upstream in the Calico repo and kubespray should use same RBAC rules. In addition this is needed because users have reported permission errors in Calico pod logs after upgrading from kubespray 2.28.1 to 2.29.0
```bash
2025-09-15 16:06:39.984 [INFO][13] kube-controllers/watchercache.go 226: Full resync is required ListRoot=".../v3/pc.org/hostendpoints"
2025-09-15 16:06:39.991 [WARNING][13] kube-controllers/watchercache.go 355: Failed to create watcher; will retry. ListRoot=".../v3/pc.org/hostendpoints" error=connection is unauthorized: hostendpoints.crd.projectcalico.org is forbidden: User "system:serviceaccount:kube-system:calico-kube-controllers" cannot watch resource "hostendpoints" in API group "crd.projectcalico.org" at the cluster scope errorsWithoutProgress=1 performFullResync=false
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12640

**Special notes for your reviewer**:
Please backport this to release-2.29. Am happy to do the backport, will need to review the docs on how to. I also haven't tested this fully.
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix(calico): Add missed rbac verb watch for hostendpoints
```
