### PR TITLE
Fix lint violation: jinja[invalid] to make pre-commit pass

### DIFF
--- a/roles/kubernetes/client/tasks/main.yml
+++ b/roles/kubernetes/client/tasks/main.yml
@@ -75,7 +75,7 @@
         context: "kubernetes-admin-{{ cluster_name }}@{{ cluster_name }}"
         override:
           clusters:
-            - "{{ admin_kubeconfig['clusters'][0] | combine({'name': cluster_name, 'cluster': admin_kubeconfig['clusters'][0]['cluster'] | combine({'server': 'https://' + (external_apiserver_address | ansible.utils.ipwrap) + ':' + (external_apiserver_port | string)})}, recursive=true) }}"
+            - "{{ admin_kubeconfig['clusters'][0] | combine({'name': cluster_name, 'cluster': admin_kubeconfig['clusters'][0]['cluster'] | combine({'server': 'https://' + (external_apiserver_address | string  | ansible.utils.ipwrap) + ':' + (external_apiserver_port | string)})}, recursive=true) }}"
           contexts:
             - "{{ admin_kubeconfig['contexts'][0] | combine({'name': context, 'context': admin_kubeconfig['contexts'][0]['context'] | combine({'cluster': cluster_name})}, recursive=true) }}"
           current-context: "{{ context }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
/kind cleanup


**What this PR does / why we need it**:
You use pre-commit as an early quality gate. For everyone working on the file in question, they would be unable to commit their changes without skipping test(s). This is not ideal because it lets other flaws through more easily. Hence, fix the violation despite the kubernetes guidance being hesitant on fixing lint violations with PRs.

I encountered this while working on #13333 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None.

**Special notes for your reviewer**:
There's an alternative solution to this as well: Ensure only valid IP addresses go through - I *think* that's not what you want because I don't know whether `external_apiserver_address` is guaranteed to be an IP or if it can be a DNS name, given you're prepending `https://` to it.

```diff
-  - "{{ admin_kubeconfig['clusters'][0] | combine({'name': cluster_name, 'cluster': admin_kubeconfig['clusters'][0]['cluster'] | combine({'server': 'https://' + (external_apiserver_address | string | ansible.utils.ipwrap) + ':' + (external_apiserver_port | string)})}, recursive=true) }}"
+  - "{{ admin_kubeconfig['clusters'][0] | combine({'name': cluster_name, 'cluster': admin_kubeconfig['clusters'][0]['cluster'] | combine({'server': 'https://' + (external_apiserver_address | string | ansible.utils.ipaddr | ansible.utils.ipwrap) + ':' + (external_apiserver_port | string)})}, recursive=true) }}"
```

Note that `ansible.utils.ipwrap` can take a list or a string but for this section a string looks like the logical choice.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Example output**:
## before
```
kubespray on  fix-lint-violation [!?] is 📦 v0.1.0 via 🐍 v3.14.6 via ⍱ 🪝 OFF
❯ uv run ansible-lint --offline
WARNING  Ignored exception from ArgsRule.matchtasks while processing playbooks/internal_facts.yml (playbook): attempted relative import with no known parent package
WARNING  Ignored exception from ArgsRule.matchtasks while processing roles/etcd/handlers/backup.yml (handlers): attempted relative import with no known parent package
WARNING  Ignored exception from ArgsRule.matchtasks while processing roles/bootstrap_os/tasks/centos.yml (tasks): attempted relative import with no known parent package
WARNING  Ignored exception from ArgsRule.matchtasks while processing roles/bootstrap_os/tasks/main.yml (tasks): attempted relative import with no known parent package
WARNING  Ignored exception from ArgsRule.matchtasks while processing roles/network_facts/tasks/main.yaml (tasks): attempted relative import with no known parent package
WARNING  Ignored exception from ArgsRule.matchtasks while processing roles/bootstrap_os/tasks/opensuse.yml (tasks): attempted relative import with no known parent package
WARNING  Ignored exception from ArgsRule.matchtasks while processing roles/system_packages/tasks/main.yml (tasks): attempted relative import with no known parent package
WARNING  Ignored exception from ArgsRule.matchtasks while processing roles/bootstrap_os/tasks/rhel.yml (tasks): attempted relative import with no known parent package
WARNING  /Users/Alexander/Documents/Repositories/kubespray/.venv/lib/python3.12/site-packages/jmespath/lexer.py:169 PendingDeprecationWarning deprecated string literal syntax
WARNING  Listing 1 violation(s) that are fatal
jinja[invalid]: An unhandled exception occurred while templating '{'clusters': ["{{ admin_kubeconfig['clusters'][0] | combine({'name': cluster_name, 'cluster': admin_kubeconfig['clusters'][0]['cluster'] | combine({'server': 'https://' + (external_apiserver_address | ansible.utils.ipwrap) + ':' + (external_apiserver_port | string)})}, recursive=true) }}"], 'contexts': ["{{ admin_kubeconfig['contexts'][0] | combine({'name': context, 'context': admin_kubeconfig['contexts'][0]['context'] | combine({'cluster': cluster_name})}, recursive=true) }}"], 'current-context': '{{ context }}'}'. Error was a <class 'ansible.errors.AnsibleFilterError'>, original message: Unrecognized type <<class 'ansible.template.native_helpers.AnsibleUndefined'>> for ipwrap filter <value>[/]
```

## after
```
kubespray on  fix-lint-violation [!?] is 📦 v0.1.0 via 🐍 v3.14.6 via ⍱ 🪝 OFF took 41s
❯ uv run ansible-lint --offline
WARNING  Ignored exception from ArgsRule.matchtasks while processing roles/system_packages/tasks/main.yml (tasks): attempted relative import with no known parent package
WARNING  Ignored exception from ArgsRule.matchtasks while processing roles/bootstrap_os/tasks/main.yml (tasks): attempted relative import with no known parent package
WARNING  Ignored exception from ArgsRule.matchtasks while processing roles/bootstrap_os/tasks/opensuse.yml (tasks): attempted relative import with no known parent package
WARNING  Ignored exception from ArgsRule.matchtasks while processing roles/network_facts/tasks/main.yaml (tasks): attempted relative import with no known parent package
WARNING  Ignored exception from ArgsRule.matchtasks while processing playbooks/internal_facts.yml (playbook): attempted relative import with no known parent package
WARNING  Ignored exception from ArgsRule.matchtasks while processing roles/etcd/handlers/backup.yml (handlers): attempted relative import with no known parent package
WARNING  Ignored exception from ArgsRule.matchtasks while processing roles/bootstrap_os/tasks/rhel.yml (tasks): attempted relative import with no known parent package
WARNING  Ignored exception from ArgsRule.matchtasks while processing roles/bootstrap_os/tasks/centos.yml (tasks): attempted relative import with no known parent package
WARNING  /Users/Alexander/Documents/Repositories/kubespray/.venv/lib/python3.12/site-packages/jmespath/lexer.py:169 PendingDeprecationWarning deprecated string literal syntax

Passed: 0 failure(s), 0 warning(s) in 927 files processed of 1231 encountered. Last profile that met the validation criteria was 'production'.
```