### PR TITLE
fix: typo in validate_inventory task name (missing backtick)

### DIFF
--- a/roles/validate_inventory/tasks/main.yml
+++ b/roles/validate_inventory/tasks/main.yml
@@ -20,7 +20,7 @@
   when:
     - not ignore_assert_errors
 
-- name: Warn if `kube_network_plugin` is `none
+- name: Warn if `kube_network_plugin` is `none`
   debug:
     msg: |
       "WARNING! => `kube_network_plugin` is set to `none`. The network configuration will be skipped.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR fixes a simple typo in the validate_inventory role task name. The closing backtick was missing in the task description "Warn if \`kube_network_plugin\` is \`none", which should be "Warn if \`kube_network_plugin\` is \`none\`".

**Which issue(s) this PR fixes**:

N/A - This is a minor documentation/typo fix that doesn't require a separate issue. The fix is straightforward and involves only a single character addition.

**Special notes for your reviewer**:

This is a trivial typo fix with no functional changes. Only the task name string is modified to properly close the markdown backtick formatting.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

Made with [Cursor](https://cursor.com)