### PR TITLE
Structured AuthenticationConfiguration file for kube-apiserver

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-cluster.yml
@@ -53,6 +53,21 @@ credentials_dir: "{{ inventory_dir }}/credentials"
 # kube_oidc_groups_claim: groups
 # kube_oidc_groups_prefix: 'oidc:'
 
+## Structured AuthenticationConfiguration https://kubernetes.io/docs/reference/access-authn-authz/authentication/#using-authentication-configuration
+## Note: --authentication-config and --oidc-* flags are mutually exclusive
+# kube_apiserver_use_authentication_config_file: false
+# kube_apiserver_authentication_config_jwt:
+#   - issuer:
+#       url: https://issuer.example.com
+#       audiences:
+#       - my-audience
+#     claimMappings:
+#       username:
+#         expression: 'claims.sub'
+# kube_apiserver_authentication_config_anonymous:
+#   enabled: "{{ kube_api_anonymous_auth }}"
+#   conditions: []
+
 ## Variables to control webhook authn/authz
 # kube_webhook_token_auth: false
 # kube_webhook_token_auth_url: https://...

--- a/roles/kubernetes/control-plane/tasks/main.yml
+++ b/roles/kubernetes/control-plane/tasks/main.yml
@@ -18,6 +18,19 @@
     mode: "0640"
   when: kube_webhook_authorization | default(false)
 
+- name: Create structured AuthenticationConfiguration file
+  copy:
+    content: "{{ authn_config | to_nice_yaml(indent=2, sort_keys=false) }}"
+    dest: "{{ kube_config_dir }}/apiserver-authentication-config-{{ kube_apiserver_authentication_config_api_version }}.yaml"
+    mode: "0640"
+  vars:
+    authn_config:
+      apiVersion: apiserver.config.k8s.io/{{ kube_apiserver_authentication_config_api_version }}
+      kind: AuthenticationConfiguration
+      jwt: "{{ kube_apiserver_authentication_config_jwt }}"
+      anonymous: "{{ kube_apiserver_authentication_config_anonymous }}"
+  when: kube_apiserver_use_authentication_config_file
+
 - name: Create structured AuthorizationConfiguration file
   copy:
     content: "{{ authz_config | to_nice_yaml(indent=2, sort_keys=false) }}"
@@ -98,6 +111,13 @@
 - name: Include kubeadm etcd extra tasks
   include_tasks: kubeadm-etcd.yml
   when: etcd_deployment_type == "kubeadm"
+
+- name: Cleanup unused AuthenticationConfiguration file versions
+  file:
+    path: "{{ kube_config_dir }}/apiserver-authentication-config-{{ item }}.yaml"
+    state: absent
+  loop: "{{ ['v1alpha1', 'v1beta1', 'v1'] | reject('equalto', kube_apiserver_authentication_config_api_version) | list }}"
+  when: kube_apiserver_use_authentication_config_file
 
 - name: Cleanup unused AuthorizationConfiguration file versions
   file:

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
@@ -131,8 +131,7 @@ apiServer:
     value: "{{ kube_apiserver_pod_eviction_not_ready_timeout_seconds }}"
   - name: default-unreachable-toleration-seconds
     value: "{{ kube_apiserver_pod_eviction_unreachable_timeout_seconds }}"
