### PR TITLE
Add generic pre upgrade hook for node

### DIFF
--- a/docs/operations/upgrades.md
+++ b/docs/operations/upgrades.md
@@ -75,6 +75,57 @@ Pausing *after* upgrading each node may be useful for rebooting the node to appl
 * `upgrade_node_post_upgrade_confirm: true` - This will pause the playbook execution after upgrading each node, but before the node is uncordoned. The play will resume when manually approved by typing "yes" at the terminal.
 * `upgrade_node_post_upgrade_pause_seconds: 60` - This will pause the playbook execution for 60 seconds after upgrading each node, but before the node is uncordoned. The play will resume automatically after 60 seconds.
 
+### Upgrade hooks
+
+During a graceful upgrade each node passes through a fixed sequence of phases:
+cordon and drain, upgrade, then uncordon. You can inject your own task files at
+four points around that sequence by pointing the following variables at one or
+more Ansible task files. Each variable is a list; every item is a path to a task
+file that is run with `include_tasks`, so the task file is evaluated in the
+context of the node currently being upgraded (`inventory_hostname`, group vars,
+etc. are all available).
+
+| Variable | Runs | Node state | Gated on `needs_cordoning` |
+| --- | --- | --- | --- |
+| `pre_cordon_hooks` | before cordon and drain | still in service | yes |
+| `pre_upgrade_hooks` | after drain, before the upgrade | cordoned and drained | no |
+| `post_upgrade_hooks` | after the upgrade, before uncordon | upgraded, still cordoned | no |
+| `post_uncordon_hooks` | after uncordon | back in service | yes |
+
+The cordon-lifecycle hooks (`pre_cordon_hooks`, `post_uncordon_hooks`) only run
+when the node is actually cordoned/uncordoned. A node that is already cordoned or
+not ready is not cordoned again (unless `upgrade_node_always_cordon: true`), so
+those hooks are skipped for it. The upgrade-lifecycle hooks (`pre_upgrade_hooks`,
+`post_upgrade_hooks`) always run, because the upgrade itself always runs.
+
+**Failure semantics:** hooks are ordinary Ansible tasks and run fail-fast. If a
+hook task fails, the upgrade aborts for that node and the node is left in
+whichever phase it had reached — untouched (`pre_cordon_hooks`), drained
+(`pre_upgrade_hooks`), cordoned (`post_upgrade_hooks`), or already back in
+service (`post_uncordon_hooks`) — for you to inspect and recover manually.
+
+Example — live-migrate OpenStack VMs off a compute node before it is drained,
+then verify they are back afterwards:
+
+```yaml
+# group_vars/all/upgrade-hooks.yml
+pre_cordon_hooks:
+  - /srv/kubespray-hooks/openstack-evacuate.yml
+post_uncordon_hooks:
+  - /srv/kubespray-hooks/openstack-verify.yml
+```
+
+```yaml
+# /srv/kubespray-hooks/openstack-evacuate.yml
+- name: Live-migrate all instances off this compute node
+  ansible.builtin.command: >-
+    openstack --os-cloud admin compute service set
+    --disable {{ inventory_hostname }} nova-compute
+  delegate_to: localhost
+  changed_when: true
+# ... migration tasks ...
+```
+
 ## Node-based upgrade
 
 If you don't want to upgrade all nodes in one run, you can use `--limit` [patterns](https://docs.ansible.com/ansible/latest/user_guide/intro_patterns.html#patterns-and-ansible-playbook-flags).

--- a/roles/upgrade/post-upgrade/defaults/main.yml
+++ b/roles/upgrade/post-upgrade/defaults/main.yml
@@ -3,3 +3,7 @@
 upgrade_post_cilium_wait_timeout: 120s
 upgrade_node_post_upgrade_confirm: false
 upgrade_node_post_upgrade_pause_seconds: 0
+
+# Lists of task files to include at upgrade hook points (see docs/operations/upgrades.md)
+post_upgrade_hooks: []
+post_uncordon_hooks: []

--- a/roles/upgrade/post-upgrade/tasks/main.yml
+++ b/roles/upgrade/post-upgrade/tasks/main.yml
@@ -25,8 +25,8 @@
     - not upgrade_node_post_upgrade_confirm
     - upgrade_node_post_upgrade_pause_seconds != 0
 
-- name: Run post upgrade hooks before uncordon
-  loop: "{{ post_upgrade_hooks | default([]) }}"
+- name: Run post-upgrade hooks after upgrade, before uncordon
+  loop: "{{ post_upgrade_hooks }}"
   ansible.builtin.include_tasks: "{{ item }}"
 
 - name: Uncordon node
