### PR TITLE
feat: harden kubeadm etcd manifest to prevent split-brain on data-dir wipe (#13261)

### DIFF
--- a/roles/kubernetes/control-plane/defaults/main/etcd.yml
+++ b/roles/kubernetes/control-plane/defaults/main/etcd.yml
@@ -27,3 +27,11 @@ etcd_extra_vars: {}
 # etcd_max_request_bytes: "1572864"
 
 etcd_compaction_retention: "8"
+
+# Harden the kubeadm-rendered etcd static-pod manifest by replacing
+# --initial-cluster=<self>/--initial-cluster-state=new with the full live
+# member list and state=existing, preventing silent split-brain on data-dir wipe.
+etcd_kubeadm_harden_manifest_enabled: false
+etcd_kubeadm_harden_manifest_path: "{{ kube_config_dir }}/manifests/etcd.yaml"
+etcd_kubeadm_harden_wait_retries: 30
+etcd_kubeadm_harden_wait_delay: 5

--- a/roles/kubernetes/control-plane/handlers/main.yml
+++ b/roles/kubernetes/control-plane/handlers/main.yml
@@ -115,3 +115,12 @@
   listen:
     - Control plane | restart kubelet
     - Control plane | Restart apiserver
+
+- name: Etcd harden | Wait for etcd to recover
+  command: "{{ bin_dir }}/etcdctl.sh endpoint health"
+  register: etcd_kubeadm_harden_health
+  changed_when: false
+  check_mode: false
+  retries: "{{ etcd_kubeadm_harden_wait_retries }}"
+  delay: "{{ etcd_kubeadm_harden_wait_delay }}"
+  until: etcd_kubeadm_harden_health.rc == 0

--- a/roles/kubernetes/control-plane/tasks/kubeadm-etcd-harden.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-etcd-harden.yml
@@ -1,0 +1,70 @@
+---
+# Hardens the kubeadm-rendered etcd static-pod manifest by replacing
+# --initial-cluster=<self> and --initial-cluster-state=new with the
+# full live member list and --initial-cluster-state=existing.
+#
+# Without this, a data-dir wipe silently re-bootstraps the local etcd
+# as a new single-node cluster (split brain).
+# References: kubeadm#2005, k/k PR #97372, etcd-io#11732.
+
+- name: Etcd harden | List live etcd cluster members
+  command: "{{ bin_dir }}/etcdctl.sh member list -w json"
+  register: etcd_kubeadm_harden_members
+  changed_when: false
+  check_mode: false
+  retries: 3
+  delay: 5
+  until: etcd_kubeadm_harden_members.rc == 0
+
+- name: Etcd harden | Parse member list
+  set_fact:
+    etcd_kubeadm_harden_member_list: "{{ etcd_kubeadm_harden_members.stdout | from_json }}"
+
+- name: Etcd harden | Assert local member is registered and not a learner
+  assert:
+    that:
+      - local_member is not none
+      - not (local_member.isLearner | default(false))
+      - local_member.name | length > 0
+      - local_member.peerURLs | length > 0
+    fail_msg: "Local etcd member not found in cluster or is a learner; refusing to harden."
+  vars:
+    local_member: >-
+      {{ (etcd_kubeadm_harden_member_list.members | default([]))
+         | selectattr('peerURLs.0', '==', etcd_peer_url)
+         | first | default(none) }}
+
+- name: Etcd harden | Build initial-cluster argument from live members
+  set_fact:
+    etcd_kubeadm_harden_initial_cluster: >-
+      {{ (etcd_kubeadm_harden_member_list.members | default([]))
+         | map(attribute='name') | zip(
+           (etcd_kubeadm_harden_member_list.members | default([]))
+           | map(attribute='peerURLs') | map('first')
+         ) | map('join', '=') | join(',') }}
+
+- name: Etcd harden | Read current etcd static-pod manifest
+  slurp:
+    src: "{{ etcd_kubeadm_harden_manifest_path }}"
+  register: etcd_kubeadm_harden_manifest
+
+- name: Etcd harden | Compute hardened manifest contents
+  set_fact:
+    etcd_kubeadm_harden_new_manifest: >-
+      {{ etcd_kubeadm_harden_manifest.content | b64decode
+         | regex_replace('(\s+)- --initial-cluster=[^\n]*\n',
+             '\1- --initial-cluster=' ~ etcd_kubeadm_harden_initial_cluster ~ '\n')
+         | regex_replace('(\s+)- --initial-cluster-state=[^\n]*\n',
+             '\1- --initial-cluster-state=existing\n') }}
+
+- name: Etcd harden | Apply hardened manifest atomically (serialized across CPs)
+  copy:
+    content: "{{ etcd_kubeadm_harden_new_manifest }}"
+    dest: "{{ etcd_kubeadm_harden_manifest_path }}"
+    owner: root
+    group: root
+    mode: "0600"
+    backup: true
+  throttle: 1
+  when: etcd_kubeadm_harden_new_manifest != (etcd_kubeadm_harden_manifest.content | b64decode)
+  notify: Etcd harden | Wait for etcd to recover

--- a/roles/kubernetes/control-plane/tasks/kubeadm-etcd.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-etcd.yml
@@ -27,3 +27,7 @@
     group: "{{ etcd_owner }}"
     mode: "0700"
   when: etcd_deployment_type == "kubeadm"
+
+- name: Harden kubeadm-rendered etcd manifest with full initial-cluster list
+  import_tasks: kubeadm-etcd-harden.yml
+  when: etcd_kubeadm_harden_manifest_enabled

--- a/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
@@ -49,6 +49,12 @@
   - etcd_deployment_type == "kubeadm"
   notify: Control plane | restart kubelet
 
+- name: Re-harden kubeadm-rendered etcd manifest after upgrade rewrite
+  import_tasks: kubeadm-etcd-harden.yml
+  when:
+  - etcd_deployment_type == "kubeadm"
+  - etcd_kubeadm_harden_manifest_enabled
+
 - name: Rewrite kubernetes control plane static pod manifests with updated configmap
   command: "{{ bin_dir }}/kubeadm init phase control-plane all --config {{ kube_config_dir }}/kubeadm-config.yaml"
   notify: Control plane | restart kubelet


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it:

Hardens the kubeadm-rendered etcd static-pod manifest on control-plane nodes by replacing the default `--initial-cluster=<self>` argument with the full live member list and setting `--initial-cluster-state=existing`.

**Problem:** When a control-plane node's etcd data directory is wiped (e.g., disk replacement, accidental delete, re-provisioning), kubeadm's default etcd manifest bootstraps a single-node cluster, causing a silent split-brain with the existing cluster members.

**Solution:** After kubeadm has initialized the cluster, this PR rewrites the etcd manifest using the live etcd member list from `etcdctl member list`. On subsequent kubeadm upgrade cycles, the manifest is re-hardened.

## Which issue(s) this PR fixes:

Fixes #13261

## Special notes for your reviewer:

Based on @felipe88alves's PR #13266 (commit 656e913). This version keeps `etcd_kubeadm_harden_manifest_enabled: false` as the default (opt-in). Tested on a single-node local VM with `etcd_deployment_type: kubeadm`.

## Does this PR introduce a user-facing change?

```release-note
Add etcd_kubeadm_harden_manifest_enabled (default: false). When enabled, rewrites the kubeadm etcd static-pod manifest with the full live member list to prevent split-brain on data-dir wipe.
```
