### PR TITLE
Deduplicate kubeadm extraArgs by building merged dicts in task layer

### DIFF
--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
@@ -58,27 +58,19 @@ etcd:
     imageTag: "{{ etcd_image_tag }}"
     dataDir: "{{ etcd_data_dir }}"
     extraArgs:
-    - name: metrics
-      value: {{ etcd_metrics }}
-    - name: election-timeout
-      value: "{{ etcd_election_timeout }}"
-    - name: heartbeat-interval
-      value: "{{ etcd_heartbeat_interval }}"
-    - name: auto-compaction-retention
-      value: "{{ etcd_compaction_retention }}"
-{% if etcd_listen_metrics_urls is defined %}
-    - name: listen-metrics-urls
-      value: "{{ etcd_listen_metrics_urls }}"
-{% endif %}
-    - name: snapshot-count
-      value: "{{ etcd_snapshot_count }}"
-    - name: quota-backend-bytes
-      value: "{{ etcd_quota_backend_bytes }}"
-    - name: max-request-bytes
-      value: "{{ etcd_max_request_bytes }}"
-    - name: log-level
-      value: "{{ etcd_log_level }}"
-{% for key, value in etcd_extra_vars.items() %}
+{% set _kubeadm_etcd_extra_args = {
+      'metrics': etcd_metrics,
+      'election-timeout': etcd_election_timeout | string,
+      'heartbeat-interval': etcd_heartbeat_interval | string,
+      'auto-compaction-retention': etcd_compaction_retention | string,
+      'snapshot-count': etcd_snapshot_count | string,
+      'quota-backend-bytes': etcd_quota_backend_bytes | string,
+      'max-request-bytes': etcd_max_request_bytes | string,
+      'log-level': etcd_log_level}
+      | combine({'listen-metrics-urls': etcd_listen_metrics_urls}
+        if etcd_listen_metrics_urls is defined else {})
+      | combine(etcd_extra_vars) %}
+{% for key, value in _kubeadm_etcd_extra_args.items() %}
     - name: {{ key }}
       value: "{{ value }}"
 {% endfor %}
@@ -125,160 +117,87 @@ certificatesDir: {{ kube_cert_dir }}
 imageRepository: {{ kubeadm_image_repo }}
 apiServer:
   extraArgs:
