### PR TITLE
Replace injected Ansible fact variables in network_facts and system_packages role

### DIFF
--- a/roles/network_facts/tasks/main.yaml
+++ b/roles/network_facts/tasks/main.yaml
@@ -2,16 +2,16 @@
 - name: Gather node IPs
   setup:
     gather_subset: '!all,!min,network'
-    filter: "ansible_default_ip*"
-  when: ansible_default_ipv4 is not defined or ansible_default_ipv6 is not defined
+    filter: "default_ip*"
+  when: "ansible_facts is not defined or 'default_ipv4' not in ansible_facts or 'default_ipv6' not in ansible_facts"
   ignore_unreachable: true
 
 - name: Set computed IPs variables
   vars:
-    fallback_ip: "{{ ansible_default_ipv4.address | d('127.0.0.1') }}"
-    fallback_ip6: "{{ ansible_default_ipv6.address | d('::1') }}"
+    fallback_ip: "{{ (ansible_facts | default({})).get('default_ipv4', {}).address | d('127.0.0.1') }}"
+    fallback_ip6: "{{ (ansible_facts | default({})).get('default_ipv6', {}).address | d('::1') }}"
     # Set 127.0.0.1 as fallback IP if we do not have host facts for host
-    # ansible_default_ipv4 isn't what you think.
+    # ansible_facts['default_ipv4'] isn't what you think.
     _ipv4: "{{ ip | default(fallback_ip) }}"
     _access_ipv4: "{{ access_ip | default(_ipv4) }}"
     _ipv6: "{{ ip6 | default(fallback_ip6) }}"
@@ -42,7 +42,7 @@
       - calico_rr
     hosts_with_no_proxy: "{{ groups_with_no_proxy | select | map('extract', groups) | select('defined') | flatten }}"
     _hostnames: "{{ (hosts_with_no_proxy +
-                      (hosts_with_no_proxy | map('extract', hostvars, morekeys=['ansible_hostname'])
+                      (hosts_with_no_proxy | map('extract', hostvars, morekeys=['ansible_facts', 'hostname'])
                       | select('defined')))
                     | unique }}"
     no_proxy_prepare:

--- a/roles/system_packages/tasks/main.yml
+++ b/roles/system_packages/tasks/main.yml
@@ -12,7 +12,7 @@
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   when:
-    - ansible_pkg_mgr == 'zypper'
+    - ansible_facts['pkg_mgr'] == 'zypper'
   tags: bootstrap_os
 
 - name: Remove legacy docker repo file
@@ -20,7 +20,7 @@
     path: "{{ yum_repo_dir }}/docker.repo"
     state: absent
   when:
-    - ansible_os_family == "RedHat"
+    - ansible_facts['os_family'] == "RedHat"
     - not is_fedora_coreos
 
 - name: Install epel-release on RHEL derivatives
@@ -28,7 +28,7 @@
     name: epel-release
     state: present
   when:
-    - ansible_os_family == "RedHat"
+    - ansible_facts['os_family'] == "RedHat"
     - not is_fedora_coreos
     - epel_enabled | bool
   tags:
@@ -42,21 +42,21 @@
   become: true
   retries: "{{ pkg_install_retries }}"
   when:
-    - ansible_distribution == "Fedora"
-    - ansible_distribution_major_version | int >= 41
+    - ansible_facts['distribution'] == "Fedora"
+    - ansible_facts['distribution_major_version'] | int >= 41
 
 - name: Manage packages
   package:
     name: "{{ item.packages }}"
     state: "{{ item.state }}"
-    update_cache: "{{ true if ansible_pkg_mgr in ['zypper', 'apt', 'dnf'] else omit }}"
-    cache_valid_time: "{{ 86400 if ansible_pkg_mgr == 'apt' else omit }}" # 24h
+    update_cache: "{{ true if ansible_facts['pkg_mgr'] in ['zypper', 'apt', 'dnf'] else omit }}"
+    cache_valid_time: "{{ 86400 if ansible_facts['pkg_mgr'] == 'apt' else omit }}" # 24h
   register: pkgs_task_result
   until: pkgs_task_result is succeeded
   retries: "{{ pkg_install_retries }}"
   delay: "{{ retry_stagger | random + 3 }}"
   when:
-    - ansible_os_family not in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
+    - ansible_facts['os_family'] not in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
     - not is_fedora_coreos
     - item.packages != []
   loop:

--- a/roles/system_packages/vars/main.yml
+++ b/roles/system_packages/vars/main.yml
@@ -3,64 +3,64 @@ pkgs_to_remove:
   systemd-timesyncd:
     - "{{ ntp_enabled }}"
     - "{{ ntp_package == 'ntp' }}"
