### PR TITLE
docs: clarify Kubernetes support window

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,12 @@ Note:
 
 ## Container Runtime Notes
 
-- The cri-o version should be aligned with the respective kubernetes version (i.e. kube_version=1.20.x, crio_version=1.20)
+- The CRI-O minor version should match the Kubernetes minor version.
 
 ## Requirements
 
-- **Minimum required version of Kubernetes is v1.30**
+- **Minimum required version of Kubernetes is v1.34.0**
+
 - **Ansible v2.14+, Jinja 2.11+ and python-netaddr is installed on the machine that will run Ansible commands**
 - The target servers must have **access to the Internet** in order to pull docker images. Otherwise, additional configuration is required (See [Offline Environment](docs/operations/offline-environment.md))
 - The target servers are configured to allow **IPv4 forwarding**.

--- a/README.md
+++ b/README.md
@@ -145,11 +145,16 @@ Note:
 
 ## Container Runtime Notes
 
-- The cri-o version should be aligned with the respective kubernetes version (i.e. kube_version=1.20.x, crio_version=1.20)
+- The CRI-O minor version should match the Kubernetes minor version.
 
 ## Requirements
 
-- **Minimum required version of Kubernetes is v1.30**
+<!-- BEGIN KUBERNETES VERSION REQUIREMENT -->
+
+- **Minimum required version of Kubernetes is v1.34.0**
+
+<!-- END KUBERNETES VERSION REQUIREMENT -->
+
 - **Ansible v2.14+, Jinja 2.11+ and python-netaddr is installed on the machine that will run Ansible commands**
 - The target servers must have **access to the Internet** in order to pull docker images. Otherwise, additional configuration is required (See [Offline Environment](docs/operations/offline-environment.md))
 - The target servers are configured to allow **IPv4 forwarding**.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@ The Kubespray Project is released on an as-needed basis. The process is as follo
 
 1. An issue is proposing a new release with a changelog since the last release. Please see [a good sample issue](https://github.com/kubernetes-sigs/kubespray/issues/8325)
 1. At least one of the [approvers](OWNERS_ALIASES) must approve this release
-1. (Only for major releases) The `kube_version_min_required` variable is set to `n-1`
+1. (Only for major releases) Keep Kubernetes binary checksums and per-minor component mappings for the default Kubernetes minor and the two previous minors (a support floor of `n-2`). The oldest `kubelet_checksums` entry determines `kube_version_min_required`.
 1. (Only for major releases) Remove hashes for [EOL versions](https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md) of kubernetes from `*_checksums` variables.
 1. Create the release note with [Kubernetes Release Notes Generator](https://github.com/kubernetes/release/blob/master/cmd/release-notes/README.md). See the following `Release note creation` section for the details.
 1. An approver creates [new release in GitHub](https://github.com/kubernetes-sigs/kubespray/releases/new) using a version and tag name like `vX.Y.Z` and attaching the release notes
@@ -30,10 +30,11 @@ The Kubespray Project is released on an as-needed basis. The process is as follo
   which ends once the milestone is closed. Then only a next major or minor release
   can be done.
 
-* Kubespray major and minor releases are bound to the given `kube_version` major/minor
-  version numbers and other components' arbitrary versions, like etcd or network plugins.
-  Older or newer component versions are not supported and not tested for the given
-  release (even if included in the checksum variables, like `kubeadm_checksums`).
+* Kubespray major and minor releases support the default `kube_version` major/minor and
+  the two previous Kubernetes minor versions when their Kubernetes binary checksums and
+  required per-minor component mappings are present. Other component versions are supported
+  only when selected by the corresponding version mappings; a checksum entry alone does not
+  imply support.
 
 * There is no unstable releases and no APIs, thus Kubespray doesn't follow
   [semver](https://semver.org/). Every version describes only a stable release.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@ The Kubespray Project is released on an as-needed basis. The process is as follo
 
 1. An issue is proposing a new release with a changelog since the last release. Please see [a good sample issue](https://github.com/kubernetes-sigs/kubespray/issues/8325)
 1. At least one of the [approvers](OWNERS_ALIASES) must approve this release
-1. (Only for major releases) The `kube_version_min_required` variable is set to `n-1`
+1. (Only for major releases) Keep Kubernetes binary checksums and per-minor component mappings for the default Kubernetes minor and the two previous minors. The oldest `kubelet_checksums` entry determines `kube_version_min_required`.
 1. (Only for major releases) Remove hashes for [EOL versions](https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md) of kubernetes from `*_checksums` variables.
 1. Create the release note with [Kubernetes Release Notes Generator](https://github.com/kubernetes/release/blob/master/cmd/release-notes/README.md). See the following `Release note creation` section for the details.
 1. An approver creates [new release in GitHub](https://github.com/kubernetes-sigs/kubespray/releases/new) using a version and tag name like `vX.Y.Z` and attaching the release notes
@@ -30,10 +30,11 @@ The Kubespray Project is released on an as-needed basis. The process is as follo
   which ends once the milestone is closed. Then only a next major or minor release
   can be done.
 
-* Kubespray major and minor releases are bound to the given `kube_version` major/minor
-  version numbers and other components' arbitrary versions, like etcd or network plugins.
-  Older or newer component versions are not supported and not tested for the given
-  release (even if included in the checksum variables, like `kubeadm_checksums`).
+* Kubespray major and minor releases support the default `kube_version` major/minor and
+  the two previous Kubernetes minor versions when their Kubernetes binary checksums and
+  required per-minor component mappings are present. Other component versions are supported
+  only when selected by the corresponding version mappings; a checksum entry alone does not
+  imply support.
 
 * There is no unstable releases and no APIs, thus Kubespray doesn't follow
   [semver](https://semver.org/). Every version describes only a stable release.

--- a/scripts/propagate_ansible_variables.yml
+++ b/scripts/propagate_ansible_variables.yml
@@ -20,6 +20,12 @@
       marker: '<!-- {mark} ANSIBLE MANAGED BLOCK -->'
       block: "\n{{ lookup('ansible.builtin.template', 'readme_versions.md.j2') }}\n\n"
       path: ../README.md
+  - name: Render minimum Kubernetes version in README.md
+    lineinfile:
+      path: ../README.md
+      regexp: '^- \*\*Minimum required version of Kubernetes is v.*\*\*$'
+      line: "- **Minimum required version of Kubernetes is v{{ kube_version_min_required }}**"
+      insertafter: '^## Requirements$'
   - name: Render Dockerfiles
     template:
       src: "{{ item }}.j2"

--- a/scripts/propagate_ansible_variables.yml
+++ b/scripts/propagate_ansible_variables.yml
@@ -20,6 +20,11 @@
       marker: '<!-- {mark} ANSIBLE MANAGED BLOCK -->'
       block: "\n{{ lookup('ansible.builtin.template', 'readme_versions.md.j2') }}\n\n"
       path: ../README.md
+  - name: Render minimum Kubernetes version in README.md
+    blockinfile:
+      marker: '<!-- {mark} KUBERNETES VERSION REQUIREMENT -->'
+      block: "\n- **Minimum required version of Kubernetes is v{{ kube_version_min_required }}**\n\n"
+      path: ../README.md
   - name: Render Dockerfiles
     template:
       src: "{{ item }}.j2"


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

- Documents the rolling Kubernetes support window: the default minor and the two previous minors.
- Clarifies that support requires Kubernetes binary checksums and corresponding per-minor component mappings.
- Generates the README minimum Kubernetes version from `kube_version_min_required`.
- Removes the stale CRI-O version example.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

`kube_version_min_required` is derived from the oldest `kubelet_checksums` entry. A checksum entry for another component alone does not imply support.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```