### PR TITLE
Updates in the calico config and template to support disabling ipv4 pools during pure ipv6 deployment

### DIFF
--- a/roles/network_plugin/calico/templates/calico-config.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-config.yml.j2
@@ -56,15 +56,8 @@ data:
           {% else %}
             "ipam": {
               "type": "calico-ipam",
-            {% if (ipv4_stack and ipv6_stack) %}
-              "assign_ipv4": "true",
-              "assign_ipv6": "true"
-            {% elseif (ipv6_stack and not ipv4_stack %}
-              "assign_ipv4": "false",
-              "assign_ipv6": "true"
-            {% elseif (ipv4_stack and not ipv6_stack %}
-              "assign_ipv4": "true"
-            {% endif %}
+              "assign_ipv4": "{{ ipv4_stack | to_json }}",
+              "assign_ipv6": "{{ ipv6_stack | to_json }}"
             },
           {% endif %}
           {% if calico_allow_ip_forwarding %}

--- a/roles/network_plugin/calico/templates/calico-config.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-config.yml.j2
@@ -56,11 +56,14 @@ data:
           {% else %}
             "ipam": {
               "type": "calico-ipam",
-            {% if ipv4_stack %}
-              "assign_ipv4": "true"{{ ',' if (ipv6_stack and ipv4_stack) }}
-            {% endif %}
-            {% if ipv6_stack %}
+            {% if (ipv4_stack and ipv6_stack) %}
+              "assign_ipv4": "true",
               "assign_ipv6": "true"
+            {% elseif (ipv6_stack and not ipv4_stack %}
+              "assign_ipv4": "false",
+              "assign_ipv6": "true"
+            {% elseif (ipv4_stack and not ipv6_stack %}
+              "assign_ipv4": "true"
             {% endif %}
             },
           {% endif %}

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -259,6 +259,10 @@ spec:
             # no effect. This should fall within `--cluster-cidr`.
             # - name: CALICO_IPV4POOL_CIDR
             #   value: "192.168.0.0/16"
+            {% if not ipv4_stack %}
+            - name: CALICO_IPV4POOL_CIDR
+              value: "none"
+            {% endif %}
             - name: CALICO_IPV4POOL_IPIP
               value: "{{ calico_ipv4pool_ipip }}"
             # Enable or Disable VXLAN on the default IP pool.

--- a/roles/network_plugin/calico/templates/calico-node.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-node.yml.j2
@@ -259,10 +259,10 @@ spec:
             # no effect. This should fall within `--cluster-cidr`.
             # - name: CALICO_IPV4POOL_CIDR
             #   value: "192.168.0.0/16"
-            {% if not ipv4_stack %}
+{% if not ipv4_stack %}
             - name: CALICO_IPV4POOL_CIDR
               value: "none"
-            {% endif %}
+{% endif %}
             - name: CALICO_IPV4POOL_IPIP
               value: "{{ calico_ipv4pool_ipip }}"
             # Enable or Disable VXLAN on the default IP pool.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
/kind feature

**What this PR does / why we need it**:
Currently, when attempting a pure IPv6 deployment, Calico still attempts to allocate IPv4 addresses and utilize IPv4 CIDR pools
This PR updates the Calico configurations to correctly handle pure IPv6 stacks by:
1. Setting `CALICO_IPV4POOL_CIDR` to `"none"` in the node environment variables when IPv4 is disabled.
2. Updating the IP assignment logic in `calico-config.yml.j2` to explicitly set `assign_ipv4` to `"false"` and `assign_ipv6` to `"true"` during pure IPv6 deployments.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/kubespray/issues/13157

**Special notes for your reviewer**:
Please double-check the Jinja2 logic for dual-stack vs single-stack assignments to ensure it doesn't break existing IPv4-only or Dual-Stack clusters.
**Does this PR introduce a user-facing change?**:
```release-note
- Calico network plugin now correctly supports disabling IPv4 pools during pure IPv6 deployments.
   - Setting CALICO_IPV4POOL_CIDR to "none" in the node environment variables when IPv4 is disabled.
   - Updating the IP assignment logic in calico-config.yml.j2 to explicitly set assign_ipv4 to "false" and assign_ipv6 to "true" during pure IPv6 deployments.
```
