### PR TITLE
Refactor offline image management to use skopeo and OCI archives

### DIFF
--- a/contrib/offline/README.md
+++ b/contrib/offline/README.md
@@ -70,7 +70,7 @@ when nginx container is running, it can be accessed through <http://127.0.0.1:80
 
 ## manage-offline-skopeo-files.sh
 
-Alternative script using skopeo for all image operations. Requires skopeo to be installed.
+Alternative script using skopeo (if installed) for image operations, with a fallback to a container runtime.
 
 This script will download all files according to `temp/files.list` and run nginx container to provide offline file download.
 
@@ -80,10 +80,16 @@ Step(1) generate `files.list`
 ./generate_list.sh
 ```
 
-Step(2) download files and run nginx container
+Step(2) download files and create the offline archive
 
 ```shell
 ./manage-offline-skopeo-files.sh create
+```
+
+Step(3) start the nginx container to serve the downloaded files
+
+```shell
+./manage-offline-skopeo-files.sh serve
 ```
 
 when nginx container is running, it can be accessed through <http://127.0.0.1:8080/>.

--- a/contrib/offline/README.md
+++ b/contrib/offline/README.md
@@ -68,6 +68,42 @@ Step(2) download files and run nginx container
 
 when nginx container is running, it can be accessed through <http://127.0.0.1:8080/>.
 
+## manage-offline-skopeo-files.sh
+
+Alternative script using skopeo for all image operations. Requires skopeo to be installed.
+
+This script will download all files according to `temp/files.list` and run nginx container to provide offline file download.
+
+Step(1) generate `files.list`
+
+```shell
+./generate_list.sh
+```
+
+Step(2) download files and run nginx container
+
+```shell
+./manage-offline-skopeo-files.sh create
+```
+
+when nginx container is running, it can be accessed through <http://127.0.0.1:8080/>.
+
+## manage-offline-skopeo-container-images.sh
+
+Alternative container image management using skopeo. Requires skopeo to be installed.
+
+Step(1) - Create container image archive:
+
+```shell
+IMAGES_FROM_FILE=contrib/offline/temp/images.list ./manage-offline-skopeo-container-images.sh create
+```
+
+Step(2) - Register images to registry:
+
+```shell
+DESTINATION_REGISTRY=my-registry:5000 ./manage-offline-skopeo-container-images.sh register
+```
+
 ## upload2artifactory.py
 
 After the steps above, this script can recursively upload each file under a directory to a generic repository in Artifactory.
@@ -87,3 +123,10 @@ export TOKEN=...
 export BASE_URL=https://artifactory.example.com/artifactory/a-generic-repo/
 ./upload2artifactory.py
 ```
+
+## Summary
+
+Choose the appropriate script based on available tools:
+
+- **Without skopeo**: Use `manage-offline-files.sh` and `manage-offline-container-images.sh`
+- **With skopeo**: Use `manage-offline-skopeo-files.sh` and `manage-offline-skopeo-container-images.sh` for better architecture/os control and optional image download skipping via `DOWNLOAD_NGINX=false`

--- a/contrib/offline/docker-daemon.json
+++ b/contrib/offline/docker-daemon.json
@@ -1,1 +1,1 @@
-{ "insecure-registries":["HOSTNAME:5000"] }
+{ "insecure-registries":["localhost:5000", "HOSTNAME:5000"] }

