### PR TITLE
Disable `discard_unpacked_layers` for containerd >= 2.1

### DIFF
--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -36,8 +36,8 @@ containerd_default_base_runtime_spec_patch:
         hard: "{{ containerd_base_runtime_spec_rlimit_nofile }}"
         soft: "{{ containerd_base_runtime_spec_rlimit_nofile }}"
 
-# Can help reduce disk usage
-# https://github.com/containerd/containerd/discussions/6295
+# Only for containerd < 2.1; discard unpacked layers to save disk space
+# https://github.com/containerd/containerd/blob/release/2.1/docs/cri/config.md#image-pull-configuration-since-containerd-v21
 containerd_discard_unpacked_layers: true
 
 containerd_base_runtime_specs:

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -78,7 +78,9 @@ oom_score = {{ containerd_oom_score }}
 
   [plugins."io.containerd.cri.v1.images"]
     snapshotter = "{{ containerd_snapshotter }}"
+{% if containerd_discard_unpacked_layers and containerd_version is version('2.1.0', '<') %}
     discard_unpacked_layers = {{ containerd_discard_unpacked_layers | lower }}
+{% endif %}
     image_pull_progress_timeout = "{{ containerd_image_pull_progress_timeout }}"
   [plugins."io.containerd.cri.v1.images".pinned_images]
     sandbox = "{{ pod_infra_image_repo }}:{{ pod_infra_image_tag }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Starting with **containerd v2.1**, the CRI plugin uses containerd’s **Transfer
Service** for image pulls by default, replacing the client-based pull mechanism.

The Transfer Service is **incompatible** with the
`discard_unpacked_layers` option. When this option is present, containerd
automatically falls back to local image pull mode and logs the following
warning:

```text
level=warning msg="Found 'DiscardUnpackedLayers' in CRI config which is incompatible with transfer service (not supported with transfer service). Falling back to local image pull mode."
```

Reference:
https://github.com/containerd/containerd/blob/release/2.1/docs/cri/config.md#image-pull-configuration-since-containerd-v21

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Does this PR introduce a user-facing change?**:

```release-note
action required
`containerd_discard_unpacked_layers` is now applied only for containerd < 2.1 to avoid warnings with the Transfer Service used in newer versions.
```
