### PR TITLE
fix(#12986): change etcd_access_address

### DIFF
--- a/roles/kubespray_defaults/defaults/main/main.yml
+++ b/roles/kubespray_defaults/defaults/main/main.yml
@@ -665,7 +665,12 @@ etcd_hosts: "{{ groups['etcd'] | default(groups['kube_control_plane']) }}"
 
 # Vars for pointing to etcd endpoints
 etcd_address: "{{ hostvars[inventory_hostname]['main_ip'] }}"
-etcd_access_address: "{{ hostvars[inventory_hostname]['main_access_ip'] }}"
+etcd_access_address: >-
+  {{
+    hostvars[inventory_hostname].main_access_ip
+    | default(hostvars[inventory_hostname].ip, true)
+    | default(hostvars[inventory_hostname].ansible_host, true)
+  }}
 etcd_events_access_address: "{{ hostvars[inventory_hostname]['main_access_ip'] }}"
 etcd_peer_url: "https://{{ etcd_access_address | ansible.utils.ipwrap }}:2380"
 etcd_client_url: "https://{{ etcd_access_address | ansible.utils.ipwrap }}:2379"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes etcd endpoint address resolution.
`etcd_access_address` now falls back in order:
`main_access_ip` -> `ip` -> `ansible_host`.
Prevents undefined/empty address failures.

**Which issue(s) this PR fixes**:
Fixes #12986

**Special notes for your reviewer**:
I reproduced the problem, If a host is unreachable, fact collection may not get main_access_ip
No change when `main_access_ip` is set.
Change only affects fallback path.

**Does this PR introduce a user-facing change?**:
```release-note
Fixed etcd access address selection: when `main_access_ip` is missing or empty, Kubespray now falls back to `ip`, then `ansible_host`.
