### PR TITLE
fix: make assert test for netaddr actually return a boolean

### DIFF
--- a/playbooks/ansible_version.yml
+++ b/playbooks/ansible_version.yml
@@ -21,7 +21,7 @@
     - name: "Check that python netaddr is installed"
       assert:
         msg: "Python netaddr is not present"
-        that: "'127.0.0.1' | ansible.utils.ipaddr"
+        that: "'127.0.0.1' | ansible.utils.ipaddr == '127.0.0.1'"
       tags:
         - check
 

--- a/roles/validate_inventory/tasks/main.yml
+++ b/roles/validate_inventory/tasks/main.yml
@@ -19,13 +19,13 @@
 
 - name: Stop if kube_control_plane group is empty
   assert:
-    that: groups.get( 'kube_control_plane' )
+    that: groups.get( 'kube_control_plane' ) != []
   run_once: true
   when: not ignore_assert_errors
 
 - name: Stop if etcd group is empty in external etcd mode
   assert:
-    that: groups.get('etcd') or etcd_deployment_type == 'kubeadm'
+    that: groups.get('etcd') != [] or etcd_deployment_type == 'kubeadm'
     fail_msg: "Group 'etcd' cannot be empty in external etcd mode"
   run_once: true
   when:
@@ -79,9 +79,8 @@
 
 - name: Check cloud_provider value
   assert:
-    that: cloud_provider == 'external'
+    that: cloud_provider in ["", 'external']
   when:
-    - cloud_provider
     - not ignore_assert_errors
 
 - name: Check external_cloud_provider value
@@ -94,7 +93,7 @@
 - name: "Check that kube_service_addresses is a network range"
   assert:
     that:
-      - kube_service_addresses | ansible.utils.ipaddr('net')
+      - kube_service_addresses | ansible.utils.ipaddr('net') is not false
     msg: "kube_service_addresses = '{{ kube_service_addresses }}' is not a valid network range"
   run_once: true
   when: ipv4_stack | bool
@@ -102,7 +101,7 @@
 - name: "Check that kube_pods_subnet is a network range"
   assert:
     that:
-      - kube_pods_subnet | ansible.utils.ipaddr('net')
+      - kube_pods_subnet | ansible.utils.ipaddr('net') is not false
     msg: "kube_pods_subnet = '{{ kube_pods_subnet }}' is not a valid network range"
   run_once: true
   when: ipv4_stack | bool


### PR DESCRIPTION
The netaddr test returns a string when the netaddr is installed. This makes Ansible 2.20 angry. Here's a fix to make sure the true case also returns a boolean instead of a string.

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This makes the assertion work properly.

**Which issue(s) this PR fixes**:

This is a small change, so I didn't file an issue first. I didn't see an issue when I briefly searched either.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

I don't think so. As far as I can tell, 2.19 works the same way. I am assuming that it doesn't throw an error when trying to run the playbook, but I don't have a direct way to test prior versions.

```release-note
Made assertion test for netaddr return a boolean in all cases 
```
