### PR TITLE
Disable controller-manager allocate-node-cidrs for cilium cluster-pool ipam

### DIFF
--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
@@ -357,7 +357,16 @@ controllerManager:
 {% endif %}
   - name: service-cluster-ip-range
     value: "{{ kube_service_subnets }}"
-{% if kube_network_plugin is defined and kube_network_plugin == "calico" and not calico_ipam_host_local %}
+{% if (
+    kube_network_plugin is defined and
+    kube_network_plugin == "calico" and
+    not calico_ipam_host_local
+  ) or (
+    kube_network_plugin is defined and
+    kube_network_plugin == "cilium" and
+    cilium_ipam_mode == "cluster-pool"
+  )
+%}
   - name: allocate-node-cidrs
     value: "false"
 {% else %}

--- a/roles/kubespray_defaults/defaults/main/main.yml
+++ b/roles/kubespray_defaults/defaults/main/main.yml
@@ -233,6 +233,10 @@ cilium_deploy_additionally: false
 #   - Ref: https://docs.cilium.io/en/stable/internals/cilium_operator/#kvstore-operations
 cilium_identity_allocation_mode: crd
 
+# The default IP address management mode is "Cluster Scope".
+# https://docs.cilium.io/en/stable/concepts/networking/ipam/
+cilium_ipam_mode: cluster-pool
+
 # Determines if calico_rr group exists
 peer_with_calico_rr: "{{ 'calico_rr' in groups and groups['calico_rr'] | length > 0 }}"
 

--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -171,10 +171,6 @@ cilium_hubble_peer_service_cluster_domain: "{{ dns_domain }}"
 
 cilium_gateway_api_enabled: false
 
-# The default IP address management mode is "Cluster Scope".
-# https://docs.cilium.io/en/stable/concepts/networking/ipam/
-cilium_ipam_mode: cluster-pool
-
 # Cluster Pod CIDRs use the kube_pods_subnet value by default.
 # If your node network is in the same range you will lose connectivity to other nodes.
 # Defaults to kube_pods_subnet if not set.


### PR DESCRIPTION
This change updates the `allocate-node-cidrs` setting to `false` for cilium when using cluster-pool IPAM mode. Previously, this setting was only applied for calico with non-host-local IPAM.

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This avoids conflicts between the Kubernetes controller-manager CIDR allocation and cilium's cluster-pool IPAM.

**Special notes for your reviewer**:
Related cilium issue: cilium/cilium#37759

**Does this PR introduce a user-facing change?**:
```release-note
Disable controller-manager allocate-node-cidrs for cilium cluster-pool ipam
```
