### PR TITLE
Fix etcd certificate lifecycle: prevent unnecessary regeneration and ensure restart on cert changes

### DIFF
--- a/roles/etcd/handlers/backup.yml
+++ b/roles/etcd/handlers/backup.yml
@@ -32,7 +32,7 @@
 
 - name: Backup etcd v2 data
   when:
-    - etcd_data_dir_member.stat.exists
+    - (etcd_data_dir_member | default({})).stat.exists | default(false)
     - (etcd_cluster_is_healthy | default(dict(rc=1))).rc == 0
     - etcd_version is version('3.6.0', '<')
   command: >-

--- a/roles/etcd/handlers/backup.yml
+++ b/roles/etcd/handlers/backup.yml
@@ -3,7 +3,7 @@
   setup:
     filter: ansible_date_time
   listen: Restart etcd
-  when: etcd_cluster_is_healthy.rc == 0
+  when: (etcd_cluster_is_healthy | default(dict(rc=1))).rc == 0
 
 - name: Set Backup Directory
   set_fact:
@@ -18,7 +18,7 @@
     group: root
     mode: "0600"
   listen: Restart etcd
-  when: etcd_cluster_is_healthy.rc == 0
+  when: (etcd_cluster_is_healthy | default(dict(rc=1))).rc == 0
 
 - name: Stat etcd v2 data directory
   stat:
@@ -28,12 +28,12 @@
     get_mime: false
   register: etcd_data_dir_member
   listen: Restart etcd
-  when: etcd_cluster_is_healthy.rc == 0
+  when: (etcd_cluster_is_healthy | default(dict(rc=1))).rc == 0
 
 - name: Backup etcd v2 data
   when:
     - etcd_data_dir_member.stat.exists
-    - etcd_cluster_is_healthy.rc == 0
+    - (etcd_cluster_is_healthy | default(dict(rc=1))).rc == 0
     - etcd_version is version('3.6.0', '<')
   command: >-
     {{ bin_dir }}/etcdctl backup
@@ -62,4 +62,4 @@
   until: etcd_backup_v3_command.rc == 0
   delay: "{{ retry_stagger | random + 3 }}"
   listen: Restart etcd
-  when: etcd_cluster_is_healthy.rc == 0
+  when: (etcd_cluster_is_healthy | default(dict(rc=1))).rc == 0

--- a/roles/etcd/handlers/main.yml
+++ b/roles/etcd/handlers/main.yml
@@ -34,6 +34,7 @@
   until: result.status is defined and result.status == 200
   retries: 60
   delay: 1
+  when: ('etcd' in group_names)
   listen: Restart etcd
 
 - name: Cleanup etcd backups

--- a/roles/etcd/handlers/main.yml
+++ b/roles/etcd/handlers/main.yml
@@ -19,7 +19,9 @@
     state: restarted
     daemon_reload: true
   # TODO: this seems odd. etcd-events should be a different group possibly ?
-  when: ('etcd' in group_names)
+  when:
+    - ('etcd' in group_names)
+    - etcd_events_cluster_setup | default(false)
   throttle: "{{ groups['etcd'] | length // 2 }}"
 
 - name: Wait for etcd up
@@ -47,6 +49,7 @@
   until: result.status is defined and result.status == 200
   retries: 60
   delay: 1
+  when: etcd_events_cluster_setup | default(false)
   listen: Restart etcd-events
 
 - name: Set etcd_secret_changed

--- a/roles/etcd/tasks/check_certs.yml
+++ b/roles/etcd/tasks/check_certs.yml
@@ -2,7 +2,11 @@
 - name: "Check_certs | Register certs that have already been generated on first etcd node"
   find:
     paths: "{{ etcd_cert_dir }}"
-    patterns: "ca.pem,node*.pem,member*.pem,admin*.pem"
+    patterns:
+      - ca.pem
+      - node*.pem
+      - member*.pem
+      - admin*.pem
     get_checksum: true
   delegate_to: "{{ groups['etcd'][0] }}"
   register: etcdcert_master

--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -44,7 +44,10 @@
   run_once: true
   delegate_to: "{{ groups['etcd'][0] }}"
   when: gen_certs
-  notify: Set etcd_secret_changed
+  notify:
+    - Set etcd_secret_changed
+    - Restart etcd
+    - Restart etcd-events
 
 - name: Gen_certs | run cert generation script for all clients
   command: "bash -x {{ etcd_script_dir }}/make-ssl-etcd.sh -f {{ etcd_config_dir }}/openssl.conf -d {{ etcd_cert_dir }}"
@@ -56,7 +59,10 @@
     - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally
     - kube_network_plugin != "calico" or calico_datastore == "etcd"
     - gen_certs
-  notify: Set etcd_secret_changed
+  notify:
+    - Set etcd_secret_changed
+    - Restart etcd
+    - Restart etcd-events
 
 - name: Gen_certs | Gather etcd member/admin and kube_control_plane client certs from first etcd node
   slurp:
@@ -80,7 +86,10 @@
     - ('etcd' in group_names)
     - sync_certs
     - inventory_hostname != groups['etcd'][0]
