### PR TITLE
Remove deprecated apiserver-count kubeadm config option

### DIFF
--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
@@ -156,8 +156,6 @@ apiServer:
   - name: disable-admission-plugins
     value: "{{ kube_apiserver_disable_admission_plugins | join(',') }}"
 {% endif %}
-  - name: apiserver-count
-    value: "{{ kube_apiserver_count }}"
   - name: endpoint-reconciler-type
     value: lease
 {% if etcd_events_cluster_enabled %}

--- a/roles/kubespray_defaults/defaults/main/main.yml
+++ b/roles/kubespray_defaults/defaults/main/main.yml
@@ -663,7 +663,6 @@ ssl_ca_dirs: |-
 # used for delegating tasks on a working control plane node
 first_kube_control_plane: "{{ groups['kube_control_plane'] | first }}"
 # Vars for pointing to kubernetes api endpoints
-kube_apiserver_count: "{{ groups['kube_control_plane'] | length }}"
 kube_apiserver_address: "{{ hostvars[inventory_hostname]['main_ip'] }}"
 kube_apiserver_access_address: "{{ hostvars[inventory_hostname]['main_access_ip'] }}"
 first_kube_control_plane_address: "{{ hostvars[groups['kube_control_plane'][0]]['main_access_ip'] }}"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
When this option is present, the kube-apiserver logs the following deprecation warning:

> Flag --apiserver-count has been deprecated, apiserver-count is deprecated and will be removed in a future version.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
