### PR TITLE
refactor/apiserver-endpoint-variables

### DIFF
--- a/docs/operations/ha-mode.md
+++ b/docs/operations/ha-mode.md
@@ -14,6 +14,14 @@ The etcd clients (kube-api-masters) are configured with the list of all etcd pee
 
 ## Kube-apiserver
 
+Kubespray uses two standardized variables to define API server endpoints:
+
+* `kube_apiserver_endpoint`: The external providing endpoint (e.g. for `admin.conf`). If a load balancer is defined, it uses it. Otherwise it falls back to the first control plane node.
+* `kube_apiserver_cluster_internal_endpoint`: The internal endpoint used by cluster components (kubelet, kube-proxy, pods). It supports the localhost load balancer if enabled, and optimizations for control plane nodes.
+
+### Localhost Loadbalancing
+
+
 K8s components require a loadbalancer to access the apiservers via a reverse
 proxy. Kubespray includes support for an nginx-based proxy that resides on each
 non-master Kubernetes node. This is referred to as localhost loadbalancing. It

--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -3,20 +3,14 @@
   set_fact:
     # noqa: jinja[spacing]
     external_apiserver_address: >-
-      {%- if loadbalancer_apiserver is defined and loadbalancer_apiserver.address is defined -%}
-      {{ loadbalancer_apiserver.address }}
-      {%- elif kubeconfig_localhost_ansible_host is defined and kubeconfig_localhost_ansible_host -%}
+      {%- if kubeconfig_localhost_ansible_host is defined and kubeconfig_localhost_ansible_host and loadbalancer_apiserver is not defined -%}
       {{ hostvars[groups['kube_control_plane'][0]].ansible_host }}
       {%- else -%}
-      {{ kube_apiserver_access_address }}
+      {{ kube_apiserver_endpoint | ansible.builtin.urlsplit('hostname') }}
       {%- endif -%}
     # noqa: jinja[spacing]
     external_apiserver_port: >-
