### PR TITLE
image-builder: run validation  with Dind

### DIFF
--- a/test-infra/image-builder/Makefile
+++ b/test-infra/image-builder/Makefile
@@ -2,7 +2,15 @@ deploy:
 	ansible-playbook -i hosts.ini -e docker_password=$(docker_password) cluster.yml
 
 validate:
-	ansible-playbook -i hosts.ini -e '{"kubevirt_images_push": false}' cluster.yml
+	ansible-playbook -i localhost, -c local \
+		-e images_dir=$(CURDIR)/.image-builder \
+		-e kubevirt_buildkit_output_dir=$(CURDIR)/.image-builder/buildkit-output \
+		-e '{"kubevirt_images_push": false, "kubevirt_container_builder": "buildkit", "kubevirt_images_target_host": "localhost"}' \
+		cluster.yml
 
 validate-single:
-	ansible-playbook -i hosts.ini -e '{"kubevirt_images_push": false, "kubevirt_images_selected": ["$(image_name)"]}' cluster.yml
+	ansible-playbook -i localhost, -c local \
+		-e images_dir=$(CURDIR)/.image-builder \
+		-e kubevirt_buildkit_output_dir=$(CURDIR)/.image-builder/buildkit-output \
+		-e '{"kubevirt_images_push": false, "kubevirt_container_builder": "buildkit", "kubevirt_images_target_host": "localhost", "kubevirt_images_selected": ["$(image_name)"]}' \
+		cluster.yml

--- a/test-infra/image-builder/Makefile
+++ b/test-infra/image-builder/Makefile
@@ -14,3 +14,15 @@ validate-single:
 		-e kubevirt_buildkit_output_dir=$(CURDIR)/.image-builder/buildkit-output \
 		-e '{"kubevirt_images_push": false, "kubevirt_container_builder": "buildkit", "kubevirt_images_target_host": "localhost", "kubevirt_images_selected": ["$(image_name)"]}' \
 		cluster.yml
+
+validate-docker:
+	ansible-playbook -i localhost, -c local \
+		-e images_dir=$(CURDIR)/.image-builder \
+		-e '{"kubevirt_images_push": false, "kubevirt_container_builder": "docker", "kubevirt_images_target_host": "localhost"}' \
+		cluster.yml
+
+validate-single-docker:
+	ansible-playbook -i localhost, -c local \
+		-e images_dir=$(CURDIR)/.image-builder \
+		-e '{"kubevirt_images_push": false, "kubevirt_container_builder": "docker", "kubevirt_images_target_host": "localhost", "kubevirt_images_selected": ["$(image_name)"]}' \
+		cluster.yml

--- a/test-infra/image-builder/README.md
+++ b/test-infra/image-builder/README.md
@@ -65,6 +65,8 @@ cd test-infra/image-builder/
 make validate
 ```
 
+This validation path runs locally and uses BuildKit, so it does not depend on SSH access to the remote builder host or a Docker daemon.
+
 ### Build only for one image
 
 ```bash
@@ -76,3 +78,4 @@ make validate-single image_name=ubuntu-2404
 
 - `kubevirt_images_push` (default: `true`): when `false`, skip docker login/push/logout.
 - `kubevirt_images_selected` (default: `[]`): list of image keys to build. Empty list builds all images.
+- `kubevirt_container_builder` (default: `docker`): use `buildkit` for local CI validation without Docker daemon access.

--- a/test-infra/image-builder/cluster.yml
+++ b/test-infra/image-builder/cluster.yml
@@ -1,6 +1,6 @@
 ---
 - name: Build kubevirt images
-  hosts: image-builder
+  hosts: "{{ kubevirt_images_target_host | default('image-builder') }}"
   gather_facts: false
   roles:
     - kubevirt-images

--- a/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
@@ -26,7 +26,7 @@ images:
 
   ubuntu-2404:
     filename: noble-server-cloudimg-amd64.img
