### PR TITLE
tests(ci): add ubuntu24 CRI-O calico upgrade and scale coverage

### DIFF
--- a/.gitlab-ci/kubevirt.yml
+++ b/.gitlab-ci/kubevirt.yml
@@ -50,6 +50,8 @@ pr:
           - ubuntu24-calico-etcd-datastore
           - ubuntu24-calico-all-in-one-hardening
           - ubuntu24-cilium-sep
+          - ubuntu24-crio-scale
+          - ubuntu24-crio-upgrade
           - ubuntu24-flannel-collection
           - ubuntu24-kube-router-sep
           - ubuntu24-kube-router-svc-proxy

--- a/docs/developers/ci.md
+++ b/docs/developers/ci.md
@@ -38,7 +38,7 @@ openeuler24 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 rockylinux10 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 rockylinux9 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 ubuntu22 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
-ubuntu24 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
+ubuntu24 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
 
 ## docker
 

--- a/tests/files/ubuntu24-crio-scale.yml
+++ b/tests/files/ubuntu24-crio-scale.yml
@@ -1,0 +1,8 @@
+---
+cloud_image: ubuntu-2404
+container_manager: crio
+
+cluster_layout:
+  - node_groups: ["kube_control_plane", "etcd"]
+  - node_groups: ["kube_node"]
+  - node_groups: ["kube_node", "for_scale"]

--- a/tests/files/ubuntu24-crio-upgrade
+++ b/tests/files/ubuntu24-crio-upgrade
@@ -1,0 +1,1 @@
+UPGRADE_TEST=graceful

--- a/tests/files/ubuntu24-crio-upgrade.yml
+++ b/tests/files/ubuntu24-crio-upgrade.yml
@@ -1,0 +1,16 @@
+---
+# Instance settings
+cloud_image: ubuntu-2404
+mode: all-in-one
+vm_memory: 1800
+
+# Kubespray settings
+container_manager: crio
+auto_renew_certificates: true
+
+# Currently ipvs not available on KVM: https://packages.ubuntu.com/search?suite=noble&arch=amd64&mode=exactfilename&searchon=contents&keywords=ip_vs_sh.ko
+kube_proxy_mode: iptables
+enable_nodelocaldns: false
+
+# Single node don't need the DNS autoscaler
+enable_dns_autoscaler: false


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
Adds CI coverage for CRI-O on Ubuntu 24.04 for the two missing paths discussed in #12650:
- graceful upgrade (`upgrade_cluster`)
- scale (`cluster --limit '!for_scale'` + `scale --limit 'for_scale'`)

Changes included:
- add `tests/files/ubuntu24-crio-upgrade.yml`
- add `tests/files/ubuntu24-crio-upgrade` (`UPGRADE_TEST=graceful`)
- add `tests/files/ubuntu24-crio-scale.yml` (Calico-based)
- wire testcases into `.gitlab-ci/kubevirt.yml`
- regenerate `docs/developers/ci.md`

**Which issue(s) this PR fixes**:
Related to #12650

**Special notes for your reviewer**:
- `ubuntu24-crio-scale` intentionally uses Calico (default plugin) to validate Ubuntu24 + CRI-O scale coverage.
- Local validation was done on 2 VMs:
  - node1: 192.168.67.142
  - node2: 192.168.67.143
- Ran:
  - `ansible-playbook -b playbooks/facts.yml`
  - `TESTCASE=ubuntu24-crio-upgrade ./tests/scripts/testcases_run.sh`
  - `TESTCASE=ubuntu24-crio-scale ./tests/scripts/testcases_run.sh`
- Scale path completed; one local-only failure was in `cluster-dump` due to missing `CI_PROJECT_DIR` (environment issue, not scale logic).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```