### PR TITLE
preinstall: generalize minimum-value semantics for managed sysctls

### DIFF
--- a/docs/operations/large-deployments.md
+++ b/docs/operations/large-deployments.md
@@ -50,3 +50,21 @@ For a large scaled deployments, consider the following configuration changes:
 
 For example, when deploying 200 nodes, you may want to run ansible with
 ``--forks=50``, ``--timeout=600`` and define the ``retry_stagger: 60``.
+
+Sysctl tuning with floor semantics
+----------------------------------
+
+`sysctl_minimum_values` defines floors that are only applied when the
+node's current value is lower, so pre-tuned images and newer kernels are
+left alone. Use `additional_sysctl_min` to add or override floors (set a
+key to `0` to disable a default); use `additional_sysctl` for
+exact-value semantics.
+
+```yaml
+additional_sysctl_min:
+  net.core.somaxconn: 65535
+  kernel.pid_max: 0
+```
+
+See `roles/kubespray_defaults/defaults/main/main.yml` for the default
+floor set.

--- a/docs/operations/large-deployments.md
+++ b/docs/operations/large-deployments.md
@@ -54,11 +54,10 @@ For example, when deploying 200 nodes, you may want to run ansible with
 Sysctl tuning with floor semantics
 ----------------------------------
 
-`sysctl_minimum_values` defines floors that are only applied when the
-node's current value is lower, so pre-tuned images and newer kernels are
-left alone. Use `additional_sysctl_min` to add or override floors (set a
-key to `0` to disable a default); use `additional_sysctl` for
-exact-value semantics.
+Built-in sysctl floors are only applied when the node's current value is
+lower, so pre-tuned images and newer kernels are left alone. Use
+`additional_sysctl_min` to add or override floors (set a key to `0` to
+disable a default); use `additional_sysctl` for exact-value semantics.
 
 ```yaml
 additional_sysctl_min:
@@ -66,5 +65,5 @@ additional_sysctl_min:
   kernel.pid_max: 0
 ```
 
-See `roles/kubespray_defaults/defaults/main/main.yml` for the default
-floor set.
+See `roles/kubespray_defaults/vars/main/main.yml` for the built-in floor
+set.

--- a/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
+++ b/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
@@ -125,17 +125,19 @@
     - { name: vm.panic_on_oom, value: 0 }
   when: kubelet_protect_kernel_defaults | bool
 
-- name: Read current sysctl values
+- name: Compute effective sysctl minimum values (defaults + user overrides)
+  set_fact:
+    _sysctl_minimum_values_effective: "{{ sysctl_minimum_values | combine(additional_sysctl_min) }}"
+
+- name: Read current sysctl values for floor-managed keys
   command: sysctl -n {{ item.key }}
   register: sysctl_settings
   changed_when: false
-  vars:
-    # For integer sysctls only
-    sysctl_minimum_values:
-      fs.inotify.max_user_instances: 8192
-  loop: "{{ sysctl_minimum_values | dict2items }}"
+  failed_when: false  # tolerate keys not present on this kernel/distro
+  check_mode: false  # read-only; must run under --check so later loop has rc/stdout
+  loop: "{{ _sysctl_minimum_values_effective | dict2items }}"
 
-- name: Increase sysctl value if lower than minimum
+- name: Increase sysctl value if lower than configured minimum
   ansible.posix.sysctl:
     sysctl_file: "{{ sysctl_file_path }}"
     name: "{{ item.item.key }}"
@@ -143,7 +145,9 @@
     state: present
     reload: true
     ignoreerrors: "{{ sysctl_ignore_unknown_keys }}"
-  when: item.stdout | int < item.item.value
+  when:
+    - item.rc | default(1) == 0
+    - (item.stdout | default('0')) | int < item.item.value | int
   loop: "{{ sysctl_settings.results }}"
 
 - name: Check dummy module

--- a/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
+++ b/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
@@ -130,10 +130,9 @@
     _sysctl_minimum_values_effective: "{{ sysctl_minimum_values | combine(additional_sysctl_min) }}"
 
 - name: Read current sysctl values for floor-managed keys
-  command: sysctl -n {{ item.key }}
+  command: sysctl --ignore -n {{ item.key }}
   register: sysctl_settings
   changed_when: false
-  failed_when: false  # tolerate keys not present on this kernel/distro
   check_mode: false  # read-only; must run under --check so later loop has rc/stdout
   loop: "{{ _sysctl_minimum_values_effective | dict2items }}"
 
