### PR TITLE
Fix missing dependency for ArgoCD master password hashing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 ansible==11.13.0
+# Prevented passlib version conflicts
+bcrypt<5
 # Needed for community.crypto module
 cryptography==49.0.0
 # Needed for jinja2 json_query templating

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ cryptography==49.0.0
 jmespath==1.1.0
 # Needed for ansible.utils.ipaddr
 netaddr==1.3.0
+# Needed for encrypt hash
+passlib==1.7.4


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

- Add missing pssslib dependency
- Add constrained bcrypt version
  since bcrypt 5.x introduces compatibility [issues](https://github.com/ansible/ansible/issues/85919
), the version has been constrained to below 5.
https://github.com/ansible/ansible/issues/85919


When deploying to k8s using ArgoCD enabled and password, the deployment fails due to missing Passlib dependency.

```sh
fatal: [node-1]: FAILED! => {"msg": "Unable to encrypt nor hash, passlib must be installed. No module named 'passlib'. Unable to encrypt nor hash, passlib must be installed. No module named 'passlib'"}
```

**Special notes for your reviewer**:
Part of code
https://github.com/kubernetes-sigs/kubespray/blob/37f7a86014e9c7cfb547487f797bb51438c1e512/roles/kubernetes-apps/argocd/tasks/main.yml#L92


It used to exist but no longer exists

https://github.com/kubernetes-sigs/kubespray/pull/10700/changes#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L39

**how to reproduce**

Env
kubespray version: 2.29.1
OS: Rocky 10.0
python version: 3.12.9
pip version: 23.3.2
```sh
python3 -m venv venv
source venv/bin/activate
pip install -r requirements.txt

# 
sed -i 's|argocd_enabled: false|argocd_enabled: true|g' inventory/mycluster/group_vars/k8s_cluster/addons.yml
sed -i 's/# argocd_namespace: argocd/argocd_namespace: argocd/' inventory/mycluster/group_vars/k8s_cluster/addons.yml
sed -i 's/# argocd_admin_password: "password"/argocd_admin_password: "password"/' inventory/mycluster/group_vars/k8s_cluster/addons.yml

ansible-playbook -i inventory/mycluster/inventory.ini -v cluster.yml 
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix ArgoCD installation failing on master password hashing.
```
