### PR TITLE
Undefined check for `apiserver_loadbalancer_domain_name` in `apiserver_sans`

### DIFF
--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -36,7 +36,7 @@
       - "localhost"
       - "127.0.0.1"
       - "::1"
-      - "{{ apiserver_loadbalancer_domain_name }}"
+      - "{{ apiserver_loadbalancer_domain_name | d('') }}"
       - "{{ loadbalancer_apiserver.address | d('') }}"
       - "{{ supplementary_addresses_in_ssl_keys }}"
       - "{{ groups['kube_control_plane'] | map('extract', hostvars, 'main_access_ip') }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Defaults `apiserver_loadbalancer_domain_name` to `''` in `apiserver_sans`, like the other nullable vars in the task, preventing undefined variable related fatal ansible errors.

#### How to reproduce
When `loadbalancer_apiserver_localhost: false` and `loadbalancer_apiserver.address` is not set (e.g. when the nginx-proxy static pod and a load balancer are not desired).

#### Root Cause
One of the undefined checks for this variable was removed from `apiserver_sans` in [PR 12507](https://github.com/kubernetes-sigs/kubespray/pull/12507/changes#diff-2510b9cc3e44d8d6e2cc83bd5b60ba888f278a70f1a87ba4df53a2d6f881fcaeR39) when the `set_fact` templating was simplified.

However, when `loadbalancer_apiserver_localhost: false` and `loadbalancer_apiserver.address` is not set, `apiserver_loadbalancer_domain_name` defaults to `undefined` instead of a string as of the cleanup in [PR 12872](https://github.com/kubernetes-sigs/kubespray/pull/12872/changes#diff-a5847a0865e64e89545ed711083f9624cf11c7b1a47408e5a71283f3c50af5adR646) .
```yaml
apiserver_loadbalancer_domain_name: "{{ 'localhost' if loadbalancer_apiserver_localhost else (loadbalancer_apiserver.address | d(undef())) }}"
```

**Special notes for your reviewer**:
I realize `apiserver_loadbalancer_domain_name` will be removed eventually by #12897 (which will be a great improvement IMO), but in the meantime this is blocking some of my cluster validation tests that don't provision a load balancer.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