@@ -145,10 +144,8 @@
     state: present
     reload: true
     ignoreerrors: "{{ sysctl_ignore_unknown_keys }}"
-  when:
-    - item.rc | default(1) == 0
-    - (item.stdout | default('0')) | int < item.item.value | int
-  loop: "{{ sysctl_settings.results }}"
+  when: item.stdout | int < item.item.value | int
+  loop: "{{ sysctl_settings.results | selectattr('stdout') }}"
 
 - name: Check dummy module
   community.general.modprobe:

--- a/roles/kubespray_defaults/defaults/main/main.yml
+++ b/roles/kubespray_defaults/defaults/main/main.yml
@@ -612,9 +612,41 @@ kubelet_protect_kernel_defaults: true
 
 # Set additional sysctl variables to modify Linux kernel variables, for example:
 # additional_sysctl:
-#  - { name: kernel.pid_max, value: 131072 }
+#  - { name: vm.swappiness, value: 10 }
 #
+# `additional_sysctl` uses exact-value semantics. For floor semantics
+# (only apply when the node's current value is lower), use
+# `additional_sysctl_min` below.
 additional_sysctl: []
+
+# Sysctl floors: only applied when the node's current value is lower than
+# the desired one, so pre-tuned images and newer kernels are not regressed.
+# Defaults are aligned with OpenShift Node Tuning Operator and kops, and
+# are outside the kubelet protect-kernel-defaults validation list.
+sysctl_minimum_values:
+  fs.inotify.max_user_instances: 8192
+  fs.inotify.max_user_watches: 65536
+  kernel.pid_max: 4194304
+  fs.aio-max-nr: 1048576
+  vm.max_map_count: 262144
+  net.netfilter.nf_conntrack_max: 1048576
+  net.core.somaxconn: 32768
+  net.core.netdev_max_backlog: 16384
+  fs.file-max: 2097152
+  net.ipv4.neigh.default.gc_thresh1: 8192
+  net.ipv4.neigh.default.gc_thresh2: 32768
+  net.ipv4.neigh.default.gc_thresh3: 65536
+  net.ipv6.neigh.default.gc_thresh1: 8192
+  net.ipv6.neigh.default.gc_thresh2: 32768
+  net.ipv6.neigh.default.gc_thresh3: 65536
+
+# User-defined sysctl floors, merged on top of `sysctl_minimum_values`
+# (user values take precedence). Set a key to 0 to disable a default floor.
+# Example:
+# additional_sysctl_min:
+#   net.core.somaxconn: 65535
+#   kernel.pid_max: 0
+additional_sysctl_min: {}
 
 ## List of key=value pairs that describe feature gates for
 ## the k8s cluster.

--- a/roles/kubespray_defaults/defaults/main/main.yml
+++ b/roles/kubespray_defaults/defaults/main/main.yml
@@ -620,9 +620,41 @@ kubelet_protect_kernel_defaults: true
 
 # Set additional sysctl variables to modify Linux kernel variables, for example:
 # additional_sysctl:
-#  - { name: kernel.pid_max, value: 131072 }
+#  - { name: vm.swappiness, value: 10 }
 #
+# `additional_sysctl` uses exact-value semantics. For floor semantics
+# (only apply when the node's current value is lower), use
+# `additional_sysctl_min` below.
 additional_sysctl: []
+
+# Sysctl floors: only applied when the node's current value is lower than
+# the desired one, so pre-tuned images and newer kernels are not regressed.
+# Defaults are aligned with OpenShift Node Tuning Operator and kops, and
+# are outside the kubelet protect-kernel-defaults validation list.
+sysctl_minimum_values:
+  fs.inotify.max_user_instances: 8192
+  fs.inotify.max_user_watches: 65536
+  kernel.pid_max: 4194304
+  fs.aio-max-nr: 1048576
+  vm.max_map_count: 262144
+  net.netfilter.nf_conntrack_max: 1048576
+  net.core.somaxconn: 32768
+  net.core.netdev_max_backlog: 16384
+  fs.file-max: 2097152
+  net.ipv4.neigh.default.gc_thresh1: 8192
+  net.ipv4.neigh.default.gc_thresh2: 32768
+  net.ipv4.neigh.default.gc_thresh3: 65536
+  net.ipv6.neigh.default.gc_thresh1: 8192
+  net.ipv6.neigh.default.gc_thresh2: 32768
+  net.ipv6.neigh.default.gc_thresh3: 65536
+
+# User-defined sysctl floors, merged on top of `sysctl_minimum_values`
+# (user values take precedence). Set a key to 0 to disable a default floor.
+# Example:
+# additional_sysctl_min:
+#   net.core.somaxconn: 65535
+#   kernel.pid_max: 0
+additional_sysctl_min: {}
 
 ## List of key=value pairs that describe feature gates for
 ## the k8s cluster.

