### PR TITLE
Wrap the image pull command with timeout to prevent indefinite hangs

### DIFF
--- a/roles/download/tasks/download_container.yml
+++ b/roles/download/tasks/download_container.yml
@@ -55,7 +55,7 @@
         - not download_run_once
 
     - name: Download_container | Download image if required
-      command: "{{ image_pull_command_on_localhost if download_localhost else image_pull_command }} {{ image_reponame }}"
+      command: "timeout {{ download_pull_timeout }} {{ image_pull_command_on_localhost if download_localhost else image_pull_command }} {{ image_reponame }}"
       delegate_to: "{{ download_delegate if download_run_once else inventory_hostname }}"
       delegate_facts: true
       run_once: "{{ download_run_once }}"

--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -55,6 +55,9 @@ download_delegate: "{% if download_localhost %}localhost{% else %}{{ groups['kub
 # Allow control the times of download retries for files and containers
 download_retries: 4
 
+# Timeout (in seconds) for container image pull commands to prevent indefinite hangs
+download_pull_timeout: 300
+
 # The docker_image_info_command might seems weird but we are using raw/endraw and `{{ `{{` }}` to manage the double jinja2 processing
 docker_image_pull_command: "{{ docker_bin_dir }}/docker pull"
 docker_image_info_command: "{{ docker_bin_dir }}/docker images -q | xargs -i {{ '{{' }} docker_bin_dir }}/docker inspect -f {% raw %}'{{ '{{' }} if .RepoTags }}{{ '{{' }} join .RepoTags \",\" }}{{ '{{' }} end }}{{ '{{' }} if .RepoDigests }},{{ '{{' }} join .RepoDigests \",\" }}{{ '{{' }} end }}' {% endraw %} {} | tr '\n' ','"


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

The `Download_container | Download image if required` task in `roles/download/tasks/download_container.yml` uses `retries` and `until` for fault tolerance, but the underlying `command` (nerdctl/ctr/crictl pull) has no timeout. When the pull command hangs  due to registry issues, network problems, or concurrency deadlocks during parallel pulls across many nodes - the Ansible task blocks indefinitely. The `retries` logic never triggers because the command never returns.

This PR wraps the pull command with GNU `timeout` using a new configurable variable `download_pull_timeout` (default: 300 seconds / 5 minutes):

```yaml
command: "timeout {{ download_pull_timeout | default(300) }} {{ image_pull_command_on_localhost if download_localhost else image_pull_command }} {{ image_reponame }}"
```

**How it works:**
- `timeout 300 nerdctl -n k8s.io pull ...` - if the pull doesn't complete in 300s, `timeout` sends SIGTERM (then SIGKILL) and exits with code 124
- Ansible sees the non-zero exit code as a failure
- The existing `until: pull_task_result is succeeded` / `retries` logic retries the pull
- Users can override the default by setting `download_pull_timeout` in their inventory/group_vars (e.g. `download_pull_timeout: 600`)

**Why `timeout` over alternatives:**
- Ansible `async/poll`: doesn't reliably kill hung child processes, interacts poorly with `until`/`retries`, and has known issues with `delegate_to`
- Ansible task-level `timeout` keyword: doesn't reliably kill child processes of the `command` module, can leave orphans
- GNU `timeout` (coreutils): present on all Linux distros kubespray targets, battle-tested, clean process termination, produces a clear exit code, zero interaction with Ansible internals

**Real-world scenario:** Hit in production when adding multiple nodes simultaneously. `nerdctl pull` for `quay.io/cilium/hubble-ui:v0.13.3` deadlocked on multiple nodes, hanging the entire Ansible run until manually cancelled.

**Which issue(s) this PR fixes**:

Fixes #13119

**Special notes for your reviewer**:

- Single-line change in `roles/download/tasks/download_container.yml`
- `timeout` is part of GNU coreutils, available on all target distros (Ubuntu, RHEL, Debian, Flatcar, etc.)
- The `| default(300)` pattern is consistent with existing conventions in the same file (e.g. `user_can_become_root | default(false)` on line 66)
- The `download_file.yml` counterpart already has timeout support via `get_url`'s native `timeout` parameter (line 70) — this brings parity to container pulls
- No changes to defaults files required; users who want to customize simply set `download_pull_timeout` in inventory

**Does this PR introduce a user-facing change?**:
```release-note
Added a configurable `download_pull_timeout` variable (default: 300s) to the download role to prevent container image pull commands from hanging indefinitely during parallel node deployments. Override via inventory/group_vars if a different timeout is needed.
```
