### PR TITLE
Remove the duplicate nodeSelector definition on DNS autoscaler

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dns-autoscaler.yml.j2
@@ -39,8 +39,6 @@ spec:
           type: RuntimeDefault
         supplementalGroups: [ 65534 ]
         fsGroup: 65534
-      nodeSelector:
-        kubernetes.io/os: linux
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
/kind bug

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes the CoreDNS autoscaler deployment template where `dns_autoscaler_deployment_nodeselector` is unintentionally overridden by a second `nodeSelector` definition.

The template currently renders two `nodeSelector` blocks. Due to YAML key overriding behavior, the second block (`kubernetes.io/os: linux`) replaces the first one, making `dns_autoscaler_deployment_nodeselector` ineffective.

This change merges the Linux OS selector with the user-defined node selector so both are applied correctly.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

The issue can be reproduced by setting `dns_autoscaler_deployment_nodeselector` in inventory and inspecting the rendered deployment manifest. The configured selector is not present because it is overridden by a later `nodeSelector` key.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed `dns_autoscaler_deployment_nodeselector` was ignored in the CoreDNS autoscaler deployment due to a duplicated `nodeSelector` field in the deployment template.
```
