### PR TITLE
Refactor: Move inline defaults to defaults/main.yml for node-taint an…

### DIFF
--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -55,7 +55,7 @@
   register: keyserver_task_result
   until: keyserver_task_result is succeeded
   retries: 4
-  delay: "{{ retry_stagger | d(3) }}"
+  delay: "{{ retry_stagger }}"
   with_items: "{{ docker_repo_key_info.repo_keys }}"
   environment: "{{ proxy_env }}"
   when: ansible_pkg_mgr == 'apt'
@@ -128,7 +128,7 @@
   register: docker_task_result
   until: docker_task_result is succeeded
   retries: 4
-  delay: "{{ retry_stagger | d(3) }}"
+  delay: "{{ retry_stagger }}"
   notify: Restart docker
   when:
     - not ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]

--- a/roles/kubernetes/node-taint/defaults/main.yml
+++ b/roles/kubernetes/node-taint/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+node_taints: []

--- a/roles/kubernetes/node-taint/tasks/main.yml
+++ b/roles/kubernetes/node-taint/tasks/main.yml
@@ -14,13 +14,13 @@
 
 - name: Populate inventory node taint
   set_fact:
-    inventory_node_taints: "{{ inventory_node_taints + ['%s' | format(item)] }}"
-  loop: "{{ node_taints | d([]) }}"
+    inventory_node_taints: "{{ inventory_node_taints + node_taints }}"
   when:
     - node_taints is defined
     - node_taints is not string
     - node_taints is not mapping
     - node_taints is iterable
+
 - debug:  # noqa name[missing]
     var: role_node_taints
 - debug:  # noqa name[missing]


### PR DESCRIPTION
**What type of PR is this?**
/kind refactor

**What this PR does / why we need it**:
This PR refactors inline default filters for node taints and moves default definitions to role defaults to improve readability, maintainability, and consistency across roles.

Previously, several tasks relied on inline default filters such as `{{ node_taints | d([]) }}`, which led to repeated default values, reduced readability due to inline logic, and made it harder to track the source of truth for variables.

This PR centralizes default values by defining `node_taints` in `defaults/main.yml` and removes inline `| d()` usage in tasks.

**Which issue(s) this PR fixes**:
Fixes #11822

**Special notes for your reviewer**:
This PR aligns with Kubespray’s refactor direction of moving defaults into `defaults/main.yml`.  
Behavior is preserved when users define `node_taints` via inventory or variables.  
When undefined, `node_taints` safely defaults to an empty list through role defaults.  
No functional logic change is intended beyond default centralization.  
The `retry_stagger` behavior alignment is intentional and now follows centralized defaults instead of inline fallbacks.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
