### PR TITLE
Add releases-notes generator script including component versions

### DIFF
--- a/scripts/generate_release_notes.sh
+++ b/scripts/generate_release_notes.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Usage:
+# generate_release_notes.sh <endrev> <startrev>
+# defautto closest tag on current branch -> current branch
+# This scripts generate the expected format for Kubespray release notes:
+# release-notes tool output + components with updated versions
+set -o pipefail
+
+endrev=${1:-$(git rev-parse --abbrev-ref HEAD)}
+startrev=${2:-$(git describe --tags --abbrev=0)}
+ORG=kubernetes-sigs REPO=kubespray release-notes --branch $endrev --start-rev $startrev --end-rev $endrev  --dependencies=false --required-author="" --output /dev/stdout | cat
+# `cat` invocation is to workaround a Linux oddity https://unix.stackexchange.com/a/716439
+# TL;DR: opening /dev/stdout and writing to it does not affect the script
+# stdout, in particular it does not change the current "cursor", meaning next
+# writes would overwrite what we just wrote
+
+if [ $? -eq 127 ]
+then
+    echo >&2 "Please install release-notes (see https://github.com/kubernetes/release/blob/master/cmd/release-notes/README.md)"
+    exit 127
+fi
+
+echo "
+
+### Components
+"
+$(dirname $0)/render_version_diff.sh $startrev ${UPSTREAM_REMOTE:-upstream}/$endrev

--- a/scripts/generate_versions.yml
+++ b/scripts/generate_versions.yml
@@ -1,0 +1,26 @@
+#!/usr/bin/env ansible-playbook
+---
+- name: Render versions of components
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  roles:
+  - kubespray_defaults
+  tasks:
+  - name: Include versions not in kubespray_defaults
+    include_vars: "{{ item }}"
+    loop:
+    - ../roles/container-engine/docker/defaults/main.yml
+    - ../roles/kubernetes/node/defaults/main.yml
+    - ../roles/kubernetes-apps/argocd/defaults/main.yml
+  - name: Get previous versions
+    vars:
+      kubernetes_version: "{{ kube_version }}"
+      versions_vars: "{{ query('varnames', '^(?!(calico_[^v]+(?# Exclude calico sub components but keep version
+                                              )|ansible|scheduler_plugins|.*config_api.*|kube_.*)).+_version$') }}"
+      _versions: "{{ query('vars', *versions_vars) }}"
+      versions: "{{ versions_vars | map('regex_replace', '_version', '')  | zip(_versions) }}"
+    copy:
+      content: "{{ versions | to_json }}"
+      dest: "{{ lookup('env', 'VERSION_FILE_PATH') }}"
+      mode: "0644"

--- a/scripts/render_version_diff.sh
+++ b/scripts/render_version_diff.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -e
+{
+    git worktree add /tmp/kubespray_old $1
+    git worktree add /tmp/kubespray_new $2
+    trap 'git worktree remove /tmp/kubespray_old; git worktree remove /tmp/kubespray_new; trap - EXIT; exit' EXIT TERM HUP INT
+    ANSIBLE_ROLES_PATH=/tmp/kubespray_new/roles VERSION_FILE_PATH=/tmp/new_versions.json scripts/generate_versions.yml
+    ANSIBLE_ROLES_PATH=/tmp/kubespray_old/roles VERSION_FILE_PATH=/tmp/old_versions.json scripts/generate_versions.yml
+} 1>&2
+jq -r --slurpfile old_versions /tmp/old_versions.json < /tmp/new_versions.json '(. - $old_versions[0] | sort)[] | "- **\(.[0])**: \(.[1])"'


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@tico88612 This should help with the releases note.
Need to add a parents script calling the releas-notes go tool and concat the output of this.

/label ci-short

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```


Example of output for current master :

```markdown
## Urgent Upgrade Notes 

### (No, really, you MUST read this before you upgrade)

