### PR TITLE
fix(cilium): wire scrape port variables to Helm values template

### DIFF
--- a/roles/network_plugin/cilium/templates/values.yaml.j2
+++ b/roles/network_plugin/cilium/templates/values.yaml.j2
@@ -109,6 +109,7 @@ hubble:
         tag: {{ cilium_hubble_ui_image_tag }}
   metrics:
     enabled: {{ cilium_hubble_metrics | to_json }}
+    port: {{ cilium_hubble_scrape_port }}
   export:
 {% if cilium_version is version('1.18.0', '>=') %}
     static:
@@ -156,6 +157,8 @@ operator:
     repository: {{ cilium_operator_image_repo }}
     tag: {{ cilium_operator_image_tag }}
   replicas: {{ cilium_operator_replicas }}
+  prometheus:
+    port: {{ cilium_operator_scrape_port }}
   extraArgs:
     {{ cilium_operator_extra_args | to_nice_yaml(indent=2) | indent(4) }}
   extraVolumes:
@@ -179,6 +182,7 @@ policyAuditMode: {{ cilium_policy_audit_mode | to_json }}
 
 prometheus:
   enabled: {{ cilium_enable_prometheus | to_json }}
+  port: {{ cilium_agent_scrape_port }}
 
 certgen:
   image:


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

`cilium_agent_scrape_port`, `cilium_operator_scrape_port` and `cilium_hubble_scrape_port` are defined in `roles/network_plugin/cilium/defaults/main.yml` but were never mapped into `values.yaml.j2`, so setting them had no effect.

This maps each one to the corresponding Cilium chart value:

| variable | chart value |
|---|---|
| `cilium_agent_scrape_port` | `prometheus.port` |
| `cilium_operator_scrape_port` | `operator.prometheus.port` |
| `cilium_hubble_scrape_port` | `hubble.metrics.port` |

Same class of bug as #13132 (fixed in #13142), and the same fix shape.

**Which issue(s) this PR fixes**:

Fixes #13369

**Special notes for your reviewer**:

The kubespray defaults (9962/9963/9965) are identical to the Cilium chart defaults, so this is a no-op for anyone who has not overridden the ports.

I checked this by rendering the template with ansible:

* with defaults: `prometheus.port: 9962`, `operator.prometheus.port: 9963`, `hubble.metrics.port: 9965`, rendered as ints, matching the chart defaults
* with overrides: the rendered values change as expected
* on master without this patch: the `port` keys are absent from the rendered output entirely, even when the variables are set

`pre-commit run --files roles/network_plugin/cilium/templates/values.yaml.j2` passes (ansible-lint, jinja-syntax-check, and the rest).

Scope note: I only wired the three ports. `operator.prometheus.enabled` is left at the chart default, and I did not touch `cilium_enable_hubble_metrics`, because the chart's `hubble.metrics.enabled` is a list and `cilium_hubble_metrics` is already mapped to it. #13369 lists a few other cilium variables that are also unreferenced, but they need different treatment (some wiring, some removal), so I left them out of this PR. Happy to follow up separately if that is useful.

**Does this PR introduce a user-facing change?**:

```release-note
Fix cilium_agent_scrape_port, cilium_operator_scrape_port and cilium_hubble_scrape_port having no effect by wiring them to the Helm values template.
```
