### PR TITLE
fix(Terraform - OpenStack): Gluster image_id and update openstack_blockstorage_volume_v3

### DIFF
--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -1006,7 +1006,7 @@ resource "openstack_compute_instance_v2" "glusterfs_node_no_floating_ip" {
   name              = "${var.cluster_name}-gfs-node-nf-${count.index + 1}"
   count             = var.number_of_gfs_nodes_no_floating_ip
   availability_zone = element(var.az_list, count.index)
-  image_name        = var.gfs_root_volume_size_in_gb == 0 ? local.image_to_use_gfs : null
+  image_id          = var.gfs_root_volume_size_in_gb == 0 ? local.image_to_use_gfs : null
   flavor_id         = var.flavor_gfs_node
   key_pair          = openstack_compute_keypair_v2.k8s.name
 
@@ -1078,7 +1078,7 @@ resource "openstack_networking_floatingip_associate_v2" "k8s_nodes" {
   port_id               = openstack_networking_port_v2.k8s_nodes_port[each.key].id
 }
 
-resource "openstack_blockstorage_volume_v2" "glusterfs_volume" {
+resource "openstack_blockstorage_volume_v3" "glusterfs_volume" {
   name        = "${var.cluster_name}-glusterfs_volume-${count.index + 1}"
   count       = var.gfs_root_volume_size_in_gb == 0 ? var.number_of_gfs_nodes_no_floating_ip : 0
   description = "Non-ephemeral volume for GlusterFS"
@@ -1088,5 +1088,5 @@ resource "openstack_blockstorage_volume_v2" "glusterfs_volume" {
 resource "openstack_compute_volume_attach_v2" "glusterfs_volume" {
   count       = var.gfs_root_volume_size_in_gb == 0 ? var.number_of_gfs_nodes_no_floating_ip : 0
   instance_id = element(openstack_compute_instance_v2.glusterfs_node_no_floating_ip.*.id, count.index)
-  volume_id   = element(openstack_blockstorage_volume_v2.glusterfs_volume.*.id, count.index)
+  volume_id   = element(openstack_blockstorage_volume_v3.glusterfs_volume.*.id, count.index)
 }


### PR DESCRIPTION
This fixes the Terraform Gluster Compute image_id bug and updates the openstack_blockstorage_volume_v2 to openstack_blockstorage_volume_v3.

Resolves:
[Bug] OpenStack Compute variable handling of image_id and image_name for Gluster nodes is broken

https://github.com/kubernetes-sigs/kubespray/issues/12902

Update openstack_blockstorage_volume_v2 to openstack_blockstorage_volume_v3

https://github.com/kubernetes-sigs/kubespray/issues/12901

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12901
Fixes #12902

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix terraform openstack compute `image_id` and update `openstack_blockstorage_volume_v3`
```
