### PR TITLE
Fix broken .ini link in getting started

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
     loadSidebar: 'docs/_sidebar.md',
     repo: 'https://github.com/kubernetes-sigs/kubespray',
     auto2top: true,
+    noCompileLinks: ['.*\.ini'],
     logo: '/logo/logo-clear.png'
   }
 </script>


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Excludes `.ini` files from being processed by docsify to fix the broken link in the get-started page linking to the example inventory file. Currently leads to a 404 page.

**Currently**
<img width="1892" height="885" alt="image" src="https://github.com/user-attachments/assets/5ed8b55d-f590-4717-a6b7-405ef41cb49f" />
<img width="1892" height="885" alt="image" src="https://github.com/user-attachments/assets/51499eef-9adc-4bd0-88a1-2c13af6fc17d" />



**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
Fix deployed [here](https://kubespray.azhan.dev/#/docs/getting_started/getting-started)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