-{% if kube_api_anonymous_auth is defined %}
-{# TODO: rework once suppport for structured auth lands #}
+{% if kube_api_anonymous_auth is defined and not kube_apiserver_use_authentication_config_file %}
   - name: anonymous-auth
     value: "{{ kube_api_anonymous_auth }}"
 {% endif %}
@@ -181,7 +180,7 @@ apiServer:
   - name: service-account-lookup
     value: "{{ kube_apiserver_service_account_lookup }}"
 {% endif %}
-{% if kube_oidc_auth and kube_oidc_url is defined and kube_oidc_client_id is defined %}
+{% if kube_oidc_auth and kube_oidc_url is defined and kube_oidc_client_id is defined and not kube_apiserver_use_authentication_config_file %}
   - name: oidc-issuer-url
     value: "{{ kube_oidc_url }}"
   - name: oidc-client-id
@@ -206,6 +205,10 @@ apiServer:
   - name: oidc-groups-prefix
     value: "{{ kube_oidc_groups_prefix }}"
 {%   endif %}
+{% endif %}
+{% if kube_apiserver_use_authentication_config_file %}
+  - name: authentication-config
+    value: "{{ kube_config_dir }}/apiserver-authentication-config-{{ kube_apiserver_authentication_config_api_version }}.yaml"
 {% endif %}
 {% if kube_webhook_token_auth %}
   - name: authentication-token-webhook-config-file
@@ -279,7 +282,7 @@ apiServer:
   - name: tracing-config-file
     value: "{{ kube_config_dir }}/tracing/apiserver-tracing.yaml"
 {% endif %}
-{% if kubernetes_audit or kube_token_auth or kube_webhook_token_auth or apiserver_extra_volumes or ssl_ca_dirs | length %}
+{% if kubernetes_audit or kube_token_auth or kube_webhook_token_auth or kube_apiserver_use_authorization_config_file or kube_apiserver_use_authentication_config_file or apiserver_extra_volumes or ssl_ca_dirs | length %}
   extraVolumes:
 {% if kube_token_auth %}
   - name: token-auth-config
@@ -300,6 +303,11 @@ apiServer:
   - name: authorization-config
     hostPath: {{ kube_config_dir }}/apiserver-authorization-config-{{ kube_apiserver_authorization_config_api_version }}.yaml
     mountPath: {{ kube_config_dir }}/apiserver-authorization-config-{{ kube_apiserver_authorization_config_api_version }}.yaml
+{% endif %}
+{% if kube_apiserver_use_authentication_config_file %}
+  - name: authentication-config
+    hostPath: {{ kube_config_dir }}/apiserver-authentication-config-{{ kube_apiserver_authentication_config_api_version }}.yaml
+    mountPath: {{ kube_config_dir }}/apiserver-authentication-config-{{ kube_apiserver_authentication_config_api_version }}.yaml
 {% endif %}
 {% if kubernetes_audit or kubernetes_audit_webhook %}
   - name: {{ audit_policy_name }}

--- a/roles/kubespray_defaults/defaults/main/main.yml
+++ b/roles/kubespray_defaults/defaults/main/main.yml
@@ -506,6 +506,33 @@ external_hcloud_cloud:
   ##    arg2: "value2"
   controller_extra_args: {}
 
+## Structured authentication config
+## Structured AuthenticationConfiguration (GA in k8s v1.34) configures the API server's authentication with a structured configuration file.
+## Note: The `--authentication-config` and `--oidc-*` flags are mutually exclusive. The two features cannot be used at the same time.
+## Docs: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#using-authentication-configuration
+## KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3331-structured-authentication-configuration
+## Config API Reference: https://kubernetes.io/docs/reference/config-api/apiserver-config.v1/#apiserver-config-k8s-io-v1-AuthenticationConfiguration
+kube_apiserver_use_authentication_config_file: false
+kube_apiserver_authentication_config_api_version: "{{ 'v1beta1' if kube_version is version('1.34.0', '<') else 'v1' }}"
+kube_apiserver_authentication_config_anonymous:
+  enabled: "{{ kube_api_anonymous_auth }}"
+  conditions: []
+kube_apiserver_authentication_config_jwt: []
+## Example structured authentication issuer config that replicates --oidc-* flag based config by reusing the kube_oidc_* variables
+# kube_apiserver_authentication_config_jwt:
+#   - issuer:
+#       url: "{{ kube_oidc_url }}"
+#       certificateAuthority: "{{ kube_oidc_ca_file }}"
+#       audiences:
+#       - "{{ kube_oidc_client_id }}"
+#     claimMappings:
+#       username:
+#         claim: "{{ kube_oidc_username_claim }}"
+#         prefix: "{{ kube_oidc_username_prefix }}"
+#       groups:
+#         claim: "{{ kube_oidc_groups_claim }}"
+#         prefix: "{{ kube_oidc_groups_prefix }}"
+
 ## List of authorization modes that must be configured for
 ## the k8s cluster. Only 'AlwaysAllow', 'AlwaysDeny', 'Node' and
 ## 'RBAC' modes are tested. Order is important.
@@ -550,21 +577,6 @@ kube_apiserver_authorization_config_authorizers:
 #     # Don't process kubeadm requests with the webhook
 #     - expression: "!('kubeadm:cluster-admins' in request.groups)"
 #     - expression: "!('system:masters' in request.groups)"
-
-## Two workarounds are required to use AuthorizationConfiguration with kubeadm v1.29.x:
-## 1. Enable the StructuredAuthorizationConfiguration feature gate:
-# kube_apiserver_feature_gates:
-# - StructuredAuthorizationConfiguration=true
-## 2. Use the following kubeadm_patches to remove defaulted authorization-mode flags (Workaround for a kubeadm defaulting bug on v1.29.x. fixed in 1.30+ via: https://github.com/kubernetes/kubernetes/pull/123654)
-# kubeadm_patches:
-# - target: kube-apiserver
-#   type: strategic
-#   patch:
-#     spec:
-#       containers:
-#       - name: kube-apiserver
-#         $deleteFromPrimitiveList/command:
-#           - --authorization-mode=Node,RBAC
 
 rbac_enabled: "{{ ('RBAC' in authorization_modes and not kube_apiserver_use_authorization_config_file) or (kube_apiserver_use_authorization_config_file and kube_apiserver_authorization_config_authorizers | selectattr('type', 'equalto', 'RBAC') | list | length > 0) }}"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Introduces support for Structured Authentication Configuration ([AuthenticationConfiguration](https://kubernetes.io/docs/reference/config-api/apiserver-config.v1/#apiserver-config-k8s-io-v1-AuthenticationConfiguration) config API for kube-apiserver), allowing users to opt-in to advanced JWT/OIDC authentication and anonymous access via a configuration file that supports CEL expressions as an alternative to the more limited kube-apiserver flags.

This is the recommended approach for modern Kubernetes clusters and unlocks the ability to directly configure multiple JWT identity providers and multiple audiences without requiring dex or keycloak to act as an OIDC proxy.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11834

**Special notes for your reviewer**:
The legacy `--oidc-*` and `--anonymous-auth` flags remain fully supported. They are automatically omitted from the kubeadm manifests only when `kube_apiserver_use_authentication_config_file: true` is set.

This aims to mirror the UX of the existing Structured AuthorizationConfiguration implementation (introduced in #11852), and incorporates feedback from a previous PR which was closed due to inactivity (#11841).

Like AuthorizationConfiguration, to prevent Ansible's `hash_behaviour=replace` from clobbering defaults when a user only partially defines the config, the configuration is split into distinct variables per top level key (`kube_apiserver_authentication_config_anonymous` and `kube_apiserver_authentication_config_jwt`) instead of a single `kube_apiserver_authentication_config` variable. The variables are merged at the use site, and can be easily extended should additions to the config file be released in the future (which will also require updates to the kubeadm-config template to avoid incompatibility conflicts between flags and file based config which are typically mutually exclusive and cannot be defined at the same time).

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add Structured AuthenticationConfiguration config file support for kube-apiserver
```
