### PR TITLE
docs(ci): clarify why build image override is required

### DIFF
--- a/.gitlab-ci/build.yml
+++ b/.gitlab-ci/build.yml
@@ -11,10 +11,9 @@ pipeline-image:
   variables:
     BUILDKITD_FLAGS: --oci-worker-no-process-sandbox
     CACHE_IMAGE: $CI_REGISTRY_IMAGE/pipeline:cache
-  # TODO: remove the override
-  # currently rebase.sh depends on bash (not available in the kaniko image)
-  # once we have a simpler rebase (which should be easy if the target branch ref is available as variable
-  # we'll be able to rebase here as well hopefully
+  # NOTE: The override is required because the default Kaniko image does NOT include any shell (not even /bin/sh),
+  # but the pipeline needs a shell to run scripts like rebase.sh. If the pipeline is refactored to remove the need for shell scripts,
+  # or if a debug image with a shell is used, this override can be removed. See https://github.com/GoogleContainerTools/kaniko for details.
   before_script:
     - mkdir -p ~/.docker
     - echo "{\"auths\":{\"$CI_REGISTRY\":{\"auth\":\"$(echo -n ${CI_REGISTRY_USER}:${CI_REGISTRY_PASSWORD} | base64)\"}}}" > ~/.docker/config.json

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -54,6 +54,7 @@
 * Getting Started
   * [Comparisons](/docs/getting_started/comparisons.md)
   * [Getting-started](/docs/getting_started/getting-started.md)
+  * [Minimal Inventory](/docs/getting_started/minimal-inventory.md)
   * [Setting-up-your-first-cluster](/docs/getting_started/setting-up-your-first-cluster.md)
 * Ingress
   * [Alb Ingress Controller](/docs/ingress/alb_ingress_controller.md)

