### PR TITLE
roles: rely on configured defaults

### DIFF
--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Download | Prepare working directories and variables
   import_tasks: prep_download.yml
   when:
-    - not skip_downloads | default(false)
+    - not skip_downloads
   tags:
     - download
     - upload
@@ -10,7 +10,7 @@
 - name: Download | Get kubeadm binary and list of required images
   include_tasks: prep_kubeadm_images.yml
   when:
-    - not skip_downloads | default(false)
+    - not skip_downloads
     - ('kube_control_plane' in group_names)
   tags:
     - download
@@ -23,8 +23,8 @@
     download: "{{ download_defaults | combine(item.value) }}"
     include_file: "download_{% if download.container %}container{% else %}file{% endif %}.yml"
   when:
-    - not skip_downloads | default(false)
+    - not skip_downloads
     - download.enabled
     - item.value.enabled
-    - (not (item.value.container | default(false))) or (item.value.container and download_container)
+    - (not download.container) or (download.container and download_container)
     - (download_run_once and inventory_hostname == download_delegate) or (group_names | intersect(download.groups) | length)

--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -8,6 +8,9 @@ cloud_resolver: []
 disable_host_nameservers: false
 # Kubespray sets this to true after clusterDNS is running to apply changes to the host resolv.conf
 dns_late: false
+# DNS resolver option timeout and retry attempts.
+dns_timeout: 2
+dns_attempts: 2
 
 # Set to true if your network does not support IPv6
 # This may be necessary for pulling Docker images from

--- a/roles/kubernetes/preinstall/tasks/0060-resolvconf.yml
+++ b/roles/kubernetes/preinstall/tasks/0060-resolvconf.yml
@@ -12,7 +12,7 @@
       {% for item in nameserverentries %}
       nameserver {{ item }}
       {% endfor %}
-      options ndots:{{ ndots }} timeout:{{ dns_timeout | default('2') }} attempts:{{ dns_attempts | default('2') }}
+      options ndots:{{ ndots }} timeout:{{ dns_timeout }} attempts:{{ dns_attempts }}
     state: present
     insertbefore: BOF
     create: true

--- a/roles/kubernetes/preinstall/tasks/0063-networkmanager-dns.yml
+++ b/roles/kubernetes/preinstall/tasks/0063-networkmanager-dns.yml
@@ -32,7 +32,7 @@
     path: /etc/NetworkManager/conf.d/dns.conf
     section: global-dns
     option: options
-    value: "ndots:{{ ndots }},timeout:{{ dns_timeout | default('2') }},attempts:{{ dns_attempts | default('2') }}"
+    value: "ndots:{{ ndots }},timeout:{{ dns_timeout }},attempts:{{ dns_attempts }}"
     mode: '0600'
     backup: "{{ leave_etc_backup_files }}"
   notify: Preinstall | update resolvconf for networkmanager

--- a/roles/kubernetes/preinstall/templates/dhclient_dnsupdate.sh.j2
+++ b/roles/kubernetes/preinstall/templates/dhclient_dnsupdate.sh.j2
@@ -6,7 +6,7 @@
 if [ $reason = "BOUND" ]; then
   if [ -n "$new_domain_search" -o -n "$new_domain_name_servers" ]; then
     RESOLV_CONF=$(cat /etc/resolv.conf | sed -r '/^options (timeout|attempts|ndots).*$/d')
-    OPTIONS="options timeout:{{ dns_timeout|default('2') }} attempts:{{ dns_attempts|default('2') }} ndots:{{ ndots }}"
+    OPTIONS="options timeout:{{ dns_timeout }} attempts:{{ dns_attempts }} ndots:{{ ndots }}"
 
     printf "%b\n" "$RESOLV_CONF\n$OPTIONS" > /etc/resolv.conf
   fi

--- a/roles/kubernetes/preinstall/templates/dhclient_dnsupdate_rh.sh.j2
+++ b/roles/kubernetes/preinstall/templates/dhclient_dnsupdate_rh.sh.j2
@@ -6,7 +6,7 @@
 zdnsupdate_config() {
   if [ -n "$new_domain_search" -o -n "$new_domain_name_servers" ]; then
     RESOLV_CONF=$(cat /etc/resolv.conf | sed -r '/^options (timeout|attempts|ndots).*$/d')
-    OPTIONS="options timeout:{{ dns_timeout|default('2') }} attempts:{{ dns_attempts|default('2') }} ndots:{{ ndots }}"
+    OPTIONS="options timeout:{{ dns_timeout }} attempts:{{ dns_attempts }} ndots:{{ ndots }}"
 
     echo -e "$RESOLV_CONF\n$OPTIONS" > /etc/resolv.conf
   fi


### PR DESCRIPTION
## What type of PR is this?

/kind cleanup

## What this PR does / why we need it

This removes a small set of repeated inline defaults from role tasks and templates where Kubespray already defines the same values in role defaults.

The change covers:

- `skip_downloads`, which is already defined in `kubespray_defaults`
- download item `container`, which is already normalized through `download_defaults`
- `dns_timeout` and `dns_attempts`, now defined once in the `kubernetes/preinstall` role defaults and reused by resolv.conf, NetworkManager, and dhclient templates

This keeps behavior unchanged while reducing duplicated fallback values in the role logic.

## Which issue(s) this PR fixes

Fixes part of #11822.

## Special notes for your reviewer

This intentionally handles a small, low-risk slice of the broader cleanup requested in #11822 rather than changing every remaining `default` filter at once.

## Does this PR introduce a user-facing change?

```release-note
NONE
```
