### PR TITLE
openstack-cleanup: delete old keypairs as well

### DIFF
--- a/scripts/openstack-cleanup/main.py
+++ b/scripts/openstack-cleanup/main.py
@@ -72,6 +72,13 @@ def main():
         if not n.is_router_external:
             fn_if_old(conn.network.delete_network, n)
 
+    log.info("Deleting keypairs...")
+    map_if_old(
+        conn.compute.delete_keypair,
+        (conn.compute.get_keypair(x.name) for x in conn.compute.keypairs()),
+        # LIST API for keypairs does not give us a created_at (WTF)
+    )
+
 
 # runs the given fn to all elements of the that are older than allowed
 def map_if_old(fn, items):


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Delete old keypair on elastx so we don't run into quota issues

Also re-work the script a bit (logging)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
