### PR TITLE
feat(csi): add OpenStack Manila CSI driver support

### DIFF
--- a/docs/CSI/manila-csi.md
+++ b/docs/CSI/manila-csi.md
@@ -1,0 +1,91 @@
+# Manila CSI Driver
+
+The Manila CSI driver allows you to provision shared filesystems backed by [OpenStack Manila](https://docs.openstack.org/manila/latest/). It is deployed from the upstream [openstack-manila-csi](https://github.com/kubernetes/cloud-provider-openstack/tree/master/charts/manila-csi-plugin) Helm chart, so Kubespray does not carry a copy of the driver manifests. Only the CephFS share protocol has been tested.
+
+Manila CSI does not mount shares itself: it forwards the node operations to a lower-level CSI driver. For CephFS this is the [ceph-csi](https://github.com/ceph/ceph-csi) node plugin, which Kubespray deploys alongside the chart. The forwarding node plugin must be running before the Manila node plugin, so this role waits for it before installing the chart.
+
+To enable the Manila CSI driver, uncomment the `manila_csi_enabled` option in `group_vars/all/openstack.yml` and set it to `true`. The chart is installed with Helm, so `helm_enabled` must also be set to `true`.
+
+You need to source the OpenStack credentials you use to deploy your machines that will host Kubernetes: `source path/to/your/openstack-rc` or `. path/to/your/openstack-rc`. These credentials are stored in the `csi-manila-secrets` secret and referenced by the storage class.
+
+The control plane node must be able to reach the chart repository `https://kubernetes.github.io/cloud-provider-openstack`, directly or through the configured `http_proxy` / `https_proxy`.
+
+If you want to deploy the Manila storage class, set `persistent_volumes_enabled` in `group_vars/k8s_cluster/k8s_cluster.yml` to `true`, and make sure the share `type` in `manila_storage_classes` matches a share type available in your cloud (`openstack share type list`).
+
+You can now run the Kubespray playbook (cluster.yml) to deploy Kubernetes over OpenStack with the Manila CSI driver enabled.
+
+## Controller replicas
+
+Unlike the Cinder CSI chart, the upstream Manila CSI chart runs the controller plugin as a single-replica StatefulSet with no leader election, so it is not possible to run several active controller replicas. The impact is limited because the controller is not on the data path: running pods keep their mounts if the controller restarts, and only new provisioning, resize and snapshot operations wait for it to come back.
+
+## Scheduling on tainted nodes
+
+Manila shares are mounted by two DaemonSets: the Manila node plugin, deployed by the chart, and the CephFS forwarding plugin. Neither tolerates node taints by default, so they do not run on control planes, and pods scheduled there cannot mount Manila shares.
+
+If you run such workloads on tainted nodes, set `manila_csi_node_tolerations` in your inventory. The value applies to both DaemonSets, so they stay consistent:
+
+```yaml
+manila_csi_node_tolerations:
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule
+```
+
+## Air-gapped installations
+
+The images deployed by the Helm chart follow `kube_image_repo`, and the ceph-csi forwarding plugin image follows `quay_image_repo`. Pointing those two variables at your internal mirror is enough; no Manila-specific override is needed.
+
+The chart itself is still fetched from the repository mentioned above, which must remain reachable from the control plane.
+
+## Usage example
+
+Once the driver is deployed, the Manila and CephFS forwarding pods run in the `kube-system` namespace:
+
+```ShellSession
+$ kubectl -n kube-system get pods | grep -Ei 'manila|cephfs'
+csi-cephfs-nodeplugin-2b9s2                    1/1     Running   0               43h
+csi-cephfs-nodeplugin-zvxt4                    1/1     Running   0               43h
+openstack-manila-csi-controllerplugin-0        4/4     Running   0               43h
+openstack-manila-csi-nodeplugin-8dntg          2/2     Running   0               43h
+openstack-manila-csi-nodeplugin-plvgd          2/2     Running   0               43h
+```
+
+The storage class uses `WaitForFirstConsumer`, so a PVC stays `Pending` until a pod consumes it. Apply the following manifest:
+
+```yaml
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: manila-test
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: manila-csi
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: manila-test
+spec:
+  containers:
+    - name: app
+      image: busybox:1.36
+      command: ["/bin/sh", "-c", "echo ok > /data/test && sleep 3600"]
+      volumeMounts:
+        - mountPath: /data
+          name: manila
+  volumes:
+    - name: manila
+      persistentVolumeClaim:
+        claimName: manila-test
+```
+
+Once the pod is scheduled, the PVC is bound and a share is created in Manila, which you can check with `openstack share list`.
+
+## Using NFS instead of CephFS
+
+The chart also supports NFS. To use it, the forwarding node plugin must be the NFS one instead of ceph-csi, and `manila_csi_values.shareProtocols` must select `NFS`. The generated CSIDriver is then `nfs.manila.csi.openstack.org`, and the storage class provisioner must be set accordingly. This path has not been tested in Kubespray.

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -42,6 +42,7 @@
   * [Azure-csi](/docs/CSI/azure-csi.md)
   * [Cinder-csi](/docs/CSI/cinder-csi.md)
   * [Gcp-pd-csi](/docs/CSI/gcp-pd-csi.md)
+  * [Manila-csi](/docs/CSI/manila-csi.md)
   * [Vsphere-csi](/docs/CSI/vsphere-csi.md)
 * Developers
   * [Ci-setup](/docs/developers/ci-setup.md)

--- a/inventory/sample/group_vars/all/openstack.yml
+++ b/inventory/sample/group_vars/all/openstack.yml
@@ -66,3 +66,14 @@
 #       availability: "nova"
 #     reclaim_policy: "Delete"
 #     volume_binding_mode: "WaitForFirstConsumer"
+
+## To use Manila CSI plugin to provision shared filesystems (CephFS) set this value to true
+## Make sure to source in the openstack credentials, and to enable Helm (helm_enabled: true)
+# manila_csi_enabled: true
+## Version of the openstack-manila-csi Helm chart
+# manila_csi_chart_version: "2.36.0"
+# manila_storage_classes:
+#   - name: "manila-csi"
+#     is_default: false
+#     parameters:
+#       type: "cephfsnative"

--- a/roles/kubernetes-apps/csi_driver/manila/defaults/main.yaml
+++ b/roles/kubernetes-apps/csi_driver/manila/defaults/main.yaml
@@ -1,0 +1,74 @@
+---
+
+# To access Manila, the CSI controller will need credentials to access
+# openstack apis. Per default this values will be
+# read from the environment.
+manila_auth_url: "{{ lookup('env', 'OS_AUTH_URL') }}"
+manila_username: "{{ lookup('env', 'OS_USERNAME') }}"
+manila_password: "{{ lookup('env', 'OS_PASSWORD') }}"
+manila_application_credential_id: "{{ lookup('env', 'OS_APPLICATION_CREDENTIAL_ID') }}"
+manila_application_credential_name: "{{ lookup('env', 'OS_APPLICATION_CREDENTIAL_NAME') }}"
+manila_application_credential_secret: "{{ lookup('env', 'OS_APPLICATION_CREDENTIAL_SECRET') }}"
+manila_region: "{{ lookup('env', 'OS_REGION_NAME') }}"
+manila_tenant_id: "{{ lookup('env', 'OS_TENANT_ID') | default(lookup('env', 'OS_PROJECT_ID'), true) }}"
+manila_tenant_name: "{{ lookup('env', 'OS_TENANT_NAME') | default(lookup('env', 'OS_PROJECT_NAME'), true) }}"
+manila_domain_name: "{{ lookup('env', 'OS_USER_DOMAIN_NAME') }}"
+manila_domain_id: "{{ lookup('env', 'OS_USER_DOMAIN_ID') }}"
+manila_project_domain_name: "{{ lookup('env', 'OS_PROJECT_DOMAIN_NAME') }}"
+manila_cacert: "{{ lookup('env', 'OS_CACERT') }}"
+
+# Manila CSI is deployed from the upstream Helm chart (openstack-manila-csi).
+manila_csi_chart_repo_name: cpo
+manila_csi_chart_repo_url: https://kubernetes.github.io/cloud-provider-openstack
+manila_csi_chart_ref: cpo/openstack-manila-csi
+manila_csi_chart_version: "2.36.0"
+
+# Helm release options.
+manila_csi_helm_wait: true
+manila_csi_helm_wait_timeout: "10m"
+manila_csi_helm_atomic: true
+
+# CephFS forwarding node plugin (ceph-csi), deployed by this role and used by
+# Manila CSI to perform the actual mounts. It is not part of the Helm chart.
+manila_cephfs_fwd_plugin_dir: "/var/lib/kubelet/plugins/cephfs.csi.ceph.com"
+manila_fwd_driver_name: "cephfs.csi.ceph.com"
+manila_log_level: 2
+
+# Image tags for the CSI sidecars deployed by the chart, and tolerations applied
+# to both node plugins (empty by default: they do not run on tainted nodes).
+manila_csi_registrar_image_tag: "v2.15.0"
+manila_csi_provisioner_image_tag: "v5.3.0"
+manila_csi_snapshotter_image_tag: "v8.4.0"
+manila_csi_resizer_image_tag: "v1.14.0"
+manila_csi_node_tolerations: []
+
+# Values passed to the Helm chart. CephFS is the only tested protocol.
+manila_csi_values:
+  shareProtocols:
+    - protocolSelector: CEPHFS
+      fsGroupPolicy: None
+      fwdNodePluginEndpoint:
+        dir: "{{ manila_cephfs_fwd_plugin_dir }}"
+        sockFile: csi.sock
+  csimanila:
+    image:
+      repository: "{{ kube_image_repo }}/provider-os/manila-csi-plugin"
+  nodeplugin:
+    tolerations: "{{ manila_csi_node_tolerations }}"
+    registrar:
+      image:
+        repository: "{{ kube_image_repo }}/sig-storage/csi-node-driver-registrar"
+        tag: "{{ manila_csi_registrar_image_tag }}"
+  controllerplugin:
+    provisioner:
+      image:
+        repository: "{{ kube_image_repo }}/sig-storage/csi-provisioner"
+        tag: "{{ manila_csi_provisioner_image_tag }}"
+    snapshotter:
+      image:
+        repository: "{{ kube_image_repo }}/sig-storage/csi-snapshotter"
+        tag: "{{ manila_csi_snapshotter_image_tag }}"
+    resizer:
+      image:
+        repository: "{{ kube_image_repo }}/sig-storage/csi-resizer"
+        tag: "{{ manila_csi_resizer_image_tag }}"

--- a/roles/kubernetes-apps/csi_driver/manila/tasks/main.yaml
+++ b/roles/kubernetes-apps/csi_driver/manila/tasks/main.yaml
@@ -1,0 +1,58 @@
+---
+- name: Manila CSI Driver | Deploy Manila CSI
+  when: inventory_hostname == groups['kube_control_plane'][0]
+  environment: "{{ proxy_env }}"
+  block:
+    - name: Manila CSI Driver | Copy OpenStack credentials secret
+      template:
+        src: manila-csi-secrets.yml.j2
+        dest: "{{ kube_config_dir }}/manila-csi-secrets.yml"
+        mode: "0640"
+
+    - name: Manila CSI Driver | Apply OpenStack credentials secret
+      kube:
+        kubectl: "{{ bin_dir }}/kubectl"
+        filename: "{{ kube_config_dir }}/manila-csi-secrets.yml"
+        state: latest
+
+    - name: Manila CSI Driver | Copy CephFS forwarding plugin manifests
+      template:
+        src: "{{ item }}.j2"
+        dest: "{{ kube_config_dir }}/{{ item }}"
+        mode: "0644"
+      loop:
+        - cephfs-csi-driver.yml
+        - cephfs-csi-nodeplugin.yml
+      register: manila_cephfs_manifests
+
+    - name: Manila CSI Driver | Apply CephFS forwarding plugin manifests
+      kube:
+        kubectl: "{{ bin_dir }}/kubectl"
+        filename: "{{ kube_config_dir }}/{{ item.item }}"
+        state: latest
+      loop: "{{ manila_cephfs_manifests.results }}"
+      when: not item is skipped
+
+    - name: Manila CSI Driver | Wait for the CephFS forwarding plugin to be ready
+      command: >-
+        {{ bin_dir }}/kubectl -n kube-system rollout status
+        daemonset/csi-cephfs-nodeplugin --timeout=180s
+      changed_when: false
+
+    - name: Manila CSI Driver | Install the Manila CSI Helm chart
+      include_role:
+        name: helm-apps
+      vars:
+        release_common_opts: {}
+        releases:
+          - name: openstack-manila-csi
+            namespace: kube-system
+            chart_ref: "{{ manila_csi_chart_ref }}"
+            chart_version: "{{ manila_csi_chart_version }}"
+            values: "{{ manila_csi_values }}"
+            wait: "{{ manila_csi_helm_wait }}"
+            wait_timeout: "{{ manila_csi_helm_wait_timeout }}"
+            atomic: "{{ manila_csi_helm_atomic }}"
+        repositories:
+          - name: "{{ manila_csi_chart_repo_name }}"
+            url: "{{ manila_csi_chart_repo_url }}"

--- a/roles/kubernetes-apps/csi_driver/manila/templates/cephfs-csi-driver.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/manila/templates/cephfs-csi-driver.yml.j2
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: {{ manila_fwd_driver_name }}
+spec:
+  attachRequired: false
+  podInfoOnMount: true
+  volumeLifecycleModes:
+    - Persistent

--- a/roles/kubernetes-apps/csi_driver/manila/templates/cephfs-csi-nodeplugin.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/manila/templates/cephfs-csi-nodeplugin.yml.j2
@@ -1,0 +1,104 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-cephfs-node-sa
+  namespace: kube-system
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-cephfs-node-role
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-cephfs-node-binding
+subjects:
+  - kind: ServiceAccount
+    name: csi-cephfs-node-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: csi-cephfs-node-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name:  csi-cephfs-nodeplugin
+  namespace: kube-system
+  labels:
+    app: csi-cephfs-nodeplugin
+spec:
+  selector:
+    matchLabels:
+      app: csi-cephfs-nodeplugin
+  template:
+    metadata:
+      labels:
+        app: csi-cephfs-nodeplugin
+    spec:
+      serviceAccountName: csi-cephfs-node-sa
+      priorityClassName: system-node-critical
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: csi-cephfsplugin
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: {{ cephfs_csi_plugin_image_repo }}:{{ cephfs_csi_plugin_image_tag }}
+          imagePullPolicy: {{ k8s_image_pull_policy }}
+          args:
+            - "--nodeid=$(NODE_ID)"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--v={{ manila_log_level | default(2) }}"
+            - "--type=cephfs"
+            - "--nodeserver"
+            - "--drivername={{ manila_fwd_driver_name }}"
+          env:
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: kubelet-dir
+              mountPath: {{ kubelet_directory | default('/var/lib/kubelet') }}
+              mountPropagation: "Bidirectional"
+            - name: keys-dir
+              mountPath: /tmp/csi/keys
+      volumes:
+        - name: socket-dir
+          hostPath:
+            path: {{ kubelet_directory | default('/var/lib/kubelet') }}/plugins/{{ manila_fwd_driver_name }}
+            type: DirectoryOrCreate
+        - name: kubelet-dir
+          hostPath:
+            path: {{ kubelet_directory | default('/var/lib/kubelet') }}
+            type: Directory
+        - name: keys-dir
+          emptyDir: {}
+{% if manila_csi_node_tolerations %}
+      tolerations:
+{{ manila_csi_node_tolerations | to_nice_yaml | indent(8, true) }}
+{% endif %}

--- a/roles/kubernetes-apps/csi_driver/manila/templates/manila-csi-secrets.yml.j2
+++ b/roles/kubernetes-apps/csi_driver/manila/templates/manila-csi-secrets.yml.j2
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: csi-manila-secrets
+  namespace: kube-system
+type: Opaque
+stringData:
+  os-authURL: "{{ manila_auth_url }}"
+  os-region: "{{ manila_region }}"
+{% if manila_application_credential_id | default('', true) | length > 0 %}
+  os-applicationCredentialID: "{{ manila_application_credential_id }}"
+  os-applicationCredentialSecret: "{{ manila_application_credential_secret }}"
+{% else %}
+  os-userName: "{{ manila_username }}"
+  os-password: "{{ manila_password }}"
+  os-projectName: "{{ manila_tenant_name }}"
+{% endif %}
+{% if manila_cacert | default('', true) | length > 0 %}
+  os-certAuthorityPath: "{{ kube_config_dir }}/manila-cacert.pem"
+{% endif %}

--- a/roles/kubernetes-apps/meta/main.yml
+++ b/roles/kubernetes-apps/meta/main.yml
@@ -61,6 +61,13 @@ dependencies:
       - gcp-pd-csi-driver
       - csi-driver
 
+  - role: kubernetes-apps/csi_driver/manila
+    when:
+      - manila_csi_enabled
+    tags:
+      - manila-csi-driver
+      - csi-driver
+
   - role: kubernetes-apps/csi_driver/upcloud
     when:
       - upcloud_csi_enabled

--- a/roles/kubernetes-apps/persistent_volumes/manila-csi/defaults/main.yml
+++ b/roles/kubernetes-apps/persistent_volumes/manila-csi/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+# StorageClass(es) created for Manila CSI. The provisioner name and the secret
+# references are fixed in the template, so only the user-facing bits are exposed
+# here. Override manila_storage_classes in the inventory to change the share
+# type, add classes or set a default class.
+manila_storage_classes:
+  - name: manila-csi
+    is_default: false
+    parameters:
+      type: "cephfsnative"

--- a/roles/kubernetes-apps/persistent_volumes/manila-csi/tasks/main.yml
+++ b/roles/kubernetes-apps/persistent_volumes/manila-csi/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Kubernetes Persistent Volumes | Copy Manila CSI Storage Class template
+  template:
+    src: "manila-csi-storage-class.yml.j2"
+    dest: "{{ kube_config_dir }}/manila-csi-storage-class.yml"
+    mode: "0644"
+  register: manifests
+  when:
+    - inventory_hostname == groups['kube_control_plane'][0]
+
+- name: Kubernetes Persistent Volumes | Add Manila CSI Storage Class
+  kube:
+    name: manila-csi
+    kubectl: "{{ bin_dir }}/kubectl"
+    resource: StorageClass
+    filename: "{{ kube_config_dir }}/manila-csi-storage-class.yml"
+    state: "latest"
+  when:
+    - inventory_hostname == groups['kube_control_plane'][0]
+    - manifests.changed

--- a/roles/kubernetes-apps/persistent_volumes/manila-csi/templates/manila-csi-storage-class.yml.j2
+++ b/roles/kubernetes-apps/persistent_volumes/manila-csi/templates/manila-csi-storage-class.yml.j2
@@ -1,0 +1,25 @@
+{% for class in manila_storage_classes %}
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: "{{ class.name }}"
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "{{ class.is_default | default(false) | ternary("true", "false") }}"
+provisioner: cephfs.manila.csi.openstack.org
+volumeBindingMode: "{{ class.volume_binding_mode | default('WaitForFirstConsumer') }}"
+reclaimPolicy: "{{ class.reclaim_policy | default('Delete') }}"
+parameters:
+{% for key, value in (class.parameters | default({})).items() %}
+  "{{ key }}": "{{ value }}"
+{% endfor %}
+  csi.storage.k8s.io/provisioner-secret-name: "csi-manila-secrets"
+  csi.storage.k8s.io/provisioner-secret-namespace: "kube-system"
+  csi.storage.k8s.io/node-stage-secret-name: "csi-manila-secrets"
+  csi.storage.k8s.io/node-stage-secret-namespace: "kube-system"
+  csi.storage.k8s.io/node-publish-secret-name: "csi-manila-secrets"
+  csi.storage.k8s.io/node-publish-secret-namespace: "kube-system"
+  csi.storage.k8s.io/controller-expand-secret-name: "csi-manila-secrets"
+  csi.storage.k8s.io/controller-expand-secret-namespace: "kube-system"
+allowVolumeExpansion: {{ expand_persistent_volumes | default(false) }}
+{% endfor %}

--- a/roles/kubernetes-apps/persistent_volumes/meta/main.yml
+++ b/roles/kubernetes-apps/persistent_volumes/meta/main.yml
@@ -28,6 +28,13 @@ dependencies:
       - persistent_volumes_gcp_pd_csi
       - gcp-pd-csi-driver
 
+  - role: kubernetes-apps/persistent_volumes/manila-csi
+    when:
+      - manila_csi_enabled
+    tags:
+      - persistent_volumes_manila_csi
+      - manila-csi-driver
+
   - role: kubernetes-apps/persistent_volumes/upcloud-csi
     when:
       - upcloud_csi_enabled

--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -363,6 +363,9 @@ gcp_pd_csi_attacher_image_tag: "v2.1.1-gke.0"
 gcp_pd_csi_resizer_image_tag: "v0.4.0-gke.0"
 gcp_pd_csi_registrar_image_tag: "v1.2.0-gke.0"
 
+cephfs_csi_plugin_image_repo: "{{ quay_image_repo }}/cephcsi/cephcsi"
+cephfs_csi_plugin_image_tag: "v3.11.0"
+
 metallb_speaker_image_repo: "{{ quay_image_repo }}/metallb/speaker"
 metallb_controller_image_repo: "{{ quay_image_repo }}/metallb/controller"
 metallb_version: 0.13.9
@@ -1023,6 +1026,15 @@ downloads:
     checksum: "{{ aws_ebs_csi_plugin_digest_checksum | default(None) }}"
     groups:
       - kube_node
+
+  cephfs_csi_plugin:
+    enabled: "{{ manila_csi_enabled }}"
+    container: true
+    repo: "{{ cephfs_csi_plugin_image_repo }}"
+    tag: "{{ cephfs_csi_plugin_image_tag }}"
+    checksum: "{{ cephfs_csi_plugin_digest_checksum | default(None) }}"
+    groups:
+      - k8s_cluster
 
   metallb_speaker:
     enabled: "{{ metallb_speaker_enabled }}"

--- a/roles/kubespray_defaults/defaults/main/main.yml
+++ b/roles/kubespray_defaults/defaults/main/main.yml
@@ -468,6 +468,7 @@ cinder_csi_enabled: false
 aws_ebs_csi_enabled: false
 azure_csi_enabled: false
 gcp_pd_csi_enabled: false
+manila_csi_enabled: false
 vsphere_csi_enabled: false
 upcloud_csi_enabled: false
 csi_snapshot_controller_enabled: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:

This PR adds support for the OpenStack Manila CSI driver, allowing Kubespray to provision shared filesystems (CephFS) backed by OpenStack Manila.

Following  feedback, the driver is deployed from the upstream `openstack-manila-csi` Helm chart via the generic `helm apps` role, so Kubespray does not maintain any of the driver manifests. A

Three things remain in the role, as they are not part of the chart:

- the OpenStack credentials Secret,
- the StorageClass, in `persistent_volumes/manila-csi` (same layout as Cinder),
- the CephFS forwarding node plugin (ceph-csi). Manila CSI does not mount shares
  itself: it forwards node operations to a lower-level driver, and its node plugin
  probes that endpoint on startup. The role deploys it and waits for its rollout
  before installing the chart.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

- Enabled with `manila_csi_enabled` (disabled by default). Requires `helm_enabled: true`.
- CephFS is the only tested protocol. The chart also supports NFS, which would need
  a different forwarding plugin; this is documented but untested here.
- The chart runs the controller as a single-replica StatefulSet with no leader
  election, unlike the Cinder chart, so multiple active replicas are not possible.
  Documented in `docs/CSI/manila-csi.md`.
- Air-gapped: chart images are mapped onto `kube_image_repo`, the ceph-csi image
  onto `quay_image_repo`, and the latter is registered in the `downloads` dict.
- Tested end to end on a CephFS-backed OpenStack cluster: provisioning, mount and
  volume expansion.

This is my first pull request here! 
This implementation is currently being tested and validated in a client environment, and the manila CSI volume provisioning has been successfully verified. 

Please let me know if any ansible adjustments or formatting fixes are needed!

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add OpenStack Manila CSI driver support (CephFS), deployed from the upstream openstack-manila-csi Helm chart.

```
