### PR TITLE
Use async/poll on drain tasks to prevent SSH connection timeouts

### DIFF
--- a/roles/remove_node/pre_remove/tasks/main.yml
+++ b/roles/remove_node/pre_remove/tasks/main.yml
@@ -17,6 +17,8 @@
       --grace-period {{ drain_grace_period }}
       --timeout {{ drain_timeout }}
       --delete-emptydir-data {{ kube_override_hostname }}
+  async: "{{ (drain_timeout | regex_replace('s$', '') | int) + 120 }}"
+  poll: 15
   when:
     - groups['kube_control_plane'] | length > 0
     # ignore servers that are not nodes

--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -59,6 +59,8 @@
         --timeout {{ drain_timeout }}
         --delete-emptydir-data {{ kube_override_hostname | default(inventory_hostname) }}
         {% if drain_pod_selector %}--pod-selector '{{ drain_pod_selector }}'{% endif %}
+      async: "{{ (drain_timeout | regex_replace('s$', '') | int) + 120 }}"
+      poll: 15
       when: drain_nodes
       register: result
       failed_when:
@@ -82,6 +84,8 @@
         --delete-emptydir-data {{ kube_override_hostname | default(inventory_hostname) }}
         {% if drain_pod_selector %}--pod-selector '{{ drain_pod_selector }}'{% endif %}
         --disable-eviction
+      async: "{{ (drain_fallback_timeout | regex_replace('s$', '') | int) + 120 }}"
+      poll: 15
       register: drain_fallback_result
       until: drain_fallback_result.rc == 0
       retries: "{{ drain_fallback_retries }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The drain tasks in upgrade and remove-node hold a single SSH connection open for the entire drain duration. When drain_timeout (default 360s) exceeds the Ansible SSH timeout, or when a bastion/firewall kills the long-lived connection, the task fails with UNREACHABLE.

This PR adds async/poll to all three drain tasks so the command runs in the background and Ansible polls with short independent SSH connections instead.


**Which issue(s) this PR fixes**:

Fixes #12297

**Special notes for your reviewer**:

The async ceiling is set to drain_timeout + 120s to ensure Ansible never kills the async job before kubectl's own timeout fires also no new variables introduced. No behavior change for the drain logic itself, same retries, same failure modes, same fallback. The only difference is the SSH connection.


**Does this PR introduce a user-facing change?**:

```release-note
Fix drain tasks failing with UNREACHABLE when drain_timeout exceeds the Ansible SSH connection timeout by using async/poll.
```
