### PR TITLE
fix: correct CiliumBGPNodeConfigOverride CRD wait condition and deprecate legacy BGP Peering Policy

### DIFF
--- a/docs/CNI/cilium.md
+++ b/docs/CNI/cilium.md
@@ -172,6 +172,10 @@ For further information, check [BGP Control Plane Resources documentation](https
 
 ### BGP Peering Policies (Legacy < v1.16)
 
+> **Warning:** The `cilium_bgp_peering_policies` variable uses the deprecated `CiliumBGPPeeringPolicy` (`cilium.io/v2alpha1`) CRD.
+> Starting with Cilium v1.16, this CRD is deprecated and generates warnings in Cilium logs.
+> Migrate to the new BGP v2 API using `cilium_bgp_cluster_configs`, `cilium_bgp_peer_configs`, `cilium_bgp_advertisements`, and `cilium_bgp_node_config_overrides`.
+
 Cilium's BGP Peering Policies can be configured with the `cilium_bgp_peering_policies` variable:
 
 ```yml

--- a/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
+++ b/inventory/sample/group_vars/k8s_cluster/k8s-net-cilium.yml
@@ -334,7 +334,9 @@ cilium_l2announcements: false
 #           - name: "peer-65000-tor2"
 #             localAddress: fd00:11:0:2::2
 
-# -- Configure BGP Peers (Legacy v1.16+)
+# -- Configure BGP Peers (Legacy < v1.16)
+# Deprecated: cilium_bgp_peering_policies uses the v2alpha1 CiliumBGPPeeringPolicy CRD which is deprecated in Cilium v1.16+.
+# Use the new bgpv2 API variables instead: cilium_bgp_cluster_configs, cilium_bgp_peer_configs, cilium_bgp_advertisements, and cilium_bgp_node_config_overrides.
 # cilium_bgp_peering_policies:
 #   - name: "01-bgp-peering-policy"
 #     spec:

--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -302,6 +302,8 @@ cilium_bgp_advertisements: []
 cilium_bgp_node_config_overrides: []
 
 # -- Configure BGP Peers (Legacy < v1.16)
+# Deprecated: cilium_bgp_peering_policies uses the v2alpha1 CiliumBGPPeeringPolicy CRD which is deprecated in Cilium v1.16+.
+# Migrate to cilium_bgp_cluster_configs, cilium_bgp_peer_configs, cilium_bgp_advertisements, and cilium_bgp_node_config_overrides.
 cilium_bgp_peering_policies: []
 
 # -- Whether to enable CNP status updates.

--- a/roles/network_plugin/cilium/tasks/apply.yml
+++ b/roles/network_plugin/cilium/tasks/apply.yml
@@ -212,7 +212,7 @@
   failed_when: false
   when:
     - inventory_hostname == groups['kube_control_plane'][0]
-    - cilium_bgp_advertisements is defined and (cilium_bgp_advertisements|length>0)
+    - cilium_bgp_node_config_overrides is defined and (cilium_bgp_node_config_overrides|length>0)
 
 - name: Cilium | Create CiliumBGPNodeConfigOverride manifests
   template:


### PR DESCRIPTION
Fixes #12819

- Fix copy-paste bug where \`cilium_bgp_advertisements\` was incorrectly used instead of \`cilium_bgp_node_config_overrides\` when waiting for the CiliumBGPNodeConfigOverride CRD to be present. This caused the CRD readiness check to be skipped when only \`cilium_bgp_node_config_overrides\` was configured, potentially leading to failures when applying BGP node config overrides.

- Add deprecation notices to docs, sample inventory, and defaults to guide users away from the legacy v2alpha1 \`CiliumBGPPeeringPolicy\` toward the supported BGP v2 API variables (\`cilium_bgp_cluster_configs\`, \`cilium_bgp_peer_configs\`, \`cilium_bgp_advertisements\`, and \`cilium_bgp_node_config_overrides\`).

```release-note
cilium: fix CiliumBGPNodeConfigOverride CRD wait condition to use the correct variable
cilium: add deprecation notices for legacy CiliumBGPPeeringPolicy (v2alpha1) and guide users to the new BGP v2 API variables
```
