### PR TITLE
Fix kubelet.conf server line indentation (#13277)

### DIFF
--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -103,8 +103,9 @@
 - name: Update server field in kubelet kubeconfig
   lineinfile:
     dest: "{{ kube_config_dir }}/kubelet.conf"
-    regexp: 'server:'
-    line: '    server: {{ kube_apiserver_endpoint }}'
+    regexp: '^(\s+)server: https.*$'
+    line: '\1server: {{ kube_apiserver_endpoint }}'
+    backrefs: true
     backup: true
   when:
     - kubeadm_config_api_fqdn is not defined
@@ -115,8 +116,8 @@
 - name: Update server field in kubelet kubeconfig - external lb
   lineinfile:
     dest: "{{ kube_config_dir }}/kubelet.conf"
-    regexp: '^    server: https'
-    line: '    server: {{ kube_apiserver_endpoint }}'
+    regexp: '^(\s+)server: https.*'
+    line: '\1server: {{ kube_apiserver_endpoint }}'
     backup: true
   when:
     - ('kube_control_plane' not in group_names)

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -118,6 +118,7 @@
     dest: "{{ kube_config_dir }}/kubelet.conf"
     regexp: '^(\s+)server: https.*'
     line: '\1server: {{ kube_apiserver_endpoint }}'
+    backrefs: true
     backup: true
   when:
     - ('kube_control_plane' not in group_names)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix invalid YAML indentation in kubelet.conf caused by hardcoded 4-space indent in lineinfile module.
The original task breaks the structure of kubelet.conf when the file uses different indentation levels.
This change uses regex back-reference to preserve original indentation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13277

**Special notes for your reviewer**:
- Uses backrefs: true to ensure group capture works
- Regex matches any indentation before "server: https"
- Safe for all indentation styles
- Only affects worker nodes when external LB is enabled

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```