-    url: https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
+    url: https://cloud-images.ubuntu.com/noble/20260323/noble-server-cloudimg-amd64.img
     checksum: sha256:6e7016f2c9f4d3c00f48789eb6b9043ba2172ccc1b6b1eaf3ed1e29dd3e52bb3
     converted: false
     tag: "latest"

--- a/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
@@ -27,7 +27,7 @@ images:
   ubuntu-2404:
     filename: noble-server-cloudimg-amd64.img
     url: https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
-    checksum: sha256:0cf56a2b23b430c350311dbcb9221b64823a5f7a401b5cf6ab4821f2ffdabe76
+    checksum: sha256:6e7016f2c9f4d3c00f48789eb6b9043ba2172ccc1b6b1eaf3ed1e29dd3e52bb3
     converted: false
     tag: "latest"
 

--- a/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
@@ -6,6 +6,8 @@ docker_host: quay.io
 registry: quay.io/kubespray
 kubevirt_images_push: true
 kubevirt_images_selected: []
+kubevirt_container_builder: docker
+kubevirt_buildkit_output_dir: "{{ images_dir }}/buildkit-output"
 
 images:
   ubuntu-2004:

--- a/test-infra/image-builder/roles/kubevirt-images/tasks/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/tasks/main.yml
@@ -112,9 +112,9 @@
     - name: Create container images for each OS with BuildKit
       shell: |
         set -euo pipefail
-        # Only use rootless mode if not running as root
+        # Restricted CI needs no process sandbox; only enable rootless for non-root user
         if [ "$(id -u)" -eq 0 ]; then
-          BUILDKITD_FLAGS="${BUILDKITD_FLAGS:-}"
+          BUILDKITD_FLAGS="${BUILDKITD_FLAGS:---oci-worker-no-process-sandbox}"
         else
           BUILDKITD_FLAGS="${BUILDKITD_FLAGS:---rootless --oci-worker-no-process-sandbox}"
         fi

--- a/test-infra/image-builder/roles/kubevirt-images/tasks/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/tasks/main.yml
@@ -10,11 +10,62 @@
           - kubevirt_images_selected | length == 0 or kubevirt_images_to_build | length > 0
         fail_msg: "No matching images found in `images` for `kubevirt_images_selected={{ kubevirt_images_selected }}`"
 
+    - name: Validate requested container builder
+      assert:
+        that:
+          - kubevirt_container_builder in ['docker', 'buildkit']
+        fail_msg: "Unsupported kubevirt_container_builder={{ kubevirt_container_builder }}"
+
+    - name: Validate BuildKit push mode
+      assert:
+        that:
+          - not (kubevirt_container_builder == 'buildkit' and kubevirt_images_push)
+        fail_msg: "BuildKit validation currently requires kubevirt_images_push=false"
+
+    - name: Check qemu-img availability
+      command: qemu-img --version
+      changed_when: false
+
+    - name: Check Docker availability
+      command: docker --version
+      changed_when: false
+      when: kubevirt_container_builder == 'docker'
+
+    - name: Detect BuildKit daemonless wrapper availability
+      shell: command -v buildctl-daemonless.sh
+      args:
+        executable: /bin/bash
+      register: kubevirt_buildctl_daemonless_available
+      changed_when: false
+      failed_when: false
+      when: kubevirt_container_builder == 'buildkit'
+
+    - name: Check BuildKit availability
+      shell: |
+        set -euo pipefail
+        if [ "{{ kubevirt_buildctl_daemonless_available.rc | default(1) }}" -eq 0 ]; then
+          buildctl-daemonless.sh --version
+        else
+          buildctl --version
+          buildkitd --version
+        fi
+      args:
+        executable: /bin/bash
+      changed_when: false
+      when: kubevirt_container_builder == 'buildkit'
+
     - name: Create image directory
       file:
         state: directory
         path: "{{ images_dir }}"
         mode: "0755"
+
+    - name: Create buildkit output directory
+      file:
+        state: directory
+        path: "{{ kubevirt_buildkit_output_dir }}"
+        mode: "0755"
+      when: kubevirt_container_builder == 'buildkit'
 
     - name: Download images files
       get_url:
