### PR TITLE
Auto-bump checksums on last 3 branches

### DIFF
--- a/.github/workflows/upgrade-patch-versions-schedule.yml
+++ b/.github/workflows/upgrade-patch-versions-schedule.yml
@@ -20,7 +20,7 @@ jobs:
           query get_release_branches($owner:String!, $name:String!) {
             repository(owner:$owner, name:$name) {
               refs(refPrefix: "refs/heads/",
-                   first: 2, # TODO increment once we have release branch with the new checksums format
+                   first: 3,
                    query: "release-",
                    orderBy: {
                      field: ALPHABETICAL,


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
We now have all supported release branches (last 3) using the new
checksums format, which means they all work with the auto-bump tooling.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