-    - "{{ ansible_os_family == 'Debian' }}"
+    - "{{ ansible_facts['os_family'] == 'Debian' }}"
 pkgs:
   apparmor:
-    - "{{ ansible_os_family == 'Debian' }}"
+    - "{{ ansible_facts['os_family'] == 'Debian' }}"
   apparmor-parser:
-    - "{{ ansible_os_family == 'Suse' }}"
+    - "{{ ansible_facts['os_family'] == 'Suse' }}"
   apt-transport-https:
-    - "{{ ansible_os_family == 'Debian' }}"
+    - "{{ ansible_facts['os_family'] == 'Debian' }}"
   aufs-tools:
-    - "{{ ansible_os_family == 'Debian' }}"
-    - "{{ ansible_distribution_major_version == '10' }}"
+    - "{{ ansible_facts['os_family'] == 'Debian' }}"
+    - "{{ ansible_facts['distribution_major_version'] == '10' }}"
     - "{{ 'k8s_cluster' in group_names }}"
   bash-completion: []
   chrony:
     - "{{ ntp_enabled }}"
     - "{{ ntp_package == 'chrony' }}"
   conntrack:
-    - "{{ ansible_os_family in ['Debian', 'RedHat'] }}"
-    - "{{ ansible_distribution != 'openEuler' }}"
+    - "{{ ansible_facts['os_family'] in ['Debian', 'RedHat'] }}"
+    - "{{ ansible_facts['distribution'] != 'openEuler' }}"
     - "{{ 'k8s_cluster' in group_names }}"
   conntrack-tools:
-    - "{{ ansible_os_family == 'Suse' or ansible_distribution in ['Amazon', 'openEuler'] }}"
+    - "{{ ansible_facts['os_family'] == 'Suse' or ansible_facts['distribution'] in ['Amazon', 'openEuler'] }}"
     - "{{ 'k8s_cluster' in group_names }}"
   container-selinux:
-    - "{{ ansible_os_family == 'RedHat' }}"
+    - "{{ ansible_facts['os_family'] == 'RedHat' }}"
     - "{{ 'k8s_cluster' in group_names }}"
   containers-basic:
-    - "{{ ansible_os_family == 'ClearLinux' }}"
+    - "{{ ansible_facts['os_family'] == 'ClearLinux' }}"
     - "{{ 'k8s_cluster' in group_names }}"
   curl: []
   device-mapper:
-    - "{{ ansible_os_family == 'Suse' or ansible_distribution == 'openEuler' }}"
+    - "{{ ansible_facts['os_family'] == 'Suse' or ansible_facts['distribution'] == 'openEuler' }}"
     - "{{ 'k8s_cluster' in group_names }}"
   device-mapper-libs:
-    - "{{ ansible_os_family == 'RedHat' }}"
-    - "{{ ansible_distribution != 'openEuler' }}"
+    - "{{ ansible_facts['os_family'] == 'RedHat' }}"
+    - "{{ ansible_facts['distribution'] != 'openEuler' }}"
   e2fsprogs: []
   ebtables: []
   gnupg:
-    - "{{ ansible_distribution == 'Debian' }}"
-    - "{{ ansible_distribution_major_version in ['11', '12'] }}"
+    - "{{ ansible_facts['distribution'] == 'Debian' }}"
+    - "{{ ansible_facts['distribution_major_version'] in ['11', '12'] }}"
     - "{{ 'k8s_cluster' in group_names }}"
   iproute:
-    - "{{ ansible_os_family == 'RedHat' }}"
+    - "{{ ansible_facts['os_family'] == 'RedHat' }}"
   iproute2:
-    - "{{ ansible_os_family != 'RedHat' }}"
+    - "{{ ansible_facts['os_family'] != 'RedHat' }}"
   ipset:
     - "{{ kube_proxy_mode != 'ipvs' }}"
     - "{{ 'k8s_cluster' in group_names }}"
   iptables:
-    - "{{ ansible_os_family in ['Debian', 'RedHat', 'Suse'] }}"
+    - "{{ ansible_facts['os_family'] in ['Debian', 'RedHat', 'Suse'] }}"
   iputils:
-    - "{{ not ansible_os_family in ['Flatcar', 'Flatcar Container Linux by Kinvolk', 'Debian'] }}"
+    - "{{ not ansible_facts['os_family'] in ['Flatcar', 'Flatcar Container Linux by Kinvolk', 'Debian'] }}"
     - "{{ main_access_ip is defined }}"
     - "{{ ping_access_ip }}"
     - "{{ not is_fedora_coreos }}"
   iputils-ping:
