### PR TITLE
fix(calico): Add missing permissions in RBAC for calico-kube-controllers

### DIFF
--- a/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-cr.yml.j2
+++ b/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-cr.yml.j2
@@ -124,4 +124,12 @@ rules:
       - list
       - update
       - watch
+  # Namespaces are watched for LoadBalancer IP allocation with namespace selector support
+  - apiGroups: [""]
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
 {% endif %}

--- a/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-cr.yml.j2
+++ b/roles/kubernetes-apps/policy_controller/calico/templates/calico-kube-cr.yml.j2
@@ -71,6 +71,7 @@ rules:
       - blockaffinities
       - ipamblocks
       - ipamhandles
+      - ipamconfigs
       - tiers
     verbs:
       - get


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
This PR adds permissions to `calico-kube-controllers`.

Starting with Calico v3.31.0, `calico-kube-conrollers` required additional `namespace` permissions.
However, in Kubespray v2.31.0, which uses Calico v3.31.5, these permissions are missing.
As a result, `calico-kube-controllers` continues to output error messages indicating insufficient permissions.
Adding these permissions resolves this issue. 
Fixed in 5cbbabf

And in this PR discussion, we discovered that there were additional permissions missing.
Similar to `namespace` permissions, the `ipamconfigs` in `resources` is present in the upstream repository but were not included in Kubespray.
Ref: https://github.com/kubernetes-sigs/kubespray/pull/13375#issuecomment-4999943553
Fixed in 594e5bc3fcb9a4533784dd2cb43eb6ed3716b19c

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13374

**Special notes for your reviewer**:
Nothing for special notes.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add missing permissions in RBAC for calico-kube-controllers with using kdd datastore.
```
