### PR TITLE
docs(offline): document cilium_install_extra_flags for offline mirror

### DIFF
--- a/inventory/sample/group_vars/all/offline.yml
+++ b/inventory/sample/group_vars/all/offline.yml
@@ -48,6 +48,10 @@
 
 # [Optional] Cilium: If using Cilium network plugin
 # ciliumcli_download_url: "{{ files_repo }}/github.com/cilium/cilium-cli/releases/download/v{{ cilium_cli_version }}/cilium-linux-{{ image_arch }}.tar.gz"
+# Cilium installs the helm chart from https://helm.cilium.io by default. In offline mode,
+# mirror the chart repository (index.yaml + cilium-{{ cilium_version }}.tgz) under files_repo
+# and point cilium install at the mirror via:
+# cilium_install_extra_flags: "--repository {{ files_repo }}/helm.cilium.io/"
 
 # [Optional] helm: only if you set helm_enabled: true
 # helm_download_url: "{{ files_repo }}/get.helm.sh/helm-v{{ helm_version }}-linux-{{ image_arch }}.tar.gz"


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

In offline mode, `cilium install` fails because the Cilium CLI tries to fetch
the helm chart from `https://helm.cilium.io`, which is unreachable from
air-gapped environments.

The workaround variable `cilium_install_extra_flags` already exists in
`roles/network_plugin/cilium/defaults/main.yml`, and #12684 documented it in
`docs/operations/offline-environment.md`. This PR adds the same hint to the
inventory sample at `inventory/sample/group_vars/all/offline.yml` — the file
users actually copy when configuring offline deployments — so the workaround
is discoverable from the inventory itself and not just the operations doc.

No code-path or default-value changes; comments only.

**Which issue(s) this PR fixes**:

Fixes #12558

**Special notes for your reviewer**:

Builds on the docs added in #12684. Tested locally with yamllint.

**Does this PR introduce a user-facing change?**:


**release-note**
```
NONE
```

