### PR TITLE
coredns: allow to customize service name

### DIFF
--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -11,6 +11,7 @@ dns_nodes_per_replica: 16
 dns_cores_per_replica: 256
 dns_prevent_single_point_failure: "{{ 'true' if dns_min_replicas | int > 1 else 'false' }}"
 enable_coredns_reverse_dns_lookups: true
+coredns_svc_name: "coredns"
 coredns_ordinal_suffix: ""
 # dns_extra_tolerations: [{effect: NoSchedule, operator: "Exists"}]
 coredns_affinity:

--- a/roles/kubernetes-apps/ansible/templates/coredns-svc.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-svc.yml.j2
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: coredns{{ coredns_ordinal_suffix }}
+  name: {{ coredns_svc_name }}{{ coredns_ordinal_suffix }}
   namespace: kube-system
   labels:
     k8s-app: kube-dns{{ coredns_ordinal_suffix }}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Some projects on Kubernetes expect the DNS service to be "kube-dns" instead of "coredns" (and it's not exactly clear why Kubespray used coredns instead of kube-dns when adding Coredns super, it's not what kubeadm does).
This allows to change the service name without breaking backwards compat.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
coredns service name can now be customized with `coredns_svc_name`
```
