### PR TITLE
Skip component releases published without binary artifacts

### DIFF
--- a/scripts/component_hash_update/src/component_hash_update/download.py
+++ b/scripts/component_hash_update/src/component_hash_update/download.py
@@ -254,9 +254,23 @@ def download_hash(downloads: {str: {str: Any}}) -> None:
         c = component + "_checksums"
         for arch in components_supported_arch[component]:
             for version in versions:
+                # Some releases are published without binary artifacts
+                try:
+                    h = get_hash(component, version, arch)
+                except requests.exceptions.HTTPError as e:
+                    if e.response is not None and e.response.status_code == 404:
+                        logger.warning(
+                            "Skipping %s %s (%s): release asset not found (404) at %s",
+                            component,
+                            version,
+                            arch,
+                            e.response.url,
+                        )
+                        continue
+                    raise
                 data[c][arch][
                     str(version)
-                ] = f"{downloads[component].get('hashtype', 'sha256')}:{get_hash(component, version, arch)}"
+                ] = f"{downloads[component].get('hashtype', 'sha256')}:{h}"
 
         data[c] = {
             arch: {

--- a/scripts/component_hash_update/src/component_hash_update/download.py
+++ b/scripts/component_hash_update/src/component_hash_update/download.py
@@ -250,6 +250,8 @@ def download_hash(downloads: {str: {str: Any}}) -> None:
                 ).hexdigest()
             return hash_file.content.decode().split()[0]
 
+    skipped_404 = set()
+    fetched = set()
     for component, versions in chain(new_versions.items(), hash_set_to_0.items()):
         c = component + "_checksums"
         for arch in components_supported_arch[component]:
@@ -259,6 +261,7 @@ def download_hash(downloads: {str: {str: Any}}) -> None:
                     data[c][arch][
                         str(version)
                     ] = f"{downloads[component].get('hashtype', 'sha256')}:{get_hash(component, version, arch)}"
+                    fetched.add(component)
                 except requests.exceptions.HTTPError as e:
                     if e.response is not None and e.response.status_code == 404:
                         logger.warning(
@@ -268,6 +271,7 @@ def download_hash(downloads: {str: {str: Any}}) -> None:
                             arch,
                             e.response.url,
                         )
+                        skipped_404.add(component)
                         continue
                     raise
 
@@ -280,6 +284,15 @@ def download_hash(downloads: {str: {str: Any}}) -> None:
             }
             for arch, versions in data[c].items()
         }
+
+    # Only 404s for a component means its release layout probably changed
+    all_missing = sorted(skipped_404 - fetched)
+    if all_missing:
+        logger.error(
+            "All hash fetches returned 404 for: %s",
+            ", ".join(all_missing),
+        )
+        sys.exit(1)
 
     with open(checksums_file, "w") as checksums_yml:
         yaml.dump(data, checksums_yml)

--- a/scripts/component_hash_update/src/component_hash_update/download.py
+++ b/scripts/component_hash_update/src/component_hash_update/download.py
@@ -256,7 +256,9 @@ def download_hash(downloads: {str: {str: Any}}) -> None:
             for version in versions:
                 # Some releases are published without binary artifacts
                 try:
-                    h = get_hash(component, version, arch)
+                    data[c][arch][
+                        str(version)
+                    ] = f"{downloads[component].get('hashtype', 'sha256')}:{get_hash(component, version, arch)}"
                 except requests.exceptions.HTTPError as e:
                     if e.response is not None and e.response.status_code == 404:
                         logger.warning(
@@ -268,9 +270,6 @@ def download_hash(downloads: {str: {str: Any}}) -> None:
                         )
                         continue
                     raise
-                data[c][arch][
-                    str(version)
-                ] = f"{downloads[component].get('hashtype', 'sha256')}:{h}"
 
         data[c] = {
             arch: {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`update-hashes` crashes when a component publishes a GitHub release that contains no binary artifacts.
The script discovers the release as a new patch version, tries to download its checksum file, gets a `404`, and `raise_for_status()` aborts the entire run.

**Special notes for your reviewer**:
In `scripts/component_hash_update/src/component_hash_update/download.py`, the per-version hash fetch now ignores a `404`: the affected version is skipped with a warning and the run continues.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
