### PR TITLE
kubeadm_images: remove obsolete backwards compat / use registry.k8s.io

### DIFF
--- a/roles/download/templates/kubeadm-images.yaml.j2
+++ b/roles/download/templates/kubeadm-images.yaml.j2
@@ -10,7 +10,7 @@ kubernetesVersion: v{{ kube_version }}
 etcd:
 {% if etcd_deployment_type == "kubeadm" %}
   local:
-    imageRepository: "{{ etcd_image_repo | regex_replace("/etcd$","") }}"
+    imageRepository: "{{ etcd_image_repo }}"
     imageTag: "{{ etcd_image_tag }}"
 {% else %}
   external:
@@ -20,5 +20,5 @@ etcd:
 {% endfor %}
 {% endif %}
 dns:
-  imageRepository: {{ coredns_image_repo | regex_replace('/coredns(?!/coredns).*$', '') }}
+  imageRepository: {{ coredns_image_repo }}
   imageTag: {{ coredns_image_tag }}

--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -214,7 +214,7 @@ skopeo_binary_checksum: "{{ skopeo_binary_checksums[image_arch][skopeo_version] 
 # Also provide the address of your own private registry.
 # And use --insecure-registry options for docker
 kube_proxy_image_repo: "{{ kube_image_repo }}/kube-proxy"
-etcd_image_repo: "{{ quay_image_repo }}/coreos/etcd"
+etcd_image_repo: "{{ kube_image_repo }}/etcd"
 etcd_image_tag: "v{{ etcd_version }}"
 flannel_image_repo: "{{ docker_image_repo }}/flannel/flannel"
 flannel_image_tag: "v{{ flannel_version }}"
@@ -275,8 +275,8 @@ coredns_supported_versions:
   '1.35': 1.12.4
   '1.34': 1.12.1
 coredns_version: "{{ coredns_supported_versions[kube_major_version] }}"
-coredns_image_repo: "{{ kube_image_repo }}{{ '/coredns' if coredns_version is version('1.7.1', '>=') else '' }}/coredns"
-coredns_image_tag: "{{ 'v' if coredns_version is version('1.7.1', '>=') else '' }}{{ coredns_version }}"
+coredns_image_repo: "{{ kube_image_repo }}/coredns/coredns"
+coredns_image_tag: "v{{ coredns_version }}"
 
 nodelocaldns_version: "1.25.0"
 nodelocaldns_image_repo: "{{ kube_image_repo }}/dns/k8s-dns-node-cache"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
- coredns: a0ee56909 (change coredns image name to `coredns/coredns` and
  prefix `v` to tag (#7570), 2021-04-30) handled the naming change of
  the coredns image in a backwards compatible way. This is no longer
  necessary for a while, so simplify things and drop back-compat
- etcd: the etcd image is now available in registry.k8s.io so use that
  instead of quay.io/coreos/

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
When using kubeadm managed etcd, use the registry.k8s.io/etcd image (instead of quay.io/coreos/etcd)
```
