### PR TITLE
[release-2.31] Fix pre-commit ansible-core 2.18

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,7 @@ repos:
     hooks:
       - id: ansible-lint
         additional_dependencies:
+          - ansible-core>=2.18.0,<2.19.0
           - jmespath==1.0.1
           - netaddr==1.3.0
           - distlib
@@ -49,7 +50,7 @@ repos:
         name: Build and install kubernetes-sigs.kubespray Ansible collection
         language: python
         additional_dependencies:
-          - ansible-core>=2.16.4
+          - ansible-core>=2.18.0,<2.19.0
           - distlib
         entry: tests/scripts/collection-build-install.sh
         pass_filenames: false
@@ -91,7 +92,7 @@ repos:
         name: Update static files referencing default kubespray values
         language: python
         additional_dependencies:
-          - ansible-core>=2.16.4
+          - ansible-core>=2.18.0,<2.19.0
         entry: scripts/propagate_ansible_variables.yml
         pass_filenames: false
 

--- a/roles/container-engine/kata-containers/molecule/default/verify.yml
+++ b/roles/container-engine/kata-containers/molecule/default/verify.yml
@@ -9,7 +9,7 @@
     failed_when: >
       version is failed or
       'kata-runtime' not in version.stdout
-  - name: Test version
+  - name: Test version check
     command: "/opt/kata/bin/kata-runtime check"
     register: check
     failed_when: >


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

The pre-commit job failing because ansible-core is too new.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