-    - "{{ ansible_os_family == 'Debian' }}"
+    - "{{ ansible_facts['os_family'] == 'Debian' }}"
     - "{{ main_access_ip is defined }}"
     - "{{ ping_access_ip }}"
   ipvsadm:
@@ -68,23 +68,23 @@ pkgs:
     - "{{ not kube_proxy_remove }}"
     - "{{ 'k8s_cluster' in group_names }}"
   libseccomp:
-    - "{{ ansible_os_family == 'RedHat' }}"
+    - "{{ ansible_facts['os_family'] == 'RedHat' }}"
   libseccomp2:
-    - "{{ ansible_os_family in ['Debian', 'Suse'] }}"
+    - "{{ ansible_facts['os_family'] in ['Debian', 'Suse'] }}"
     - "{{ 'k8s_cluster' in group_names }}"
   libselinux-python:
-    - "{{ ansible_distribution == 'Amazon' }}"
+    - "{{ ansible_facts['distribution'] == 'Amazon' }}"
   libselinux-python3:
-    - "{{ ansible_distribution == 'Fedora' }}"
+    - "{{ ansible_facts['distribution'] == 'Fedora' }}"
   mergerfs:
-    - "{{ ansible_distribution == 'Debian' }}"
-    - "{{ ansible_distribution_major_version == '12' }}"
+    - "{{ ansible_facts['distribution'] == 'Debian' }}"
+    - "{{ ansible_facts['distribution_major_version'] == '12' }}"
   nftables:
     - "{{ kube_proxy_mode == 'nftables' }}"
     - "{{ not kube_proxy_remove }}"
     - "{{ 'k8s_cluster' in group_names }}"
   nss:
-    - "{{ ansible_os_family == 'RedHat' }}"
+    - "{{ ansible_facts['os_family'] == 'RedHat' }}"
   ntp:
     - "{{ ntp_enabled }}"
     - "{{ ntp_package == 'ntp' }}"
@@ -93,22 +93,22 @@ pkgs:
     - "{{ ntp_package == 'ntpsec' }}"
   openssl: []
   python-apt:
-    - "{{ ansible_os_family == 'Debian' }}"
-    - "{{ ansible_distribution_major_version == '10' }}"
+    - "{{ ansible_facts['os_family'] == 'Debian' }}"
+    - "{{ ansible_facts['distribution_major_version'] == '10' }}"
   python-cryptography:
-    - "{{ ansible_os_family == 'Suse' and ansible_distribution_version is version('15.4', '<') }}"
+    - "{{ ansible_facts['os_family'] == 'Suse' and ansible_facts['distribution_version'] is version('15.4', '<') }}"
   python3-apt:
-    - "{{ ansible_os_family == 'Debian' }}"
-    - "{{ ansible_distribution_major_version != '10' }}"
+    - "{{ ansible_facts['os_family'] == 'Debian' }}"
+    - "{{ ansible_facts['distribution_major_version'] != '10' }}"
   python3-cryptography:
-    - "{{ ansible_os_family == 'Suse' and ansible_distribution_version is version('15.4', '>=') }}"
+    - "{{ ansible_facts['os_family'] == 'Suse' and ansible_facts['distribution_version'] is version('15.4', '>=') }}"
   python3-libselinux:
-    - "{{ ansible_distribution in ['RedHat', 'CentOS'] }}"
+    - "{{ ansible_facts['distribution'] in ['RedHat', 'CentOS'] }}"
   rsync: []
   socat: []
   software-properties-common:
-    - "{{ ansible_os_family == 'Debian' }}"
-    - "{{ ansible_distribution_major_version != '13' }}"
+    - "{{ ansible_facts['os_family'] == 'Debian' }}"
+    - "{{ ansible_facts['distribution_major_version'] != '13' }}"
   tar: []
   unzip: []
   xfsprogs: []


### PR DESCRIPTION
The old way of injecting facts as variables is deprecated. Switching to the new way.

roles updated:
* network_facts
* system_packages

/kind bug

**Special notes for your reviewer:**
Injecting facts as vars is deprecated. See [here](https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_13.html#inject-facts-as-vars).

Just so you know, I am using a local branch modified to allow the use of ansible 2.20. These changes should be backward compatible with 2.18/19, which are the currently supported versions of ansible for kubespray.

**Does this PR introduce a user-facing change?**
```release-note
NONE
```
