### PR TITLE
Update kube-vip to v1.0.3

### DIFF
--- a/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
@@ -27,7 +27,7 @@ spec:
       value: {{ kube_vip_services_interface | string | to_json }}
 {% endif %}
 {% if kube_vip_cidr %}
-    - name: vip_cidr
+    - name: vip_{% if kube_vip_image_tag is version('v0.9.0', '>=') %}subnet{% else %}cidr{% endif %}
       value: {{ kube_vip_cidr | string | to_json }}
 {% endif %}
 {% if kube_vip_dns_mode %}

--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -266,7 +266,7 @@ external_openstack_cloud_controller_image_repo: "{{ kube_image_repo }}/provider-
 external_openstack_cloud_controller_image_tag: "v1.32.0"
 
 kube_vip_image_repo: "{{ github_image_repo }}/kube-vip/kube-vip{{ '-iptables' if kube_vip_lb_fwdmethod == 'masquerade' else '' }}"
-kube_vip_image_tag: v0.8.9
+kube_vip_image_tag: v1.0.3
 nginx_image_repo: "{{ docker_image_repo }}/library/nginx"
 nginx_image_tag: 1.28.0-alpine
 haproxy_image_repo: "{{ docker_image_repo }}/library/haproxy"


### PR DESCRIPTION
- What type of PR is this?

    /kind feature

- What this PR does / why we need it:

Update kube-vip to v1.0.3

- Special notes for your reviewer:

cf https://github.com/kube-vip/kube-vip/releases/tag/v0.9.0 : 
> When you use the environment variable vip_cidr please rename it to vip_subnet

```release-note
Update kube-vip to v1.0.3
```