### PR TITLE
docs: require daily CI before tagging a release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,7 @@ The Kubespray Project is released on an as-needed basis. The process is as follo
 1. (Only for major releases) The `kube_version_min_required` variable is set to `n-1`
 1. (Only for major releases) Remove hashes for [EOL versions](https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md) of kubernetes from `*_checksums` variables.
 1. Create the release note with [Kubernetes Release Notes Generator](https://github.com/kubernetes/release/blob/master/cmd/release-notes/README.md). See the following `Release note creation` section for the details.
+1. Before tagging `vX.Y.Z`, run the full CI suite on the release preparation pull request with the Prow command `/label ci-full` and ensure all triggered jobs pass.
 1. An approver creates [new release in GitHub](https://github.com/kubernetes-sigs/kubespray/releases/new) using a version and tag name like `vX.Y.Z` and attaching the release notes
 1. (Only for major releases) An approver creates a release branch in the form `release-X.Y`
 1. (For major releases) On the `master` branch: bump the version in `galaxy.yml` to the next expected major release (X.y.0 with y = Y + 1), make a Pull Request.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,7 +7,7 @@ The Kubespray Project is released on an as-needed basis. The process is as follo
 1. (Only for major releases) The `kube_version_min_required` variable is set to `n-1`
 1. (Only for major releases) Remove hashes for [EOL versions](https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md) of kubernetes from `*_checksums` variables.
 1. Create the release note with [Kubernetes Release Notes Generator](https://github.com/kubernetes/release/blob/master/cmd/release-notes/README.md). See the following `Release note creation` section for the details.
-1. Before tagging `vX.Y.Z`, run GitLab `daily-ci` and verify its SHA matches the release commit. Link the pipeline in the release issue and review any allowed failures.
+1. Before tagging `vX.Y.Z`, run GitLab `daily-ci` for the release commit and verify the pipeline's commit SHA matches. Link the pipeline in the release issue and review any jobs marked `allow_failure`.
 1. An approver creates [new release in GitHub](https://github.com/kubernetes-sigs/kubespray/releases/new) using a version and tag name like `vX.Y.Z` and attaching the release notes
 1. (Only for major releases) An approver creates a release branch in the form `release-X.Y`
 1. (For major releases) On the `master` branch: bump the version in `galaxy.yml` to the next expected major release (X.y.0 with y = Y + 1), make a Pull Request.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,7 +7,7 @@ The Kubespray Project is released on an as-needed basis. The process is as follo
 1. (Only for major releases) The `kube_version_min_required` variable is set to `n-1`
 1. (Only for major releases) Remove hashes for [EOL versions](https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md) of kubernetes from `*_checksums` variables.
 1. Create the release note with [Kubernetes Release Notes Generator](https://github.com/kubernetes/release/blob/master/cmd/release-notes/README.md). See the following `Release note creation` section for the details.
-1. Before tagging `vX.Y.Z`, run the full CI suite on the release preparation pull request with the Prow command `/label ci-full` and ensure all triggered jobs pass.
+1. Before tagging `vX.Y.Z`, run GitLab `daily-ci` and verify its SHA matches the release commit. Link the pipeline in the release issue and review any allowed failures.
 1. An approver creates [new release in GitHub](https://github.com/kubernetes-sigs/kubespray/releases/new) using a version and tag name like `vX.Y.Z` and attaching the release notes
 1. (Only for major releases) An approver creates a release branch in the form `release-X.Y`
 1. (For major releases) On the `master` branch: bump the version in `galaxy.yml` to the next expected major release (X.y.0 with y = Y + 1), make a Pull Request.


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Require the exact release commit to be validated by GitLab `daily-ci` before tagging. The pipeline must be linked in the release issue, and allowed failures must be reviewed.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

`daily-ci` includes schedule-only jobs that are not covered by the PR `ci-full` label.

This PR was written in part with the assistance of generative AI.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
