### PR TITLE
Support authentication for custom CNI Helm repositories

### DIFF
--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-custom-cni.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-custom-cni.yml
@@ -31,9 +31,11 @@
 # custom_cni_chart_repository_url: ""
 #
 ## Helm repository username, if authentication is required
-# custom_cni_chart_repository_username: "<helm_repository_user>"
+## Username and password must be defined together
+# custom_cni_chart_repository_username: "<helm_repository_username>"
 #
 ## Helm repository password, if authentication is required
+## Store sensitive values securely, for example using Ansible Vault
 # custom_cni_chart_repository_password: "<helm_repository_password>"
 #
 ## Helm chart reference - path to the chart in the repository
@@ -50,8 +52,6 @@
 # custom_cni_chart_release_name: cilium
 # custom_cni_chart_repository_name: cilium
 # custom_cni_chart_repository_url: https://helm.cilium.io
-# custom_cni_chart_repository_username: "<helm_repository_user>"
-# custom_cni_chart_repository_password: "<helm_repository_password>"
 # custom_cni_chart_ref: cilium/cilium
 # custom_cni_chart_version: <chart version> (e.g.: 1.14.3)
 # custom_cni_chart_values:

--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-custom-cni.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-custom-cni.yml
@@ -30,6 +30,12 @@
 ## Helm repository URL
 # custom_cni_chart_repository_url: ""
 #
+## Helm repository username, if authentication is required
+# custom_cni_chart_repository_username: "<helm_repository_user>"
+#
+## Helm repository password, if authentication is required
+# custom_cni_chart_repository_password: "<helm_repository_password>"
+#
 ## Helm chart reference - path to the chart in the repository
 # custom_cni_chart_ref: ""
 #
@@ -44,6 +50,8 @@
 # custom_cni_chart_release_name: cilium
 # custom_cni_chart_repository_name: cilium
 # custom_cni_chart_repository_url: https://helm.cilium.io
+# custom_cni_chart_repository_username: "<helm_repository_user>"
+# custom_cni_chart_repository_password: "<helm_repository_password>"
 # custom_cni_chart_ref: cilium/cilium
 # custom_cni_chart_version: <chart version> (e.g.: 1.14.3)
 # custom_cni_chart_values:

--- a/roles/network_plugin/custom_cni/meta/main.yml
+++ b/roles/network_plugin/custom_cni/meta/main.yml
@@ -17,3 +17,5 @@ dependencies:
     repositories:
       - name: "{{ custom_cni_chart_repository_name }}"
         url: "{{ custom_cni_chart_repository_url }}"
+        username: "{{ custom_cni_chart_repository_username | default(omit) }}"
+        password: "{{ custom_cni_chart_repository_password | default(omit) }}"


### PR DESCRIPTION
## What this PR does

This PR adds optional Helm repository authentication support to the `custom_cni` network plugin role.

It updates:

```text
roles/network_plugin/custom_cni/meta/main.yml
```

to pass optional `username` and `password` values to the `helm-apps` role when a custom CNI is deployed from a Helm chart repository.

The added fields are:

```yaml
username: "{{ custom_cni_chart_repository_username | default(omit) }}"
password: "{{ custom_cni_chart_repository_password | default(omit) }}"
```

This PR also updates the sample custom CNI inventory file:

```text
inventory/sample/group_vars/k8s_cluster/k8s-net-custom-cni.yml
```

to document the optional variables:

```yaml
# custom_cni_chart_repository_username: "<helm_repository_username>"
# custom_cni_chart_repository_password: "<helm_repository_password>"
```

## Why this is needed

The current `custom_cni` Helm chart deployment option supports configuring a Helm repository name and URL, but it does not provide a way to pass authentication credentials for private Helm repositories.

This is useful for environments where the custom CNI chart is stored in an authenticated internal Helm repository, such as:

* Nexus Repository
* Harbor
* ChartMuseum
* Artifactory
* Other private Helm chart repositories

Without these variables, users must patch the Kubespray role locally when their Helm repository requires authentication.

## Backward compatibility

This change is backward-compatible.

The new fields use `default(omit)`, so they are only passed when the user explicitly defines:

```yaml
custom_cni_chart_repository_username
custom_cni_chart_repository_password
```

Existing deployments using public or unauthenticated Helm repositories should continue to work without any change.

## Security notes

No real credentials are added in this PR.

The sample inventory only documents placeholder values as commented examples. Users who need repository authentication can define these variables in their own inventory, preferably using Ansible Vault or another secret-management method.

## Testing

* [✔] Ran `pre-commit run --all-files`
* [✔] Ran `ansible-playbook -i inventory/sample/inventory.ini cluster.yml --syntax-check`
* [✔] Verified with Ansible Core 2.16.14 that a public repository works when neither credential variable is defined
* [✔] Verified that an authenticated repository accepts the username and password when both variables are defined
* [✔] Verified that defining only one credential fails with `parameters are required together: repo_username, repo_password`

## Additional context

This change allows Kubespray users to deploy a custom CNI from a private authenticated Helm repository without maintaining a local patch to the `custom_cni` role.

## Release note

```release-note
Added optional authentication variables for custom CNI Helm chart repositories: `custom_cni_chart_repository_username` and `custom_cni_chart_repository_password`.
```
