### PR TITLE
Update README.md of helm-apps role

### DIFF
--- a/roles/helm-apps/README.md
+++ b/roles/helm-apps/README.md
@@ -22,6 +22,7 @@ Playbook example:
 - hosts: kube_control_plane[0]
   gather_facts: no
   roles:
+    - { role: kubespray_defaults }
     - name: helm-apps
       releases:
         - name: app

--- a/roles/helm-apps/README.md
+++ b/roles/helm-apps/README.md
@@ -32,9 +32,9 @@ Playbook example:
           namespace: app
           chart_ref: simple-app/simple-app
           wait_timeout: "10m" # override the same option in `release_common_opts`
-      repositories: "{{ repos }}"
+      repositories: 
         - name: simple-app
           url: "https://blog.leiwang.info/simple-app"
-      release_common_opts: "{{ helm_params }}"
+      release_common_opts:
         wait_timeout: "5m"
 ```


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

The current documentation instructs users to add the helm-apps role directly to their play. However, following the documented steps results in the following error during execution:

`The task includes an option with an undefined variable. The error was: 'download_run_once' is undefined`

This happens because `helm-apps `depends on the` kubernetes-apps/helm` role, which in turn expects variables provided by the `kubespray_defaults` role. When `kubespray_defaults` is not included in the play, required variables (such as `download_run_once`) are missing, causing the playbook to fail.

This commit updates the role integration to ensure that `kubespray_defaults` is loaded before `helm-apps`, aligning the dependency order with what the upstream roles expect


**Which issue(s) this PR fixes**:
Fixes #11345

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
`Update provided documentation of how to add helm applications to Kubernetes
`
