### PR TITLE
network_plugin/cilium: fail fast when Gateway API CRDs are incompatible

### DIFF
--- a/roles/network_plugin/cilium/tasks/check.yml
+++ b/roles/network_plugin/cilium/tasks/check.yml
@@ -67,3 +67,19 @@
     that: "cilium_hubble_event_buffer_capacity in [1, 3, 7, 15, 31, 63, 127, 255, 511, 1023, 2047, 4095, 8191, 16383, 32767, 65535]"
     msg: "Error: cilium_hubble_event_buffer_capacity:{{ cilium_hubble_event_buffer_capacity }} is not a power of 2 minus 1 and it should be between 1 and 65535."
   when: cilium_hubble_event_buffer_capacity is defined
+
+# Cilium < 1.20 only supports Gateway API v1.4.1; v1.5+ standard channel drops
+# TLSRoute v1alpha2 (served=false) which makes cilium-operator CrashLoopBackOff.
+# Fix is in Cilium 1.20+ (cilium/cilium#45251) and will not be backported.
+- name: Stop if cilium_gateway_api_enabled is incompatible with the Gateway API CRD bundle
+  assert:
+    that:
+      - gateway_api_version is version('1.5.0', '<') or gateway_api_channel != 'standard'
+    msg: |
+      Cilium < 1.20 only supports Gateway API v1.4.1, see
+      https://docs.cilium.io/en/stable/network/servicemesh/gateway-api/gateway-api/.
+      Pin gateway_api_version: '1.4.1', or set gateway_api_channel: 'experimental'.
+  when:
+    - cilium_gateway_api_enabled
+    - gateway_api_enabled
+    - cilium_version is version('1.20.0', '<')


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Cilium < 1.20 unconditionally registers a field indexer for `TLSRoute` `v1alpha2` when the Gateway API controller is enabled, but Gateway API >= 1.5.0 ships `TLSRoute` `v1alpha2` with `served=false` in the standard channel. The result is `cilium-operator` CrashLoopBackOff with:

```
no matches for kind "TLSRoute" in version "gateway.networking.k8s.io/v1alpha2"
```

The Cilium fix is in [cilium/cilium#45251](https://github.com/cilium/cilium/pull/45251) (1.20+ only) and [will not be backported](https://github.com/cilium/cilium/issues/45139#issuecomment-3025000000) (see also [cilium/cilium#44920](https://github.com/cilium/cilium/issues/44920) and [cilium/cilium#45139](https://github.com/cilium/cilium/issues/45139)). Cilium 1.19.x [officially supports Gateway API v1.4.1 only](https://docs.cilium.io/en/v1.19/network/servicemesh/gateway-api/gateway-api/).

This PR adds a preflight `assert` so the bad combo fails at deploy time with a clear, actionable message and two workarounds, instead of leaving users to debug `cilium-operator` after deployment.

The assert only fires when ALL of these hold:
- `cilium_gateway_api_enabled: true`
- `gateway_api_enabled: true` (kubespray manages the CRD bundle)
- `cilium_version < 1.20.0`
- `gateway_api_version >= 1.5.0`
- `gateway_api_channel == "standard"`

It will become a no-op automatically once kubespray master bumps to Cilium 1.20+, so no future cleanup is needed.

**Which issue(s) this PR fixes**:

Fixes [#13222](https://github.com/kubernetes-sigs/kubespray/issues/13222)

**Special notes for your reviewer**:

- No CI test currently combines `cilium_gateway_api_enabled: true` with kubespray-managed Gateway API CRDs, so existing jobs are unaffected (the assert's `when` is false in every existing test).
- Backports to `release-2.31` (cilium 1.19.3) and `release-2.30` (cilium 1.18.6) will follow once this lands, since both branches default to Gateway API v1.5.1 standard and ship a Cilium older than 1.20.
- A separate Cilium 1.20 bump on master will be tracked once 1.20 GAs (currently only `v1.20.0-pre.1` is available).

**Does this PR introduce a user-facing change?**:

```release-note
[cilium] Fail fast with a clear error when `cilium_gateway_api_enabled: true` is combined with Gateway API >= 1.5.0 standard channel and Cilium < 1.20, instead of leaving cilium-operator in CrashLoopBackOff. Workarounds: pin `gateway_api_version: "1.4.1"` or set `gateway_api_channel: "experimental"`.
```