### PR TITLE
[BUG] Fix etcd-events handler throttle to use correct host group

### DIFF
--- a/roles/etcd/handlers/main.yml
+++ b/roles/etcd/handlers/main.yml
@@ -18,9 +18,8 @@
     name: etcd-events
     state: restarted
     daemon_reload: true
-  # TODO: this seems odd. etcd-events should be a different group possibly ?
   when: ('etcd' in group_names)
-  throttle: "{{ groups['etcd'] | length // 2 }}"
+  throttle: "{{ groups['etcd_events'] | default(groups['etcd']) | length // 2 }}"
 
 - name: Wait for etcd up
   uri:


### PR DESCRIPTION
**What this PR does / why we need it:**

The `Restart etcd-events` handler in `roles/etcd/handlers/main.yml` uses `groups['etcd']` for its throttle calculation, which is the main etcd cluster group. The etcd-events cluster is a separate etcd cluster with its own quorum requirements, so it should use its own node count.

Currently, if the etcd-events cluster runs on a different set of nodes (or a different node count) than the main etcd cluster:
- If etcd-events has **fewer nodes** than etcd → throttle is too permissive, risking quorum loss during rolling restart
- If etcd-events has **more nodes** than etcd → throttle is too restrictive, making restarts slower than necessary

The original developer left a TODO comment acknowledging this was wrong but it was never fixed.

**Which issue(s) this PR fixes:**

Fixes #13345

**Does this PR introduce a user-facing change?**

```release-note
[BUG] Fix etcd-events handler throttle to use correct host group (groups['etcd_events']) with fallback to groups['etcd']
```