--- a/contrib/offline/manage-offline-skopeo-container-images.sh
+++ b/contrib/offline/manage-offline-skopeo-container-images.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OPTION=${1:-}
+CURRENT_DIR=$(cd "$(dirname "$0")" && pwd)
+TEMP_DIR=$(mktemp -d)
+IMAGE_TAR_FILE="${CURRENT_DIR}/container-images.tar.gz"
+IMAGE_DIR="${CURRENT_DIR}/container-images"
+IMAGE_LIST="${IMAGE_DIR}/container-images.txt"
+RETRY_COUNT=5
+
+case "$(uname -m)" in
+  x86_64)  TARGET_ARCH="amd64" ;;
+  aarch64|arm64) TARGET_ARCH="arm64" ;;
+  *) TARGET_ARCH="amd64" ;;
+esac
+TARGET_OS="linux"
+
+function create_container_image_tar() {
+  echo "[INFO] Platform: $(uname -s)/$(uname -m) -> ${TARGET_OS}/${TARGET_ARCH}"
+  : "${IMAGES_FROM_FILE:?IMAGES_FROM_FILE must point to an images list file (e.g. contrib/offline/temp/images.list)}"
+  echo "[INFO] Getting images from ${IMAGES_FROM_FILE}"
+  [ -f "${IMAGES_FROM_FILE}" ] || { echo "[ERROR] ${IMAGES_FROM_FILE} not found"; exit 1; }
+  IMAGES=$(realpath "${IMAGES_FROM_FILE}")
+
+
+  rm -rf "${IMAGE_DIR}" "${IMAGE_TAR_FILE}"
+  mkdir -p "${IMAGE_DIR}"
+  cd "${IMAGE_DIR}"
+
+  echo "[INFO] Downloading registry:latest"
+  skopeo copy --override-os="${TARGET_OS}" --override-arch="${TARGET_ARCH}" \
+    --src-tls-verify=false --retry-times="${RETRY_COUNT}" \
+    "docker://registry:latest" "docker-archive:${IMAGE_DIR}/registry-latest.tar:registry:latest"
+
+  total=$(wc -l < "${IMAGES}")
+  n=0
+  while read -r image || [ -n "${image}" ]; do
+    n=$((n + 1))
+    FILE_NAME="$(echo "${image}" | tr '/:' '--' | sed 's/@.*//').oci"
+
+    echo "[${n}/${total}] ${image}"
+
+    skopeo copy --override-os="${TARGET_OS}" --override-arch="${TARGET_ARCH}" \
+      --src-tls-verify=false --retry-times="${RETRY_COUNT}" \
+      "docker://${image}" "oci-archive:${IMAGE_DIR}/${FILE_NAME}" || \
+    skopeo copy --all --src-tls-verify=false --retry-times="${RETRY_COUNT}" \
+      "docker://${image}" "oci-archive:${IMAGE_DIR}/${FILE_NAME}"
+
+
+    FIRST_PART=$(echo "${image}" | awk -F"/" '{print $1}')
+    FIRST_PART_HOST=$(echo "${FIRST_PART}" | awk -F":" '{print $1}')
+    if [[ "${FIRST_PART_HOST}" =~ ^(registry.k8s.io|gcr.io|ghcr.io|docker.io|quay.io)$ ]] || \
+       [[ -n "${PRIVATE_REGISTRY:-}" && "${FIRST_PART_HOST}" = "${PRIVATE_REGISTRY}" ]]; then
+      image=$(echo "${image}" | sed "s@^${FIRST_PART}/@@")
+    fi
+    echo "${FILE_NAME}  ${image}" >> "${IMAGE_LIST}"
+  done < "${IMAGES}"
+
+  cd ..
+  tar -zcf "${IMAGE_TAR_FILE}" ./container-images
+
+  echo "[INFO] Done: ${IMAGE_TAR_FILE}"
+}
+
+function sed_inplace() {
+	if [ "$(uname)" = "Darwin" ]; then
+		sed -i '' "$@"
+	else
+		sed -i "$@"
+	fi
+}
+
+function register_container_images() {
+  REGISTRY_PORT=${REGISTRY_PORT:-"5000"}
+
+  if [ -z "${DESTINATION_REGISTRY:-}" ]; then
+    DESTINATION_REGISTRY="localhost:${REGISTRY_PORT}"
+    echo "[INFO] Creating local registry on ${DESTINATION_REGISTRY}"
+    create_registry=true
+  else
+    echo "[INFO] Pushing to ${DESTINATION_REGISTRY}"
+    create_registry=false
+  fi
+
+  [ -f "${IMAGE_TAR_FILE}" ] || { echo "[ERROR] ${IMAGE_TAR_FILE} not found"; exit 1; }
+  mkdir -p "${TEMP_DIR}"
+
+  if [ -d /etc/docker/ ] && [ -f "${CURRENT_DIR}/docker-daemon.json" ]; then
+    sudo cp "${CURRENT_DIR}/docker-daemon.json" /etc/docker/daemon.json 2>/dev/null || echo "[WARN] Could not update docker daemon.json"
+    if sudo grep -q "HOSTNAME" /etc/docker/daemon.json 2>/dev/null; then
+      sed_inplace "s@HOSTNAME@$(hostname)@g" /etc/docker/daemon.json
+    fi
+  elif [ -d /etc/containers/ ] && [ -f "${CURRENT_DIR}/registries.conf" ]; then
+    sudo cp "${CURRENT_DIR}/registries.conf" /etc/containers/registries.conf 2>/dev/null || echo "[WARN] Could not update containers registries.conf"
+    if sudo grep -q "HOSTNAME" /etc/containers/registries.conf 2>/dev/null; then
+      sed_inplace "s@HOSTNAME@$(hostname)@g" /etc/containers/registries.conf
+    fi
+  else
+    echo "[INFO] No docker daemon configuration found, continuing anyway"
+  fi
+
+  tar -zxf "${IMAGE_TAR_FILE}" -C "${CURRENT_DIR}"
+
+  if ${create_registry}; then
+    sudo "${runtime}" load -i "${IMAGE_DIR}/registry-latest.tar"
+    sudo "${runtime}" container inspect registry >/dev/null 2>&1 || \
+      sudo "${runtime}" run --restart=always -d -p "${REGISTRY_PORT}:${REGISTRY_PORT}" --name registry registry:latest
+  fi
+
+  total=$(wc -l < "${IMAGE_LIST}")
+  n=0
+  while read -r line; do
+    n=$((n + 1))
+    file_name=$(echo "${line}" | awk '{print $1}')
+    raw_image=$(echo "${line}" | awk '{print $2}')
+    new_image="${DESTINATION_REGISTRY}/${raw_image}"
+
+    echo "[${n}/${total}] ${new_image}"
+    skopeo copy --all --dest-tls-verify=false "oci-archive:${IMAGE_DIR}/${file_name}" "docker://${new_image}"
+  done <<< "$(cat "${IMAGE_LIST}")"
+
+  echo "[INFO] Done: registry ${DESTINATION_REGISTRY}"
+}
+
+if ! command -v skopeo &>/dev/null 2>&1; then
+  echo "[ERROR] skopeo not found"
+  exit 1
+fi
+
+trap 'rm -rf "${TEMP_DIR}"' EXIT
+
+case "${OPTION}" in
+  create)   create_container_image_tar ;;
+  register)
+    runtime=""
+    for cmd in nerdctl podman docker; do
+      if command -v "${cmd}" &>/dev/null; then
+        runtime="${cmd}"
+        break
+      fi
+    done
+    [ -z "${runtime}" ] && { echo "[ERROR] No container runtime found"; exit 1; }
+    register_container_images
+    ;;
+  *)
+    echo "Usage: $0 [create|register]"
+    echo "  IMAGES_FROM_FILE=<path>    - images list file"
+    echo "  DESTINATION_REGISTRY=<h:p> - target registry"
+    echo "  REGISTRY_PORT=<port>       - local port (default: 5000)"
+    ;;
+esac

