### PR TITLE
bump(download): Flannel v0.27.3 → v0.28.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Note:
   - [cni-plugins](https://github.com/containernetworking/plugins) 1.8.0
   - [calico](https://github.com/projectcalico/calico) 3.30.7
   - [cilium](https://github.com/cilium/cilium) 1.19.3
-  - [flannel](https://github.com/flannel-io/flannel) 0.27.3
+  - [flannel](https://github.com/flannel-io/flannel) 0.28.4
   - [kube-ovn](https://github.com/alauda/kube-ovn) 1.12.21
   - [kube-router](https://github.com/cloudnativelabs/kube-router) 2.1.1
   - [multus](https://github.com/k8snetworkplumbingwg/multus-cni) 4.2.2

--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -112,7 +112,7 @@ calico_apiserver_version: "{{ calico_version }}"
 typha_enabled: false
 calico_apiserver_enabled: false
 
-flannel_version: 0.27.3
+flannel_version: 0.28.4
 flannel_cni_version: 1.7.1-flannel1
 cni_version: "{{ (cni_binary_checksums['amd64'] | dict2items)[0].key }}"
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Bump Flannel from v0.27.3 to v0.28.4, the latest stable release. Includes bug fixes and improvements for better networking stability.

**Which issue(s) this PR fixes**:
Fixes #13182

**Special notes for your reviewer**:
Only `flannel_version` updated. Please advise if `flannel_cni_version` also needs bumping.

**Does this PR introduce a user-facing change?**:
```release-note
Bump Flannel to v0.28.4.
```
