### PR TITLE
Add optional IO scheduling support for etcd systemd service

### DIFF
--- a/docs/operations/etcd.md
+++ b/docs/operations/etcd.md
@@ -53,7 +53,9 @@ etcd_listen_metrics_urls: "http://0.0.0.0:2381"
 
 ## IO Scheduling
 
-For host deployment, etcd is configured with [systemd IO scheduling](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html) to prioritize disk access. These settings persist across restarts.
+For host deployment, you can optionally configure [systemd IO scheduling](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html) to prioritize etcd disk access. These settings persist across restarts.
+
+By default, IO scheduling is not configured (kernel default: `none: prio 0`). To enable it, define the following variables in your inventory:
 
 ```yaml
 etcd_io_scheduling_class: "best-effort"  # Acceptable values: "realtime", "best-effort", "idle"

--- a/docs/operations/etcd.md
+++ b/docs/operations/etcd.md
@@ -50,3 +50,12 @@ To fully override metrics exposition urls, define it in the inventory with:
 ```yaml
 etcd_listen_metrics_urls: "http://0.0.0.0:2381"
 ```
+
+## IO Scheduling
+
+For host deployment, etcd is configured with [systemd IO scheduling](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html) to prioritize disk access. These settings persist across restarts.
+
+```yaml
+etcd_io_scheduling_class: "best-effort"  # Acceptable values: "realtime", "best-effort", "idle"
+etcd_io_scheduling_priority: 0  # Acceptable values: 0 (highest) to 7 (lowest)
+```

--- a/roles/etcd/templates/etcd-events-host.service.j2
+++ b/roles/etcd/templates/etcd-events-host.service.j2
@@ -11,8 +11,12 @@ NotifyAccess=all
 Restart=always
 RestartSec=10s
 LimitNOFILE=40000
+{% if etcd_io_scheduling_class is defined %}
 IOSchedulingClass={{ etcd_io_scheduling_class }}
+{% endif %}
+{% if etcd_io_scheduling_priority is defined %}
 IOSchedulingPriority={{ etcd_io_scheduling_priority }}
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/etcd/templates/etcd-events-host.service.j2
+++ b/roles/etcd/templates/etcd-events-host.service.j2
@@ -11,6 +11,12 @@ NotifyAccess=all
 Restart=always
 RestartSec=10s
 LimitNOFILE=40000
+{% if etcd_io_scheduling_class is defined %}
+IOSchedulingClass={{ etcd_io_scheduling_class }}
+{% endif %}
+{% if etcd_io_scheduling_priority is defined %}
+IOSchedulingPriority={{ etcd_io_scheduling_priority }}
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/etcd/templates/etcd-events-host.service.j2
+++ b/roles/etcd/templates/etcd-events-host.service.j2
@@ -11,12 +11,8 @@ NotifyAccess=all
 Restart=always
 RestartSec=10s
 LimitNOFILE=40000
-{% if etcd_io_scheduling_class is defined %}
 IOSchedulingClass={{ etcd_io_scheduling_class }}
-{% endif %}
-{% if etcd_io_scheduling_priority is defined %}
 IOSchedulingPriority={{ etcd_io_scheduling_priority }}
-{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/etcd/templates/etcd-host.service.j2
+++ b/roles/etcd/templates/etcd-host.service.j2
@@ -11,8 +11,12 @@ NotifyAccess=all
 Restart=always
 RestartSec=10s
 LimitNOFILE=40000
+{% if etcd_io_scheduling_class is defined %}
 IOSchedulingClass={{ etcd_io_scheduling_class }}
+{% endif %}
+{% if etcd_io_scheduling_priority is defined %}
 IOSchedulingPriority={{ etcd_io_scheduling_priority }}
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/etcd/templates/etcd-host.service.j2
+++ b/roles/etcd/templates/etcd-host.service.j2
@@ -11,6 +11,12 @@ NotifyAccess=all
 Restart=always
 RestartSec=10s
 LimitNOFILE=40000
+{% if etcd_io_scheduling_class is defined %}
+IOSchedulingClass={{ etcd_io_scheduling_class }}
+{% endif %}
+{% if etcd_io_scheduling_priority is defined %}
+IOSchedulingPriority={{ etcd_io_scheduling_priority }}
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/etcd/templates/etcd-host.service.j2
+++ b/roles/etcd/templates/etcd-host.service.j2
@@ -11,12 +11,8 @@ NotifyAccess=all
 Restart=always
 RestartSec=10s
 LimitNOFILE=40000
-{% if etcd_io_scheduling_class is defined %}
 IOSchedulingClass={{ etcd_io_scheduling_class }}
-{% endif %}
-{% if etcd_io_scheduling_priority is defined %}
 IOSchedulingPriority={{ etcd_io_scheduling_priority }}
-{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/etcd_defaults/defaults/main.yml
+++ b/roles/etcd_defaults/defaults/main.yml
@@ -68,7 +68,6 @@ etcd_max_request_bytes: "1572864"
 etcd_blkio_weight: 1000
 
 # IO scheduling for etcd systemd service (host deployment only)
-# Ref: https://github.com/kubernetes-sigs/kubespray/issues/12574
 etcd_io_scheduling_class: "best-effort"  # Acceptable values: "realtime", "best-effort", "idle"
 etcd_io_scheduling_priority: 0  # Acceptable values: 0 (highest) to 7 (lowest)
 

--- a/roles/etcd_defaults/defaults/main.yml
+++ b/roles/etcd_defaults/defaults/main.yml
@@ -68,8 +68,8 @@ etcd_max_request_bytes: "1572864"
 etcd_blkio_weight: 1000
 
 # Experimental: IO scheduling for etcd systemd service (host deployment only)
-etcd_io_scheduling_class: "best-effort"  # Acceptable values: "realtime", "best-effort", "idle"
-etcd_io_scheduling_priority: 0  # Acceptable values: 0 (highest) to 7 (lowest)
+# etcd_io_scheduling_class: "best-effort"  # Acceptable values: "realtime", "best-effort", "idle"
+# etcd_io_scheduling_priority: 0  # Acceptable values: 0 (highest) to 7 (lowest)
 
 etcd_node_cert_hosts: "{{ groups['k8s_cluster'] }}"
 

--- a/roles/etcd_defaults/defaults/main.yml
+++ b/roles/etcd_defaults/defaults/main.yml
@@ -69,8 +69,8 @@ etcd_blkio_weight: 1000
 
 # IO scheduling for etcd systemd service (host deployment only)
 # Ref: https://github.com/kubernetes-sigs/kubespray/issues/12574
-# etcd_io_scheduling_class: "best-effort"
-# etcd_io_scheduling_priority: 0
+etcd_io_scheduling_class: "best-effort"  # Acceptable values: "realtime", "best-effort", "idle"
+etcd_io_scheduling_priority: 0  # Acceptable values: 0 (highest) to 7 (lowest)
 
 etcd_node_cert_hosts: "{{ groups['k8s_cluster'] }}"
 

--- a/roles/etcd_defaults/defaults/main.yml
+++ b/roles/etcd_defaults/defaults/main.yml
@@ -67,6 +67,11 @@ etcd_max_request_bytes: "1572864"
 
 etcd_blkio_weight: 1000
 
+# IO scheduling for etcd systemd service (host deployment only)
+# Ref: https://github.com/kubernetes-sigs/kubespray/issues/12574
+# etcd_io_scheduling_class: "best-effort"
+# etcd_io_scheduling_priority: 0
+
 etcd_node_cert_hosts: "{{ groups['k8s_cluster'] }}"
 
 ## Etcd auto compaction retention for mvcc key value store in hour

--- a/roles/etcd_defaults/defaults/main.yml
+++ b/roles/etcd_defaults/defaults/main.yml
@@ -67,7 +67,7 @@ etcd_max_request_bytes: "1572864"
 
 etcd_blkio_weight: 1000
 
-# IO scheduling for etcd systemd service (host deployment only)
+# Experimental: IO scheduling for etcd systemd service (host deployment only)
 etcd_io_scheduling_class: "best-effort"  # Acceptable values: "realtime", "best-effort", "idle"
 etcd_io_scheduling_priority: 0  # Acceptable values: 0 (highest) to 7 (lowest)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

/kind feature

**What this PR does / why we need it**:

Adds optional `IOSchedulingClass` and `IOSchedulingPriority` support for the etcd systemd service (host deployment only).

Manual `ionice` settings are lost when etcd restarts. This PR allows users to configure IO scheduling via systemd service directives, which persist across restarts.

**Which issue(s) this PR fixes**:
Fixes #12574

**Special notes for your reviewer**:
- variables are commented out in role defaults, no behavior change unless explicitly defined.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add optional etcd IO scheduling support via `etcd_io_scheduling_class` and `etcd_io_scheduling_priority` variables for host deployment
```
