### PR TITLE
Use kubeadm to generate admin kubeconfig

### DIFF
--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -26,11 +26,21 @@
     mode: "0700"
     state: directory
 
-- name: Copy admin kubeconfig to current/ansible become user home
+- name: Generate admin kubeconfig using kubeadm
+  command: >-
+    {{ bin_dir }}/kubeadm kubeconfig user
+    --client-name=kubernetes-admin
+    --org=system:masters
+    --config {{ kube_config_dir }}/kubeadm-config.yaml
+  register: kubeadm_admin_kubeconfig
+  changed_when: false
+  run_once: true
+  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+
+- name: Write admin kubeconfig to current/ansible become user home
   copy:
-    src: "{{ kube_config_dir }}/admin.conf"
+    content: "{{ kubeadm_admin_kubeconfig.stdout }}"
     dest: "{{ ansible_env.HOME | default('/root') }}/.kube/config"
-    remote_src: true
     mode: "0600"
     backup: true
 
@@ -51,36 +61,23 @@
     port: "{{ kube_apiserver_port }}"
     timeout: 180
 
-- name: Get admin kubeconfig from remote host
-  slurp:
-    src: "{{ kube_config_dir }}/admin.conf"
-  run_once: true
-  register: raw_admin_kubeconfig
-  when: kubeconfig_localhost
-
-- name: Convert kubeconfig to YAML
-  set_fact:
-    admin_kubeconfig: "{{ raw_admin_kubeconfig.content | b64decode | from_yaml }}"
-  when: kubeconfig_localhost
-
-- name: Override username in kubeconfig
-  set_fact:
-    final_admin_kubeconfig: "{{ admin_kubeconfig | combine(override_cluster_name, recursive=true) | combine(override_context, recursive=true) | combine(override_user, recursive=true) }}"
-  vars:
-    cluster_infos: "{{ admin_kubeconfig['clusters'][0]['cluster'] }}"
-    user_certs: "{{ admin_kubeconfig['users'][0]['user'] }}"
-    username: "kubernetes-admin-{{ cluster_name }}"
-    context: "kubernetes-admin-{{ cluster_name }}@{{ cluster_name }}"
-    override_cluster_name: "{{ {'clusters': [{'cluster': (cluster_infos | combine({'server': 'https://' + (external_apiserver_address | ansible.utils.ipwrap) + ':' + (external_apiserver_port | string)})), 'name': cluster_name}]} }}"
-    override_context: "{{ {'contexts': [{'context': {'user': username, 'cluster': cluster_name}, 'name': context}], 'current-context': context} }}"
-    override_user: "{{ {'users': [{'name': username, 'user': user_certs}]} }}"
-  when: kubeconfig_localhost
-
 - name: Write admin kubeconfig on ansible host
   copy:
-    content: "{{ final_admin_kubeconfig | to_nice_yaml(indent=2) }}"
+    content: "{{ kubeadm_admin_kubeconfig.stdout | from_yaml | combine(override, recursive=true) | to_nice_yaml(indent=2) }}"
     dest: "{{ artifacts_dir }}/admin.conf"
     mode: "0600"
+  vars:
+    admin_kubeconfig: "{{ kubeadm_admin_kubeconfig.stdout | from_yaml }}"
+    username: "kubernetes-admin-{{ cluster_name }}"
+    context: "kubernetes-admin-{{ cluster_name }}@{{ cluster_name }}"
+    override:
+      clusters:
+        - "{{ admin_kubeconfig['clusters'][0] | combine({'name': cluster_name, 'cluster': admin_kubeconfig['clusters'][0]['cluster'] | combine({'server': 'https://' + (external_apiserver_address | ansible.utils.ipwrap) + ':' + (external_apiserver_port | string)})}, recursive=true) }}"
+      contexts:
+        - "{{ admin_kubeconfig['contexts'][0] | combine({'name': context, 'context': admin_kubeconfig['contexts'][0]['context'] | combine({'user': username, 'cluster': cluster_name})}, recursive=true) }}"
+      current-context: "{{ context }}"
+      users:
+        - "{{ admin_kubeconfig['users'][0] | combine({'name': username}, recursive=true) }}"
   delegate_to: localhost
   connection: local
   become: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
Replaces the kubespray client kubeconfig generation with kubeadm’s kubeconfig user output, while keeping the same output locations. This reduces custom maintenance and aligns with upstream kubeadm behaviour.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12798


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
     None
```
