### PR TITLE
Add removed-vars validation to validate_inventory

### DIFF
--- a/roles/validate_inventory/tasks/main.yml
+++ b/roles/validate_inventory/tasks/main.yml
@@ -6,6 +6,15 @@
 # -> nothing depending on facts or similar cluster state
 # Checks depending on current state (of the nodes or the cluster)
 # should be in roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
+- name: Fail if removed variables are used
+  vars:
+    removed_vars: []
+    removed_vars_found: "{{ query('varnames', '^' + (removed_vars | join('|')) + '$') }}"
+  assert:
+    that: removed_vars_found | length == 0
+    fail_msg: "Removed variables present: {{ removed_vars_found | join(', ') }}"
+  run_once: true
+
 - name: Stop if kube_control_plane group is empty
   assert:
     that: groups.get( 'kube_control_plane' )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
This PR implements a validation check to detect removed variables and display an error at playbook start, as described in issue #11039.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11039 

**Special notes for your reviewer**:

As a test case, I added `etcd_deployment_type` as a deprecated variable (from issue #11649 discussion about eventually replacing `docker` with `kubeadm`). This validates that the framework works correctly for tracking variable deprecation across releases.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
ACTION REQUIRED: Adds automated validation role to detect removed variables at playbook start. Playbooks will abort on `removed vars`. Users must migrate away from the listed removed variables to avoid playbook failures.
```
