### PR TITLE
Bump galaxy.yml version to 2.26.2

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: kubernetes_sigs
 description: Deploy a production ready Kubernetes cluster
 name: kubespray
-version: 2.26.1
+version: 2.26.2
 readme: README.md
 authors:
   - The Kubespray maintainers (https://kubernetes.slack.com/channels/kubespray)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Bump `galaxy.yml` version from `2.26.1` to `2.26.2` after the v2.26.1 release.

**Which issue(s) this PR fixes**:

Part of the v2.26.1 release process (https://github.com/kubernetes-sigs/kubespray/issues/13150).

**Special notes for your reviewer**:

Single-line change in `galaxy.yml` — version bump only.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```