### PR TITLE
Releng: bump galaxy version 2.32.0

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: kubernetes_sigs
 description: Deploy a production ready Kubernetes cluster
 name: kubespray
-version: 2.31.0
+version: 2.32.0
 readme: README.md
 authors:
   - The Kubespray maintainers (https://kubernetes.slack.com/channels/kubespray)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Bump `galaxy.yml` to `2.32.0` after the `v2.31.0` release, per the [release process](https://github.com/kubernetes-sigs/kubespray/blob/master/RELEASE.md):

> (For major releases) On the `master` branch: bump the version in `galaxy.yml` to the next expected major release (X.y.0 with y = Y + 1), make a Pull Request.

Follows the same pattern as previous releng bumps (#12909, #12622).

**Which issue(s) this PR fixes**:

Follow-up to https://github.com/kubernetes-sigs/kubespray/issues/13176

**Special notes for your reviewer**:

The `release-2.31` branch and the `v2.31.0` GitHub release have already been cut from `1c9add48975060f45396b34d8e022c30d7f80dab`.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```