### PR TITLE
Refactor(defaults): centralize remove node defaults

### DIFF
--- a/roles/remove-node/post-remove/tasks/main.yml
+++ b/roles/remove-node/post-remove/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 - name: Remove-node | Delete node
-  command: "{{ kubectl }} delete node {{ kube_override_hostname | default(inventory_hostname) }}"
+  command: "{{ kubectl }} delete node {{ kube_override_hostname }}"
   delegate_to: "{{ groups['kube_control_plane'] | first }}"
   when:
     - groups['kube_control_plane'] | length > 0
     # ignore servers that are not nodes
-    - ('k8s_cluster' in group_names) and kube_override_hostname | default(inventory_hostname) in nodes.stdout_lines
+    - ('k8s_cluster' in group_names) and kube_override_hostname in nodes.stdout_lines
   retries: "{{ delete_node_retries }}"
   # Sometimes the api-server can have a short window of indisponibility when we delete a control plane node
   delay: "{{ delete_node_delay_seconds }}"

--- a/roles/remove_node/pre_remove/tasks/main.yml
+++ b/roles/remove_node/pre_remove/tasks/main.yml
@@ -16,11 +16,11 @@
       --ignore-daemonsets
       --grace-period {{ drain_grace_period }}
       --timeout {{ drain_timeout }}
-      --delete-emptydir-data {{ kube_override_hostname | default(inventory_hostname) }}
+      --delete-emptydir-data {{ kube_override_hostname }}
   when:
     - groups['kube_control_plane'] | length > 0
     # ignore servers that are not nodes
-    - kube_override_hostname | default(inventory_hostname) in nodes.stdout_lines
+    - kube_override_hostname in nodes.stdout_lines
   register: result
   failed_when: result.rc != 0 and not allow_ungraceful_removal
   delegate_to: "{{ groups['kube_control_plane'] | first }}"
@@ -34,10 +34,10 @@
   register: nodes_with_volumes
   delegate_to: "{{ groups['kube_control_plane'] | first }}"
   changed_when: false
-  until: not (kube_override_hostname | default(inventory_hostname) in nodes_with_volumes.stdout_lines)
+  until: not (kube_override_hostname in nodes_with_volumes.stdout_lines)
   retries: 3
   delay: "{{ drain_grace_period }}"
   when:
     - groups['kube_control_plane'] | length > 0
     - not allow_ungraceful_removal
-    - kube_override_hostname | default(inventory_hostname) in nodes.stdout_lines
+    - kube_override_hostname in nodes.stdout_lines


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind cleanup

**What this PR does / why we need it**:
Moves inline defaults out of tasks and into role defaults for  `remove_node`. This reduces repeated | default(...) usage and aligns with #11822.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


**Special notes for your reviewer**:
No functional behavior change intended.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