--- a/roles/kubespray_defaults/defaults/main/main.yml
+++ b/roles/kubespray_defaults/defaults/main/main.yml
@@ -627,28 +627,7 @@ kubelet_protect_kernel_defaults: true
 # `additional_sysctl_min` below.
 additional_sysctl: []
 
-# Sysctl floors: only applied when the node's current value is lower than
-# the desired one, so pre-tuned images and newer kernels are not regressed.
-# Defaults are aligned with OpenShift Node Tuning Operator and kops, and
-# are outside the kubelet protect-kernel-defaults validation list.
-sysctl_minimum_values:
-  fs.inotify.max_user_instances: 8192
-  fs.inotify.max_user_watches: 65536
-  kernel.pid_max: 4194304
-  fs.aio-max-nr: 1048576
-  vm.max_map_count: 262144
-  net.netfilter.nf_conntrack_max: 1048576
-  net.core.somaxconn: 32768
-  net.core.netdev_max_backlog: 16384
-  fs.file-max: 2097152
-  net.ipv4.neigh.default.gc_thresh1: 8192
-  net.ipv4.neigh.default.gc_thresh2: 32768
-  net.ipv4.neigh.default.gc_thresh3: 65536
-  net.ipv6.neigh.default.gc_thresh1: 8192
-  net.ipv6.neigh.default.gc_thresh2: 32768
-  net.ipv6.neigh.default.gc_thresh3: 65536
-
-# User-defined sysctl floors, merged on top of `sysctl_minimum_values`
+# User-defined sysctl floors, merged on top of the built-in floor values
 # (user values take precedence). Set a key to 0 to disable a default floor.
 # Example:
 # additional_sysctl_min:

--- a/roles/kubespray_defaults/vars/main/main.yml
+++ b/roles/kubespray_defaults/vars/main/main.yml
@@ -20,6 +20,27 @@ etcd_supported_versions:
 
 kube_proxy_deployed: "{{ 'addon/kube-proxy' not in kubeadm_init_phases_skip }}"
 
+# Sysctl floors: only applied when the node's current value is lower than
+# the desired one, so pre-tuned images and newer kernels are not regressed.
+# Values are aligned with OpenShift Node Tuning Operator and kops, and
+# are outside the kubelet protect-kernel-defaults validation list.
+sysctl_minimum_values:
+  fs.inotify.max_user_instances: 8192
+  fs.inotify.max_user_watches: 65536
+  kernel.pid_max: 4194304
+  fs.aio-max-nr: 1048576
+  vm.max_map_count: 262144
+  net.netfilter.nf_conntrack_max: 1048576
+  net.core.somaxconn: 32768
+  net.core.netdev_max_backlog: 16384
+  fs.file-max: 2097152
+  net.ipv4.neigh.default.gc_thresh1: 8192
+  net.ipv4.neigh.default.gc_thresh2: 32768
+  net.ipv4.neigh.default.gc_thresh3: 65536
+  net.ipv6.neigh.default.gc_thresh1: 8192
+  net.ipv6.neigh.default.gc_thresh2: 32768
+  net.ipv6.neigh.default.gc_thresh3: 65536
+
 # The lowest version allowed to upgrade from (same as calico_version in the previous branch)
 calico_min_version_required: "3.27.0"
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Generalize the minimum-value (floor) sysctl pattern that was introduced for a single key in #13075:

- Move the hardcoded `sysctl_minimum_values` map out of `roles/kubernetes/preinstall/tasks/0080-system-configurations.yml` into an internal role variable in `roles/kubespray_defaults/vars/main/main.yml`; users customize the floor set through `additional_sysctl_min`.
- Introduce `additional_sysctl_min` so users can declare their own sysctl floors (parallel to `additional_sysctl`, but with floor semantics).
- Expand the default floor set with widely-used tunables (pid_max, nf_conntrack_max, neigh gc thresholds, inotify limits, somaxconn, ...).

