### PR TITLE
Enable create_namespace option for custom_cni with helm

### DIFF
--- a/roles/network_plugin/custom_cni/meta/main.yml
+++ b/roles/network_plugin/custom_cni/meta/main.yml
@@ -14,6 +14,7 @@ dependencies:
         chart_ref: "{{ custom_cni_chart_ref }}"
         chart_version: "{{ custom_cni_chart_version }}"
         wait: true
+        create_namespace: true
         values: "{{ custom_cni_chart_values }}"
     repositories:
       - name: "{{ custom_cni_chart_repository_name }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This pull request enables the `create_namespace` option for custom CNI installation with Helm.

When installing a CNI via Helm, it is common to deploy it into a dedicated namespace. Enabling this option ensures that the namespace is created automatically if it does not already exist. This prevents the playbook from failing on newly created clusters where the target namespace is typically absent.

**Does this PR introduce a user-facing change?**:
```release-note
Enable create_namespace option for custom_cni with helm
```
