### PR TITLE
Add upstream DNS over TLS (DoT) support for CoreDNS and NodeLocalDNS

### DIFF
--- a/inventory/sample/group_vars/all/all.yml
+++ b/inventory/sample/group_vars/all/all.yml
@@ -36,9 +36,24 @@ loadbalancer_apiserver_healthcheck_port: 8081
 # disable_host_nameservers: false
 
 ## Upstream dns servers
+## Format supports multiple styles:
+## - Simple IP: '8.8.8.8'
+## - IP with port: '8.8.8.8:5353'
+## - DNS over TLS with SNI: 'tls://8.8.8.8#dns.google'
+## - TLS with custom port: 'tls://8.8.8.8:8853#dns.google'
+##
+## Simple format:
 # upstream_dns_servers:
 #   - 8.8.8.8
 #   - 8.8.4.4
+##
+## DNS over TLS format (recommended for privacy):
+# upstream_dns_servers:
+#   - tls://8.8.8.8#dns.google
+#   - tls://1.1.1.1#cloudflare-dns.com
+#   - 192.168.1.1  # Local plain DNS
+## Each DNS server can have a different SNI
+## Supported by CoreDNS, NodeLocalDNS and systemd-resolved
 
 ## There are some changes specific to the cloud providers
 ## for instance we need to encapsulate packets with some network plugins

--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -55,6 +55,34 @@ old_dns_domains: []
 # dns_upstream_forward_extra_opts apply to coredns forward section as well as nodelocaldns upstream target forward section
 # dns_upstream_forward_extra_opts:
 #   policy: sequential
+#
+# Note: upstream_dns_servers supports DNS over TLS using the format: tls://ip:port#sni
+# Port defaults to 853 if not specified. Examples:
+#   upstream_dns_servers:
+#     - tls://8.8.8.8#dns.google
+#     - tls://1.1.1.1:853#cloudflare-dns.com
+#     - 192.168.1.1  # Plain DNS still supported
+#
+# Set to true if DNS servers ONLY support DoT (port 853) and NOT plain DNS (port 53)
+# This will enforce resolvconf_mode: none to avoid plain DNS fallback failures on hosts
+# dns_upstream_tls_only: false
+#
+# When using DNS over TLS with internal PKI, specify CA bundle path:
+# dns_upstream_tls_ca_file: /etc/ssl/certs/ca-bundle.crt
+# If empty and TLS is used, the system CA bundle will be mounted from the host
+dns_upstream_tls_ca_file: ""
+# System CA path is automatically detected based on OS family
+# Debian/Ubuntu: /etc/ssl/certs/ca-certificates.crt
+# RHEL/CentOS/Rocky/AlmaLinux: /etc/pki/tls/certs/ca-bundle.crt
+# openSUSE/SLES: /etc/ssl/ca-bundle.pem
+dns_upstream_tls_ca_system_path: >-
+  {% if ansible_os_family == "RedHat" -%}
+  /etc/pki/tls/certs/ca-bundle.crt
+  {%- elif ansible_os_family == "Suse" -%}
+  /etc/ssl/ca-bundle.pem
+  {%- else -%}
+  /etc/ssl/certs/ca-certificates.crt
+  {%- endif %}
 
 # Apply extra options to coredns kubernetes plugin
 # coredns_kubernetes_extra_opts:

--- a/roles/kubernetes-apps/ansible/tasks/main.yml
+++ b/roles/kubernetes-apps/ansible/tasks/main.yml
@@ -22,6 +22,7 @@
     - coredns
   vars:
     clusterIP: "{{ skydns_server }}"
+    dns_upstream_use_tls: "{{ upstream_dns_servers | select('match', '^tls://') | list | length > 0 }}"
   when:
     - dns_mode in ['coredns', 'coredns_dual']
     - deploy_coredns
@@ -38,6 +39,7 @@
   vars:
     clusterIP: "{{ skydns_server_secondary }}"
     coredns_ordinal_suffix: "-secondary"
+    dns_upstream_use_tls: "{{ upstream_dns_servers | select('match', '^tls://') | list | length > 0 }}"
   when:
     - dns_mode == 'coredns_dual'
     - deploy_coredns
@@ -68,12 +70,7 @@
       {%- else -%}
       {{ primaryClusterIP }}
       {%- endif -%}
