### PR TITLE
Update pause image to 3.10.1 for Kubernetes 1.34

### DIFF
--- a/roles/kubespray_defaults/vars/main/main.yml
+++ b/roles/kubespray_defaults/vars/main/main.yml
@@ -7,7 +7,7 @@ kube_next: "{{ ((kube_version | split('.'))[1] | int) + 1 }}"
 kube_major_next_version: "1.{{ kube_next }}"
 
 pod_infra_supported_versions:
-  '1.34': '3.10'
+  '1.34': '3.10.1'
   '1.33': '3.10'
   '1.32': '3.10'
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

Ref: https://github.com/kubernetes/kubernetes/pull/130713

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
