### PR TITLE
Fix custom_cni manifest apply failure for multi-namespace resources

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-custom-cni.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-custom-cni.yml
@@ -9,10 +9,16 @@
 ## List of Kubernetes resource manifest files
 ## See tests/files/custom_cni/README.md for example
 # custom_cni_manifests: []
+#
+## Namespace passed to kubectl when applying manifests.
+## Set to an empty string for multi-namespace manifests where every namespaced
+## resource declares metadata.namespace.
+# custom_cni_namespace: "kube-system"
 
 ## OPTION 1 EXAMPLE - Cilium static manifests in Kubespray tree
 # custom_cni_manifests:
 #   - "{{ playbook_dir }}/../tests/files/custom_cni/cilium.yaml"
+# custom_cni_namespace: ""
 
 ## OPTION 2 - Helm chart application
 ## This allows the CNI backend to be deployed to Kubespray cluster

--- a/roles/network_plugin/custom_cni/defaults/main.yml
+++ b/roles/network_plugin/custom_cni/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 
 custom_cni_manifests: []
+custom_cni_namespace: kube-system
 
 custom_cni_chart_namespace: kube-system
 custom_cni_chart_release_name: ""

--- a/roles/network_plugin/custom_cni/tasks/main.yml
+++ b/roles/network_plugin/custom_cni/tasks/main.yml
@@ -19,7 +19,6 @@
 
   - name: Custom CNI | Start Resources
     kube:
-      namespace: "kube-system"
       kubectl: "{{ bin_dir }}/kubectl"
       filename: "{{ kube_config_dir }}/{{ item | basename | replace('.j2', '') }}"
       state: "latest"

--- a/roles/network_plugin/custom_cni/tasks/main.yml
+++ b/roles/network_plugin/custom_cni/tasks/main.yml
@@ -19,7 +19,7 @@
 
   - name: Custom CNI | Start Resources
     kube:
-      namespace: "kube-system"
+      namespace: "{{ custom_cni_namespace | default(omit, true) }}"
       kubectl: "{{ bin_dir }}/kubectl"
       filename: "{{ kube_config_dir }}/{{ item | basename | replace('.j2', '') }}"
       state: "latest"

--- a/tests/files/custom_cni/README.md
+++ b/tests/files/custom_cni/README.md
@@ -9,3 +9,17 @@ helm repo add cilium https://helm.cilium.io/
 helm repo update
 helm template cilium/cilium -n kube-system -f values.yaml > cilium.yaml
 ```
+
+The generated Cilium manifest contains resources in both the `kube-system` and
+`cilium-secrets` namespaces. Configure the static manifest example without a
+kubectl namespace argument:
+
+```yaml
+custom_cni_manifests:
+  - "{{ playbook_dir }}/../tests/files/custom_cni/cilium.yaml"
+custom_cni_namespace: ""
+```
+
+When `custom_cni_namespace` is empty, every namespaced resource in the
+manifests should declare `metadata.namespace`. Otherwise, kubectl applies the
+resource to the current context's default namespace.

--- a/tests/files/debian11-custom-cni.yml
+++ b/tests/files/debian11-custom-cni.yml
@@ -7,6 +7,7 @@ kube_owner: root
 kube_network_plugin: custom_cni
 custom_cni_manifests:
   - "{{ playbook_dir }}/../tests/files/custom_cni/cilium.yaml"
+custom_cni_namespace: ""
 
 # Use static containerd binary for older distributions like Debian 11.
 containerd_static_binary: true


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Adds `custom_cni_namespace` for static manifest deployments. It defaults to `kube-system`, preserving existing behavior. Setting it to an empty value omits kubectl's namespace flag, allowing manifests to contain resources from multiple namespaces when namespaced resources declare `metadata.namespace`.

The Debian custom-CNI test opts into this behavior for Cilium's `kube-system` and `cilium-secrets` resources.

**Which issue(s) this PR fixes**:

Fixes #13205

**Special notes for your reviewer**:

This addresses the compatibility concern raised in review without changing the default behavior.

This PR was written in part with the assistance of generative AI.

**Does this PR introduce a user-facing change?**:

```release-note
Custom CNI static manifests can set `custom_cni_namespace` to an empty value to apply resources across multiple namespaces. The default remains `kube-system`.
```
