### PR TITLE
feat: user namespaces with custom ID range

### DIFF
--- a/docs/CRI/containerd.md
+++ b/docs/CRI/containerd.md
@@ -53,6 +53,30 @@ containerd_registries_mirrors:
 
 The `containerd_registries` and `containerd_insecure_registries` configs are deprecated.
 
+### Optional: Pod user namespaces subid ranges
+
+Kubernetes pod user namespaces require compatible Kubernetes, containerd, OCI runtime
+(`runc`/equivalent), and Linux kernel support. Kubespray can manage the subordinate
+uid/gid ranges used for custom mappings by writing `/etc/subuid` and `/etc/subgid`.
+
+Example:
+
+```yaml
+containerd_userns_subid_enable: true
+containerd_userns_subid_user: kubelet
+containerd_userns_subid_create_local_user: true
+containerd_userns_subuid_start: 2130706432
+containerd_userns_subuid_length: 16777216
+containerd_userns_subgid_start: 2130706432
+containerd_userns_subgid_length: 16777216
+```
+
+Notes:
+
+- Set `containerd_userns_subid_create_local_user: false` if the user is managed by LDAP/SSSD.
+- Kubespray only configures the node-side subid allocation; workloads still need to request pod user namespaces.
+- Kernels without tmpfs idmap support (for example many EL9-era kernels) may prevent userns pods from mounting Secret/ConfigMap volumes.
+
 ### Containerd Runtimes
 
 Containerd supports multiple runtime configurations that can be used with

--- a/inventory/sample/group_vars/all/containerd.yml
+++ b/inventory/sample/group_vars/all/containerd.yml
@@ -59,3 +59,16 @@
 #   - registry: 10.0.0.2:5000
 #     username: user
 #     password: pass
+
+# Optional: configure subordinate uid/gid ranges for pod user namespaces
+# Requires compatible Kubernetes/containerd/runc/kernel versions.
+# On kernels without tmpfs idmap support (e.g. many EL9-era kernels), pods using
+# user namespaces may fail to mount Secret/ConfigMap volumes.
+# containerd_userns_subid_enable: true
+# containerd_userns_subid_user: kubelet
+# Set to false when the user is provided by LDAP/SSSD or otherwise already exists.
+# containerd_userns_subid_create_local_user: true
+# containerd_userns_subuid_start: 2130706432
+# containerd_userns_subuid_length: 16777216
+# containerd_userns_subgid_start: 2130706432
+# containerd_userns_subgid_length: 16777216

--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -92,6 +92,25 @@ containerd_extra_args: ''
 #     another_option: "value"
 containerd_extra_runtime_args: {}
 
+# Configure subordinate uid/gid mappings used by pod user namespaces
+# (containerd 2.x + compatible kernel/Kubernetes/runtime required).
+containerd_userns_subid_enable: false
+containerd_userns_subid_user: kubelet
+containerd_userns_subid_create_local_user: true
+containerd_userns_subid_user_shell: /sbin/nologin
+containerd_userns_subid_manage_packages: true
+containerd_userns_subid_packages:
+  Debian: uidmap
+  RedHat: shadow-utils
+  Suse: shadow
+  default: ""
+# Reserve 16M uids and gids for user namespaces (256 pods * 65536 uids/gids)
+# at the end of the uid/gid space
+containerd_userns_subuid_start: 2130706432
+containerd_userns_subuid_length: 16777216
+containerd_userns_subgid_start: 2130706432
+containerd_userns_subgid_length: 16777216
+
 # Configure registry auth (if applicable to secure/insecure registries)
 containerd_registry_auth: []
 #  - registry: 10.0.0.2:5000

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -43,6 +43,71 @@
   notify: Restart containerd
   when: http_proxy is defined or https_proxy is defined
 
