### PR TITLE
docs: remove outdated ansible-galaxy install from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,6 @@ To install development dependencies you can set up a python virtual env with the
 virtualenv venv
 source venv/bin/activate
 pip install -r tests/requirements.txt
-ansible-galaxy install -r tests/requirements.yml
 ```
 
 #### Linting


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Remove the `ansible-galaxy install -r tests/requirements.yml` line from CONTRIBUTING.md.

`tests/requirements.yml` was removed in ef95eb078 ("Cleanup unused CI tooling", #11014), but CONTRIBUTING.md was not updated. This causes the environment setup to fail for new contributors.

All required collections are already bundled in `ansible==11.13.0` (specified in `requirements.txt`).

Fixes #13037

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```