-  - name: etcd-compaction-interval
-    value: "{{ kube_apiserver_etcd_compaction_interval }}"
-  - name: default-not-ready-toleration-seconds
-    value: "{{ kube_apiserver_pod_eviction_not_ready_timeout_seconds }}"
-  - name: default-unreachable-toleration-seconds
-    value: "{{ kube_apiserver_pod_eviction_unreachable_timeout_seconds }}"
-{% if kube_api_anonymous_auth is defined %}
-{# TODO: rework once suppport for structured auth lands #}
-  - name: anonymous-auth
-    value: "{{ kube_api_anonymous_auth }}"
-{% endif %}
-{% if kube_apiserver_use_authorization_config_file %}
-  - name: authorization-config
-    value: "{{ kube_config_dir }}/apiserver-authorization-config-{{ kube_apiserver_authorization_config_api_version }}.yaml"
-{% else %}
-  - name: authorization-mode
-    value: "{{ authorization_modes | join(',') }}"
-{% endif %}
-  - name: bind-address
-    value: "{{ kube_apiserver_bind_address }}"
-{% if kube_apiserver_enable_admission_plugins | length > 0 %}
-  - name: enable-admission-plugins
-    value: "{{ kube_apiserver_enable_admission_plugins | join(',') }}"
-{% endif %}
-{% if kube_apiserver_admission_control_config_file %}
-  - name: admission-control-config-file
-    value: "{{ kube_config_dir }}/admission-controls.yaml"
-{% endif %}
-{% if kube_apiserver_disable_admission_plugins | length > 0 %}
-  - name: disable-admission-plugins
-    value: "{{ kube_apiserver_disable_admission_plugins | join(',') }}"
-{% endif %}
-  - name: apiserver-count
-    value: "{{ kube_apiserver_count }}"
-  - name: endpoint-reconciler-type
-    value: lease
-{% if etcd_events_cluster_enabled %}
-  - name: etcd-servers-overrides
-    value: "/events#{{ etcd_events_access_addresses_semicolon }}"
-{% endif %}
-  - name: service-node-port-range
-    value: "{{ kube_apiserver_node_port_range }}"
-  - name: service-cluster-ip-range
-    value: "{{ kube_service_subnets }}"
-  - name: kubelet-preferred-address-types
-    value: "{{ kubelet_preferred_address_types }}"
-  - name: profiling
-    value: "{{ kube_profiling }}"
-  - name: request-timeout
-    value: "{{ kube_apiserver_request_timeout }}"
-  - name: enable-aggregator-routing
-    value: "{{ kube_api_aggregator_routing }}"
-{% if kube_apiserver_service_account_lookup %}
-  - name: service-account-lookup
-    value: "{{ kube_apiserver_service_account_lookup }}"
-{% endif %}
-{% if kube_oidc_auth and kube_oidc_url is defined and kube_oidc_client_id is defined %}
-  - name: oidc-issuer-url
-    value: "{{ kube_oidc_url }}"
-  - name: oidc-client-id
-    value: "{{ kube_oidc_client_id }}"
-{%   if kube_oidc_ca_file is defined %}
-  - name: oidc-ca-file
-    value: "{{ kube_oidc_ca_file }}"
-{%   endif %}
-{%   if kube_oidc_username_claim is defined %}
-  - name: oidc-username-claim
-    value: "{{ kube_oidc_username_claim }}"
-{%   endif %}
-{%   if kube_oidc_groups_claim is defined %}
-  - name: oidc-groups-claim
-    value: "{{ kube_oidc_groups_claim }}"
-{%   endif %}
-{%   if kube_oidc_username_prefix is defined %}
-  - name: oidc-username-prefix
-    value: "{{ kube_oidc_username_prefix }}"
-{%   endif %}
-{%   if kube_oidc_groups_prefix is defined %}
-  - name: oidc-groups-prefix
-    value: "{{ kube_oidc_groups_prefix }}"
-{%   endif %}
-{% endif %}
-{% if kube_webhook_token_auth %}
-  - name: authentication-token-webhook-config-file
-    value: "{{ kube_config_dir }}/webhook-token-auth-config.yaml"
-{% endif %}
-{% if kube_webhook_authorization and not kube_apiserver_use_authorization_config_file %}
-  - name: authorization-webhook-config-file
-    value: "{{ kube_config_dir }}/webhook-authorization-config.yaml"
-{% endif %}
-{% if kube_encrypt_secret_data %}
-  - name: encryption-provider-config
-    value: "{{ kube_cert_dir }}/secrets_encryption.yaml"
-{% endif %}
-  - name: storage-backend
-    value: "{{ kube_apiserver_storage_backend }}"
-{% if kube_api_runtime_config | length > 0 %}
-  - name: runtime-config
-    value: "{{ kube_api_runtime_config | join(',') }}"
-{% endif %}
-  - name: allow-privileged
-    value: "true"
-{% if kubernetes_audit or kubernetes_audit_webhook %}
-  - name: audit-policy-file
-    value: "{{ audit_policy_file }}"
-{% endif %}
-{% if kubernetes_audit %}
-  - name: audit-log-path
-    value: "{{ audit_log_path }}"
-  - name: audit-log-maxage
-    value: "{{ audit_log_maxage }}"
-  - name: audit-log-maxbackup
-    value: "{{ audit_log_maxbackups }}"
-  - name: audit-log-maxsize
-    value: "{{ audit_log_maxsize }}"
-{% endif %}
-{% if kubernetes_audit_webhook %}
-  - name: audit-webhook-config-file
-    value: "{{ audit_webhook_config_file }}"
-  - name: audit-webhook-mode
-    value: "{{ audit_webhook_mode }}"
-{% if audit_webhook_mode == "batch" %}
-  - name: audit-webhook-batch-max-size
-    value: "{{ audit_webhook_batch_max_size }}"
-  - name: audit-webhook-batch-max-wait
-    value: "{{ audit_webhook_batch_max_wait }}"
-{% endif %}
-{% endif %}
-{% for key in kube_kubeadm_apiserver_extra_args %}
-  - name: "{{ key }}"
-    value: "{{ kube_kubeadm_apiserver_extra_args[key] }}"
+{% set _kubeadm_apiserver_extra_args = {
+    'etcd-compaction-interval': kube_apiserver_etcd_compaction_interval,
+    'default-not-ready-toleration-seconds': kube_apiserver_pod_eviction_not_ready_timeout_seconds | string,
+    'default-unreachable-toleration-seconds': kube_apiserver_pod_eviction_unreachable_timeout_seconds | string,
+    'bind-address': kube_apiserver_bind_address,
+    'apiserver-count': kube_apiserver_count | string,
+    'endpoint-reconciler-type': 'lease',
+    'service-node-port-range': kube_apiserver_node_port_range,
+    'service-cluster-ip-range': kube_service_subnets,
+    'kubelet-preferred-address-types': kubelet_preferred_address_types,
+    'profiling': kube_profiling | string,
+    'request-timeout': kube_apiserver_request_timeout,
+    'enable-aggregator-routing': kube_api_aggregator_routing | string,
+    'storage-backend': kube_apiserver_storage_backend,
+    'allow-privileged': 'true',
+    'event-ttl': event_ttl_duration}
+    | combine({'anonymous-auth': kube_api_anonymous_auth | string}
+      if kube_api_anonymous_auth is defined else {})
+    | combine({'authorization-config': kube_config_dir ~ '/apiserver-authorization-config-' ~ kube_apiserver_authorization_config_api_version ~ '.yaml'}
+      if kube_apiserver_use_authorization_config_file
+      else {'authorization-mode': authorization_modes | join(',')})
+    | combine({'enable-admission-plugins': kube_apiserver_enable_admission_plugins | join(',')}
+      if kube_apiserver_enable_admission_plugins | length > 0 else {})
+    | combine({'admission-control-config-file': kube_config_dir ~ '/admission-controls.yaml'}
+      if kube_apiserver_admission_control_config_file else {})
+    | combine({'disable-admission-plugins': kube_apiserver_disable_admission_plugins | join(',')}
+      if kube_apiserver_disable_admission_plugins | length > 0 else {})
+    | combine({'etcd-servers-overrides': '/events#' ~ etcd_events_access_addresses_semicolon}
+      if etcd_events_cluster_enabled else {})
+    | combine({'token-auth-file': kube_token_dir ~ '/known_tokens.csv'}
+      if kube_token_auth else {})
+    | combine({'service-account-lookup': kube_apiserver_service_account_lookup | string}
+      if kube_apiserver_service_account_lookup else {})
+    | combine({'oidc-issuer-url': kube_oidc_url, 'oidc-client-id': kube_oidc_client_id}
+      if (kube_oidc_auth and kube_oidc_url is defined and kube_oidc_client_id is defined) else {})
+    | combine({'oidc-ca-file': kube_oidc_ca_file}
+      if (kube_oidc_auth and kube_oidc_url is defined and kube_oidc_client_id is defined and kube_oidc_ca_file is defined) else {})
+    | combine({'oidc-username-claim': kube_oidc_username_claim}
+      if (kube_oidc_auth and kube_oidc_url is defined and kube_oidc_client_id is defined and kube_oidc_username_claim is defined) else {})
+    | combine({'oidc-groups-claim': kube_oidc_groups_claim}
+      if (kube_oidc_auth and kube_oidc_url is defined and kube_oidc_client_id is defined and kube_oidc_groups_claim is defined) else {})
+    | combine({'oidc-username-prefix': kube_oidc_username_prefix}
+      if (kube_oidc_auth and kube_oidc_url is defined and kube_oidc_client_id is defined and kube_oidc_username_prefix is defined) else {})
+    | combine({'oidc-groups-prefix': kube_oidc_groups_prefix}
+      if (kube_oidc_auth and kube_oidc_url is defined and kube_oidc_client_id is defined and kube_oidc_groups_prefix is defined) else {})
+    | combine({'authentication-token-webhook-config-file': kube_config_dir ~ '/webhook-token-auth-config.yaml'}
+      if kube_webhook_token_auth else {})
+    | combine({'authorization-webhook-config-file': kube_config_dir ~ '/webhook-authorization-config.yaml'}
+      if (kube_webhook_authorization and not kube_apiserver_use_authorization_config_file) else {})
+    | combine({'encryption-provider-config': kube_cert_dir ~ '/secrets_encryption.yaml'}
+      if kube_encrypt_secret_data else {})
+    | combine({'runtime-config': kube_api_runtime_config | join(',')}
+      if kube_api_runtime_config | length > 0 else {})
+    | combine({'audit-policy-file': audit_policy_file}
+      if (kubernetes_audit or kubernetes_audit_webhook) else {})
+    | combine({'audit-log-path': audit_log_path,
+               'audit-log-maxage': audit_log_maxage | string,
+               'audit-log-maxbackup': audit_log_maxbackups | string,
+               'audit-log-maxsize': audit_log_maxsize | string}
+      if kubernetes_audit else {})
+    | combine({'audit-webhook-config-file': audit_webhook_config_file,
+               'audit-webhook-mode': audit_webhook_mode}
+      if kubernetes_audit_webhook else {})
+    | combine({'audit-webhook-batch-max-size': audit_webhook_batch_max_size | string,
+               'audit-webhook-batch-max-wait': audit_webhook_batch_max_wait | string}
+      if (kubernetes_audit_webhook and audit_webhook_mode == 'batch') else {})
+    | combine({'feature-gates': (kube_apiserver_feature_gates | default(kube_feature_gates, true)) | join(',')}
+      if (kube_apiserver_feature_gates | default([]) or kube_feature_gates | default([])) else {})
+    | combine({'tls-min-version': tls_min_version}
+      if tls_min_version is defined else {})
+    | combine({'tls-cipher-suites': tls_cipher_suites | join(',')}
+      if tls_cipher_suites is defined else {})
+    | combine({'kubelet-certificate-authority': kube_cert_dir ~ '/ca.crt'}
+      if kubelet_rotate_server_certificates else {})
+    | combine({'tracing-config-file': kube_config_dir ~ '/tracing/apiserver-tracing.yaml'}
+      if kube_apiserver_tracing else {})
+    | combine(kube_kubeadm_apiserver_extra_args) %}
+{% for key, value in _kubeadm_apiserver_extra_args.items() %}
+  - name: {{ key }}
+    value: "{{ value }}"
 {% endfor %}
-{% if kube_apiserver_feature_gates or kube_feature_gates %}
-  - name: feature-gates
-    value: "{{ kube_apiserver_feature_gates | default(kube_feature_gates, true) | join(',') }}"
-{% endif %}
-{% if tls_min_version is defined %}
-  - name: tls-min-version
-    value: "{{ tls_min_version }}"
-{% endif %}
-{% if tls_cipher_suites is defined %}
-  - name: tls-cipher-suites
-    value: "{% for tls in tls_cipher_suites %}{{ tls }}{{ ',' if not loop.last else '' }}{% endfor %}"
-{% endif %}
-  - name: event-ttl
-    value: "{{ event_ttl_duration }}"
-{% if kubelet_rotate_server_certificates %}
-  - name: kubelet-certificate-authority
-    value: "{{ kube_cert_dir }}/ca.crt"
-{% endif %}
-{% if kube_apiserver_tracing %}
-  - name: tracing-config-file
-    value: "{{ kube_config_dir }}/tracing/apiserver-tracing.yaml"
-{% endif %}
 {% if kubernetes_audit or kube_token_auth or kube_webhook_token_auth or apiserver_extra_volumes or ssl_ca_dirs | length %}
   extraVolumes:
 {% if kube_token_auth %}
@@ -347,63 +266,38 @@ apiServer:
 {% endfor %}
 controllerManager:
   extraArgs:
-  - name: node-monitor-grace-period
-    value: "{{ kube_controller_node_monitor_grace_period }}"
-  - name: node-monitor-period
-    value: "{{ kube_controller_node_monitor_period }}"
-{% if kube_network_plugin is defined and kube_network_plugin not in ["kube-ovn"] %}
-  - name: cluster-cidr
-    value: "{{ kube_pods_subnets }}"
-{% endif %}
-  - name: service-cluster-ip-range
-    value: "{{ kube_service_subnets }}"
-{% if kube_network_plugin is defined and kube_network_plugin == "calico" and not calico_ipam_host_local %}
-  - name: allocate-node-cidrs
-    value: "false"
-{% else %}
-{% if ipv4_stack %}
-  - name: node-cidr-mask-size-ipv4
-    value: "{{ kube_network_node_prefix }}"
-{% endif %}
-{% if ipv6_stack %}
-  - name: node-cidr-mask-size-ipv6
-    value: "{{ kube_network_node_prefix_ipv6 }}"
-{% endif %}
-{% endif %}
-  - name: profiling
-    value: "{{ kube_profiling }}"
-  - name: terminated-pod-gc-threshold
-    value: "{{ kube_controller_terminated_pod_gc_threshold }}"
-  - name: bind-address
-    value: "{{ kube_controller_manager_bind_address }}"
-  - name: leader-elect-lease-duration
-    value: "{{ kube_controller_manager_leader_elect_lease_duration }}"
-  - name: leader-elect-renew-deadline
-    value: "{{ kube_controller_manager_leader_elect_renew_deadline }}"
-{% if kube_controller_feature_gates or kube_feature_gates %}
-  - name: feature-gates
-    value: "{{ kube_controller_feature_gates | default(kube_feature_gates, true) | join(',') }}"
-{% endif %}
-{% for key in kube_kubeadm_controller_extra_args %}
-  - name: "{{ key }}"
-    value: "{{ kube_kubeadm_controller_extra_args[key] }}"
+{% set _kubeadm_controller_extra_args = {
+    'node-monitor-grace-period': kube_controller_node_monitor_grace_period,
+    'node-monitor-period': kube_controller_node_monitor_period,
+    'service-cluster-ip-range': kube_service_subnets,
+    'profiling': kube_profiling | string,
+    'terminated-pod-gc-threshold': kube_controller_terminated_pod_gc_threshold | string,
+    'bind-address': kube_controller_manager_bind_address,
+    'leader-elect-lease-duration': kube_controller_manager_leader_elect_lease_duration,
+    'leader-elect-renew-deadline': kube_controller_manager_leader_elect_renew_deadline}
+    | combine({'cluster-cidr': kube_pods_subnets}
+      if (kube_network_plugin is defined and kube_network_plugin not in ["kube-ovn"]) else {})
+    | combine({'allocate-node-cidrs': 'false'}
+      if (kube_network_plugin is defined and kube_network_plugin == "calico" and not calico_ipam_host_local) else {})
+    | combine({'node-cidr-mask-size-ipv4': kube_network_node_prefix | string}
+      if (not (kube_network_plugin is defined and kube_network_plugin == "calico" and not calico_ipam_host_local) and ipv4_stack | default(false)) else {})
+    | combine({'node-cidr-mask-size-ipv6': kube_network_node_prefix_ipv6 | string}
+      if (not (kube_network_plugin is defined and kube_network_plugin == "calico" and not calico_ipam_host_local) and ipv6_stack | default(false)) else {})
+    | combine({'feature-gates': (kube_controller_feature_gates | default(kube_feature_gates, true)) | join(',')}
+      if (kube_controller_feature_gates | default([]) or kube_feature_gates | default([])) else {})
+    | combine({'configure-cloud-routes': 'false'}
+      if (kube_network_plugin is defined and kube_network_plugin not in ["cloud"]) else {})
+    | combine({'flex-volume-plugin-dir': kubelet_flexvolumes_plugins_dir}
+      if kubelet_flexvolumes_plugins_dir is defined else {})
+    | combine({'tls-min-version': tls_min_version}
+      if tls_min_version is defined else {})
+    | combine({'tls-cipher-suites': tls_cipher_suites | join(',')}
+      if tls_cipher_suites is defined else {})
+    | combine(kube_kubeadm_controller_extra_args) %}
+{% for key, value in _kubeadm_controller_extra_args.items() %}
+  - name: {{ key }}
+    value: "{{ value }}"
 {% endfor %}
-{% if kube_network_plugin is defined and kube_network_plugin not in ["cloud"] %}
-  - name: configure-cloud-routes
-    value: "false"
-{% endif %}
-{% if kubelet_flexvolumes_plugins_dir is defined %}
-  - name: flex-volume-plugin-dir
-    value: "{{ kubelet_flexvolumes_plugins_dir }}"
-{% endif %}
-{% if tls_min_version is defined %}
-  - name: tls-min-version
-    value: "{{ tls_min_version }}"
-{% endif %}
-{% if tls_cipher_suites is defined %}
-  - name: tls-cipher-suites
-    value: "{% for tls in tls_cipher_suites %}{{ tls }}{{ ',' if not loop.last else '' }}{% endfor %}"
-{% endif %}
 {% if controller_manager_extra_volumes %}
   extraVolumes:
 {% for volume in controller_manager_extra_volumes %}
@@ -415,30 +309,21 @@ controllerManager:
 {% endif %}
 scheduler:
   extraArgs:
-  - name: bind-address
-    value: "{{ kube_scheduler_bind_address }}"
-  - name: config
-    value: "{{ kube_config_dir }}/kubescheduler-config.yaml"
-{% if kube_scheduler_feature_gates or kube_feature_gates %}
-  - name: feature-gates
-    value: "{{ kube_scheduler_feature_gates | default(kube_feature_gates, true) | join(',') }}"
-{% endif %}
-  - name: profiling
-    value: "{{ kube_profiling }}"
-{% if kube_kubeadm_scheduler_extra_args | length > 0 %}
-{% for key in kube_kubeadm_scheduler_extra_args %}
-  - name: "{{ key }}"
-    value: "{{ kube_kubeadm_scheduler_extra_args[key] }}"
+{% set _kubeadm_scheduler_extra_args = {
+    'bind-address': kube_scheduler_bind_address,
+    'config': kube_config_dir ~ '/kubescheduler-config.yaml',
+    'profiling': kube_profiling | string}
+    | combine({'feature-gates': (kube_scheduler_feature_gates | default(kube_feature_gates, true)) | join(',')}
+      if (kube_scheduler_feature_gates | default([]) or kube_feature_gates | default([])) else {})
+    | combine({'tls-min-version': tls_min_version}
+      if tls_min_version is defined else {})
+    | combine({'tls-cipher-suites': tls_cipher_suites | join(',')}
+      if tls_cipher_suites is defined else {})
+    | combine(kube_kubeadm_scheduler_extra_args) %}
+{% for key, value in _kubeadm_scheduler_extra_args.items() %}
+  - name: {{ key }}
+    value: "{{ value }}"
 {% endfor %}
-{% endif %}
-{% if tls_min_version is defined %}
-  - name: tls-min-version
-    value: "{{ tls_min_version }}"
-{% endif %}
-{% if tls_cipher_suites is defined %}
-  - name: tls-cipher-suites
-    value: "{% for tls in tls_cipher_suites %}{{ tls }}{{ ',' if not loop.last else '' }}{% endfor %}"
-{% endif %}
   extraVolumes:
   - name: kubescheduler-config
     hostPath: {{ kube_config_dir }}/kubescheduler-config.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

When users set `kube_kubeadm_*_extra_args` with keys that overlap kubespray's hardcoded defaults (e.g. `default-not-ready-toleration-seconds`, `node-monitor-grace-period`), both the default and user values are rendered into the kubeadm config. kubeadm sorts extraArgs alphabetically, so the default value can silently win over the user's intended override.

This PR moves extraArgs construction from the Jinja2 templates into a dedicated file (`kubeadm-args.yml`) that uses `set_fact` with chained `combine()` calls. User-provided `kube_kubeadm_*_extra_args` are merged last, so they override defaults on key conflict. The templates then just iterate the pre-built dict - duplicates are structurally impossible.

This follows VannTen's suggested approach from #12021 and mirrors the existing `kubelet_config_extra_args | combine(...)` pattern in `roles/kubernetes/node/tasks/facts.yml`.

Affected components: apiserver, controller-manager, scheduler, etcd (both v1beta3 and v1beta4 templates).

**Which issue(s) this PR fixes**:

Fixes #12021

**Special notes for your reviewer**:

- The `kubeadm-args.yml` file is a new task file included from `kubeadm-setup.yml`. 
   **Open question**: should this logic live in its own file or be inlined into `kubeadm-setup.yml`? Feedback welcome.
- All values are now consistently quoted in rendered output. Some v1beta3 values were previously unquoted 

**Does this PR introduce a user-facing change?**:

```release-note
Fix duplicate extraArgs in kubeadm config when kube_kubeadm_*_extra_args overlap with default args. User-provided values now correctly override defaults.
```
