### PR TITLE
flannel: set EnableNFTables when kube_proxy_mode use nftables

### DIFF
--- a/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
+++ b/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
@@ -101,9 +101,6 @@ spec:
               fieldPath: metadata.namespace
         - name: EVENT_QUEUE_DEPTH
           value: "5000"
-        # CONT_WHEN_CACHE_NOT_READY added in flannel v0.27.1
-        # - name: CONT_WHEN_CACHE_NOT_READY
-        #   value: "false"
         volumeMounts:
         - name: run
           mountPath: /run/flannel

--- a/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
+++ b/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
@@ -28,7 +28,6 @@ data:
         }
       ]
     }
-  # EnableNFTables added in flannel v0.25.5
   net-conf.json: |
     {
 {% if ipv4_stack %}
@@ -39,7 +38,9 @@ data:
       "EnableIPv6": true,
       "IPv6Network": "{{ kube_pods_subnet_ipv6 }}",
 {% endif %}
+{% if flannel_version is version('0.25.5', '>=') %}
       "EnableNFTables": {{ (kube_proxy_mode == 'nftables') | bool | to_json }},
+{% endif %}
       "Backend": {
         "Type": "{{ flannel_backend_type }}"{% if flannel_backend_type == "vxlan" %},
         "VNI": {{ flannel_vxlan_vni }},

--- a/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
+++ b/roles/network_plugin/flannel/templates/cni-flannel.yml.j2
@@ -28,6 +28,7 @@ data:
         }
       ]
     }
