### PR TITLE
Reboot only when required, add the option to clean packages.

### DIFF
--- a/docs/operations/upgrades.md
+++ b/docs/operations/upgrades.md
@@ -438,4 +438,4 @@ This can be changed to `always` or `never`.
 
 Note: Downloads will happen twice unless `system_upgrade_reboot` is `never`.
 
-Nodes can be cleaned of packages to reduce disk space usage with `system_upgrade_autoclean: true`
+Debian based nodes can be cleaned of packages to reduce disk space usage with `system_upgrade_autoclean: true`

--- a/docs/operations/upgrades.md
+++ b/docs/operations/upgrades.md
@@ -437,3 +437,5 @@ Nodes will be rebooted when there are package upgrades (`system_upgrade_reboot: 
 This can be changed to `always` or `never`.
 
 Note: Downloads will happen twice unless `system_upgrade_reboot` is `never`.
+
+Nodes can be cleaned of packages to reduce disk space usage with `system_upgrade_autoclean: true`

--- a/roles/kubespray_defaults/defaults/main/main.yml
+++ b/roles/kubespray_defaults/defaults/main/main.yml
@@ -808,6 +808,7 @@ sysctl_ignore_unknown_keys: false
 
 system_upgrade: false
 system_upgrade_reboot: on-upgrade  # never, always
+system_upgrade_autoclean: false
 
 # Enables or disables the scheduler plugins.
 scheduler_plugins_enabled: false

--- a/roles/upgrade/system-upgrade/tasks/apt.yml
+++ b/roles/upgrade/system-upgrade/tasks/apt.yml
@@ -5,10 +5,23 @@
     upgrade: dist
     autoremove: true
     dpkg_options: force-confold,force-confdef
-  register: apt_upgrade
 
-- name: Reboot after APT Dist-Upgrade  # noqa no-handler
+- name: Check if a reboot is required
+  ansible.builtin.stat:
+    path: /var/run/reboot-required
+    get_checksum: false
+  register: reboot_required
+
+- name: Reboot server if required to apply updates
+  ansible.builtin.reboot:
+    msg: "The system is going down for reboot NOW!"
+    post_reboot_delay: 30
   when:
-  - apt_upgrade.changed or system_upgrade_reboot == 'always'
-  - system_upgrade_reboot != 'never'
-  reboot:
+    - reboot_required.stat.exists
+    - system_upgrade_reboot != 'never'
+
+- name: APT Autoclean
+  apt:
+    autoclean: true
+  when:
+    - system_upgrade_autoclean

--- a/tests/files/ubuntu22-calico-all-in-one-upgrade.yml
+++ b/tests/files/ubuntu22-calico-all-in-one-upgrade.yml
@@ -6,6 +6,7 @@ vm_memory: 3072
 
 # Kubespray settings
 auto_renew_certificates: true
+system_upgrade_autoclean: true
 
 # Currently ipvs not available on KVM: https://packages.ubuntu.com/search?suite=focal&arch=amd64&mode=exactfilename&searchon=contents&keywords=ip_vs_sh.ko
 kube_proxy_mode: iptables

--- a/tests/files/ubuntu24-crio-upgrade.yml
+++ b/tests/files/ubuntu24-crio-upgrade.yml
@@ -7,6 +7,7 @@ vm_memory: 3072
 # Kubespray settings
 container_manager: crio
 auto_renew_certificates: true
+system_upgrade_autoclean: true
 
 # Currently ipvs not available on KVM: https://packages.ubuntu.com/search?suite=noble&arch=amd64&mode=exactfilename&searchon=contents&keywords=ip_vs_sh.ko
 kube_proxy_mode: iptables


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
* Only reboot nodes when required for Debian based distro's. This prevents node reboots for regular package updates and speeds up the pipeline.
* Allow cleanup of the apt package cache, this reduced the used disk space for nodes.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
A new option was added to allow cleanup of the apt package cache with `system_upgrade_autoclean: true`.
```