--- a/docs/getting_started/getting-started.md
+++ b/docs/getting_started/getting-started.md
@@ -6,6 +6,9 @@ Install Ansible according to [Ansible installation guide](/docs/ansible/ansible.
 
 ## Building your own inventory
 
+For a lightweight approach using only the files you need, see the [Minimal Inventory
+guide](minimal-inventory.md).
+
 Ansible inventory can be stored in 3 formats: YAML, JSON, or INI-like. See the
 [example inventory](/inventory/sample/inventory.ini)
 and [Ansible documentation on building your inventory](https://docs.ansible.com/ansible/latest/inventory_guide/intro_inventory.html),

--- a/docs/getting_started/minimal-inventory.md
+++ b/docs/getting_started/minimal-inventory.md
@@ -1,0 +1,244 @@
+# Minimal Inventory Guide
+
+This document describes best practices for managing Kubespray custom configurations
+in a separate git repository with minimal files.
+
+## Why a Minimal Inventory
+
+Many tutorials recommend copying the entire `inventory/sample` directory to
+`inventory/myclustername` and then modifying options directly in those files.
+While this works well for getting started, it results in:
+
+- A large number of files in your custom git repository
+- Difficulty distinguishing which settings differ from Kubespray defaults
+- Increased maintenance burden when Kubespray updates sample files
+
+A better approach is to keep only the files that contain your custom
+configuration and reference Kubespray as a git submodule. This makes it easy
+to track what you have customized and to update Kubespray independently.
+
+## Minimal Inventory Structure
+
+For most clusters, you only need these two files:
+
+```
+your-repo/
+├── inventory/
+│   └── mycluster/
+│       ├── hosts.yaml          # Cluster topology (nodes and groups)
+│       └── group_vars/
+│           └── all.yaml        # Custom configuration overrides
+├── kubespray                   # Submodule pointing to Kubespray
+└── .gitmodules
+```
+
+## Hosts File
+
+Create `inventory/mycluster/hosts.yaml` to define your cluster topology.
+
+### Single-node cluster example
+
+```yaml
+all:
+  hosts:
+    node1:
+      ansible_host: 192.168.1.10
+      # Internal IP for the node (optional)
+      # ip: 10.0.0.2
+  children:
+    kube_control_plane:
+      hosts:
+        node1:
+    kube_node:
+      hosts:
+        node1:
+    etcd:
+      hosts:
+        node1:
+    k8s_cluster:
+      children:
+        kube_control_plane:
+        kube_node:
+```
+
+### Multi-node HA cluster example
+
+```yaml
+all:
+  vars:
+    ansible_user: deploy
+    # ansible_ssh_private_key_file: ~/.ssh/id_rsa
+  hosts:
+    controller1:
+      ansible_host: 192.168.1.10
+    controller2:
+      ansible_host: 192.168.1.11
+    controller3:
+      ansible_host: 192.168.1.12
+    worker1:
+      ansible_host: 192.168.1.20
+    worker2:
+      ansible_host: 192.168.1.21
+    worker3:
+      ansible_host: 192.168.1.22
+  children:
+    kube_control_plane:
+      hosts:
+        controller1:
+        controller2:
+        controller3:
+    kube_node:
+      hosts:
+        worker1:
+        worker2:
+        worker3:
+    etcd:
+      hosts:
+        controller1:
+        controller2:
+        controller3:
+    k8s_cluster:
+      children:
+        kube_control_plane:
+        kube_node:
+```
+
+> **Note:** `etcd` is defined as a child of `kube_control_plane` for a
+"stacked" etcd topology. For external etcd, create a separate `[etcd]` group
+with its own hosts.
+
+## Group Variables File
+
+Create `inventory/mycluster/group_vars/all.yaml` with only the settings that
+differ from Kubespray defaults:
+
+```yaml
+# Cluster identity
+cluster_name: mycluster.example.com
+
+# SSL certificate SAN entries
+supplementary_addresses_in_ssl_keys:
+  - controller1.example.com
+  - controller2.example.com
+  - controller3.example.com
+
+# Enable optional components
+helm_enabled: true
+metrics_server_enabled: true
+metrics_server_kubelet_insecure_tls: true
+krew_enabled: true
+```
+
+You only need to list variables that you want to override. Kubespray has
+sensible defaults for most settings. Check
+`roles/kubespray_defaults/defaults/main/` for the complete list of default
+values.
+
+## Setting Up Kubespray as a Git Submodule
+
+This workflow keeps Kubespray as a dependency rather than copying all files:
+
+1. **Initialize your repository:**
+
+   ```bash
+   git init
+   git remote add origin <your-repo-url>
+   ```
+
+2. **Add Kubespray as a submodule:**
+
+   ```bash
+   git submodule add https://github.com/kubernetes-sigs/kubespray.git kubespray
+   ```
+
+3. **Create your inventory structure:**
+
+   ```bash
+   mkdir -p inventory/mycluster/group_vars
+   ```
+
+4. **Create `hosts.yaml` and `group_vars/all.yaml`** as described above.
+
+5. **Commit your changes:**
+
+   ```bash
+   git add .gitmodules kubespray inventory/
+   git commit -m "Add minimal Kubespray inventory"
+   ```
+
+## Running Kubespray
+
+Navigate to the Kubespray directory and run the playbook:
+
+```bash
+cd kubespray
+ansible-playbook -i ../inventory/mycluster cluster.yml -b -v
+  --private-key=~/.ssh/id_rsa
+```
+
+Or set the `ANSIBLE_INVENTORY` environment variable:
+
+```bash
+export ANSIBLE_INVENTORY=../inventory/mycluster
+cd kubespray
+ansible-playbook cluster.yml -b -v --private-key=~/.ssh/id_rsa
+```
+
+## Organizing Group-Specific Variables
+
+As your configuration grows, you may want to organize variables by group:
+
+```
+inventory/mycluster/
+├── hosts.yaml
+└── group_vars/
+    ├── all.yaml                    # Global settings
+    ├── kube_control_plane.yaml     # Control plane only
+    ├── kube_node.yaml              # Worker nodes only
+    └── etcd.yaml                   # etcd nodes only
+```
+
+Example `group_vars/kube_control_plane.yaml`:
+
+```yaml
+supplementary_addresses_in_ssl_keys:
+  - controller1.example.com
+  - controller2.example.com
+  - controller3.example.com
+```
+
+This approach keeps your configuration organized and makes it clear which
+settings apply to which nodes.
+
+## Using INI Format Instead of YAML
+
+If you prefer the INI format, you can use `hosts.ini`:
+
+```ini
+[kube_control_plane]
+controller1 ansible_host=192.168.1.10
+controller2 ansible_host=192.168.1.11
+controller3 ansible_host=192.168.1.12
+
+[kube_node]
+worker1 ansible_host=192.168.1.20
+worker2 ansible_host=192.168.1.21
+worker3 ansible_host=192.168.1.22
+
+[etcd:children]
+kube_control_plane
+
+[k8s_cluster:children]
+kube_control_plane
+kube_node
+```
+
+## Migrating from inventory/sample
+
+If you have an existing cluster based on `inventory/sample`, you can migrate
+to a minimal inventory:
+
+1. Create a new inventory directory
+2. Copy your `hosts.yaml` (or create a new one from the examples above)
+3. Review your existing `group_vars` and copy only the non-default settings
+4. Test with the new inventory before removing the old files

--- a/roles/kubernetes/kubeadm_common/defaults/main.yml
+++ b/roles/kubernetes/kubeadm_common/defaults/main.yml
@@ -1,8 +1,6 @@
 ---
 kubeadm_patches_dir: "{{ kube_config_dir }}/patches"
 kubeadm_patches: []
-# Default patch type for kubeadm patches when not explicitly specified
-kubeadm_patch_default_type: strategic
 
 # See https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/control-plane-flags/#patches
 # Correspondance with this link

--- a/roles/kubernetes/kubeadm_common/defaults/main.yml
+++ b/roles/kubernetes/kubeadm_common/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 kubeadm_patches_dir: "{{ kube_config_dir }}/patches"
 kubeadm_patches: []
+# Default patch type for kubeadm patches when not explicitly specified
+kubeadm_patch_default_type: strategic
+
 # See https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/control-plane-flags/#patches
 # Correspondance with this link
 # patchtype = type

--- a/roles/kubernetes/kubeadm_common/tasks/main.yml
+++ b/roles/kubernetes/kubeadm_common/tasks/main.yml
@@ -19,7 +19,7 @@
 - name: Kubeadm | Copy kubeadm patches from inventory files
   copy:
     content: "{{ item.patch | to_yaml }}"
-    dest: "{{ kubeadm_patches_dir }}/{{ item.target }}{{ suffix }}+{{ item.type | default(kubeadm_patch_default_type) }}.yaml"
+    dest: "{{ kubeadm_patches_dir }}/{{ item.target }}{{ suffix }}+{{ item.type | d('strategic') }}.yaml"
     owner: "root"
     mode: "0644"
   loop: "{{ kubeadm_patches }}"

--- a/roles/kubernetes/kubeadm_common/tasks/main.yml
+++ b/roles/kubernetes/kubeadm_common/tasks/main.yml
@@ -19,7 +19,7 @@
 - name: Kubeadm | Copy kubeadm patches from inventory files
   copy:
     content: "{{ item.patch | to_yaml }}"
-    dest: "{{ kubeadm_patches_dir }}/{{ item.target }}{{ suffix }}+{{ item.type | d('strategic') }}.yaml"
+    dest: "{{ kubeadm_patches_dir }}/{{ item.target }}{{ suffix }}+{{ item.type | default(kubeadm_patch_default_type) }}.yaml"
     owner: "root"
     mode: "0644"
   loop: "{{ kubeadm_patches }}"

--- a/roles/kubernetes/node-label/defaults/main.yml
+++ b/roles/kubernetes/node-label/defaults/main.yml
@@ -1,0 +1,7 @@
+# Node labels to be applied to nodes
+# Format: dictionary of key=value pairs
+# Example:
+# node_labels:
+#   "topology.kubernetes.io/zone": "us-east-1a"
+#   "node.kubernetes.io/instance-type": "m5.large"
+node_labels: {}

--- a/roles/kubernetes/node-label/tasks/main.yml
+++ b/roles/kubernetes/node-label/tasks/main.yml
@@ -30,9 +30,8 @@
 - name: Populate inventory node label
   set_fact:
     inventory_node_labels: "{{ inventory_node_labels + ['%s=%s' | format(item.key, item.value)] }}"
-  loop: "{{ node_labels | d({}) | dict2items }}"
+  loop: "{{ node_labels | dict2items }}"
   when:
-    - node_labels is defined
     - node_labels is mapping
 
 - debug:  # noqa name[missing]

--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -382,7 +382,7 @@ downloads:
     tag: "{{ etcd_image_tag }}"
     checksum: >-
       {{ etcd_binary_checksum if (etcd_deployment_type == 'host')
-      else etcd_digest_checksum | default(None) }}
+      else etcd_digest_checksum | d(None) }}
     url: "{{ etcd_download_url }}"
     unarchive: "{{ etcd_deployment_type == 'host' }}"
     owner: "root"
