### PR TITLE
Test: check nologin files are gone

### DIFF
--- a/tests/cloud_playbooks/create-kubevirt.yml
+++ b/tests/cloud_playbooks/create-kubevirt.yml
@@ -22,3 +22,14 @@
       port: 22
       timeout: 240
     delegate_to: localhost
+  - name: Wait for nologin to be gone
+    become: true
+    wait_for:
+      path: "{{ item }}"
+      state: absent
+      timeout: 300
+    loop:
+      - /run/nologin
+      - /etc/nologin
+    retries: 10
+    delay: 10


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

When testing Ubuntu 24.04, you might encounter `System is booting up. Unprivileged users are not permitted to log in yet.`

**Which issue(s) this PR fixes**:

Related #12359

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
