### PR TITLE
fix(gateway-api): use server-side apply to avoid annotation size limit

### DIFF
--- a/roles/kubernetes-apps/common_crds/gateway_api/tasks/main.yml
+++ b/roles/kubernetes-apps/common_crds/gateway_api/tasks/main.yml
@@ -24,10 +24,11 @@
     - "inventory_hostname == groups['kube_control_plane'][0]"
 
 - name: Gateway API | Install Gateway API
-  kube:
-    name: Gateway API
-    kubectl: "{{ bin_dir }}/kubectl"
-    filename: "{{ kube_config_dir }}/addons/gateway_api/{{ gateway_api_channel }}-install.yaml"
-    state: latest
+  command: >
+    {{ kubectl }} apply
+    --server-side=true
+    -f {{ kube_config_dir }}/addons/gateway_api/{{ gateway_api_channel }}-install.yaml
+  register: gateway_api_result
+  changed_when: "'created' in gateway_api_result.stdout or 'configured' in gateway_api_result.stdout or 'serverside-applied' in gateway_api_result.stdout"
   when:
     - "inventory_hostname == groups['kube_control_plane'][0]"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The Gateway API HTTPRoute CRD in experimental channel (v1.5.x+) exceeds Kubernetes' 262144-byte annotation limit when using client-side apply, causing installation failures.

This PR switches the Gateway API installation task from using the `kube` module (client-side apply) to the `command` module with `kubectl apply --server-side` to bypass the annotation size limitation.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

- Tested with Gateway API v1.5.1 experimental channel
- The `--server-side=true` flag is the recommended approach for large CRDs
- `--force-conflicts` handles ownership conflicts during upgrades
- Backward compatible with existing installations

**Does this PR introduce a user-facing change?**:

```release-note
Gateway API CRDs installation now uses server-side apply to support experimental channel v1.5.x+
