### PR TITLE
Align nginx worker_rlimit_nofile with containerd defaults

### DIFF
--- a/roles/kubernetes/node/templates/loadbalancer/nginx.conf.j2
+++ b/roles/kubernetes/node/templates/loadbalancer/nginx.conf.j2
@@ -1,7 +1,7 @@
 error_log stderr notice;
 
 worker_processes 2;
-worker_rlimit_nofile 130048;
+worker_rlimit_nofile 65535;
 worker_shutdown_timeout 10s;
 
 events {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This prevents nginx proxy startup failures caused by mismatched RLIMIT_NOFILE defaults between nginx and containerd.

**Which issue(s) this PR fixes**:
Fixes #13253

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
