### PR TITLE
network_plugin/custom_cni: drop hardcoded kube-system namespace on apply

### DIFF
--- a/roles/network_plugin/custom_cni/tasks/main.yml
+++ b/roles/network_plugin/custom_cni/tasks/main.yml
@@ -18,8 +18,16 @@
     run_once: true
 
   - name: Custom CNI | Start Resources
+    # Don't pin --namespace to kube-system here. Modern CNI manifests
+    # (Cilium 1.18+ and others) ship resources scoped to multiple
+    # namespaces in one YAML - kube-system plus cilium-secrets, for
+    # example. Forcing --namespace=kube-system then errors with
+    # "the namespace from the provided object does not match the
+    # namespace" for every resource that belongs to a different
+    # namespace. Let kubectl apply resolve the namespace from each
+    # resource's own metadata and fall back to the default namespace
+    # only when the resource doesn't specify one (#13205).
     kube:
-      namespace: "kube-system"
       kubectl: "{{ bin_dir }}/kubectl"
       filename: "{{ kube_config_dir }}/{{ item | basename | replace('.j2', '') }}"
       state: "latest"


### PR DESCRIPTION
## Summary

Fixes #13205.

The `debian11-custom-cni` CI job fails since the Cilium test bundle was bumped to 1.18 in #13002. Cilium 1.18 splits its YAML across two namespaces (`kube-system` + `cilium-secrets`). The `Custom CNI | Start Resources` task pins `--namespace=kube-system` on `kubectl apply`, so `kubectl` refuses every resource that belongs to `cilium-secrets` with:

```
the namespace from the provided object "cilium-secrets" does not match the namespace "kube-system".
You must pass '--namespace=cilium-secrets' to perform this operation.
```

## Fix

Drop the `namespace: "kube-system"` key on the `kube:` task so `kubectl apply` resolves the namespace from each resource's own metadata (`metadata.namespace`) and falls back to the default namespace only when the resource doesn't specify one. Manifests that only touch `kube-system` are unaffected because their ServiceAccount/ConfigMap/DaemonSet/etc. still carry `metadata.namespace: kube-system` in the YAML.

## Test plan

- [ ] `pr_full` debian11-custom-cni CI run passes against the updated Cilium 1.18.6 `tests/files/custom_cni/cilium.yaml`.
- [ ] Older manifests that used the inherited namespace continue to apply: a manifest with no `metadata.namespace` on a ServiceAccount now ends up in the current `kubectl` default context namespace (`default`) instead of `kube-system`. This is a minor behavior change only for manifests that relied on the module to supply the namespace. If that's a concern, a follow-up could re-add `namespace: "{{ custom_cni_default_namespace | default('kube-system') }}"` once it becomes an opt-in variable — but the current `kube-system` hardcode is actively incorrect for multi-namespace bundles.
