### PR TITLE
change kubectl_node_schedulable var

### DIFF
--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -31,14 +31,14 @@
   command: >
     {{ kubectl }} get node {{ kube_override_hostname | default(inventory_hostname) }}
     -o jsonpath='{ .spec.unschedulable }'
-  register: kubectl_node_schedulable
+  register: kubectl_node_unschedulable
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
   failed_when: false
   changed_when: false
 
 - name: Set if node needs cordoning
   set_fact:
-    needs_cordoning: "{{ (kubectl_node_ready.stdout == 'True' and not kubectl_node_schedulable.stdout) or upgrade_node_always_cordon }}"
+    needs_cordoning: "{{ (kubectl_node_ready.stdout == 'True' and not kubectl_node_unschedulable.stdout) or upgrade_node_always_cordon }}"
 
 - name: Node draining
   delegate_to: "{{ groups['kube_control_plane'][0] }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
If you have these nodes:
```
cluster-k8s-node-x39      Ready                      <none>          279d     v1.29.10
cluster-k8s-node-x40      Ready,SchedulingDisabled   <none>          279d     v1.29.10
```
then the results of this query are:
```
$ kubectl get node cluster-k8s-node-x39 -o jsonpath='{ .spec.unschedulable }'
$ kubectl get node cluster-k8s-node-x40 -o jsonpath='{ .spec.unschedulable }'
true
```

In other words `kubectl_node_schedulable` is the opposite of what it says - it is true if the node is _un_ schedulable.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Make the name of the variable match the logic of the variable to improve readability and avoid the risk of confusion and errors.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
