### PR TITLE
Add services RBAC for calico-kube-controllers in KDD mode

### DIFF
--- a/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-cr.yml.j2
+++ b/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-cr.yml.j2
@@ -114,4 +114,14 @@ rules:
       - update
       # watch for changes
       - watch
+  # Services are monitored for service LoadBalancer IP allocation
+  - apiGroups: [""]
+    resources:
+      - services
+      - services/status
+    verbs:
+      - get
+      - list
+      - update
+      - watch
 {% endif %}


### PR DESCRIPTION
Commit 5fb85dc added service permissions for etcd datastore mode, but the same permissions are needed for KDD (Kubernetes datastore) mode.

Fixes: #12927

```release-note
Add service RBAC for Calico Kubernetes datastore so Calico can monitor LoadBalancer IP allocation
```