### PR TITLE
feat: add SR-IOV Network Operator support

### DIFF
--- a/docs/CNI/sriov.md
+++ b/docs/CNI/sriov.md
@@ -1,0 +1,260 @@
+# SR-IOV Network Operator
+
+**Note:** SR-IOV support is not currently covered in kubespray CI and
+support for it is currently considered experimental.
+
+The [SR-IOV Network Operator](https://github.com/k8snetworkplumbingwg/sriov-network-operator) manages SR-IOV network devices and network attachments in Kubernetes. Kubespray deploys it via the upstream Helm chart.
+
+## Requirements
+
+SR-IOV requires Multus and physical NICs that support SR-IOV (Intel X710/E810, Mellanox ConnectX-4/5/6, etc.). IOMMU must be enabled in BIOS and kernel boot parameters (`intel_iommu=on` or `amd_iommu=on`).
+
+## Installation
+
+Enable both Multus and SR-IOV in your inventory:
+
+```yml
+kube_network_plugin_multus: true
+kube_network_plugin_sriov: true
+```
+
+To customize configuration, copy the sample file:
+
+```ShellSession
+cp inventory/sample/group_vars/k8s_cluster/k8s-net-sriov.yml \
+   inventory/mycluster/group_vars/k8s_cluster/
+```
+
+See `roles/network_plugin/sriov/defaults/main.yml` for all available variables.
+
+Deploy as usual:
+
+```ShellSession
+ansible-playbook -i inventory/mycluster/hosts.ini cluster.yml
+```
+
+Or deploy only SR-IOV:
+
+```ShellSession
+ansible-playbook -i inventory/mycluster/hosts.ini cluster.yml --tags sriov
+```
+
+### Verify the deployment
+
+```ShellSession
+kubectl get pods -n sriov-network-operator
+```
+
+The operator pod and config daemon should be Running. On nodes with SR-IOV hardware, the operator automatically discovers available devices:
+
+```ShellSession
+kubectl get sriovnetworknodestates -n sriov-network-operator
+kubectl get sriovnetworknodestate <node-name> -n sriov-network-operator -o yaml
+```
+
+## Configuration
+
+### Disable node draining
+
+For single-node or development clusters where draining is not possible:
+
+```yml
+sriov_operator_disable_drain: true
+```
+
+### Resource prefix
+
+The default resource prefix is `openshift.io` (upstream default). Pods request SR-IOV VFs using this prefix, e.g. `openshift.io/intel_sriov_netdevice: '1'`.
+
+```yml
+sriov_operator_resource_prefix: "openshift.io"
+```
+
+### Admission controller
+
+The operator includes an optional webhook for validating SR-IOV CRs. Disabled by default:
+
+```yml
+sriov_operator_enable_admission_controller: true
+```
+
+### Prometheus metrics
+
+```yml
+sriov_operator_enable_prometheus: true
+```
+
+### Extra Helm values
+
+For chart values not exposed as Kubespray variables:
+
+```yml
+sriov_operator_extra_values:
+  supportedExtraNICs: ["myNIC"]
+```
+
+## Usage
+
+After the operator is deployed, SR-IOV is configured through Kubernetes CRs. Label nodes that have SR-IOV NICs first:
+
+```ShellSession
+kubectl label node <node-name> feature.node.kubernetes.io/network-sriov.capable=true
+```
+
+### Create a SriovNetworkNodePolicy
+
+This tells the operator how to configure VFs on matching nodes:
+
+```yaml
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: policy-intel-nic
+  namespace: sriov-network-operator
+spec:
+  nodeSelector:
+    feature.node.kubernetes.io/network-sriov.capable: "true"
+  resourceName: intel_sriov_netdevice
+  priority: 99
+  numVfs: 8
+  mtu: 1500
+  nicSelector:
+    pfNames: ["ens1f0"]
+  deviceType: netdevice
+```
+
+Apply and watch progress:
+
+```ShellSession
+kubectl apply -f sriov-policy.yaml
+kubectl get sriovnetworknodestates -n sriov-network-operator -w
+```
+
+The config daemon will drain nodes before reconfiguring NICs (unless `sriov_operator_disable_drain: true`).
+
+### Create a SriovNetwork
+
+This automatically generates a Multus NetworkAttachmentDefinition:
+
+```yaml
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: sriov-network-1
+  namespace: sriov-network-operator
+spec:
+  resourceName: intel_sriov_netdevice
+  networkNamespace: default
+  ipam: |
+    {
+      "type": "host-local",
+      "subnet": "10.56.217.0/24",
+      "rangeStart": "10.56.217.171",
+      "rangeEnd": "10.56.217.181",
+      "routes": [{"dst": "0.0.0.0/0"}],
+      "gateway": "10.56.217.1"
+    }
+```
+
+### Use SR-IOV in pods
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  annotations:
+    k8s.v1.cni.cncf.io/networks: sriov-network-1
+spec:
+  containers:
+  - name: test-container
+    image: centos:7
+    command: ["/bin/sh", "-c", "sleep 99999"]
+    resources:
+      requests:
+        openshift.io/intel_sriov_netdevice: '1'
+      limits:
+        openshift.io/intel_sriov_netdevice: '1'
+```
+
+Verify the SR-IOV interface is attached:
+
+```ShellSession
+kubectl exec -it test-pod -- ip link show
+# eth0 (primary) + net1 (SR-IOV VF)
+```
+
+## DPDK workloads
+
+For DPDK applications, set `deviceType: vfio-pci` in the policy:
+
+```yaml
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: policy-dpdk
+  namespace: sriov-network-operator
+spec:
+  nodeSelector:
+    feature.node.kubernetes.io/network-sriov.capable: "true"
+  resourceName: intel_sriov_dpdk
+  numVfs: 4
+  nicSelector:
+    pfNames: ["ens1f1"]
+  deviceType: vfio-pci
+```
+
+DPDK pods need hugepages and extra capabilities:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dpdk-pod
+spec:
+  containers:
+  - name: dpdk-app
+    image: dpdk-app:latest
+    securityContext:
+      capabilities:
+        add: ["IPC_LOCK", "SYS_RESOURCE"]
+    volumeMounts:
+    - name: hugepages
+      mountPath: /dev/hugepages
+    resources:
+      requests:
+        openshift.io/intel_sriov_dpdk: '2'
+        memory: 2Gi
+        hugepages-1Gi: 2Gi
+      limits:
+        openshift.io/intel_sriov_dpdk: '2'
+        memory: 2Gi
+        hugepages-1Gi: 2Gi
+  volumes:
+  - name: hugepages
+    emptyDir:
+      medium: HugePages
+```
+
+## Mellanox/NVIDIA NICs
+
+For ConnectX NICs with RDMA:
+
+```yaml
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: policy-mellanox
+  namespace: sriov-network-operator
+spec:
+  nodeSelector:
+    feature.node.kubernetes.io/network-sriov.capable: "true"
+  resourceName: mlnx_sriov_netdevice
+  numVfs: 8
+  nicSelector:
+    vendor: "15b3"
+  deviceType: netdevice
+  isRdma: true
+```
+
+For more details, see the [SR-IOV Network Operator documentation](https://github.com/k8snetworkplumbingwg/sriov-network-operator).

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -31,6 +31,7 @@
   * [Kube-router](/docs/CNI/kube-router.md)
   * [Macvlan](/docs/CNI/macvlan.md)
   * [Multus](/docs/CNI/multus.md)
+  * [Sriov](/docs/CNI/sriov.md)
 * CRI
   * [Containerd](/docs/CRI/containerd.md)
   * [Cri-o](/docs/CRI/cri-o.md)

--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-sriov.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-sriov.yml
@@ -1,0 +1,20 @@
+---
+# see roles/network_plugin/sriov/defaults/main.yml
+# see docs/CNI/sriov.md for usage examples
+
+## Requires: kube_network_plugin_multus: true
+## Requires: SR-IOV capable NICs on worker nodes
+
+# kube_network_plugin_sriov: false
+# sriov_operator_version: "1.6.0"
+
+# sriov_operator_log_level: 2
+# sriov_operator_disable_drain: false
+# sriov_operator_configuration_mode: "daemon"
+# sriov_operator_resource_prefix: "openshift.io"
+# sriov_operator_enable_admission_controller: false
+
+# sriov_operator_enable_prometheus: false
+
+# Pass-through for extra chart values
+# sriov_operator_extra_values: {}

--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -124,6 +124,7 @@ kube_ovn_version: "1.12.21"
 kube_ovn_dpdk_version: "19.11-v{{ kube_ovn_version }}"
 kube_router_version: "2.1.1"
 multus_version: "4.2.2"
+sriov_operator_version: "1.6.0"
 helm_version: "{{ (helm_archive_checksums['amd64'] | dict2items)[0].key }}"
 nerdctl_version: "{{ (nerdctl_archive_checksums['amd64'] | dict2items)[0].key }}"
 skopeo_version: "{{ (skopeo_binary_checksums['amd64'] | dict2items)[0].key }}"
@@ -262,6 +263,28 @@ kube_router_image_repo: "{{ docker_image_repo }}/cloudnativelabs/kube-router"
 kube_router_image_tag: "v{{ kube_router_version }}"
 multus_image_repo: "{{ github_image_repo }}/k8snetworkplumbingwg/multus-cni"
 multus_image_tag: "v{{ multus_version }}"
+sriov_operator_image_repo: "{{ github_image_repo }}/k8snetworkplumbingwg/sriov-network-operator"
+sriov_operator_image_tag: "v{{ sriov_operator_version }}"
+sriov_config_daemon_image_repo: "{{ github_image_repo }}/k8snetworkplumbingwg/sriov-network-operator-config-daemon"
+sriov_config_daemon_image_tag: "v{{ sriov_operator_version }}"
+sriov_webhook_image_repo: "{{ github_image_repo }}/k8snetworkplumbingwg/sriov-network-operator-webhook"
+sriov_webhook_image_tag: "v{{ sriov_operator_version }}"
+sriov_cni_image_repo: "{{ github_image_repo }}/k8snetworkplumbingwg/sriov-cni"
+sriov_cni_image_tag: "v2.10.0"
+sriov_ib_cni_image_repo: "{{ github_image_repo }}/k8snetworkplumbingwg/ib-sriov-cni"
+sriov_ib_cni_image_tag: "v1.3.0"
+sriov_ovs_cni_image_repo: "{{ github_image_repo }}/k8snetworkplumbingwg/ovs-cni-plugin"
+sriov_ovs_cni_image_tag: "v0.39.0"
+sriov_rdma_cni_image_repo: "{{ github_image_repo }}/k8snetworkplumbingwg/rdma-cni"
+sriov_rdma_cni_image_tag: "v1.4.0"
+sriov_device_plugin_image_repo: "{{ github_image_repo }}/k8snetworkplumbingwg/sriov-network-device-plugin"
+sriov_device_plugin_image_tag: "v3.10.0"
+sriov_resources_injector_image_repo: "{{ github_image_repo }}/k8snetworkplumbingwg/network-resources-injector"
+sriov_resources_injector_image_tag: "v1.8.0"
+sriov_metrics_exporter_image_repo: "{{ github_image_repo }}/k8snetworkplumbingwg/sriov-network-metrics-exporter"
+sriov_metrics_exporter_image_tag: "v1.2.0"
+sriov_kube_rbac_proxy_image_repo: "{{ gcr_image_repo }}/kubebuilder/kube-rbac-proxy"
+sriov_kube_rbac_proxy_image_tag: "v0.15.0"
 external_openstack_cloud_controller_image_repo: "{{ kube_image_repo }}/provider-os/openstack-cloud-controller-manager"
 external_openstack_cloud_controller_image_tag: "v1.32.0"
 
@@ -699,6 +722,105 @@ downloads:
     groups:
       - k8s_cluster
 
+  sriov_network_operator:
+    enabled: "{{ kube_network_plugin_sriov }}"
+    container: true
+    repo: "{{ sriov_operator_image_repo }}"
+    tag: "{{ sriov_operator_image_tag }}"
+    checksum: "{{ sriov_operator_digest_checksum | default(None) }}"
+    groups:
+      - k8s_cluster
+
+  sriov_config_daemon:
+    enabled: "{{ kube_network_plugin_sriov }}"
+    container: true
+    repo: "{{ sriov_config_daemon_image_repo }}"
+    tag: "{{ sriov_config_daemon_image_tag }}"
+    checksum: "{{ sriov_config_daemon_digest_checksum | default(None) }}"
+    groups:
+      - k8s_cluster
+
+  sriov_webhook:
+    enabled: "{{ kube_network_plugin_sriov }}"
+    container: true
+    repo: "{{ sriov_webhook_image_repo }}"
+    tag: "{{ sriov_webhook_image_tag }}"
+    checksum: "{{ sriov_webhook_digest_checksum | default(None) }}"
+    groups:
+      - k8s_cluster
+
+  sriov_cni:
+    enabled: "{{ kube_network_plugin_sriov }}"
+    container: true
+    repo: "{{ sriov_cni_image_repo }}"
+    tag: "{{ sriov_cni_image_tag }}"
+    checksum: "{{ sriov_cni_digest_checksum | default(None) }}"
+    groups:
+      - k8s_cluster
+
+  sriov_ib_cni:
+    enabled: "{{ kube_network_plugin_sriov }}"
+    container: true
+    repo: "{{ sriov_ib_cni_image_repo }}"
+    tag: "{{ sriov_ib_cni_image_tag }}"
+    checksum: "{{ sriov_ib_cni_digest_checksum | default(None) }}"
+    groups:
+      - k8s_cluster
+
+  sriov_ovs_cni:
+    enabled: "{{ kube_network_plugin_sriov }}"
+    container: true
+    repo: "{{ sriov_ovs_cni_image_repo }}"
+    tag: "{{ sriov_ovs_cni_image_tag }}"
+    checksum: "{{ sriov_ovs_cni_digest_checksum | default(None) }}"
+    groups:
+      - k8s_cluster
+
+  sriov_rdma_cni:
+    enabled: "{{ kube_network_plugin_sriov }}"
+    container: true
+    repo: "{{ sriov_rdma_cni_image_repo }}"
+    tag: "{{ sriov_rdma_cni_image_tag }}"
+    checksum: "{{ sriov_rdma_cni_digest_checksum | default(None) }}"
+    groups:
+      - k8s_cluster
+
+  sriov_device_plugin:
+    enabled: "{{ kube_network_plugin_sriov }}"
+    container: true
+    repo: "{{ sriov_device_plugin_image_repo }}"
+    tag: "{{ sriov_device_plugin_image_tag }}"
+    checksum: "{{ sriov_device_plugin_digest_checksum | default(None) }}"
+    groups:
+      - k8s_cluster
+
+  sriov_resources_injector:
+    enabled: "{{ kube_network_plugin_sriov }}"
+    container: true
+    repo: "{{ sriov_resources_injector_image_repo }}"
+    tag: "{{ sriov_resources_injector_image_tag }}"
+    checksum: "{{ sriov_resources_injector_digest_checksum | default(None) }}"
+    groups:
+      - k8s_cluster
+
+  sriov_metrics_exporter:
+    enabled: "{{ kube_network_plugin_sriov }}"
+    container: true
+    repo: "{{ sriov_metrics_exporter_image_repo }}"
+    tag: "{{ sriov_metrics_exporter_image_tag }}"
+    checksum: "{{ sriov_metrics_exporter_digest_checksum | default(None) }}"
+    groups:
+      - k8s_cluster
+
+  sriov_kube_rbac_proxy:
+    enabled: "{{ kube_network_plugin_sriov }}"
+    container: true
+    repo: "{{ sriov_kube_rbac_proxy_image_repo }}"
+    tag: "{{ sriov_kube_rbac_proxy_image_tag }}"
+    checksum: "{{ sriov_kube_rbac_proxy_digest_checksum | default(None) }}"
+    groups:
+      - k8s_cluster
+
   flannel:
     enabled: "{{ kube_network_plugin == 'flannel' }}"
     container: true
@@ -872,7 +994,7 @@ downloads:
       - kube_control_plane
 
   helm:
-    enabled: "{{ helm_enabled }}"
+    enabled: "{{ helm_enabled or kube_network_plugin_sriov }}"
     file: true
     dest: "{{ local_release_dir }}/helm-{{ helm_version }}/helm-{{ helm_version }}-linux-{{ image_arch }}.tar.gz"
     checksum: "{{ helm_archive_checksum }}"

--- a/roles/kubespray_defaults/defaults/main/main.yml
+++ b/roles/kubespray_defaults/defaults/main/main.yml
@@ -214,6 +214,7 @@ kube_log_level: 2
 # Can also be set to 'cloud', which lets the cloud provider setup appropriate routing
 kube_network_plugin: calico
 kube_network_plugin_multus: false
+kube_network_plugin_sriov: false
 
 ## Network plugin options with dependencies across the whole playbook
 

--- a/roles/network_plugin/sriov/defaults/main.yml
+++ b/roles/network_plugin/sriov/defaults/main.yml
@@ -1,0 +1,34 @@
+---
+# Helm chart reference (OCI registry)
+sriov_operator_chart_repo: "oci://ghcr.io/k8snetworkplumbingwg"
+sriov_operator_chart_name: "sriov-network-operator-chart"
+
+sriov_operator_namespace: "sriov-network-operator"
+sriov_operator_cluster_type: "kubernetes"
+
+# All image repos/tags are in roles/kubespray_defaults/defaults/main/download.yml
+
+sriov_operator_log_level: 2
+sriov_operator_disable_drain: false
+sriov_operator_configuration_mode: "daemon"
+sriov_operator_resource_prefix: "openshift.io"
+sriov_operator_disable_plugins: []
+sriov_operator_enable_admission_controller: false
+sriov_cni_bin_dir: "/opt/cni/bin"
+
+sriov_operator_tolerations:
+  - key: node-role.kubernetes.io/master
+    operator: Exists
+    effect: NoSchedule
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule
+
+sriov_operator_enable_prometheus: false
+sriov_metrics_exporter_port: 9110
+
+sriov_operator_wait_timeout: 300
+
+# Pass-through for any extra chart values not covered above
+# sriov_operator_extra_values: { supportedExtraNICs: ["myNIC"] }
+sriov_operator_extra_values: {}

--- a/roles/network_plugin/sriov/tasks/main.yml
+++ b/roles/network_plugin/sriov/tasks/main.yml
@@ -1,0 +1,69 @@
+---
+- name: SR-IOV Network Operator | Verify Multus is enabled
+  assert:
+    that:
+      - kube_network_plugin_multus | default(false) | bool
+    fail_msg: >-
+      SR-IOV requires Multus CNI. Please set 'kube_network_plugin_multus: true'.
+  when: inventory_hostname == groups['kube_control_plane'][0]
+
+- name: SR-IOV Network Operator | Copy helm binary from download dir
+  copy:
+    src: "{{ local_release_dir }}/helm-{{ helm_version }}/linux-{{ image_arch }}/helm"
+    dest: "{{ bin_dir }}/helm"
+    mode: "0755"
+    remote_src: true
+  when: inventory_hostname == groups['kube_control_plane'][0]
+
+- name: SR-IOV Network Operator | Render values
+  template:
+    src: values.yaml.j2
+    dest: "{{ kube_config_dir }}/sriov-operator-values.yaml"
+    mode: "0644"
+  when: inventory_hostname == groups['kube_control_plane'][0]
+
+- name: SR-IOV Network Operator | Copy extra values
+  copy:
+    content: "{{ sriov_operator_extra_values | to_nice_yaml(indent=2) }}"
+    dest: "{{ kube_config_dir }}/sriov-operator-extra-values.yaml"
+    mode: "0644"
+  when: inventory_hostname == groups['kube_control_plane'][0]
+
+- name: SR-IOV Network Operator | Deploy via Helm  # noqa no-changed-when
+  environment: "{{ proxy_env }}"
+  command: >-
+    {{ bin_dir }}/helm upgrade --install
+    sriov-network-operator
+    {{ sriov_operator_chart_repo }}/{{ sriov_operator_chart_name }}
+    --version {{ sriov_operator_version }}
+    --namespace {{ sriov_operator_namespace }}
+    --create-namespace
+    --values {{ kube_config_dir }}/sriov-operator-values.yaml
+    --values {{ kube_config_dir }}/sriov-operator-extra-values.yaml
+    --wait
+    --timeout {{ sriov_operator_wait_timeout }}s
+  when: inventory_hostname == groups['kube_control_plane'][0]
+
+- name: SR-IOV Network Operator | Wait for operator pod to be ready
+  command: >-
+    {{ kubectl }} -n {{ sriov_operator_namespace }}
+    get pods -l app=sriov-network-operator
+    -o jsonpath='{.items[?(@.status.phase!="Running")].metadata.name}'
+  register: sriov_operator_pods_not_ready
+  until: sriov_operator_pods_not_ready.stdout == ""
+  retries: 30
+  delay: 10
+  changed_when: false
+  failed_when: false
+  when: inventory_hostname == groups['kube_control_plane'][0]
+
+- name: SR-IOV Network Operator | Wait for SriovNetworkNodeState CRD
+  command: >-
+    {{ kubectl }} wait --for condition=established --timeout=60s
+    crd/sriovnetworknodestates.sriovnetwork.openshift.io
+  register: sriov_crd_ready
+  retries: 5
+  delay: 10
+  changed_when: false
+  failed_when: false
+  when: inventory_hostname == groups['kube_control_plane'][0]

--- a/roles/network_plugin/sriov/templates/values.yaml.j2
+++ b/roles/network_plugin/sriov/templates/values.yaml.j2
@@ -1,0 +1,50 @@
+#jinja2: trim_blocks: True, lstrip_blocks: True
+operator:
+  tolerations:
+    {{ sriov_operator_tolerations | to_nice_yaml(indent=2) | indent(4) }}
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: In
+                values: [""]
+{% if sriov_operator_resources is defined %}
+  resources:
+    {{ sriov_operator_resources | to_nice_yaml(indent=2) | indent(4) }}
+{% endif %}
+  resourcePrefix: {{ sriov_operator_resource_prefix }}
+  cniBinPath: {{ sriov_cni_bin_dir }}
+  clusterType: {{ sriov_operator_cluster_type }}
+  admissionControllers:
+    enabled: {{ sriov_operator_enable_admission_controller | to_json }}
+  metricsExporter:
+    port: "{{ sriov_metrics_exporter_port }}"
+{% if sriov_operator_enable_prometheus %}
+    prometheusOperator:
+      enabled: true
+{% endif %}
+
+sriovOperatorConfig:
+  deploy: true
+  logLevel: {{ sriov_operator_log_level }}
+  disableDrain: {{ sriov_operator_disable_drain | to_json }}
+  configurationMode: {{ sriov_operator_configuration_mode }}
+{% if sriov_operator_disable_plugins | length > 0 %}
+  disablePlugins: {{ sriov_operator_disable_plugins | to_json }}
+{% endif %}
+
+images:
+  operator: "{{ sriov_operator_image_repo }}:{{ sriov_operator_image_tag }}"
+  sriovConfigDaemon: "{{ sriov_config_daemon_image_repo }}:{{ sriov_config_daemon_image_tag }}"
+  sriovCni: "{{ sriov_cni_image_repo }}:{{ sriov_cni_image_tag }}"
+  ibSriovCni: "{{ sriov_ib_cni_image_repo }}:{{ sriov_ib_cni_image_tag }}"
+  ovsCni: "{{ sriov_ovs_cni_image_repo }}:{{ sriov_ovs_cni_image_tag }}"
+  rdmaCni: "{{ sriov_rdma_cni_image_repo }}:{{ sriov_rdma_cni_image_tag }}"
+  sriovDevicePlugin: "{{ sriov_device_plugin_image_repo }}:{{ sriov_device_plugin_image_tag }}"
+  resourcesInjector: "{{ sriov_resources_injector_image_repo }}:{{ sriov_resources_injector_image_tag }}"
+  webhook: "{{ sriov_webhook_image_repo }}:{{ sriov_webhook_image_tag }}"
+  metricsExporter: "{{ sriov_metrics_exporter_image_repo }}:{{ sriov_metrics_exporter_image_tag }}"
+  metricsExporterKubeRbacProxy: "{{ sriov_kube_rbac_proxy_image_repo }}:{{ sriov_kube_rbac_proxy_image_tag }}"

--- a/roles/network_plugin/tasks/main.yml
+++ b/roles/network_plugin/tasks/main.yml
@@ -45,3 +45,14 @@
   when: kube_network_plugin_multus
   tags:
     - multus
+
+- name: SR-IOV Network Operator
+  include_role:
+    name: network_plugin/sriov
+    apply:
+      tags:
+        - sriov
+        - network
+  when: kube_network_plugin_sriov
+  tags:
+    - sriov


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

Add SR-IOV Network Operator support for 5G/Telco CNF workloads. The operator is deployed via its official Helm chart (OCI registry), following a thin-layer approach where Kubespray only manages the Helm install and upstream (Red Hat + NVIDIA) maintains all deployment manifests inside the chart.

New role at `roles/network_plugin/sriov/` with ~60 lines of Ansible that:
- Renders a Helm values template
- Runs `helm upgrade --install` for idempotent deployment
- Waits for operator readiness and CRD establishment

**Which issue(s) this PR fixes**:

Fixes #12540

**Special notes for your reviewer**:

- Requires `kube_network_plugin_multus: true` as a prerequisite
- No CI testing possible (requires physical SR-IOV NICs, same situation as Multus)
- Verified locally on k3s cluster: operator pod Running, all 7 CRDs established, `helm upgrade --install` idempotent on re-run
- `ansible-lint` passes at production profile, `yamllint --strict` passes, `markdownlint` passes

**Does this PR introduce a user-facing change?**:

```release-note
Add SR-IOV Network Operator support via Helm chart for 5G/Telco CNF workloads
```