### PR TITLE
bugfix: Remove default value for kube_vip_cidr

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -66,7 +66,7 @@ kube_vip_version: 0.8.0
 kube_vip_arp_enabled: false
 kube_vip_interface:
 kube_vip_services_interface:
-kube_vip_cidr: 32
+kube_vip_cidr:
 kube_vip_dns_mode: first
 kube_vip_controlplane_enabled: false
 kube_vip_ddns_enabled: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

The default value for kube_vip_cidr: 32 in roles/kubernetes/node/defaults/main.yml causes kube-vip pod manifests to be generated with invalid YAML syntax, preventing kube-vip from starting and breaking control plane high availability.

The generated manifest at /etc/kubernetes/manifests/kube-vip.yml contains malformed YAML:

```yaml
# BROKEN - line 23:
    - name: vip_subnet      value: "32"
```

When kube_vip_cidr: 32 is set, this block renders with the value on the same line as the name, creating invalid YAML syntax. The correct YAML should be:

```yaml
- name: vip_subnet
  value: "32"
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12839

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
