### PR TITLE
Fix the (upgrade/remove_node) + collection test cases

### DIFF
--- a/remove_node.yml
+++ b/remove_node.yml
@@ -1,0 +1,3 @@
+---
+- name: Remove node
+  ansible.builtin.import_playbook: playbooks/remove_node.yml

--- a/tests/scripts/testcases_run.sh
+++ b/tests/scripts/testcases_run.sh
@@ -70,7 +70,7 @@ if [ "${UPGRADE_TEST}" != "false" ]; then
         run_playbook cluster
         ;;
     "graceful")
-        run_playbook upgrade-cluster
+        run_playbook upgrade_cluster
         ;;
     *)
         ;;

--- a/upgrade_cluster.yml
+++ b/upgrade_cluster.yml
@@ -1,0 +1,3 @@
+---
+- name: Upgrade cluster
+  ansible.builtin.import_playbook: playbooks/upgrade_cluster.yml


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The 'old' playbook and the collection use '-' and '_' as separator,
which breaks the logic in scripts/testcases_run.sh.

Add aliases using the old schemes to make the test work and avoid
breaking anything.

Both '-' and '_' variants will be deleted once we switch to supporting
collection only.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
