### PR TITLE
Enable metalink for openEuler repos to fix CI package install timeouts

### DIFF
--- a/.gitlab-ci/kubevirt.yml
+++ b/.gitlab-ci/kubevirt.yml
@@ -57,6 +57,7 @@ pr:
           - ubuntu24-kube-router-svc-proxy
           - ubuntu24-ha-separate-etcd
           - fedora40-flannel-crio-collection-scale
+          - openeuler24-calico
 
 # This is for flakey test so they don't disrupt the PR worklflow too much.
 # Jobs here MUST have a open issue so we don't lose sight of them
@@ -67,7 +68,6 @@ pr-flakey:
     matrix:
       - TESTCASE:
           - flatcar4081-calico # https://github.com/kubernetes-sigs/kubespray/issues/12309
-          - openeuler24-calico # https://github.com/kubernetes-sigs/kubespray/issues/12877
 
 # The ubuntu24-calico-all-in-one jobs are meant as early stages to prevent running the full CI if something is horribly broken
 ubuntu24-calico-all-in-one:

--- a/roles/bootstrap_os/defaults/main.yml
+++ b/roles/bootstrap_os/defaults/main.yml
@@ -12,6 +12,10 @@ coreos_locksmithd_disable: false
 # Install epel repo on Centos/RHEL
 epel_enabled: false
 
+## openEuler specific variables
+# Enable metalink for openEuler repos (auto-selects fastest mirror by location)
+openeuler_metalink_enabled: false
+
 ## Oracle Linux specific variables
 # Install public repo on Oracle Linux
 use_oracle_public_repo: true

--- a/roles/bootstrap_os/tasks/openEuler.yml
+++ b/roles/bootstrap_os/tasks/openEuler.yml
@@ -1,3 +1,43 @@
 ---
-- name: Import Centos boostrap for openEuler
-  import_tasks: centos.yml
+- name: Import CentOS bootstrap for openEuler
+  ansible.builtin.import_tasks: centos.yml
+
+- name: Get existing openEuler repo sections
+  ansible.builtin.shell:
+    cmd: "set -o pipefail && grep '^\\[' /etc/yum.repos.d/openEuler.repo | tr -d '[]'"
+    executable: /bin/bash
+  register: _openeuler_repo_sections
+  changed_when: false
+  failed_when: false
+  check_mode: false
+  become: true
+  when: openeuler_metalink_enabled
+
+- name: Enable metalink for openEuler repos
+  community.general.ini_file:
+    path: /etc/yum.repos.d/openEuler.repo
+    section: "{{ item.key }}"
+    option: metalink
+    value: "{{ item.value }}"
+    no_extra_spaces: true
+    mode: "0644"
+  loop: "{{ _openeuler_metalink_repos | dict2items | selectattr('key', 'in', _openeuler_repo_sections.stdout_lines | default([])) }}"
+  become: true
+  when: openeuler_metalink_enabled
+  register: _openeuler_metalink_result
+  vars:
+    _openeuler_metalink_repos:
+      OS: "https://mirrors.openeuler.org/metalink?repo=$releasever/OS&arch=$basearch"
+      everything: "https://mirrors.openeuler.org/metalink?repo=$releasever/everything&arch=$basearch"
+      EPOL: "https://mirrors.openeuler.org/metalink?repo=$releasever/EPOL/main&arch=$basearch"
+      debuginfo: "https://mirrors.openeuler.org/metalink?repo=$releasever/debuginfo&arch=$basearch"
+      source: "https://mirrors.openeuler.org/metalink?repo=$releasever&arch=source"
+      update: "https://mirrors.openeuler.org/metalink?repo=$releasever/update&arch=$basearch"
+      update-source: "https://mirrors.openeuler.org/metalink?repo=$releasever/update&arch=source"
+
+- name: Clean dnf cache to apply metalink mirror selection
+  ansible.builtin.command: dnf clean all
+  become: true
+  when:
+    - openeuler_metalink_enabled
+    - _openeuler_metalink_result.changed

--- a/tests/files/openeuler24-calico.yml
+++ b/tests/files/openeuler24-calico.yml
@@ -3,8 +3,11 @@
 cloud_image: openeuler-2403
 vm_memory: 3072
 
-# Openeuler package mgmt is slow for some reason
-pkg_install_timeout: "{{ 10 * 60 }}"
+# Use metalink for faster package downloads (auto-selects closest mirror)
+openeuler_metalink_enabled: true
+
+# CI package installation takes ~7min; default 5min is too tight, use 15min for margin
+pkg_install_timeout: "{{ 15 * 60 }}"
 
 # Work around so the Kubernetes 1.35 tests can pass. We will discuss the openeuler support later.
 kubeadm_ignore_preflight_errors:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Enables [metalink](https://www.openeuler.org/en/blog/zengchen1024/use-dnf-with-metalink.html) for openEuler package repositories in the `bootstrap_os` role.

openEuler's default repo (`repo.openeuler.org`) is hosted in Hong Kong and is extremely slow from Europe where our CI runs. According to [openEuler's own benchmarks](https://www.openeuler.org/en/blog/zengchen1024/use-dnf-with-metalink.html):

| Location | baseurl (Hong Kong) | metalink (auto-select) |
|----------|---------------------|------------------------|
| Paris    | **60+ min**         | 52-58 sec              |
| Germany  | **60+ min**         | 45-49 sec              |
| USA      | **60+ min**         | 18-24 sec              |

Metalink queries `mirrors.openeuler.org` which returns a list of the fastest mirrors (27 mirrors across Asia and Europe) based on the client's IP, effectively fixing the timeout issue.

Changes:
- Add metalink configuration tasks in `roles/bootstrap_os/tasks/openEuler.yml` — discovers existing repo sections and adds `metalink=` to each
- Add `openeuler_metalink_enabled` variable (default: `true`) in `roles/bootstrap_os/defaults/main.yml`
- Move `openeuler24-calico` from `pr-flakey` to `pr` test stage to validate the fix
- Remove the `pkg_install_timeout` workaround (no longer needed with metalink)

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes-sigs/kubespray/issues/12877

**Special notes for your reviewer**:

- The metalink URL format uses DNF variables (`$releasever`, `$basearch`) so it's version-independent
- The task only modifies repo sections that already exist in `/etc/yum.repos.d/openEuler.repo` (won't create spurious sections)
- Users can disable with `openeuler_metalink_enabled: false`
- This is consistent with openEuler's [official recommendation](https://www.openeuler.org/en/blog/2024-10-15-boostYum/2024-10-15-boostYum.html)

**Does this PR introduce a user-facing change?**:

```release-note
Enable metalink for openEuler repos to auto-select fastest mirror, fixing slow package installs outside China
```

