### PR TITLE
CI: make /tmp/releases world-readable

### DIFF
--- a/tests/cloud_playbooks/roles/packet-ci/vars/main.yml
+++ b/tests/cloud_playbooks/roles/packet-ci/vars/main.yml
@@ -50,6 +50,8 @@ cloudinit_config: |
       partition: 'none'
   mounts:
     - ['/dev/disk/by-id/virtio-2825A83CBDC8A32D5E', '/tmp/releases']
+  runcmd:
+    - chmod 777 /tmp/releases
 
 ignition_config:
   ignition:
@@ -68,3 +70,9 @@ ignition_config:
         format: ext4
         path: /tmp/releases
         wipeFilesystem: true
+    directories:
+      - path: /tmp/releases
+        # ignition require a integer, so using the octal notation is easier
+        # than noting it in decimal form
+        # yamllint disable-line rule:octal-values
+        mode: 0777


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Make the disk for releases in CI world readable (like /tmp in most distributions)
This match the expectations of a typical local_release_dir location.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Cherry-picked from #12937

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
