### PR TITLE
fix(openeuler): add configurable openeuler_repo_baseurl for faster mirrors

### DIFF
--- a/roles/bootstrap_os/defaults/main.yml
+++ b/roles/bootstrap_os/defaults/main.yml
@@ -15,6 +15,10 @@ epel_enabled: false
 ## openEuler specific variables
 # Enable metalink for openEuler repos (auto-selects fastest mirror by location)
 openeuler_metalink_enabled: false
+# Override the default baseurl host for openEuler repos.
+# Used as fallback when metalink is unavailable (502/timeout).
+# Default repo.openeuler.org (Hong Kong) is slow from many CI/cloud environments.
+openeuler_repo_baseurl: ""
 
 ## Oracle Linux specific variables
 # Install public repo on Oracle Linux

--- a/roles/bootstrap_os/tasks/openEuler.yml
+++ b/roles/bootstrap_os/tasks/openEuler.yml
@@ -54,6 +54,15 @@
       update: "https://mirrors.openeuler.org/metalink?repo={{ _openeuler_releasever }}/update&arch=$basearch"
       update-source: "https://mirrors.openeuler.org/metalink?repo={{ _openeuler_releasever }}/update&arch=source"
 
+- name: Override baseurl to a faster mirror (fallback when metalink is unavailable)
+  ansible.builtin.replace:
+    path: /etc/yum.repos.d/openEuler.repo
+    regexp: 'baseurl=http://repo\.openeuler\.org/'
+    replace: "baseurl={{ openeuler_repo_baseurl }}/"
+    mode: "0644"
+  become: true
+  when: openeuler_repo_baseurl | default('') | length > 0
+
 - name: Clean dnf metadata cache to apply metalink mirror selection
   ansible.builtin.command: dnf clean metadata
   become: true

--- a/roles/bootstrap_os/tasks/openEuler.yml
+++ b/roles/bootstrap_os/tasks/openEuler.yml
@@ -54,6 +54,15 @@
       update: "https://mirrors.openeuler.org/metalink?repo={{ _openeuler_releasever }}/update&arch=$basearch"
       update-source: "https://mirrors.openeuler.org/metalink?repo={{ _openeuler_releasever }}/update&arch=source"
 
+- name: Override baseurl to a faster mirror (fallback when metalink is unavailable)
+  ansible.builtin.replace:
+    path: /etc/yum.repos.d/openEuler.repo
+    regexp: 'baseurl=http://repo\.openeuler\.org/'
+    replace: "baseurl={{ openeuler_repo_baseurl }}/"
+    mode: "0644"
+  become: true
+  when: openeuler_repo_baseurl != ""
+
 - name: Clean dnf metadata cache to apply metalink mirror selection
   ansible.builtin.command: dnf clean metadata
   become: true

--- a/tests/files/openeuler24-calico.yml
+++ b/tests/files/openeuler24-calico.yml
@@ -3,8 +3,8 @@
 cloud_image: openeuler-2403
 vm_memory: 3072
 
-# Use metalink for faster package downloads (auto-selects closest mirror)
-openeuler_metalink_enabled: true
+# Use Huawei Cloud CDN instead of the default repo.openeuler.org (unreachable from Oracle Cloud CI)
+openeuler_repo_baseurl: "https://repo.huaweicloud.com/openeuler"
 
 # CI package installation takes ~7min; default 5min is too tight, use 15min for margin
 pkg_install_timeout: "{{ 15 * 60 }}"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

[#13144](https://github.com/kubernetes-sigs/kubespray/pull/13144) already fixed the openEuler metalink URL by parsing `/etc/openEuler-release` so the repo segment matches what the metalink service expects (e.g. `24.03LTS` instead of DNF’s `24.03`).

This PR adds **`openeuler_repo_baseurl`**: when set, bootstrap replaces `baseurl=http://repo.openeuler.org/` in `/etc/yum.repos.d/openEuler.repo` with the chosen mirror. That helps CI and users in regions where the default host is slow or unreachable.

`tests/files/openeuler24-calico.yml` sets Huawei Cloud CDN for Kubespray CI. The default remains empty, so existing inventories are unchanged unless they set the variable.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes-sigs/kubespray/issues/12877

**Special notes for your reviewer**:

- Scope after rebase: defaults + one `replace` task in `roles/bootstrap_os/tasks/openEuler.yml` + CI vars only.

**Does this PR introduce a user-facing change?**:

```release-note
Add openeuler_repo_baseurl to override the default openEuler package repo base URL for faster or reachable mirrors
```