@@ -589,7 +589,7 @@ downloads:
     container: true
     repo: "{{ cilium_image_repo }}"
     tag: "{{ cilium_image_tag }}"
-    checksum: "{{ cilium_digest_checksum | default(None) }}"
+    checksum: "{{ cilium_digest_checksum | d(None) }}"
     groups:
       - k8s_cluster
 
@@ -598,7 +598,7 @@ downloads:
     container: true
     repo: "{{ cilium_operator_image_repo }}"
     tag: "{{ cilium_operator_image_tag }}"
-    checksum: "{{ cilium_operator_digest_checksum | default(None) }}"
+    checksum: "{{ cilium_operator_digest_checksum | d(None) }}"
     groups:
       - k8s_cluster
 
@@ -607,7 +607,7 @@ downloads:
     container: true
     repo: "{{ cilium_hubble_relay_image_repo }}"
     tag: "{{ cilium_hubble_relay_image_tag }}"
-    checksum: "{{ cilium_hubble_relay_digest_checksum | default(None) }}"
+    checksum: "{{ cilium_hubble_relay_digest_checksum | d(None) }}"
     groups:
       - k8s_cluster
 
@@ -616,7 +616,7 @@ downloads:
     container: true
     repo: "{{ cilium_hubble_certgen_image_repo }}"
     tag: "{{ cilium_hubble_certgen_image_tag }}"
