### PR TITLE
terraform openstack: allow ICMPv6 by default

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -281,9 +281,9 @@ For your cluster, edit `inventory/$CLUSTER/cluster.tfvars`.
 |`k8s_allowed_remote_ips_ipv6` | List of IPv6 CIDR allowed to initiate a SSH connection, empty by default |
 |`k8s_allowed_egress_ipv6_ips` | List of IPv6 CIDRs allowed for egress traffic, `["::/0"]` by default |
 |`worker_allowed_ports` | List of ports to open on worker nodes, `[{ "protocol" = "tcp", "port_range_min" = 30000, "port_range_max" = 32767, "remote_ip_prefix" = "0.0.0.0/0"}]` by default |
-|`worker_allowed_ports_ipv6` | List of ports to open on worker nodes for IPv6 CIDR blocks, `[{ "protocol" = "tcp", "port_range_min" = 30000, "port_range_max" = 32767, "remote_ip_prefix" = "::/0"}]` by default |
+|`worker_allowed_ports_ipv6` | List of ports to open on worker nodes for IPv6 CIDR blocks, `[{ "protocol" = "tcp", "port_range_min" = 30000, "port_range_max" = 32767, "remote_ip_prefix" = "::/0"}, { "protocol" = "ipv6-icmp", "port_range_min" = 0, "port_range_max" = 0, "remote_ip_prefix" = "::/0"}]` by default |
 |`master_allowed_ports` | List of ports to open on master nodes, expected format is `[{ "protocol" = "tcp", "port_range_min" = 443, "port_range_max" = 443, "remote_ip_prefix" = "0.0.0.0/0"}]`, empty by default |
-|`master_allowed_ports_ipv6` | List of ports to open on master nodes for IPv6 CIDR blocks, expected format is `[{ "protocol" = "tcp", "port_range_min" = 443, "port_range_max" = 443, "remote_ip_prefix" = "::/0"}]`, empty by default |
+|`master_allowed_ports_ipv6` | List of ports to open on master nodes for IPv6 CIDR blocks, `[{ "protocol" = "ipv6-icmp", "port_range_min" = 0, "port_range_max" = 0, "remote_ip_prefix" = "::/0"}]` by default |
 |`node_root_volume_size_in_gb` | Size of the root volume for nodes, 0 to use ephemeral storage |
 |`master_root_volume_size_in_gb` | Size of the root volume for masters, 0 to use ephemeral storage |
 |`master_volume_type` | Volume type of the root volume for control_plane, 'Default' by default |

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -271,7 +271,14 @@ variable "master_allowed_ports" {
 variable "master_allowed_ports_ipv6" {
   type = list(any)
 
-  default = []
+  default = [
+    {
+      "protocol"         = "ipv6-icmp"
+      "port_range_min"   = 0
+      "port_range_max"   = 0
+      "remote_ip_prefix" = "::/0"
+    },
+  ]
 }
 
 variable "worker_allowed_ports" {
@@ -295,6 +302,12 @@ variable "worker_allowed_ports_ipv6" {
       "protocol"         = "tcp"
       "port_range_min"   = 30000
       "port_range_max"   = 32767
+      "remote_ip_prefix" = "::/0"
+    },
+    {
+      "protocol"         = "ipv6-icmp"
+      "port_range_min"   = 0
+      "port_range_max"   = 0
       "remote_ip_prefix" = "::/0"
     },
   ]


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Enable inbound ICMPv6 by default.

**Special notes for your reviewer**:
With IPv4, there were arguments to be made (at least historically, maybe not as relevant anymore) about whether ICMP should be allowed (and which types and codes) in firewall rules for security reasons. However, the ICMPv6 protocol was designed with hindsight of IPv4 ICMP, and ICMPv6 is generally required for robust IPv6 functionality. If you block ICMPv6 by default you can expect to have IPv6 problems.

 - http://shouldiblockicmp.com/  ?
 - https://datatracker.ietf.org/doc/html/rfc4890#section-4.3

I don't think Openstack provides any granularity to allow specific sub-types of ICMPv6 (or if so, it isn't really documented) :  https://docs.openstack.org/python-openstackclient/train/cli/command-objects/security-group-rule.html

I would say allowing ICMPv6 is arguably not as much of a security risk as exposing all nodePorts by default. But I would be glad to hear opinions about this.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The default Openstack security groups now allow ICMPv6 for general IPv6 functionality.
```
