### PR TITLE
fix(cilium): fail fast when kube_owner is not root

### DIFF
--- a/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
+++ b/roles/kubernetes/preinstall/tasks/0040-verify-settings.yml
@@ -68,6 +68,18 @@
     - kube_network_plugin == 'cilium' or cilium_deploy_additionally
     - not ignore_assert_errors
 
+- name: Stop if kube_owner is not root when using cilium
+  assert:
+    that: kube_owner == 'root'
+    fail_msg: |
+      kube_owner is set to '{{ kube_owner }}', but cilium requires it to be 'root'.
+      Cilium's init containers run as UID 0 with capabilities (including CAP_DAC_OVERRIDE) dropped,
+      so host paths it writes to (e.g. /opt/cni/bin) must be owned by root or it will fail with
+      a permission error. See https://github.com/kubernetes-sigs/kubespray/issues/13378
+  when:
+    - kube_network_plugin == 'cilium' or cilium_deploy_additionally
+    - not ignore_assert_errors
+
 - name: Stop if kernel version is too low for nftables
   assert:
     that: ansible_facts['kernel'].split('-')[0] is version('5.13', '>=')


### PR DESCRIPTION
 /kind bug

**What this PR does / why we need it**:
Cilium's init containers (e.g. `mount-cgroup`) run as UID 0 with
capabilities dropped, including `CAP_DAC_OVERRIDE`. Without that
capability, UID 0 is still subject to normal DAC permission checks, so any
host path they write to must be owned by root. kubespray previously
created `/opt/cni/bin` with `owner: kube_owner` (default `kube`), so
Cilium 1.19.x fails to write CNI binaries there with a permission error.

This PR:
- Decouples `/opt/cni/bin` ownership from `kube_owner`, always creating it
as `root:root`
- Applies the same default change to `network_plugin/cni` role's
`cni_bin_owner`
- Adds a pre-flight assert that fails fast with a clear message if
`kube_network_plugin == cilium` and `kube_owner != root`, catching the
same class of problem for other kube_owner-dependent paths (e.g.
`/etc/cni/net.d`)

**Which issue(s) this PR fixes**:
Fixes #13378

**Special notes for your reviewer**:
None.

**Does this PR introduce a user-facing change?**:
```release-note
`/opt/cni/bin` is now always created with root ownership, independent of
`kube_owner`, fixing Cilium 1.19.x CNI binary install failures caused by
dropped capabilities. A pre-flight check now fails fast if
`kube_network_plugin: cilium` is combined with a non-root `kube_owner`.
```