### PR TITLE
Remove deprecated apiVersion from VolumeSnapshotClass.

### DIFF
--- a/roles/kubernetes-apps/snapshots/cinder-csi/templates/cinder-csi-snapshot-class.yml.j2
+++ b/roles/kubernetes-apps/snapshots/cinder-csi/templates/cinder-csi-snapshot-class.yml.j2
@@ -1,7 +1,7 @@
 {% for class in snapshot_classes %}
 ---
 kind: VolumeSnapshotClass
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 metadata:
   name: "{{ class.name }}"
   annotations:


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug


**What this PR does / why we need it**:
Use the current apiVersion for VolumeSnapshotClass

**Which issue(s) this PR fixes**:
Fixes #12867

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE


