### PR TITLE
image-builder: add staging OCI publish path

### DIFF
--- a/test-infra/image-builder/Makefile
+++ b/test-infra/image-builder/Makefile
@@ -1,5 +1,47 @@
+docker_host ?= quay.io
+docker_login ?= true
+docker_user ?= kubespray+buildvmimages
+registry ?= quay.io/kubespray
+staging_registry ?= us-central1-docker.pkg.dev/k8s-staging-images/kubespray
+
 deploy:
-	ansible-playbook -i hosts.ini -e docker_password=$(docker_password) cluster.yml
+	ansible-playbook -i hosts.ini \
+		-e docker_host=$(docker_host) \
+		-e docker_login=$(docker_login) \
+		-e docker_user=$(docker_user) \
+		-e docker_password=$(docker_password) \
+		-e registry=$(registry) \
+		cluster.yml
+
+push-docker:
+	ansible-playbook -i localhost, -c local \
+		-e images_dir=$(CURDIR)/.image-builder \
+		-e docker_host=$(docker_host) \
+		-e docker_login=$(docker_login) \
+		-e docker_user=$(docker_user) \
+		-e docker_password=$(docker_password) \
+		-e registry=$(registry) \
+		-e '{"kubevirt_images_push": true, "kubevirt_container_builder": "docker", "kubevirt_images_target_host": "localhost"}' \
+		cluster.yml
+
+push-single-docker:
+	ansible-playbook -i localhost, -c local \
+		-e images_dir=$(CURDIR)/.image-builder \
+		-e docker_host=$(docker_host) \
+		-e docker_login=$(docker_login) \
+		-e docker_user=$(docker_user) \
+		-e docker_password=$(docker_password) \
+		-e registry=$(registry) \
+		-e '{"kubevirt_images_push": true, "kubevirt_container_builder": "docker", "kubevirt_images_target_host": "localhost", "kubevirt_images_selected": ["$(image_name)"]}' \
+		cluster.yml
+
+push-single-staging:
+	ansible-playbook -i localhost, -c local \
+		-e images_dir=$(CURDIR)/.image-builder \
+		-e docker_host=us-central1-docker.pkg.dev \
+		-e registry=$(staging_registry) \
+		-e '{"docker_login": false, "kubevirt_images_push": true, "kubevirt_container_builder": "docker", "kubevirt_images_target_host": "localhost", "kubevirt_images_selected": ["$(image_name)"]}' \
+		cluster.yml
 
 validate:
 	ansible-playbook -i localhost, -c local \

--- a/test-infra/image-builder/README.md
+++ b/test-infra/image-builder/README.md
@@ -4,7 +4,13 @@ Build and push KubeVirt VM disk images to quay.io for Kubespray CI testing.
 
 ## How It Works
 
-The Ansible playbook downloads upstream cloud images, converts them to qcow2, resizes (+8G), wraps each in a Docker image based on `kubevirt/registry-disk-v1alpha`, and pushes to `quay.io/kubespray/vm-<os-name>:<tag>`.
+The Ansible playbook downloads upstream cloud images, converts them to qcow2, resizes (+8G), wraps each in a Docker image based on `kubevirt/registry-disk-v1alpha`, and pushes to `quay.io/kubespray/vm-<os-name>:<tag>` by default. Trusted CI jobs can override the target registry for staged image publishing.
+
+The trusted staging publish path uses Cloud Build authentication and skips `docker login`:
+
+```bash
+make push-single-staging image_name=ubuntu-2404
+```
 
 ## Prerequisites
 

--- a/test-infra/image-builder/cloudbuild-staging.yaml
+++ b/test-infra/image-builder/cloudbuild-staging.yaml
@@ -1,0 +1,20 @@
+---
+
+timeout: 7200s
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f
+    args:
+      - bash
+      - -ceu
+      - |
+        apk add --no-cache ansible-core qemu-img
+        ansible-galaxy collection install community.general -p /usr/share/ansible/collections
+        make -C test-infra/image-builder push-single-staging \
+          image_name=ubuntu-2404 \
+          staging_registry=us-central1-docker.pkg.dev/$PROJECT_ID/kubespray
+substitutions:
+  _PULL_BASE_REF: "master"
+images:
+  - us-central1-docker.pkg.dev/$PROJECT_ID/kubespray/vm-ubuntu-2404:latest

--- a/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
@@ -3,6 +3,7 @@ images_dir: /images/base
 
 docker_user: kubespray+buildvmimages
 docker_host: quay.io
+docker_login: true
 registry: quay.io/kubespray
 kubevirt_images_push: true
 kubevirt_images_selected: []

--- a/test-infra/image-builder/roles/kubevirt-images/tasks/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/tasks/main.yml
@@ -186,6 +186,7 @@
       when:
         - kubevirt_container_builder == 'docker'
         - kubevirt_images_push
+        - docker_login
 
     - name: Docker push image
       command: docker push {{ registry }}/vm-{{ item.key }}:{{ item.value.tag }}
@@ -199,3 +200,4 @@
       when:
         - kubevirt_container_builder == 'docker'
         - kubevirt_images_push
+        - docker_login


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

 /kind feature


**What this PR does / why we need it**:

Adds a staging OCI publish path for `test-infra/image-builder`.

The default/manual path still targets `quay.io/kubespray`, but trusted CI can now publish to the community-owned staging registry using Cloud Build authentication.

This change starts with a single canary image:

- `ubuntu-2404`

Changes made:
- Adds `push-single-staging`
- Adds `docker_login` so trusted staging pushes can skip `docker login`
- Adds `cloudbuild-staging.yaml` for the Cloud Build publish flow
- Documents the staging publish target


The staging registry has a 90-day retention policy, which maintainers agreed is acceptable for these CI images.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
Related issue:
- https://github.com/kubernetes-sigs/kubespray/issues/12383

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE

```
