### PR TITLE
fix(cilium): quote empty string defaults to prevent null in Helm values

### DIFF
--- a/roles/network_plugin/cilium/templates/values.yaml.j2
+++ b/roles/network_plugin/cilium/templates/values.yaml.j2
@@ -62,8 +62,8 @@ cni:
 
 autoDirectNodeRoutes: {{ cilium_auto_direct_node_routes | to_json }}
 
-ipv4NativeRoutingCIDR: {{ cilium_native_routing_cidr }}
-ipv6NativeRoutingCIDR: {{ cilium_native_routing_cidr_ipv6 }}
+ipv4NativeRoutingCIDR: "{{ cilium_native_routing_cidr }}"
+ipv6NativeRoutingCIDR: "{{ cilium_native_routing_cidr_ipv6 }}"
 
 encryption:
   enabled: {{ cilium_encryption_enabled | to_json }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

By default, in an IPv4 stack, when enabling Cluster Mesh with Cilium, the Helm values generate `null` for `cilium_native_routing_cidr_ipv6`. This causes a failure in the Cilium CLI. For consistency, this behavior should be applied to both IPv4 and IPv6 variables (`cilium_native_routing_cidr` and `cilium_native_routing_cidr_ipv6`). More details are available in the issue description.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kubespray/issues/13089

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