-    checksum: "{{ cilium_hubble_certgen_digest_checksum | default(None) }}"
+    checksum: "{{ cilium_hubble_certgen_digest_checksum | d(None) }}"
     groups:
       - k8s_cluster
 
@@ -625,7 +625,7 @@ downloads:
     container: true
     repo: "{{ cilium_hubble_ui_image_repo }}"
     tag: "{{ cilium_hubble_ui_image_tag }}"
-    checksum: "{{ cilium_hubble_ui_digest_checksum | default(None) }}"
+    checksum: "{{ cilium_hubble_ui_digest_checksum | d(None) }}"
     groups:
       - k8s_cluster
 
@@ -634,7 +634,7 @@ downloads:
     container: true
     repo: "{{ cilium_hubble_ui_backend_image_repo }}"
     tag: "{{ cilium_hubble_ui_backend_image_tag }}"
-    checksum: "{{ cilium_hubble_ui_backend_digest_checksum | default(None) }}"
+    checksum: "{{ cilium_hubble_ui_backend_digest_checksum | d(None) }}"
     groups:
       - k8s_cluster
 
@@ -643,7 +643,7 @@ downloads:
     container: true
     repo: "{{ cilium_hubble_envoy_image_repo }}"
     tag: "{{ cilium_hubble_envoy_image_tag }}"
-    checksum: "{{ cilium_hubble_envoy_digest_checksum | default(None) }}"
+    checksum: "{{ cilium_hubble_envoy_digest_checksum | d(None) }}"
     groups:
       - k8s_cluster
 
@@ -664,7 +664,7 @@ downloads:
     container: true
     repo: "{{ multus_image_repo }}"
     tag: "{{ multus_image_tag }}"
-    checksum: "{{ multus_digest_checksum | default(None) }}"
+    checksum: "{{ multus_digest_checksum | d(None) }}"
     groups:
       - k8s_cluster
 
@@ -673,7 +673,7 @@ downloads:
     container: true
     repo: "{{ flannel_image_repo }}"
     tag: "{{ flannel_image_tag }}"
-    checksum: "{{ flannel_digest_checksum | default(None) }}"
+    checksum: "{{ flannel_digest_checksum | d(None) }}"
     groups:
       - k8s_cluster
 
@@ -682,7 +682,7 @@ downloads:
     container: true
     repo: "{{ flannel_init_image_repo }}"
     tag: "{{ flannel_init_image_tag }}"
-    checksum: "{{ flannel_init_digest_checksum | default(None) }}"
+    checksum: "{{ flannel_init_digest_checksum | d(None) }}"
     groups:
       - k8s_cluster
 
@@ -703,7 +703,7 @@ downloads:
     container: true
     repo: "{{ calico_node_image_repo }}"
     tag: "{{ calico_node_image_tag }}"
-    checksum: "{{ calico_node_digest_checksum | default(None) }}"
+    checksum: "{{ calico_node_digest_checksum | d(None) }}"
     groups:
       - k8s_cluster
 
