### PR TITLE
Add separate kubeadm_upgrade_apply_phases_skip variable

### DIFF
--- a/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
@@ -41,7 +41,7 @@
   until: kube_proxy_upload_config.rc == 0
   when:
   - inventory_hostname == first_kube_control_plane
-  - ('addon/kube-proxy' not in kubeadm_init_phases_skip)
+  - ('addon/kube-proxy' not in kubeadm_upgrade_apply_phases_skip)
 
 - name: Rewrite kubeadm managed etcd static pod manifests with updated configmap
   command: "{{ bin_dir }}/kubeadm init phase etcd local --config {{ kube_config_dir }}/kubeadm-config.yaml"

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
@@ -473,7 +473,7 @@ apply:
 {% endif %}
   imagePullPolicy: {{ k8s_image_pull_policy }}
   imagePullSerial: {{ kubeadm_image_pull_serial | lower }}
-{% for skip_phase in kubeadm_init_phases_skip %}
+{% for skip_phase in kubeadm_upgrade_apply_phases_skip %}
 {% if loop.first %}
   skipPhases:
 {% endif %}

--- a/roles/kubespray_defaults/defaults/main/main.yml
+++ b/roles/kubespray_defaults/defaults/main/main.yml
@@ -66,11 +66,28 @@ kubeadm_join_phases_skip_default: []
 kubeadm_join_phases_skip: >-
  {{ kubeadm_join_phases_skip_default }}
 
+# List of kubeadm upgrade apply phases that should be skipped when upgrading the first control plane node
+# Supports different phases than kubeadm init (e.g. mark-control-plane is not valid for upgrade)
+# Valid phases: preflight, control-plane, upload-config, kubelet-config, bootstrap-token, addon/coredns, addon/kube-proxy, post-upgrade
+kubeadm_upgrade_apply_phases_skip_default: [ "addon/coredns" ]
+kubeadm_upgrade_apply_phases_skip: >-
+  {%- if kube_network_plugin == 'kube-router' and (kube_router_run_service_proxy is defined and kube_router_run_service_proxy) -%}
+  {{ kubeadm_upgrade_apply_phases_skip_default + ["addon/kube-proxy"] }}
+  {%- elif kube_network_plugin == 'cilium' and (cilium_kube_proxy_replacement is defined and (cilium_kube_proxy_replacement == 'strict' or (cilium_kube_proxy_replacement | bool) or (cilium_kube_proxy_replacement | string | lower == 'true') )) -%}
+  {{ kubeadm_upgrade_apply_phases_skip_default + ["addon/kube-proxy"] }}
+  {%- elif kube_network_plugin == 'calico' and (calico_bpf_enabled is defined and calico_bpf_enabled) -%}
+  {{ kubeadm_upgrade_apply_phases_skip_default + ["addon/kube-proxy"] }}
+  {%- elif kube_proxy_remove is defined and kube_proxy_remove -%}
+  {{ kubeadm_upgrade_apply_phases_skip_default + ["addon/kube-proxy"] }}
+  {%- else -%}
+  {{ kubeadm_upgrade_apply_phases_skip_default }}
+  {%- endif -%}
+
 # List of kubeadm upgrade node phases that should be skipped when upgrading a secondary control plane node (supports different phases than kubeadm init and kubeadm upgrade apply)
 kubeadm_upgrade_node_phases_skip_default: []
 kubeadm_upgrade_node_phases_skip: >-
   {%- if kube_version is version('1.32.0', '>=') -%}
-  {{ kubeadm_upgrade_node_phases_skip_default + kubeadm_init_phases_skip }}
+  {{ kubeadm_upgrade_node_phases_skip_default + kubeadm_upgrade_apply_phases_skip }}
   {%- else -%}
   {{ kubeadm_upgrade_node_phases_skip_default }}
   {%- endif -%}


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

I ran into an issue where `kubeadm upgrade apply` fails with "invalid phase name" when users add init-only phases (like `mark-control-plane`) to `kubeadm_init_phases_skip_default`.

The root cause is that `kubeadm-upgrade.yml` and the upgrade section of `kubeadm-config.v1beta4.yaml.j2` reuse `kubeadm_init_phases_skip` directly. `kubeadm init` and `kubeadm upgrade apply` support different phase sets, so init-only phases passed to upgrade blow up.

I followed the existing pattern (there's already a separate `kubeadm_join_phases_skip` for join operations) and introduced `kubeadm_upgrade_apply_phases_skip` with its own `_default` list. The default skips `addon/coredns` and conditionally adds `addon/kube-proxy` based on the network plugin - same logic as before, just decoupled from init.

I also updated `kubeadm_upgrade_node_phases_skip` to reference the new variable instead of `kubeadm_init_phases_skip`, since secondary control plane upgrades should follow upgrade phases too.

Valid upgrade apply phases for reference: `preflight`, `control-plane`, `upload-config`, `kubelet-config`, `bootstrap-token`, `addon/coredns`, `addon/kube-proxy`, `post-upgrade`.

**Which issue(s) this PR fixes**:

Fixes #12818

**Special notes for your reviewer**:

This is a kinda backwards-compatible change. Users who haven't customized `kubeadm_init_phases_skip_default` will see no behavior change. Users who have customized it for init-only phases will no longer have upgrades break.

**Does this PR introduce a user-facing change?**:

```release-note
Add separate kubeadm_upgrade_apply_phases_skip variable so kubeadm init and upgrade phases can be configured independently. Previously, customizing kubeadm_init_phases_skip_default with init-only phases (e.g. mark-control-plane) would cause kubeadm upgrade to fail.
```
