### PR TITLE
k8s-certs-renew: derive next run from calendar to stop forced monthly renewal

### DIFF
--- a/roles/kubernetes/control-plane/templates/k8s-certs-renew.sh.j2
+++ b/roles/kubernetes/control-plane/templates/k8s-certs-renew.sh.j2
@@ -5,13 +5,30 @@ echo "## Check Expiration before renewal ##"
 {{ bin_dir }}/kubeadm certs check-expiration
 
 days_buffer=7 # set a time margin, because we should not renew at the last moment
-next_time=$(systemctl show k8s-certs-renew.timer  -p NextElapseUSecRealtime --value)
-
+# Derive the next scheduled run from the calendar rather than the timer's
+# NextElapseUSecRealtime: systemd clears that property while the service the timer
+# triggered is still running, so it is always empty here and the expiry comparison
+# below is skipped, forcing a renewal on every timer fire (see #13072). Fall back to
+# the timer property if systemd-analyze cannot resolve the calendar.
+next_time=$(LC_ALL=C systemd-analyze calendar "{{ auto_renew_certificates_systemd_calendar }}" 2>/dev/null | sed -n 's/^[[:space:]]*Next elapse:[[:space:]]*//p')
 if [ "${next_time}" == "" ]; then
+	next_time=$(systemctl show k8s-certs-renew.timer -p NextElapseUSecRealtime --value)
+fi
+
+# Convert the next scheduled run into an epoch, adding the safety buffer. Guard the
+# parse: systemd-analyze prints "Next elapse: never" for a calendar with no future run,
+# and any other unparseable value must also fall through to a direct renewal. Without
+# this guard an unparseable next_time leaves target_time empty, the arithmetic below
+# yields a large negative threshold, and the script exits without ever renewing.
+target_time=""
+if [ "${next_time}" != "" ]; then
+	target_time=$(date -d "${next_time} + ${days_buffer} days" +%s 2>/dev/null) || target_time=""
+fi
+
+if [ "${target_time}" == "" ]; then
 	echo "## Skip expiry comparison due to fail to parse next elapse from systemd calendar,do renewal directly ##"
 else
 	current_time=$(date +%s)
-	target_time=$(date -d "${next_time} + ${days_buffer} days" +%s) # $next_time - $days_buffer days
 	expiry_threshold=$(( ${target_time} - ${current_time} ))
 	expired_certs=$({{ bin_dir }}/kubeadm certs check-expiration -o jsonpath="{.certificates[?(@.residualTime<${expiry_threshold}.0)]}")
     if [ "${expired_certs}" == "" ];then


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`k8s-certs-renew.sh` decided whether to renew control-plane certificates by reading the next scheduled run from the timer's `NextElapseUSecRealtime` property. systemd clears that property while the service the timer triggered is still running, so it is **always empty during the script's own execution**. The empty value made the script take the "skip expiry comparison, renew directly" branch and run `kubeadm certs renew all` on **every** timer fire — effectively renewing all control-plane certificates monthly (and restarting the control-plane pods) instead of only when they are close to expiry.

This computes the next elapse from the calendar spec with `systemd-analyze calendar` instead, which is independent of the timer's activation state, so the expiry comparison works as intended. If `systemd-analyze` cannot resolve the calendar, it falls back to the previous `NextElapseUSecRealtime` lookup.

It also guards the date parse: `systemd-analyze` prints `Next elapse: never` for a calendar with no future run (e.g. a bounded one-shot override), and any unparseable `next_time` must fall through to a direct renewal as well. Without that guard an empty `target_time` produces a large negative expiry threshold and the script would exit **without renewing at all** — worse than the original bug. With the guard, an unresolvable schedule degrades to the pre-existing "renew directly" behavior.

**Which issue(s) this PR fixes**:

Fixes #13072

**Special notes for your reviewer**:

- This restores the *intended* behavior. The expiry-comparison path was effectively dead before this change (it was always skipped), so in practice renewals become roughly annual instead of monthly and the monthly control-plane pod restart stops.
- `systemd-analyze calendar` has existed since systemd v235; the `Next elapse:` label is unchanged from v239 through current. On systemd too old to have the verb (e.g. Amazon Linux 2 / systemd 219), the command produces no output, `next_time` is empty, and the script falls back exactly to today's behavior — no regression.
- Verified on a systemd 252 host. The single quoted calendar spec always yields exactly one `Next elapse:` line, `sed` extracts it, and `date -d "${next_time} + ${days_buffer} days"` parses it (including a trailing timezone abbreviation and numeric offsets such as `+0330`). Branch behavior with a mocked `kubeadm`:

  | calendar spec | cert state | result |
  | --- | --- | --- |
  | default monthly | far from expiry (300d) | skip renew, exit 0 |
  | default monthly | near expiry (5d) | proceed to renew |
  | past one-shot (`Next elapse: never`) | far from expiry | renew directly |
  | invalid spec (empty) | far from expiry | renew directly |

- One user-visible side effect worth calling out: because of the bug, `systemctl start k8s-certs-renew.service` used to be a guaranteed force-renew. It is now conditional on expiry. The explicit force path remains `kubeadm certs renew all`.
- These templated shell scripts don't have a unit-test harness in the repo (shellcheck CI matches `*.sh`, not `*.sh.j2`), so this was verified manually as above; happy to add a test if reviewers would like one in a particular form.
- Approach suggested by @zhenliangliang in the issue discussion.
- Parts of this change were drafted with the assistance of generative AI; I have reviewed, understand, and tested all of it.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed the `k8s-certs-renew` service renewing all control-plane certificates on every monthly timer fire; certificates are now renewed only when they are close to expiry, as intended.
```
