### PR TITLE
image-builder/ add build-only validation mode and image selection

### DIFF
--- a/test-infra/image-builder/Makefile
+++ b/test-infra/image-builder/Makefile
@@ -1,2 +1,8 @@
 deploy:
 	ansible-playbook -i hosts.ini -e docker_password=$(docker_password) cluster.yml
+
+validate:
+	ansible-playbook -i hosts.ini -e '{"kubevirt_images_push": false}' cluster.yml
+
+validate-single:
+	ansible-playbook -i hosts.ini -e '{"kubevirt_images_push": false, "kubevirt_images_selected": ["$(image_name)"]}' cluster.yml

--- a/test-infra/image-builder/README.md
+++ b/test-infra/image-builder/README.md
@@ -55,3 +55,24 @@ make docker_password=<quay-robot-token>
 
 3. Submit a PR with the `defaults/main.yml` change so CI can use the new image.
    See [#12379](https://github.com/kubernetes-sigs/kubespray/pull/12379) for an example.
+
+## CI Validation
+
+### Build only
+
+```bash
+cd test-infra/image-builder/
+make validate
+```
+
+### Build only for one image
+
+```bash
+cd test-infra/image-builder/
+make validate-single image_name=ubuntu-2404
+```
+
+## Runtime Variables
+
+- `kubevirt_images_push` (default: `true`): when `false`, skip docker login/push/logout.
+- `kubevirt_images_selected` (default: `[]`): list of image keys to build. Empty list builds all images.

--- a/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
@@ -4,6 +4,8 @@ images_dir: /images/base
 docker_user: kubespray+buildvmimages
 docker_host: quay.io
 registry: quay.io/kubespray
+kubevirt_images_push: true
+kubevirt_images_selected: []
 
 images:
   ubuntu-2004:

--- a/test-infra/image-builder/roles/kubevirt-images/tasks/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/tasks/main.yml
@@ -1,58 +1,71 @@
 ---
 
-- name: Create image directory
-  file:
-    state: directory
-    path: "{{ images_dir }}"
-    mode: "0755"
+- name: Build kubevirt images
+  vars:
+    kubevirt_images_to_build: "{{ images | dict2items if kubevirt_images_selected | length == 0 else ([images] | community.general.keep_keys(target=kubevirt_images_selected))[0] | dict2items }}"
+  block:
+    - name: Validate selected image names
+      assert:
+        that:
+          - kubevirt_images_selected | length == 0 or kubevirt_images_to_build | length > 0
+        fail_msg: "No matching images found in `images` for `kubevirt_images_selected={{ kubevirt_images_selected }}`"
 
-- name: Download images files
-  get_url:
-    url: "{{ item.value.url }}"
-    dest: "{{ images_dir }}/{{ item.value.filename }}"
-    checksum: "{{ item.value.checksum }}"
-    mode: "0644"
-  loop: "{{ images | dict2items }}"
+    - name: Create image directory
+      file:
+        state: directory
+        path: "{{ images_dir }}"
+        mode: "0755"
 
-- name: Unxz compressed images
-  command: unxz --force {{ images_dir }}/{{ item.value.filename }}
-  loop: "{{ images | dict2items }}"
-  when:
-    - item.value.filename.endswith('.xz')
+    - name: Download images files
+      get_url:
+        url: "{{ item.value.url }}"
+        dest: "{{ images_dir }}/{{ item.value.filename }}"
+        checksum: "{{ item.value.checksum }}"
+        mode: "0644"
+      loop: "{{ kubevirt_images_to_build }}"
 
-- name: Convert images which is not in qcow2 format
-  command: qemu-img convert -O qcow2 {{ images_dir }}/{{ item.value.filename.rstrip('.xz') }} {{ images_dir }}/{{ item.key }}.qcow2
-  loop: "{{ images | dict2items }}"
-  when:
-    - not (item.value.converted | bool)
+    - name: Unxz compressed images
+      command: unxz --force {{ images_dir }}/{{ item.value.filename }}
+      loop: "{{ kubevirt_images_to_build }}"
+      when:
+        - item.value.filename.endswith('.xz')
 
-- name: Make sure all images are ending with qcow2
-  command: cp {{ images_dir }}/{{ item.value.filename.rstrip('.xz') }} {{ images_dir }}/{{ item.key }}.qcow2
-  loop: "{{ images | dict2items }}"
-  when:
-    - item.value.converted | bool
+    - name: Convert images which is not in qcow2 format
+      command: qemu-img convert -O qcow2 {{ images_dir }}/{{ item.value.filename.rstrip('.xz') }} {{ images_dir }}/{{ item.key }}.qcow2
+      loop: "{{ kubevirt_images_to_build }}"
+      when:
+        - not (item.value.converted | bool)
 
-- name: Resize images
-  command: qemu-img resize {{ images_dir }}/{{ item.key }}.qcow2 +8G
-  loop: "{{ images | dict2items }}"
+    - name: Make sure all images are ending with qcow2
+      command: cp {{ images_dir }}/{{ item.value.filename.rstrip('.xz') }} {{ images_dir }}/{{ item.key }}.qcow2
+      loop: "{{ kubevirt_images_to_build }}"
+      when:
+        - item.value.converted | bool
 
-# STEP 2: Include the images inside a container
-- name: Template default Dockerfile
-  template:
-    src: Dockerfile
-    dest: "{{ images_dir }}/Dockerfile"
-    mode: "0644"
+    - name: Resize images
+      command: qemu-img resize {{ images_dir }}/{{ item.key }}.qcow2 +8G
+      loop: "{{ kubevirt_images_to_build }}"
 
-- name: Create docker images for each OS
-  command: docker build -t {{ registry }}/vm-{{ item.key }}:{{ item.value.tag }} --build-arg cloud_image="{{ item.key }}.qcow2" {{ images_dir }}
-  loop: "{{ images | dict2items }}"
+    # STEP 2: Include the images inside a container
+    - name: Template default Dockerfile
+      template:
+        src: Dockerfile
+        dest: "{{ images_dir }}/Dockerfile"
+        mode: "0644"
 
-- name: Docker login
-  command: docker login -u="{{ docker_user }}" -p="{{ docker_password }}" "{{ docker_host }}"
+    - name: Create docker images for each OS
+      command: docker build -t {{ registry }}/vm-{{ item.key }}:{{ item.value.tag }} --build-arg cloud_image="{{ item.key }}.qcow2" {{ images_dir }}
+      loop: "{{ kubevirt_images_to_build }}"
 
-- name: Docker push image
-  command: docker push {{ registry }}/vm-{{ item.key }}:{{ item.value.tag }}
-  loop: "{{ images | dict2items }}"
+    - name: Docker login
+      command: docker login -u="{{ docker_user }}" -p="{{ docker_password }}" "{{ docker_host }}"
+      when: kubevirt_images_push
 
-- name: Docker logout
-  command: docker logout -u="{{ docker_user }}" "{{ docker_host }}"
+    - name: Docker push image
+      command: docker push {{ registry }}/vm-{{ item.key }}:{{ item.value.tag }}
+      loop: "{{ kubevirt_images_to_build }}"
+      when: kubevirt_images_push
+
+    - name: Docker logout
+      command: docker logout -u="{{ docker_user }}" "{{ docker_host }}"
+      when: kubevirt_images_push


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds a build-only validation mode to test-infra/image-builder so we can validate `image-builder `changes in CI without pushing images to quay.io.

The current manual build/push workflow is preserved as the default.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #12383

**Special notes for your reviewer**:

- This PR does not change registry or push destination.
- This PR does not enable automated push yet, it only adds validation capability.
- Manual make `docker_password=<token>` push workflow remains unchanged.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
