### PR TITLE
Remove legacy tasks that were scheduled for cleanup

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -432,16 +432,6 @@
     - files
     - dns
 
-  # TODO: remove after release 2.29
-- name: Reset | remove host entries from /etc/hosts
-  blockinfile:
-    path: "/etc/hosts"
-    state: absent
-    marker: "# Ansible inventory hosts {mark}"
-  tags:
-    - files
-    - dns
-
 - name: Reset | include file with reset tasks specific to the network_plugin if exists
   include_role:
     name: "network_plugin/{{ kube_network_plugin }}"

--- a/roles/validate_inventory/tasks/main.yml
+++ b/roles/validate_inventory/tasks/main.yml
@@ -6,14 +6,6 @@
 # -> nothing depending on facts or similar cluster state
 # Checks depending on current state (of the nodes or the cluster)
 # should be in roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
-- name: Stop if removed tags are used
-  assert:
-    msg: The tag 'master' is removed. Use 'control-plane' instead
-    that:
-      - ('master' not in ansible_run_tags)
-      - ('master' not in ansible_skip_tags)
-        # TODO: Remove checks after next release
-
 - name: Stop if kube_control_plane group is empty
   assert:
     that: groups.get( 'kube_control_plane' )


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Remove old tasks that are no longer needed:

* Reset | remove host entries from /etc/hosts
* Stop if removed tags are used

These were scheduled for removal after release 2.29.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
