### PR TITLE
Add toggle to disable node subnet allocation

### DIFF
--- a/roles/kubernetes/control-plane/defaults/main/main.yml
+++ b/roles/kubernetes/control-plane/defaults/main/main.yml
@@ -41,6 +41,9 @@ control_plane_health_retries: 60  # Default retries for apiserver, scheduler, co
 kube_controller_manager_leader_elect_lease_duration: 15s
 kube_controller_manager_leader_elect_renew_deadline: 10s
 
+# Controls whether or not the kube_controller_manager allocates subnets for the node object
+kube_controller_manager_allocate_node_cidrs: true
+
 # discovery_timeout modifies the discovery timeout
 discovery_timeout: 5m0s
 

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
@@ -365,14 +365,15 @@ controllerManager:
 {% endif %}
   - name: service-cluster-ip-range
     value: "{{ kube_service_subnets }}"
-{% if (
-    kube_network_plugin is defined and
-    kube_network_plugin == "calico" and
-    not calico_ipam_host_local
-  ) or (
-    kube_network_plugin is defined and
-    kube_network_plugin == "cilium" and
-    cilium_ipam_mode == "cluster-pool"
+{% if not kube_controller_manager_allocate_node_cidrs
+  or kube_network_plugin is defined and (
+    (
+      kube_network_plugin == "calico" and
+      not calico_ipam_host_local
+    ) or (
+      kube_network_plugin == "cilium" and
+      cilium_ipam_mode == "cluster-pool"
+    )
   )
 %}
   - name: allocate-node-cidrs


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

I need to disable the subnet allocation as I use cilium + multi-pool and I deploy Cilium manually using `custom_cni`.

**Which issue(s) this PR fixes**:
Ref #13148 

**Does this PR introduce a user-facing change?**:
```release-note
kube-controller-manager's subnet allocation can now be toggled with `kube_controller_manager_allocate_node_cidrs`
```
