### PR TITLE
fix(cilium): use operator-generic image for cilium-operator

### DIFF
--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -596,7 +596,7 @@ downloads:
   cilium_operator:
     enabled: "{{ kube_network_plugin == 'cilium' or cilium_deploy_additionally }}"
     container: true
-    repo: "{{ cilium_operator_image_repo }}"
+    repo: "{{ cilium_operator_image_repo }}-generic"
     tag: "{{ cilium_operator_image_tag }}"
     checksum: "{{ cilium_operator_digest_checksum | default(None) }}"
     groups:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Kubespray synced `cilium/operator` to offline registries and passed that repository to the Cilium Helm chart, but the chart builds the operator image as `{repository}-{cloud}` (e.g. `operator-generic` for default non-cloud deployments). Offline clusters therefore lacked `cilium/operator-generic` or pulled the wrong image, leading to `ErrImagePull` or `CrashLoopBackOff` (`cilium-operator-generic`: executable file not found).

This PR:

- Sets `cilium_operator_image_repo` to `cilium/operator-generic` so image sync matches the chart.
- Uses `operator.image.override` in the Helm values template so the chart does not append `-generic` again when the repository already includes it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13252

**Special notes for your reviewer**:

- Targets the default non-cloud (`generic`) Cilium operator, which matches the usual Kubespray deployment. Cloud-specific operator images (`operator-aws`, etc.) are unchanged and not configured in Kubespray today.
- Aligns with the existing offline-registry guidance in `docs/operations/offline-environment.md` that documents `operator.image.override` with `operator-generic`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```