### PR TITLE
Feat: make kube-vip BGP source configurable

### DIFF
--- a/docs/ingress/kube-vip.md
+++ b/docs/ingress/kube-vip.md
@@ -63,6 +63,8 @@ kube_vip_bgppeers:
 # kube_vip_bgp_peeraddress:
 # kube_vip_bgp_peerpass:
 # kube_vip_bgp_peeras:
+# kube_vip_bgp_sourceip:
+# kube_vip_bgp_sourceif:
 ```
 
 If using [control plane load-balancing](https://kube-vip.io/docs/about/architecture/#control-plane-load-balancing):

--- a/inventory/sample/group_vars/k8s_cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s_cluster/addons.yml
@@ -199,6 +199,8 @@ kube_vip_enabled: false
 # kube_vip_leasename: plndr-cp-lock
 # kube_vip_enable_node_labeling: false
 # kube_vip_lb_fwdmethod: local
+# kube_vip_bgp_sourceip:
+# kube_vip_bgp_sourceif:
 
 # Node Feature Discovery
 node_feature_discovery_enabled: false

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -86,6 +86,8 @@ kube_vip_leaseduration: 5
 kube_vip_renewdeadline: 3
 kube_vip_retryperiod: 1
 kube_vip_enable_node_labeling: false
+kube_vip_bgp_sourceip:
+kube_vip_bgp_sourceif:
 
 # Requests for load balancer app
 loadbalancer_apiserver_memory_requests: 32M

--- a/roles/kubernetes/node/tasks/loadbalancer/kube-vip.yml
+++ b/roles/kubernetes/node/tasks/loadbalancer/kube-vip.yml
@@ -6,6 +6,17 @@
     - kube_proxy_mode == 'ipvs' and not kube_proxy_strict_arp
     - kube_vip_arp_enabled
 
+- name: Kube-vip | Check mutually exclusive BGP source settings
+  vars:
+    kube_vip_bgp_sourceip_normalized: "{{ kube_vip_bgp_sourceip | default('', true) | string | trim }}"
+    kube_vip_bgp_sourceif_normalized: "{{ kube_vip_bgp_sourceif | default('', true) | string | trim }}"
+  assert:
+    that:
+      - kube_vip_bgp_sourceip_normalized == '' or kube_vip_bgp_sourceif_normalized == ''
+    fail_msg: "kube-vip allows only one of kube_vip_bgp_sourceip or kube_vip_bgp_sourceif."
+  when:
+    - kube_vip_bgp_enabled | default(false)
+
 - name: Kube-vip | Check if super-admin.conf exists
   stat:
     path: "{{ kube_config_dir }}/super-admin.conf"

--- a/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
@@ -85,6 +85,16 @@ spec:
       value: {{ kube_vip_bgp_peerpass | to_json }}
     - name: bgp_peeras
       value: {{ kube_vip_bgp_peeras | string | to_json }}
+{% set kube_vip_bgp_sourceip_normalized = kube_vip_bgp_sourceip | default('', true) | string | trim %}
+{% if kube_vip_bgp_sourceip_normalized %}
+    - name: bgp_sourceip
+      value: {{ kube_vip_bgp_sourceip_normalized | to_json }}
+{% endif %}
+{% set kube_vip_bgp_sourceif_normalized = kube_vip_bgp_sourceif | default('', true) | string | trim %}
+{% if kube_vip_bgp_sourceif_normalized %}
+    - name: bgp_sourceif
+      value: {{ kube_vip_bgp_sourceif_normalized | to_json }}
+{% endif %}
 {% if kube_vip_bgppeers %}
     - name: bgp_peers
       value: {{ kube_vip_bgppeers | join(',')  | to_json }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind flake

/kind feature

**What this PR does / why we need it**:
This is needed in complex setups with multiple interfaces and/or addresses where source IP selection MUST be configurable. For example, when using different IPs to avoid BGP Connection Collision on nodes running multiple BGP speakers.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12840

**Special notes for your reviewer**:
1) I added a check for situations when a user adds both variables bgp_sourceip and bgp_sourceif.
2) I added default values ('') for variables in kube-vip.manifest.j2 to avoid the AnsibleUndefinedVariable error if a user defines only one variable.
3) I checked it in my home lab with multiple interfaces on controllers and frr in BGP neighbors 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add support for kube-vip BGP source selection in Kubespray by exposing `kube_vip_bgp_sourceip` and `kube_vip_bgp_sourceif` (mutually exclusive).
```
