### PR TITLE
fix: skip kube-proxy-only tasks when kube_proxy_remove is true

### DIFF
--- a/roles/kubernetes-apps/metallb/tasks/main.yml
+++ b/roles/kubernetes-apps/metallb/tasks/main.yml
@@ -4,7 +4,7 @@
     msg: "MetalLB require kube_proxy_strict_arp = true, see https://github.com/danderson/metallb/issues/153#issuecomment-518651132"
   when:
     - kube_proxy_mode == 'ipvs' and not kube_proxy_strict_arp
-    - not (kube_proxy_remove | default(false) | bool)
+    - not kube_proxy_remove
 
 - name: Kubernetes Apps | Check that the deprecated 'matallb_auto_assign' variable is not used anymore
   fail:

--- a/roles/kubernetes-apps/metallb/tasks/main.yml
+++ b/roles/kubernetes-apps/metallb/tasks/main.yml
@@ -3,7 +3,8 @@
   fail:
     msg: "MetalLB require kube_proxy_strict_arp = true, see https://github.com/danderson/metallb/issues/153#issuecomment-518651132"
   when:
-    - "kube_proxy_mode == 'ipvs' and not kube_proxy_strict_arp"
+    - kube_proxy_mode == 'ipvs' and not kube_proxy_strict_arp
+    - not (kube_proxy_remove | default(false) | bool)
 
 - name: Kubernetes Apps | Check that the deprecated 'matallb_auto_assign' variable is not used anymore
   fail:

--- a/roles/kubernetes/node/tasks/loadbalancer/kube-vip.yml
+++ b/roles/kubernetes/node/tasks/loadbalancer/kube-vip.yml
@@ -4,6 +4,7 @@
     msg: "kube-vip require kube_proxy_strict_arp = true, see https://github.com/kube-vip/kube-vip/blob/main/docs/kubernetes/arp/index.md"
   when:
     - kube_proxy_mode == 'ipvs' and not kube_proxy_strict_arp
+    - not (kube_proxy_remove | default(false) | bool)
     - kube_vip_arp_enabled
 
 - name: Kube-vip | Check mutually exclusive BGP source settings

--- a/roles/kubernetes/node/tasks/loadbalancer/kube-vip.yml
+++ b/roles/kubernetes/node/tasks/loadbalancer/kube-vip.yml
@@ -4,7 +4,7 @@
     msg: "kube-vip require kube_proxy_strict_arp = true, see https://github.com/kube-vip/kube-vip/blob/main/docs/kubernetes/arp/index.md"
   when:
     - kube_proxy_mode == 'ipvs' and not kube_proxy_strict_arp
-    - not (kube_proxy_remove | default(false) | bool)
+    - not kube_proxy_remove
     - kube_vip_arp_enabled
 
 - name: Kube-vip | Check mutually exclusive BGP source settings

--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -116,7 +116,7 @@
   loop: "{{ kube_proxy_ipvs_modules }}"
   when:
     - kube_proxy_mode == 'ipvs'
-    - not (kube_proxy_remove | default(false) | bool)
+    - not kube_proxy_remove
   tags:
     - kube-proxy
 
@@ -132,7 +132,7 @@
     - nf_conntrack_ipv4
   when:
     - kube_proxy_mode == 'ipvs'
-    - not (kube_proxy_remove | default(false) | bool)
+    - not kube_proxy_remove
     - modprobe_conntrack_module is not defined or modprobe_conntrack_module is ansible.builtin.failed  # loop until first success
   tags:
     - kube-proxy
@@ -144,7 +144,7 @@
     persistent: present
   when:
     - kube_proxy_mode == 'nftables'
-    - not (kube_proxy_remove | default(false) | bool)
+    - not kube_proxy_remove
   tags:
     - kube-proxy
 

--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -114,7 +114,9 @@
     state: present
     persistent: present
   loop: "{{ kube_proxy_ipvs_modules }}"
-  when: kube_proxy_mode == 'ipvs'
+  when:
+    - kube_proxy_mode == 'ipvs'
+    - not (kube_proxy_remove | default(false) | bool)
   tags:
     - kube-proxy
 
@@ -130,6 +132,7 @@
     - nf_conntrack_ipv4
   when:
     - kube_proxy_mode == 'ipvs'
+    - not (kube_proxy_remove | default(false) | bool)
     - modprobe_conntrack_module is not defined or modprobe_conntrack_module is ansible.builtin.failed  # loop until first success
   tags:
     - kube-proxy
@@ -139,7 +142,9 @@
     name: "nf_tables"
     state: present
     persistent: present
-  when: kube_proxy_mode == 'nftables'
+  when:
+    - kube_proxy_mode == 'nftables'
+    - not (kube_proxy_remove | default(false) | bool)
   tags:
     - kube-proxy
 

