### PR TITLE
Added kube_version check

### DIFF
--- a/roles/validate_inventory/tasks/main.yml
+++ b/roles/validate_inventory/tasks/main.yml
@@ -213,3 +213,13 @@
   when:
     - kube_external_ca_mode
     - not ignore_assert_errors
+
+- name: Download_file | Check if requested Kubernetes are supported
+  assert:
+    that:
+      - kube_version in kubeadm_checksums[image_arch]
+      - kube_version in kubelet_checksums[image_arch]
+      - kube_version in kubectl_checksums[image_arch]
+    msg: >-
+      Kubernetes v{{ kube_version }} is not supported for {{ image_arch }}.
+      Please check roles/kubespray_defaults/vars/main/checksums.yml for supported versions.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

Input validation on inventory kube_version is needed as too many users specify kube_versions not supported by the kubespray release without noticing, see (https://github.com/kubernetes-sigs/kubespray/issues/13029). Currently, specifying a kube_version not represented in the checksums in the role kubespray_defaults leads to a cryptic and rather untelling "Undefined Variable" error downstream when the variable 'file_path_cached' is assigned leaving the users unaware of the root cause.

**Which issue(s) this PR fixes:**

Fixes #13029


**Perfomed Tests**

Tested that when a kube_version is specified in the inventory that is not present in the checksums the error message is thrown. When a kube_version is used that is represented, the install proceeds as normal.


```release-note
Improved validation for kube_version in validate_inventory role. Users will now receive a clear error message if a specified version is missing from the checksums dictionary, preventing cryptic "AnsibleUndefined" errors during the download phase.
```
