### PR TITLE
Fix cilium deployments when IPsec is used (defined or not)

### DIFF
--- a/docs/CNI/cilium.md
+++ b/docs/CNI/cilium.md
@@ -287,8 +287,8 @@ cilium_encryption_enabled: true
 cilium_encryption_type: "ipsec"
 ```
 
-The third variable is `cilium_ipsec_key`. You need to create a secret key string for this variable.
-Kubespray does not automate this process.
+The third variable is `cilium_ipsec_key`. If you don't want kubespray to create a random key set it here.
+If you want kubespray to create it automatically leave `cilium_ipsec_key` empty and set `cilium_ipsec_key_algo`.
 Cilium documentation currently recommends creating a key using the following command:
 
 ```shell

--- a/roles/network_plugin/cilium/tasks/apply.yml
+++ b/roles/network_plugin/cilium/tasks/apply.yml
@@ -10,6 +10,24 @@
   set_fact:
     cilium_action: "{{ 'install' if ('release: not found' in cilium_release_info.stderr | default('') or 'release: not found' in cilium_release_info.stdout | default('')) else 'upgrade' }}"
 
+- name: Cilium | Create custom IPsec secret
+  kube:
+    name: "cilium"
+    kubectl: "{{ bin_dir }}/kubectl"
+    resource: "Secret"
+    filename: "{{ kube_config_dir }}/cilium-secret.yml"
+    state: "latest"
+  when:
+    - inventory_hostname == groups['kube_control_plane'][0]
+    - cilium_encryption_enabled | bool and cilium_encryption_type == 'ipsec' and cilium_ipsec_key is defined
+
+- name: Cilium | Create IPsec secret
+  environment: "{{ proxy_env }}"
+  command: "{{ bin_dir }}/cilium encrypt create-key --auth-algo {{ cilium_ipsec_key_algo | default('rfc4106-gcm-aes') }}"
+  when:
+    - inventory_hostname == groups['kube_control_plane'][0]
+    - cilium_encryption_enabled | bool and cilium_encryption_type == 'ipsec' and cilium_ipsec_key is not defined
+
 - name: Cilium | Install
   environment: "{{ proxy_env }}"
   command: "{{ bin_dir }}/cilium {{ cilium_action }} --version {{ cilium_version }} -f {{ kube_config_dir }}/cilium-values.yaml -f {{ kube_config_dir }}/cilium-extra-values.yaml {{ cilium_install_extra_flags }}"

--- a/roles/network_plugin/cilium/tasks/install.yml
+++ b/roles/network_plugin/cilium/tasks/install.yml
@@ -38,6 +38,15 @@
   when:
     - inventory_hostname == groups['kube_control_plane'][0]
 
+- name: Cilium | Create secret
+  template:
+    src: cilium/secret.yml.j2
+    dest: "{{ kube_config_dir }}/cilium-secret.yml"
+    mode: "0644"
+  when:
+    - inventory_hostname == groups['kube_control_plane'][0]
+    - cilium_encryption_enabled | bool and cilium_encryption_type == 'ipsec' and cilium_ipsec_key is defined
+
 - name: Cilium | Copy extra values
   copy:
     content: "{{ cilium_extra_values | to_nice_yaml(indent=2) }}"

--- a/roles/network_plugin/cilium/templates/cilium/secret.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/secret.yml.j2
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+data:
+  keys: {{ cilium_ipsec_key }}
+kind: Secret
+metadata:
+  name: cilium-ipsec-keys
+  namespace: kube-system
+type: Opaque


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Fixes cluster creation when cilium is used with IPsec as encryption method
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13054

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
Fixed fresh cluster creation regression with cilium IPsec encryption after cilium setup was migrated to cilium-cli
```release-note
Fixed fresh cluster creation with cilium IPsec encryption
```
