### PR TITLE
Fix calico api server permissions

### DIFF
--- a/roles/network_plugin/calico/templates/calico-apiserver.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-apiserver.yml.j2
@@ -177,6 +177,9 @@ rules:
   - blockaffinities
   - caliconodestatuses
   - tiers
+  - stagednetworkpolicies
+  - stagedglobalnetworkpolicies
+  - stagedkubernetesnetworkpolicies
   verbs:
   - get
   - list


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Upstream issue: https://github.com/projectcalico/calico/issues/11017

**Special notes for your reviewer**:
Please backport it to `release-2.30` and `release-2.29` branches.

**Does this PR introduce a user-facing change?**:
```release-note
Fix calico missing staged policy permissions for api server
```