### PR TITLE
ci: migrate KubeVirt Fedora jobs from EOL 39–41 to Fedora 42 and 43

### DIFF
--- a/.gitlab-ci/kubevirt.yml
+++ b/.gitlab-ci/kubevirt.yml
@@ -40,8 +40,8 @@ pr:
           - debian11-macvlan
           - debian12-cilium
           - debian13-cilium
-          - fedora39-kube-router
-          - fedora41-kube-router
+          - fedora42-kube-router
+          - fedora43-kube-router
           - fedora42-calico
           - rockylinux9-cilium
           - rockylinux10-cilium
@@ -56,7 +56,7 @@ pr:
           - ubuntu24-kube-router-sep
           - ubuntu24-kube-router-svc-proxy
           - ubuntu24-ha-separate-etcd
-          - fedora40-flannel-crio-collection-scale
+          - fedora43-flannel-crio-collection-scale
 
 # This is for flakey test so they don't disrupt the PR worklflow too much.
 # Jobs here MUST have a open issue so we don't lose sight of them
@@ -105,10 +105,10 @@ pr_full:
           - debian11-custom-cni
           - debian11-kubelet-csr-approver
           - debian12-custom-cni-helm
-          - fedora39-calico-swap-selinux
-          - fedora39-crio
-          - fedora41-calico-swap-selinux
-          - fedora41-crio
+          - fedora42-calico-swap-selinux
+          - fedora42-crio
+          - fedora43-calico-swap-selinux
+          - fedora43-crio
           - ubuntu24-calico-ha-wireguard
           - ubuntu24-flannel-ha
           - ubuntu24-flannel-ha-once
@@ -166,9 +166,9 @@ periodic:
           - debian11-calico-upgrade
           - debian11-calico-upgrade-once
           - debian12-cilium-svc-proxy
-          - fedora39-calico-selinux
-          - fedora40-docker-calico
-          - fedora41-calico-selinux
+          - fedora42-calico-selinux
+          - fedora43-calico-selinux
+          - fedora43-docker-calico
           - ubuntu24-calico-etcd-kubeadm-upgrade-ha
           - ubuntu24-calico-ha-recover
           - ubuntu24-calico-ha-recover-noquorum

--- a/docs/developers/ci.md
+++ b/docs/developers/ci.md
@@ -11,10 +11,8 @@ amazon |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian11 |  :white_check_mark: | :x: | :white_check_mark: | :x: | :x: | :x: | :white_check_mark: |
 debian12 |  :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | :x: | :x: | :x: |
 debian13 |  :white_check_mark: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
-fedora39 |  :white_check_mark: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: |
-fedora40 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
-fedora41 |  :white_check_mark: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: |
-fedora42 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
+fedora42 |  :white_check_mark: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: |
+fedora43 |  :white_check_mark: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: |
 flatcar4081 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
 openeuler24 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
 rockylinux10 |  :white_check_mark: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
@@ -31,10 +29,8 @@ amazon |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian11 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian12 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian13 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
-fedora39 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
-fedora40 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
-fedora41 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
-fedora42 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
+fedora42 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
+fedora43 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
 flatcar4081 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 openeuler24 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 rockylinux10 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
@@ -51,10 +47,8 @@ amazon |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian11 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian12 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian13 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
-fedora39 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
-fedora40 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
-fedora41 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 fedora42 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
+fedora43 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
 flatcar4081 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 openeuler24 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 rockylinux10 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |

--- a/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
@@ -71,6 +71,13 @@ images:
     converted: true
     tag: "latest"
 
+  fedora-43:
+    filename: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
+    url: https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
+    checksum: sha256:846574c8a97cd2d8dc1f231062d73107cc85cbbbda56335e264a46e3a6c8ab2f
+    converted: true
+    tag: "latest"
+
   fedora-coreos:
     filename: fedora-coreos-32.20200601.3.0-openstack.x86_64.qcow2.xz
     url: https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-openstack.x86_64.qcow2.xz

--- a/tests/files/fedora42-calico-selinux.yml
+++ b/tests/files/fedora42-calico-selinux.yml
@@ -1,6 +1,6 @@
 ---
 # Instance settings
-cloud_image: fedora-39
+cloud_image: fedora-42
 
 # Kubespray settings
 auto_renew_certificates: true

--- a/tests/files/fedora42-calico-swap-selinux.yml
+++ b/tests/files/fedora42-calico-swap-selinux.yml
@@ -1,6 +1,6 @@
 ---
 # Instance settings
-cloud_image: fedora-41
+cloud_image: fedora-42
 
 # Kubespray settings
 auto_renew_certificates: true

--- a/tests/files/fedora42-crio.yml
+++ b/tests/files/fedora42-crio.yml
@@ -1,10 +1,7 @@
 ---
 # Instance settings
-cloud_image: fedora-39
+cloud_image: fedora-42
 
 # Kubespray settings
 container_manager: crio
 auto_renew_certificates: true
-
-# Test with SELinux in enforcing mode
-preinstall_selinux_state: enforcing

--- a/tests/files/fedora42-kube-router.yml
+++ b/tests/files/fedora42-kube-router.yml
@@ -1,5 +1,5 @@
 ---
