### PR TITLE
StartLimitBurst=10

### DIFF
--- a/roles/container-engine/cri-dockerd/handlers/main.yml
+++ b/roles/container-engine/cri-dockerd/handlers/main.yml
@@ -6,12 +6,6 @@
     masked: false
   listen: Restart and enable cri-dockerd
 
-- name: Cri-dockerd | restart docker.service
-  service:
-    name: docker.service
-    state: restarted
-  listen: Restart and enable cri-dockerd
-
 - name: Cri-dockerd | reload cri-dockerd.socket
   service:
     name: cri-dockerd.socket

--- a/roles/container-engine/docker/templates/docker.service.j2
+++ b/roles/container-engine/docker/templates/docker.service.j2
@@ -30,7 +30,7 @@ LimitCORE=infinity
 TimeoutStartSec=1min
 # restart the docker process if it exits prematurely
 Restart=on-failure
-StartLimitBurst=3
+StartLimitBurst=10
 StartLimitInterval=60s
 # Set the cgroup slice of the service so that kube reserved takes effect
 {% if kube_reserved is defined and kube_reserved|bool %}


### PR DESCRIPTION
---
**What this PR does / why we need it**:
This PR fixes the cri-dockerd restart burst issue by increasing the systemd `StartLimitBurst` value 

Changes:

Increased StartLimitBurst to 10 in roles/container-engine/docker/templates/docker.service.j2.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:

```release-note
Increased StartLimitBurst to 10 for docker service to prevent cri-dockerd restart throttling
```
