### PR TITLE
fix(reset): add etcd backup directory cleanup to prevent redeployment failures

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -395,6 +395,7 @@
     - /etc/origin/ovn
     - "{{ sysctl_file_path }}"
     - /etc/crictl.yaml
+    - "{{ etcd_backup_prefix }}"
   ignore_errors: true  # noqa ignore-errors
   tags:
     - files
@@ -466,17 +467,3 @@
         name: "{{ item }}"
         state: restarted
       loop: "{{ service_status.results | selectattr('status.ActiveState', '==', 'active') | map(attribute='item') }}"
-
-- name: Find etcd backup directories
-  find:
-    paths: /var/backups
-    patterns: "etcd-*"
-    file_type: directory
-  register: etcd_backup_dirs
-
-- name: Remove etcd backup directories
-  file:
-    path: "{{ item.path }}"
-    state: absent
-  loop: "{{ etcd_backup_dirs.files }}"
-  when: etcd_backup_dirs.files | length > 0

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -466,3 +466,17 @@
         name: "{{ item }}"
         state: restarted
       loop: "{{ service_status.results | selectattr('status.ActiveState', '==', 'active') | map(attribute='item') }}"
+
+- name: Find etcd backup directories
+  find:
+    paths: /var/backups
+    patterns: "etcd-*"
+    file_type: directory
+  register: etcd_backup_dirs
+
+- name: Remove etcd backup directories
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ etcd_backup_dirs.files }}"
+  when: etcd_backup_dirs.files | length > 0


### PR DESCRIPTION
**What type of PR is this?**
/kind fix

**What this PR does / why we need it:**

This PR removes the etcd backup directory in the reset role.

The reset playbook did not remove the etcd backup directory (/var/backups/etcd by default). As a result, stale backup data from the previous deployment remained on the node, causing subsequent cluster deployments to fail or hang during the etcd backup job.

This can lead to increased operational toil, with users spending additional time troubleshooting failed or stuck deployments.


**Special notes for your reviewer:**
The etcd_backup_prefix variable already exists in Kubespray and points to the etcd backup directory (e.g., /var/backups/etcd)

```release-note
Fixed reset playbook to clean up etcd backup directory, preventing cluster redeployment failures
```

Does this PR introduce a user-facing change?:
NONE