### PR TITLE
Make cordon/uncordon confirmation prompts consistent

### DIFF
--- a/roles/upgrade/post-upgrade/tasks/main.yml
+++ b/roles/upgrade/post-upgrade/tasks/main.yml
@@ -14,7 +14,7 @@
 - name: Confirm node uncordon
   pause:
     echo: true
-    prompt: "Ready to uncordon node {{ kube_override_hostname | default(inventory_hostname) }}?"
+    prompt: "Ready to uncordon node {{ kube_override_hostname | default(inventory_hostname) }}? (Press Enter to continue or Ctrl+C for other options)"
   when:
     - upgrade_node_post_upgrade_confirm
 

--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Confirm node upgrade
   pause:
     echo: true
-    prompt: "Ready to upgrade node {{ kube_override_hostname | default(inventory_hostname) }}? (Press Enter to continue or Ctrl+C for other options)"
+    prompt: "Ready to cordon and upgrade node {{ kube_override_hostname | default(inventory_hostname) }}? (Press Enter to continue or Ctrl+C for other options)"
   when:
     - upgrade_node_confirm
 


### PR DESCRIPTION
Mention cordon explicitly in the pre-upgrade prompt and add the node name plus the same continue/cancel hint to the uncordon prompt so both prompts share consistent wording.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When upgrading a cluster with many nodes, it is useful to always exactly to know which node we are working with. Furthermore, consistent wording is always preferable over inconsistent wording. It's not a big change, but I think it makes live a bit easier.


**Which issue(s) this PR fixes**:  No related issue.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


**Special notes for your reviewer**: Nothing.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
