### PR TITLE
Add calico-tier-getter RBAC

### DIFF
--- a/roles/network_plugin/calico/templates/calico-cr.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-cr.yml.j2
@@ -215,3 +215,17 @@ rules:
       - calico-cni-plugin
     verbs:
       - create
+{% if calico_version is version('3.29.0', '>=') %}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: calico-tier-getter
+rules:
+  - apiGroups:
+      - "projectcalico.org"
+    resources:
+      - "tiers"
+    verbs:
+      - "get"
+{% endif %}

--- a/roles/network_plugin/calico/templates/calico-crb.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-crb.yml.j2
@@ -26,3 +26,18 @@ subjects:
 - kind: ServiceAccount
   name: calico-cni-plugin
   namespace: kube-system
+{% if calico_version is version('3.29.0', '>=') %}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-tier-getter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-tier-getter
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: system:kube-controller-manager
+{% endif %}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Which issue(s) this PR fixes**:
Fixes #12480

**Special notes for your reviewer**:
Please backport it to `release-2.30`, `release-2.29` and `release-2.28`(if still supported) branches.

**Does this PR introduce a user-facing change?**:
```release-note
Fix calico missing RBAC permissions for kube-controller-manager to access tiers in manifest installs, which was preventing proper resource garbage collection.
```
