### PR TITLE
Set http proxy environments for helm app installations

### DIFF
--- a/roles/helm-apps/tasks/main.yml
+++ b/roles/helm-apps/tasks/main.yml
@@ -1,9 +1,15 @@
 ---
 - name: Add Helm repositories
+  environment:
+    http_proxy: "{{ http_proxy | default('') }}"
+    https_proxy: "{{ https_proxy | default('') }}"
   kubernetes.core.helm_repository: "{{ helm_repository_defaults | combine(item) }}"  # noqa args[module]
   loop: "{{ repositories }}"
 
 - name: Update Helm repositories
+  environment:
+    http_proxy: "{{ http_proxy | default('') }}"
+    https_proxy: "{{ https_proxy | default('') }}"
   kubernetes.core.helm:
     state: absent
     binary_path: "{{ bin_dir }}/helm"
@@ -15,5 +21,8 @@
     - helm_update
 
 - name: Install Helm Applications
+  environment:
+    http_proxy: "{{ http_proxy | default('') }}"
+    https_proxy: "{{ https_proxy | default('') }}"
   kubernetes.core.helm: "{{ helm_defaults | combine(release_common_opts, item) }}"  # noqa args[module]
   loop: "{{ releases }}"

--- a/roles/helm-apps/tasks/main.yml
+++ b/roles/helm-apps/tasks/main.yml
@@ -1,15 +1,11 @@
 ---
 - name: Add Helm repositories
-  environment:
-    http_proxy: "{{ http_proxy | default('') }}"
-    https_proxy: "{{ https_proxy | default('') }}"
+  environment: "{{ proxy_env }}"
   kubernetes.core.helm_repository: "{{ helm_repository_defaults | combine(item) }}"  # noqa args[module]
   loop: "{{ repositories }}"
 
 - name: Update Helm repositories
-  environment:
-    http_proxy: "{{ http_proxy | default('') }}"
-    https_proxy: "{{ https_proxy | default('') }}"
+  environment: "{{ proxy_env }}"
   kubernetes.core.helm:
     state: absent
     binary_path: "{{ bin_dir }}/helm"
@@ -21,8 +17,6 @@
     - helm_update
 
 - name: Install Helm Applications
-  environment:
-    http_proxy: "{{ http_proxy | default('') }}"
-    https_proxy: "{{ https_proxy | default('') }}"
+  environment: "{{ proxy_env }}"
   kubernetes.core.helm: "{{ helm_defaults | combine(release_common_opts, item) }}"  # noqa args[module]
   loop: "{{ releases }}"

--- a/roles/kubernetes-apps/kubelet-csr-approver/meta/main.yml
+++ b/roles/kubernetes-apps/kubelet-csr-approver/meta/main.yml
@@ -4,9 +4,7 @@ dependencies:
     when:
       - inventory_hostname == groups['kube_control_plane'][0]
       - kubelet_csr_approver_enabled
-    environment:
-      http_proxy: "{{ http_proxy | default('') }}"
-      https_proxy: "{{ https_proxy | default('') }}"
+    environment: "{{ proxy_env }}"
     release_common_opts: {}
     releases:
       - name: kubelet-csr-approver

--- a/roles/network_plugin/custom_cni/meta/main.yml
+++ b/roles/network_plugin/custom_cni/meta/main.yml
@@ -4,9 +4,7 @@ dependencies:
     when:
       - inventory_hostname == groups['kube_control_plane'][0]
       - custom_cni_chart_release_name | length > 0
-    environment:
-      http_proxy: "{{ http_proxy | default('') }}"
-      https_proxy: "{{ https_proxy | default('') }}"
+    environment: "{{ proxy_env }}"
     release_common_opts: {}
     releases:
       - name: "{{ custom_cni_chart_release_name }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

On installations that use proxies for external connectivity the installation of helm charts will fail.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixes cluster setup in setups needing an http_proxy for external connectivity
```
