### PR TITLE
fix: default to uncordoning nodes in post-upgrade

### DIFF
--- a/roles/upgrade/post-upgrade/tasks/main.yml
+++ b/roles/upgrade/post-upgrade/tasks/main.yml
@@ -1,4 +1,21 @@
 ---
+- name: Check if node is unschedulable (fallback)
+  command: >
+    {{ kubectl }} get node {{ kube_override_hostname | default(inventory_hostname) }}
+    -o jsonpath='{ .spec.unschedulable }'
+  register: kubectl_node_unschedulable
+  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  failed_when: false
+  changed_when: false
+  when:
+    - needs_cordoning is not defined
+
+- name: Set needs_cordoning from node state (fallback)
+  set_fact:
+    needs_cordoning: "{{ kubectl_node_unschedulable.stdout | default('') | bool }}"
+  when:
+    - needs_cordoning is not defined
+
 - name: Wait for cilium
   when:
     - needs_cordoning | default(false)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
When running the `upgrade_cluster` playbook with paused steps (`upgrade_node_confirm=true`) or `serial: 1`, the first control plane node gets stuck in a `SchedulingDisabled` state after the upgrade. 

The `Uncordon node` task in the `post-upgrade` role is skipped for the first node because the `needs_cordoning` fact (which is set natively dynamically in `pre-upgrade`) is lost by the time `post-upgrade` runs due to the 12 intermediate roles executing in between. The existing `needs_cordoning | default(false)` expression evaluates to false, causing the uncordon to be skipped.

This PR adds a defensive fallback at the top of the `post-upgrade` role: if the `needs_cordoning` fact is undefined (which only happens when lost), it explicitly queries the node's `.spec.unschedulable` state via the Kubernetes API and sets the fact accordingly. Because the fallback is guarded by `when: needs_cordoning is not defined`, there is zero behavior change for the normal execution path.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13030

**Special notes for your reviewer**:
The fallback check mirrors the exact `kubectl get node` and `delegate_to` pattern already standardly used in [pre-upgrade/tasks/main.yml]

The pre-existing `needs_cordoning | default(false)` conditions on tasks were intentionally left untouched so that standalone `post-upgrade` module runs (via `--tags`) still default to a no-op safety.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix first control plane node remaining cordoned after cluster upgrade
```
