### PR TITLE
[release-2.29] Releng: galaxy version to 2.29.1

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: kubernetes_sigs
 description: Deploy a production ready Kubernetes cluster
 name: kubespray
-version: 2.29.0
+version: 2.29.1
 readme: README.md
 authors:
   - The Kubespray maintainers (https://kubernetes.slack.com/channels/kubespray)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Releng version 2.29.1

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
