### PR TITLE
Remove dangling 'list' from mutually_exclusive in kube.py

### DIFF
--- a/plugins/modules/kube.py
+++ b/plugins/modules/kube.py
@@ -325,9 +325,8 @@ def main():
             log_level=dict(default=0, type='int'),
             state=dict(default='present', choices=['present', 'absent', 'latest', 'reloaded', 'stopped', 'exists']),
             recursive=dict(default=False, type='bool'),
-            ),
-            mutually_exclusive=[['filename', 'list']]
-        )
+        ),
+    )
 
     changed = False
 


### PR DESCRIPTION
/kind bug

What this PR does / why we need it:
Removes dangling 'list' from mutually_exclusive in
plugins/modules/kube.py:329. The string 'list' references a
parameter that does not exist in argument_spec — the constraint
can never trigger. This is dead code left from an incomplete
feature implementation.

Which issue(s) this PR fixes:
Fixes #13351

Special notes for your reviewer:
No functional change. The dead constraint has been inert for
~3 years since the file was introduced in commit acbf44a1b.

Does this PR introduce a user-facing change?:
```release-note
NONE
```