### PR TITLE
Add rbac for calico kube-controllers to access services

### DIFF
--- a/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-cr.yml.j2
+++ b/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-cr.yml.j2
@@ -26,6 +26,16 @@ rules:
     verbs:
       - watch
       - list
+  # Services are monitored for service LoadBalancer IP allocation
+  - apiGroups: [""]
+    resources:
+      - services
+      - services/status
+    verbs:
+      - get
+      - list
+      - update
+      - watch
 {% elif calico_datastore == "kdd" %}
   # Nodes are watched to monitor for deletions.
   - apiGroups: [""]


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:

This fixes the missing permissions in calico-kube-controllers ClusterRole when using etcd datastore in Calico >= 3.30.2 as done in calico 3.30.3 cf https://github.com/projectcalico/calico/issues/10762.

**Which issue(s) this PR fixes**:

Couldn't find existing issue for this in kubespray repository.

```release-note
Fix RBAC for calico using the etcd datastore
```