### PR TITLE
Add helm.cilium.io mirror support and switch to operator-generic image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 temp
 contrib/offline/container-images
 contrib/offline/container-images.tar.gz
+contrib/offline/helm-charts
+contrib/offline/helm-charts.tar.gz
 contrib/offline/offline-files
 contrib/offline/offline-files.tar.gz
 .idea

--- a/contrib/offline/generate_list.sh
+++ b/contrib/offline/generate_list.sh
@@ -8,6 +8,7 @@ REPO_ROOT_DIR="${CURRENT_DIR%/contrib/offline}"
 : ${DOWNLOAD_YML:="roles/kubespray_defaults/defaults/main/download.yml"}
 
 mkdir -p ${TEMP_DIR}
+rm -f ${TEMP_DIR}/*.template
 
 # generate all download files url template
 grep 'download_url:' ${REPO_ROOT_DIR}/${DOWNLOAD_YML} \
@@ -27,7 +28,16 @@ for i in $KUBE_IMAGES; do
     echo "{{ kube_image_repo }}/$i:v{{ kube_version }}" >> ${TEMP_DIR}/images.list.template
 done
 
-# run ansible to expand templates
+# Generate Helm charts list template
+# Extract Helm chart repository URLs from download.yml
+CILIUM_REPO=$(sed -n 's/^cilium_chart_repo:[[:space:]]*//p' "${REPO_ROOT_DIR}/${DOWNLOAD_YML}" | tr -d '"' | head -n1)
+CILIUM_VERSION=$(sed -n 's/^cilium_version:[[:space:]]*//p' "${REPO_ROOT_DIR}/${DOWNLOAD_YML}" | tr -d '"' | head -n1)
+
+if [[ -n "${CILIUM_VERSION}" && -n "${CILIUM_REPO}" ]]; then
+    echo "oci://${CILIUM_REPO}:${CILIUM_VERSION}" >> "${TEMP_DIR}/helm.list.template"
+fi
+
+# Run ansible to expand templates
 /bin/cp ${CURRENT_DIR}/generate_list.yml ${REPO_ROOT_DIR}
 
 (cd ${REPO_ROOT_DIR} && ansible-playbook $* generate_list.yml && /bin/rm generate_list.yml) || exit 1

--- a/contrib/offline/generate_list.yml
+++ b/contrib/offline/generate_list.yml
@@ -20,3 +20,4 @@
       with_items:
         - files
         - images
+        - helm

