### PR TITLE
Add cilium_chart_values

### DIFF
--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -366,3 +366,8 @@ cilium_install_extra_flags: ""
 # Cilium extra values, use any values from cilium Helm Chart
 # ref: https://docs.cilium.io/en/stable/helm-reference/
 cilium_extra_values: {}
+
+# Cilium helm chart values overrides.
+# This map is recursively merged into cilium-values.yaml after it is rendered from values.yaml.j2.
+# This allows configuring fields that are not explicitly templated.
+cilium_chart_values: {}

--- a/roles/network_plugin/cilium/tasks/install.yml
+++ b/roles/network_plugin/cilium/tasks/install.yml
@@ -45,6 +45,29 @@
   when:
     - inventory_hostname == groups['kube_control_plane'][0]
 
+# Use the rendered values file as the default values
+# and recursively merge cilium_chart_values as override values.
+- name: Cilium | Patch values
+  when:
+    - inventory_hostname == groups['kube_control_plane'][0]
+    - cilium_chart_values != None
+  block:
+    - name: Cilium | Read rendered values
+      slurp:
+        src: "{{ kube_config_dir }}/cilium-values.yaml"
+      register: cilium_values_file
+
+    - name: Cilium | Patch rendered values
+      copy:
+        content: >
+          {{
+            cilium_values_file.content | b64decode | from_yaml
+            | combine(cilium_chart_values | default({}), recursive=True)
+            | cilium_values | to_nice_yaml(indent=2) | indent(2)
+          }}
+        dest: "{{ kube_config_dir }}/cilium-values.yaml"
+        mode: "0644"
+
 - name: Cilium | Copy extra values
   copy:
     content: "{{ cilium_extra_values | to_nice_yaml(indent=2) }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:
Added a new `cilium_chart_values` variable to optionally patch the rendered cilium helm chart values yaml. This allows configuring fields that are not explicitly templated.

Example:
```
cilium_chart_values:
  prometheus:
    enabled: true
    serviceMonitor:
      enabled: true
  operator:
    prometheus:
      serviceMonitor:
        enabled: true
  hubble:
    metrics:
      serviceMonitor:
        enabled: true
```

Related:
- Helm chart readme: https://github.com/cilium/cilium/tree/v1.18.2/install/kubernetes/cilium
- Default values: https://github.com/cilium/cilium/blob/v1.18.2/install/kubernetes/cilium/values.yaml
- Template: https://github.com/kubernetes-sigs/kubespray/blob/v2.28.1/roles/network_plugin/cilium/templates/values.yaml.j2

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
Is there a good way to add tests for this?

**Does this PR introduce a user-facing change?**:
```release-note
Added a new `cilium_chart_values` variable to optionally patch the rendered cilium helm chart values yaml. This allows configuring fields that are not explicitly templated.
```
