### PR TITLE
Remove deprecated keys from containerd config

### DIFF
--- a/docs/CRI/containerd.md
+++ b/docs/CRI/containerd.md
@@ -65,9 +65,8 @@ In kubespray, the default runtime name is "runc", and it can be configured with 
 containerd_runc_runtime:
   name: runc
   type: "io.containerd.runc.v2"
-  engine: ""
-  root: ""
   options:
+    Root: ""
     SystemdCgroup: "false"
     BinaryName: /usr/local/bin/my-runc
   base_runtime_spec: cri-base.json

--- a/inventory/sample/group_vars/all/containerd.yml
+++ b/inventory/sample/group_vars/all/containerd.yml
@@ -11,15 +11,15 @@
 # containerd_runc_runtime:
 #   name: runc
 #   type: "io.containerd.runc.v2"
-#   engine: ""
-#   root: ""
+#   options:
+#     Root: ""
 
 # containerd_additional_runtimes:
 # Example for Kata Containers as additional runtime:
 #   - name: kata
 #     type: "io.containerd.kata.v2"
-#     engine: ""
-#     root: ""
+#     options:
+#       Root: ""
 
 # containerd_grpc_max_recv_message_size: 16777216
 # containerd_grpc_max_send_message_size: 16777216

--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -13,10 +13,9 @@ containerd_snapshotter: "overlayfs"
 containerd_runc_runtime:
   name: runc
   type: "io.containerd.runc.v2"
-  engine: ""
-  root: ""
   base_runtime_spec: cri-base.json
   options:
+    Root: ""
     SystemdCgroup: "{{ containerd_use_systemd_cgroup | ternary('true', 'false') }}"
     BinaryName: "{{ bin_dir }}/runc"
 
@@ -24,8 +23,8 @@ containerd_additional_runtimes: []
 # Example for Kata Containers as additional runtime:
 #  - name: kata
 #    type: "io.containerd.kata.v2"
-#    engine: ""
-#    root: ""
+#    options:
+#      Root: ""
 
 containerd_base_runtime_spec_rlimit_nofile: 65535
 

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -52,8 +52,6 @@ oom_score = {{ containerd_oom_score }}
 {% for runtime in [containerd_runc_runtime] + containerd_additional_runtimes %}
        [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.{{ runtime.name }}]
          runtime_type = "{{ runtime.type }}"
-         runtime_engine = "{{ runtime.engine }}"
-         runtime_root = "{{ runtime.root }}"
 {% if runtime.base_runtime_spec is defined %}
          base_runtime_spec = "{{ containerd_cfg_dir }}/{{ runtime.base_runtime_spec }}"
 {% endif %}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR removes the `runtime_engine` and `runtime_root` keys from `containerd` config.
These fields were deprecated in `containerd` v1.3 and officially removed in v2.0.
Keeping them in a 'version = 3' config triggers strict-mode warnings in logs.

```text
level=warning msg="Ignoring unknown key in TOML for plugin" error="strict mode: fields in the document are missing in the target struct" key="containerd runtimes runc runtime_engine" plugin=io.containerd.cri.v1.runtime
level=warning msg="Ignoring unknown key in TOML for plugin" error="strict mode: fields in the document are missing in the target struct" key="containerd runtimes runc runtime_root" plugin=io.containerd.cri.v1.runtime
```

Refrence:

https://github.com/containerd/containerd/blob/release/2.0/RELEASES.md#deprecated-config-properties

**Does this PR introduce a user-facing change?**:

```release-note
Removed deprecated `runtime_engine` and `runtime_root` keys from containerd configuration.
```
