### PR TITLE
refactor(bastion-ssh-config): Centralize bastion_port default value

### DIFF
--- a/roles/bastion-ssh-config/defaults/main.yml
+++ b/roles/bastion-ssh-config/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 ssh_bastion_confing__name: ssh-bastion.conf
+bastion_ssh_port_default: 22

--- a/roles/bastion-ssh-config/tasks/main.yml
+++ b/roles/bastion-ssh-config/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Set bastion host IP and port
   set_fact:
     bastion_ip: "{{ hostvars[groups['bastion'][0]]['ansible_host'] | d(hostvars[groups['bastion'][0]]['ansible_ssh_host']) }}"
-    bastion_port: "{{ hostvars[groups['bastion'][0]]['ansible_port'] | d(hostvars[groups['bastion'][0]]['ansible_ssh_port']) | d(22) }}"
+    bastion_port: "{{ hostvars[groups['bastion'][0]]['ansible_port'] | d(hostvars[groups['bastion'][0]]['ansible_ssh_port']) | d(bastion_ssh_port_default) }}"
   delegate_to: localhost
   connection: local
 


### PR DESCRIPTION
Move the hardcoded default port (22) from the set_fact task in tasks/main.yml to defaults/main.yml as bastion_ssh_port_default to improve maintainability and adhere to variable definition best practices.

> /kind cleanup

**What this PR does / why we need it**:
https://github.com/kubernetes-sigs/kubespray/issues/11822

**Which issue(s) this PR fixes**: 
https://github.com/kubernetes-sigs/kubespray/issues/11822
Fixes #11822

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
```release-note

```
