### PR TITLE
Fix bad permissions for calico certificates

### DIFF
--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -5,8 +5,7 @@
     group: "{{ etcd_cert_group }}"
     state: directory
     owner: "{{ etcd_owner }}"
-    mode: "{{ etcd_cert_dir_mode }}"
-    recurse: true
+    mode: "0700"
 
 - name: "Gen_certs | create etcd script dir (on {{ groups['etcd'][0] }})"
   file:
@@ -144,15 +143,6 @@
     - kube_network_plugin != "calico" or calico_datastore == "etcd"
     - ('k8s_cluster' in group_names) and
         sync_certs | default(false) and inventory_hostname not in groups['etcd']
-
-- name: Gen_certs | check certificate permissions
-  file:
-    path: "{{ etcd_cert_dir }}"
-    group: "{{ etcd_cert_group }}"
-    state: directory
-    owner: "{{ etcd_owner }}"
-    mode: "{{ etcd_cert_dir_mode }}"
-    recurse: true
 
 # This is a hack around the fact kubeadm expect the same certs path on all kube_control_plane
 # TODO: fix certs generation to have the same file everywhere

--- a/roles/etcd_defaults/defaults/main.yml
+++ b/roles/etcd_defaults/defaults/main.yml
@@ -18,7 +18,6 @@ etcd_backup_retention_count: -1
 force_etcd_cert_refresh: true
 etcd_config_dir: /etc/ssl/etcd
 etcd_cert_dir: "{{ etcd_config_dir }}/ssl"
-etcd_cert_dir_mode: "0700"
 etcd_cert_group: root
 # Note: This does not set up DNS entries. It simply adds the following DNS
 # entries to the certificate


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix bad permissions on calico certs.
Add CI to test the upgrade path.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The bug 

**Does this PR introduce a user-facing change?**:
```release-note
Fix broken upgrade path/control plane node rotation for cluster using calico in etcd datastore mode with separate etcd.
`etcd_cert_dir_mode` is deleted (always use `0700`)
```
