### PR TITLE
fix kubectl server-side apply and prevent conflicts when server_side_apply=true

### DIFF
--- a/plugins/modules/kube.py
+++ b/plugins/modules/kube.py
@@ -88,6 +88,12 @@ options:
       - Process the directory used in -f, --filename recursively.
         Useful when you want to manage related manifests organized
         within the same directory.
+  server_side_apply:
+    required: false
+    default: false
+    description:
+      - Use server-side apply instead of client-side apply (implies --force-conflicts).
+        Required for resources whose manifests exceed the annotation size limit.
 requirements:
   - kubectl
 author: "Kenny Jones (@kenjones-cisco)"
@@ -149,6 +155,7 @@ class KubeManager(object):
         self.resource = module.params.get('resource')
         self.label = module.params.get('label')
         self.recursive = module.params.get('recursive')
+        self.server_side_apply = module.params.get('server_side_apply')
 
     def _execute(self, cmd):
         args = self.base_cmd + cmd
@@ -175,7 +182,9 @@ class KubeManager(object):
 
         cmd = ['apply']
 
-        if force:
+        if self.server_side_apply:
+            cmd.extend(['--server-side', '--force-conflicts'])
+        elif force:
             cmd.append('--force')
 
         if self.wait:
@@ -195,7 +204,9 @@ class KubeManager(object):
 
         cmd = ['apply']
 
-        if force:
+        if self.server_side_apply:
+            cmd.extend(['--server-side', '--force-conflicts'])
+        elif force:
             cmd.append('--force')
 
         if self.wait:
@@ -325,6 +336,7 @@ def main():
             log_level=dict(default=0, type='int'),
             state=dict(default='present', choices=['present', 'absent', 'latest', 'reloaded', 'stopped', 'exists']),
             recursive=dict(default=False, type='bool'),
+            server_side_apply=dict(default=False, type='bool'),
             ),
             mutually_exclusive=[['filename', 'list']]
         )

--- a/plugins/modules/kube.py
+++ b/plugins/modules/kube.py
@@ -177,7 +177,7 @@ class KubeManager(object):
             return None
         return out.splitlines()
 
-    def create(self, check=True, force=True):
+    def create(self, check=True):
         if check and self.exists():
             return []
 
@@ -211,7 +211,7 @@ class KubeManager(object):
         if self.server_side_apply:
             cmd.append('--server-side')
 
-        if force:
+        if self.force:
             cmd.append('--force')
             if self.server_side_apply:
                 cmd.append('--force-conflicts')

--- a/plugins/modules/kube.py
+++ b/plugins/modules/kube.py
@@ -92,7 +92,8 @@ options:
     required: false
     default: false
     description:
-      - Use server-side apply instead of client-side apply (implies --force-conflicts).
+      - Use server-side apply instead of client-side apply.
+        When combined with force, uses --force-conflicts instead of --force.
         Required for resources whose manifests exceed the annotation size limit.
 requirements:
   - kubectl
@@ -183,9 +184,12 @@ class KubeManager(object):
         cmd = ['apply']
 
         if self.server_side_apply:
-            cmd.extend(['--server-side', '--force-conflicts'])
-        elif force:
+            cmd.append('--server-side')
+
+        if force:
             cmd.append('--force')
+            if self.server_side_apply:
+                cmd.append('--force-conflicts')
 
         if self.wait:
             cmd.append('--wait')
@@ -205,9 +209,12 @@ class KubeManager(object):
         cmd = ['apply']
 
         if self.server_side_apply:
-            cmd.extend(['--server-side', '--force-conflicts'])
-        elif force:
+            cmd.append('--server-side')
+
+        if force:
             cmd.append('--force')
+            if self.server_side_apply:
+                cmd.append('--force-conflicts')
 
         if self.wait:
             cmd.append('--wait')