--- a/contrib/offline/manage-offline-skopeo-container-images.sh
+++ b/contrib/offline/manage-offline-skopeo-container-images.sh
@@ -29,8 +29,9 @@ function create_container_image_tar() {
   cd "${IMAGE_DIR}"
 
   echo "[INFO] Downloading registry:latest"
+  : "${SRC_TLS_VERIFY:=false}"
   skopeo copy --override-os="${TARGET_OS}" --override-arch="${TARGET_ARCH}" \
-    --src-tls-verify=false --retry-times="${RETRY_COUNT}" \
+    --src-tls-verify="${SRC_TLS_VERIFY}" --retry-times="${RETRY_COUNT}" \
     "docker://registry:latest" "docker-archive:${IMAGE_DIR}/registry-latest.tar:registry:latest"
 
   total=$(wc -l < "${IMAGES}")
@@ -42,9 +43,9 @@ function create_container_image_tar() {
     echo "[${n}/${total}] ${image}"
 
     skopeo copy --override-os="${TARGET_OS}" --override-arch="${TARGET_ARCH}" \
-      --src-tls-verify=false --retry-times="${RETRY_COUNT}" \
+      --src-tls-verify="${SRC_TLS_VERIFY}" --retry-times="${RETRY_COUNT}" \
       "docker://${image}" "oci-archive:${IMAGE_DIR}/${FILE_NAME}" || \
-    skopeo copy --all --src-tls-verify=false --retry-times="${RETRY_COUNT}" \
+    skopeo copy --all --src-tls-verify="${SRC_TLS_VERIFY}" --retry-times="${RETRY_COUNT}" \
       "docker://${image}" "oci-archive:${IMAGE_DIR}/${FILE_NAME}"
 
 
@@ -105,7 +106,7 @@ function register_container_images() {
   if ${create_registry}; then
     sudo "${runtime}" load -i "${IMAGE_DIR}/registry-latest.tar"
     sudo "${runtime}" container inspect registry >/dev/null 2>&1 || \
-      sudo "${runtime}" run --restart=always -d -p "${REGISTRY_PORT}:${REGISTRY_PORT}" --name registry registry:latest
+      sudo "${runtime}" run --restart=always -d -p "${REGISTRY_PORT}:5000" --name registry registry:latest
   fi
 
   total=$(wc -l < "${IMAGE_LIST}")

--- a/contrib/offline/manage-offline-skopeo-files.sh
+++ b/contrib/offline/manage-offline-skopeo-files.sh
@@ -57,7 +57,7 @@ function create_offline_files() {
 
     echo "[INFO] Downloading files from list"
     while read -r url; do
-        wget -nH --cut-dirs=2 -P "${OFFLINE_FILES_DIR}" "${url}" || echo "[WARN] Failed to download: ${url}"
+        wget -x -P "${OFFLINE_FILES_DIR}" "${url}" || { echo "[ERROR] Failed to download: ${url}"; exit 1; }
     done < "${FILES_LIST}"
 
     tar -C "${CURRENT_DIR}" -czvf "${OFFLINE_FILES_ARCHIVE}" "${OFFLINE_FILES_DIR_NAME}"
@@ -78,7 +78,12 @@ function serve_offline_files() {
     fi
 
     if sudo "${runtime}" container inspect nginx-files >/dev/null 2>&1; then
-        echo "[INFO] nginx-files container already running"
+        if sudo "${runtime}" inspect --format '{{.State.Running}}' nginx-files 2>/dev/null | grep -q 'true'; then
+            echo "[INFO] nginx-files container already running"
+            return 0
+        fi
+        echo "[INFO] Starting existing nginx-files container"
+        sudo "${runtime}" start nginx-files >/dev/null 2>&1 || { echo "[ERROR] Failed to start nginx-files container"; exit 1; }
         return 0
     fi
 

--- a/contrib/offline/manage-offline-skopeo-files.sh
+++ b/contrib/offline/manage-offline-skopeo-files.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -euo pipefail
+
+OPTION=${1:-}
+DOWNLOAD_NGINX=${DOWNLOAD_NGINX:-true}
+
+CURRENT_DIR=$( dirname "$(readlink -f "$0")" )
+OFFLINE_FILES_DIR_NAME="offline-files"
+OFFLINE_FILES_DIR="${CURRENT_DIR}/${OFFLINE_FILES_DIR_NAME}"
+OFFLINE_FILES_ARCHIVE="${CURRENT_DIR}/offline-files.tar.gz"
+NGINX_IMAGE_ARCHIVE="${OFFLINE_FILES_DIR}/nginx-alpine.tar"
+FILES_LIST=${FILES_LIST:-"${CURRENT_DIR}/temp/files.list"}
+NGINX_PORT=${NGINX_PORT:-8080}
+
+function detect_runtime() {
+    for runtime in nerdctl podman docker; do
+        if command -v "${runtime}" &>/dev/null 2>&1; then
+            echo "${runtime}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+function create_offline_files() {
+    if [ ! -f "${FILES_LIST}" ]; then
+        echo "[ERROR] ${FILES_LIST} not found, run ./generate_list.sh first"
+        exit 1
+    fi
+
+    rm -rf "${OFFLINE_FILES_DIR}"
+    rm -f "${OFFLINE_FILES_ARCHIVE}"
+    mkdir -p "${OFFLINE_FILES_DIR}"
+
+    case "$(uname -m)" in
+        x86_64) TARGET_ARCH="amd64" ;;
+        aarch64|arm64) TARGET_ARCH="arm64" ;;
+        *) TARGET_ARCH="amd64" ;;
+    esac
+    TARGET_OS="linux"
+
+    echo "[INFO] Downloading nginx:alpine image"
+    if [ "${DOWNLOAD_NGINX}" = "true" ]; then
+        if command -v skopeo &>/dev/null 2>&1; then
+            skopeo copy \
+                --override-os="${TARGET_OS}" --override-arch="${TARGET_ARCH}" \
+                "docker://nginx:alpine" "docker-archive:${NGINX_IMAGE_ARCHIVE}:nginx:alpine"
+        else
+            runtime=$(detect_runtime) || { echo "[ERROR] No container runtime found"; exit 1; }
+            echo "[INFO] Using ${runtime} to pull nginx:alpine"
+            sudo "${runtime}" pull nginx:alpine
+            sudo "${runtime}" save -o "${NGINX_IMAGE_ARCHIVE}" nginx:alpine
+        fi
+    else
+        echo "[INFO] Skipping nginx download"
+    fi
+
+    echo "[INFO] Downloading files from list"
+    while read -r url; do
+        wget -nH --cut-dirs=2 -P "${OFFLINE_FILES_DIR}" "${url}" || echo "[WARN] Failed to download: ${url}"
+    done < "${FILES_LIST}"
+
+    tar -C "${CURRENT_DIR}" -czvf "${OFFLINE_FILES_ARCHIVE}" "${OFFLINE_FILES_DIR_NAME}"
+    echo "[INFO] Done: ${OFFLINE_FILES_ARCHIVE}"
+}
+
+function serve_offline_files() {
+    runtime=$(detect_runtime) || { echo "[ERROR] No container runtime found"; exit 1; }
+
+    if [ -f "${OFFLINE_FILES_ARCHIVE}" ] && [ ! -d "${OFFLINE_FILES_DIR}" ]; then
+        echo "[INFO] Extracting archive"
+        tar -xzf "${OFFLINE_FILES_ARCHIVE}" -C "${CURRENT_DIR}"
+    fi
+
+    if [ ! -d "${OFFLINE_FILES_DIR}" ]; then
+        echo "[ERROR] ${OFFLINE_FILES_DIR} not found"
+        exit 1
+    fi
+
+    if sudo "${runtime}" container inspect nginx-files >/dev/null 2>&1; then
+        echo "[INFO] nginx-files container already running"
+        return 0
+    fi
+
+    if [ -f "${NGINX_IMAGE_ARCHIVE}" ]; then
+        echo "[INFO] Loading nginx from local archive"
+        sudo "${runtime}" load -i "${NGINX_IMAGE_ARCHIVE}"
+    else
+        echo "[WARN] nginx:alpine not found locally, attempting to pull"
+    fi
+
+    sudo --preserve-env=http_proxy,https_proxy,no_proxy "${runtime}" run \
+        --restart=always -d -p "${NGINX_PORT}:80" \
+        --volume "${OFFLINE_FILES_DIR}":/usr/share/nginx/html/download \
+        --volume "${CURRENT_DIR}"/nginx.conf:/etc/nginx/nginx.conf \
+        --name nginx-files nginx:alpine
+
+    echo "[INFO] nginx serving at http://localhost:${NGINX_PORT}"
+}
+
+case "${OPTION}" in
+    create)
+        create_offline_files
+        ;;
+    serve)
+        serve_offline_files
+        ;;
+    *)
+        echo "Usage: $0 [create|serve]"
+        echo "  create - download files and nginx image"
+        echo "  serve  - start nginx server"
+        echo ""
+        echo "Environment variables:"
+        echo "  DOWNLOAD_NGINX=false  - skip nginx download"
+        ;;
+esac

