### PR TITLE
fix: bind loadbalancer healthcheck endpoint to localhost by default (…

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -143,6 +143,12 @@ kubelet_healthz_port: 10248
 # Bind address for healthz for Kubelet
 kubelet_healthz_bind_address: 127.0.0.1
 
+# Bind addresses for healthz for the internal load balancer (nginx/haproxy)
+# Defaults to localhost for security. Set to 0.0.0.0 if external health checks are needed.
+loadbalancer_apiserver_healthcheck_bind_address: 127.0.0.1
+# Defaults to IPv6 localhost. Set to :: if external health checks are needed.
+loadbalancer_apiserver_healthcheck_bind_address_ipv6: ::1
+
 # sysctl_file_path to add sysctl conf to
 sysctl_file_path: "/etc/sysctl.d/99-sysctl.conf"
 

--- a/roles/kubernetes/node/templates/loadbalancer/haproxy.cfg.j2
+++ b/roles/kubernetes/node/templates/loadbalancer/haproxy.cfg.j2
@@ -21,9 +21,9 @@ defaults
 
 {% if loadbalancer_apiserver_healthcheck_port is defined -%}
 frontend healthz
-  bind 0.0.0.0:{{ loadbalancer_apiserver_healthcheck_port }}
+  bind {{ loadbalancer_apiserver_healthcheck_bind_address }}:{{ loadbalancer_apiserver_healthcheck_port }}
   {% if ipv6_stack -%}
-  bind :::{{ loadbalancer_apiserver_healthcheck_port }}
+  bind [{{ loadbalancer_apiserver_healthcheck_bind_address_ipv6 }}]:{{ loadbalancer_apiserver_healthcheck_port }}
   {% endif -%}
   mode http
   monitor-uri /healthz

--- a/roles/kubernetes/node/templates/loadbalancer/nginx.conf.j2
+++ b/roles/kubernetes/node/templates/loadbalancer/nginx.conf.j2
@@ -43,9 +43,9 @@ http {
 
   {% if loadbalancer_apiserver_healthcheck_port is defined -%}
   server {
-    listen {{ loadbalancer_apiserver_healthcheck_port }};
+    listen {{ loadbalancer_apiserver_healthcheck_bind_address }}:{{ loadbalancer_apiserver_healthcheck_port }};
     {% if ipv6_stack -%}
-    listen [::]:{{ loadbalancer_apiserver_healthcheck_port }};
+    listen [{{ loadbalancer_apiserver_healthcheck_bind_address_ipv6 }}]:{{ loadbalancer_apiserver_healthcheck_port }};
     {% endif -%}
     location /healthz {
       access_log off;


### PR DESCRIPTION
fix: bind loadbalancer healthcheck endpoint to localhost by default (#12809)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR addresses a security concern where the internal NGINX/HAProxy load balancer health check endpoint was bound to all interfaces (0.0.0.0:8081 and [::]:8081) when `loadbalancer_apiserver_localhost: true` is enabled. This unnecessarily exposes an internal endpoint to external networks.

The fix introduces two new variables for full control over bind addresses:
- `loadbalancer_apiserver_healthcheck_bind_address` - defaults to `127.0.0.1` (IPv4 localhost)
- `loadbalancer_apiserver_healthcheck_bind_address_ipv6` - defaults to `::1` (IPv6 localhost)

Key improvements:
- Binds to localhost only by default for improved security posture
- Fully configurable for both IPv4 and IPv6 independently
- Can be overridden to `0.0.0.0`/`::` if external health checks are needed
- Both NGINX and HAProxy templates have been updated for consistency

**Which issue(s) this PR fixes**:

Fixes #12809

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
The internal load balancer health check endpoint now binds to localhost (127.0.0.1 for IPv4, ::1 for IPv6) by default instead of all interfaces (0.0.0.0, ::) for improved security. Users requiring external health check access can configure `loadbalancer_apiserver_healthcheck_bind_address` and `loadbalancer_apiserver_healthcheck_bind_address_ipv6` to bind to all interfaces.


```release-note
The internal load balancer health check endpoint now binds to localhost by default
```