### PR TITLE
Fixed pre-commit and pin Python Client version in pipeline

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,7 @@ repos:
     hooks:
       - id: ansible-lint
         additional_dependencies:
+          - ansible-core>=2.18.0,<2.19.0
           - jmespath==1.0.1
           - netaddr==1.3.0
           - distlib
@@ -49,7 +50,7 @@ repos:
         name: Build and install kubernetes-sigs.kubespray Ansible collection
         language: python
         additional_dependencies:
-          - ansible-core>=2.16.4
+          - ansible-core>=2.18.0,<2.19.0
           - distlib
         entry: tests/scripts/collection-build-install.sh
         pass_filenames: false
@@ -91,7 +92,7 @@ repos:
         name: Update static files referencing default kubespray values
         language: python
         additional_dependencies:
-          - ansible-core>=2.16.4
+          - ansible-core>=2.18.0,<2.19.0
         entry: scripts/propagate_ansible_variables.yml
         pass_filenames: false
 

--- a/pipeline.Dockerfile
+++ b/pipeline.Dockerfile
@@ -55,5 +55,5 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1 \
     && rm vagrant_${VAGRANT_VERSION}-1_$(dpkg --print-architecture).deb \
     && vagrant plugin install vagrant-libvirt \
     # Install Kubernetes collections
-    && pip install --break-system-packages --no-compile --no-cache-dir kubernetes \
-    && ansible-galaxy collection install kubernetes.core
+    && pip install --break-system-packages --no-compile --no-cache-dir kubernetes==35.0.0 \
+    && ansible-galaxy collection install kubernetes.core:==6.4.0

--- a/roles/container-engine/kata-containers/molecule/default/verify.yml
+++ b/roles/container-engine/kata-containers/molecule/default/verify.yml
@@ -9,7 +9,7 @@
     failed_when: >
       version is failed or
       'kata-runtime' not in version.stdout
-  - name: Test version
+  - name: Test version check
     command: "/opt/kata/bin/kata-runtime check"
     register: check
     failed_when: >

--- a/scripts/pipeline.Dockerfile.j2
+++ b/scripts/pipeline.Dockerfile.j2
@@ -55,5 +55,5 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1 \
     && rm vagrant_${VAGRANT_VERSION}-1_$(dpkg --print-architecture).deb \
     && vagrant plugin install vagrant-libvirt \
     # Install Kubernetes collections
-    && pip install --break-system-packages --no-compile --no-cache-dir kubernetes \
-    && ansible-galaxy collection install kubernetes.core
+    && pip install --break-system-packages --no-compile --no-cache-dir kubernetes==35.0.0 \
+    && ansible-galaxy collection install kubernetes.core:==6.4.0


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

Now the Kubespray CI's jobs are all failing. Fix the pre-commit and pin the Kubernetes Python Client version 35.0.0.

**Special notes for your reviewer**:

Upstream issue: https://github.com/kubernetes-client/python/issues/2582

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
