### PR TITLE
updated prometheus-operator crd checksum autobump

### DIFF
--- a/scripts/component_hash_update/src/component_hash_update/components.py
+++ b/scripts/component_hash_update/src/component_hash_update/components.py
@@ -118,7 +118,7 @@ infos = {
     },
     "prometheus_operator_crds": {
         "url": "https://github.com/prometheus-operator/prometheus-operator/releases/download/v{version}/stripped-down-crds.yaml",
-        "graphql_id": "MDEwOlJlcG9zaXRvcnk2ODk2NDI2Mw==",
+        "graphql_id": "R_kgDOBBxPpw",
         "binary": True,
     },
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR adds `prometheus_operator_crds` to the `component_hash_update` script, enabling automatic checksum updates for Prometheus Operator CRDs when running the update script.

This was missed when the CRDs were originally introduced and is required to support patch update PR workflows.

**Which issue(s) this PR fixes**:
Fixes #12938

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
