### PR TITLE
Fix openstack terraform group vars

### DIFF
--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -98,7 +98,7 @@ module "compute" {
   etcd_server_group_policy                     = var.etcd_server_group_policy
   extra_sec_groups                             = var.extra_sec_groups
   extra_sec_groups_name                        = var.extra_sec_groups_name
-  group_vars_path                              = var.group_vars_path
+  group_vars_path                              = abspath(var.group_vars_path)
   port_security_enabled                        = var.port_security_enabled
   force_null_port_security                     = var.force_null_port_security
   network_router_id                            = module.network.router_id

--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -374,7 +374,7 @@ resource "openstack_compute_instance_v2" "bastion" {
   }
 
   provisioner "local-exec" {
-    command = "sed -e s/USER/${var.ssh_user}/ -e s/BASTION_ADDRESS/${var.bastion_fips[0]}/ ${path.module}/ansible_bastion_template.txt > ${var.group_vars_path}/no_floating.yml"
+    command = "mkdir -p \"${var.group_vars_path}\" && sed -e s/USER/${var.ssh_user}/ -e s/BASTION_ADDRESS/${var.bastion_fips[0]}/ \"${path.module}/ansible_bastion_template.txt\" > \"${var.group_vars_path}/no_floating.yml\""
   }
 }
 
@@ -512,7 +512,7 @@ resource "openstack_compute_instance_v2" "k8s_masters" {
   }
 
   provisioner "local-exec" {
-    command = "%{if each.value.floating_ip}sed s/USER/${var.ssh_user}/ ${path.module}/ansible_bastion_template.txt | sed s/BASTION_ADDRESS/${element(concat(var.bastion_fips, [for key, value in var.k8s_masters_fips : value.address]), 0)}/ > ${var.group_vars_path}/no_floating.yml%{else}true%{endif}"
+    command = "%{if each.value.floating_ip}mkdir -p \"${var.group_vars_path}\" && sed s/USER/${var.ssh_user}/ \"${path.module}/ansible_bastion_template.txt\" | sed s/BASTION_ADDRESS/${element(concat(var.bastion_fips, [for key, value in var.k8s_masters_fips : value.address]), 0)}/ > \"${var.group_vars_path}/no_floating.yml\"%{else}true%{endif}"
   }
 }
 
@@ -582,7 +582,7 @@ resource "openstack_compute_instance_v2" "k8s_master_no_etcd" {
   }
 
   provisioner "local-exec" {
-    command = "sed -e s/USER/${var.ssh_user}/ -e s/BASTION_ADDRESS/${element(concat(var.bastion_fips, var.k8s_master_fips), 0)}/ ${path.module}/ansible_bastion_template.txt > ${var.group_vars_path}/no_floating.yml"
+    command = "mkdir -p \"${var.group_vars_path}\" && sed -e s/USER/${var.ssh_user}/ -e s/BASTION_ADDRESS/${element(concat(var.bastion_fips, var.k8s_master_fips), 0)}/ \"${path.module}/ansible_bastion_template.txt\" > \"${var.group_vars_path}/no_floating.yml\""
   }
 }
 
@@ -841,7 +841,7 @@ resource "openstack_compute_instance_v2" "k8s_node" {
   }
 
   provisioner "local-exec" {
-    command = "sed -e s/USER/${var.ssh_user}/ -e s/BASTION_ADDRESS/${element(concat(var.bastion_fips, var.k8s_node_fips), 0)}/ ${path.module}/ansible_bastion_template.txt > ${var.group_vars_path}/no_floating.yml"
+    command = "mkdir -p \"${var.group_vars_path}\" && sed -e s/USER/${var.ssh_user}/ -e s/BASTION_ADDRESS/${element(concat(var.bastion_fips, var.k8s_node_fips), 0)}/ \"${path.module}/ansible_bastion_template.txt\" > \"${var.group_vars_path}/no_floating.yml\""
   }
 }
 
@@ -978,7 +978,7 @@ resource "openstack_compute_instance_v2" "k8s_nodes" {
   }
 
   provisioner "local-exec" {
-    command = "%{if each.value.floating_ip}sed -e s/USER/${var.ssh_user}/ -e s/BASTION_ADDRESS/${element(concat(var.bastion_fips, [for key, value in var.k8s_nodes_fips : value.address]), 0)}/ ${path.module}/ansible_bastion_template.txt > ${var.group_vars_path}/no_floating.yml%{else}true%{endif}"
+    command = "%{if each.value.floating_ip}mkdir -p \"${var.group_vars_path}\" && sed -e s/USER/${var.ssh_user}/ -e s/BASTION_ADDRESS/${element(concat(var.bastion_fips, [for key, value in var.k8s_nodes_fips : value.address]), 0)}/ \"${path.module}/ansible_bastion_template.txt\" > \"${var.group_vars_path}/no_floating.yml\"%{else}true%{endif}"
   }
 }
 


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Fixes an OpenStack Terraform workflow issue where the `local-exec` provisioner could fail while generating `group_vars/no_floating.yml`.

The failure occurs because the module assumed the target `group_vars` directory existed relative to the module execution path. This breaks when Terraform is executed using `-chdir` or from automation environments where the working directory differs from the module path.

This PR:

* passes an absolute `group_vars_path`
* creates the destination directory using `mkdir -p`
* keeps generated file paths quoted for safer shell execution

**Which issue(s) this PR fixes**:

Fixes #13201

**Special notes for your reviewer**:

Validated using:

```bash id="r04fql"
terraform -chdir="contrib/terraform/openstack" validate
```

and verified successful execution of:

```bash id="0pmv8q"
terraform -chdir="contrib/terraform/openstack" apply \
  -var-file=$PWD/inventory/test-cluster/cluster.tfvars
```

**Does this PR introduce a user-facing change?**:

```release-note
Fixed an issue in the OpenStack Terraform workflow where generating group_vars/no_floating.yml could fail when Terraform was executed using -chdir or from different working directories.
```
