### PR TITLE
fix: Jinja version test warning

### DIFF
--- a/playbooks/ansible_version.yml
+++ b/playbooks/ansible_version.yml
@@ -24,10 +24,3 @@
         that: "'127.0.0.1' | ansible.utils.ipaddr == '127.0.0.1'"
       tags:
         - check
-
-    - name: "Check that jinja is not too old (install via pip)"
-      assert:
-        msg: "Your Jinja version is too old, install via pip"
-        that: "{% set test %}It works{% endset %}{{ test == 'It works' }}"
-      tags:
-        - check


### PR DESCRIPTION
The jinja version test conditional uses jinja in the condition, which is deprecated. I have refactored the playbook to to set a fact instead so that the fact can be used in the condition instead.


/kind bug

**Special notes for your reviewer:**
This removes a warning when using ansible 2.20. I am not including the switch to ansible 2.20 since this only fixes one of the warnings I have run into. The change appears to be backward compatible, so there is not hard requirement to upgrade ansible for this change.

**Does this PR introduce a user-facing change?:**
```release-note
NONE
```