- Action required
  `containerd_discard_unpacked_layers` is now applied only for containerd < 2.1 to avoid warnings with the Transfer Service used in newer versions. (#12821, @guoard)
 - Cilium `k8sServiceHost` and `k8sServicePort` are now derived from `kube_apiserver_global_endpoint` instead of being auto-detected, so users must ensure this endpoint is correctly set and reachable from all nodes. (#12624, @r3m8)
 
## Changes by Kind

### API Change

- Removed deprecated `runtime_engine` and `runtime_root` keys from containerd configuration. (#12820, @guoard)

### Feature

- Crio: add option pull_progress_timeout (#12555, @pedro-peter)
- RockyLinux 10 support (experimental) (#12355, @tico88612)
- Support kubernetes v1.34.1 (#12549, @i-yasuda)
- The default Openstack security groups now allow ICMPv6 for general IPv6 functionality. (#12805, @rptaylor)
- Update kube-vip to v1.0.3 (#12815, @LawiK974)
- Upgrade Gateway API to 1.4.0 (#12714, @tico88612)
- Upgrade containerd/nerdctl default version to 2.2.1 (#12825, @guoard)
- `contrib/collection.sh` will create and install the source as collection. (#12660, @bbaassssiiee)

### Documentation

- Fix(cilium): prevent installation failure with unprivileged agent (#12628, @r3m8)
- The default namespace for MetalLB resources is now `metallb-system`. (#12860, @kittywaresz)

### Bug or Regression

- Action-required
  Adding a control plane node in first place is now explicitly unsupported, the new control plane should be placed at the end of your `kube_control_plane` group (#12636, @clwluvw)
- Deployments using Calico in vxlan mode without eBPF but with localhost load balancers will now work. (#12598, @rickerc)
- Fix Calico apiserver RBAC permissions for Kubernetes 1.33+ (#12654, @rickerc)
- Fix Cilium loadBalancer.mode rendering in Kubespray values template. (#12701, @intojhanurag)
- Fix automatic certs renew with systemd timer (#12876, @VannTen)
- Fix kubeadm init retry after first failure on cluster creation (#12785, @VannTen)
- Fix(calico): Add missed rbac verb watch for hostendpoints (#12641, @jmeza-xyz)
- Fixed an issue in the config.json.j2 template where the CRI-O registry authentication configuration could render invalid JSON when multiple `crio_registry_auth` entries were defined, resulting in duplicate top-level `auths` keys in the generated config. (#12845, @accuROAMC)
- Removing external etcd member (not stacked with control plane) should now work without erroring out because the node is not in the kubernetes cluster (#12682, @VannTen)
- Update CSI components image version (#12627, @xin053)
- [feat] Setting timezone under SELinux. (#12436, @bbaassssiiee)
- `apiserver_loadbalancer_domain_name` default to `loadbalancer_apiserver.address` if defined (#12872, @VannTen)

### Other (Cleanup or Flake)

- Old versions of several components are removed (#12735, @VannTen)
- Remove left-over 'master' tags (#12795, @VannTen)
- Use cilium native CNI chaining for portmap plugin instead of manually writing /etc/cni/net.d/000-cilium-portmap.conflist (#12814, @ThisIsQasim)

### Uncategorized

- Fix RBAC for calico using the etcd datastore (#12828, @LawiK974)

### Components

- **calico**: 3.30.5
- **cilium**: 1.18.5
- **cilium_cli**: 0.18.9
- **containerd**: 2.2.1
- **coredns**: 1.12.1
- **cri_dockerd**: 0.3.22
- **crictl**: 1.34.0
- **crio**: 1.34.4
- **etcd**: 3.5.26
- **gateway_api**: 1.4.1
- **gvisor**: 20260112.0
- **kubernetes**: 1.34.3
- **nerdctl**: 2.2.1
- **pod_infra**: 3.10.1
- **runc**: 1.3.4
- **youki**: 0.5.7
```
