### PR TITLE
Fix Multus manifest generation with global inventory

### DIFF
--- a/roles/network_plugin/multus/tasks/main.yml
+++ b/roles/network_plugin/multus/tasks/main.yml
@@ -27,13 +27,8 @@
     - {name: multus-daemonset-crio, file: multus-daemonset-crio.yml, type: daemonset, engine: crio }
   register: multus_manifest_2
   vars:
-    host_query: "[?value.container_manager=='{{ container_manager }}'].key | [0]"
-    vars_from_node: >-
-      {{
-        dict(groups['k8s_cluster'] | zip(groups['k8s_cluster'] | map('extract', hostvars)))
-        | dict2items
-        | json_query(host_query)
-      }}
+    host_query: "[?container_manager=='{{ container_manager }}']|[0].inventory_hostname"
+    vars_from_node: "{{ ansible_play_hosts_all | map('extract', hostvars) | list | json_query(host_query) }}"
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
   when:
     - item.engine in container_manager_types

--- a/roles/network_plugin/multus/tasks/main.yml
+++ b/roles/network_plugin/multus/tasks/main.yml
@@ -27,8 +27,13 @@
     - {name: multus-daemonset-crio, file: multus-daemonset-crio.yml, type: daemonset, engine: crio }
   register: multus_manifest_2
   vars:
-    host_query: "*|[?container_manager=='{{ container_manager }}']|[0].inventory_hostname"
-    vars_from_node: "{{ hostvars | json_query(host_query) }}"
+    host_query: "[?value.container_manager=='{{ container_manager }}'].key | [0]"
+    vars_from_node: >-
+      {{
+        dict(groups['k8s_cluster'] | zip(groups['k8s_cluster'] | map('extract', hostvars)))
+        | dict2items
+        | json_query(host_query)
+      }}
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
   when:
     - item.engine in container_manager_types


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Limits Multus host lookup to hosts from the current `k8s_cluster` group when selecting a representative node for daemonset manifest generation.

Previously the lookup was performed against all `hostvars`, which could include hosts from unrelated clusters when using a global inventory. In such cases the selected host could belong to another cluster, causing the manifest generation task to be skipped for the current deployment.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

The change preserves the existing behavior of generating a single daemonset manifest per container runtime while restricting the lookup scope to the current Kubespray cluster.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