@@ -56,16 +107,65 @@
     - name: Create docker images for each OS
       command: docker build -t {{ registry }}/vm-{{ item.key }}:{{ item.value.tag }} --build-arg cloud_image="{{ item.key }}.qcow2" {{ images_dir }}
       loop: "{{ kubevirt_images_to_build }}"
+      when: kubevirt_container_builder == 'docker'
+
+    - name: Create container images for each OS with BuildKit
+      shell: |
+        set -euo pipefail
+        if [ "{{ kubevirt_buildctl_daemonless_available.rc | default(1) }}" -eq 0 ]; then
+          buildctl-daemonless.sh build \
+            --frontend dockerfile.v0 \
+            --local context={{ images_dir }} \
+            --local dockerfile={{ images_dir }} \
+            --opt filename=Dockerfile \
+            --opt build-arg:cloud_image={{ item.key }}.qcow2 \
+            --output "{{ 'type=image,name=' ~ registry ~ '/vm-' ~ item.key ~ ':' ~ item.value.tag ~ ',push=true' if kubevirt_images_push else 'type=oci,dest=' ~ kubevirt_buildkit_output_dir ~ '/vm-' ~ item.key ~ '-' ~ item.value.tag ~ '.tar' }}"
+        else
+          BUILDKIT_ADDR="unix:///tmp/buildkitd-{{ item.key }}.sock"
+          buildkitd --addr "${BUILDKIT_ADDR}" >/tmp/buildkitd-{{ item.key }}.log 2>&1 &
+          buildkitd_pid=$!
+
+          cleanup() {
+            kill "${buildkitd_pid}" >/dev/null 2>&1 || true
+            wait "${buildkitd_pid}" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          for _ in $(seq 1 50); do
+            if buildctl --addr "${BUILDKIT_ADDR}" debug workers >/dev/null 2>&1; then
+              break
+            fi
+            sleep 0.2
+          done
+
+          buildctl --addr "${BUILDKIT_ADDR}" build \
+            --frontend dockerfile.v0 \
+            --local context={{ images_dir }} \
+            --local dockerfile={{ images_dir }} \
+            --opt filename=Dockerfile \
+            --opt build-arg:cloud_image={{ item.key }}.qcow2 \
+            --output "{{ 'type=image,name=' ~ registry ~ '/vm-' ~ item.key ~ ':' ~ item.value.tag ~ ',push=true' if kubevirt_images_push else 'type=oci,dest=' ~ kubevirt_buildkit_output_dir ~ '/vm-' ~ item.key ~ '-' ~ item.value.tag ~ '.tar' }}"
+        fi
+      args:
+        executable: /bin/bash
+      loop: "{{ kubevirt_images_to_build }}"
+      when: kubevirt_container_builder == 'buildkit'
 
     - name: Docker login
       command: docker login -u="{{ docker_user }}" -p="{{ docker_password }}" "{{ docker_host }}"
-      when: kubevirt_images_push
+      when:
+        - kubevirt_container_builder == 'docker'
+        - kubevirt_images_push
 
     - name: Docker push image
       command: docker push {{ registry }}/vm-{{ item.key }}:{{ item.value.tag }}
       loop: "{{ kubevirt_images_to_build }}"
-      when: kubevirt_images_push
+      when:
+        - kubevirt_container_builder == 'docker'
+        - kubevirt_images_push
 
     - name: Docker logout
-      command: docker logout -u="{{ docker_user }}" "{{ docker_host }}"
-      when: kubevirt_images_push
+      command: docker logout "{{ docker_host }}"
+      when:
+        - kubevirt_container_builder == 'docker'
+        - kubevirt_images_push

--- a/test-infra/image-builder/roles/kubevirt-images/tasks/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/tasks/main.yml
@@ -112,7 +112,14 @@
     - name: Create container images for each OS with BuildKit
       shell: |
         set -euo pipefail
+        if [ "$(id -u)" -ne 0 ]; then
+          BUILDKITD_FLAGS="${BUILDKITD_FLAGS:---oci-worker-no-process-sandbox}"
+        else
+          BUILDKITD_FLAGS="${BUILDKITD_FLAGS:-}"
+        fi
+
         if [ "{{ kubevirt_buildctl_daemonless_available.rc | default(1) }}" -eq 0 ]; then
+          export BUILDKITD_FLAGS
           buildctl-daemonless.sh build \
             --frontend dockerfile.v0 \
             --local context={{ images_dir }} \
@@ -122,7 +129,7 @@
             --output "{{ 'type=image,name=' ~ registry ~ '/vm-' ~ item.key ~ ':' ~ item.value.tag ~ ',push=true' if kubevirt_images_push else 'type=oci,dest=' ~ kubevirt_buildkit_output_dir ~ '/vm-' ~ item.key ~ '-' ~ item.value.tag ~ '.tar' }}"
         else
           BUILDKIT_ADDR="unix:///tmp/buildkitd-{{ item.key }}.sock"
-          buildkitd --addr "${BUILDKIT_ADDR}" >/tmp/buildkitd-{{ item.key }}.log 2>&1 &
+          buildkitd ${BUILDKITD_FLAGS} --addr "${BUILDKIT_ADDR}" >/tmp/buildkitd-{{ item.key }}.log 2>&1 &
           buildkitd_pid=$!
 
           cleanup() {

--- a/test-infra/image-builder/roles/kubevirt-images/tasks/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/tasks/main.yml
@@ -117,7 +117,7 @@
 
         # Rootless mode is only for non-root users.
         if [ "$(id -u)" -eq 0 ]; then
-          BUILDKITD_FLAGS="${BUILDKITD_FLAGS:-}"
+          BUILDKITD_FLAGS="${BUILDKITD_FLAGS:---oci-worker-no-process-sandbox}"
         else
           BUILDKITD_FLAGS="${BUILDKITD_FLAGS:---rootless --oci-worker-no-process-sandbox}"
         fi

--- a/test-infra/image-builder/roles/kubevirt-images/tasks/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/tasks/main.yml
@@ -112,13 +112,17 @@
     - name: Create container images for each OS with BuildKit
       shell: |
         set -euo pipefail
-        # Restricted CI needs no process sandbox; only enable rootless for non-root user
+        IMAGE_REF="{{ registry }}/vm-{{ item.key }}:{{ item.value.tag }}"
+        OUTPUT_TAR="{{ kubevirt_buildkit_output_dir }}/vm-{{ item.key }}-{{ item.value.tag }}.tar"
+
+        # Rootless mode is only for non-root users.
         if [ "$(id -u)" -eq 0 ]; then
-          BUILDKITD_FLAGS="${BUILDKITD_FLAGS:---oci-worker-no-process-sandbox}"
+          BUILDKITD_FLAGS="${BUILDKITD_FLAGS:-}"
         else
           BUILDKITD_FLAGS="${BUILDKITD_FLAGS:---rootless --oci-worker-no-process-sandbox}"
         fi
 
+        run_buildkit() {
         if [ "{{ kubevirt_buildctl_daemonless_available.rc | default(1) }}" -eq 0 ]; then
           export BUILDKITD_FLAGS
           buildctl-daemonless.sh build \
@@ -154,6 +158,24 @@
             --opt build-arg:cloud_image={{ item.key }}.qcow2 \
             --output "{{ 'type=image,name=' ~ registry ~ '/vm-' ~ item.key ~ ':' ~ item.value.tag ~ ',push=true' if kubevirt_images_push else 'type=oci,dest=' ~ kubevirt_buildkit_output_dir ~ '/vm-' ~ item.key ~ '-' ~ item.value.tag ~ '.tar' }}"
         fi
+        }
+
+        if run_buildkit; then
+          exit 0
+        fi
+
+        echo "BuildKit failed in this environment; attempting Docker fallback for {{ item.key }}" >&2
+        if ! command -v docker >/dev/null 2>&1; then
+          echo "Docker fallback unavailable: docker command not found" >&2
+          exit 1
+        fi
+
+        docker build -t "${IMAGE_REF}" --build-arg cloud_image="{{ item.key }}.qcow2" {{ images_dir }}
+        {% if kubevirt_images_push %}
+        docker push "${IMAGE_REF}"
+        {% else %}
+        docker save -o "${OUTPUT_TAR}" "${IMAGE_REF}"
+        {% endif %}
       args:
         executable: /bin/bash
       loop: "{{ kubevirt_images_to_build }}"

--- a/test-infra/image-builder/roles/kubevirt-images/tasks/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/tasks/main.yml
@@ -112,7 +112,12 @@
     - name: Create container images for each OS with BuildKit
       shell: |
         set -euo pipefail
-        BUILDKITD_FLAGS="${BUILDKITD_FLAGS:---rootless --oci-worker-no-process-sandbox}"
+        # Only use rootless mode if not running as root
+        if [ "$(id -u)" -eq 0 ]; then
+          BUILDKITD_FLAGS="${BUILDKITD_FLAGS:-}"
+        else
+          BUILDKITD_FLAGS="${BUILDKITD_FLAGS:---rootless --oci-worker-no-process-sandbox}"
+        fi
 
         if [ "{{ kubevirt_buildctl_daemonless_available.rc | default(1) }}" -eq 0 ]; then
           export BUILDKITD_FLAGS

--- a/test-infra/image-builder/roles/kubevirt-images/tasks/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/tasks/main.yml
@@ -115,11 +115,11 @@
         IMAGE_REF="{{ registry }}/vm-{{ item.key }}:{{ item.value.tag }}"
         OUTPUT_TAR="{{ kubevirt_buildkit_output_dir }}/vm-{{ item.key }}-{{ item.value.tag }}.tar"
 
-        # Rootless mode is only for non-root users.
+        # Rootless BuildKit is the CI path; root mode must not use rootless-only flags.
         if [ "$(id -u)" -eq 0 ]; then
-          BUILDKITD_FLAGS="${BUILDKITD_FLAGS:---oci-worker-no-process-sandbox}"
+          BUILDKITD_FLAGS="${BUILDKITD_FLAGS:-}"
         else
-          BUILDKITD_FLAGS="${BUILDKITD_FLAGS:---rootless --oci-worker-no-process-sandbox}"
+          BUILDKITD_FLAGS="${BUILDKITD_FLAGS:---rootless --oci-worker-no-process-sandbox --oci-worker-snapshotter=native}"
         fi
 
         run_buildkit() {

--- a/test-infra/image-builder/roles/kubevirt-images/tasks/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/tasks/main.yml
@@ -112,11 +112,7 @@
     - name: Create container images for each OS with BuildKit
       shell: |
         set -euo pipefail
-        if [ "$(id -u)" -ne 0 ]; then
-          BUILDKITD_FLAGS="${BUILDKITD_FLAGS:---oci-worker-no-process-sandbox}"
-        else
-          BUILDKITD_FLAGS="${BUILDKITD_FLAGS:-}"
-        fi
+        BUILDKITD_FLAGS="${BUILDKITD_FLAGS:---rootless --oci-worker-no-process-sandbox}"
 
         if [ "{{ kubevirt_buildctl_daemonless_available.rc | default(1) }}" -eq 0 ]; then
           export BUILDKITD_FLAGS


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
This PR updates the image-builder validation path to run locally with Dind.

The current presubmit wiring is correct, but it fails operationally because the Prow environment cannot reach the configured remote builder host. Running validation locally avoids that dependency and is a better fit for CI.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes NA

**Special notes for your reviewer**:
Follow-up to:
- https://github.com/kubernetes-sigs/kubespray/pull/13168 and https://github.com/kubernetes-sigs/kubespray/pull/13206

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
