### PR TITLE
Adjust hubble export values for cilium 1.18 schema change

### DIFF
--- a/roles/network_plugin/cilium/templates/values.yaml.j2
+++ b/roles/network_plugin/cilium/templates/values.yaml.j2
@@ -107,8 +107,14 @@ hubble:
   metrics:
     enabled: {{ cilium_hubble_metrics | to_json }}
   export:
+{% if cilium_version is version('1.18.0', '>=') %}
+    static:
+      fileMaxBackups: {{ cilium_hubble_export_file_max_backups }}
+      fileMaxSizeMb: {{ cilium_hubble_export_file_max_size_mb }}
+{% else %}
     fileMaxBackups: {{ cilium_hubble_export_file_max_backups }}
     fileMaxSizeMb: {{ cilium_hubble_export_file_max_size_mb }}
+{% endif %}
     dynamic:
       enabled: {{ cilium_hubble_export_dynamic_enabled | to_json }}
       config:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Cilium 1.18 changed the Hubble exporter configuration schema so that the static exporter settings are now expected under the `hubble.export.static` key.

upstream change: cilium/cilium#36974

**Special notes for your reviewer**:
Please backport it to the `release-2.29` branch.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```