### PR TITLE
Fix inverted ignore_errors condition causing false failures when scaling etcd-events

### DIFF
--- a/roles/etcd/tasks/configure.yml
+++ b/roles/etcd/tasks/configure.yml
@@ -93,7 +93,7 @@
     name: etcd-events
     state: started
     enabled: true
-  ignore_errors: "{{ etcd_events_cluster_is_healthy.rc != 0 }}"  # noqa ignore-errors
+  ignore_errors: "{{ etcd_events_cluster_is_healthy.rc == 0 }}"  # noqa ignore-errors
   when:
     - ('etcd' in group_names)
     - etcd_events_cluster_setup


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

When scaling a new etcd node into a cluster that uses `etcd_events_cluster_setup: true`, the playbook fails on `Configure | Ensure etcd-events is running` — even when the etcd-events cluster is perfectly healthy. This has been a known pain point for users scaling their control planes, often leading to debugging dead ends.

**The root cause** is a one-character bug on line 96 of `roles/etcd/tasks/configure.yml`:
```yaml
# Before (buggy)
ignore_errors: "{{ etcd_events_cluster_is_healthy.rc != 0 }}"

# After (fixed)
ignore_errors: "{{ etcd_events_cluster_is_healthy.rc == 0 }}"
```

The `!=` should be `==`, matching the identical pattern used for the main etcd service on line 85. This was accidentally flipped in commit 7516fe142 when the `# noqa ignore-errors` comment was added.

**What this means in practice:**
- **Before (broken):** Adding a node to a *healthy* etcd-events cluster → startup errors NOT ignored → playbook fails (false positive)
- **Before (broken):** Adding a node to an *unhealthy* etcd-events cluster → startup errors ARE ignored → real cluster issues get silently swallowed (false negative)
- **After (fixed):** Behavior matches main etcd — transient startup failures on new nodes are only ignored when the existing cluster confirms it is healthy.

**Which issue(s) this PR fixes**:
Fixes #13342

**Special notes for your reviewer**:

This is a tiny diff — literally one character (`!=` → `==`). The correct pattern exists on the very next block above (line 85), confirming it was a copy-paste operator flip. The bug has been in the codebase since commit 7516fe142 (July 2021).

I verified with `git blame` and `git diff` that pre-7516fe142 the code was correct:
```yaml
ignore_errors: "{{ etcd_events_cluster_is_healthy.rc == 0 }}"
```

**Does this PR introduce a user-facing change?**:
```release-note
Fixed an inverted `ignore_errors` condition for the etcd-events service startup that caused false positive failures when scaling new etcd nodes into a healthy etcd-events cluster, and silently suppressed errors when the cluster was unhealthy.
```
