### PR TITLE
kubeadm_patches: remove old patches on inventory change

### DIFF
--- a/roles/kubernetes/kubeadm_common/tasks/main.yml
+++ b/roles/kubernetes/kubeadm_common/tasks/main.yml
@@ -3,8 +3,18 @@
   file:
     path: "{{ kubeadm_patches_dir }}"
     state: directory
-    mode: "0640"
+    mode: "0750"
   when: kubeadm_patches | length > 0
+
+- name: Kubeadm | List existing kubeadm patches
+  find:
+    paths:
+      - "{{ kubeadm_patches_dir }}"
+    file_type: file
+    use_regex: true
+    patterns:
+      - '^(kube-apiserver|kube-controller-manager|kube-scheduler|etcd|kubeletconfiguration)[0-9]+\+(strategic|json|merge).yaml$'
+  register: existing_kubeadm_patches
 
 - name: Kubeadm | Copy kubeadm patches from inventory files
   copy:
@@ -15,3 +25,13 @@
   loop: "{{ kubeadm_patches }}"
   loop_control:
     index_var: suffix
+  register: current_kubeadm_patches
+
+- name: Kubeadm | Delete old patches
+  loop: "{{ existing_kubeadm_patches.files | map(attribute='path') |
+            difference(
+            current_kubeadm_patches.results | map(attribute='dest')
+            ) }}"
+  file:
+    state: absent
+    path: "{{ item }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently, if changing the inventory variable `kubeadm_patches`, new
patches will be created, but the existing ones will also be left on the
filesystem, and applied by kubeadm ; this means that removed or changed
configuration can linger.

Cleanup old patches (which are the difference between existing patches
on filesystem and the one created for the current runs).


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Kubeadm patches not present in the `kubeadm_patches` variable are now removed from the managed nodes automatically 
```
