### PR TITLE
enable gateway api in cert-manager if gateway_api_enabled=true

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s_cluster/addons.yml
@@ -61,6 +61,8 @@ local_volume_provisioner_enabled: false
 # snapshot_controller_namespace: kube-system
 
 # Gateway API CRDs
+# deploys gateway.networking.k8s.io API group
+# and enables Gateway API in cert-manager
 gateway_api_enabled: false
 
 # ALB ingress controller deployment
@@ -102,6 +104,7 @@ cert_manager_enabled: false
 #     - "1.1.1.1"
 #     - "8.8.8.8"
 
+# To enable Gateway API in cert-manager controller, set gateway_api_enabled to true - no need extra args here
 # cert_manager_controller_extra_args:
 #   - "--dns01-recursive-nameservers-only=true"
 #   - "--dns01-recursive-nameservers=1.1.1.1:53,8.8.8.8:53"

--- a/inventory/sample/group_vars/k8s_cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s_cluster/addons.yml
@@ -104,7 +104,7 @@ cert_manager_enabled: false
 #     - "1.1.1.1"
 #     - "8.8.8.8"
 
-# To enable Gateway API in cert-manager controller, set gateway_api_enabled to true - no need extra args here
+# To enable Gateway API in the cert-manager controller (cert-manager >= 1.15), set gateway_api_enabled to true; no extra args are required.
 # cert_manager_controller_extra_args:
 #   - "--dns01-recursive-nameservers-only=true"
 #   - "--dns01-recursive-nameservers=1.1.1.1:53,8.8.8.8:53"

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
@@ -994,6 +994,9 @@ spec:
           - --v=2
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace={{ cert_manager_leader_election_namespace }}
+{% if gateway_api_enabled | default(false) %}
+          - --enable-gateway-api
+{% endif %}
 {% for extra_arg in cert_manager_controller_extra_args %}
           - {{ extra_arg }}
 {% endfor %}

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
@@ -994,7 +994,7 @@ spec:
           - --v=2
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace={{ cert_manager_leader_election_namespace }}
-{% if gateway_api_enabled %}
+{% if (gateway_api_enabled | default(false) | bool) and (cert_manager_version is version('1.15.0', '>=')) %}
           - --enable-gateway-api
 {% endif %}
 {% for extra_arg in cert_manager_controller_extra_args %}

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/templates/cert-manager.yml.j2
@@ -994,7 +994,7 @@ spec:
           - --v=2
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace={{ cert_manager_leader_election_namespace }}
-{% if gateway_api_enabled | default(false) %}
+{% if gateway_api_enabled %}
           - --enable-gateway-api
 {% endif %}
 {% for extra_arg in cert_manager_controller_extra_args %}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When using Gateway API instead of Ingress, cert-manager requires "--enable-gateway-api" flag in order to manage challenges through the Gateway API - otherwise challenges fail.

Since Gateway API feature is enabled from inventory variable `gateway_api_enabled: true`, the solution is simply to add the flag when _gateway_api_enabled_ is set to _true_.

**Which issue(s) this PR fixes**:

Fixes #12712   (partialy) 

**Special notes for your reviewer**:

Tested with simultaneously adding the same option to `cert_manager_controller_extra_args` list : 
```yaml
gateway_api_enabled: true
cert_manager_controller_extra_args:
  - "--enable-gateway-api"
```
This setting adds the line/flag twice, as expected, and it makes no difference for cert-manager-controller.
Cert-manager starts as expected with Gateway API feature enabled.

Tested with cert-manager v1.19.2 , v1.19.3 and v1.19.4 -> ok

**Does this PR introduce a user-facing change?**:
NONE

```release-note
Enable Gateway API in cert-manager when variable "gateway_api_enabled=true"
```
