### PR TITLE
Add variable to delay the playbook execution after node reboot. Also fixing some missed changes of 13327

### DIFF
--- a/docs/operations/upgrades.md
+++ b/docs/operations/upgrades.md
@@ -436,6 +436,9 @@ ansible-playbook upgrade-cluster.yml -b -i inventory/sample/inventory.ini -e sys
 Nodes will be rebooted when there are package upgrades (`system_upgrade_reboot: on-upgrade`).
 This can be changed to `always` or `never`.
 
+If you want like 60 sec delay in playbook execution after reboot use variable `node_post_reboot_delay_seconds: 60`
+This could be useful to give some extra time for services and networking on the node to start after boot, before continue with the playbook tasks.
+
 Note: Downloads will happen twice unless `system_upgrade_reboot` is `never`.
 
-Debian based nodes can be cleaned of packages to reduce disk space usage with `system_upgrade_autoclean: true`
+Nodes can be cleaned of package caches to reduce disk space usage with `system_upgrade_autoclean: true`

--- a/roles/upgrade/system-upgrade/defaults/main.yml
+++ b/roles/upgrade/system-upgrade/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+node_post_reboot_delay_seconds: 0

--- a/roles/upgrade/system-upgrade/tasks/apt.yml
+++ b/roles/upgrade/system-upgrade/tasks/apt.yml
@@ -12,12 +12,12 @@
     get_checksum: false
   register: reboot_required
 
-- name: Reboot server if required to apply updates
+- name: Reboot server if required or requested to apply updates
   ansible.builtin.reboot:
     msg: "The system is going down for reboot NOW!"
-    post_reboot_delay: 30
+    post_reboot_delay: "{{ node_post_reboot_delay_seconds }}"
   when:
-    - reboot_required.stat.exists
+    - reboot_required.stat.exists or system_upgrade_reboot == 'always'
     - system_upgrade_reboot != 'never'
 
 - name: APT Autoclean

--- a/roles/upgrade/system-upgrade/tasks/yum.yml
+++ b/roles/upgrade/system-upgrade/tasks/yum.yml
@@ -5,8 +5,25 @@
     state: latest
   register: yum_upgrade
 
-- name: Reboot after YUM upgrade  # noqa no-handler
+- name: Check if reboot is required
+  ansible.builtin.command:
+    cmd: needs-restarting --reboothint
+  register: reboot_required
+  changed_when: false
+  failed_when: reboot_required.rc == 2
+
+- name: Reboot server if required or requested to apply updates
+  ansible.builtin.reboot:
+    msg: "The system is going down for reboot NOW!"
+    post_reboot_delay: "{{ node_post_reboot_delay_seconds }}"
   when:
-  - yum_upgrade.changed or system_upgrade_reboot == 'always'
-  - system_upgrade_reboot != 'never'
-  reboot:
+    - reboot_required.rc == 1 or system_upgrade_reboot == 'always'
+    - system_upgrade_reboot != 'never'
+
+- name: Clean all Package caches
+  ansible.builtin.command:
+    cmd: yum clean all
+  changed_when: true
+  failed_when: false
+  when:
+    - system_upgrade_autoclean


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind bug
/kind feature

**What this PR does / why we need it**:

Give option to delay playbook runs for configured seconds after node reboot if doing system package upgrades.

Sometimes could be an issue if playbook try to do tasks right after reboot module reports node is accessible.
Like linked issue with cilium host firewall that could make hang the playbook runs in some cases. With this could configure some extra delay to wait after reboot.


Also it fixes some changes with #13327:
1, That change doesn't mention to change default 0 post reboot delay seconds to 30. With above variable it's defaults set back to 0 and can be set with variable

2, That change doesn't mention to remove handling system_upgrade_reboot == 'always' . This change puts it back.


Also give the same reboot if required and after that package cache cleanup to the yum packages.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13335 
Fixes #13327

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
