### PR TITLE
ci: automate building OS images for kubevirt CI

### DIFF
--- a/.github/workflows/build-ci-images.yml
+++ b/.github/workflows/build-ci-images.yml
@@ -1,0 +1,32 @@
+name: Build CI OS Images
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - test-infra/image-builder/**
+  schedule:
+    - cron: "0 3 * * 0"
+
+jobs:
+  build-images:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-utils
+          sudo snap install yq
+
+      - name: Login to Quay
+        run: |
+          echo "${{ secrets.QUAY_PASSWORD }}" | \
+          docker login quay.io -u "${{ secrets.QUAY_USER }}" --password-stdin
+
+      - name: Build and push images
+        run: |
+          bash test-infra/image-builder/scripts/build-images.sh
+

--- a/test-infra/image-builder/scripts/build-images.sh
+++ b/test-infra/image-builder/scripts/build-images.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGES_YAML="test-infra/image-builder/roles/kubevirt-images/defaults/main.yml"
+WORKDIR="${WORKDIR:-/tmp/kubevirt-images}"
+
+mkdir -p "$WORKDIR"
+
+yq -r '.images | keys[]' "$IMAGES_YAML" | while read -r image; do
+  echo "==> Processing $image"
+
+  filename=$(yq -r ".images.\"$image\".filename" "$IMAGES_YAML")
+  url=$(yq -r ".images.\"$image\".url" "$IMAGES_YAML")
+  checksum=$(yq -r ".images.\"$image\".checksum" "$IMAGES_YAML")
+  converted=$(yq -r ".images.\"$image\".converted" "$IMAGES_YAML")
+  tag=$(yq -r ".images.\"$image\".tag" "$IMAGES_YAML")
+
+  image_path="$WORKDIR/$filename"
+
+  curl -L "$url" -o "$image_path"
+
+  if [[ "$checksum" == sha256:* ]]; then
+    echo "${checksum#sha256:}  $image_path" | sha256sum -c -
+  else
+    echo "${checksum#sha512:}  $image_path" | sha512sum -c -
+  fi
+
+  if [[ "$converted" == "true" ]]; then
+    qemu-img convert -O qcow2 "$image_path" "$image_path.converted"
+    image_path="$image_path.converted"
+  fi
+
+  docker build \
+    --build-arg IMAGE="$image_path" \
+    -t quay.io/kubespray/$image:$tag \
+    test-infra/image-builder/docker
+
+  docker push quay.io/kubespray/$image:$tag
+done
+


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR introduces CI automation to build and publish OS images used by
kubevirt-based Kubespray CI. The existing image definitions under
`test-infra/image-builder/roles/kubevirt-images/defaults/main.yml`
are treated as the single source of truth and are now consumed
automatically by a build script and GitHub Actions workflow.

This removes the need for manual image builds and ensures CI-tested
distributions are kept up to date in a reproducible manner.

**Which issue(s) this PR fixes**:

Fixes #12383

**Special notes for your reviewer**:

- No changes were made to existing image definitions.
- The automation is fully driven by the existing defaults YAML.
- CI runs on merge to `main` and on a scheduled basis.
- Secrets required for pushing images are documented.

**Does this PR introduce a user-facing change?**:

NONE
