### PR TITLE
Replace injected Ansible fact variables in download and etcd roles

### DIFF
--- a/roles/download/tasks/prep_download.yml
+++ b/roles/download/tasks/prep_download.yml
@@ -72,7 +72,7 @@
     mode: "0755"
     owner: "{{ ansible_ssh_user | default(ansible_user_id) }}"
   when:
-    - ansible_os_family not in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
+    - ansible_facts['os_family'] not in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
 
 - name: Prep_download | Create local cache for files and images on control node
   file:

--- a/roles/etcd/handlers/backup.yml
+++ b/roles/etcd/handlers/backup.yml
@@ -7,7 +7,7 @@
 
 - name: Set Backup Directory
   set_fact:
-    etcd_backup_directory: "{{ etcd_backup_prefix }}/etcd-{{ ansible_date_time.date }}_{{ ansible_date_time.time }}"
+    etcd_backup_directory: "{{ etcd_backup_prefix }}/etcd-{{ ansible_facts['date_time']['date'] }}_{{ ansible_facts['date_time']['time'] }}"
   listen: Restart etcd
 
 - name: Create Backup Directory

--- a/roles/etcd/meta/main.yml
+++ b/roles/etcd/meta/main.yml
@@ -2,8 +2,8 @@
 dependencies:
   - role: adduser
     user: "{{ addusers.etcd }}"
-    when: not (ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk", "ClearLinux"] or is_fedora_coreos)
+    when: not (ansible_facts['os_family'] in ["Flatcar", "Flatcar Container Linux by Kinvolk", "ClearLinux"] or is_fedora_coreos)
   - role: adduser
     user: "{{ addusers.kube }}"
-    when: not (ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk", "ClearLinux"] or is_fedora_coreos)
+    when: not (ansible_facts['os_family'] in ["Flatcar", "Flatcar Container Linux by Kinvolk", "ClearLinux"] or is_fedora_coreos)
   - role: etcd_defaults

--- a/roles/etcd/tasks/upd_ca_trust.yml
+++ b/roles/etcd/tasks/upd_ca_trust.yml
@@ -2,15 +2,15 @@
 - name: Gen_certs | target ca-certificate store file
   set_fact:
     ca_cert_path: |-
-      {% if ansible_os_family == "Debian" -%}
+      {% if ansible_facts['os_family'] == "Debian" -%}
       /usr/local/share/ca-certificates/etcd-ca.crt
-      {%- elif ansible_os_family == "RedHat" -%}
+      {%- elif ansible_facts['os_family'] == "RedHat" -%}
       /etc/pki/ca-trust/source/anchors/etcd-ca.crt
-      {%- elif ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"] -%}
+      {%- elif ansible_facts['os_family'] in ["Flatcar", "Flatcar Container Linux by Kinvolk"] -%}
       /etc/ssl/certs/etcd-ca.pem
-      {%- elif ansible_os_family == "Suse" -%}
+      {%- elif ansible_facts['os_family'] == "Suse" -%}
       /etc/pki/trust/anchors/etcd-ca.pem
-      {%- elif ansible_os_family == "ClearLinux" -%}
+      {%- elif ansible_facts['os_family'] == "ClearLinux" -%}
       /usr/share/ca-certs/etcd-ca.pem
       {%- endif %}
   tags:
@@ -26,12 +26,12 @@
 
 - name: Gen_certs | update ca-certificates (Debian/Ubuntu/SUSE/Flatcar)  # noqa no-handler
   command: update-ca-certificates
-  when: etcd_ca_cert.changed and ansible_os_family in ["Debian", "Flatcar", "Flatcar Container Linux by Kinvolk", "Suse"]
+  when: etcd_ca_cert.changed and ansible_facts['os_family'] in ["Debian", "Flatcar", "Flatcar Container Linux by Kinvolk", "Suse"]
 
 - name: Gen_certs | update ca-certificates (RedHat)  # noqa no-handler
   command: update-ca-trust extract
-  when: etcd_ca_cert.changed and ansible_os_family == "RedHat"
+  when: etcd_ca_cert.changed and ansible_facts['os_family'] == "RedHat"
 
 - name: Gen_certs | update ca-certificates (ClearLinux)  # noqa no-handler
   command: clrtrust add "{{ ca_cert_path }}"
-  when: etcd_ca_cert.changed and ansible_os_family == "ClearLinux"
+  when: etcd_ca_cert.changed and ansible_facts['os_family'] == "ClearLinux"

--- a/roles/etcd_defaults/defaults/main.yml
+++ b/roles/etcd_defaults/defaults/main.yml
@@ -49,7 +49,7 @@ etcd_extra_vars: {}
 ## Etcd is restricted by default to 512M on systems under 4GB RAM, 512MB is not enough for much more than testing.
 ## Set this if your etcd nodes have less than 4GB but you want more RAM for etcd. Set to 0 for unrestricted RAM.
 ## This value is only relevant when deploying etcd with `etcd_deployment_type: docker`
-etcd_memory_limit: "{% if ansible_memtotal_mb < 4096 %}512M{% else %}0{% endif %}"
+etcd_memory_limit: "{% if ansible_facts['memtotal_mb'] < 4096 %}512M{% else %}0{% endif %}"
 
 ## Etcd has a default of 2G for its space quota. If you put a value in etcd_memory_limit which is less than
 ## etcd_quota_backend_bytes, you may encounter out of memory terminations of the etcd cluster. Please check


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

 /kind cleanup

**What this PR does / why we need it**:

This PR updates the download, etcd, and etcd_defaults roles to replace usage of injected Ansible fact variables (`ansible_*`) with `ansible_facts[...]`. This ensures compatibility with upcoming Ansible 2.24 changes, where fact injection will be disabled by default.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to #13208

**Special notes for your reviewer**:

- Changes are limited to the download, etcd, and etcd_defaults roles for focused review.
- Existing logic and behavior are preserved.
- No changes were made to hostvars, ansible_env, connection variables, or set_fact usage.

Roles reviewed with no required changes:
- dynamic_groups
- etcdctl_etcdutl

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