+- name: Containerd | Assert version supports pod user namespaces subid setup
+  assert:
+    that:
+      - containerd_version is version('2.0.0', '>=')
+    fail_msg: >-
+      containerd_userns_subid_enable requires containerd >= 2.0.0.
+      Current configured version: {{ containerd_version }}
+  when: containerd_userns_subid_enable | bool
+
+- name: Containerd | Install subid tooling package for pod user namespaces
+  package:
+    name: "{{ containerd_userns_subid_package }}"
+    state: present
+  vars:
+    containerd_userns_subid_package: >-
+      {{
+        containerd_userns_subid_packages.get(
+          ansible_distribution,
+          containerd_userns_subid_packages.get(
+            ansible_os_family,
+            containerd_userns_subid_packages.default
+          )
+        )
+      }}
+  when:
+    - containerd_userns_subid_enable | bool
+    - containerd_userns_subid_manage_packages | bool
+    - containerd_userns_subid_package | length > 0
+
+- name: Containerd | Create local group for pod user namespaces subid owner
+  group:
+    name: "{{ containerd_userns_subid_user }}"
+    system: true
+  when:
+    - containerd_userns_subid_enable | bool
+    - containerd_userns_subid_create_local_user | bool
+
+- name: Containerd | Create local user for pod user namespaces subid owner
+  user:
+    name: "{{ containerd_userns_subid_user }}"
+    group: "{{ containerd_userns_subid_user }}"
+    shell: "{{ containerd_userns_subid_user_shell }}"
+    create_home: false
+    system: true
+  when:
+    - containerd_userns_subid_enable | bool
+    - containerd_userns_subid_create_local_user | bool
+
+- name: Containerd | Configure uid/gid ranges for pod user namespaces
+  lineinfile:
+    path: "{{ item.path }}"
+    line: "{{ item.entry }}"
+    regex: "^\\s*{{ containerd_userns_subid_user }}:"
+    create: true
+    state: present
+  loop:
+    - path: /etc/subuid
+      entry: "{{ containerd_userns_subid_user }}:{{ containerd_userns_subuid_start }}:{{ containerd_userns_subuid_length }}"
+    - path: /etc/subgid
+      entry: "{{ containerd_userns_subid_user }}:{{ containerd_userns_subgid_start }}:{{ containerd_userns_subgid_length }}"
+  loop_control:
+    label: "{{ item.path }}"
+  when:
+    - containerd_userns_subid_enable | bool
+
 - name: Containerd | Generate default base_runtime_spec
   register: ctr_oci_spec
   command: "{{ containerd_bin_dir }}/ctr oci spec"


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:

This PR adds opt-in support for managing subordinate UID/GID mappings (/etc/subuid, /etc/subgid) for Kubernetes pod user namespaces when using the containerd runtime.

It introduces new containerd role variables to:

enable/disable subid management,
configure a custom subid owner user (default kubelet),
optionally create that local user/group,
define custom subordinate UID/GID ranges.
This is needed for environments that require custom ID range control (for example LDAP/SSSD-managed nodes or reserved UID/GID ranges), and helps make pod user namespace deployments reproducible through Kubespray.

Which issue(s) this PR fixes:

Related to #12857

Special notes for your reviewer:

Default behavior is unchanged (containerd_userns_subid_enable: false).
The implementation is containerd-only and reuses the same lineinfile pattern already used by the CRI-O role for subid management.
This PR configures node-side prerequisites only; workloads still need to request pod user namespaces.
I also documented kernel/runtime limitations (e.g. older kernels without tmpfs idmap support may block Secret/ConfigMap mounts in userns pods).
Does this PR introduce a user-facing change?:

Added optional containerd configuration to manage subordinate UID/GID mappings
(`/etc/subuid` and `/etc/subgid`) for Kubernetes pod user namespaces, including
custom ID ranges and an optional local subid owner user (default `kubelet`).

This is disabled by default and intended for environments that need explicit
control of user namespace ID ranges (for example LDAP/SSSD-integrated nodes).
