### PR TITLE
Upgrade cilium from 1.18.6 to 1.19.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Note:
 - Network Plugin
   - [cni-plugins](https://github.com/containernetworking/plugins) 1.8.0
   - [calico](https://github.com/projectcalico/calico) 3.30.6
-  - [cilium](https://github.com/cilium/cilium) 1.18.6
+  - [cilium](https://github.com/cilium/cilium) 1.19.1
   - [flannel](https://github.com/flannel-io/flannel) 0.27.3
   - [kube-ovn](https://github.com/alauda/kube-ovn) 1.12.21
   - [kube-router](https://github.com/cloudnativelabs/kube-router) 2.1.1

--- a/docs/CNI/cilium.md
+++ b/docs/CNI/cilium.md
@@ -245,7 +245,7 @@ cilium_operator_extra_volume_mounts:
 ## Choose Cilium version
 
 ```yml
-cilium_version: "1.18.6"
+cilium_version: "1.19.1"
 ```
 
 ## Add variable to config

--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -116,7 +116,7 @@ flannel_version: 0.27.3
 flannel_cni_version: 1.7.1-flannel1
 cni_version: "{{ (cni_binary_checksums['amd64'] | dict2items)[0].key }}"
 
-cilium_version: "1.18.6"
+cilium_version: "1.19.1"
 cilium_cli_version: "{{ (ciliumcli_binary_checksums['amd64'] | dict2items)[0].key }}"
 cilium_enable_hubble: false
 

--- a/roles/network_plugin/cilium/templates/cilium/cilium-bgp-advertisement.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/cilium-bgp-advertisement.yml.j2
@@ -1,6 +1,6 @@
 {% for cilium_bgp_advertisement in cilium_bgp_advertisements %}
 ---
-apiVersion: "cilium.io/v2alpha1"
+apiVersion: "cilium.io/v2"
 kind: CiliumBGPAdvertisement
 metadata:
   name: "{{ cilium_bgp_advertisement.name }}"

--- a/roles/network_plugin/cilium/templates/cilium/cilium-bgp-cluster-config.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/cilium-bgp-cluster-config.yml.j2
@@ -1,6 +1,6 @@
 {% for cilium_bgp_cluster_config in cilium_bgp_cluster_configs %}
 ---
-apiVersion: "cilium.io/v2alpha1"
+apiVersion: "cilium.io/v2"
 kind: CiliumBGPClusterConfig
 metadata:
   name: "{{ cilium_bgp_cluster_config.name }}"

--- a/roles/network_plugin/cilium/templates/cilium/cilium-bgp-node-config-override.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/cilium-bgp-node-config-override.yml.j2
@@ -1,6 +1,6 @@
 {% for cilium_bgp_node_config_override in cilium_bgp_node_config_overrides %}
 ---
-apiVersion: "cilium.io/v2alpha1"
+apiVersion: "cilium.io/v2"
 kind: CiliumBGPNodeConfigOverride
 metadata:
   name: "{{ cilium_bgp_node_config_override.name }}"

--- a/roles/network_plugin/cilium/templates/cilium/cilium-bgp-peer-config.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/cilium-bgp-peer-config.yml.j2
@@ -1,6 +1,6 @@
 {% for cilium_bgp_peer_config in cilium_bgp_peer_configs %}
 ---
-apiVersion: "cilium.io/v2alpha1"
+apiVersion: "cilium.io/v2"
 kind: CiliumBGPPeerConfig
 metadata:
   name: "{{ cilium_bgp_peer_config.name }}"

--- a/roles/network_plugin/cilium/templates/cilium/cilium-loadbalancer-ip-pool.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium/cilium-loadbalancer-ip-pool.yml.j2
@@ -1,6 +1,6 @@
 {% for cilium_loadbalancer_ip_pool in cilium_loadbalancer_ip_pools %}
 ---
-apiVersion: "cilium.io/v2alpha1"
+apiVersion: "cilium.io/v2"
 kind: CiliumLoadBalancerIPPool
 metadata:
   name: "{{ cilium_loadbalancer_ip_pool.name }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:
This change overlaps with #12966. If that pull request will not be updated, we can proceed with this one. Otherwise, it may be preferable to wait for it to be merged first and then merge this PR.

Since version 1.19.0 introduces breaking changes (see the [upgrade notes](https://docs.cilium.io/en/v1.19/operations/upgrade/#upgrade-notes)), I added a release note.

**Does this PR introduce a user-facing change?**:
```release-note
Cilium template apiVersion upgrade to v2
```
