### PR TITLE
Rename cilium certgen and envoy image variables

### DIFF
--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -238,14 +238,14 @@ cilium_operator_image_repo: "{{ quay_image_repo }}/cilium/operator"
 cilium_operator_image_tag: "v{{ cilium_version }}"
 cilium_hubble_relay_image_repo: "{{ quay_image_repo }}/cilium/hubble-relay"
 cilium_hubble_relay_image_tag: "v{{ cilium_version }}"
-cilium_hubble_certgen_image_repo: "{{ quay_image_repo }}/cilium/certgen"
-cilium_hubble_certgen_image_tag: "v0.4.5"
+cilium_certgen_image_repo: "{{ quay_image_repo }}/cilium/certgen"
+cilium_certgen_image_tag: "v0.4.5"
 cilium_hubble_ui_image_repo: "{{ quay_image_repo }}/cilium/hubble-ui"
 cilium_hubble_ui_image_tag: "v0.13.5"
 cilium_hubble_ui_backend_image_repo: "{{ quay_image_repo }}/cilium/hubble-ui-backend"
 cilium_hubble_ui_backend_image_tag: "v0.13.5"
-cilium_hubble_envoy_image_repo: "{{ quay_image_repo }}/cilium/cilium-envoy"
-cilium_hubble_envoy_image_tag: "v1.37.2-1778236003-7c2f6580d32e50f1a6866c12122662856f54eec2"
+cilium_envoy_image_repo: "{{ quay_image_repo }}/cilium/cilium-envoy"
+cilium_envoy_image_tag: "v1.37.2-1778236003-7c2f6580d32e50f1a6866c12122662856f54eec2"
 kube_ovn_container_image_repo: "{{ docker_image_repo }}/kubeovn/kube-ovn"
 kube_ovn_container_image_tag: "v{{ kube_ovn_version }}"
 kube_ovn_vpc_container_image_repo: "{{ docker_image_repo }}/kubeovn/vpc-nat-gateway"
@@ -611,12 +611,12 @@ downloads:
     groups:
       - k8s_cluster
 
-  cilium_hubble_certgen:
-    enabled: "{{ cilium_enable_hubble }}"
+  cilium_certgen:
+    enabled: "{{ kube_network_plugin == 'cilium' }}"
     container: true
-    repo: "{{ cilium_hubble_certgen_image_repo }}"
-    tag: "{{ cilium_hubble_certgen_image_tag }}"
-    checksum: "{{ cilium_hubble_certgen_digest_checksum | default(None) }}"
+    repo: "{{ cilium_certgen_image_repo }}"
+    tag: "{{ cilium_certgen_image_tag }}"
+    checksum: "{{ cilium_certgen_digest_checksum | default(None) }}"
     groups:
       - k8s_cluster
 
@@ -638,12 +638,12 @@ downloads:
     groups:
       - k8s_cluster
 
-  cilium_hubble_envoy:
-    enabled: "{{ cilium_enable_hubble }}"
+  cilium_envoy:
+    enabled: "{{ kube_network_plugin == 'cilium' }}"
     container: true
-    repo: "{{ cilium_hubble_envoy_image_repo }}"
-    tag: "{{ cilium_hubble_envoy_image_tag }}"
-    checksum: "{{ cilium_hubble_envoy_digest_checksum | default(None) }}"
+    repo: "{{ cilium_envoy_image_repo }}"
+    tag: "{{ cilium_envoy_image_tag }}"
+    checksum: "{{ cilium_envoy_digest_checksum | default(None) }}"
     groups:
       - k8s_cluster
 

--- a/roles/network_plugin/cilium/templates/values.yaml.j2
+++ b/roles/network_plugin/cilium/templates/values.yaml.j2
@@ -182,13 +182,13 @@ prometheus:
 
 certgen:
   image:
-    repository: {{ cilium_hubble_certgen_image_repo }}
-    tag: {{ cilium_hubble_certgen_image_tag }}
+    repository: {{ cilium_certgen_image_repo }}
+    tag: {{ cilium_certgen_image_tag }}
 
 envoy:
   image:
-    repository: {{ cilium_hubble_envoy_image_repo }}
-    tag: {{ cilium_hubble_envoy_image_tag }}
+    repository: {{ cilium_envoy_image_repo }}
+    tag: {{ cilium_envoy_image_tag }}
 
 extraConfig:
   {{ cilium_config_extra_vars | to_yaml | indent(2) }}


### PR DESCRIPTION
Rename hubble specific cilium image variables to more generic names:

- `cilium_hubble_certgen_image_repo` -> `cilium_certgen_image_repo`
- `cilium_hubble_certgen_image_tag` -> `cilium_certgen_image_tag`
- `cilium_hubble_envoy_image_repo` -> `cilium_envoy_image_repo`
- `cilium_hubble_envoy_image_tag` -> `cilium_envoy_image_tag`
 
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The previous variable names incorrectly implied that these images are
used exclusively by hubble.

`certgen` is also used by Cluster Mesh

`envoy` is not only used for hubble. It is also required for L7 network
policy support and is deployed by default on new clusters.

This change makes the variable naming more accurate and aligns it with
their actual usage scope.

**Does this PR introduce a user-facing change?**:
```release-note
ACTION REQUIRED: Cilium image variables renamed: `cilium_hubble_certgen_image_{repo,tag}` -> `cilium_certgen_image_{repo,tag}`, `cilium_hubble_envoy_image_{repo,tag}` -> `cilium_envoy_image_{repo,tag}`
```