-cloud_image: fedora-41
+cloud_image: fedora-42
 cluster_layout:
   - node_groups: ['kube_control_plane', 'etcd', 'kube_node']
   - node_groups: ['kube_node']

--- a/tests/files/fedora43-calico-selinux.yml
+++ b/tests/files/fedora43-calico-selinux.yml
@@ -1,6 +1,6 @@
 ---
 # Instance settings
-cloud_image: fedora-41
+cloud_image: fedora-43
 
 # Kubespray settings
 auto_renew_certificates: true

--- a/tests/files/fedora43-calico-swap-selinux.yml
+++ b/tests/files/fedora43-calico-swap-selinux.yml
@@ -1,6 +1,6 @@
 ---
 # Instance settings
-cloud_image: fedora-39
+cloud_image: fedora-43
 
 # Kubespray settings
 auto_renew_certificates: true

--- a/tests/files/fedora43-crio.yml
+++ b/tests/files/fedora43-crio.yml
@@ -1,7 +1,10 @@
 ---
 # Instance settings
-cloud_image: fedora-41
+cloud_image: fedora-43
 
 # Kubespray settings
 container_manager: crio
 auto_renew_certificates: true
+
+# Test with SELinux in enforcing mode
+preinstall_selinux_state: enforcing

--- a/tests/files/fedora43-docker-calico.yml
+++ b/tests/files/fedora43-docker-calico.yml
@@ -1,6 +1,6 @@
 ---
 # Instance settings
-cloud_image: fedora-40
+cloud_image: fedora-43
 
 # Kubespray settings
 auto_renew_certificates: true

--- a/tests/files/fedora43-flannel-crio-collection-scale.yml
+++ b/tests/files/fedora43-flannel-crio-collection-scale.yml
@@ -1,5 +1,5 @@
 ---
-cloud_image: fedora-40
+cloud_image: fedora-43
 network_plugin: flannel
 container_manager: crio
 

--- a/tests/files/fedora43-kube-router.yml
+++ b/tests/files/fedora43-kube-router.yml
@@ -1,5 +1,5 @@
 ---
-cloud_image: fedora-39
+cloud_image: fedora-43
 cluster_layout:
   - node_groups: ['kube_control_plane', 'etcd', 'kube_node']
   - node_groups: ['kube_node']


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Fedora 39, 40, and 41 are End-of-Life and no longer receive security updates:

| Version | EOL date   | Notes |
| ------- | ---------- | ----- |
| 39      | 2024-11-26 | EOL |
| 40      | 2025-05-13 | EOL |
| 41      | 2025-12-15 | EOL |
| 42      | 2026-05-13 | Supported (short horizon) |
| 43      | 2026-12-09 | Latest stable |

Running CI on EOL distros produces noise from kernel / SELinux / package-repo drift that upstream no longer patches (for example recent flaky `pr_full: [fedora39-crio]` runs).

This PR retargets the **KubeVirt / GitLab CI** Fedora matrix to **Fedora 42** and **Fedora 43** while keeping **10** Fedora-based testcase configurations (same scenarios; newer base images).

**Testcase retargeting (high level)**

- Former **fedora41-*** jobs → **fedora42-*** (kube-router, calico-swap-selinux, crio, calico-selinux in periodic).
- Former **fedora39-*** jobs → **fedora43-*** (kube-router, calico-swap-selinux, crio, calico-selinux in periodic).
- Former **fedora40-*** jobs → **fedora43-*** (flannel-crio-collection-scale, docker-calico).
- **fedora42-calico** in the default `pr` matrix stays as the single-node Calico job on Fedora 42 (former fedora41-calico).

Files touched:

- `test-infra/image-builder/roles/kubevirt-images/defaults/main.yml` — add `fedora-43` cloud image metadata
- `tests/files/` — rename / update `cloud_image` for the Fedora testcase YAMLs
- `.gitlab-ci/kubevirt.yml` — rename `TESTCASE` entries in `pr`, `pr_full`, and `periodic`
- `docs/developers/ci.md` — regenerated via `./tests/scripts/md-table/main.py`

**Which issue(s) this PR fixes**:

Ref https://github.com/kubernetes-sigs/kubespray/issues/12383

**Special notes for your reviewer**:

- **Image availability**: `quay.io/kubespray/vm-fedora-43:latest` is built and pushed for this work. Reference digest: `sha256:3f56e667e09ed8fd66bee062347afc64af3403a91a4fd59772ce6878c834d2b3`. GitLab jobs that use `cloud_image: fedora-43` pick it up automatically once this PR is merged.
- Fedora 42 reaches EOL on 2026-05-13; a follow-up can move more F42 jobs to F43 (or newer) after that. This PR keeps both F42 and F43 in the matrix for version diversity.
- `Vagrantfile` still references older Fedora boxes for local development — intentionally out of scope here.

**Does this PR introduce a user-facing change?**:

```release-note
CI: KubeVirt GitLab jobs that used end-of-life Fedora 39, 40, or 41 now run on supported Fedora 42 and Fedora 43 cloud images.
```
