### PR TITLE
preinstall: add cgroup v1 precheck for kubelet_fail_cgroup_v1

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
@@ -45,6 +45,34 @@
   changed_when: false
   when: not ignore_assert_errors
 
+# Precheck for cgroup v1 incompatibility with kubelet_fail_cgroup_v1: true (Kubernetes >= 1.35)
+# See: https://github.com/kubernetes-sigs/kubespray/issues/12948
+# See: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/5573-remove-cgroup-v1/README.md
+- name: Stop if kubelet_fail_cgroup_v1 is true on a cgroup v1 node
+  when:
+    - not ignore_assert_errors
+    - kubelet_fail_cgroup_v1 | default(true) | bool
+    - kube_version is version('1.35.0', '>=')
+  block:
+    - name: Detect cgroup version
+      command: stat -fc %T /sys/fs/cgroup/
+      register: cgroup_stat
+      changed_when: false
+
+    - name: Fail if cgroup v1 detected with kubelet_fail_cgroup_v1 enabled
+      assert:
+        that: cgroup_stat.stdout == "cgroup2fs"
+        fail_msg: >-
+          This node uses cgroup v1 (detected filesystem type: {{ cgroup_stat.stdout }}),
+          but kubelet_fail_cgroup_v1 is set to true (the default for Kubernetes >= 1.35).
+          The kubelet will refuse to start on cgroup v1 nodes with this setting.
+
+          To resolve this, either:
+            1. Migrate the node to cgroup v2 (recommended), or
+            2. Set kubelet_fail_cgroup_v1: false in your inventory/group_vars
+
+          See: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/5573-remove-cgroup-v1/README.md
+
 - name: Stop if ip var does not match local ips
   assert:
     that: (ip in ansible_all_ipv4_addresses) or (ip in ansible_all_ipv6_addresses)

--- a/roles/validate_inventory/tasks/main.yml
+++ b/roles/validate_inventory/tasks/main.yml
@@ -52,6 +52,7 @@
       - download_always_pull | type_debug == 'bool'
       - helm_enabled | type_debug == 'bool'
       - openstack_lbaas_enabled | type_debug == 'bool'
+      - kubelet_fail_cgroup_v1 | type_debug == 'bool'
   run_once: true
   when: not ignore_assert_errors
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
This PR adds a fail-fast precheck during the preinstall phase ([0040-verify-settings.yml]) to detect if a user is attempting to install/upgrade Kubernetes >= 1.35.0 on a node running cgroup v1 while `kubelet_fail_cgroup_v1` is set to `true`. 

Kubernetes 1.35+ defaults `FailCgroupV1` to `true` as part of the cgroup v1 deprecation process (KEP-5573: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/5573-remove-cgroup-v1/README.md#risks-and-mitigations). 

Kubespray correctly aligns with this upstream default. However, without this precheck, users on cgroup v1 nodes would experience a cryptic kubelet failure mid-upgrade. This check stops the Ansible run early and provides an informative error message explicitly outlining the two mitigation paths:
1. Migrate the node to cgroup v2 (recommended)
2. Override the default by setting `kubelet_fail_cgroup_v1: false`

This PR also adds boolean type validation for `kubelet_fail_cgroup_v1` in `validate_inventory` to catch string-type misconfigurations early.

In summary, this PR basically does the following:

- Add a preinstall precheck that fails early with an informative error when kubelet_fail_cgroup_v1 is true on nodes running cgroup v1. This prevents kubelet start failures mid-upgrade on cgroup v1 systems.
- The check detects the cgroup version via stat -fc %T /sys/fs/cgroup/ and provides clear remediation steps: either migrate to cgroup v2 or set kubelet_fail_cgroup_v1: false in inventory/group_vars.
- Also adds kubelet_fail_cgroup_v1 to the known booleans validation in validate_inventory to catch string-type misconfigurations early.


For more details, please see: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/5573-remove-cgroup-v1/README.md

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12948


**Special notes for your reviewer**:
This implements the mitigation proposed in #12812 (comment). The precheck detects cgroup versions via `stat -fc %T /sys/fs/cgroup/` (looking for `cgroup2fs` vs `tmpfs`). Existing CI (like [openeuler24-calico.yml]) is not broken because it already overrides `kubelet_fail_cgroup_v1: false`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added a preinstall precheck that fails early with an informative error when attempting to install Kubernetes >= 1.35.0 on cgroup v1 nodes with `kubelet_fail_cgroup_v1` set to `true` (the default). For details, please visit these two issues: https://github.com/kubernetes-sigs/kubespray/issues/12948 and https://github.com/kubernetes-sigs/kubespray/pull/12812.
```