--- a/contrib/offline/manage-offline-helm-charts.sh
+++ b/contrib/offline/manage-offline-helm-charts.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+OPTION=$1
+CURRENT_DIR=$(cd $(dirname $0); pwd)
+TEMP_DIR="${CURRENT_DIR}/temp"
+
+CHART_TAR_FILE="${CURRENT_DIR}/helm-charts.tar.gz"
+CHART_DIR="${CURRENT_DIR}/helm-charts"
+HELM_LIST="${HELM_LIST:-${TEMP_DIR}/helm.list}"
+
+# Convert to absolute path if relative
+if [[ ! "${HELM_LIST}" = /* ]]; then
+	HELM_LIST="${CURRENT_DIR}/${HELM_LIST}"
+fi
+
+CHART_LIST="${CHART_DIR}/helm-list.txt"
+REGISTRY_PORT=${REGISTRY_PORT:-5000}
+REGISTRY_HOST="${REGISTRY_HOST:-localhost}"
+DESTINATION_REGISTRY="${DESTINATION_REGISTRY:-${REGISTRY_HOST}}"
+
+function create_helm_chart_tar() {
+	set -e
+
+	if [ ! -f "${HELM_LIST}" ]; then
+		echo "${HELM_LIST} is not a file"
+		exit 1
+	fi
+
+	rm -f  ${CHART_TAR_FILE}
+	rm -rf ${CHART_DIR}
+	mkdir  ${CHART_DIR}
+	cd     ${CHART_DIR}
+
+	if ! command -v helm &> /dev/null; then
+		echo "Error: helm command not found"
+		exit 1
+	fi
+
+	while read -r chart_url || [[ -n "${chart_url}" ]]; do
+		[[ -z "${chart_url}" || "${chart_url}" =~ ^# ]] && continue
+
+		chart_name=$(echo "${chart_url}" | sed 's@.*/@@' | sed 's/:.*//')
+		chart_version=$(echo "${chart_url}" | sed 's@.*:@@')
+		FILE_NAME="${chart_name}-${chart_version}.tgz"
+
+		echo "Downloading: ${chart_url}"
+		helm pull "${chart_url}" --untar=false
+
+	_chart_ref=$(echo "${chart_url}" | sed 's@^oci://@@')
+		echo "${FILE_NAME}  ${_chart_ref}" >> ${CHART_LIST}
+		echo "Processed: ${chart_url} -> ${FILE_NAME}"
+	done < "${HELM_LIST}"
+
+	cd ..
+	tar -zcvf ${CHART_TAR_FILE} ./helm-charts
+	rm -rf ${CHART_DIR}
+
+	echo ""
+	echo "${CHART_TAR_FILE} is created to contain your Helm charts."
+	echo "Please keep this file and bring it to your offline environment."
+}
+
+function register_helm_charts() {
+	if [ ! -f ${CHART_TAR_FILE} ]; then
+		echo "${CHART_TAR_FILE} should exist."
+		exit 1
+	fi
+
+	if [ ! -f ${CHART_LIST} ]; then
+		echo "${CHART_LIST} should exist."
+		exit 1
+	fi
+
+	mkdir -p ${TEMP_DIR}
+	rm -rf "${TEMP_DIR}/helm-charts" 2>/dev/null || true
+	tar -zxvf ${CHART_TAR_FILE} -C ${TEMP_DIR}
+
+	if ! command -v helm &> /dev/null; then
+		echo "Error: helm command not found"
+		exit 1
+	fi
+
+	LEGACY_CHART_DIR="${TEMP_DIR}/helm-charts"
+	if [[ -d "${LEGACY_CHART_DIR}" && "${LEGACY_CHART_DIR}" != "${CHART_DIR}" ]]; then
+		rm -rf "${CHART_DIR}"
+		mv "${LEGACY_CHART_DIR}" "${CHART_DIR}"
+	fi
+
+	cd "${CHART_DIR}"
+
+	while read -r line; do
+		file_name=$(echo "${line}" | awk '{print $1}')
+		chart_url=$(echo "${line}" | awk '{print $2}')
+		
+		chart_ref="${chart_url}"
+		if [[ "${chart_url}" =~ ^oci:// ]]; then
+			chart_ref=$(echo "${chart_url}" | sed 's@^oci://@@')
+		fi
+
+		raw_chart=$(echo "${chart_ref}" | sed 's@:[^:]*$@@')
+		if [[ "${DESTINATION_REGISTRY}" == "localhost" ||("${DESTINATION_REGISTRY}" == "${REGISTRY_HOST}" && ("${REGISTRY_HOST}" == "localhost" || "${REGISTRY_HOST}" == "127.0.0.1")) ]]; then
+			helm push "${file_name}" "oci://${DESTINATION_REGISTRY}:${REGISTRY_PORT}/${raw_chart}" --plain-http
+		else
+			helm push "${file_name}" "oci://${DESTINATION_REGISTRY}:${REGISTRY_PORT}/${raw_chart}"
+		fi
+	done <<< "$(cat ${CHART_LIST})"
+
+	echo "Succeeded to register Helm charts to local registry."
+}
+
+if [ "${OPTION}" == "create" ]; then
+	create_helm_chart_tar
+elif [ "${OPTION}" == "register" ]; then
+	register_helm_charts
+else
+	echo "This script has two features:"
+	echo "(1) Get Helm charts from list and create tar archive"
+	echo "(2) Deploy local Helm registry and register the charts to the registry."
+	echo ""
+	echo "Step(1) should be done online site as a preparation, then we bring"
+	echo "the gotten charts to the target offline environment."
+	echo "Then we will run step(2) for registering the charts to local registry."
+	echo ""
+	echo "${CHART_TAR_FILE} is created to contain your Helm charts."
+	echo "Please keep this file and bring it to your offline environment."
+	echo ""
+	echo "Step(1) can be operated with:"
+	echo " $ ./manage-offline-helm-charts.sh   create"
+	echo ""
+	echo "Step(2) can be operated with:"
+	echo " $ ./manage-offline-helm-charts.sh   register"
+	echo ""
+	echo "Please specify 'create' or 'register'."
+	echo ""
+	exit 1
+fi

--- a/docs/operations/offline-environment.md
+++ b/docs/operations/offline-environment.md
@@ -24,8 +24,6 @@ In addition, you can find some tools for offline deployment under [contrib/offli
 
 ## Tip: use the original domains as top directories in the files_repo, i.e `github.com/`, `dl.k8s.io/`, `storage.googleapis.com/`, `get.helm.sh/`
 
-## Tip: for Cilium ensure to mirror <https://helm.cilium.io/index.yaml> and the chart cilium-1.18.2.tgz in files_repo
-
 ## Access Control
 
 ### Note: access controlled files_repo
@@ -61,7 +59,7 @@ registry_pass: !vault |
           3164
 ```
 
-To enable Containerd **2+** to access the private registry:
+Edit [your inventory](/inventory/sample/group_vars/all/containerd.yml) Containerd **2+** to access the private registry:
 
 ```yaml
 
@@ -80,7 +78,7 @@ containerd_registries_mirrors:
           Authorization: ["Basic {{ (registry_user + ':' + registry_pass) | b64encode }}"]
 ```
 
-To enable Containerd **1.7** to access the private registry:
+Edit [your inventory](/inventory/sample/group_vars/all/containerd.yml) Containerd **1.7** to access the private registry:
 
 ```yaml
 containerd_registry_auth:
@@ -106,13 +104,6 @@ dl_k8s_io_url: "{{ files_repo }}/dl.k8s.io"
 storage_googleapis_url: "{{ files_repo }}/storage.googleapis.com"
 get_helm_url: "{{ files_repo }}/get.helm.sh"
 local_path_provisioner_helper_image_repo: "{{ registry_host }}/busybox"
-# Insecure registries for containerd (see authenticated example above)
-containerd_registries_mirrors:
-  - prefix: "{{ registry_addr }}"
-    mirrors:
-      - host: "{{ registry_host }}"
-        capabilities: ["pull", "resolve"]
-        skip_verify: true
 
 # Cilium
 cilium_install_extra_flags: "--repository {{ files_repo }}/helm.cilium.io/"

--- a/docs/operations/offline-environment.md
+++ b/docs/operations/offline-environment.md
@@ -106,7 +106,7 @@ get_helm_url: "{{ files_repo }}/get.helm.sh"
 local_path_provisioner_helper_image_repo: "{{ registry_host }}/busybox"
 
 # Cilium
-cilium_install_extra_flags: "--repository {{ files_repo }}/helm.cilium.io/"
+cilium_chart_repo: ""{{ registry_host }}/quay.io/cilium/charts/cilium"
 cilium_extra_values:
   image:
     useDigest: false
@@ -123,7 +123,7 @@ cilium_extra_values:
           useDigest: false
   operator:
     image:
-      override: "{{ registry_host }}/cilium/operator-generic:v1.18.2"
+      override: "{{ registry_host }}/{{ cilium_operator_image_repo }}-generic:{{ cilium_operator_image_tag }}"
       useDigest: false
       extension: ""
   certgen:

--- a/inventory/sample/group_vars/all/offline.yml
+++ b/inventory/sample/group_vars/all/offline.yml
@@ -17,6 +17,9 @@
 # docker_image_repo: "{{ registry_host }}"
 # quay_image_repo: "{{ registry_host }}"
 
+## OCI Chart repositories
+# cilium_chart_repo: ""{{ registry_host }}/quay.io//cilium/charts/cilium"
+
 ## Kubernetes components
 # kubeadm_download_url: "{{ files_repo }}/dl.k8s.io/release/v{{ kube_version }}/bin/linux/{{ image_arch }}/kubeadm"
 # kubectl_download_url: "{{ files_repo }}/dl.k8s.io/release/v{{ kube_version }}/bin/linux/{{ image_arch }}/kubectl"
@@ -48,7 +51,7 @@
 
 # [Optional] Cilium: If using Cilium network plugin
 # ciliumcli_download_url: "{{ files_repo }}/github.com/cilium/cilium-cli/releases/download/v{{ cilium_cli_version }}/cilium-linux-{{ image_arch }}.tar.gz"
-# cilium_install_extra_flags: "--repository {{ files_repo }}/helm.cilium.io/"
+# cilium_chart_repo: "{{ registry_host }}/quay.io/cilium/charts/cilium"
 # cilium_extra_values:
 #   image:
 #     useDigest: false
@@ -65,7 +68,7 @@
 #           useDigest: false
 #   operator:
 #     image:
-#       override: "{{ registry_host }}/cilium/operator-generic:v1.18.2"
+#       override: "{{ registry_host }}/{{ cilium_operator_image_repo }}-generic:{{ cilium_operator_image_tag }}"
 #       useDigest: false
 #       extension: ""
 #   certgen:

--- a/inventory/sample/group_vars/all/offline.yml
+++ b/inventory/sample/group_vars/all/offline.yml
@@ -48,6 +48,32 @@
 
 # [Optional] Cilium: If using Cilium network plugin
 # ciliumcli_download_url: "{{ files_repo }}/github.com/cilium/cilium-cli/releases/download/v{{ cilium_cli_version }}/cilium-linux-{{ image_arch }}.tar.gz"
+# cilium_install_extra_flags: "--repository {{ files_repo }}/helm.cilium.io/"
+# cilium_extra_values:
+#   image:
+#     useDigest: false
+#   hubble:
+#     relay:
+#       image:
+#         useDigest: false
+#     ui:
+#       backend:
+#         image:
+#           useDigest: false
+#       frontend:
+#         image:
+#           useDigest: false
+#   operator:
+#     image:
+#       override: "{{ registry_host }}/cilium/operator-generic:v1.18.2"
+#       useDigest: false
+#       extension: ""
+#   certgen:
+#     image:
+#       useDigest: false
+#   envoy:
+#     image:
+#       useDigest: false
 
 # [Optional] helm: only if you set helm_enabled: true
 # helm_download_url: "{{ files_repo }}/get.helm.sh/helm-v{{ helm_version }}-linux-{{ image_arch }}.tar.gz"

--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
@@ -386,3 +386,6 @@ cilium_l2announcements: false
 # Cilium extra values, use any values from cilium Helm Chart
 # ref: https://docs.cilium.io/en/stable/helm-reference/
 # cilium_extra_values: {}
+
+# Cilium extra install flags
+# cilium_install_extra_flags: ""

--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -151,7 +151,6 @@ github_url: https://github.com
 dl_k8s_io_url: https://dl.k8s.io
 storage_googleapis_url: https://storage.googleapis.com
 get_helm_url: https://get.helm.sh
-helm_cilium_io_url: https://helm.cilium.io
 
 # Download URLs
 kubelet_download_url: "{{ dl_k8s_io_url }}/release/v{{ kube_version }}/bin/linux/{{ image_arch }}/kubelet"
@@ -162,8 +161,6 @@ cni_download_url: "{{ github_url }}/containernetworking/plugins/releases/downloa
 calicoctl_download_url: "{{ github_url }}/projectcalico/calico/releases/download/v{{ calico_ctl_version }}/calicoctl-linux-{{ image_arch }}"
 calico_crds_download_url: "{{ github_url }}/projectcalico/calico/raw/v{{ calico_version }}/manifests/crds.yaml"
 ciliumcli_download_url: "{{ github_url }}/cilium/cilium-cli/releases/download/v{{ cilium_cli_version }}/cilium-linux-{{ image_arch }}.tar.gz"
-cilium_index_download_url: "{{ helm_cilium_io_url }}/index.yaml"
-cilium_helm_download_url: "{{ helm_cilium_io_url }}/cilium-${cilium_version}.tgz"
 crictl_download_url: "{{ github_url }}/kubernetes-sigs/cri-tools/releases/download/v{{ crictl_version }}/crictl-v{{ crictl_version }}-{{ ansible_system | lower }}-{{ image_arch }}.tar.gz"
 crio_download_url: "{{ storage_googleapis_url }}/cri-o/artifacts/cri-o.{{ image_arch }}.v{{ crio_version }}.tar.gz"
 helm_download_url: "{{ get_helm_url }}/helm-v{{ helm_version }}-linux-{{ image_arch }}.tar.gz"
@@ -235,6 +232,7 @@ calico_apiserver_image_repo: "{{ quay_image_repo }}/calico/apiserver"
 calico_apiserver_image_tag: "v{{ calico_apiserver_version }}"
 pod_infra_image_repo: "{{ kube_image_repo }}/pause"
 pod_infra_image_tag: "{{ pod_infra_version }}"
+cilium_chart_repo: "{{ quay_image_repo }}/cilium/charts/cilium"
 cilium_image_repo: "{{ quay_image_repo }}/cilium/cilium"
 cilium_image_tag: "v{{ cilium_version }}"
 cilium_operator_image_repo: "{{ quay_image_repo }}/cilium/operator"

--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -151,6 +151,7 @@ github_url: https://github.com
 dl_k8s_io_url: https://dl.k8s.io
 storage_googleapis_url: https://storage.googleapis.com
 get_helm_url: https://get.helm.sh
+helm_cilium_io_url: https://helm.cilium.io
 
 # Download URLs
 kubelet_download_url: "{{ dl_k8s_io_url }}/release/v{{ kube_version }}/bin/linux/{{ image_arch }}/kubelet"
@@ -161,6 +162,8 @@ cni_download_url: "{{ github_url }}/containernetworking/plugins/releases/downloa
 calicoctl_download_url: "{{ github_url }}/projectcalico/calico/releases/download/v{{ calico_ctl_version }}/calicoctl-linux-{{ image_arch }}"
 calico_crds_download_url: "{{ github_url }}/projectcalico/calico/raw/v{{ calico_version }}/manifests/crds.yaml"
 ciliumcli_download_url: "{{ github_url }}/cilium/cilium-cli/releases/download/v{{ cilium_cli_version }}/cilium-linux-{{ image_arch }}.tar.gz"
+cilium_index_download_url: "{{ helm_cilium_io_url }}/index.yaml"
+cilium_helm_download_url: "{{ helm_cilium_io_url }}/cilium-${cilium_version}.tgz"
 crictl_download_url: "{{ github_url }}/kubernetes-sigs/cri-tools/releases/download/v{{ crictl_version }}/crictl-v{{ crictl_version }}-{{ ansible_system | lower }}-{{ image_arch }}.tar.gz"
 crio_download_url: "{{ storage_googleapis_url }}/cri-o/artifacts/cri-o.{{ image_arch }}.v{{ crio_version }}.tar.gz"
 helm_download_url: "{{ get_helm_url }}/helm-v{{ helm_version }}-linux-{{ image_arch }}.tar.gz"
@@ -234,7 +237,7 @@ pod_infra_image_repo: "{{ kube_image_repo }}/pause"
 pod_infra_image_tag: "{{ pod_infra_version }}"
 cilium_image_repo: "{{ quay_image_repo }}/cilium/cilium"
 cilium_image_tag: "v{{ cilium_version }}"
-cilium_operator_image_repo: "{{ quay_image_repo }}/cilium/operator"
+cilium_operator_image_repo: "{{ quay_image_repo }}/cilium/operator-generic"
 cilium_operator_image_tag: "v{{ cilium_version }}"
 cilium_hubble_relay_image_repo: "{{ quay_image_repo }}/cilium/hubble-relay"
 cilium_hubble_relay_image_tag: "v{{ cilium_version }}"

--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -237,7 +237,7 @@ pod_infra_image_repo: "{{ kube_image_repo }}/pause"
 pod_infra_image_tag: "{{ pod_infra_version }}"
 cilium_image_repo: "{{ quay_image_repo }}/cilium/cilium"
 cilium_image_tag: "v{{ cilium_version }}"
-cilium_operator_image_repo: "{{ quay_image_repo }}/cilium/operator-generic"
+cilium_operator_image_repo: "{{ quay_image_repo }}/cilium/operator"
 cilium_operator_image_tag: "v{{ cilium_version }}"
 cilium_hubble_relay_image_repo: "{{ quay_image_repo }}/cilium/hubble-relay"
 cilium_hubble_relay_image_tag: "v{{ cilium_version }}"
@@ -599,7 +599,7 @@ downloads:
   cilium_operator:
     enabled: "{{ kube_network_plugin == 'cilium' or cilium_deploy_additionally }}"
     container: true
-    repo: "{{ cilium_operator_image_repo }}"
+    repo: "{{ cilium_operator_image_repo }}-generic"
     tag: "{{ cilium_operator_image_tag }}"
     checksum: "{{ cilium_operator_digest_checksum | default(None) }}"
     groups:

--- a/roles/network_plugin/cilium/tasks/apply.yml
+++ b/roles/network_plugin/cilium/tasks/apply.yml
@@ -12,7 +12,7 @@
 
 - name: Cilium | Install
   environment: "{{ proxy_env }}"
-  command: "{{ bin_dir }}/cilium {{ cilium_action }} --version {{ cilium_version }} -f {{ kube_config_dir }}/cilium-values.yaml -f {{ kube_config_dir }}/cilium-extra-values.yaml {{ cilium_install_extra_flags }}"
+  command: "{{ bin_dir }}/cilium {{ cilium_action }} --repository oci://{{ cilium_chart_repo }} --version {{ cilium_version }} -f {{ kube_config_dir }}/cilium-values.yaml -f {{ kube_config_dir }}/cilium-extra-values.yaml {{ cilium_install_extra_flags }}"
   when: inventory_hostname == groups['kube_control_plane'][0]
 
 - name: Cilium | Wait for pods to run


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

This PR improves offline deployment support for Cilium.

Changes included:
- Add `helm_cilium_io_url` as a configurable base URL for Cilium Helm artifacts.
- Add `cilium_index_download_url` and `cilium_helm_download_url` variables to simplify mirroring of Cilium Helm resources in offline environments.
- Switch the default Cilium operator image from `cilium/operator` to `cilium/operator-generic`, which is the image actually used by recent Cilium releases.
- Move Cilium offline configuration examples from the documentation into `inventory/sample/group_vars/all/offline.yml` to provide a reusable inventory example.

These changes make it easier to prepare and maintain offline repositories when deploying Kubespray with Cilium.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

The changes were validated in an offline environment using mirrored artifacts and images.

**Does this PR introduce a user-facing change?**:

```release-note
Improve offline deployment support for Cilium by adding configurable download URLs for Helm artifacts, updating the default operator image to operator-generic, and providing inventory examples for offline environments.
```