### PR TITLE
Remove software-properties-common from pipeline.Dockerfile

### DIFF
--- a/pipeline.Dockerfile
+++ b/pipeline.Dockerfile
@@ -27,14 +27,14 @@ RUN apt update -q \
          ca-certificates \
          curl \
          gnupg2 \
-         software-properties-common \
          unzip \
          libvirt-clients \
          qemu-utils \
          qemu-kvm \
          dnsmasq \
-    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
-    && add-apt-repository "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+        && curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
+        && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+            $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | tee /etc/apt/sources.list.d/docker.list \
     && apt update -q \
     && apt install --no-install-recommends -yq docker-ce \
     && apt autoremove -yqq --purge && apt clean && rm -rf /var/lib/apt/lists/* /var/log/*

--- a/scripts/pipeline.Dockerfile.j2
+++ b/scripts/pipeline.Dockerfile.j2
@@ -27,14 +27,14 @@ RUN apt update -q \
          ca-certificates \
          curl \
          gnupg2 \
-         software-properties-common \
          unzip \
          libvirt-clients \
          qemu-utils \
          qemu-kvm \
          dnsmasq \
-    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
-    && add-apt-repository "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+        && curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
+        && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+            $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | tee /etc/apt/sources.list.d/docker.list \
     && apt update -q \
     && apt install --no-install-recommends -yq docker-ce \
     && apt autoremove -yqq --purge && apt clean && rm -rf /var/lib/apt/lists/* /var/log/*


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind cleanup

**What this PR does / why we need it**:
`python3-cryptography` was being installed as a transitive dependency. The root cause was `software-properties-common`, which was only used to provide `add-apt-repository`.

Instead of working around the issue with `pip install --ignore-installed`, this change removes `software-properties-common` entirely and switches to using apt keyring files for repository configuration, replacing the deprecated `apt-key` approach.

Removing `software-properties-common` prevents its dependency chain from being installed and eliminates the build warning:

```
Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead
```

This results in fewer packages in the image and a cleaner apt setup.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kubespray/pull/12935#issuecomment-3834880883

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
