### PR TITLE
Test: fix crio-upgrade vm_memory not enough for testing

### DIFF
--- a/tests/files/ubuntu24-crio-upgrade.yml
+++ b/tests/files/ubuntu24-crio-upgrade.yml
@@ -2,7 +2,7 @@
 # Instance settings
 cloud_image: ubuntu-2404
 mode: all-in-one
-vm_memory: 1800
+vm_memory: 3072
 
 # Kubespray settings
 container_manager: crio


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

We move the test to hydrophone. This will need to increase memory.

**Which issue(s) this PR fixes**:

Related https://github.com/kubernetes-sigs/kubespray/pull/13058#issuecomment-3973811105

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
