### PR TITLE
dependabot: ignore ansible major version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
         patterns:
           - molecule
           - molecule-plugins*
+    ignore:
+      # Ansible major versions are upgraded manually to support multiple OS/Python versions.
+      - dependency-name: "ansible"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     labels:


### PR DESCRIPTION
**What type of PR is this?**
 /kind feature

**What this PR does / why we need it**:

Ansible major versions are upgraded manually to support multiple OS/Python versions. This PR configures Dependabot to still propose minor and patch updates while skipping semver-major bumps.

Adds an `ignore` rule for the `ansible` dependency in `.github/dependabot.yml` with `update-types: ["version-update:semver-major"]`.

**Which issue(s) this PR fixes**:
Fixes #13308

**Special notes for your reviewer**:

No functional change to Kubespray itself — this only affects Dependabot behavior for `requirements.txt`. Minor and patch Ansible updates (e.g. `11.13.0` → `11.14.0`) will still be proposed automatically.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```