### PR TITLE
fix: typo alico_ipv6 silently breaks IPv6 Calico pool validation

### DIFF
--- a/roles/network_plugin/calico/tasks/check.yml
+++ b/roles/network_plugin/calico/tasks/check.yml
@@ -189,7 +189,7 @@
     calico_pool_conf: '{{ calico_ipv6.stdout | from_json }}'
   when:
     - ipv6_stack | bool
-    - alico_ipv6 is defined
+    - calico_ipv6 is defined
     - calico_ipv6.rc == 0 and calico_ipv6.stdout
   run_once: true
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
@@ -204,7 +204,7 @@
     msg: "Your ipv6 inventory doesn't match the current cluster configuration"
   when:
     - ipv6_stack | bool
-    - calico_pool_ipv6_conf is defined
+    - calico_pool_conf is defined
   run_once: true
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes two bugs in `roles/network_plugin/calico/tasks/check.yml` that cause IPv6 Calico pool configuration validation to be silently skipped when deploying with `ipv6_stack: true`.

**Bug 1 — Typo on line 192:**
The `when` condition reads `alico_ipv6 is defined` (missing leading `c`). The variable registered on line 182 is `calico_ipv6`, so `alico_ipv6` is never defined and Jinja2 evaluates this as `False`. This causes the `set_fact` task that populates `calico_pool_conf` to always be skipped for IPv6.

**Bug 2 — Wrong variable name on line 207:**
The assertion `"Check if ipv6 inventory match current cluster configuration"` gates on `calico_pool_ipv6_conf is defined`, but the `set_fact` on line 189 sets `calico_pool_conf` (without `_ipv6`). The assertion therefore never runs even if Bug 1 were fixed.

The IPv4 equivalent at lines 153-175 works correctly and follows the correct pattern. This fix makes IPv6 validation behave identically.

**Which issue(s) this PR fixes**:

Fixes #13341

**Special notes for your reviewer**:

The fix is minimal — two one-word changes on two lines. No new files, no config changes, no documentation needed.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```