### PR TITLE
fix(control-plane): rescue secondary kubeadm join; skip Ready-wait for placeholder CNI

### DIFF
--- a/roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml
@@ -84,23 +84,49 @@
     - not kubeadm_already_run.stat.exists
 
 - name: Joining control plane node to the cluster.
-  command: >-
-    {{ bin_dir }}/kubeadm join
-    --config {{ kube_config_dir }}/kubeadm-controlplane.yaml
-    --ignore-preflight-errors={{ kubeadm_ignore_preflight_errors | join(',') }}
-    --skip-phases={{ kubeadm_join_phases_skip | join(',') }}
-  environment:
-    PATH: "{{ bin_dir }}:{{ ansible_env.PATH }}"
-  register: kubeadm_join_control_plane
-  retries: 3
-  throttle: 1
-  until: kubeadm_join_control_plane is succeeded
   when:
     - inventory_hostname != first_kube_control_plane
     - kubeadm_already_run is not defined or not kubeadm_already_run.stat.exists
+  environment:
+    PATH: "{{ bin_dir }}:{{ ansible_env.PATH }}"
+  block:
+    - name: Joining control plane node to the cluster. (1st try)
+      command: >-
+        {{ bin_dir }}/kubeadm join
+        --config {{ kube_config_dir }}/kubeadm-controlplane.yaml
+        --ignore-preflight-errors={{ kubeadm_ignore_preflight_errors | join(',') }}
+        --skip-phases={{ kubeadm_join_phases_skip | join(',') }}
+      register: kubeadm_join_control_plane
+      throttle: 1
+  rescue:
+    - name: Reset cert directory before retrying control plane join
+      command: "{{ bin_dir }}/kubeadm reset -f --cert-dir {{ kube_cert_dir }}"
+      environment:
+        PATH: "{{ bin_dir }}:{{ ansible_env.PATH }}"
+    - name: Joining control plane node to the cluster. (retry)
+      command: >-
+        {{ bin_dir }}/kubeadm join
+        --config {{ kube_config_dir }}/kubeadm-controlplane.yaml
+        --ignore-preflight-errors={{ _ignore_errors | flatten | join(',') }}
+        --skip-phases={{ kubeadm_join_phases_skip | join(',') }}
+      vars:
+        _errors_from_first_try:
+          - 'FileAvailable--etc-kubernetes-manifests-kube-controller-manager.yaml'
+          - 'FileAvailable--etc-kubernetes-manifests-kube-scheduler.yaml'
+          - 'FileAvailable--etc-kubernetes-manifests-kube-apiserver.yaml'
+          - 'Port-10250'
+        _ignore_errors:
+          - "{{ kubeadm_ignore_preflight_errors }}"
+          - "{{ _errors_from_first_try if 'all' not in kubeadm_ignore_preflight_errors else [] }}"
+      register: kubeadm_join_control_plane
+      retries: 2
+      until: kubeadm_join_control_plane is succeeded
+      throttle: 1
 
 - name: Wait for new control plane nodes to be Ready
-  when: kubeadm_already_run.stat.exists
+  when:
+    - kubeadm_already_run.stat.exists
+    - kube_network_plugin not in ['cni', 'none']
   run_once: true
   command: >
     {{ kubectl }} get nodes --selector node-role.kubernetes.io/control-plane


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes two related bugs in `roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml` that together make HA control-plane installs un-rerunnable when the secondary join's first attempt fails.

1. **Wrap `kubeadm join` in `block:/rescue:` with reset between attempts.** The current `retries: 3, until: succeeded` retries the command in place. A failed first attempt leaves the static-pod manifests it wrote under `/etc/kubernetes/manifests/`, so retries 2 and 3 trip kubeadm's `FileAvailable--etc-kubernetes-manifests-kube-{apiserver,controller-manager,scheduler}.yaml` preflight checks and fail before kubeadm does anything else. Ansible only prints the last attempt's stderr, so the real attempt-1 cause is masked. On rescue we now run `kubeadm reset -f --cert-dir {{ kube_cert_dir }}` and retry with `--ignore-preflight-errors=FileAvailable--*,Port-10250`. This mirrors the existing pattern for primary init in `kubeadm-setup.yml:175-211`.

2. **Skip `Wait for new control plane nodes to be Ready` when `kube_network_plugin in ['cni', 'none']`.** Added in #12794, this task polls Ready for `control_plane_node_become_ready_tries × delay = 24 × 5s`. In `cni`/`none` modes kubespray installs no CNI — the operator supplies one out-of-band — so nodes cannot reach Ready inside `cluster.yml` and the wait is a guaranteed timeout that then fails the play.

**Which issue(s) this PR fixes**:

Fixes #13279

**Special notes for your reviewer**:

- Rescue block is intentionally shaped like `kubeadm-setup.yml:175-211` so primary-init and secondary-join retry behavior stay consistent.
- The Ready-wait skip preserves the wait for every in-cluster CNI plugin. Only the explicit "kubespray does not install CNI" modes (`cni`, `none`) are excluded.

**Does this PR introduce a user-facing change?**:

```release-note
Fix secondary control-plane `kubeadm join` so a failed first attempt no longer traps retries on the `FileAvailable--etc-kubernetes-manifests-kube-{apiserver,controller-manager,scheduler}.yaml` preflight: the rescue path now runs `kubeadm reset -f` and retries with those errors plus `Port-10250` added to `--ignore-preflight-errors`. Also skip the post-join "Wait for new control plane nodes to be Ready" task when `kube_network_plugin` is `cni` or `none`, since CNI is installed out-of-band in those modes and nodes cannot reach Ready inside the playbook.
```