### PR TITLE
fix(tests): use kube_network_plugin in fedora43-flannel-crio test

### DIFF
--- a/docs/developers/ci.md
+++ b/docs/developers/ci.md
@@ -30,7 +30,7 @@ debian11 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian12 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 debian13 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 fedora42 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
-fedora43 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
+fedora43 |  :white_check_mark: | :x: | :x: | :white_check_mark: | :x: | :x: | :x: |
 flatcar4081 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 openeuler24 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 rockylinux10 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |

--- a/tests/files/fedora43-flannel-crio-collection-scale.yml
+++ b/tests/files/fedora43-flannel-crio-collection-scale.yml
@@ -1,6 +1,6 @@
 ---
 cloud_image: fedora-43
-network_plugin: flannel
+kube_network_plugin: flannel
 container_manager: crio
 
 cluster_layout:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
tests/files/fedora43-flannel-crio-collection-scale.yml set network_plugin: flannel on line 3, but Kubespray roles read kube_network_plugin (defaulting to calico in roles/kubespray_defaults/defaults/main/main.yml:216). The wrong variable created an Ansible var that no role ever consumed. The test silently ran with Calico instead of Flannel, giving false CI coverage.

All other flannel test configs correctly use kube_network_plugin: flannel (ubuntu24-flannel.yml, ubuntu24-flannel-ha.yml, ubuntu24-flannel-ha-once.yml, ubuntu24-flannel-collection.yml).

**Which issue(s) this PR fixes:**
Fixes #13349

**Special notes for your reviewer:**
One-line variable rename in a test config. No functional code changes. Bug has been present since the file was created.

**Does this PR introduce a user-facing change?:**
```release-note
NONE
```