### PR TITLE
Gather ansible_os_family in reset

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -451,6 +451,11 @@
   tags:
     - network
 
+- name: Gather OS family
+  ansible.builtin.setup:
+    gather_subset: distribution
+    filter: ansible_os_family
+
 - name: Reset | Restart network
   when:
     - ansible_os_family not in ["Flatcar", "Flatcar Container Linux by Kinvolk"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR gathers just the `ansible_os_family` that is required by the [next task](https://github.com/kubernetes-sigs/kubespray/blob/97a3776d8e977a94ef0daafa7ca119b2f8906c4d/roles/reset/tasks/main.yml#L454). This allows running the playbook without `gather_facts: true`, which increases the speed of exection.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12593

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