+  # EnableNFTables added in flannel v0.25.5
   net-conf.json: |
     {
 {% if ipv4_stack %}
@@ -38,6 +39,7 @@ data:
       "EnableIPv6": true,
       "IPv6Network": "{{ kube_pods_subnet_ipv6 }}",
 {% endif %}
+      "EnableNFTables": {{ (kube_proxy_mode == 'nftables') | bool | to_json }},
       "Backend": {
         "Type": "{{ flannel_backend_type }}"{% if flannel_backend_type == "vxlan" %},
         "VNI": {{ flannel_vxlan_vni }},
@@ -99,6 +101,9 @@ spec:
               fieldPath: metadata.namespace
         - name: EVENT_QUEUE_DEPTH
           value: "5000"
+        # CONT_WHEN_CACHE_NOT_READY added in flannel v0.27.1
+        # - name: CONT_WHEN_CACHE_NOT_READY
+        #   value: "false"
         volumeMounts:
         - name: run
           mountPath: /run/flannel


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

Testing RL10 deployment using flannel showed an issue.
Since iptables is no longer included in RL10.  iptables mode kube-proxy would enter crash-loop and fail to start.  However, iptables is still being used even when kube-proxy is set to nftables mode.  

The iptables-nft shim is not capable for flannel needs.  

Ansible Log:
```python
TASK [network_plugin/flannel : Flannel | Wait for flannel subnet.env file presence] ***
fatal: [k8s-node-001]: FAILED! => {"changed": false, "elapsed": 600, "msg": "Timeout when waiting for file /run/flannel/subnet.env"}
fatal: [k8s-node-002]: FAILED! => {"changed": false, "elapsed": 600, "msg": "Timeout when waiting for file /run/flannel/subnet.env"}
fatal: [k8s-node-003]: FAILED! => {"changed": false, "elapsed": 600, "msg": "Timeout when waiting for file /run/flannel/subnet.env"}
```

kube-proxy log(when using iptables mode on RL10):
```python
[rocky@k8s-node-001 ~]$ k logs -n kube-system ds/kube-proxy
Found 3 pods, using pod/kube-proxy-2prqb
I0528 23:46:29.343902       1 shared_informer.go:370] "Waiting for caches to sync"
I0528 23:46:29.444858       1 shared_informer.go:377] "Caches are synced"
I0528 23:46:29.444891       1 server.go:218] "Successfully retrieved NodeIPs" NodeIPs=["10.10.1.200"]
I0528 23:46:29.449627       1 conntrack.go:57] "Setting nf_conntrack_max" nfConntrackMax=524288
E0528 23:46:29.449793       1 server.go:255] "Kube-proxy configuration may be incomplete or incorrect" err="nodePortAddresses is unset; NodePort connections will be accepted on all local IPs. Consider using `--nodeport-addresses primary`"
I0528 23:46:29.465596       1 server.go:264] "kube-proxy running in dual-stack mode" primary ipFamily="IPv4"
I0528 23:46:29.465641       1 server_linux.go:136] "Using iptables Proxier"
I0528 23:46:29.469797       1 proxier.go:242] "Setting route_localnet=1 to allow node-ports on localhost; to change this either disable iptables.localhostNodePorts (--iptables-localhost-nodeports) or set nodePortAddresses (--nodeport-addresses) to filter loopback addresses" ipFamily="IPv4"
E0528 23:46:29.472928       1 proxier.go:270] "Failed to create nfacct runner, nfacct based metrics won't be available" err="nfacct sub-system not available" ipFamily="IPv4"
E0528 23:46:29.474694       1 proxier.go:270] "Failed to create nfacct runner, nfacct based metrics won't be available" err="nfacct sub-system not available" ipFamily="IPv6"
I0528 23:46:29.474748       1 server.go:529] "Version info" version="v1.35.5"
I0528 23:46:29.474761       1 server.go:531] "Golang settings" GOGC="" GOMAXPROCS="" GOTRACEBACK=""
E0528 23:46:29.476462       1 metrics.go:379] "failed to initialize nfacct client" err="nfacct sub-system not available"
E0528 23:46:29.478048       1 metrics.go:379] "failed to initialize nfacct client" err="nfacct sub-system not available"
I0528 23:46:29.478827       1 config.go:106] "Starting endpoint slice config controller"
I0528 23:46:29.478847       1 shared_informer.go:349] "Waiting for caches to sync" controller="endpoint slice config"
I0528 23:46:29.478852       1 config.go:200] "Starting service config controller"
I0528 23:46:29.478866       1 shared_informer.go:349] "Waiting for caches to sync" controller="service config"
I0528 23:46:29.478870       1 config.go:403] "Starting serviceCIDR config controller"
I0528 23:46:29.478879       1 config.go:309] "Starting node config controller"
I0528 23:46:29.478881       1 shared_informer.go:349] "Waiting for caches to sync" controller="serviceCIDR config"
I0528 23:46:29.478887       1 shared_informer.go:349] "Waiting for caches to sync" controller="node config"
I0528 23:46:29.578972       1 shared_informer.go:356] "Caches are synced" controller="serviceCIDR config"
I0528 23:46:29.578991       1 shared_informer.go:356] "Caches are synced" controller="node config"
I0528 23:46:29.579006       1 shared_informer.go:356] "Caches are synced" controller="service config"
I0528 23:46:29.579057       1 shared_informer.go:356] "Caches are synced" controller="endpoint slice config"
E0528 23:46:29.662791       1 proxier.go:807] "Failed to ensure chain jumps" err=<
        error appending rule: exit status 4: Warning: Extension conntrack revision 0 not supported, missing kernel module?
        Warning: Extension comment revision 0 not supported, missing kernel module?
        iptables v1.8.9 (nf_tables):  RULE_INSERT failed (No such file or directory): rule in chain INPUT
 > ipFamily="IPv4" table="filter" srcChain="INPUT" dstChain="KUBE-EXTERNAL-SERVICES"
I0528 23:46:29.662830       1 proxier.go:770] "Sync failed" ipFamily="IPv4" retryingTime="30s"
E0528 23:46:29.670487       1 proxier.go:807] "Failed to ensure chain jumps" err=<
        error checking rule: exit status 2: Warning: Extension conntrack is not supported, missing kernel module?
        ip6tables v1.8.9 (nf_tables): Couldn't load match `conntrack':No such file or directory

        Try `ip6tables -h' or 'ip6tables --help' for more information.
 > ipFamily="IPv6" table="filter" srcChain="INPUT" dstChain="KUBE-EXTERNAL-SERVICES"
I0528 23:46:29.670511       1 proxier.go:770] "Sync failed" ipFamily="IPv6" retryingTime="30s
```

Log(when using nft mode but EnableNFTables not specified):
```python
# kube-proxy (successfully running)
$ k -n kube-system logs ds/kube-proxy

Found 3 pods, using pod/kube-proxy-nv9jj
I0529 00:59:34.498180       1 shared_informer.go:370] "Waiting for caches to sync"
I0529 00:59:34.599309       1 shared_informer.go:377] "Caches are synced"
I0529 00:59:34.599361       1 server.go:218] "Successfully retrieved NodeIPs" NodeIPs=["10.10.1.243"]
I0529 00:59:34.604568       1 conntrack.go:57] "Setting nf_conntrack_max" nfConntrackMax=524288
I0529 00:59:34.604859       1 server.go:264] "kube-proxy running in dual-stack mode" primary ipFamily="IPv4"
I0529 00:59:34.604887       1 server_linux.go:253] "Using nftables Proxier"
I0529 00:59:34.649984       1 server.go:529] "Version info" version="v1.35.5"
I0529 00:59:34.650027       1 server.go:531] "Golang settings" GOGC="" GOMAXPROCS="" GOTRACEBACK=""
I0529 00:59:34.650923       1 config.go:106] "Starting endpoint slice config controller"
I0529 00:59:34.650937       1 shared_informer.go:349] "Waiting for caches to sync" controller="endpoint slice config"
I0529 00:59:34.650944       1 config.go:200] "Starting service config controller"
I0529 00:59:34.650956       1 shared_informer.go:349] "Waiting for caches to sync" controller="service config"
I0529 00:59:34.650969       1 config.go:309] "Starting node config controller"
I0529 00:59:34.650983       1 shared_informer.go:349] "Waiting for caches to sync" controller="node config"
I0529 00:59:34.650974       1 config.go:403] "Starting serviceCIDR config controller"
I0529 00:59:34.651034       1 shared_informer.go:349] "Waiting for caches to sync" controller="serviceCIDR config"
I0529 00:59:34.751398       1 shared_informer.go:356] "Caches are synced" controller="serviceCIDR config"
I0529 00:59:34.751438       1 shared_informer.go:356] "Caches are synced" controller="service config"
I0529 00:59:34.751460       1 shared_informer.go:356] "Caches are synced" controller="node config"
I0529 00:59:34.751474       1 shared_informer.go:356] "Caches are synced" controller="endpoint slice config"

# flannel(failing)
$ k -n kube-system logs ds/kube-flannel

Defaulted container "kube-flannel" out of: kube-flannel, install-cni-plugin (init), install-cni (init)
I0529 01:05:20.199384       1 main.go:226] CLI flags config: {etcdEndpoints:http://127.0.0.1:4001,http://127.0.0.1:2379 etcdPrefix:/coreos.com/network etcdKeyfile: etcdCertfile: etcdCAFile: etcdUsername: etcdPassword: version:false kubeSubnetMgr:true kubeApiUrl: kubeAnnotationPrefix:flannel.alpha.coreos.com kubeConfigFile: iface:[] ifaceRegex:[] ipMasq:true ipMasqRandomFullyDisable:false ifaceCanReach: subnetFile:/run/flannel/subnet.env publicIP: publicIPv6: subnetLeaseRenewMargin:60 healthzIP:0.0.0.0 healthzPort:0 iptablesResyncSeconds:5 iptablesForwardRules:true blackholeRoute:false netConfPath:/etc/kube-flannel/net-conf.json setNodeNetworkUnavailable:true}
W0529 01:05:20.199466       1 client_config.go:667] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
I0529 01:05:20.261635       1 kube.go:537] Starting kube subnet manager
I0529 01:05:20.261669       1 kube.go:139] Waiting 10m0s for node controller to sync
I0529 01:05:21.261819       1 kube.go:163] Node controller sync successful
I0529 01:05:21.261843       1 main.go:252] Created subnet manager: Kubernetes Subnet Manager - k8s-node-003
I0529 01:05:21.261850       1 main.go:255] Installing signal handlers
I0529 01:05:21.262040       1 main.go:534] Found network config - Backend type: vxlan
E0529 01:05:21.262140       1 main.go:289] Failed to check br_netfilter: stat /proc/sys/net/bridge/bridge-nf-call-iptables: no such file or directory
[rocky@k8s-node-001 ~]$
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Flannel v0.25.5+ uses EnableNFTables when `kube_proxy_mode` is nftables
```