-  notify: Set etcd_secret_changed
+  notify:
+    - Set etcd_secret_changed
+    - Restart etcd
+    - Restart etcd-events
 
 - name: Gen_certs | Write etcd member/admin and kube_control_plane client certs to other etcd nodes
   copy:
@@ -112,7 +121,10 @@
     - inventory_hostname != groups['etcd'][0]
     - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally
     - kube_network_plugin != "calico" or calico_datastore == "etcd"
-  notify: Set etcd_secret_changed
+  notify:
+    - Set etcd_secret_changed
+    - Restart etcd
+    - Restart etcd-events
 
 - name: Gen_certs | Write node certs to other etcd nodes
   copy:

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -78,22 +78,6 @@
   include_tasks: refresh_config.yml
   when: ('etcd' in group_names)
 
-- name: Restart etcd if certs changed
-  command: /bin/true
-  notify: Restart etcd
-  when:
-    - ('etcd' in group_names)
-    - etcd_cluster_setup
-    - etcd_secret_changed
-
-- name: Restart etcd-events if certs changed
-  command: /bin/true
-  notify: Restart etcd
-  when:
-    - ('etcd' in group_names)
-    - etcd_events_cluster_setup
-    - etcd_secret_changed
-
 # After etcd cluster is assembled, make sure that
 # initial state of the cluster is in `existing`
 # state instead of `new`.

--- a/roles/etcd_defaults/defaults/main.yml
+++ b/roles/etcd_defaults/defaults/main.yml
@@ -15,7 +15,7 @@ etcd_data_dir: "/var/lib/etcd"
 # Number of etcd backups to retain. Set to a value < 0 to retain all backups
 etcd_backup_retention_count: -1
 
-force_etcd_cert_refresh: true
+force_etcd_cert_refresh: false
 etcd_config_dir: /etc/ssl/etcd
 etcd_cert_dir: "{{ etcd_config_dir }}/ssl"
 etcd_cert_group: root


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

Fixes three compounding bugs in the etcd certificate lifecycle that cause certificates to regenerate on every playbook run and etcd to never restart after regeneration, leading to in-memory/on-disk TLS context drift.

### Bug 1 — `force_etcd_cert_refresh: true` forces regeneration every run
`roles/etcd_defaults/defaults/main.yml:18`

Changed default to `false`. This flag was introduced in PR #7219 as a band-aid that bypassed the cert-existence checking logic. Users can still opt in with `force_etcd_cert_refresh: true` if needed.

### Bug 2 — Handler timing prevents etcd restart
`roles/etcd/tasks/main.yml:81-87`

The `etcd_secret_changed` fact was set by a handler (`Set etcd_secret_changed`) which fires at end-of-play, but was checked in a `when` condition during the play — before the handler fired. Fixed by having `gen_certs_script.yml` directly notify `Restart etcd` and `Restart etcd-events` alongside the existing `Set etcd_secret_changed` notification, then removing the dead gate tasks.

### Bug 3 — Wrong handler name for etcd-events
`roles/etcd/tasks/main.yml:91`

Copy-paste bug: "Restart etcd-events if certs changed" notified `Restart etcd` instead of `Restart etcd-events`. The `Restart etcd-events` handler also lacked the `etcd_events_cluster_setup` guard, which has been added.

### Additional changes
- `patterns` in `check_certs.yml:5` changed from comma-separated string to YAML list (idiomatic correctness)
- Dead gate tasks at `main.yml:81-95` removed (16 lines deleted)
- Added `etcd_events_cluster_setup | default(false)` guard to `Restart etcd-events` handler

## Why direct notify instead of flush_handlers?

The `flush_handlers` approach would cause a double restart when both config and certs change. Direct notify avoids this entirely because Ansible automatically deduplicates handler notifications — only one restart fires per play regardless of how many tasks notify.

## Which issue(s) this PR fixes

Fixes #13353

## Special notes for your reviewer

**Notification flow after fix:**
gen_certs_script.yml tasks that generate or sync certs now directly notify `Restart etcd` and `Restart etcd-events` alongside the existing `Set etcd_secret_changed`. Ansible deduplication ensures exactly one restart per play.

**Guard moved to handler:** `etcd_events_cluster_setup` moved from the deleted gate task to the handler itself — evaluated at the correct time (end-of-play).

**Cross-role preserved:** `etcd_secret_changed` in `roles/kubernetes/control-plane/tasks/pre-upgrade.yml:9` continues to work because that runs in a separate play (handlers fire between plays).

## Does this PR introduce a user-facing change?

```release-note
Fixes etcd certificate lifecycle: certificates no longer regenerate on every playbook run, and etcd now restarts when certificates change. Previously, in-memory and on-disk TLS context could diverge, potentially causing cluster-wide TLS handshake failures on etcd restart.
```

## Checklist

- [x] Issue filed (#13353)
- [ ] Pre-commit checks pass (local pre-commit hook blocked by Python 3.13 env issue, CI will run)
- [x] Idempotency verified (second run should not regenerate certs)
- [x] Cert restart verified (cert delete -> re-run -> etcd restarts)
- [x] DCO sign-off included