### PR TITLE
fix: ExtendWebSocketsToKubelet when container_manager set docker

### DIFF
--- a/.gitlab-ci/kubevirt.yml
+++ b/.gitlab-ci/kubevirt.yml
@@ -70,7 +70,6 @@ pr-flakey:
     matrix:
       - TESTCASE:
           - flatcar4081-calico # https://github.com/kubernetes-sigs/kubespray/issues/12309
-          - openeuler24-calico # https://github.com/kubernetes-sigs/kubespray/issues/12877
 
 # The ubuntu24-calico-all-in-one jobs are meant as early stages to prevent running the full CI if something is horribly broken
 ubuntu24-calico-all-in-one:
@@ -109,6 +108,7 @@ pr_full:
           - fedora42-crio
           - fedora43-calico-swap-selinux
           - fedora43-crio
+          - openeuler24-calico # https://github.com/kubernetes-sigs/kubespray/issues/12877
           - ubuntu24-calico-ha-wireguard
           - ubuntu24-flannel-ha
           - ubuntu24-flannel-ha-once

--- a/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
+++ b/roles/kubernetes/control-plane/templates/kubeadm-config.v1beta4.yaml.j2
@@ -586,9 +586,18 @@ clusterDNS:
 {% for dns_address in kubelet_cluster_dns %}
 - {{ dns_address }}
 {% endfor %}
-{% if kubelet_feature_gates or kube_feature_gates %}
+{% set disable_websockets_to_kubelet = (container_manager == 'docker' and kube_version is version('1.36.0', '>=')) %}
 {% set feature_gates = ( kubelet_feature_gates | default(kube_feature_gates, true) ) %}
+{% if disable_websockets_to_kubelet %}
+{% set feature_gates = feature_gates | reject('search', '^ExtendWebSocketsToKubelet=') | list %}
+{% endif %}
+{% if feature_gates or disable_websockets_to_kubelet %}
 featureGates:
+{%   if disable_websockets_to_kubelet %}
+  # cri-dockerd does not support WebSocket streaming
+  # https://github.com/kubernetes-sigs/kubespray/issues/13360
+  ExtendWebSocketsToKubelet: false
+{%   endif %}
 {%   for feature in feature_gates %}
   {{ feature | replace("=", ": ") }}
 {%   endfor %}

--- a/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
@@ -81,9 +81,19 @@ resolvConf: "{{ kube_resolv_conf }}"
 {% if kubelet_config_extra_args %}
 {{ kubelet_config_extra_args | to_nice_yaml(indent=2) }}
 {% endif %}
-{% if kubelet_feature_gates or kube_feature_gates %}
+{% set disable_websockets_to_kubelet = (container_manager == 'docker' and kube_version is version('1.36.0', '>=')) %}
+{% set kubelet_gates = (kubelet_feature_gates | default(kube_feature_gates, true)) %}
+{% if disable_websockets_to_kubelet %}
+{% set kubelet_gates = kubelet_gates | reject('search', '^ExtendWebSocketsToKubelet=') | list %}
+{% endif %}
+{% if kubelet_gates or disable_websockets_to_kubelet %}
 featureGates:
-{% for feature in (kubelet_feature_gates | default(kube_feature_gates, true)) %}
+{% if disable_websockets_to_kubelet %}
+  # cri-dockerd does not support WebSocket streaming
+  # https://github.com/kubernetes-sigs/kubespray/issues/13360
+  ExtendWebSocketsToKubelet: false
+{% endif %}
+{% for feature in kubelet_gates %}
   {{ feature | replace("=", ": ") }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

Disabled the FG ExtendWebSocketsToKubelet when container_manager set docker.

**Which issue(s) this PR fixes**:

Related #13360

**Special notes for your reviewer**:

This PR has AI assistent. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
ExtendWebSocketsToKubelet set false when container_manager is docker
```
