### PR TITLE
Fix kubeadm task failure when cilium_identity_allocation_mode is undefined

### DIFF
--- a/roles/kubespray_defaults/defaults/main/main.yml
+++ b/roles/kubespray_defaults/defaults/main/main.yml
@@ -218,6 +218,21 @@ kube_network_plugin_multus: false
 # This enables to deploy cilium alongside another CNI to replace kube-proxy.
 cilium_deploy_additionally: false
 
+# Identity allocation mode selects how identities are shared between cilium
+# nodes by setting how they are stored. The options are "crd" or "kvstore".
+# - "crd" stores identities in kubernetes as CRDs (custom resource definition).
+#   These can be queried with:
+#     `kubectl get ciliumid`
+# - "kvstore" stores identities in an etcd kvstore.
+# - In order to support External Workloads, "crd" is required
+#   - Ref: https://docs.cilium.io/en/stable/gettingstarted/external-workloads/#setting-up-support-for-external-workloads-beta
+# - KVStore operations are only required when cilium-operator is running with any of the below options:
+#   - --synchronize-k8s-services
+#   - --synchronize-k8s-nodes
+#   - --identity-allocation-mode=kvstore
+#   - Ref: https://docs.cilium.io/en/stable/internals/cilium_operator/#kvstore-operations
+cilium_identity_allocation_mode: crd
+
 # Determines if calico_rr group exists
 peer_with_calico_rr: "{{ 'calico_rr' in groups and groups['calico_rr'] | length > 0 }}"
 

--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -14,21 +14,6 @@ cilium_l2announcements: false
 # Cilium agent health port
 cilium_agent_health_port: "9879"
 
-# Identity allocation mode selects how identities are shared between cilium
-# nodes by setting how they are stored. The options are "crd" or "kvstore".
-# - "crd" stores identities in kubernetes as CRDs (custom resource definition).
-#   These can be queried with:
-#     `kubectl get ciliumid`
-# - "kvstore" stores identities in an etcd kvstore.
-# - In order to support External Workloads, "crd" is required
-#   - Ref: https://docs.cilium.io/en/stable/gettingstarted/external-workloads/#setting-up-support-for-external-workloads-beta
-# - KVStore operations are only required when cilium-operator is running with any of the below options:
-#   - --synchronize-k8s-services
-#   - --synchronize-k8s-nodes
-#   - --identity-allocation-mode=kvstore
-#   - Ref: https://docs.cilium.io/en/stable/internals/cilium_operator/#kvstore-operations
-cilium_identity_allocation_mode: crd
-
 # Etcd SSL dirs
 cilium_cert_dir: /etc/cilium/certs
 kube_etcd_cacert_file: ca.pem


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

``` 
TASK [kubernetes/kubeadm : Extract etcd certs from control plane if using etcd kubeadm mode] ***
fatal: [node2]: FAILED! => {"msg": "The conditional check 'kube_network_plugin != \"cilium\" or cilium_identity_allocation_mode != 'crd'' failed. The error was: error while evaluating conditional (kube_network_plugin != \"cilium\" or cilium_identity_allocation_mode != 'crd'): 'cilium_identity_allocation_mode' is undefined. 
'cilium_identity_allocation_mode' is undefined\n\nThe error appears to be in '/kubespray/roles/kubernetes/kubeadm/tasks/main.yml': line 211, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n    - kube_network_plugin != \"calico\" or calico_datastore == \"etcd\"\n    - kube_network_plugin != \"cilium\" or cilium_identity_allocation_mode != 'crd'\n      ^ here\n"}
```

Move cilium_identity_allocation_mode: crd from roles/network_plugin/cilium/defaults/main.yml to roles/kubespray_defaults/defaults/main/main.yml, making it a global default available regardless of the chosen CNI.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
