### PR TITLE
cri-o: fix duplicate top-level "auths" keys in registry config template

### DIFF
--- a/roles/container-engine/cri-o/templates/config.json.j2
+++ b/roles/container-engine/cri-o/templates/config.json.j2
@@ -1,16 +1,16 @@
 {% if crio_registry_auth is defined and crio_registry_auth|length %}
 {
-{% for reg in crio_registry_auth %}
   "auths": {
+{% for reg in crio_registry_auth %}
     "{{ reg.registry }}": {
       "auth": "{{ (reg.username + ':' + reg.password) | string | b64encode }}"
-    }
 {% if not loop.last %}
-  },
+    },
 {% else %}
-  }
+    }
 {% endif %}
 {% endfor %}
+  }
 }
 {% else %}
 {}


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

The config.json.j2 template for CRI-O was generating invalid JSON when multiple
`crio_registry_auth` entries were defined, resulting in multiple top-level
"auths" objects being rendered, for example:

```json
{
  "auths": { "registry1": { "auth": "xxxx" } },
  "auths": { "registry2": { "auth": "yyyy" } }
}
```

This change moves the loop inside a single "auths" object so that all registries
are rendered as siblings under one top-level "auths" key, producing valid Docker
config JSON:

```json
{
  "auths": {
    "registry1": { "auth": "xxxx" },
    "registry2": { "auth": "yyyy" }
  }
}
```

**Which issue(s) this PR fixes**:

None filed — this fixes a template bug.  

**Special notes for your reviewer**:

This is a straightforward template fix; no additional testing required beyond
normal CI.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed an issue in the config.json.j2 template where the CRI-O registry authentication configuration could render invalid JSON when multiple `crio_registry_auth` entries were defined, resulting in duplicate top-level `auths` keys in the generated config.
```