@@ -712,7 +712,7 @@ downloads:
     container: true
     repo: "{{ calico_cni_image_repo }}"
     tag: "{{ calico_cni_image_tag }}"
-    checksum: "{{ calico_cni_digest_checksum | default(None) }}"
+    checksum: "{{ calico_cni_digest_checksum | d(None) }}"
     groups:
       - k8s_cluster
 
@@ -721,7 +721,7 @@ downloads:
     container: true
     repo: "{{ calico_policy_image_repo }}"
     tag: "{{ calico_policy_image_tag }}"
-    checksum: "{{ calico_policy_digest_checksum | default(None) }}"
+    checksum: "{{ calico_policy_digest_checksum | d(None) }}"
     groups:
       - k8s_cluster
 
@@ -730,7 +730,7 @@ downloads:
     container: true
     repo: "{{ calico_typha_image_repo }}"
     tag: "{{ calico_typha_image_tag }}"
-    checksum: "{{ calico_typha_digest_checksum | default(None) }}"
+    checksum: "{{ calico_typha_digest_checksum | d(None) }}"
     groups:
       - k8s_cluster
 
@@ -739,7 +739,7 @@ downloads:
     container: true
     repo: "{{ calico_apiserver_image_repo }}"
     tag: "{{ calico_apiserver_image_tag }}"
-    checksum: "{{ calico_apiserver_digest_checksum | default(None) }}"
+    checksum: "{{ calico_apiserver_digest_checksum | d(None) }}"
     groups:
       - k8s_cluster
 
@@ -759,7 +759,7 @@ downloads:
     container: true
     repo: "{{ kube_ovn_container_image_repo }}"
     tag: "{{ kube_ovn_container_image_tag }}"
-    checksum: "{{ kube_ovn_digest_checksum | default(None) }}"
+    checksum: "{{ kube_ovn_digest_checksum | d(None) }}"
     groups:
       - k8s_cluster
 
@@ -768,7 +768,7 @@ downloads:
     container: true
     repo: "{{ kube_router_image_repo }}"
     tag: "{{ kube_router_image_tag }}"
-    checksum: "{{ kube_router_digest_checksum | default(None) }}"
+    checksum: "{{ kube_router_digest_checksum | d(None) }}"
     groups:
       - k8s_cluster
 
@@ -777,7 +777,7 @@ downloads:
     container: true
     repo: "{{ pod_infra_image_repo }}"
     tag: "{{ pod_infra_image_tag }}"
-    checksum: "{{ pod_infra_digest_checksum | default(None) }}"
+    checksum: "{{ pod_infra_digest_checksum | d(None) }}"
     groups:
       - k8s_cluster
 
@@ -786,7 +786,7 @@ downloads:
     container: true
     repo: "{{ kube_vip_image_repo }}"
     tag: "{{ kube_vip_image_tag }}"
-    checksum: "{{ kube_vip_digest_checksum | default(None) }}"
+    checksum: "{{ kube_vip_digest_checksum | d(None) }}"
     groups:
       - kube_control_plane
 
@@ -795,7 +795,7 @@ downloads:
     container: true
     repo: "{{ nginx_image_repo }}"
     tag: "{{ nginx_image_tag }}"
-    checksum: "{{ nginx_digest_checksum | default(None) }}"
+    checksum: "{{ nginx_digest_checksum | d(None) }}"
     groups:
       - kube_node
 
@@ -804,7 +804,7 @@ downloads:
     container: true
     repo: "{{ haproxy_image_repo }}"
     tag: "{{ haproxy_image_tag }}"
-    checksum: "{{ haproxy_digest_checksum | default(None) }}"
+    checksum: "{{ haproxy_digest_checksum | d(None) }}"
     groups:
       - kube_node
 
@@ -813,7 +813,7 @@ downloads:
     container: true
     repo: "{{ coredns_image_repo }}"
     tag: "{{ coredns_image_tag }}"
-    checksum: "{{ coredns_digest_checksum | default(None) }}"
+    checksum: "{{ coredns_digest_checksum | d(None) }}"
     groups:
       - k8s_cluster
 
@@ -822,7 +822,7 @@ downloads:
     container: true
     repo: "{{ nodelocaldns_image_repo }}"
     tag: "{{ nodelocaldns_image_tag }}"
-    checksum: "{{ nodelocaldns_digest_checksum | default(None) }}"
+    checksum: "{{ nodelocaldns_digest_checksum | d(None) }}"
     groups:
       - k8s_cluster
 
