### PR TITLE
Added more verbose error messages for the case of non-supported kube …

### DIFF
--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: Download | Download files / images
   include_tasks: "{{ include_file }}"
-  loop: "{{ (downloads | default({})) | combine(kubeadm_images) | dict2items }}"
+  loop: "{{ downloads | combine(kubeadm_images) | dict2items }}"
   vars:
     download: "{{ download_defaults | combine(item.value) }}"
     include_file: "download_{% if download.container %}container{% else %}file{% endif %}.yml"


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Input validation on inventory kube_version is needed as too many users specify kube_versions not supported by the kubespray release without noticing, see (https://github.com/kubernetes-sigs/kubespray/issues/13029). Currently, specifying a kube_version not represented in the checksums in the role kubespray_defaults leads to a cryptic and rather untelling "Undefined Variable" error downstream when the variable 'file_path_cached' is assigned leaving the users unaware of the root cause.

**Which issue(s) this PR fixes**:

Fixes (https://github.com/kubernetes-sigs/kubespray/issues/13029)

**Does this PR introduce a user-facing change?**:

Improved validation for kube_version in validate_inventory role. Users will now receive a clear error message if a specified version is missing from the checksums dictionary, preventing cryptic "AnsibleUndefined" errors during the download phase.

**Perfomed Tests **

Tested that when a kube_version is specified in the inventory that is not present in the checksums the error message is thrown. When a kube_version is used that is represented, the install proceeds as normal.
