### PR TITLE
fix: remove redundant cni dependency for flannel/kube-router/macvlan/multus

### DIFF
--- a/roles/network_plugin/flannel/meta/main.yml
+++ b/roles/network_plugin/flannel/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - role: network_plugin/cni

--- a/roles/network_plugin/kube-router/meta/main.yml
+++ b/roles/network_plugin/kube-router/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - role: network_plugin/cni

--- a/roles/network_plugin/macvlan/meta/main.yml
+++ b/roles/network_plugin/macvlan/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - role: network_plugin/cni

--- a/roles/network_plugin/multus/meta/main.yml
+++ b/roles/network_plugin/multus/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - role: network_plugin/cni


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

 /kind bug

**What this PR does / why we need it**:

This is basically a follow-up to https://github.com/kubernetes-sigs/kubespray/issues/9549 and https://github.com/kubernetes-sigs/kubespray/pull/9563. When trying to remove node from cluster which has Flannel CNI, the job will fail with:
```
$ ansible-playbook -i inventory/kubespray-local-deployment/inventory.yml remove-node.yml -e node=kubespray-node-3 -b -v \
  --private-key=~/.ssh/id_ed25519
...
TASK [network_plugin/cni : CNI | Copy cni plugins] ****************************************************************************************
fatal: [kubespray-node-3]: FAILED! => {"changed": false, "msg": "Source '/tmp/releases/cni-plugins-linux-amd64-1.8.0.tgz' does not exist"}
...
```

Based on previous discussions, this dependency can be safely removed since it's not needed ever since https://github.com/kubernetes-sigs/kubespray/pull/9367/files.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Haven't created one for Flannel.
**Special notes for your reviewer**:

Made this PR based on suggestions [here](https://github.com/kubernetes-sigs/kubespray/pull/9550#issuecomment-1409713447).

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix: remove redundant cni dependency for flannel/kube-router/macvlan/multus
```