-    upstreamForwardTarget: >-
-      {%- if upstream_dns_servers | length > 0 -%}
-      {{ upstream_dns_servers | join(' ') }}
-      {%- else -%}
-      /etc/resolv.conf
-      {%- endif -%}
+    dns_upstream_use_tls: "{{ upstream_dns_servers | select('match', '^tls://') | list | length > 0 }}"
 
 - name: Kubernetes Apps | Etcd metrics endpoints
   command:

--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -68,9 +68,41 @@ data:
 {% endif %}
         }
         prometheus :9153
-        forward . {{ upstream_dns_servers | join(' ') if upstream_dns_servers | length > 0 else '/etc/resolv.conf' }} {
+{% set ns_plain = namespace(groups={}) %}
+{% for server in upstream_dns_servers %}
+{%   if server.startswith('tls://') %}
+{%     set parts = server | regex_replace('^tls://([^:#]+)(?::(\d+))?(?:#(.+))?$', '\\1,\\2,\\3') | split(',') %}
+{%     set addr = parts[0] %}
+{%     set port = parts[1] if parts[1] else '853' %}
+{%     set sni = parts[2] if parts[2] else addr %}
+{%     set server_str = 'tls://' ~ addr ~ ':' ~ port %}
+{%     if sni in ns_plain.groups %}
+{%       set _ = ns_plain.groups[sni].append(server_str) %}
+{%     else %}
+{%       set _ = ns_plain.groups.update({sni: [server_str]}) %}
+{%     endif %}
+{%   else %}
+{%     set parts = server | regex_replace('^([^:]+)(?::(\d+))?$', '\\1,\\2') | split(',') %}
+{%     set addr = parts[0] %}
+{%     set port = parts[1] if parts[1] else '' %}
+{%     set server_str = addr ~ (':' ~ port if port else '') %}
+{%     if '' in ns_plain.groups %}
+{%       set _ = ns_plain.groups[''].append(server_str) %}
+{%     else %}
+{%       set _ = ns_plain.groups.update({'': [server_str]}) %}
+{%     endif %}
+{%   endif %}
+{% endfor %}
+{% if ns_plain.groups | length > 0 %}
+{% for sni, servers in ns_plain.groups.items() %}
+        forward . {{ servers | join(' ') }} {
+{%   if not sni %}
           prefer_udp
+{%   endif %}
           max_concurrent 1000
+{%   if sni %}
+          tls_servername {{ sni }}
+{%   endif %}
 {% if dns_upstream_forward_extra_opts is defined %}
 {% for optname, optvalue in dns_upstream_forward_extra_opts.items() %}
           {{ (optname ~ ' ' ~ optvalue) | trim }}
@@ -79,6 +111,18 @@ data:
 {% endfor %}
 {% endif %}
         }
+{% endfor %}
+{% else %}
+        forward . /etc/resolv.conf {
+          prefer_udp
+          max_concurrent 1000
+{% if dns_upstream_forward_extra_opts is defined %}
+{% for optname, optvalue in dns_upstream_forward_extra_opts.items() %}
+          {{ (optname ~ ' ' ~ optvalue) | trim }}
+{% endfor %}
+{% endif %}
+        }
+{% endif %}
 {% if enable_coredns_k8s_external %}
         k8s_external {{ coredns_k8s_external_zone }}
 {% endif %}

--- a/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-deployment.yml.j2
@@ -64,6 +64,11 @@ spec:
         volumeMounts:
         - name: config-volume
           mountPath: /etc/coredns
+{% if dns_upstream_use_tls %}
+        - name: tls-ca-volume
+          mountPath: /etc/ssl/certs
+          readOnly: true
+{% endif %}
         ports:
         - containerPort: 53
           name: dns
@@ -110,3 +115,10 @@ spec:
             - key: hosts
               path: hosts
 {% endif %}
+{% if dns_upstream_use_tls %}
+        - name: tls-ca-volume
+          hostPath:
+            path: {{ dns_upstream_tls_ca_file if dns_upstream_tls_ca_file else '/etc/ssl/certs' }}
+            type: {{ 'File' if dns_upstream_tls_ca_file else 'Directory' }}
+{% endif %}
+---

--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2
@@ -83,14 +83,58 @@ data:
         reload
         loop
         bind {{ nodelocaldns_ip }}
-        forward . {{ upstreamForwardTarget }}{% if dns_upstream_forward_extra_opts is defined %} {
+{% set ns_plain = namespace(groups={}) %}
+{% if upstream_dns_servers | length > 0 %}
+{% for server in upstream_dns_servers %}
+{%   if server.startswith('tls://') %}
+{%     set parts = server | regex_replace('^tls://([^:#]+)(?::(\d+))?(?:#(.+))?$', '\\1,\\2,\\3') | split(',') %}
+{%     set addr = parts[0] %}
+{%     set port = parts[1] if parts[1] else '853' %}
+{%     set sni = parts[2] if parts[2] else addr %}
+{%     set server_str = 'tls://' ~ addr ~ ':' ~ port %}
+{%     if sni in ns_plain.groups %}
+{%       set _ = ns_plain.groups[sni].append(server_str) %}
+{%     else %}
+{%       set _ = ns_plain.groups.update({sni: [server_str]}) %}
+{%     endif %}
+{%   else %}
+{%     set parts = server | regex_replace('^([^:]+)(?::(\d+))?$', '\\1,\\2') | split(',') %}
+{%     set addr = parts[0] %}
+{%     set port = parts[1] if parts[1] else '' %}
+{%     set server_str = addr ~ (':' ~ port if port else '') %}
+{%     if '' in ns_plain.groups %}
+{%       set _ = ns_plain.groups[''].append(server_str) %}
+{%     else %}
+{%       set _ = ns_plain.groups.update({'': [server_str]}) %}
+{%     endif %}
+{%   endif %}
+{% endfor %}
+{% endif %}
+{% if ns_plain.groups | length > 0 %}
+{% for sni, servers in ns_plain.groups.items() %}
+        forward . {{ servers | join(' ') }}{% if sni or dns_upstream_forward_extra_opts is defined %} {
+{%   if sni %}
+          tls_servername {{ sni }}
+{%   endif %}
+{% if dns_upstream_forward_extra_opts is defined %}
 {% for optname, optvalue in dns_upstream_forward_extra_opts.items() %}
           {{ (optname ~ ' ' ~ optvalue) | trim }}
           {# do not add a trailing space when optvalue == ''
              workaround for: https://github.com/kubernetes/kubernetes/issues/36222 #}
 {% endfor %}
+{% endif %}
         }{% endif %}
 
+{% endfor %}
+{% else %}
+        forward . /etc/resolv.conf{% if dns_upstream_forward_extra_opts is defined %} {
+          prefer_udp
+{% for optname, optvalue in dns_upstream_forward_extra_opts.items() %}
+          {{ (optname ~ ' ' ~ optvalue) | trim }}
+{% endfor %}
+        }{% endif %}
+
+{% endif %}
         prometheus {% if nodelocaldns_bind_metrics_host_ip %}{$MY_HOST_IP}{% endif %}:{{ nodelocaldns_prometheus_port }}
 {% if dns_etchosts | default(None) %}
         hosts /etc/coredns/hosts {
@@ -170,14 +214,58 @@ data:
         reload
         loop
         bind {{ nodelocaldns_ip }}
-        forward . {{ upstreamForwardTarget }}{% if dns_upstream_forward_extra_opts is defined %} {
+{% set ns_plain = namespace(groups={}) %}
+{% if upstream_dns_servers | length > 0 %}
+{% for server in upstream_dns_servers %}
+{%   if server.startswith('tls://') %}
+{%     set parts = server | regex_replace('^tls://([^:#]+)(?::(\d+))?(?:#(.+))?$', '\\1,\\2,\\3') | split(',') %}
+{%     set addr = parts[0] %}
+{%     set port = parts[1] if parts[1] else '853' %}
+{%     set sni = parts[2] if parts[2] else addr %}
+{%     set server_str = 'tls://' ~ addr ~ ':' ~ port %}
+{%     if sni in ns_plain.groups %}
+{%       set _ = ns_plain.groups[sni].append(server_str) %}
+{%     else %}
+{%       set _ = ns_plain.groups.update({sni: [server_str]}) %}
+{%     endif %}
+{%   else %}
+{%     set parts = server | regex_replace('^([^:]+)(?::(\d+))?$', '\\1,\\2') | split(',') %}
+{%     set addr = parts[0] %}
+{%     set port = parts[1] if parts[1] else '' %}
+{%     set server_str = addr ~ (':' ~ port if port else '') %}
+{%     if '' in ns_plain.groups %}
+{%       set _ = ns_plain.groups[''].append(server_str) %}
+{%     else %}
+{%       set _ = ns_plain.groups.update({'': [server_str]}) %}
+{%     endif %}
+{%   endif %}
+{% endfor %}
+{% endif %}
+{% if ns_plain.groups | length > 0 %}
+{% for sni, servers in ns_plain.groups.items() %}
+        forward . {{ servers | join(' ') }}{% if sni or dns_upstream_forward_extra_opts is defined %} {
+{%   if sni %}
+          tls_servername {{ sni }}
+{%   endif %}
+{% if dns_upstream_forward_extra_opts is defined %}
 {% for optname, optvalue in dns_upstream_forward_extra_opts.items() %}
           {{ (optname ~ ' ' ~ optvalue) | trim }}
           {# do not add a trailing space when optvalue == ''
              workaround for: https://github.com/kubernetes/kubernetes/issues/36222 #}
 {% endfor %}
+{% endif %}
         }{% endif %}
 
+{% endfor %}
+{% else %}
+        forward . /etc/resolv.conf{% if dns_upstream_forward_extra_opts is defined %} {
+          prefer_udp
+{% for optname, optvalue in dns_upstream_forward_extra_opts.items() %}
+          {{ (optname ~ ' ' ~ optvalue) | trim }}
+{% endfor %}
+        }{% endif %}
+
+{% endif %}
         prometheus {% if nodelocaldns_bind_metrics_host_ip %}{$MY_HOST_IP}{% endif %}:{{ nodelocaldns_secondary_prometheus_port }}
 {% if dns_etchosts | default(None) %}
         hosts /etc/coredns/hosts {

--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-daemonset.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-daemonset.yml.j2
@@ -93,6 +93,11 @@ spec:
           mountPath: /etc/coredns
         - name: xtables-lock
           mountPath: /run/xtables.lock
+{% if dns_upstream_use_tls %}
+        - name: tls-ca-volume
+          mountPath: /etc/ssl/certs
+          readOnly: true
+{% endif %}
       volumes:
         - name: config-volume
           configMap:
@@ -108,6 +113,12 @@ spec:
           hostPath:
             path: /run/xtables.lock
             type: FileOrCreate
+{% if dns_upstream_use_tls %}
+        - name: tls-ca-volume
+          hostPath:
+            path: {{ dns_upstream_tls_ca_file if dns_upstream_tls_ca_file else '/etc/ssl/certs' }}
+            type: {{ 'File' if dns_upstream_tls_ca_file else 'Directory' }}
+{% endif %}
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0

--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-second-daemonset.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-second-daemonset.yml.j2
@@ -78,6 +78,11 @@ spec:
           mountPath: /etc/coredns
         - name: xtables-lock
           mountPath: /run/xtables.lock
+{% if dns_upstream_use_tls %}
+        - name: tls-ca-volume
+          mountPath: /etc/ssl/certs
+          readOnly: true
+{% endif %}
         lifecycle:
           preStop:
             exec:
@@ -100,6 +105,12 @@ spec:
           hostPath:
             path: /run/xtables.lock
             type: FileOrCreate
+{% if dns_upstream_use_tls %}
+        - name: tls-ca-volume
+          hostPath:
+            path: {{ dns_upstream_tls_ca_file if dns_upstream_tls_ca_file else '/etc/ssl/certs' }}
+            type: {{ 'File' if dns_upstream_tls_ca_file else 'Directory' }}
+{% endif %}
       # Implement a time skew between the main nodelocaldns and this secondary.
       # Since the two nodelocaldns instances share the :53 port, we want to keep
       # at least one running at any time even if the manifests are replaced simultaneously

--- a/roles/kubespray_defaults/defaults/main/main.yml
+++ b/roles/kubespray_defaults/defaults/main/main.yml
@@ -133,6 +133,16 @@ enable_dns_autoscaler: true
 
 # DNS servers added after the cluster DNS
 # These will also be used as upstream by Coredns for out-cluster queries
+# Format supports:
+# - Simple IP: '8.8.8.8'
+# - IP with port: '8.8.8.8:5353'
+# - DNS over TLS: 'tls://8.8.8.8#dns.google'
+# - TLS with custom port: 'tls://8.8.8.8:8853#dns.google'
+# Examples:
+#   upstream_dns_servers:
+#     - tls://8.8.8.8#dns.google
+#     - tls://1.1.1.1#cloudflare-dns.com
+#     - 192.168.1.1  # Local plain DNS
 upstream_dns_servers: []
 
 # Enable nodelocal dns cache

--- a/roles/validate_inventory/tasks/main.yml
+++ b/roles/validate_inventory/tasks/main.yml
@@ -170,6 +170,41 @@
     msg: The selected choice is not supported
   run_once: true
 
+- name: Stop if DoT-only DNS servers are used without resolvconf_mode none
+  assert:
+    that:
+      - resolvconf_mode == 'none'
+    msg: |
+      dns_upstream_tls_only is set to true, indicating DNS servers ONLY support DoT (port 853).
+      This requires resolvconf_mode='none' to prevent plain DNS fallback failures on host systems.
+      Current resolvconf_mode={{ resolvconf_mode }}
+  when:
+    - dns_upstream_tls_only | default(false) | bool
+  run_once: true
+
+- name: Warn if DNS over TLS is used with mixed mode
+  debug:
+    msg: |
+      INFO: DNS over TLS (tls:// prefix in upstream_dns_servers) is configured with resolvconf_mode={{ resolvconf_mode }}.
+
+      Current behavior:
+      - Pods will use DoT via CoreDNS/NodeLocalDNS (secure, encrypted on port 853)
+      - Host systems will use plain DNS via /etc/resolv.conf (unencrypted on port 53)
+
+      This works ONLY if your DNS servers support BOTH protocols:
+      - Plain DNS on port 53 (for hosts)
+      - DNS over TLS on port 853 (for pods)
+
+      If your DNS servers are DoT-only (port 853 only), set:
+        dns_upstream_tls_only: true
+        resolvconf_mode: none
+  when:
+    - upstream_dns_servers is defined
+    - upstream_dns_servers | select('match', '^tls://') | list | length > 0
+    - resolvconf_mode != 'none'
+    - not (dns_upstream_tls_only | default(false) | bool)
+  run_once: true
+
 - name: Warn if `enable_dual_stack_networks` is set
   debug:
     msg: "WARNING! => `enable_dual_stack_networks` deprecation. Please switch to using ipv4_stack and ipv6_stack."


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds support for DNS over TLS (DoT) for upstream DNS servers in CoreDNS and NodeLocalDNS configurations.

**Motivation:**
Current Kubespray only supports plain DNS (port 53) for upstream resolvers. With increasing privacy concerns and widespread DoT support from DNS providers, encrypted DNS resolution is becoming a standard security practice.

**Changes:**
- Adds `tls://ip:port#sni` format support for `upstream_dns_servers`
- SNI-based grouping for multiple upstream servers
- OS-specific CA bundle detection
- Two operation modes:
  - **DoT-only**: Servers supporting only port 853 (with validation)
  - **Mixed mode**: Dual-protocol servers (port 53 for hosts, port 853 for pods)
- Backward compatible: empty `upstream_dns_servers` still uses `/etc/resolv.conf`

**Configuration examples:**
```yaml
# DoT-only (recommended)
dns_upstream_tls_only: true
resolvconf_mode: none
upstream_dns_servers:
  - tls://8.8.8.8#dns.google
  - tls://1.1.1.1#cloudflare-dns.com

# Dual-protocol (flexible)
upstream_dns_servers:
  - tls://8.8.8.8#dns.google  # Pods use DoT (853)
# Hosts use plain DNS via /etc/resolv.conf (53)
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

- All pre-commit hooks pass (yamllint, markdownlint, trailing-whitespace, end-of-file)
- Comprehensive documentation added (in `docs/advanced/dns-stack.md`)
- No breaking changes
- CoreDNS/NodeLocalDNS versions: All currently supported versions have DoT support
- The implementation uses only native Jinja2 features to avoid external dependencies

**Does this PR introduce a user-facing change?**:

```release-note
Add DNS over TLS (DoT) support for upstream DNS servers in CoreDNS and NodeLocalDNS. Configure encrypted DNS queries using `upstream_dns_servers` with `tls://ip:port#sni` format. Supports both DoT-only and dual-protocol (plain + TLS) configurations. CA bundle detection for supported OS families.
```