--- a/plugins/modules/kube.py
+++ b/plugins/modules/kube.py
@@ -186,7 +186,7 @@ class KubeManager(object):
         if self.server_side_apply:
             cmd.append('--server-side')
 
-        if force:
+        if self.force:
             cmd.append('--force')
             if self.server_side_apply:
                 cmd.append('--force-conflicts')

--- a/plugins/modules/kube.py
+++ b/plugins/modules/kube.py
@@ -204,7 +204,7 @@ class KubeManager(object):
 
         return self._execute(cmd)
 
-    def replace(self, force=True):
+    def replace(self):
 
         cmd = ['apply']
 

--- a/plugins/modules/kube.py
+++ b/plugins/modules/kube.py
@@ -88,6 +88,12 @@ options:
       - Process the directory used in -f, --filename recursively.
         Useful when you want to manage related manifests organized
         within the same directory.
+  server_side_apply:
+    required: false
+    default: false
+    description:
+      - Use server-side apply instead of client-side apply (implies --force-conflicts).
+        Required for resources whose manifests exceed the annotation size limit.
 requirements:
   - kubectl
 author: "Kenny Jones (@kenjones-cisco)"
@@ -149,6 +155,7 @@ class KubeManager(object):
         self.resource = module.params.get('resource')
         self.label = module.params.get('label')
         self.recursive = module.params.get('recursive')
+        self.server_side_apply = module.params.get('server_side_apply')
 
     def _execute(self, cmd):
         args = self.base_cmd + cmd
@@ -175,7 +182,9 @@ class KubeManager(object):
 
         cmd = ['apply']
 
-        if force:
+        if self.server_side_apply:
+            cmd.extend(['--server-side', '--force-conflicts'])
+        elif force:
             cmd.append('--force')
 
         if self.wait:
@@ -195,7 +204,9 @@ class KubeManager(object):
 
         cmd = ['apply']
 
-        if force:
+        if self.server_side_apply:
+            cmd.extend(['--server-side', '--force-conflicts'])
+        elif force:
             cmd.append('--force')
 
         if self.wait:
@@ -325,6 +336,7 @@ def main():
             log_level=dict(default=0, type='int'),
             state=dict(default='present', choices=['present', 'absent', 'latest', 'reloaded', 'stopped', 'exists']),
             recursive=dict(default=False, type='bool'),
+            server_side_apply=dict(default=False, type='bool'),
         ),
     )
 

--- a/roles/kubernetes-apps/common_crds/gateway_api/tasks/main.yml
+++ b/roles/kubernetes-apps/common_crds/gateway_api/tasks/main.yml
@@ -29,6 +29,7 @@
     kubectl: "{{ bin_dir }}/kubectl"
     filename: "{{ kube_config_dir }}/addons/gateway_api/{{ gateway_api_channel }}-install.yaml"
     state: latest
+    force: true
     server_side_apply: "{{ server_side_apply | default(false) }}"
   when:
     - "inventory_hostname == groups['kube_control_plane'][0]"

--- a/roles/kubernetes-apps/common_crds/gateway_api/tasks/main.yml
+++ b/roles/kubernetes-apps/common_crds/gateway_api/tasks/main.yml
@@ -29,5 +29,6 @@
     kubectl: "{{ bin_dir }}/kubectl"
     filename: "{{ kube_config_dir }}/addons/gateway_api/{{ gateway_api_channel }}-install.yaml"
     state: latest
+    server_side_apply: "{{ server_side_apply | default(false) }}"
   when:
     - "inventory_hostname == groups['kube_control_plane'][0]"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #13086 
Fixes #13084

**Special notes for your reviewer**:

The default mode is still _client-side_, unless you decide that _server-side_ apply becomes the new default for the "kube" module.

This change fixes the "kubectl apply" failure for manifests updates too big for keeping the previous manifest in the annotations.

**Does this PR introduce a user-facing change?**:

```release-note
"kube" module respects `server_side_apply: true` variable
```
