### PR TITLE
control-plane: fix kubeadm ops when advertiseAddress cannot be derived from default gateway

### DIFF
--- a/roles/download/templates/kubeadm-images.yaml.j2
+++ b/roles/download/templates/kubeadm-images.yaml.j2
@@ -1,5 +1,7 @@
 apiVersion: kubeadm.k8s.io/v1beta4
 kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: "{{ kube_apiserver_address }}"
 nodeRegistration:
   criSocket: {{ cri_socket }}
 ---

--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -221,7 +221,7 @@
 - name: Create hardcoded kubeadm token for joining nodes with 24h expiration (if defined)
   shell: >-
     {{ bin_dir }}/kubeadm --kubeconfig {{ kube_config_dir }}/admin.conf token delete {{ kubeadm_token }} || :;
-    {{ bin_dir }}/kubeadm --kubeconfig {{ kube_config_dir }}/admin.conf token create {{ kubeadm_token }}
+    {{ bin_dir }}/kubeadm --kubeconfig {{ kube_config_dir }}/admin.conf token create {{ kubeadm_token }} --config={{ kube_config_dir }}/kubeadm-config.yaml
   changed_when: false
   when:
     - inventory_hostname == first_kube_control_plane
@@ -235,7 +235,7 @@
   when: inventory_hostname == first_kube_control_plane and remove_anonymous_access
 
 - name: Create kubeadm token for joining nodes with 24h expiration (default)
-  command: "{{ bin_dir }}/kubeadm --kubeconfig {{ kube_config_dir }}/admin.conf token create"
+  command: "{{ bin_dir }}/kubeadm --kubeconfig {{ kube_config_dir }}/admin.conf token create --config={{ kube_config_dir }}/kubeadm-config.yaml"
   changed_when: false
   register: temp_token
   retries: 5

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -40,7 +40,7 @@
   run_once: true
 
 - name: Create kubeadm token for joining nodes with 24h expiration (default)
-  command: "{{ bin_dir }}/kubeadm token create"
+  command: "{{ bin_dir }}/kubeadm token create --config={{ kube_config_dir }}/kubeadm-config.yaml"
   register: temp_token
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
   when: kubeadm_token is not defined


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes kubeadm operations in environments where the API server advertise address cannot be automatically derived from the default gateway (e.g., custom network configurations, multi-homed nodes, or non-standard routing setups).

**Does this PR introduce a user-facing change?**:

```release-note
Fixes kubeadm operations in environments where the API server advertise address cannot be automatically derived from the default gateway
```
