### PR TITLE
Chore: change the GitHub Actions uses commit hash

### DIFF
--- a/.github/workflows/upgrade-patch-versions.yml
+++ b/.github/workflows/upgrade-patch-versions.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         ref: ${{ inputs.branch }}
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.13'
         cache: 'pip'
@@ -22,7 +22,7 @@ jobs:
     - run: update-hashes
       env:
         API_KEY: ${{ secrets.GITHUB_TOKEN }}
-    - uses: actions/cache@v5
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         key: pre-commit-hook-propagate
         path: |


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

GItHub Actions auto bump not working currently because we use the tag.

**Special notes for your reviewer**:

https://github.com/kubernetes-sigs/kubespray/actions/runs/25299624816

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
