### PR TITLE
fix(cni): use root as owner for /opt/cni/bin when using Cilium

### DIFF
--- a/roles/network_plugin/cni/tasks/main.yml
+++ b/roles/network_plugin/cni/tasks/main.yml
@@ -4,7 +4,7 @@
     path: /opt/cni/bin
     state: directory
     mode: "0755"
-    owner: "{{ cni_bin_owner }}"
+    owner: "{{ 'root' if (kube_network_plugin == 'cilium' or cilium_deploy_additionally) else cni_bin_owner }}"
     recurse: true
 
 - name: CNI | Copy cni plugins
@@ -12,5 +12,5 @@
     src: "{{ downloads.cni.dest }}"
     dest: "/opt/cni/bin"
     mode: "0755"
-    owner: "{{ cni_bin_owner }}"
+    owner: "{{ 'root' if (kube_network_plugin == 'cilium' or cilium_deploy_additionally) else cni_bin_owner }}"
     remote_src: true


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When `kube_network_plugin: cilium` or `cilium_deploy_additionally: true`, the `network_plugin/cni` role creates `/opt/cni/bin` with `owner: kube` (via `cni_bin_owner`). Cilium's `mount-cgroup` init container mounts this directory as `/hostbin` and attempts to copy `cilium-mount` into it as root. Since the directory is owned by `kube` with mode `0755`, root has no write permission, causing the init container to crash-loop with:

```
cp: cannot create regular file '/hostbin/cilium-mount': Permission denied
```

This fix sets `owner: root` for `/opt/cni/bin` and its contents when Cilium is in use, consistent with how the rest of the codebase checks for Cilium usage (`kube_network_plugin == 'cilium' or cilium_deploy_additionally`).

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

The condition `kube_network_plugin == 'cilium' or cilium_deploy_additionally` is the same pattern used across the codebase (e.g. `roles/network_plugin/cilium/tasks/check.yml`, `roles/kubespray_defaults/defaults/main/download.yml`) to detect Cilium usage, including the case where `kube_network_plugin: cni` is used together with `cilium_deploy_additionally: true` (common when master nodes also act as workers).

**Does this PR introduce a user-facing change?**:

```release-note
Fix /opt/cni/bin directory owner when using Cilium as the network plugin.
Previously the directory was owned by `kube`, causing Cilium's init container
to fail with "Permission denied" when copying binaries to the host. The
directory is now owned by `root` when `kube_network_plugin: cilium` or
`cilium_deploy_additionally: true`.
```
