### PR TITLE
feat(audit): add audit_policy_global_omit_stages variable to audit policy

### DIFF
--- a/docs/ansible/vars.md
+++ b/docs/ansible/vars.md
@@ -305,6 +305,8 @@ node_taints:
   * `audit_policy_file`: "{{ kube_config_dir }}/audit-policy/apiserver-audit-policy.yaml"
 
   By default, the `audit_policy_file` contains [default rules](https://github.com/kubernetes-sigs/kubespray/blob/master/roles/kubernetes/control-plane/templates/apiserver-audit-policy.yaml.j2) that can be overridden with the `audit_policy_custom_rules` variable.
+
+  Using the `audit_policy_global_omit_stages` variable set List of audit stages to omit globally in the audit policy. Applied at the top-level omitStages.
 * *kubernetes_audit_webhook* - When set to `true`, enables the webhook audit backend.
   The webhook parameters can be tuned via the following variables (which default values are shown below):
   * `audit_webhook_config_file`: "{{ kube_config_dir }}/audit-policy/apiserver-audit-webhook-config.yaml"

--- a/roles/kubernetes/control-plane/defaults/main/main.yml
+++ b/roles/kubernetes/control-plane/defaults/main/main.yml
@@ -66,6 +66,11 @@ audit_policy_file: "{{ kube_config_dir }}/audit-policy/apiserver-audit-policy.ya
 #     verbs: []
 #     resources: []
 
+# audit global omit stages
+# you can set List of audit stages to omit globally in the audit policy.
+# e.g. audit_policy_global_omit_stages: ["RequestReceived"]
+audit_policy_global_omit_stages: []
+
 # audit log hostpath
 audit_log_name: audit-logs
 audit_log_hostpath: /var/log/kubernetes/audit

--- a/roles/kubernetes/control-plane/templates/apiserver-audit-policy.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/apiserver-audit-policy.yaml.j2
@@ -1,5 +1,8 @@
 apiVersion: audit.k8s.io/v1
 kind: Policy
+{% if audit_policy_global_omit_stages %}
+omitStages: {{ audit_policy_global_omit_stages | to_json }}
+{% endif %}
 rules:
 {% if audit_policy_custom_rules is defined and audit_policy_custom_rules != "" %}
 {{ audit_policy_custom_rules | indent(2, true) }}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add support for a global omitStages setting in the audit policy via `audit_policy_global_omit_stages` variable. It provides a simple way to exclude specific audit stages (e.g., ResponseStarted, Panic) across all rules, which was not previously possible in Kubespray.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Due to my mistake, PR #12580 was closed, so I have reopened it by submitting this new pull request. Thank you for your understanding.

**Does this PR introduce a user-facing change?**:

```release-note
Add audit_policy_global_omit_stages variable to configure global omitStages in the audit policy.
```