### PR TITLE
fix Cilium task conditional to handle undefined variables

### DIFF
--- a/roles/network_plugin/cilium/tasks/check.yml
+++ b/roles/network_plugin/cilium/tasks/check.yml
@@ -18,7 +18,7 @@
   when:
     - cilium_ipsec_enabled is defined
     - cilium_ipsec_enabled
-    - kube_network_plugin == 'cilium' or cilium_deploy_additionally
+    - kube_network_plugin | default('') == 'cilium' or cilium_deploy_additionally | default(false)
 
 - name: Stop if kernel version is too low for Cilium Wireguard encryption
   assert:


### PR DESCRIPTION
Fix conditional check for Cilium deployment to handle undefined variables
Previously, the task used:
  - kube_network_plugin == 'cilium' or cilium_deploy_additionally

This can fail if cilium_deploy_additionally is undefined, causing Ansible to error.
Updated the condition to use defaults:
  - kube_network_plugin | default('') == 'cilium'
    or cilium_deploy_additionally | default(false)

This ensures the task is safe to run even when optional variables are not defined,
preventing runtime errors and improving Kubespray robustness.