### PR TITLE
fix: make offline containerd URL generation respect containerd_static…

### DIFF
--- a/inventory/sample/group_vars/all/offline.yml
+++ b/inventory/sample/group_vars/all/offline.yml
@@ -71,7 +71,7 @@
 # skopeo_download_url: "{{ files_repo }}/github.com/lework/skopeo-binary/releases/download/v{{ skopeo_version }}/skopeo-linux-{{ image_arch }}"
 
 # [Optional] containerd: only if you set container_runtime: containerd
-# containerd_download_url: "{{ files_repo }}/github.com/containerd/containerd/releases/download/v{{ containerd_version }}/containerd-{{ containerd_version }}-linux-{{ image_arch }}.tar.gz"
+# containerd_download_url: "{{ files_repo }}/github.com/containerd/containerd/releases/download/v{{ containerd_version }}/containerd-{{ 'static-' if containerd_static_binary }}{{ containerd_version }}-linux-{{ image_arch }}.tar.gz"
 # nerdctl_download_url: "{{ files_repo }}/github.com/containerd/nerdctl/releases/download/v{{ nerdctl_version }}/nerdctl-{{ nerdctl_version }}-{{ ansible_system | lower }}-{{ image_arch }}.tar.gz"
 
 # [Optional] runsc,containerd-shim-runsc: only if you set gvisor_enabled: true


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Fixes offline containerd URL generation in the sample inventory to correctly respect the `containerd_static_binary` setting.

**Special notes for your reviewer**:

The sample inventory currently generates the offline containerd download URL independently of `containerd_static_binary`. This change ensures the generated URL matches the configured containerd static binary.

**Does this PR introduce a user-facing change?**:

```release-note
Offline containerd download URLs in the sample inventory now automatically use the correct binary release variant based on `containerd_static_binary`.
```