--- a/contrib/offline/nginx.conf
+++ b/contrib/offline/nginx.conf
@@ -17,12 +17,10 @@ http {
     keepalive_timeout   65;
     types_hash_max_size 2048;
     default_type        application/octet-stream;
-    include /etc/nginx/conf.d/*.conf;
     server {
         listen       80 default_server;
         listen       [::]:80 default_server;
         server_name  _;
-        include /etc/nginx/default.d/*.conf;
         location / {
             root    /usr/share/nginx/html/download;
         autoindex on;

--- a/contrib/offline/registries.conf
+++ b/contrib/offline/registries.conf
@@ -2,7 +2,7 @@
 registries = ['registry.access.redhat.com', 'registry.redhat.io', 'docker.io']
 
 [registries.insecure]
-registries = ['HOSTNAME:5000']
+registries = ['localhost:5000', 'HOSTNAME:5000']
 
 [registries.block]
 registries = []


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

This PR refactors the offline image and file management scripts to improve portability, reliability, and cross-platform support.

Main changes include:

* Replace `docker`/`podman`/`nerdctl` image operations with `skopeo` and OCI archives to preserve image metadata and manifest lists during offline transfers.
* Add architecture detection (`amd64`/`arm64`) and Linux platform selection to improve cross-platform compatibility.
* Use `localhost` instead of the system hostname when configuring and accessing the local registry.
* Improve error handling by enabling `set -euo pipefail`.
* Simplify runtime-specific logic in the offline scripts.
* Simplify `nginx.conf` and related configuration files used by the offline file server.

The previous offline image workflow relied on `docker save` and `docker load`, which do not preserve OCI manifest lists and platform descriptors associated with multi-architecture images. As a result, some images could not be pushed to the destination registry after being transferred through the offline workflow.

Using OCI archives with `skopeo` preserves manifest lists and platform metadata throughout the transfer process, allowing both single-platform and multi-platform images to be transferred and registered consistently.

In addition, the previous nginx configuration loaded default server definitions from the container image through `conf.d` and `default.d` include directives. Depending on the image contents, this could result in multiple server blocks being loaded simultaneously, causing unexpected behavior and configuration conflicts. The configuration has been simplified to ensure that only the intended offline file server configuration is used.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

During validation, issues were observed with Kubernetes images distributed as OCI manifest lists.

With the previous implementation, the following scenario could be reproduced:

```text
Loaded image: registry.k8s.io/kube-apiserver:v1.33.11
The push refers to repository [localhost:5000/registry.k8s.io/kube-apiserver]
image with reference localhost:5000/registry.k8s.io/kube-apiserver:v1.33.11 was found but does not provide any platform
```

The issue occurs because `docker save`/`docker load` lose the OCI manifest list information required to determine which platform-specific manifest should be pushed to the destination registry.

The OCI-based workflow implemented in this PR preserves manifest lists and platform metadata, eliminating these failures and providing consistent behavior across supported environments.

The changes were validated using both single-platform images and multi-architecture images represented by OCI manifest lists.

**Does this PR introduce a user-facing change?**:

```release-note
Improved offline image and file management workflows by switching image handling to skopeo with OCI archives, preserving multi-architecture image metadata, adding cross-platform architecture support, using localhost for local registry configuration, simplifying nginx configuration, and improving offline runtime reliability.
```
