### PR TITLE
Added register and changed_when conditions to kubectl apply tasks in …

### DIFF
--- a/roles/kubernetes-apps/ansible/tasks/main.yml
+++ b/roles/kubernetes-apps/ansible/tasks/main.yml
@@ -15,6 +15,8 @@
   command:
     cmd: "{{ kubectl_apply_stdin }}"
     stdin: "{{ lookup('template', item) }}"
+  register: kubectl_apply_coredns
+  changed_when: "' created' in kubectl_apply_coredns.stdout or ' configured' in kubectl_apply_coredns.stdout"
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
   run_once: true
   loop: "{{ coredns_manifests | flatten }}"
@@ -30,6 +32,8 @@
   command:
     cmd: "{{ kubectl_apply_stdin }}"
     stdin: "{{ lookup('template', item) }}"
+  register: kubectl_apply_coredns_secondary
+  changed_when: "' created' in kubectl_apply_coredns_secondary.stdout or ' configured' in kubectl_apply_coredns_secondary.stdout"
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
   run_once: true
   loop: "{{ coredns_manifests | flatten }}"
@@ -46,11 +50,11 @@
   command:
     cmd: "{{ kubectl_apply_stdin }}"
     stdin: "{{ lookup('template', item) }}"
+  register: kubectl_apply_nodelocaldns
+  changed_when: "' created' in kubectl_apply_nodelocaldns.stdout or ' configured' in kubectl_apply_nodelocaldns.stdout"
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
   run_once: true
   loop: "{{ nodelocaldns_manifests | flatten }}"
-  when:
-    - enable_nodelocaldns
   tags:
     - nodelocaldns
     - coredns
@@ -74,24 +78,34 @@
       {%- else -%}
       /etc/resolv.conf
       {%- endif -%}
+  when:
+    - enable_nodelocaldns
+    - dns_mode in ['coredns', 'coredns_dual', 'manual']
+    - deploy_coredns
 
 - name: Kubernetes Apps | Etcd metrics endpoints
   command:
     cmd: "{{ kubectl_apply_stdin }}"
     stdin: "{{ lookup('template', item) }}"
+  register: kubectl_apply_etcd_metrics
+  changed_when: "' created' in kubectl_apply_etcd_metrics.stdout or ' configured' in kubectl_apply_etcd_metrics.stdout"
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
   run_once: true
   loop:
     - etcd_metrics-endpoints.yml.j2
     - etcd_metrics-service.yml.j2
-  when: etcd_metrics_port is defined and etcd_metrics_service_labels is defined
   tags:
     - etcd_metrics
+  when:
+    - etcd_deployment_type != 'kubeadm'
+    - etcd_metrics_port is defined and etcd_metrics_service_labels is defined
 
 - name: Kubernetes Apps | Netchecker
   command:
     cmd: "{{ kubectl_apply_stdin }}"
     stdin: "{{ lookup('template', item) }}"
+  register: kubectl_apply_netchecker
+  changed_when: "' created' in kubectl_apply_netchecker.stdout or ' configured' in kubectl_apply_netchecker.stdout"
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
   run_once: true
   vars:

--- a/roles/kubernetes-apps/common_crds/prometheus_operator_crds/tasks/main.yml
+++ b/roles/kubernetes-apps/common_crds/prometheus_operator_crds/tasks/main.yml
@@ -7,5 +7,7 @@
 - name: Prometheus Operator CRDs | Install
   command:
     cmd: "{{ bin_dir }}/kubectl apply -f {{ local_release_dir }}/prometheus-operator-crds.yaml"
+  register: kubectl_apply_crds
+  changed_when: "' created' in kubectl_apply_crds.stdout or ' configured' in kubectl_apply_crds.stdout"
   when:
     - "inventory_hostname == groups['kube_control_plane'][0]"

--- a/roles/kubernetes-apps/csi_driver/vsphere/tasks/main.yml
+++ b/roles/kubernetes-apps/csi_driver/vsphere/tasks/main.yml
@@ -51,5 +51,7 @@
   command:
     cmd: "{{ kubectl }} apply -f -"
     stdin: "{{ vsphere_csi_secret_manifest.stdout }}"
+  register: kubectl_apply_vsphere_secret
+  changed_when: "' created' in kubectl_apply_vsphere_secret.stdout or ' configured' in kubectl_apply_vsphere_secret.stdout"
   when: inventory_hostname == groups['kube_control_plane'][0]
   no_log: "{{ not (unsafe_show_logs | bool) }}"

--- a/roles/kubernetes-apps/external_cloud_controller/vsphere/tasks/main.yml
+++ b/roles/kubernetes-apps/external_cloud_controller/vsphere/tasks/main.yml
@@ -33,6 +33,8 @@
   command:
     cmd: "{{ bin_dir }}/kubectl apply -f -"
     stdin: "{{ external_vsphere_configmap_manifest.stdout }}"
+  register: kubectl_apply_configmap
+  changed_when: "' created' in kubectl_apply_configmap.stdout or ' configured' in kubectl_apply_configmap.stdout"
   when: inventory_hostname == groups['kube_control_plane'][0]
 
 - name: External vSphere Cloud Controller | Apply Manifests

--- a/tests/testcases/030_check-network.yml
+++ b/tests/testcases/030_check-network.yml
@@ -54,34 +54,35 @@
 - name: Run 2 agnhost pods in test ns
   command:
     cmd: "{{ bin_dir }}/kubectl apply --namespace test -f -"
-    stdin: |
-      apiVersion: apps/v1
-      kind: Deployment
-      metadata:
-        name: agnhost
-      spec:
-        replicas: 2
-        selector:
-          matchLabels:
+  register: kubectl_apply_agnhost
+  changed_when: "' created' in kubectl_apply_agnhost.stdout or ' configured' in kubectl_apply_agnhost.stdout"
+  stdin: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: agnhost
+    spec:
+      replicas: 2
+      selector:
+        matchLabels:
+          app: agnhost
+      template:
+        metadata:
+          labels:
             app: agnhost
-        template:
-          metadata:
-            labels:
-              app: agnhost
-          spec:
-            containers:
-            - name: agnhost
-              image: {{ test_image_repo }}:{{ test_image_tag }}
-              command: ['/agnhost', 'netexec', '--http-port=8080']
-              securityContext:
-                allowPrivilegeEscalation: false
-                capabilities:
-                  drop: ['ALL']
+        spec:
+          containers:
+          - name: agnhost
+            image: {{ test_image_repo }}:{{ test_image_tag }}
+            command: ['/agnhost', 'netexec', '--http-port=8080']
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ['ALL']
                 runAsUser: 1000
                 runAsNonRoot: true
                 seccompProfile:
                   type: RuntimeDefault
-  changed_when: false
 
 - name: Check that all pods are running and ready
   vars:


### PR DESCRIPTION
…all places for proper idempotency

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug

**What this PR does / why we need it**:
Fixes kubectl apply tasks that report changes on every run even when Kubernetes resources are already in the desired state. This breaks idempotency expectations and causes noisy change reporting. The fix adds proper `changed_when` conditions to only report changes when resources are actually created or configured.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13033

**Special notes for your reviewer**:
This implements the "Using kubectl apply status" approach suggested in the issue. All kubectl apply tasks now use `changed_when: "' created' in result.stdout or ' configured' in result.stdout"` pattern.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed kubectl apply tasks to only report changes when Kubernetes resources are actually created or configured, improving Ansible playbook idempotency.