### PR TITLE
Use kubeadm:cluster-admins group

### DIFF
--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -30,7 +30,7 @@
   command: >-
     {{ bin_dir }}/kubeadm kubeconfig user
     --client-name=kubernetes-admin
-    --org=system:masters
+    --org=kubeadm:cluster-admins
     --config {{ kube_config_dir }}/kubeadm-config.yaml
   register: kubeadm_admin_kubeconfig
   changed_when: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind feature


**What this PR does / why we need it**:
Switch the kubeadm kubeconfig user group from system:masters to `kubeadm:cluster-admins`, aligning with kubeadm’s intended admin group and avoiding reserved `system:masters`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A (follow‑up to #12958 [review comment](https://github.com/kubernetes-sigs/kubespray/pull/12958#discussion_r2768003759))

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Use kubeadm:cluster-admins group for admin kubeconfig generation.
```
