### PR TITLE
fix(metallb): wire metallb_controller_tolerations into controller Dep…

### DIFF
--- a/roles/kubernetes-apps/metallb/templates/metallb.yaml.j2
+++ b/roles/kubernetes-apps/metallb/templates/metallb.yaml.j2
@@ -1752,9 +1752,10 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
-{% if metallb_config.controller is defined and metallb_config.controller.tolerations is defined %}
+{% set controller_tolerations = metallb_controller_tolerations + (metallb_config.controller.tolerations if metallb_config.controller is defined and metallb_config.controller.tolerations is defined else []) %}
+{% if controller_tolerations %}
       tolerations:
-        {{ metallb_config.controller.tolerations | to_nice_yaml(indent=2) | indent(width=8) }}
+        {{ controller_tolerations | to_nice_yaml(indent=2) | indent(width=8) }}
 {%- endif %}
       nodeSelector:
         {{ metallb_controller_nodeselector | to_nice_yaml | indent(width=8) -}}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`metallb_controller_tolerations` is defined in
`roles/kubernetes-apps/metallb/defaults/main.yml` but is never consumed by
`metallb.yaml.j2` — setting it has no effect. Only
`metallb_config.controller.tolerations` reaches the controller Deployment,
while the speaker DaemonSet correctly honors both `metallb_speaker_tolerations`
and its `metallb_config` override.

The wiring existed when the variable was introduced in #7334 and was lost in
#9120 when the manifest was regenerated for the CRD notation switch.

This PR merges the role default with the optional `metallb_config.controller.tolerations`
override and emits the `tolerations` key only when the merged list is non-empty,
so rendering is unchanged for users who set neither variable.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
The speaker block concatenates the two sources the same way; this implementation
additionally avoids emitting a bare `[]` item list when the default is empty and
an override is present.

**Does this PR introduce a user-facing change?**:
```release-note
Fixed `metallb_controller_tolerations` being silently ignored; it is now applied to the MetalLB controller Deployment.