### PR TITLE
Update Calico apiserver RBAC for Kubernetes 1.33+

### DIFF
--- a/roles/network_plugin/calico/templates/calico-apiserver.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-apiserver.yml.j2
@@ -235,6 +235,8 @@ rules:
   resources:
   - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
+  - validatingadmissionpolicies        # Required for Kubernetes 1.33+
+  - validatingadmissionpolicybindings  # Required for Kubernetes 1.33+
   verbs:
   - get
   - list


### PR DESCRIPTION
Add missing RBAC permissions for Calico apiserver to function correctly with Kubernetes 1.33+

Changes:

1. Add K8s 1.33 ValidatingAdmissionPolicy resources to calico-webhook-reader
   - validatingadmissionpolicies
   - validatingadmissionpolicybindings

Kubernetes 1.33 introduced ValidatingAdmissionPolicy resources (KEP-3488) that require explicit RBAC permissions. Without these changes, Calico apiserver on k8s 1.33+ will not work

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Without this, calico apiserver won't work on kubernetes 1.33 and greater due to RBAC errors. Additionally other RBAC errors will spam the logs

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12653 

**Special notes for your reviewer**:

I tested deployments with this of both 1.32 and 1.33 to confirm backwards compatibility. ValidatingAdmissionPolicy resources were introduced in 1.33 so this isn't needed prior to then, but is harmless to do on older versions since the permissions will just be ignored. That seemed cleaner than an if version check, but I can update to do one if preferred...

The ValidatingAdmissionPolicy part is critical if you use apiserver on 1.33 or later

The stagednetworkpolicy part is a more general cleanup just to avoid harmless but noisy log spamming

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix Calico apiserver RBAC permissions for Kubernetes 1.33+
```
