### PR TITLE
Fix Cilium loadBalancer.mode rendering in Kubespray template

### DIFF
--- a/roles/network_plugin/cilium/templates/values.yaml.j2
+++ b/roles/network_plugin/cilium/templates/values.yaml.j2
@@ -27,7 +27,7 @@ identityAllocationMode: {{ cilium_identity_allocation_mode }}
 
 tunnelProtocol: {{ cilium_tunnel_mode }}
 
-loadbalancer:
+loadBalancer:
   mode: {{ cilium_loadbalancer_mode }}
 
 kubeProxyReplacement: {{ cilium_kube_proxy_replacement | to_json }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes incorrect `loadbalancer` key rendering in the Cilium `values.yaml` template.  
Cilium expects the camelCase key `loadBalancer.mode`, but Kubespray rendered it as  
`loadbalancer.mode`, causing the setting to be ignored.  
This patch corrects the key so Cilium can properly configure load balancer mode (e.g., DSR).

**Which issue(s) this PR fixes**:
Fixes #12666

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
Fix Cilium loadBalancer.mode rendering in Kubespray values template.
```
