### PR TITLE
docs: fix release-notes command in release guide

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -58,7 +58,7 @@ You can create a release note with:
 export GITHUB_TOKEN=<your-github-token>
 export ORG=kubernetes-sigs
 export REPO=kubespray
-release-notes --start-sha <The start commit-id> --end-sha <The end commit-id> --dependencies=false --output=/tmp/kubespray-release-note --required-author=""
+release-notes generate --org "${ORG}" --repo "${REPO}" --repo-path "${PWD}" --start-sha <The start commit-id> --end-sha <The end commit-id> --dependencies=false --output=/tmp/kubespray-release-note
 ```
 
 If the release note file(/tmp/kubespray-release-note) contains "### Uncategorized" pull requests, those pull requests don't have a valid kind label(`kind/feature`, etc.).


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Updates the release note generation example in `RELEASE.md` to match the current `release-notes` CLI. The example now uses the `generate` subcommand, passes `--org` and `--repo`, and includes `--repo-path` for local tag discovery.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Verified against the current local `release-notes --help` output, which no longer includes `--required-author`.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```