### PR TITLE
CI: runs openeuler on less PR

### DIFF
--- a/.gitlab-ci/kubevirt.yml
+++ b/.gitlab-ci/kubevirt.yml
@@ -62,7 +62,10 @@ pr:
 # Jobs here MUST have a open issue so we don't lose sight of them
 pr-flakey:
   extends: pr
-  retry: 1
+  rules:
+    - if: $PR_LABELS =~ /.*(ci-extended|ci-full).*/
+      when: on_success
+  retry: 2
   parallel:
     matrix:
       - TESTCASE:


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
Openeuler has a lot of flakes, so let's try to make it less painful on
PR by putting it in extended + adding a 2nd retry


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @yankay

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
