### PR TITLE
Set fs.inotify.max_user_instances=8192 by default

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
+++ b/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
@@ -125,6 +125,27 @@
     - { name: vm.panic_on_oom, value: 0 }
   when: kubelet_protect_kernel_defaults | bool
 
+- name: Read current sysctl values
+  command: sysctl -n {{ item.key }}
+  register: sysctl_settings
+  changed_when: false
+  vars:
+    # For integer sysctls only
+    sysctl_minimum_values:
+      fs.inotify.max_user_instances: 8192
+  loop: "{{ sysctl_minimum_values | dict2items }}"
+
+- name: Increase sysctl value if lower than minimum
+  ansible.posix.sysctl:
+    sysctl_file: "{{ sysctl_file_path }}"
+    name: "{{ item.item.key }}"
+    value: "{{ item.item.value }}"
+    state: present
+    reload: true
+    ignoreerrors: "{{ sysctl_ignore_unknown_keys }}"
+  when: item.stdout | int < item.item.value
+  loop: "{{ sysctl_settings.results }}"
+
 - name: Check dummy module
   community.general.modprobe:
     name: dummy


### PR DESCRIPTION


**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Increase sysctl fs.inotify.max_user_instances by default

**Which issue(s) this PR fixes**:
Sporadic error messages like "failed to create fsnotify watcher: too many open files"

**Special notes for your reviewer**:

It seems like most k8s distributions have already increased this , typically to 8192, out of the box to ensure a robust user experience.

I checked and found that the system default limit of 128 (on Almalinux 9 anyway) was more than 50% reached, even on some small nodes in a dev cluster.
```
# for pid in /proc/[0-9]*; do
  uid=$(awk '/^Uid:/ {print $2}' "$pid/status" 2>/dev/null) || continue
  user=$(getent passwd "$uid" | cut -d: -f1)
  for fd in "$pid"/fd/*; do
    target=$(readlink "$fd" 2>/dev/null) || continue
    if [[ $target == anon_inode:inotify* ]]; then
      echo "${user:-$uid}"
    fi
  done
done | sort | uniq -c | sort -nr
     66 root
      3 almalinux
      2 polkitd
      1 dbus
```
On other large nodes in prod clusters the limit was exceeded, causing issues. These errors can be tricky to track down, because they don't show up anywhere in system logs, only sometimes when viewing pod logs, depending how you read them (e.g. with or without `-f`). In particular, when kubelet is affected (rather than the user app in the pod), the error messages are not actually present in the log file, but they are displayed when viewing the log file because of how kubelet tries to open the log file. When the limit is hit for UID 0 it most likely causes other issues with kubelet or containerd that would be difficult to pinpoint.

References:
- [kURL uses 8192 by default](https://community.replicated.com/t/how-to-fix-failed-to-create-fsnotify-watcher-error-when-running-support-bundle/1514)
- [bottlerocket uses 8192 by default](https://github.com/bottlerocket-os/bottlerocket/pull/2335)
- [kops uses 8192 by default](https://github.com/kubernetes/kops/pull/2913)
- https://github.com/derailed/k9s/issues/1399

If you follow those links there is a lot of background / supporting discussion and detail.

This may not be "kubelet expected" per se, but I"m not sure if the other parameters in this list are either, and I thought it was better than setting this in `additional_sysctls` because those could get inadvertently overwritten.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Increase fs.inotify.max_user_instances to 8192 by default
```
