### PR TITLE
k8s-certs-renew: fix broken script

### DIFF
--- a/roles/kubernetes/control-plane/templates/k8s-certs-renew.sh.j2
+++ b/roles/kubernetes/control-plane/templates/k8s-certs-renew.sh.j2
@@ -5,7 +5,6 @@ echo "## Check Expiration before renewal ##"
 {{ bin_dir }}/kubeadm certs check-expiration
 
 days_buffer=7 # set a time margin, because we should not renew at the last moment
-calendar={{ auto_renew_certificates_systemd_calendar }}
 next_time=$(systemctl show k8s-certs-renew.timer  -p NextElapseUSecRealtime --value)
 
 if [ "${next_time}" == "" ]; then


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Unproquer quoting of variable assignment make the shell interpret it as
a command ; since the variable is unused anyway, just delete it.


**Which issue(s) this PR fixes**:
Fixes #12875

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fix automatic certs renew with systemd timer
```