--- a/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
@@ -73,6 +73,7 @@
     that: ansible_kernel.split('-')[0] is version('5.13', '>=')
   when:
     - kube_proxy_mode == 'nftables'
+    - not (kube_proxy_remove | default(false) | bool)
     - not ignore_assert_errors
 
 - name: Stop if bad hostname

--- a/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
@@ -73,7 +73,7 @@
     that: ansible_kernel.split('-')[0] is version('5.13', '>=')
   when:
     - kube_proxy_mode == 'nftables'
-    - not (kube_proxy_remove | default(false) | bool)
+    - not kube_proxy_remove
     - not ignore_assert_errors
 
 - name: Stop if bad hostname

--- a/roles/kubespray_defaults/defaults/main/main.yml
+++ b/roles/kubespray_defaults/defaults/main/main.yml
@@ -33,6 +33,10 @@ kube_version_min_required: "{{ (kubelet_checksums['amd64'] | dict2items)[-1].key
 ## Kube Proxy mode One of ['ipvs', 'iptables', 'nftables']
 kube_proxy_mode: ipvs
 
+# When true, kubeadm skips the kube-proxy addon (for example Cilium kube-proxy replacement).
+# Node and package tasks that exist only for kube-proxy also honor this (IPVS/nftables modules, ipvsadm, strict_arp checks).
+kube_proxy_remove: false
+
 # Debugging option for the kubeadm config validate command
 # Set to false only for development and testing scenarios where validation is expected to fail (pre-release Kubernetes versions, etc.)
 kubeadm_config_validate_enabled: true

--- a/roles/system_packages/vars/main.yml
+++ b/roles/system_packages/vars/main.yml
@@ -65,6 +65,7 @@ pkgs:
     - "{{ ping_access_ip }}"
   ipvsadm:
     - "{{ kube_proxy_mode == 'ipvs' }}"
+    - "{{ not (kube_proxy_remove | default(false) | bool) }}"
     - "{{ 'k8s_cluster' in group_names }}"
   libseccomp:
     - "{{ ansible_os_family == 'RedHat' }}"
@@ -80,6 +81,7 @@ pkgs:
     - "{{ ansible_distribution_major_version == '12' }}"
   nftables:
     - "{{ kube_proxy_mode == 'nftables' }}"
+    - "{{ not (kube_proxy_remove | default(false) | bool) }}"
     - "{{ 'k8s_cluster' in group_names }}"
   nss:
     - "{{ ansible_os_family == 'RedHat' }}"

--- a/roles/system_packages/vars/main.yml
+++ b/roles/system_packages/vars/main.yml
@@ -65,7 +65,7 @@ pkgs:
     - "{{ ping_access_ip }}"
   ipvsadm:
     - "{{ kube_proxy_mode == 'ipvs' }}"
-    - "{{ not (kube_proxy_remove | default(false) | bool) }}"
+    - "{{ not kube_proxy_remove }}"
     - "{{ 'k8s_cluster' in group_names }}"
   libseccomp:
     - "{{ ansible_os_family == 'RedHat' }}"
@@ -81,7 +81,7 @@ pkgs:
     - "{{ ansible_distribution_major_version == '12' }}"
   nftables:
     - "{{ kube_proxy_mode == 'nftables' }}"
-    - "{{ not (kube_proxy_remove | default(false) | bool) }}"
+    - "{{ not kube_proxy_remove }}"
     - "{{ 'k8s_cluster' in group_names }}"
   nss:
     - "{{ ansible_os_family == 'RedHat' }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

When `kube_proxy_remove` is true, kubeadm already skips the kube-proxy addon, but `kube_proxy_mode` still defaults to `ipvs`. Several tasks only keyed off `kube_proxy_mode`, so IPVS/nftables kernel modules were still loaded, `ipvsadm` / `nftables` packages could still be installed, kube-vip and MetalLB still enforced the kube-proxy IPVS + strict ARP rule, and the nftables kernel preinstall assert could still run.

This PR gates those kube-proxy-only paths on `kube_proxy_remove` (with `| default(false)` where inventory may omit the variable) and sets `kube_proxy_remove: false` in `kubespray_defaults` with a short comment so the variable is explicit and documented.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13213

**Special notes for your reviewer**:

`br_netfilter` / bridge sysctl tasks in `roles/kubernetes/node/tasks/main.yml` were intentionally not tied to `kube_proxy_remove`; they are not IPVS-specific and remain useful for many CNI setups.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
When `kube_proxy_remove` is enabled, Kubespray no longer loads kube-proxy IPVS/nftables-only kernel modules, omits `ipvsadm`/`nftables` package selection for kube-proxy-only use, skips kube-proxy IPVS strict ARP checks for kube-vip and MetalLB, and skips the nftables kube-proxy kernel version assert. A default `kube_proxy_remove: false` is documented in kubespray defaults.
```