### PR TITLE
Fix Flatcar flaky CI by enabling apiserver wait after DNS handler

### DIFF
--- a/roles/kubernetes/preinstall/handlers/main.yml
+++ b/roles/kubernetes/preinstall/handlers/main.yml
@@ -2,7 +2,7 @@
 - name: Preinstall | apply resolvconf cloud-init
   command: /usr/bin/coreos-cloudinit --from-file {{ resolveconf_cloud_init_conf }}
   when: ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
-  listen: Preinstall | update resolvconf for Flatcar Container Linux by Kinvolk
+  listen: Preinstall | propagate resolvconf to k8s components
 
 - name: Preinstall | reload NetworkManager
   service:
@@ -24,7 +24,6 @@
   when: not dns_early | bool
   listen:
     - Preinstall | propagate resolvconf to k8s components
-    - Preinstall | update resolvconf for Flatcar Container Linux by Kinvolk
     - Preinstall | update resolvconf for networkmanager
 
 # FIXME(mattymo): Also restart for kubeadm mode
@@ -119,7 +118,6 @@
     - ('kube_control_plane' in group_names)
     - dns_mode != 'none'
     - resolvconf_mode == 'host_resolvconf'
-    - not ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"] and not is_fedora_coreos
   listen: Preinstall | propagate resolvconf to k8s components
 
 - name: Preinstall | Restart systemd-resolved

--- a/roles/kubernetes/preinstall/tasks/0060-resolvconf.yml
+++ b/roles/kubernetes/preinstall/tasks/0060-resolvconf.yml
@@ -53,5 +53,5 @@
     src: resolvconf.j2
     owner: root
     mode: "0644"
-  notify: Preinstall | update resolvconf for Flatcar Container Linux by Kinvolk
+  notify: Preinstall | propagate resolvconf to k8s components
   when: ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
Fix flaky `flatcar4081-calico` CI. After the handler refactor in #10542, Flatcar started running `crictl rmp` (sandbox removal) but the `wait for apiserver` handler still excluded Flatcar, leaving pods orphaned as `ContainerStatusUnknown`.

**Changes:**
- Remove the Flatcar/Fedora CoreOS exclusion from `wait for the apiserver to be running`
- Unify the Flatcar-specific notify channel into the shared `propagate resolvconf to k8s components` channel (the cloud-init handler is still guarded by `when: Flatcar`)

**Which issue(s) this PR fixes**:
Fixes #12309

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```