### PR TITLE
fix(containerd): avoid duplicate runsc runtime when defined in contai…

### DIFF
--- a/roles/container-engine/containerd/templates/config-v1.toml.j2
+++ b/roles/container-engine/containerd/templates/config-v1.toml.j2
@@ -67,8 +67,11 @@ oom_score = {{ containerd_oom_score }}
           runtime_type = "io.containerd.kata-qemu.v2"
 {% endif %}
 {% if gvisor_enabled %}
+{% set runsc_in_additional = containerd_additional_runtimes | default([]) | selectattr('name', 'equalto', 'runsc') | list | length > 0 %}
+{% if not runsc_in_additional %}
         [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc]
           runtime_type = "io.containerd.runsc.v1"
+{% endif %}
 {% endif %}
     [plugins."io.containerd.grpc.v1.cri".registry]
       config_path = "{{ containerd_cfg_dir }}/certs.d"

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -70,8 +70,11 @@ oom_score = {{ containerd_oom_score }}
          runtime_type = "io.containerd.kata-qemu.v2"
 {% endif %}
 {% if gvisor_enabled %}
+{% set runsc_in_additional = containerd_additional_runtimes | default([]) | selectattr('name', 'equalto', 'runsc') | list | length > 0 %}
+{% if not runsc_in_additional %}
        [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runsc]
          runtime_type = "io.containerd.runsc.v1"
+{% endif %}
 {% endif %}
 
   [plugins."io.containerd.cri.v1.images"]


### PR DESCRIPTION
…nerd_additional_runtimes

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

When both `gvisor_enabled=true` and `runsc` is defined in `containerd_additional_runtimes`, containerd config would have duplicate `[plugins.*.runtimes.runsc]` sections causing containerd to fail.

Users often define runsc in containerd_additional_runtimes to customize options (TypeUrl, ConfigPath) while still needing gvisor_enabled=true to trigger binary installation.

Fix by checking if runsc is already in containerd_additional_runtimes before adding the default gvisor block.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

```release-note
Fix to avoid duplicate runsc runtime when defined in containerd_additional_runtimes
```