### PR TITLE
seperates openEuler 

### DIFF
--- a/roles/system_packages/tasks/main.yml
+++ b/roles/system_packages/tasks/main.yml
@@ -44,7 +44,31 @@
   until: pkgs_task_result is succeeded
   retries: "{{ pkg_install_retries }}"
   delay: "{{ retry_stagger | random + 3 }}"
-  when: not (ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"] or is_fedora_coreos)
+  when:
+    - ansible_distribution != "openEuler"
+    - not (ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"] or is_fedora_coreos)
+  loop:
+    - { packages: "{{ pkgs_to_remove }}", state: "absent", action_label: "remove" }
+    - { packages: "{{ pkgs }}", state: "present", action_label: "install" }
+  loop_control:
+    label: "{{ item.action_label }}"
+  tags:
+    - bootstrap_os
+
+- name: Manage packages (openEuler)
+  dnf:
+    name: "{{ item.packages | dict2items | selectattr('value', 'ansible.builtin.all') | map(attribute='key') }}"
+    state: "{{ item.state }}"
+    update_cache: true
+    lock_timeout: 60
+    disable_gpg_check: true
+  register: pkgs_task_result
+  until: pkgs_task_result is succeeded
+  retries: "{{ pkg_install_retries }}"
+  delay: "{{ retry_stagger | random + 3 }}"
+  when:
+    - ansible_distribution == "openEuler"
+    - not is_fedora_coreos
   loop:
     - { packages: "{{ pkgs_to_remove }}", state: "absent", action_label: "remove" }
     - { packages: "{{ pkgs }}", state: "present", action_label: "install" }


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
openEuler CI jobs for Kubespray are currently timing out during the `system_packages` role without any task failures.  
The job exceeds the GitLab CI timeout (1h) and is terminated while Ansible is still running.

The last visible task in the failing jobs is:
`system_packages : Remove legacy docker repo file`, which completes successfully.  
The playbook appears to hang afterward during package management.

On openEuler, the generic `package` module invokes `dnf` without any bounded timeout.
In CI environments, `dnf` can block indefinitely (e.g. repo metadata refresh, locks, or GPG prompts),
leading to silent hangs and job timeouts.

This PR switches openEuler to use the `dnf` module directly with a bounded `lock_timeout`,
while keeping existing behavior unchanged for all other distributions.

**Which issue(s) this PR fixes**:
Fixes #12877 

Special notes for your reviewer:
- The change is scoped to openEuler only
- No behavior changes for other OS
- Retry logic and package lists remain unchanged
- This mirrors existing distro-specific handling already present in the role (e.g. SUSE/zypper)


**Does this PR introduce a user-facing change?**:
NONE

release-note
NONE
