### PR TITLE
Add containerd.runtime.extra_args configuration

### DIFF
--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -59,7 +59,17 @@ oom_score = {{ containerd_oom_score }}
 {% if runtime.base_runtime_spec is defined %}
          base_runtime_spec = "{{ containerd_cfg_dir }}/{{ runtime.base_runtime_spec }}"
 {% endif %}
-
+{% if runtime.extra_args is defined %}
+{% for key, value in runtime.extra_args.items() %}
+{% if value is string %}
+         {{ key }} = "{{ value }}"
+{% elif value is boolean %}
+         {{ key }} = {{ value | lower }}
+{% else %}
+         {{ key }} = {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
          [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.{{ runtime.name }}.options]
 {% for key, value in runtime.options.items() %}
 {% if value | string != "true" and value | string != "false" %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds the ability to configure containerd runtime options. Our main use case was to enable the `cgroup_writable` option, but I tried to generalize so that the rest of the options can be included. `cgroups_writable` specifically is also relevant for [KEP 5474](https://www.kubernetes.dev/resources/keps/5474/) and is needed for running specific kinds of workloads in Kubernetes (in our case it was FreeIPA).

Example of usage:

```
containerd_runc_runtime:
  name: runc
  type: "io.containerd.runc.v2"
  base_runtime_spec: cri-base.json
  extra_args:
    cgroup_writable: true
  options:
    Root: ""
    SystemdCgroup: "{{ containerd_use_systemd_cgroup | ternary('true', 'false') }}"
    BinaryName: "{{ bin_dir }}/runc"
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Did not find any relevant issues.

**Special notes for your reviewer**:

* The name could be changed, I just couldn't think of a better one, however I could see confusion arising between this and `containerd_extra_runtime_args`.
* I'm not sure if this should be also added to the containerd v.1 template.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
containerd runtime options can be configured under  `runtime.extra_args`
```
