### PR TITLE
Fix post-remove node deletion silently skipped due to cross-play variable scoping

### DIFF
--- a/roles/remove-node/post-remove/tasks/main.yml
+++ b/roles/remove-node/post-remove/tasks/main.yml
@@ -1,11 +1,17 @@
 ---
-- name: Remove-node | Delete node
+- name: post-remove | Get current kubernetes nodes
+  command: "{{ kubectl }} get nodes -o jsonpath='{.items[*].metadata.name}'"
+  delegate_to: "{{ groups['kube_control_plane'] | first }}"
+  register: current_k8s_nodes
+  when: groups['kube_control_plane'] | length > 0
+  changed_when: false
+
+- name: post-remove | Delete node
   command: "{{ kubectl }} delete node {{ kube_override_hostname }}"
   delegate_to: "{{ groups['kube_control_plane'] | first }}"
   when:
     - groups['kube_control_plane'] | length > 0
-    # ignore servers that are not nodes
-    - ('k8s_cluster' in group_names) and kube_override_hostname in nodes.stdout_lines
+    - kube_override_hostname in current_k8s_nodes.stdout.split()
   retries: "{{ delete_node_retries }}"
   # Sometimes the api-server can have a short window of indisponibility when we delete a control plane node
   delay: "{{ delete_node_delay_seconds }}"


### PR DESCRIPTION
## What this PR does / why we need it

When removing a node via `ansible-playbook playbooks/remove_node.yml -e node=my-node`, the `kubectl delete node` task in the "Post node removal" play is silently skipped. The node is removed from etcd and reset locally, but the Kubernetes Node object persists as an orphaned `NotReady` node.

This PR makes the `post-remove` role **self-contained** by fetching the current node list locally within the same play scope, instead of relying on a `register` variable from a different play that was never in scope.

## Which issue(s) this PR fixes

Fixes #13355

## Root Cause

In `playbooks/remove_node.yml`, the workflow is split into separate plays. The `register: nodes` in `roles/remove_node/pre_remove/tasks/main.yml` stores the result in `hostvars[inventory_hostname]` for the "Reset node" play only. When the "Post node removal" play evaluates `kube_override_hostname in nodes.stdout_lines`, `nodes` is undefined — the `when` condition fails, and `kubectl delete node` never executes.

This was introduced in PR #9244 (commit `ad7cefa35`) when the author added `inventory_hostname in nodes.stdout_lines` as a guard but incorrectly assumed the variable was accessible across different play scopes.

## What this PR changes

Changed 1 file: `roles/remove-node/post-remove/tasks/main.yml` (9 insertions, 3 deletions)

**Before:** The delete task relied on `nodes.stdout_lines` — a `register` variable from a different play scope, which was always undefined.

**After:** Added a `kubectl get nodes` task that fetches the current node list within the same play scope. The delete task uses this self-contained result (`current_k8s_nodes.stdout.split()`) for its `when` condition. The `.split()` ensures exact hostname matching, preventing false positives from substring matches (e.g. `"node"` matching `"node10"`).

## Alternative approaches considered

1. **Option A (chosen):** Self-contained post-remove — fetch node list locally. Preserves the 3-play architectural separation (Prep -> Reset -> Cleanup), makes the role independently functional for direct importers.
2. **Option B:** Merge `kubectl delete node` into `pre_remove` role. Rejected because it breaks the logical separation of concerns and would require moving role defaults.

## Special notes for reviewers

- The 3-play structure (Validate -> Reset -> Post-remove) is preserved unchanged
- The `post-remove` role defaults (`delete_node_retries`, `delete_node_delay_seconds`) remain in the same role scope and are unaffected
- The `retries`/`until` loop is kept for handling transient API server blips during control plane node deletion

## Release note

```release-note
Fix kubectl delete node in remove_node.yml being silently skipped due to undefined cross-play registered variable. The post-remove role now fetches the node list locally within the same play scope, ensuring the node is always deleted from the cluster on removal.
```