@@ -831,7 +831,7 @@ downloads:
     container: true
     repo: "{{ dnsautoscaler_image_repo }}"
     tag: "{{ dnsautoscaler_image_tag }}"
-    checksum: "{{ dnsautoscaler_digest_checksum | default(None) }}"
+    checksum: "{{ dnsautoscaler_digest_checksum | d(None) }}"
     groups:
       - kube_control_plane
 
@@ -852,7 +852,7 @@ downloads:
     container: true
     repo: "{{ registry_image_repo }}"
     tag: "{{ registry_image_tag }}"
-    checksum: "{{ registry_digest_checksum | default(None) }}"
+    checksum: "{{ registry_digest_checksum | d(None) }}"
     groups:
       - kube_node
 
@@ -861,7 +861,7 @@ downloads:
     container: true
     repo: "{{ metrics_server_image_repo }}"
     tag: "{{ metrics_server_image_tag }}"
-    checksum: "{{ metrics_server_digest_checksum | default(None) }}"
+    checksum: "{{ metrics_server_digest_checksum | d(None) }}"
     groups:
       - kube_control_plane
 
@@ -870,7 +870,7 @@ downloads:
     container: true
     repo: "{{ local_volume_provisioner_image_repo }}"
     tag: "{{ local_volume_provisioner_image_tag }}"
-    checksum: "{{ local_volume_provisioner_digest_checksum | default(None) }}"
+    checksum: "{{ local_volume_provisioner_digest_checksum | d(None) }}"
     groups:
       - kube_node
 
@@ -879,7 +879,7 @@ downloads:
     container: true
     repo: "{{ local_path_provisioner_image_repo }}"
     tag: "{{ local_path_provisioner_image_tag }}"
-    checksum: "{{ local_path_provisioner_digest_checksum | default(None) }}"
+    checksum: "{{ local_path_provisioner_digest_checksum | d(None) }}"
     groups:
       - kube_node
 
@@ -888,7 +888,7 @@ downloads:
     container: true
     repo: "{{ alb_ingress_image_repo }}"
     tag: "{{ alb_ingress_image_tag }}"
-    checksum: "{{ ingress_alb_controller_digest_checksum | default(None) }}"
+    checksum: "{{ ingress_alb_controller_digest_checksum | d(None) }}"
     groups:
       - kube_node
 
@@ -897,7 +897,7 @@ downloads:
     container: true
     repo: "{{ cert_manager_controller_image_repo }}"
     tag: "{{ cert_manager_controller_image_tag }}"
-    checksum: "{{ cert_manager_controller_digest_checksum | default(None) }}"
+    checksum: "{{ cert_manager_controller_digest_checksum | d(None) }}"
     groups:
       - kube_node
 
@@ -906,7 +906,7 @@ downloads:
     container: true
     repo: "{{ cert_manager_cainjector_image_repo }}"
     tag: "{{ cert_manager_cainjector_image_tag }}"
-    checksum: "{{ cert_manager_cainjector_digest_checksum | default(None) }}"
+    checksum: "{{ cert_manager_cainjector_digest_checksum | d(None) }}"
     groups:
       - kube_node
 
@@ -915,7 +915,7 @@ downloads:
     container: true
     repo: "{{ cert_manager_webhook_image_repo }}"
     tag: "{{ cert_manager_webhook_image_tag }}"
-    checksum: "{{ cert_manager_webhook_digest_checksum | default(None) }}"
+    checksum: "{{ cert_manager_webhook_digest_checksum | d(None) }}"
     groups:
       - kube_node
 
@@ -948,7 +948,7 @@ downloads:
     container: true
     repo: "{{ csi_attacher_image_repo }}"
     tag: "{{ csi_attacher_image_tag }}"
-    checksum: "{{ csi_attacher_digest_checksum | default(None) }}"
+    checksum: "{{ csi_attacher_digest_checksum | d(None) }}"
     groups:
       - kube_node
 
@@ -957,7 +957,7 @@ downloads:
     container: true
     repo: "{{ csi_provisioner_image_repo }}"
     tag: "{{ csi_provisioner_image_tag }}"
-    checksum: "{{ csi_provisioner_digest_checksum | default(None) }}"
+    checksum: "{{ csi_provisioner_digest_checksum | d(None) }}"
     groups:
       - kube_node
 