-      {%- if loadbalancer_apiserver is defined and loadbalancer_apiserver.address is defined and loadbalancer_apiserver.port is defined -%}
-      {{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
-      {%- else -%}
-      {{ kube_apiserver_port }}
-      {%- endif -%}
+      {{ kube_apiserver_endpoint | ansible.builtin.urlsplit('port') }}
   tags:
     - facts
 

--- a/roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml
@@ -1,16 +1,4 @@
 ---
-- name: Set kubeadm_discovery_address
-  set_fact:
-    # noqa: jinja[spacing]
-    kubeadm_discovery_address: >-
-      {%- if "127.0.0.1" in kube_apiserver_endpoint or "localhost" in kube_apiserver_endpoint -%}
-      {{ first_kube_control_plane_address | ansible.utils.ipwrap }}:{{ kube_apiserver_port }}
-      {%- else -%}
-      {{ kube_apiserver_endpoint | regex_replace('https://', '') }}
-      {%- endif %}
-  tags:
-    - facts
-
 - name: Obtain kubeadm certificate key for joining control planes nodes
   when:
     - not kube_external_ca_mode
@@ -31,7 +19,7 @@
 
 - name: Wait for k8s apiserver
   wait_for:
-    host: "{{ kubeadm_discovery_address | regex_replace('\\]?:\\d+$', '') | regex_replace('^\\[', '') }}"
+    host: "{{ kubeadm_discovery_address | regex_replace(':\d+$', '') | regex_replace('^\\[', '') | regex_replace('\\]$', '') }}"
     port: "{{ kubeadm_discovery_address.split(':')[-1] }}"
     timeout: 180
 

--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -87,11 +87,7 @@
   when: kube_apiserver_tracing
   notify: Control plane | Restart apiserver
 
-# Nginx LB(default), If kubeadm_config_api_fqdn is defined, use other LB by kubeadm controlPlaneEndpoint.
-- name: Set kubeadm_config_api_fqdn define
-  set_fact:
-    kubeadm_config_api_fqdn: "{{ apiserver_loadbalancer_domain_name }}"
-  when: loadbalancer_apiserver is defined
+
 
 - name: Kubeadm | Create kubeadm config
   template:

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta3.yaml.j2
@@ -97,11 +97,7 @@ featureGates:
 {%   endfor %}
 {% endif %}
 kubernetesVersion: v{{ kube_version }}
-{% if kubeadm_config_api_fqdn is defined %}
-controlPlaneEndpoint: "{{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}"
-{% else %}
-controlPlaneEndpoint: "{{ main_ip | ansible.utils.ipwrap }}:{{ kube_apiserver_port }}"
-{% endif %}
+controlPlaneEndpoint: "{{ kube_apiserver_endpoint | ansible.builtin.urlsplit('netloc') }}"
 certificatesDir: {{ kube_cert_dir }}
 imageRepository: {{ kubeadm_image_repo }}
 apiServer:

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
@@ -116,11 +116,7 @@ featureGates:
 {%   endfor %}
 {% endif %}
 kubernetesVersion: v{{ kube_version }}
-{% if kubeadm_config_api_fqdn is defined %}
-controlPlaneEndpoint: "{{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}"
-{% else %}
-controlPlaneEndpoint: "{{ main_ip | ansible.utils.ipwrap }}:{{ kube_apiserver_port }}"
-{% endif %}
+controlPlaneEndpoint: "{{ kube_apiserver_endpoint | ansible.builtin.urlsplit('netloc') }}"
 certificatesDir: {{ kube_cert_dir }}
 imageRepository: {{ kubeadm_image_repo }}
 apiServer:

--- a/roles/kubernetes/control-plane/templates/kubeadm-controlplane.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-controlplane.yaml.j2
@@ -6,11 +6,7 @@ discovery:
     kubeConfigPath: {{ kube_config_dir }}/cluster-info-discovery-kubeconfig.yaml
 {% else %}
   bootstrapToken:
-{% if kubeadm_config_api_fqdn is defined %}
-    apiServerEndpoint: {{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
-{% else %}
     apiServerEndpoint: "{{ kubeadm_discovery_address }}"
-{% endif %}
     token: {{ kubeadm_token }}
     unsafeSkipCAVerification: true
 {% endif %}

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -1,16 +1,4 @@
 ---
-- name: Set kubeadm_discovery_address
-  set_fact:
-    # noqa: jinja[spacing]
-    kubeadm_discovery_address: >-
-      {%- if "127.0.0.1" in kube_apiserver_endpoint or "localhost" in kube_apiserver_endpoint -%}
-      {{ first_kube_control_plane_address | ansible.utils.ipwrap }}:{{ kube_apiserver_port }}
-      {%- else -%}
-      {{ kube_apiserver_endpoint | replace("https://", "") }}
-      {%- endif %}
-  tags:
-    - facts
-
 - name: Check if kubelet.conf exists
   stat:
     path: "{{ kube_config_dir }}/kubelet.conf"
@@ -104,23 +92,10 @@
   lineinfile:
     dest: "{{ kube_config_dir }}/kubelet.conf"
     regexp: 'server:'
-    line: '    server: {{ kube_apiserver_endpoint }}'
-    backup: true
-  when:
-    - kubeadm_config_api_fqdn is not defined
-    - ('kube_control_plane' not in group_names)
-    - kubeadm_discovery_address != kube_apiserver_endpoint | replace("https://", "")
-  notify: Kubeadm | restart kubelet
-
-- name: Update server field in kubelet kubeconfig - external lb
-  lineinfile:
-    dest: "{{ kube_config_dir }}/kubelet.conf"
-    regexp: '^    server: https'
-    line: '    server: {{ kube_apiserver_endpoint }}'
+    line: '    server: {{ kube_apiserver_cluster_internal_endpoint }}'
     backup: true
   when:
     - ('kube_control_plane' not in group_names)
-    - loadbalancer_apiserver is defined
   notify: Kubeadm | restart kubelet
 
 - name: Get current resourceVersion of kube-proxy configmap
@@ -134,30 +109,10 @@
   tags:
     - kube-proxy
 
-# FIXME(mattymo): Need to point to localhost, otherwise control plane nodes will all point
-#                 incorrectly to first control plane node, creating SPoF.
 - name: Update server field in kube-proxy kubeconfig
   shell: >-
     set -o pipefail && {{ kubectl }} get configmap kube-proxy -n kube-system -o yaml
-    | sed 's#server:.*#server: https://127.0.0.1:{{ kube_apiserver_port }}#g'
-    | {{ kubectl }} replace -f -
-  args:
-    executable: /bin/bash
-  run_once: true
-  delegate_to: "{{ groups['kube_control_plane'] | first }}"
-  delegate_facts: false
-  when:
-    - kubeadm_config_api_fqdn is not defined
-    - kubeadm_discovery_address != kube_apiserver_endpoint | replace("https://", "")
-    - kube_proxy_deployed
-    - loadbalancer_apiserver_localhost
-  tags:
-    - kube-proxy
-
-- name: Update server field in kube-proxy kubeconfig - external lb
-  shell: >-
-    set -o pipefail && {{ kubectl }} get configmap kube-proxy -n kube-system -o yaml
-    | sed 's#server:.*#server: {{kube_apiserver_endpoint}}#g'
+    | sed 's#server:.*#server: {{ kube_apiserver_cluster_internal_endpoint }}#g'
     | {{ kubectl }} replace -f -
   args:
     executable: /bin/bash
@@ -166,7 +121,6 @@
   delegate_facts: false
   when:
     - kube_proxy_deployed
-    - loadbalancer_apiserver is defined
   tags:
     - kube-proxy
 

--- a/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.j2
+++ b/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.j2
@@ -7,11 +7,7 @@ discovery:
     kubeConfigPath: {{ kube_config_dir }}/cluster-info-discovery-kubeconfig.yaml
 {% else %}
   bootstrapToken:
-{% if kubeadm_config_api_fqdn is defined %}
-    apiServerEndpoint: "{{ kubeadm_config_api_fqdn }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}"
-{% else %}
     apiServerEndpoint: "{{ kubeadm_discovery_address }}"
-{% endif %}
     token: {{ kubeadm_token }}
 {% if ca_cert_content is defined %}
     caCertHashes:

--- a/roles/kubespray_defaults/defaults/main/main.yml
+++ b/roles/kubespray_defaults/defaults/main/main.yml
@@ -642,23 +642,30 @@ loadbalancer_apiserver_localhost: "{{ loadbalancer_apiserver is not defined }}"
 loadbalancer_apiserver_type: "nginx"
 # applied if only external loadbalancer_apiserver is defined, otherwise ignored
 apiserver_loadbalancer_domain_name: "{{ 'localhost' if loadbalancer_apiserver_localhost else (loadbalancer_apiserver.address | d(undef())) }}"
-kube_apiserver_global_endpoint: |-
+kube_apiserver_global_endpoint: "{{ kube_apiserver_cluster_internal_endpoint }}"
+kube_apiserver_endpoint: |-
   {% if loadbalancer_apiserver is defined -%}
-      https://{{ apiserver_loadbalancer_domain_name | ansible.utils.ipwrap }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
+      https://{{ apiserver_loadbalancer_domain_name | default(loadbalancer_apiserver.address) | ansible.utils.ipwrap }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
+  {%- else -%}
+      https://{{ first_kube_control_plane_address | ansible.utils.ipwrap }}:{{ kube_apiserver_port }}
+  {%- endif %}
+kube_apiserver_cluster_internal_endpoint: |-
+  {%- if 'kube_control_plane' in group_names and loadbalancer_apiserver_localhost -%}
+      https://127.0.0.1:{{ kube_apiserver_port }}
+  {%- elif loadbalancer_apiserver is defined -%}
+      https://{{ apiserver_loadbalancer_domain_name | default(loadbalancer_apiserver.address) | ansible.utils.ipwrap }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
+  {%- elif 'kube_control_plane' in group_names -%}
+      https://{{ kube_apiserver_bind_address | regex_replace('::', '127.0.0.1') | ansible.utils.ipwrap }}:{{ kube_apiserver_port }}
   {%- elif loadbalancer_apiserver_localhost -%}
       https://localhost:{{ loadbalancer_apiserver_port | default(kube_apiserver_port) }}
   {%- else -%}
       https://{{ first_kube_control_plane_address | ansible.utils.ipwrap }}:{{ kube_apiserver_port }}
   {%- endif %}
-kube_apiserver_endpoint: |-
-  {% if loadbalancer_apiserver is defined -%}
-      https://{{ apiserver_loadbalancer_domain_name | ansible.utils.ipwrap }}:{{ loadbalancer_apiserver.port | default(kube_apiserver_port) }}
-  {%- elif ('kube_control_plane' not in group_names) and loadbalancer_apiserver_localhost -%}
-      https://localhost:{{ loadbalancer_apiserver_port | default(kube_apiserver_port) }}
-  {%- elif 'kube_control_plane' in group_names -%}
-  https://{{ kube_apiserver_bind_address | regex_replace('::', '127.0.0.1') | ansible.utils.ipwrap }}:{{ kube_apiserver_port }}
+kubeadm_discovery_address: |-
+  {%- if "127.0.0.1" in kube_apiserver_endpoint or "localhost" in kube_apiserver_endpoint -%}
+      {{ first_kube_control_plane_address | ansible.utils.ipwrap }}:{{ kube_apiserver_port }}
   {%- else -%}
-      https://{{ first_kube_control_plane_address | ansible.utils.ipwrap }}:{{ kube_apiserver_port }}
+      {{ kube_apiserver_endpoint | replace("https://", "") }}
   {%- endif %}
 kube_apiserver_client_cert: "{{ kube_cert_dir }}/ca.crt"
 kube_apiserver_client_key: "{{ kube_cert_dir }}/ca.key"

--- a/roles/network_plugin/calico/templates/kubernetes-services-endpoint.yml.j2
+++ b/roles/network_plugin/calico/templates/kubernetes-services-endpoint.yml.j2
@@ -6,6 +6,6 @@ metadata:
   name: kubernetes-services-endpoint
 data:
 {% if calico_bpf_enabled or loadbalancer_apiserver_localhost %}
-  KUBERNETES_SERVICE_HOST: "{{ kube_apiserver_global_endpoint | urlsplit('hostname') }}"
-  KUBERNETES_SERVICE_PORT: "{{ kube_apiserver_global_endpoint | urlsplit('port') }}"
+  KUBERNETES_SERVICE_HOST: "{{ kube_apiserver_cluster_internal_endpoint | urlsplit('hostname') }}"
+  KUBERNETES_SERVICE_PORT: "{{ kube_apiserver_cluster_internal_endpoint | urlsplit('port') }}"
 {% endif %}

--- a/roles/network_plugin/cilium/templates/values.yaml.j2
+++ b/roles/network_plugin/cilium/templates/values.yaml.j2
@@ -7,8 +7,8 @@ image:
   repository: {{ cilium_image_repo }}
   tag: {{ cilium_image_tag }}
 
-k8sServiceHost: "{{ kube_apiserver_global_endpoint | urlsplit('hostname') }}"
-k8sServicePort: "{{ kube_apiserver_global_endpoint | urlsplit('port') }}"
+k8sServiceHost: "{{ kube_apiserver_cluster_internal_endpoint | urlsplit('hostname') }}"
+k8sServicePort: "{{ kube_apiserver_cluster_internal_endpoint | urlsplit('port') }}"
 
 ipv4:
   enabled: {{ cilium_enable_ipv4 | to_json }}


### PR DESCRIPTION
**What type of PR is this?**
/kind refactor

**What this PR does / why we need it**:
This PR refactors and standardizes the variables used to configure the Kubernetes API server endpoint and load balancer behavior in Kubespray.

Currently, Kubespray uses multiple overlapping variables (`loadbalancer_apiserver.address`, `loadbalancer_apiserver.port`, `apiserver_loadbalancer_domain_name`, and `kubeadm_config_api_fqdn`) with inconsistent naming and usage across roles and templates. This results in duplicated logic, hard-to-follow conditionals, and inconsistent behavior across HA, non-HA, and localhost load balancer modes.

This PR introduces two standardized variables:
- `kube_apiserver_endpoint`: the external endpoint used by clients (e.g. admin kubeconfig)
- `kube_apiserver_cluster_internal_endpoint`: the internal endpoint used by cluster components (kubelet, kube-proxy, pods)

The new variables provide a single source of truth and remove the need for multiple condition branches throughout Kubespray.

Key changes:
- Replace usage of `loadbalancer_apiserver.*`, `apiserver_loadbalancer_domain_name`, and `kubeadm_config_api_fqdn` across templates and roles
- Remove the `kubeadm_config_api_fqdn` fact generation
- Update kubeadm config templates (`controlPlaneEndpoint`, discovery address, kubeadm client config)
- Update kubelet, kube-proxy, and CNI (Calico/Cilium) configurations to use the internal endpoint
- Keep backward compatibility by deriving the new variables from existing configuration and aliasing `kube_apiserver_global_endpoint`
- Update HA documentation to describe the new variables

This refactor reduces redundancy, improves readability, and makes API server endpoint configuration consistent across all deployment modes.

**Which issue(s) this PR fixes**:
Fixes #12883 

**Special notes for your reviewer**:
- This PR is a pure refactor and does not change intended behavior of HA, non-HA, or localhost load balancer modes
- Existing configurations using `loadbalancer_apiserver` continue to work as the new variables derive from them
- etcd configuration and networking behavior are not modified
- Endpoint parsing uses `ansible.builtin.urlsplit` where host/port extraction is required

**Does this PR introduce a user-facing change?**:
```release-note
Standardizes API server endpoint configuration by introducing `kube_apiserver_endpoint` (external access) and `kube_apiserver_cluster_internal_endpoint` (internal cluster access) and deprecating older load balancer variables.
```