### PR TITLE
Sonobuoy: use non-disruptive-conformance mode with --e2e-parallel=tru…

### DIFF
--- a/tests/testcases/tests.yml
+++ b/tests/testcases/tests.yml
@@ -49,6 +49,6 @@
       vars:
         sonobuoy_version: 0.57.3
         sonobuoy_arch: amd64
-        sonobuoy_parallel: 30
+        sonobuoy_parallel: true
         sonobuoy_path: /usr/local/bin/sonobuoy
-        sonobuoy_mode: Quick
+        sonobuoy_mode:  non-disruptive-conformance


### PR DESCRIPTION
Kubespray currently runs Sonobuoy in quick mode, although there is an open request to move to non-disruptive-conformance (https://github.com/kubernetes-sigs/kubespray/issues/12657).
One of the main concerns raised in that discussion was that non-disruptive-conformance can take a long time (~2 hours).
During testing, I found that enabling parallel execution in Sonobuoy significantly reduces runtime while keeping the same non-disruptive conformance coverage.
This issue proposes addressing both points together:
Switch Sonobuoy test mode from quick to non-disruptive-conformance
Enable Sonobuoy parallel execution to keep runtime reasonable.Also note that in the current state, --e2e-parallel=30 is used. If --e2e-parallel=true is set instead, the tests will automatically run in parallel across all available nodes, so there is no need to specify a numeric value.