### PR TITLE
Add dns-autoscaler ConfigMap template (#12789)

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/dns-autoscaler-configmap.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dns-autoscaler-configmap.yml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dns-autoscaler{{ coredns_ordinal_suffix }}
+  namespace: kube-system
+  labels:
+    k8s-app: dns-autoscaler{{ coredns_ordinal_suffix }}
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  linear: '{"preventSinglePointFailure":{{ dns_prevent_single_point_failure }},"coresPerReplica":{{ dns_cores_per_replica }},"nodesPerReplica":{{ dns_nodes_per_replica }},"min":{{ dns_min_replicas }}}'

--- a/roles/kubernetes-apps/ansible/vars/main.yml
+++ b/roles/kubernetes-apps/ansible/vars/main.yml
@@ -2,6 +2,7 @@
 dns_autoscaler_manifests:
 - dns-autoscaler-sa.yml.j2
 - dns-autoscaler.yml.j2
+- dns-autoscaler-configmap.yml.j2
 - dns-autoscaler-clusterrole.yml.j2
 - dns-autoscaler-clusterrolebinding.yml.j2
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
This PR makes DNS autoscaler configuration explicit by rendering and applying a managed ConfigMap from Kubespray. It removes reliance on the autoscaler’s internal fallback defaults, ensuring consistent, predictable, and reproducible DNS autoscaling behavior across clusters.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12789

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
Yes. Kubespray now explicitly renders and manages the DNS autoscaler ConfigMap instead of relying on the autoscaler’s internal default configuration. While the default values remain unchanged, the resulting cluster resources and configuration ownership are now user-visible and fully managed by Kubespray.
```release-note
Kubespray now explicitly creates and manages the DNS autoscaler ConfigMap instead of relying on upstream default configuration, ensuring consistent and reproducible DNS autoscaler behavior.
```
