### PR TITLE
add metallb_namespace default value and docs update

### DIFF
--- a/docs/ingress/metallb.md
+++ b/docs/ingress/metallb.md
@@ -21,6 +21,12 @@ metallb_enabled: true
 metallb_speaker_enabled: true
 ```
 
+By default, MetalLB resources are deployed into the `metallb-system` namespace. You can override this namespace using a variable.
+
+```yaml
+metallb_namespace: woodenlb-system
+```
+
 By default only the MetalLB BGP speaker is allowed to run on control plane nodes. If you have a single node cluster or a cluster where control plane are also worker nodes you may need to enable tolerations for the MetalLB controller:
 
 ```yaml

--- a/roles/kubernetes-apps/metallb/defaults/main.yml
+++ b/roles/kubernetes-apps/metallb/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 metallb_enabled: false
 metallb_log_level: info
+metallb_namespace: "metallb-system"
 metallb_port: "7472"
 metallb_memberlist_port: "7946"
 metallb_speaker_enabled: "{{ metallb_enabled }}"


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This PR improves the usability of the MetalLB installation process by:
- Explicitly documenting the `metallb_namespace` variable, which is used during installation
- Assigning a default value to the `metallb_namespace` variable: `metallb-system`

**Which issue(s) this PR fixes**:

Fixes #12859

**Special notes for your reviewer**:

Please correct me if I am wrong with the release notes

**Does this PR introduce a user-facing change?**:

```release-note
The default namespace for MetalLB resources is now `metallb-system`.
```
