### PR TITLE
fix: use nodelocaldns_ip with ipv6 address

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2
@@ -45,7 +45,7 @@ data:
             force_tcp
         }
         prometheus {% if nodelocaldns_bind_metrics_host_ip %}{$MY_HOST_IP}{% endif %}:{{ nodelocaldns_prometheus_port }}
-        health {{ nodelocaldns_ip }}:{{ nodelocaldns_health_port }}
+        health {{ nodelocaldns_ip | ansible.utils.ipwrap }}:{{ nodelocaldns_health_port }}
 {% if dns_etchosts | default(None) %}
         hosts /etc/coredns/hosts {
           fallthrough
@@ -132,7 +132,7 @@ data:
             force_tcp
         }
         prometheus {% if nodelocaldns_bind_metrics_host_ip %}{$MY_HOST_IP}{% endif %}:{{ nodelocaldns_secondary_prometheus_port }}
-        health {{ nodelocaldns_ip }}:{{ nodelocaldns_second_health_port }}
+        health {{ nodelocaldns_ip | ansible.utils.ipwrap }}:{{ nodelocaldns_second_health_port }}
 {% if dns_etchosts | default(None) %}
         hosts /etc/coredns/hosts {
           fallthrough


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

In an ipv6-only cluster, nodelocaldns_ip must be changed to an ipv6 address. This PR fix the nodelocaldns container to launch error:

```
2026/02/25 11:04:26 [INFO] Starting node-cache image: 1.25.0
2026/02/25 11:04:26 [INFO] Using Corefile /etc/coredns/Corefile
2026/02/25 11:04:26 [INFO] Using Pidfile
2026/02/25 11:04:26 [ERROR] Failed to read node-cache coreFile /etc/coredns/Corefile.base - open /etc/coredns/Corefile.base: no such file or directory
2026/02/25 11:04:26 [INFO] Skipping kube-dns configmap sync as no directory was specified
plugin/health: address fd00:1:2:3::10:9254: too many colons in address
```

**Which issue(s) this PR fixes**:
Fixes #13078

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
"NONE"
```
