### PR TITLE
feat: harden kubeadm etcd manifest to prevent split-brain on data-dir wipe

### DIFF
--- a/roles/kubernetes/control-plane/defaults/main/etcd.yml
+++ b/roles/kubernetes/control-plane/defaults/main/etcd.yml
@@ -27,3 +27,11 @@ etcd_extra_vars: {}
 # etcd_max_request_bytes: "1572864"
 
 etcd_compaction_retention: "8"
+
+# Harden the kubeadm-rendered etcd static-pod manifest by replacing
+# --initial-cluster=<self>/--initial-cluster-state=new with the full live
+# member list and state=existing, preventing silent split-brain on data-dir wipe.
+etcd_kubeadm_harden_manifest_enabled: false
+etcd_kubeadm_harden_manifest_path: "{{ kube_config_dir }}/manifests/etcd.yaml"
+etcd_kubeadm_harden_wait_retries: 30
+etcd_kubeadm_harden_wait_delay: 5

--- a/roles/kubernetes/control-plane/handlers/main.yml
+++ b/roles/kubernetes/control-plane/handlers/main.yml
@@ -115,3 +115,12 @@
   listen:
     - Control plane | restart kubelet
     - Control plane | Restart apiserver
+
+- name: Etcd harden | Wait for etcd to recover
+  command: "{{ bin_dir }}/etcdctl.sh endpoint health"
+  register: etcd_kubeadm_harden_health
+  changed_when: false
+  check_mode: false
+  retries: "{{ etcd_kubeadm_harden_wait_retries }}"
+  delay: "{{ etcd_kubeadm_harden_wait_delay }}"
+  until: etcd_kubeadm_harden_health.rc == 0

--- a/roles/kubernetes/control-plane/tasks/kubeadm-etcd-harden.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-etcd-harden.yml
@@ -1,0 +1,70 @@
+---
+# Hardens the kubeadm-rendered etcd static-pod manifest by replacing
+# --initial-cluster=<self> and --initial-cluster-state=new with the
+# full live member list and --initial-cluster-state=existing.
+#
+# Without this, a data-dir wipe silently re-bootstraps the local etcd
+# as a new single-node cluster (split brain).
+# References: kubeadm#2005, k/k PR #97372, etcd-io#11732.
+
+- name: Etcd harden | List live etcd cluster members
+  command: "{{ bin_dir }}/etcdctl.sh member list -w json"
+  register: etcd_kubeadm_harden_members
+  changed_when: false
+  check_mode: false
+  retries: 3
+  delay: 5
+  until: etcd_kubeadm_harden_members.rc == 0
+
+- name: Etcd harden | Parse member list
+  set_fact:
+    etcd_kubeadm_harden_member_list: "{{ etcd_kubeadm_harden_members.stdout | from_json }}"
+
+- name: Etcd harden | Assert local member is registered and not a learner
+  assert:
+    that:
+      - local_member is not none
+      - not (local_member.isLearner | default(false))
+      - local_member.name | length > 0
+      - local_member.peerURLs | length > 0
+    fail_msg: "Local etcd member not found in cluster or is a learner; refusing to harden."
+  vars:
+    local_member: >-
+      {{ (etcd_kubeadm_harden_member_list.members | default([]))
+         | selectattr('peerURLs.0', '==', etcd_peer_url)
+         | first | default(none) }}
+
+- name: Etcd harden | Build initial-cluster argument from live members
+  set_fact:
+    etcd_kubeadm_harden_initial_cluster: >-
+      {{ (etcd_kubeadm_harden_member_list.members | default([]))
+         | map(attribute='name') | zip(
+           (etcd_kubeadm_harden_member_list.members | default([]))
+           | map(attribute='peerURLs') | map('first')
+         ) | map('join', '=') | join(',') }}
+
+- name: Etcd harden | Read current etcd static-pod manifest
+  slurp:
+    src: "{{ etcd_kubeadm_harden_manifest_path }}"
+  register: etcd_kubeadm_harden_manifest
+
+- name: Etcd harden | Compute hardened manifest contents
+  set_fact:
+    etcd_kubeadm_harden_new_manifest: >-
+      {{ etcd_kubeadm_harden_manifest.content | b64decode
+         | regex_replace('(\s+)- --initial-cluster=[^\n]*\n',
+             '\1- --initial-cluster=' ~ etcd_kubeadm_harden_initial_cluster ~ '\n')
+         | regex_replace('(\s+)- --initial-cluster-state=[^\n]*\n',
+             '\1- --initial-cluster-state=existing\n') }}
+
+- name: Etcd harden | Apply hardened manifest atomically (serialized across CPs)
+  copy:
+    content: "{{ etcd_kubeadm_harden_new_manifest }}"
+    dest: "{{ etcd_kubeadm_harden_manifest_path }}"
+    owner: root
+    group: root
+    mode: "0600"
+    backup: true
+  throttle: 1
+  when: etcd_kubeadm_harden_new_manifest != (etcd_kubeadm_harden_manifest.content | b64decode)
+  notify: Etcd harden | Wait for etcd to recover

--- a/roles/kubernetes/control-plane/tasks/kubeadm-etcd.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-etcd.yml
@@ -27,3 +27,7 @@
     group: "{{ etcd_owner }}"
     mode: "0700"
   when: etcd_deployment_type == "kubeadm"
+
+- name: Harden kubeadm-rendered etcd manifest with full initial-cluster list
+  import_tasks: kubeadm-etcd-harden.yml
+  when: etcd_kubeadm_harden_manifest_enabled

--- a/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
@@ -49,6 +49,12 @@
   - etcd_deployment_type == "kubeadm"
   notify: Control plane | restart kubelet
 
+- name: Re-harden kubeadm-rendered etcd manifest after upgrade rewrite
+  import_tasks: kubeadm-etcd-harden.yml
+  when:
+  - etcd_deployment_type == "kubeadm"
+  - etcd_kubeadm_harden_manifest_enabled
+
 - name: Rewrite kubernetes control plane static pod manifests with updated configmap
   command: "{{ bin_dir }}/kubeadm init phase control-plane all --config {{ kube_config_dir }}/kubeadm-config.yaml"
   notify: Control plane | restart kubelet


### PR DESCRIPTION
- Add kubeadm-etcd-harden.yml task that rewrites --initial-cluster and --initial-cluster-state in the etcd static-pod manifest using the live member list
- Invoke hardening from both kubeadm-etcd.yml (initial setup) and kubeadm-upgrade.yml (post-upgrade rewrite)
- Assert local member is registered and non-learner before applying, and wait for etcd health recovery after manifest rewrite
- Add configurable defaults for manifest path, retry count, and retry delay

What type of PR is this?
/kind feature

Which issue(s) this PR fixes:

- #13261

```release-note
Add opt-in hardening of the kubeadm-rendered etcd static-pod manifest to prevent silent split-brain on data-dir wipe (etcd_kubeadm_harden_manifest_enabled)
```