### PR TITLE
fix(download): Change failure condition for image save task

### DIFF
--- a/roles/download/tasks/download_container.yml
+++ b/roles/download/tasks/download_container.yml
@@ -74,7 +74,7 @@
       delegate_to: "{{ download_delegate }}"
       delegate_facts: false
       register: container_save_status
-      failed_when: container_save_status.stderr
+      failed_when: container_save_status.rc != 0
       run_once: true
       become: "{{ user_can_become_root | default(false) or not download_localhost }}"
       when:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes the failure condition for the "Download_container | Save and compress image" task in the download role.

The previous condition `failed_when: container_save_status.stderr` incorrectly treats any stderr output as a failure. However, `nerdctl image save` outputs progress information (download progress bars, layer status, etc.) to stderr during normal operations, causing successful image saves to be marked as failed even when the command returns exit code 0.

This PR changes the failure condition to `failed_when: container_save_status.rc != 0`, which only marks the task as failed when the command actually returns a non-zero exit code, properly reflecting the actual command status.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

This issue occurs specifically when using `nerdctl` as the container tool with `download_run_once: true` enabled. The task succeeds (rc=0) but Ansible marks it as failed due to stderr output containing progress information.

The fix aligns the failure detection with standard shell command practices - relying on exit codes rather than stderr content.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed image save task incorrectly failing when using nerdctl due to progress output in stderr