@@ -966,7 +966,7 @@ downloads:
     container: true
     repo: "{{ csi_snapshotter_image_repo }}"
     tag: "{{ csi_snapshotter_image_tag }}"
-    checksum: "{{ csi_snapshotter_digest_checksum | default(None) }}"
+    checksum: "{{ csi_snapshotter_digest_checksum | d(None) }}"
     groups:
       - kube_node
 
@@ -975,7 +975,7 @@ downloads:
     container: true
     repo: "{{ snapshot_controller_image_repo }}"
     tag: "{{ snapshot_controller_image_tag }}"
-    checksum: "{{ snapshot_controller_digest_checksum | default(None) }}"
+    checksum: "{{ snapshot_controller_digest_checksum | d(None) }}"
     groups:
       - kube_node
 
@@ -984,7 +984,7 @@ downloads:
     container: true
     repo: "{{ csi_resizer_image_repo }}"
     tag: "{{ csi_resizer_image_tag }}"
-    checksum: "{{ csi_resizer_digest_checksum | default(None) }}"
+    checksum: "{{ csi_resizer_digest_checksum | d(None) }}"
     groups:
       - kube_node
 
@@ -993,7 +993,7 @@ downloads:
     container: true
     repo: "{{ csi_livenessprobe_image_repo }}"
     tag: "{{ csi_livenessprobe_image_tag }}"
-    checksum: "{{ csi_livenessprobe_digest_checksum | default(None) }}"
+    checksum: "{{ csi_livenessprobe_digest_checksum | d(None) }}"
     groups:
       - kube_node
 
@@ -1002,7 +1002,7 @@ downloads:
     container: true
     repo: "{{ csi_node_driver_registrar_image_repo }}"
     tag: "{{ csi_node_driver_registrar_image_tag }}"
-    checksum: "{{ csi_node_driver_registrar_digest_checksum | default(None) }}"
+    checksum: "{{ csi_node_driver_registrar_digest_checksum | d(None) }}"
     groups:
       - kube_node
 
@@ -1011,7 +1011,7 @@ downloads:
     container: true
     repo: "{{ cinder_csi_plugin_image_repo }}"
     tag: "{{ cinder_csi_plugin_image_tag }}"
-    checksum: "{{ cinder_csi_plugin_digest_checksum | default(None) }}"
+    checksum: "{{ cinder_csi_plugin_digest_checksum | d(None) }}"
     groups:
       - kube_node
 
@@ -1020,7 +1020,7 @@ downloads:
     container: true
     repo: "{{ aws_ebs_csi_plugin_image_repo }}"
     tag: "{{ aws_ebs_csi_plugin_image_tag }}"
-    checksum: "{{ aws_ebs_csi_plugin_digest_checksum | default(None) }}"
+    checksum: "{{ aws_ebs_csi_plugin_digest_checksum | d(None) }}"
     groups:
       - kube_node
 
@@ -1029,7 +1029,7 @@ downloads:
     container: true
     repo: "{{ metallb_speaker_image_repo }}"
     tag: "{{ metallb_image_tag }}"
-    checksum: "{{ metallb_speaker_digest_checksum | default(None) }}"
+    checksum: "{{ metallb_speaker_digest_checksum | d(None) }}"
     groups:
       - kube_control_plane
 
@@ -1038,7 +1038,7 @@ downloads:
     container: true
     repo: "{{ metallb_controller_image_repo }}"
     tag: "{{ metallb_image_tag }}"
-    checksum: "{{ metallb_controller_digest_checksum | default(None) }}"
+    checksum: "{{ metallb_controller_digest_checksum | d(None) }}"
     groups:
       - kube_control_plane
 

--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -382,7 +382,7 @@ downloads:
     tag: "{{ etcd_image_tag }}"
     checksum: >-
       {{ etcd_binary_checksum if (etcd_deployment_type == 'host')
-      else etcd_digest_checksum | d(None) }}
+      else etcd_digest_checksum | default(None) }}
     url: "{{ etcd_download_url }}"
     unarchive: "{{ etcd_deployment_type == 'host' }}"
     owner: "root"


### PR DESCRIPTION
This PR updates the comment in build.yml to clarify the reason for the custom build image override.
The default Kaniko image does not include a shell, but the pipeline requires one to run scripts like rebase.sh 

This documentation improvement aims to help future contributors understand the current setup and what would be needed to remove the override.

No functional changes are introduced.

Thanks