### PR TITLE
cilium: render routingMode: native when cilium_tunnel_mode is disabled

### DIFF
--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -26,7 +26,10 @@ cilium_cpu_limit: 500m
 cilium_memory_requests: 64M
 cilium_cpu_requests: 100m
 
-# Overlay Network Mode
+# Cilium tunnel mode. Possible values: vxlan, geneve, disabled.
+# Set to 'disabled' to use native routing without tunneling.
+# When set to 'disabled', Kubespray renders routingMode: native in the Helm
+# values instead of tunnelProtocol, which is required by Cilium >= 1.14.
 cilium_tunnel_mode: vxlan
 
 # LoadBalancer Mode (snat/dsr/hybrid) Ref: https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/#dsr-mode

--- a/roles/network_plugin/cilium/templates/values.yaml.j2
+++ b/roles/network_plugin/cilium/templates/values.yaml.j2
@@ -25,7 +25,11 @@ healthPort: {{ cilium_agent_health_port }}
 
 identityAllocationMode: {{ cilium_identity_allocation_mode }}
 
+{% if cilium_tunnel_mode == 'disabled' %}
+routingMode: native
+{% else %}
 tunnelProtocol: {{ cilium_tunnel_mode }}
+{% endif %}
 
 loadBalancer:
   mode: {{ cilium_loadbalancer_mode }}


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it

When `cilium_tunnel_mode: disabled` is set in inventory, the previous
template rendered `tunnelProtocol: disabled` in the Helm values.
Cilium does not recognize this value and falls back to `vxlan`, which
directly conflicts with `routingMode: native` and causes agents to
CrashLoopBackOff.

The fix renders `routingMode: native` instead when `cilium_tunnel_mode`
is `disabled`, matching the Cilium Helm chart API.

## Which issue(s) this PR fixes

Related to issue 13267

## Does this PR introduce a user-facing change?

Users no longer need to manually inject `tunnelProtocol: ""` via
`cilium_extra_values`. Setting `cilium_tunnel_mode: disabled` now
works as documented in defaults/main.yml.

```release-note
Fix Cilium CrashLoopBackOff when cilium_tunnel_mode is set to disabled
by rendering routingMode: native instead of tunnelProtocol: disabled
in the Helm values.
```