### PR TITLE
ci: add trailing / for local_release_dir

### DIFF
--- a/tests/common_vars.yml
+++ b/tests/common_vars.yml
@@ -37,4 +37,4 @@ nginx_image_repo: "{{ quay_image_repo }}/kubespray/nginx"
 flannel_image_repo: "{{ quay_image_repo }}/kubespray/flannel"
 flannel_init_image_repo: "{{ quay_image_repo }}/kubespray/flannel-cni-plugin"
 
-local_release_dir: "{{ '/tmp/releases' if inventory_hostname != 'localhost' else (lookup('env', 'PWD') + '/downloads') }}"
+local_release_dir: "{{ '/tmp/releases/' if inventory_hostname != 'localhost' else (lookup('env', 'PWD') + '/downloads/') }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Consistency with the default value which use a trailing / as well

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This is a fixup of #12692, basically

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cherrypick release-2.29
