### PR TITLE
kube-vip: add optional Prometheus metrics via Ansible variables

### DIFF
--- a/docs/ingress/kube-vip.md
+++ b/docs/ingress/kube-vip.md
@@ -86,3 +86,12 @@ kube_vip_leaseduration: 30
 kube_vip_renewdeadline: 20
 kube_vip_retryperiod: 4
 ```
+
+To expose [Prometheus metrics](https://kube-vip.io/docs/installation/flags/#environment-variables) from the kube-vip static pod, set `kube_vip_metrics_enabled`. `kube_vip_metrics_port` is an integer; the manifest sets `prometheus_server` to `:PORT` because kube-vip passes that value to Go's HTTP listen address (see [`servePrometheusHTTPServer` in kube-vip](https://github.com/kube-vip/kube-vip/blob/main/cmd/kube-vip.go)). The manifest `ports` entry uses the same number for tooling that reads the pod spec.
+
+Kubespray defaults `kube_vip_metrics_port` to `2112`, matching upstream kube-vip's `--prometheusHTTPServer` default. Override it if your scrape config expects another port.
+
+```yaml
+kube_vip_metrics_enabled: true
+# kube_vip_metrics_port: 2112
+```

--- a/inventory/sample/group_vars/k8s_cluster/addons.yml
+++ b/inventory/sample/group_vars/k8s_cluster/addons.yml
@@ -201,6 +201,8 @@ kube_vip_enabled: false
 # kube_vip_lb_fwdmethod: local
 # kube_vip_bgp_sourceip:
 # kube_vip_bgp_sourceif:
+# kube_vip_metrics_enabled: false
+# kube_vip_metrics_port: 2112
 
 # Node Feature Discovery
 node_feature_discovery_enabled: false

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -88,6 +88,9 @@ kube_vip_retryperiod: 1
 kube_vip_enable_node_labeling: false
 kube_vip_bgp_sourceip:
 kube_vip_bgp_sourceif:
+kube_vip_metrics_enabled: false
+# TCP port for kube-vip Prometheus metrics; manifest sets prometheus_server to :PORT (same as kube-vip upstream default, see cmd/kube-vip.go).
+kube_vip_metrics_port: 2112
 
 # Requests for load balancer app
 loadbalancer_apiserver_memory_requests: 32M

--- a/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
@@ -110,10 +110,20 @@ spec:
     - name: lb_fwdmethod
       value: {{ kube_vip_lb_fwdmethod | string | to_json }}
 {% endif %}
+{% if kube_vip_metrics_enabled %}
+    - name: prometheus_server
+      value: {{ (':' ~ (kube_vip_metrics_port | string)) | to_json }}
+{% endif %}
     image: {{ kube_vip_image_repo }}:{{ kube_vip_image_tag }}
     imagePullPolicy: {{ k8s_image_pull_policy }}
     name: kube-vip
     resources: {}
+{% if kube_vip_metrics_enabled %}
+    ports:
+    - name: metrics
+      containerPort: {{ kube_vip_metrics_port }}
+      protocol: TCP
+{% endif %}
 {% if kube_vip_lb_fwdmethod == "masquerade" %}
     securityContext:
       privileged: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds optional Prometheus metrics for the kube-vip static pod through Ansible variables. When `kube_vip_metrics_enabled` is true, the generated manifest sets the `prometheus_server` environment variable (from `kube_vip_metrics_port`, default `2112`) and declares a named `metrics` container port so scrapers can treat the endpoint as documented. Defaults keep current behavior unchanged (`kube_vip_metrics_enabled: false`). Sample inventory comments and `docs/ingress/kube-vip.md` describe how to turn the feature on.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13220

**Special notes for your reviewer**:

The numeric `containerPort` is derived with `regex_replace('^.*:', '') | int` so bind strings such as `2112` or `0.0.0.0:2112` map to the correct port; plain numeric values still work. The pod remains `hostNetwork: true`; the port declaration is mainly for documentation and tooling that read the manifest.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Kubespray: kube-vip static pod can optionally expose Prometheus metrics via `kube_vip_metrics_enabled` and `kube_vip_metrics_port` (see kube-vip docs and `docs/ingress/kube-vip.md`).
```