### PR TITLE
Add a default (empty) value for `supplementary_addresses_in_ssl_keys`

### DIFF
--- a/roles/kubernetes/control-plane/defaults/main/main.yml
+++ b/roles/kubernetes/control-plane/defaults/main/main.yml
@@ -240,6 +240,10 @@ auto_renew_certificates_systemd_calendar: "Mon *-*-1,2,3,4,5,6,7 03:00:00"
 # we can opt out from the default behavior by setting kubeadm_upgrade_auto_cert_renewal to false
 kubeadm_upgrade_auto_cert_renewal: true
 
+# Add Subject Alternative Names to the Kubernetes apiserver certificates.
+# Useful if you access the API from multiples load balancers, for instance.
+supplementary_addresses_in_ssl_keys: []
+
 # Bash alias of kubectl to interact with Kubernetes cluster much easier
 # kubectl_alias: k
 

--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -38,7 +38,7 @@
       - "::1"
       - "{{ apiserver_loadbalancer_domain_name }}"
       - "{{ loadbalancer_apiserver.address | d('') }}"
-      - "{{ supplementary_addresses_in_ssl_keys | d([]) }}"
+      - "{{ supplementary_addresses_in_ssl_keys }}"
       - "{{ groups['kube_control_plane'] | map('extract', hostvars, 'main_access_ip') }}"
       - "{{ groups['kube_control_plane'] | map('extract', hostvars, 'main_ip') }}"
       - "{{ groups['kube_control_plane'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | select('defined') }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Most variables should have a default instead of relying on the default
filter.

(Note that the variable is misnomed, this should be certs and not keys,
but it's not worth breaking compat).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
