### PR TITLE
CI: gives a little more time for openeuler to manage packages

### DIFF
--- a/tests/files/openeuler24-calico.yml
+++ b/tests/files/openeuler24-calico.yml
@@ -3,6 +3,9 @@
 cloud_image: openeuler-2403
 vm_memory: 3072
 
+# Openeuler package mgmt is slow for some reason
+pkg_install_timeout: "{{ 10 * 60 }}"
+
 # Work around so the Kubernetes 1.35 tests can pass. We will discuss the openeuler support later.
 kubeadm_ignore_preflight_errors:
   - SystemVerification


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Follow-up to #12878

I'm seeing successful openeuler runs with 4m30s in the package tasks, so I suppose it occasionnaly takes a bit more time even if it does not fail.
Let's give it some breathing room.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
