### PR TITLE
kubeadm setup: enhance retry with etcd error ignore

### DIFF
--- a/roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml
@@ -84,17 +84,46 @@
     - not kubeadm_already_run.stat.exists
 
 - name: Joining control plane node to the cluster.
-  command: >-
-    {{ bin_dir }}/kubeadm join
-    --config {{ kube_config_dir }}/kubeadm-controlplane.yaml
-    --ignore-preflight-errors={{ kubeadm_ignore_preflight_errors | join(',') }}
-    --skip-phases={{ kubeadm_join_phases_skip | join(',') }}
+  vars:
+    kubeadm_join_control_plane_cmd: >-
+      {{ bin_dir }}/kubeadm join
+      --config {{ kube_config_dir }}/kubeadm-controlplane.yaml
+      --ignore-preflight-errors={{ _ignore_errors | flatten | join(',') }}
+      --skip-phases={{ kubeadm_join_phases_skip | join(',') }}
+    _ignore_errors: "{{ kubeadm_ignore_preflight_errors }}"
   environment:
     PATH: "{{ bin_dir }}:{{ ansible_env.PATH }}"
-  register: kubeadm_join_control_plane
-  retries: 3
   throttle: 1
-  until: kubeadm_join_control_plane is succeeded
+  block:
+    - name: Joining control plane node to the cluster (1st try)
+      command: "{{ kubeadm_join_control_plane_cmd }}"
+      register: kubeadm_join_control_plane
+  rescue:
+    # Retry is because join sometimes fails
+    # This retry task is separated from 1st task to show log of failure of 1st task.
+    - name: Joining control plane node to the cluster (retry)
+      command: "{{ kubeadm_join_control_plane_cmd }}"
+      vars:
+        _errors_from_first_try:
+          - 'FileAvailable--etc-kubernetes-kubelet.conf'
+          - 'FileAvailable--etc-kubernetes-bootstrap-kubelet.conf'
+          - 'Port-10250' # kubelet
+          - 'FileAvailable--etc-kubernetes-manifests-kube-controller-manager.yaml'
+          - 'Port-10257' # kube-controller-manager
+          - 'FileAvailable--etc-kubernetes-manifests-kube-scheduler.yaml'
+          - 'Port-10259' # kube-scheduler
+          - 'FileAvailable--etc-kubernetes-manifests-kube-apiserver.yaml'
+          - 'Port-{{ kube_apiserver_port }}'
+          - "{{ 'FileAvailable--etc-kubernetes-manifests-etcd.yaml' if etcd_deployment_type == 'kubeadm' else '' }}"
+          - "{{ 'DirAvailable--var-lib-etcd' if etcd_deployment_type == 'kubeadm' else '' }}"
+          - "{{ 'Port-2379' if etcd_deployment_type == 'kubeadm' else '' }}" # etcd client
+          - "{{ 'Port-2380' if etcd_deployment_type == 'kubeadm' else '' }}" # etcd peer
+        _ignore_errors:
+          - "{{ kubeadm_ignore_preflight_errors }}"
+          - "{{ _errors_from_first_try if 'all' not in kubeadm_ignore_preflight_errors else [] }}"
+      register: kubeadm_join_control_plane
+      retries: 2
+      until: kubeadm_join_control_plane is succeeded
   when:
     - inventory_hostname != first_kube_control_plane
     - kubeadm_already_run is not defined or not kubeadm_already_run.stat.exists

--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -198,10 +198,17 @@
       command: "{{ kubeadm_init_first_control_plane_cmd }}"
       vars:
         _errors_from_first_try:
+          - 'Port-10250' # kubelet
           - 'FileAvailable--etc-kubernetes-manifests-kube-controller-manager.yaml'
+          - 'Port-10257' # kube-controller-manager
           - 'FileAvailable--etc-kubernetes-manifests-kube-scheduler.yaml'
+          - 'Port-10259' # kube-scheduler
           - 'FileAvailable--etc-kubernetes-manifests-kube-apiserver.yaml'
-          - 'Port-10250'
+          - 'Port-{{ kube_apiserver_port }}'
+          - "{{ 'FileAvailable--etc-kubernetes-manifests-etcd.yaml' if etcd_deployment_type == 'kubeadm' else '' }}"
+          - "{{ 'DirAvailable--var-lib-etcd' if etcd_deployment_type == 'kubeadm' else '' }}"
+          - "{{ 'Port-2379' if etcd_deployment_type == 'kubeadm' else '' }}" # etcd client
+          - "{{ 'Port-2380' if etcd_deployment_type == 'kubeadm' else '' }}" # etcd peer
         _ignore_errors:
           - "{{ kubeadm_ignore_preflight_errors }}"
           - "{{ _errors_from_first_try if 'all' not in kubeadm_ignore_preflight_errors else [] }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Fixes this error during retry:
[preflight] Some fatal errors occurred:
	[ERROR FileAvailable--etc-kubernetes-manifests-etcd.yaml]: /etc/kubernetes/manifests/etcd.yaml already exists
[preflight] If you know what you are doing, you can make a check non-fatal with `--ignore-preflight-errors=...` error: error execution phase preflight: preflight checks failed To see the stack trace of this error execute with --v=5 or higher

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
