### PR TITLE
docs: updated Openstack Terraform

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -94,7 +94,7 @@ binaries available on hyperkube v1.4.3_coreos.0 or higher.
 
 ## Requirements
 
-- [Install OpenTofu](https://opentofu.org/docs/intro/install/) 1.9clear.0 or later
+- [Install OpenTofu](https://opentofu.org/docs/intro/install/) 1.9.0 or later
 - [Install Ansible](https://docs.ansible.com/ansible/latest/intro_installation.html)
 - you already have a suitable OS image in Glance
 - you already have a floating IP pool created


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This PR updates and cleans up the documentation for deploying to OpenStack environments. This is mentioned in #12888.

**Which issue(s) this PR fixes**:
Fixes #12888

The changes have been made in the following file:
https://github.com/kubernetes-sigs/kubespray/blob/master/contrib/terraform/openstack/README.md

In this file, changes have been made at 3 places.

- **Included `OpenStack Support Documentation`**
  1. Helps users find Kubernetes cloud provider configuration steps

- **Fixed Terraform version requirement**
  1. Updated from "0.14 or later" to "1.3.0 or later"
  2. `1.3.0` has been taken according to [versions.tf](https://github.com/kubernetes-sigs/kubespray/blob/master/contrib/terraform/openstack/versions.tf)

- **Updated Terraform provider documentation link**
  1. Changed from deprecated `terraform.io/docs/providers/openstack/` to current `registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs`
  2. [OpenStack Provider Link](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs)
  3. Ensures users access maintained documentation

**Special notes for your reviewer**:
All the pre-commit checks have been passed.

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
