### PR TITLE
ansible-lint: disable jinja[spacing] warning

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -34,6 +34,8 @@ skip_list:
   # Disable run-once check with free strategy
   # (Disabled in June 2023 after ansible upgrade; FIXME)
   - 'run-once[task]'
+
+  - 'jinja[spacing]'
 exclude_paths:
   # Generated files
   - tests/files/custom_cni/cilium.yaml


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This pollutes ansible-lint output and force us to scroll to check what
the actuall issues are.
The spacing issues are minor and very opinionated, so it's no great
loss.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/label ci-short
