### PR TITLE
Fix OpenStack Terraform group_vars_path handling

### DIFF
--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -374,7 +374,7 @@ resource "openstack_compute_instance_v2" "bastion" {
   }
 
   provisioner "local-exec" {
-    command = "sed -e s/USER/${var.ssh_user}/ -e s/BASTION_ADDRESS/${var.bastion_fips[0]}/ ${path.module}/ansible_bastion_template.txt > ${var.group_vars_path}/no_floating.yml"
+    command = "mkdir -p ${var.group_vars_path} && sed -e s/USER/${var.ssh_user}/ -e s/BASTION_ADDRESS/${var.bastion_fips[0]}/ ${path.module}/ansible_bastion_template.txt > ${var.group_vars_path}/no_floating.yml"
   }
 }
 
@@ -444,7 +444,7 @@ resource "openstack_compute_instance_v2" "k8s_master" {
   }
 
   provisioner "local-exec" {
-    command = "sed -e s/USER/${var.ssh_user}/ -e s/BASTION_ADDRESS/${element(concat(var.bastion_fips, var.k8s_master_fips), 0)}/ ${path.module}/ansible_bastion_template.txt > ${var.group_vars_path}/no_floating.yml"
+    command = "mkdir -p ${var.group_vars_path} && sed -e s/USER/${var.ssh_user}/ -e s/BASTION_ADDRESS/${element(concat(var.bastion_fips, var.k8s_master_fips), 0)}/ ${path.module}/ansible_bastion_template.txt > ${var.group_vars_path}/no_floating.yml"
   }
 }
 
@@ -512,7 +512,7 @@ resource "openstack_compute_instance_v2" "k8s_masters" {
   }
 
   provisioner "local-exec" {
-    command = "%{if each.value.floating_ip}sed s/USER/${var.ssh_user}/ ${path.module}/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(concat(var.bastion_fips, [for key, value in var.k8s_masters_fips : value.address]), 0)}/ > ${var.group_vars_path}/no_floating.yml%{else}true%{endif}"
+    command = "%{if each.value.floating_ip}mkdir -p ${var.group_vars_path} && sed s/USER/${var.ssh_user}/ ${path.module}/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(concat(var.bastion_fips, [for key, value in var.k8s_masters_fips : value.address]), 0)}/ > ${var.group_vars_path}/no_floating.yml%{else}true%{endif}"
   }
 }
 
@@ -582,7 +582,7 @@ resource "openstack_compute_instance_v2" "k8s_master_no_etcd" {
   }
 
   provisioner "local-exec" {
-    command = "sed -e s/USER/${var.ssh_user}/ -e s/BASTION_ADDRESS/${element(concat(var.bastion_fips, var.k8s_master_fips), 0)}/ ${path.module}/ansible_bastion_template.txt > ${var.group_vars_path}/no_floating.yml"
+    command = "mkdir -p ${var.group_vars_path} && sed -e s/USER/${var.ssh_user}/ -e s/BASTION_ADDRESS/${element(concat(var.bastion_fips, var.k8s_master_fips), 0)}/ ${path.module}/ansible_bastion_template.txt > ${var.group_vars_path}/no_floating.yml"
   }
 }
 
@@ -841,7 +841,7 @@ resource "openstack_compute_instance_v2" "k8s_node" {
   }
 
   provisioner "local-exec" {
-    command = "sed -e s/USER/${var.ssh_user}/ -e s/BASTION_ADDRESS/${element(concat(var.bastion_fips, var.k8s_node_fips), 0)}/ ${path.module}/ansible_bastion_template.txt > ${var.group_vars_path}/no_floating.yml"
+    command = "mkdir -p ${var.group_vars_path} && sed -e s/USER/${var.ssh_user}/ -e s/BASTION_ADDRESS/${element(concat(var.bastion_fips, var.k8s_node_fips), 0)}/ ${path.module}/ansible_bastion_template.txt > ${var.group_vars_path}/no_floating.yml"
   }
 }
 
@@ -978,7 +978,7 @@ resource "openstack_compute_instance_v2" "k8s_nodes" {
   }
 
   provisioner "local-exec" {
-    command = "%{if each.value.floating_ip}sed -e s/USER/${var.ssh_user}/ -e s/BASTION_ADDRESS/${element(concat(var.bastion_fips, [for key, value in var.k8s_nodes_fips : value.address]), 0)}/ ${path.module}/ansible_bastion_template.txt > ${var.group_vars_path}/no_floating.yml%{else}true%{endif}"
+    command = "%{if each.value.floating_ip}mkdir -p ${var.group_vars_path} && sed -e s/USER/${var.ssh_user}/ -e s/BASTION_ADDRESS/${element(concat(var.bastion_fips, [for key, value in var.k8s_nodes_fips : value.address]), 0)}/ ${path.module}/ansible_bastion_template.txt > ${var.group_vars_path}/no_floating.yml%{else}true%{endif}"
   }
 }
 

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -398,7 +398,7 @@ variable "image_master_uuid" {
 }
 
 variable "group_vars_path" {
-  description = "path to the inventory group vars directory"
+  description = "Absolute path to the inventory group_vars directory. Relative paths may fail when using terraform -chdir."
   type        = string
   default     = "./group_vars"
 }

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -398,7 +398,7 @@ variable "image_master_uuid" {
 }
 
 variable "group_vars_path" {
-  description = "Absolute path to the inventory group_vars directory. Relative paths may fail when using terraform -chdir."
+  description = "Path to the inventory group_vars directory (absolute recommended; relative paths may fail when using terraform -chdir)."
   type        = string
   default     = "./group_vars"
 }


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Fixes an issue in the OpenStack Terraform provider where `local-exec` provisioners writing `no_floating.yml` fail when Terraform is executed using `terraform -chdir`.

The current implementation writes:

`> ${var.group_vars_path}/no_floating.yml`

with the default:

`group_vars_path = "./group_vars"`

When Terraform is run from `contrib/terraform/openstack` using `-chdir`, the relative path resolves from the Terraform working directory instead of the inventory directory, causing:

`cannot create ./group_vars/no_floating.yml: Directory nonexistent`

This PR makes the behavior safer by:

1. Adding `mkdir -p ${var.group_vars_path}` before all `sed` commands that generate `no_floating.yml`
2. Improving the `group_vars_path` variable description to clarify that absolute paths are recommended because relative paths may fail with `terraform -chdir`

This prevents failures during bastion and node creation and makes the OpenStack Terraform workflow more reliable.

**Which issue(s) this PR fixes**:

Fixes #13201

**Special notes for your reviewer**:

Issue was reproduced while deploying Kubespray on OpenStack with an existing Neutron network and no-floating-IP worker nodes.

Terraform failed during bastion creation because `group_vars/no_floating.yml` could not be created even though the inventory directory contained `group_vars/`.

Root cause was relative path resolution under `terraform -chdir`.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed OpenStack Terraform deployment failure where `no_floating.yml` generation could fail when using `terraform -chdir` due to relative `group_vars_path` resolution. The local-exec provisioner now ensures the directory exists before writing the file, and variable documentation now recommends using absolute paths.
```
<img width="2148" height="641" alt="Screenshot From 2026-04-20 11-24-06" src="https://github.com/user-attachments/assets/4a526f3f-a8f7-419e-8147-8e4d4c765a4f" />
