### PR TITLE
Add helm.cilium.io mirror support and switch to operator-generic image

### DIFF
--- a/docs/operations/offline-environment.md
+++ b/docs/operations/offline-environment.md
@@ -24,8 +24,6 @@ In addition, you can find some tools for offline deployment under [contrib/offli
 
 ## Tip: use the original domains as top directories in the files_repo, i.e `github.com/`, `dl.k8s.io/`, `storage.googleapis.com/`, `get.helm.sh/`
 
-## Tip: for Cilium ensure to mirror <https://helm.cilium.io/index.yaml> and the chart cilium-1.18.2.tgz in files_repo
-
 ## Access Control
 
 ### Note: access controlled files_repo
@@ -61,7 +59,7 @@ registry_pass: !vault |
           3164
 ```
 
-To enable Containerd **2+** to access the private registry:
+Edit [your inventory](/inventory/sample/group_vars/all/containerd.yml) Containerd **2+** to access the private registry:
 
 ```yaml
 
@@ -80,7 +78,7 @@ containerd_registries_mirrors:
           Authorization: ["Basic {{ (registry_user + ':' + registry_pass) | b64encode }}"]
 ```
 
-To enable Containerd **1.7** to access the private registry:
+Edit [your inventory](/inventory/sample/group_vars/all/containerd.yml) Containerd **1.7** to access the private registry:
 
 ```yaml
 containerd_registry_auth:
@@ -106,13 +104,6 @@ dl_k8s_io_url: "{{ files_repo }}/dl.k8s.io"
 storage_googleapis_url: "{{ files_repo }}/storage.googleapis.com"
 get_helm_url: "{{ files_repo }}/get.helm.sh"
 local_path_provisioner_helper_image_repo: "{{ registry_host }}/busybox"
-# Insecure registries for containerd (see authenticated example above)
-containerd_registries_mirrors:
-  - prefix: "{{ registry_addr }}"
-    mirrors:
-      - host: "{{ registry_host }}"
-        capabilities: ["pull", "resolve"]
-        skip_verify: true
 
 # Cilium
 cilium_install_extra_flags: "--repository {{ files_repo }}/helm.cilium.io/"

--- a/inventory/sample/group_vars/all/offline.yml
+++ b/inventory/sample/group_vars/all/offline.yml
@@ -48,6 +48,32 @@
 
 # [Optional] Cilium: If using Cilium network plugin
 # ciliumcli_download_url: "{{ files_repo }}/github.com/cilium/cilium-cli/releases/download/v{{ cilium_cli_version }}/cilium-linux-{{ image_arch }}.tar.gz"
+# cilium_install_extra_flags: "--repository {{ files_repo }}/helm.cilium.io/"
+# cilium_extra_values:
+#   image:
+#     useDigest: false
+#   hubble:
+#     relay:
+#       image:
+#         useDigest: false
+#     ui:
+#       backend:
+#         image:
+#           useDigest: false
+#       frontend:
+#         image:
+#           useDigest: false
+#   operator:
+#     image:
+#       override: "{{ registry_host }}/cilium/operator-generic:v1.18.2"
+#       useDigest: false
+#       extension: ""
+#   certgen:
+#     image:
+#       useDigest: false
+#   envoy:
+#     image:
+#       useDigest: false
 
 # [Optional] helm: only if you set helm_enabled: true
 # helm_download_url: "{{ files_repo }}/get.helm.sh/helm-v{{ helm_version }}-linux-{{ image_arch }}.tar.gz"

--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -151,6 +151,7 @@ github_url: https://github.com
 dl_k8s_io_url: https://dl.k8s.io
 storage_googleapis_url: https://storage.googleapis.com
 get_helm_url: https://get.helm.sh
+helm_cilium_io_url: https://helm.cilium.io
 
 # Download URLs
 kubelet_download_url: "{{ dl_k8s_io_url }}/release/v{{ kube_version }}/bin/linux/{{ image_arch }}/kubelet"
@@ -161,6 +162,8 @@ cni_download_url: "{{ github_url }}/containernetworking/plugins/releases/downloa
 calicoctl_download_url: "{{ github_url }}/projectcalico/calico/releases/download/v{{ calico_ctl_version }}/calicoctl-linux-{{ image_arch }}"
 calico_crds_download_url: "{{ github_url }}/projectcalico/calico/raw/v{{ calico_version }}/manifests/crds.yaml"
 ciliumcli_download_url: "{{ github_url }}/cilium/cilium-cli/releases/download/v{{ cilium_cli_version }}/cilium-linux-{{ image_arch }}.tar.gz"
+cilium_index_download_url: "{{ helm_cilium_io_url }}/index.yaml"
+cilium_helm_download_url: "{{ helm_cilium_io_url }}/cilium-${cilium_version}.tgz"
 crictl_download_url: "{{ github_url }}/kubernetes-sigs/cri-tools/releases/download/v{{ crictl_version }}/crictl-v{{ crictl_version }}-{{ ansible_system | lower }}-{{ image_arch }}.tar.gz"
 crio_download_url: "{{ storage_googleapis_url }}/cri-o/artifacts/cri-o.{{ image_arch }}.v{{ crio_version }}.tar.gz"
 helm_download_url: "{{ get_helm_url }}/helm-v{{ helm_version }}-linux-{{ image_arch }}.tar.gz"
@@ -234,7 +237,7 @@ pod_infra_image_repo: "{{ kube_image_repo }}/pause"
 pod_infra_image_tag: "{{ pod_infra_version }}"
 cilium_image_repo: "{{ quay_image_repo }}/cilium/cilium"
 cilium_image_tag: "v{{ cilium_version }}"
-cilium_operator_image_repo: "{{ quay_image_repo }}/cilium/operator"
+cilium_operator_image_repo: "{{ quay_image_repo }}/cilium/operator-generic"
 cilium_operator_image_tag: "v{{ cilium_version }}"
 cilium_hubble_relay_image_repo: "{{ quay_image_repo }}/cilium/hubble-relay"
 cilium_hubble_relay_image_tag: "v{{ cilium_version }}"


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

This PR improves offline deployment support for Cilium.

Changes included:
- Add `helm_cilium_io_url` as a configurable base URL for Cilium Helm artifacts.
- Add `cilium_index_download_url` and `cilium_helm_download_url` variables to simplify mirroring of Cilium Helm resources in offline environments.
- Switch the default Cilium operator image from `cilium/operator` to `cilium/operator-generic`, which is the image actually used by recent Cilium releases.
- Move Cilium offline configuration examples from the documentation into `inventory/sample/group_vars/all/offline.yml` to provide a reusable inventory example.

These changes make it easier to prepare and maintain offline repositories when deploying Kubespray with Cilium.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

The changes were validated in an offline environment using mirrored artifacts and images.

**Does this PR introduce a user-facing change?**:

```release-note
Improve offline deployment support for Cilium by adding configurable download URLs for Helm artifacts, updating the default operator image to operator-generic, and providing inventory examples for offline environments.
```