### PR TITLE
Remove download support for old calico versions

### DIFF
--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -784,9 +784,9 @@ downloads:
     url: "{{ calico_crds_download_url }}"
     unarchive: true
     unarchive_extra_opts:
-      - "{{ '--strip=6' if (calico_version is version('3.22.3', '<')) else '--strip=3' }}"
+      - "--strip=3"
       - "--wildcards"
-      - "{{ '*/_includes/charts/calico/crds/kdd/' if (calico_version is version('3.22.3', '<')) else '*/libcalico-go/config/crd/' }}"
+      - "*/libcalico-go/config/crd/"
     owner: "root"
     mode: "0755"
     groups:

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -126,23 +126,9 @@
     - ('kube_control_plane' in group_names)
     - calico_datastore == "kdd"
   block:
-    - name: Calico | Check if extra directory is needed
-      stat:
-        path: "{{ local_release_dir }}/calico-{{ calico_version }}-kdd-crds/{{ 'kdd' if (calico_version is version('3.22.3', '<')) else 'crd' }}"
-      register: kdd_path
-    - name: Calico | Set kdd path when calico < v3.22.3
-      set_fact:
-        calico_kdd_path: "{{ local_release_dir }}/calico-{{ calico_version }}-kdd-crds{{ '/kdd' if kdd_path.stat.exists is defined and kdd_path.stat.exists }}"
-      when:
-        - calico_version is version('3.22.3', '<')
-    - name: Calico | Set kdd path when calico > 3.22.2
-      set_fact:
-        calico_kdd_path: "{{ local_release_dir }}/calico-{{ calico_version }}-kdd-crds{{ '/crd' if kdd_path.stat.exists is defined and kdd_path.stat.exists }}"
-      when:
-        - calico_version is version('3.22.2', '>')
     - name: Calico | Create calico manifests for kdd
       assemble:
-        src: "{{ calico_kdd_path }}"
+        src: "{{ local_release_dir }}/calico-{{ calico_version }}-kdd-crds/crd/"
         dest: "{{ kube_config_dir }}/kdd-crds.yml"
         mode: "0644"
         delimiter: "---\n"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Remove logic for handling calico artefacts we no longer deploy (old versions)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Extracted from #12299 to make it smaller and easier to review

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
