### PR TITLE
Use run_once for kubeadm init phase upload-certs

### DIFF
--- a/roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml
@@ -11,24 +11,23 @@
   tags:
     - facts
 
-- name: Upload certificates so they are fresh and not expired
-  command: >-
-    {{ bin_dir }}/kubeadm init phase
-    --config {{ kube_config_dir }}/kubeadm-config.yaml
-    upload-certs
-    --upload-certs
-  register: kubeadm_upload_cert
+- name: Obtain kubeadm certificate key for joining control planes nodes
   when:
-    - inventory_hostname == first_kube_control_plane
     - not kube_external_ca_mode
-
-- name: Parse certificate key if not set
-  set_fact:
-    kubeadm_certificate_key: "{{ hostvars[first_kube_control_plane]['kubeadm_upload_cert'].stdout_lines[-1] | trim }}"
   run_once: true
-  when:
-    - hostvars[first_kube_control_plane]['kubeadm_upload_cert'] is defined
-    - hostvars[first_kube_control_plane]['kubeadm_upload_cert'] is not skipped
+  block:
+    - name: Upload certificates so they are fresh and not expired
+      command: >-
+        {{ bin_dir }}/kubeadm init phase
+        --config {{ kube_config_dir }}/kubeadm-config.yaml
+        upload-certs
+        --upload-certs
+      register: kubeadm_upload_cert
+      delegate_to: "{{ first_kube_control_plane }}"
+
+    - name: Parse certificate key if not set
+      set_fact:
+        kubeadm_certificate_key: "{{ kubeadm_upload_cert.stdout_lines[-1] | trim }}"
 
 - name: Wait for k8s apiserver
   wait_for:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Before "5ca23e3bf (Changed to use first_kube_control_plane to parse
kubeadm_certificate_key (#11875), 2025-01-14)", kubespray would have
problem adding new control planes when the order of the nodes in kubectl
output and the ansible inventory were not the same.

But the underlying problem is that the operation is fundamentally
something that should be done only once, and recorded for all host in
play.

Since `register` and `sef_fact` when used with `run_once` set the
variable for all the hosts, use it. Also allows to use the variable
directly instead of relying on hostvars to make the task more readable.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
