### PR TITLE
system_packages: skip action if package set is empty

### DIFF
--- a/roles/system_packages/tasks/main.yml
+++ b/roles/system_packages/tasks/main.yml
@@ -47,7 +47,7 @@
 
 - name: Manage packages
   package:
-    name: "{{ item.packages | dict2items | selectattr('value', 'ansible.builtin.all') | map(attribute='key') }}"
+    name: "{{ item.packages }}"
     state: "{{ item.state }}"
     update_cache: "{{ true if ansible_pkg_mgr in ['zypper', 'apt', 'dnf'] else omit }}"
     cache_valid_time: "{{ 86400 if ansible_pkg_mgr == 'apt' else omit }}" # 24h
@@ -55,10 +55,17 @@
   until: pkgs_task_result is succeeded
   retries: "{{ pkg_install_retries }}"
   delay: "{{ retry_stagger | random + 3 }}"
-  when: not (ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"] or is_fedora_coreos)
+  when:
+    - ansible_os_family not in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
+    - not is_fedora_coreos
+    - item.packages != []
   loop:
-    - { packages: "{{ pkgs_to_remove }}", state: "absent", action_label: "remove" }
-    - { packages: "{{ pkgs }}", state: "present", action_label: "install" }
+    - packages: "{{ pkgs_to_remove | dict2items | selectattr('value', 'ansible.builtin.all') | map(attribute='key') }}"
+      state: "absent"
+      action_label: "remove"
+    - packages: "{{ pkgs | dict2items | selectattr('value', 'ansible.builtin.all') | map(attribute='key') }}"
+      state: "present"
+      action_label: "install"
   loop_control:
     label: "{{ item.action_label }}"
   tags:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
We currently invoke the package module even if the set of package is
empty.

This apparently make the package manager of OpenEuler to regularly time
out.


**Which issue(s) this PR fixes**:
Fixes #
Migth help with #12877

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Skip package management when there is no packages to install or remove
```
