### PR TITLE
Fix: cilium pods can't bootstrap due to mount-cgroup permission denied

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
@@ -387,4 +387,6 @@ cilium_l2announcements: false
 
 # Cilium extra values, use any values from cilium Helm Chart
 # ref: https://docs.cilium.io/en/stable/helm-reference/
-# cilium_extra_values: {}
+cilium_extra_values:
+  securityContext:
+    privileged: true


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug


**What this PR does / why we need it**:

cilium pods can't bootstrap due to mount-cgroup permission denied on Rockylinux 9.2 with cilium version 1.18.4.

This PR fixed the bug by overwriting chart value cilium_extra_values with securityContext.privileged: true

**Which issue(s) this PR fixes**:

Fixes #12769

**Special notes for your reviewer**:

-  The new variable is optional and defaults to the cilium upstream chart repository.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