@@ -34,3 +34,9 @@
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
   when:
     - needs_cordoning | default(false)
+
+- name: Run post-uncordon hooks after uncordon
+  when:
+    - needs_cordoning | default(false)
+  loop: "{{ post_uncordon_hooks }}"
+  ansible.builtin.include_tasks: "{{ item }}"

--- a/roles/upgrade/pre-upgrade/defaults/main.yml
+++ b/roles/upgrade/pre-upgrade/defaults/main.yml
@@ -18,3 +18,7 @@ upgrade_node_fail_if_drain_fails: true
 
 upgrade_node_confirm: false
 upgrade_node_pause_seconds: 0
+
+# Lists of task files to include at upgrade hook points (see docs/operations/upgrades.md)
+pre_cordon_hooks: []
+pre_upgrade_hooks: []

--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -40,10 +40,10 @@
   set_fact:
     needs_cordoning: "{{ (kubectl_node_ready.stdout == 'True' and not kubectl_node_unschedulable.stdout) or upgrade_node_always_cordon }}"
 
-- name: Run pre upgrade hooks before draining
+- name: Run pre-cordon hooks before cordoning and draining
   when:
     - needs_cordoning
-  loop: "{{ pre_upgrade_hooks | default([]) }}"
+  loop: "{{ pre_cordon_hooks }}"
   ansible.builtin.include_tasks: "{{ item }}"
 
 - name: Node draining
@@ -106,3 +106,7 @@
       fail:
         msg: "Failed to drain node {{ kube_override_hostname | default(inventory_hostname) }}"
       when: upgrade_node_fail_if_drain_fails
+
+- name: Run pre-upgrade hooks after draining, before upgrade
+  loop: "{{ pre_upgrade_hooks }}"
+  ansible.builtin.include_tasks: "{{ item }}"

--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -40,6 +40,12 @@
   set_fact:
     needs_cordoning: "{{ (kubectl_node_ready.stdout == 'True' and not kubectl_node_unschedulable.stdout) or upgrade_node_always_cordon }}"
 
+- name: Run pre upgrade hooks before draining
+  when:
+    - needs_cordoning
+  loop: "{{ pre_upgrade_hooks | default([]) }}"
+  ansible.builtin.include_tasks: "{{ item }}"
+
 - name: Node draining
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
   when:


### PR DESCRIPTION
This patch is based on #11368 and adds the ability to run a hook job before drain of a node. My specific use-case is doing live migration of all VMs running in OpenStack in Kubernetes before draining a host, allowing OpenStack workloads to survive upgrades. I am sure other use-cases are available too :)

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Kubespray already exposes `post_upgrade_hooks` for running custom tasks per-host **after** the kubelet/containerd upgrade but **before** uncordon. This PR adds a symmetrical `pre_upgrade_hooks` for running custom tasks per-host **before** the drain happens.

Without a pre-drain hook there is no clean place to inject workload-level prep work that has to happen while the node is still hosting workloads, such as live-migrating OpenStack VMs off a compute node, gracefully draining stateful clients, scheduling-policy adjustments, or anything else that needs the node to still be schedulable.

The hook fires from `roles/upgrade/pre-upgrade/tasks/main.yml` right after `needs_cordoning` is set and right before the `Node draining` block, mirroring the existing post-hook shape:

```yaml
- name: Run pre upgrade hooks before draining
  when:
    - needs_cordoning
  loop: "{{ pre_upgrade_hooks | default([]) }}"
  ansible.builtin.include_tasks: "{{ item }}"
```

Default is an empty list, so the change is a no-op for any user who does not set the variable.

**Which issue(s) this PR fixes**:

Fixes #13288

**Special notes for your reviewer**:

- Builds on the same mechanism as #11368 (`post_upgrade_hooks`): same variable shape, same `include_tasks` loop, just earlier in the per-host serial loop.
- Gated on `needs_cordoning` so the hook only fires for nodes that will actually be drained on this run, matching the gating of the `Node draining` block right below it.
- No new dependencies, no defaults change, no behavior change unless the user sets `pre_upgrade_hooks`.

**Does this PR introduce a user-facing change?**:
Yes 

```release-note
Add `pre_upgrade_hooks` variable to `upgrade-cluster.yml`, mirroring the existing `post_upgrade_hooks`. Hook tasks listed in this variable run per-host before the drain step during a cluster upgrade, providing a place to perform workload-aware preparation such as live-migrating OpenStack VMs off a compute node.
```
