### PR TITLE
fix: ensure consistent etcd certificate permissions on first etcd node

### DIFF
--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -58,7 +58,7 @@
     - gen_certs
   notify: Set etcd_secret_changed
 
-- name: Gen_certs | Ensure consistent etcd certificate permissions on first etcd node
+- name: Gen_certs | Ensure core etcd certificate permissions on first etcd node
   ansible.builtin.file:
     path: "{{ item }}"
     owner: "{{ etcd_owner }}"
@@ -73,13 +73,31 @@
         '{{ etcd_cert_dir }}/member-{{ node }}.pem',
         '{{ etcd_cert_dir }}/member-{{ node }}-key.pem',
         {% endfor %}]"
-    - "[{% for node in groups['k8s_cluster'] %}
+    - "[{% for node in groups['kube_control_plane'] %}
         '{{ etcd_cert_dir }}/node-{{ node }}.pem',
         '{{ etcd_cert_dir }}/node-{{ node }}-key.pem',
         {% endfor %}]"
   run_once: true
   delegate_to: "{{ groups['etcd'][0] }}"
   when: gen_certs
+
+- name: Gen_certs | Ensure all-node client certificate permissions on first etcd node
+  ansible.builtin.file:
+    path: "{{ item }}"
+    owner: "{{ etcd_owner }}"
+    group: "{{ etcd_cert_group }}"
+    mode: "0640"
+  with_items:
+    - "[{% for node in groups['k8s_cluster'] %}
+        '{{ etcd_cert_dir }}/node-{{ node }}.pem',
+        '{{ etcd_cert_dir }}/node-{{ node }}-key.pem',
+        {% endfor %}]"
+  run_once: true
+  delegate_to: "{{ groups['etcd'][0] }}"
+  when:
+    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally
+    - kube_network_plugin != "calico" or calico_datastore == "etcd"
+    - gen_certs
 
 - name: Gen_certs | Gather etcd member/admin and kube_control_plane client certs from first etcd node
   slurp:

--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -58,6 +58,29 @@
     - gen_certs
   notify: Set etcd_secret_changed
 
+- name: Gen_certs | Ensure consistent etcd certificate permissions on first etcd node
+  ansible.builtin.file:
+    path: "{{ item }}"
+    owner: "{{ etcd_owner }}"
+    group: "{{ etcd_cert_group }}"
+    mode: "0640"
+  with_items:
+    - "{{ etcd_cert_dir }}/ca.pem"
+    - "{{ etcd_cert_dir }}/ca-key.pem"
+    - "[{% for node in groups['etcd'] %}
+        '{{ etcd_cert_dir }}/admin-{{ node }}.pem',
+        '{{ etcd_cert_dir }}/admin-{{ node }}-key.pem',
+        '{{ etcd_cert_dir }}/member-{{ node }}.pem',
+        '{{ etcd_cert_dir }}/member-{{ node }}-key.pem',
+        {% endfor %}]"
+    - "[{% for node in groups['k8s_cluster'] %}
+        '{{ etcd_cert_dir }}/node-{{ node }}.pem',
+        '{{ etcd_cert_dir }}/node-{{ node }}-key.pem',
+        {% endfor %}]"
+  run_once: true
+  delegate_to: "{{ groups['etcd'][0] }}"
+  when: gen_certs
+
 - name: Gen_certs | Gather etcd member/admin and kube_control_plane client certs from first etcd node
   slurp:
     src: "{{ item }}"


### PR DESCRIPTION
Fixes #13250

The etcd certificate generation script runs on the first etcd node and creates certs with default ownership/permissions (root:root, umask-based), while the subsequent copy task sets explicit ownership/permissions (etcd:root, 0640) on the remaining etcd nodes. This leads to inconsistent permissions that can cause issues such as etcd backup jobs failing on the first node due to missing read access.

Add a task after cert generation to explicitly set ownership and permissions on the first etcd node to match what the copy task applies to other nodes.

```release-note
etcd: ensure consistent certificate permissions on the first etcd node by explicitly setting owner, group, and mode after generation
```