### PR TITLE
fix: install ipvsadm for kube-vip load balancing with nftables proxy

### DIFF
--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -115,8 +115,7 @@
     persistent: present
   loop: "{{ kube_proxy_ipvs_modules }}"
   when:
-    - kube_proxy_mode == 'ipvs'
-    - not kube_proxy_remove
+    - ipvs_required | bool
   tags:
     - kube-proxy
 
@@ -131,8 +130,7 @@
     - nf_conntrack
     - nf_conntrack_ipv4
   when:
-    - kube_proxy_mode == 'ipvs'
-    - not kube_proxy_remove
+    - ipvs_required | bool
     - modprobe_conntrack_module is not defined or modprobe_conntrack_module is ansible.builtin.failed  # loop until first success
   tags:
     - kube-proxy

--- a/roles/kubespray_defaults/defaults/main/main.yml
+++ b/roles/kubespray_defaults/defaults/main/main.yml
@@ -37,6 +37,9 @@ kube_proxy_mode: ipvs
 # Node and package tasks that exist only for kube-proxy also honor this (IPVS/nftables modules, ipvsadm, strict_arp checks).
 kube_proxy_remove: false
 
+# Install IPVS packages/modules when kube-proxy uses IPVS or kube-vip control plane load balancing uses IPVS (local forwarding).
+ipvs_required: "{{ (kube_proxy_mode == 'ipvs' and not kube_proxy_remove) or (kube_vip_enabled | bool and kube_vip_lb_enable | bool and kube_vip_lb_fwdmethod != 'masquerade') }}"
+
 # Debugging option for the kubeadm config validate command
 # Set to false only for development and testing scenarios where validation is expected to fail (pre-release Kubernetes versions, etc.)
 kubeadm_config_validate_enabled: true
@@ -98,6 +101,7 @@ ignore_assert_errors: false
 
 # kube-vip
 kube_vip_enabled: false
+kube_vip_lb_enable: false
 kube_vip_lb_fwdmethod: local
 kube_vip_address:
 

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -256,7 +256,7 @@
   command: "ipvsadm -C"
   ignore_errors: true  # noqa ignore-errors
   when:
-    - kube_proxy_mode == 'ipvs' and 'k8s_cluster' in group_names
+    - ipvs_required | bool and 'k8s_cluster' in group_names
 
 - name: Reset | check kube-ipvs0 network device
   stat:

--- a/roles/system_packages/vars/main.yml
+++ b/roles/system_packages/vars/main.yml
@@ -64,8 +64,7 @@ pkgs:
     - "{{ main_access_ip is defined }}"
     - "{{ ping_access_ip }}"
   ipvsadm:
-    - "{{ kube_proxy_mode == 'ipvs' }}"
-    - "{{ not kube_proxy_remove }}"
+    - "{{ ipvs_required }}"
     - "{{ 'k8s_cluster' in group_names }}"
   libseccomp:
     - "{{ ansible_os_family == 'RedHat' }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

`ipvsadm` and IPVS kernel modules were only installed when `kube_proxy_mode` was `ipvs`. When using `kube_proxy_mode: nftables` with kube-vip control plane load balancing enabled, `ipvsadm` was not installed even though kube-vip uses IPVS for local forwarding on control plane nodes.

This PR introduces a shared `ipvs_required` variable and uses it consistently for:
- `ipvsadm` package installation (`system_packages`)
- IPVS kernel module loading (`kubernetes/node`)
- IPVS table cleanup during reset (`reset`)

`ipvs_required` is true when:
- kube-proxy uses IPVS (`kube_proxy_mode: ipvs` and `kube_proxy_remove: false`), or
- kube-vip control plane load balancing is enabled (`kube_vip_enabled` and `kube_vip_lb_enable`) with a non-masquerade forwarding method (`kube_vip_lb_fwdmethod != masquerade`)

`kube_vip_lb_enable` is also added to `kubespray_defaults` so it is available during bootstrap when `system_packages` runs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13321

**Special notes for your reviewer**:

Per triage on the issue, IPVS packages are gated on `kube_vip_lb_enable`, not just `kube_vip_enabled`. Users need both `kube_vip_enabled: true` and `kube_vip_lb_enable: true` for `ipvsadm` to be installed when `kube_proxy_mode` is `nftables`. With `kube_vip_lb_fwdmethod: masquerade`, `ipvsadm` is intentionally not installed since that mode uses iptables.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```