### PR TITLE
[kata-containers] Update configuration to support kata 3.4.0

### DIFF
--- a/roles/container-engine/kata-containers/templates/configuration-qemu.toml.j2
+++ b/roles/container-engine/kata-containers/templates/configuration-qemu.toml.j2
@@ -678,6 +678,16 @@ experimental=[]
 # (default: false)
 # enable_pprof = true
 
+{% if kata_containers_version is version('3.4.0', '>=') %}
+# Indicates the CreateContainer request timeout needed for the workload(s)
+# It using guest_pull this includes the time to pull the image inside the guest
+# Defaults to 60 second(s)
+# Note: The effective timeout is determined by the lesser of two values: runtime-request-timeout from kubelet config
+# (https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#:~:text=runtime%2Drequest%2Dtimeout) and create_container_timeout.
+# In essence, the timeout used for guest pull=runtime-request-timeout<create_container_timeout?runtime-request-timeout:create_container_timeout.
+create_container_timeout = 60
+{% endif %}
+
 # WARNING: All the options in the following section have not been implemented yet.
 # This section was added as a placeholder. DO NOT USE IT!
 [image]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Added create_container_timeout parameter for Kata Containers. Without this parameter, the new version of Kata fails to create containers properly and encounters the error:

failed to create shim task: context deadline exceeded

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
Added create_container_timeout parameter for Kata Containers to resolve the "failed to create shim task: context deadline exceeded" error when creating containers with new Kata versions.