Floor semantics: only apply a managed value when the node's current value is **lower** than the desired one. If the node already uses a higher value, leave it alone. This avoids silently regressing pre-tuned images (Bottlerocket, EKS AMIs, OpenShift RHCOS, hardened distros) and newer kernels (e.g. Linux 5.11+ where `fs.inotify.max_user_watches` is computed dynamically from memory and may exceed common hardcoded values).

The default `sysctl_minimum_values` is aligned with prior art from the [OpenShift Node Tuning Operator](https://github.com/openshift/cluster-node-tuning-operator) (TuneD's `=>` floor syntax in the [`openshift`](https://github.com/redhat-performance/tuned/blob/master/profiles/openshift/tuned.conf) and [`openshift-node`](https://github.com/redhat-performance/tuned/blob/master/profiles/openshift-node/tuned.conf) profiles, e.g. `kernel.pid_max=>4194304`, `fs.aio-max-nr=>1048576`) and [kops `nodeup/pkg/model/sysctls.go`](https://github.com/kubernetes/kops/blob/master/nodeup/pkg/model/sysctls.go).

| Sysctl key | Default floor | Source |
|---|---:|---|
| `fs.inotify.max_user_instances` | `8192` | OpenShift, kops, #13075 |
| `fs.inotify.max_user_watches` | `65536` | OpenShift |
| `kernel.pid_max` | `4194304` | OpenShift (`=>` floor) |
| `fs.aio-max-nr` | `1048576` | OpenShift (`=>` floor) |
| `vm.max_map_count` | `262144` | OpenShift |
| `net.netfilter.nf_conntrack_max` | `1048576` | OpenShift |
| `net.core.somaxconn` | `32768` | kops |
| `net.core.netdev_max_backlog` | `16384` | kops |
| `fs.file-max` | `2097152` | kops |
| `net.ipv4.neigh.default.gc_thresh{1,2,3}` | `8192` / `32768` / `65536` | OpenShift |
| `net.ipv6.neigh.default.gc_thresh{1,2,3}` | `8192` / `32768` / `65536` | OpenShift |

**Which issue(s) this PR fixes**:

Fixes #13209

**Special notes for your reviewer**:

This PR was written in part with the assistance of generative AI.

- None of the floor keys are part of the kubelet `protect-kernel-defaults` validation list (`vm.overcommit_memory`, `vm.panic_on_oom`, `kernel.panic`, `kernel.panic_on_oops`, `kernel.keys.root_max{keys,bytes}`), so the floor mechanism cannot interfere with kubelet startup.
- Keys not present on the running kernel/distro (e.g. `net.netfilter.nf_conntrack_max` when `nf_conntrack` is not loaded) are skipped via `sysctl --ignore`; empty results are filtered before applying floors, while other read errors still fail.
- `additional_sysctl` keeps its exact-value semantics and is unchanged for backward compatibility.
- Users can disable a default floor by setting it to `0` in `additional_sysctl_min` (the current value is virtually always `>= 0`, so the apply condition will never trigger).
- Documentation appended to `docs/operations/large-deployments.md` (the most relevant existing page) instead of adding a new doc.

Other prior art surveyed:
- [RKE2 `pkg/cli/cmds/profile_linux.go`](https://github.com/rancher/rke2/blob/master/pkg/cli/cmds/profile_linux.go) - read-then-decide pattern for CIS validation.
- [kubean-io/kube-node-tuning](https://github.com/kubean-io/kube-node-tuning) - DaemonSet-based sysctl tuning.
- [Talos `KernelParamDefaultsController`](https://github.com/siderolabs/talos/blob/main/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults.go) - default kernel parameters baked into the OS.
- [Bottlerocket #2335](https://github.com/bottlerocket-os/bottlerocket/pull/2335), kURL - `fs.inotify.max_user_instances=8192` by default.

**Does this PR introduce a user-facing change?**:

```release-note
Add `additional_sysctl_min` for declaring sysctl values with floor semantics: the value is only applied when the node's current value is lower than the desired one. The default `sysctl_minimum_values` is expanded to cover common container-density and networking tunables (kernel.pid_max, nf_conntrack_max, neigh gc thresholds, inotify limits, etc.), aligned with prior art from OpenShift Node Tuning Operator and kops. Existing `additional_sysctl` (exact-value semantics) is unchanged.
```

