### PR TITLE
docs: add README for test-infra/image-builder

### DIFF
--- a/test-infra/image-builder/README.md
+++ b/test-infra/image-builder/README.md
@@ -1,0 +1,57 @@
+# KubeVirt Image Builder
+
+Build and push KubeVirt VM disk images to quay.io for Kubespray CI testing.
+
+## How It Works
+
+The Ansible playbook downloads upstream cloud images, converts them to qcow2, resizes (+8G), wraps each in a Docker image based on `kubevirt/registry-disk-v1alpha`, and pushes to `quay.io/kubespray/vm-<os-name>:<tag>`.
+
+## Prerequisites
+
+- Docker, `qemu-img`, Ansible
+- Push access to [quay.io/kubespray](https://quay.io/organization/kubespray) (robot account `kubespray+buildvmimages`)
+
+## Image Definitions
+
+All OS images are defined in [`roles/kubevirt-images/defaults/main.yml`](roles/kubevirt-images/defaults/main.yml).
+
+Each entry specifies:
+
+| Field | Description |
+|-------|-------------|
+| `filename` | Downloaded file name |
+| `url` | Upstream cloud image URL |
+| `checksum` | Checksum for download verification |
+| `converted` | `true` if the source is already qcow2, `false` if conversion is needed |
+| `tag` | Docker image tag (usually `latest`) |
+
+## Usage
+
+### Build and push all images
+
+```bash
+cd test-infra/image-builder/
+make docker_password=<quay-robot-token>
+```
+
+### Add a new OS image
+
+1. Add a new entry to `roles/kubevirt-images/defaults/main.yml`:
+
+   ```yaml
+   new-os-name:
+     filename: cloud-image-file.qcow2
+     url: https://example.com/cloud-image-file.qcow2
+     checksum: sha256:<hash>
+     converted: true
+     tag: "latest"
+   ```
+
+2. Build and push the image:
+
+   ```bash
+   make docker_password=<quay-robot-token>
+   ```
+
+3. Submit a PR with the `defaults/main.yml` change so CI can use the new image.
+   See [#12379](https://github.com/kubernetes-sigs/kubespray/pull/12379) for an example.


### PR DESCRIPTION
## What this PR does / why we need it

Adds a README to `test-infra/image-builder/` documenting the KubeVirt VM disk image build process used by Kubespray CI. This helps onboard contributors and reduces the bottleneck of only a few maintainers knowing the manual process.

The README covers:
- How the build pipeline works (download → convert → resize → docker build → push)
- Prerequisites (docker, qemu-img, quay.io credentials)
- Usage instructions (`make` and manual single-image push)
- How to add a new OS image (see [#12379](https://github.com/kubernetes-sigs/kubespray/pull/12379) for a concrete example)
- File structure overview

## Which issue(s) this PR fixes

Ref https://github.com/kubernetes-sigs/kubespray/issues/12383

## Special notes for your reviewer

This is a documentation-only change. The build process itself is unchanged.

## Does this PR introduce a user-facing change?

```release-note
NONE
```

/kind documentation