### PR TITLE
Sliding-window worker upgrades without a strategy plugin

### DIFF
--- a/.gitlab-ci/kubevirt.yml
+++ b/.gitlab-ci/kubevirt.yml
@@ -47,6 +47,7 @@ pr:
           - rockylinux10-cilium
           - ubuntu22-calico-all-in-one
           - ubuntu22-calico-all-in-one-upgrade
+          - ubuntu24-calico-graceful-rolling-upgrade
           - ubuntu24-calico-etcd-datastore
           - ubuntu24-calico-all-in-one-hardening
           - ubuntu24-cilium-sep

--- a/.gitlab-ci/kubevirt.yml
+++ b/.gitlab-ci/kubevirt.yml
@@ -50,6 +50,7 @@ pr:
           - ubuntu22-calico-all-in-one-upgrade
           - ubuntu24-calico-all-in-one-hardening
           - ubuntu24-calico-etcd-datastore
+          - ubuntu24-calico-graceful-rolling-upgrade
           - ubuntu24-cilium-sep
           - ubuntu24-crio-scale
           - ubuntu24-crio-upgrade

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,16 @@ repos:
         entry: tests/scripts/collection-build-install.sh
         pass_filenames: false
 
+      - id: plugin-unit-tests
+        name: Run the Python plugin unit tests
+        language: python
+        entry: python -m pytest tests/unit
+        pass_filenames: false
+        files: "^(plugins/|tests/unit/)"
+        additional_dependencies:
+          - ansible-core>=2.18.0,<2.19.0
+          - pytest
+
       - id: generate-docs-sidebar
         name: generate-docs-sidebar
         entry: scripts/gen_docs_sidebar.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,16 @@ repos:
         entry: tests/scripts/collection-build-install.sh
         pass_filenames: false
 
+      - id: plugin-unit-tests
+        name: Run the Python plugin unit tests
+        language: python
+        entry: python -m pytest tests/unit
+        pass_filenames: false
+        files: "^(plugins/|tests/unit/)"
+        additional_dependencies:
+          - ansible-core>=2.18.0,<2.19.0
+          - pytest
+
       - id: generate-docs-sidebar
         name: generate-docs-sidebar
         entry: scripts/gen_docs_sidebar.sh

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -15,6 +15,7 @@ timeout = 300
 stdout_callback = default
 display_skipped_hosts = no
 library = ./library
+action_plugins = ./plugins/action
 callbacks_enabled = profile_tasks
 roles_path = roles:$VIRTUAL_ENV/usr/local/share/kubespray/roles:$VIRTUAL_ENV/usr/local/share/ansible/roles:/usr/share/kubespray/roles
 deprecation_warnings=False

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -47,6 +47,7 @@
   * [Ci-setup](/docs/developers/ci-setup.md)
   * [Ci](/docs/developers/ci.md)
   * [Test Cases](/docs/developers/test_cases.md)
+  * [Upgrade-slots](/docs/developers/upgrade-slots.md)
   * [Vagrant](/docs/developers/vagrant.md)
 * External Storage Provisioners
   * [Local Volume Provisioner](/docs/external_storage_provisioners/local_volume_provisioner.md)
@@ -83,6 +84,7 @@
   * [Offline-environment](/docs/operations/offline-environment.md)
   * [Port-requirements](/docs/operations/port-requirements.md)
   * [Recover-control-plane](/docs/operations/recover-control-plane.md)
+  * [Upgrade-strategies](/docs/operations/upgrade-strategies.md)
   * [Upgrades](/docs/operations/upgrades.md)
 * Roadmap
   * [Roadmap](/docs/roadmap/roadmap.md)

--- a/docs/developers/upgrade-slots.md
+++ b/docs/developers/upgrade-slots.md
@@ -1,0 +1,222 @@
+# Sliding-window upgrades: design notes
+
+How `upgrade_strategy: graceful_rolling` is built and, more usefully, which
+ansible-core behaviours forced it into this shape. Read
+[Upgrade strategies](/docs/operations/upgrade-strategies.md) first for what the
+feature does; this document is for changing it.
+
+All ansible-core references below are against **2.18.14**, which is what
+`ansible==11.13.0` in `requirements.txt` currently resolves to. Re-check them
+when that pin moves.
+
+## Why not a strategy plugin
+
+The obvious implementation is a custom strategy plugin, and
+[PR #13080](https://github.com/kubernetes-sigs/kubespray/pull/13080) was exactly
+that. It was closed because ansible-core
+[deprecated custom strategy plugins](https://github.com/ansible/ansible/issues/84725)
+with no replacement API announced. Only *custom* ones: the issue is explicit
+that "the existing strategy plugins in ansible-core will remain".
+
+That matters, because the built-in `host_pinned` already *is* a sliding window:
+
+> Ansible will not wait for other hosts to finish the current task before
+> queuing the next task for a host that has finished. Once a host is done with
+> the play, it opens its slot to a new host that was waiting to start.
+
+`host_pinned` (`ansible/plugins/strategy/host_pinned.py:43`) is `free` with
+`_host_pinned = True`, which caps in-flight hosts at the fork count. So the
+closed PR's 714-line fork of `free.StrategyModule.run()` existed for two
+features only: a window narrower than `forks`, and per-group ceilings. Both fit
+in action plugins, which are a supported, stable extension point.
+
+## Architecture
+
+```text
+playbooks/upgrade_cluster.yml     worker play: strategy host_pinned, serial 100%
+  └── block:
+        acquire_upgrade_slot      blocks until a slot is free, writes a lease
+        ... pre-upgrade → container-engine → node → kubeadm → post-upgrade ...
+        meta: flush_handlers      services restart before the slot is handed on
+        set_fact upgrade_slot_node_ok
+      always:
+        release_upgrade_slot      deletes the lease; marks failure if the fact is unset
+```
+
+`plugins/action/{acquire,release}_upgrade_slot.py` coordinate through a
+directory of lease files on the controller, serialised with `fcntl.flock`. One
+file per host holding a slot; a `UPGRADE_FAILED` marker file when a node has
+failed.
+
+`serial: 100%` puts every node in one batch so the strategy sees them all at
+once; the window is then enforced by the semaphore rather than by `serial`,
+which is what allows it to be narrower than `forks` and to vary per group.
+
+## The four constraints that shaped this
+
+Everything awkward in the implementation traces back to one of these. None are
+kubespray's doing.
+
+### 1. `run_once` is ignored outside `linear`
+
+`free.py:172` warns and then runs the task **on every host**. There is no
+opt-out.
+
+This is why only the worker play is rolling. The control-plane play already runs
+`serial: 1` (a window of one is the same thing) and installs cluster-wide
+addons; the calico play applies cluster-wide manifests and never cordons a node,
+so a window would add risk without removing a bottleneck.
+
+It is also why `roles/kubernetes/kubeadm` was split. Its kube-proxy ConfigMap
+rewrite and `kubectl delete pod -l k8s-app=kube-proxy` are cluster-scoped and
+`run_once`. Under `free` that is N concurrent `kubectl replace` calls on one
+object and N cluster-wide kube-proxy restarts. They now live in
+`tasks/kube_proxy_kubeconfig.yml` behind `kubeadm_patch_kube_proxy`, which
+**defaults to off** — a play must ask for them, and only a linear play may.
+`cluster.yml` and `scale.yml` opt in; `upgrade_cluster.yml` runs them once in a
+dedicated linear play after the window.
+
+Deriving that flag from `upgrade_strategy` does not work: it is an
+inventory-level setting, so `graceful_rolling` in `group_vars` would silently
+disable the patch for ordinary `cluster.yml` runs. Ansible exposes no magic
+variable for the running play's strategy (`ansible_play_name`,
+`ansible_play_hosts`, `ansible_play_hosts_all`, `ansible_play_batch`,
+`ansible_play_role_names` — that is the complete list), so the role cannot
+detect its own context. Hence the fail-safe default instead.
+
+### 2. `any_errors_fatal` and `max_fail_percentage` only exist in `linear`
+
+They are implemented in `linear.py:328` and `linear.py:336`. `free.py:81` and
+`free.py:194` only print a warning. The worker play sets
+`any_errors_fatal: true`, and switching it to `host_pinned` silently drops that.
+
+`upgrade_abort_on_failure` (default true) restores the intent where it matters:
+`release_upgrade_slot` writes the failure marker, and every subsequent
+`acquire_upgrade_slot` fails instead of granting a slot. Nodes already inside
+the window finish rather than being abandoned mid-drain.
+
+This is deliberately weaker than `any_errors_fatal` — it stops nodes from
+*starting*, it cannot interrupt one already running.
+
+### 3. `pause` aborts the play outright
+
+`pause` sets `BYPASS_HOST_LOOP`, and `free.py:168` raises `AnsibleError` rather
+than running it. The raise happens at dispatch, **before the task's `when:` is
+evaluated**, so a false condition does not help and neither does asserting the
+confirm flags are unset. Every rolling upgrade died the moment the worker play
+reached `upgrade/pre-upgrade`.
+
+The two prompts therefore live in `confirm_upgrade.yml` /
+`confirm_uncordon.yml`, pulled in with `include_tasks` (dynamic, so they only
+enter the play when actually wanted). The timed waits moved to `wait_for`, which
+sleeps when given neither port nor path (`modules/wait_for.py:542`) and runs per
+host.
+
+`pause` and `add_host` are the only ansible-core action plugins with
+`BYPASS_HOST_LOOP`. `add_host` appears in none of the roles the worker play
+runs.
+
+### 4. A waiting host occupies a worker
+
+`acquire_upgrade_slot` blocks, and a blocked task holds its fork. The window is
+therefore clamped to `forks - 1`, with a warning rather than a hard failure —
+Ansible's default of 5 forks would otherwise turn the default `"20%"`
+concurrency into an abort on any cluster above 25 nodes.
+
+The fork count is read from `context.CLIARGS` first: `DEFAULT_FORKS` has **no
+`cli:` mapping** in `config/base.yml`, so `-f/--forks` never reaches the
+constant. Reading `C.DEFAULT_FORKS` alone makes `-f 20` invisible.
+
+## Details worth knowing before changing something
+
+**Lease location.** Inside Ansible's own per-run controller temp directory
+(`~/.ansible/tmp/ansible-local-<run>/kubespray-upgrade/`). That directory is
+created once per invocation, inherited by every worker across `fork()`, and
+removed when the run ends — so slots are scoped to one run, concurrent
+invocations never collide, and nothing is left behind. It also sits under
+`$HOME` with mode 0700, unlike a predictable path in `/tmp`. `os.getpgid(0)` is
+only a fallback; two playbooks started from one non-interactive shell script
+share a process group.
+
+**`flock`** means the controller must be Linux or macOS. Managed nodes are
+unaffected — the plugins set `_requires_connection = False` and never open a
+connection.
+
+**Handler ordering is already correct.** `Play.compile()`
+(`playbook/play.py:292`) inserts an implicit `flush_handlers` block between the
+roles/tasks section and `post_tasks`. The explicit `meta: flush_handlers` at the
+end of the block is belt-and-braces: it guarantees kubelet and the container
+runtime have restarted before the slot is handed to the next node.
+
+**`block`/`always`, deliberately no `rescue`.** A `rescue` would change what
+happens under `linear`, which is the default and must stay untouched. Instead
+the last task in the block sets `upgrade_slot_node_ok`, and `always` passes
+`mark_failed: "{{ not (upgrade_slot_node_ok | default(false)) }}"`. Its absence
+*is* the failure signal. This also means `ansible_failed_task` is unavailable,
+which is why the abort message names the failing node but not the task.
+
+**`roles:` became `tasks:` + `import_role`** because `always:` needs a block.
+Checked before doing it: the worker play's roles keep their defaults to
+themselves — nothing in it reads a sibling role's `defaults/`. `import_role` is
+static, so tags propagate exactly as the `roles:` shorthand did.
+
+## Testing
+
+`tests/unit/plugins/action/test_upgrade_slots.py` covers the parts that are pure
+functions: percentage resolution and clamping, per-group ceilings and the
+default bucket, the lease lifecycle including abandoned-lease reclaim, and the
+fork-count lookup. Run with `python -m pytest tests/unit`; wired into
+`.pre-commit-config.yaml`.
+
+The CI job `ubuntu24-calico-graceful-rolling-upgrade` uses `mode: ha`. Not
+`all-in-one` — that node is in both `kube_control_plane` and `kube_node`, so
+`kube_node:calico_rr:!kube_control_plane` is empty and the rolling play would be
+skipped without failing. `ha` gives one dedicated worker, enough to exercise the
+plugins, the validation play, `host_pinned` and the pause path. It does **not**
+exercise the window; that needs three workers (`mode: node-etcd-client` is the
+only stock layout that provides them).
+
+`system_upgrade: true` was verified separately, on a three-VM cluster with one
+control-plane node and two workers, at a fixed Kubernetes version so that only
+the system-upgrade path was under test. Both workers entered the window, ran
+the `download` role **inside** the `host_pinned` play (290 tasks), rebooted
+(`"rebooted": true`), and released their slots — leases live on the controller,
+so a managed-node reboot does not lose one. The three `run_once: true` tasks in
+`download/tasks/prep_download.yml` executed on zero hosts, held off by their own
+`when` guards; the `run_once` warning the strategy prints at dispatch is
+therefore cosmetic here. The combinations that are *not* safe are rejected by
+the validation play before anything runs.
+
+Measured on six VMs, three workers, window and `serial` both 2:
+
+| Situation | `linear` | `graceful_rolling` |
+|---|---|---|
+| Uniform nodes | same | same |
+| One node 150s slower | 471s | 369s |
+| PDB `minAvailable: 2` | drain fails after 591s | 394s |
+
+The uniform row is not a disappointment, it is arithmetic: the window admits the
+next node when one finishes, which is when a batch would have rotated anyway.
+
+## Adding a role to the rolling play
+
+Check it for:
+
+- `run_once` — it will run on every node
+- `pause` or any other `BYPASS_HOST_LOOP` action — it will abort the play
+- `delegate_to` a single control-plane node combined with cluster-wide writes —
+  correct per node, harmful when several nodes do it at once
+- `any_errors_fatal` on a task — silently ignored
+
+Node-local work is safe. Cluster-wide work belongs in a separate linear play.
+
+## On an ansible-core bump
+
+Re-verify, in order of how quietly they would break:
+
+1. `free.py` still only *warns* about `run_once` rather than raising
+2. `BYPASS_HOST_LOOP` is still limited to `pause` and `add_host`
+3. `any_errors_fatal` is still absent from the free-family strategies (if it
+   gains support, `upgrade_abort_on_failure` can be retired)
+4. `DEFAULT_LOCAL_TMP` still names a per-run directory that is cleaned up
+5. `DEFAULT_FORKS` still has no `cli:` mapping

--- a/docs/operations/upgrade-strategies.md
+++ b/docs/operations/upgrade-strategies.md
@@ -1,0 +1,215 @@
+# Upgrade strategies
+
+`upgrade-cluster.yml` walks through the worker nodes in one of two ways,
+selected with `upgrade_strategy`.
+
+| | `linear` (default) | `graceful_rolling` |
+|---|---|---|
+| Node selection | `serial:` batches | sliding window |
+| A slow node holds up | the rest of its batch | nobody |
+| Window size | `serial` | `upgrade_node_concurrency` |
+| Per-group ceilings | no | yes |
+| Stops on a failed node | `any_errors_fatal` | `upgrade_abort_on_failure` |
+| Interactive `pause:` prompts | yes | no |
+
+`linear` is unchanged and remains the default. Nothing in this document
+applies unless you opt in.
+
+## The problem with batches
+
+With `serial: 20%` on a 20-node cluster, Ansible upgrades four nodes, waits for
+all four, then starts the next four. One node that drains slowly - a large
+StatefulSet, a `PodDisruptionBudget` that only releases a pod every few minutes -
+holds the other three idle even though the cluster has capacity to keep going.
+
+Worse, the batch is drained as a unit. If four nodes each host a replica of a
+Deployment with `minAvailable: 3`, the API server refuses the fourth eviction
+and the batch blocks until `drain_timeout` expires.
+
+`graceful_rolling` replaces the batch with a window. Every node runs
+independently; a node that finishes hands its slot to the next waiting node
+immediately. With a window of 2 that same cluster never has more than two nodes
+cordoned, and no node ever waits for a peer.
+
+## When it actually helps
+
+Not always, and it is worth knowing when not. With nodes that all take the same
+time and nothing blocking eviction, a window of N and `serial: N` finish
+together - the window can only start the next node once one has finished, which
+is when the batch would have rotated anyway.
+
+The difference appears in two situations. Measured on three worker nodes with a
+window (and `serial`) of 2:
+
+| Situation | `linear` | `graceful_rolling` |
+|---|---|---|
+| One node 150s slower than its peers | 471s | 369s (-22%) |
+| `PodDisruptionBudget`, `minAvailable: 2` | drain fails after 591s | 394s |
+
+The second row is not a speed difference. `serial: 2` drains both nodes of a
+batch in lockstep: the first eviction is allowed, the second would breach the
+budget, and the budget cannot recover because the first node may not uncordon
+until the whole batch clears the drain task. Both nodes fail. The window
+staggers the nodes instead, so the second drain starts after the first node is
+already back - in that run it never hit the budget at all.
+
+Uneven node durations are the common case in practice: a node hosting a large
+StatefulSet, a slow disk, a `terminationGracePeriodSeconds` measured in
+minutes.
+
+## Enabling it
+
+```yaml
+# inventory/mycluster/group_vars/all/upgrade.yml
+upgrade_strategy: graceful_rolling
+upgrade_node_concurrency: 3
+```
+
+```console
+ansible-playbook -i inventory/mycluster/hosts.yaml -f 10 upgrade-cluster.yml
+```
+
+**The fork count must exceed the window.** A node waiting for a slot occupies an
+Ansible worker, so `upgrade_node_concurrency` is capped at `forks - 1` and you
+will see a warning if your value is clamped. Ansible's default is 5 forks, which
+allows a window of 4; pass `-f`, set `ANSIBLE_FORKS`, or put `forks` in the
+`[defaults]` section of `ansible.cfg` to go wider. Forks above the window cost
+almost nothing - the extra workers just sleep.
+
+### Per-group ceilings
+
+`upgrade_per_group_concurrency` constrains individual inventory groups on top of
+the global window. A node starts only when every ceiling that applies to it has
+room:
+
+```yaml
+upgrade_node_concurrency: 6
+upgrade_per_group_concurrency:
+  calico_rr: 1     # never take two route reflectors down together
+  gpu_nodes: 2     # scarce hardware, drain gently
+```
+
+The key `default` covers nodes that are in none of the listed groups.
+
+A percentage is taken of the group's own hosts in this play, not of the whole
+cluster — `calico_rr: "50%"` means half of the route reflectors. `default` is
+resolved against the nodes matching none of the other listed groups.
+
+### All settings
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `upgrade_strategy` | `linear` | `linear` or `graceful_rolling`. |
+| `upgrade_node_concurrency` | `"20%"` | Window size; integer or percentage of the play's hosts. Percentages round down with a floor of 1, exactly as `serial` does. Capped at `forks - 1`. |
+| `upgrade_per_group_concurrency` | `{}` | Per-group ceilings; percentages count the group's own hosts. |
+| `upgrade_abort_on_failure` | `true` | Stop draining further nodes once one has failed. |
+| `upgrade_slot_poll_interval` | `5.0` | Seconds between checks while a node waits. |
+| `upgrade_slot_lease_ttl` | `3600` | Age at which a slot is treated as abandoned and reclaimed. |
+| `upgrade_slot_timeout` | `0` | Seconds a node may wait before failing; `0` waits indefinitely. |
+
+## What you give up
+
+ansible-core implements `any_errors_fatal` and `max_fail_percentage` only in the
+`linear` strategy. Under `free` and `host_pinned` both are silently ignored -
+the strategy prints a warning and carries on. Since `graceful_rolling` runs on
+`host_pinned`, **`any_errors_fatal` has no effect on the worker play.**
+
+`upgrade_abort_on_failure` (on by default) replaces it at the point that
+matters: when a node fails, every node that has not yet been drained fails
+immediately instead of starting. Nodes already inside the window finish their
+upgrade rather than being abandoned mid-drain, which is what you want - a node
+that is cordoned and drained should be brought back up.
+
+Set `upgrade_abort_on_failure: false` if you would rather let the rollout
+continue past a broken node.
+
+Interactive prompts are rejected outright. `upgrade_node_confirm` and
+`upgrade_node_post_upgrade_confirm` need `linear`: several nodes upgrade at
+once, so their prompts would arrive interleaved on one terminal, and each
+unanswered prompt pins a worker. The playbook fails early with this combination
+rather than hanging.
+
+There is a mechanical reason too. The `pause` module sets `BYPASS_HOST_LOOP`,
+and `free`/`host_pinned` abort the whole run when they encounter such a task -
+*before* evaluating its `when:`, so a false condition is no protection. The two
+prompts therefore live in files that `upgrade/{pre,post}-upgrade` include
+dynamically, which keeps them out of the play unless they are really wanted.
+
+The timed waits are unaffected: `upgrade_node_pause_seconds` and
+`upgrade_node_post_upgrade_pause_seconds` work under both strategies. They use
+`wait_for`, which runs per host and does not bypass the host loop.
+
+## Scope
+
+Only the worker play uses the sliding window. The other plays stay `linear`,
+deliberately:
+
+- **Control plane** already runs `serial: 1`. A window of one is the same thing,
+  and the play also installs cluster-wide addons that must run exactly once.
+- **The calico / cloud-controller play** applies cluster-wide manifests and
+  never cordons a node, so the window would add risk without removing a
+  bottleneck.
+
+This matters because `run_once` is not honoured outside the `linear` strategy -
+`free` warns and then runs the task on *every* host. A `kubectl replace` on a
+shared ConfigMap or a `kubectl delete pod -l k8s-app=kube-proxy` executed once
+per node is a genuine outage.
+
+`roles/kubernetes/kubeadm` contains exactly such tasks, the kube-proxy
+kubeconfig rewrite. They sit behind `kubeadm_patch_kube_proxy`, which defaults
+to **off**: a play has to ask for them, and only a linear play may. `cluster.yml`
+and `scale.yml` opt in; the rolling worker play cannot and does not, and
+`upgrade_cluster.yml` runs them once for the whole cluster in a separate linear
+play afterwards. Defaulting to off means a play added later is safe until
+someone deliberately makes it unsafe, rather than the other way round.
+
+If you add roles to the worker play, check them for `run_once`, `delegate_to`
+against a single control-plane node, and anything that mutates cluster-wide
+state. Node-local work is safe; cluster-wide work is not.
+
+## How it works
+
+Two action plugins implement the window as a semaphore on the Ansible
+controller. They are ordinary action plugins - a stable, public extension point,
+unlike the custom strategy plugins that ansible-core
+[deprecated in 2.19](https://github.com/ansible/ansible/issues/84725).
+
+```text
+acquire_upgrade_slot     first task in the block
+  ├── another node already failed?  ─▶ fail fast, do not drain
+  ├── reclaim leases older than upgrade_slot_lease_ttl
+  ├── wait while active leases >= window, or a group ceiling is full
+  └── write <ansible run tmpdir>/kubespray-upgrade/<node>.lease
+
+     ... cordon, drain, upgrade, uncordon, flush handlers ...
+
+release_upgrade_slot     always: section, so a failed node releases too
+  ├── delete the lease, freeing the slot for the next node
+  └── if the node failed, write the UPGRADE_FAILED marker
+```
+
+Leases live inside Ansible's own controller-side temporary directory
+(`~/.ansible/tmp/ansible-local-<run>/`). That directory is created once per
+invocation and removed when the run ends, so concurrent `ansible-playbook`
+invocations never share slots and a finished run leaves nothing behind. It sits
+under `$HOME` with mode 0700 rather than in `/tmp`, where a predictable path
+would be open to races on a shared controller.
+
+Mutual exclusion uses `flock(2)`, so the Ansible controller must be Linux or
+macOS. Managed nodes are unaffected - the plugins never connect to them.
+
+## Verifying the window
+
+Watch the cordoned nodes during an upgrade - the count should never exceed
+`upgrade_node_concurrency`:
+
+```console
+watch -n2 "kubectl get nodes | grep -c SchedulingDisabled"
+```
+
+Run with `-vv` to see each node acquire and release:
+
+```text
+acquire_upgrade_slot: node3 acquired a slot after 41.2s (2/2 in flight)
+release_upgrade_slot: node1 released its slot
+```

--- a/docs/operations/upgrades.md
+++ b/docs/operations/upgrades.md
@@ -63,6 +63,24 @@ You can control how many nodes are upgraded at the same time by modifying the an
 ansible-playbook upgrade-cluster.yml -b -i inventory/sample/inventory.ini -e kube_version=1.20.7 -e "serial=1"
 ```
 
+Batches have two costs: every node in a batch waits for the slowest one, and the
+whole batch is drained at once, which can deadlock against a
+`PodDisruptionBudget`. The opt-in `graceful_rolling` strategy replaces the batch
+with a sliding window, so a node that finishes frees its slot immediately and
+nodes are never drained in lockstep:
+
+```ShellSession
+ansible-playbook upgrade-cluster.yml -b -i inventory/sample/inventory.ini \
+  -e kube_version=1.36.3 \
+  -e upgrade_strategy=graceful_rolling \
+  -e upgrade_node_concurrency=3 \
+  --forks 10
+```
+
+The fork count has to exceed the concurrency. See
+[Upgrade strategies](/docs/operations/upgrade-strategies.md) for the full
+comparison, the per-group ceilings, and what the strategy gives up.
+
 ### Pausing the upgrade
 
 If you want to manually control the upgrade procedure, you can set some variables to pause the upgrade playbook. Pausing *before* upgrading each upgrade may be useful for inspecting pods running on that node, or performing manual actions on the node:

--- a/playbooks/cluster.yml
+++ b/playbooks/cluster.yml
@@ -49,7 +49,8 @@
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray_defaults }
-    - { role: kubernetes/kubeadm, tags: kubeadm}
+    # This play is linear, so the role's cluster-scoped run_once tasks are safe.
+    - { role: kubernetes/kubeadm, tags: kubeadm, kubeadm_patch_kube_proxy: true }
     - { role: kubernetes/node-label, tags: node-label }
     - { role: kubernetes/node-taint, tags: node-taint }
     - { role: kubernetes-apps/common_crds }

--- a/playbooks/scale.yml
+++ b/playbooks/scale.yml
@@ -78,7 +78,8 @@
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray_defaults }
-    - { role: kubernetes/kubeadm, tags: kubeadm }
+    # This play is linear, so the role's cluster-scoped run_once tasks are safe.
+    - { role: kubernetes/kubeadm, tags: kubeadm, kubeadm_patch_kube_proxy: true }
     - { role: kubernetes/node-label, tags: node-label }
     - { role: kubernetes/node-taint, tags: node-taint }
     - { role: network_plugin, tags: network }

--- a/playbooks/upgrade_cluster.yml
+++ b/playbooks/upgrade_cluster.yml
@@ -75,23 +75,199 @@
     - { role: network_plugin, tags: network }
     - { role: kubernetes-apps/policy_controller, tags: policy-controller }
 
+- name: Validate the worker upgrade settings
+  hosts: kube_node:calico_rr:!kube_control_plane
+  gather_facts: false
+  any_errors_fatal: true
+  environment: "{{ proxy_disable_env }}"
+  roles:
+    - { role: kubespray_defaults }
+  tasks:
+    - name: Check upgrade_strategy is a known value
+      assert:
+        that: upgrade_strategy in ['linear', 'graceful_rolling']
+        fail_msg: >-
+          upgrade_strategy is '{{ upgrade_strategy }}', expected 'linear' or
+          'graceful_rolling'. See docs/operations/upgrade-strategies.md.
+      run_once: true
+
+    - name: Check the preconditions of the graceful_rolling strategy
+      when: upgrade_strategy == 'graceful_rolling'
+      run_once: true
+      block:
+        # The prompts would arrive interleaved from several nodes on one
+        # terminal, and each waiting prompt pins an Ansible worker.
+        # Both default to false in the upgrade/{pre,post}-upgrade roles, which
+        # this play does not load - so an undefined value means "not set".
+        - name: Check that no interactive pause is configured
+          assert:
+            that:
+              - not (upgrade_node_confirm | default(false) | bool)
+              - not (upgrade_node_post_upgrade_confirm | default(false) | bool)
+            fail_msg: >-
+              upgrade_node_confirm and upgrade_node_post_upgrade_confirm need
+              upgrade_strategy=linear. Under graceful_rolling several nodes
+              upgrade at once, so their prompts cannot be answered in order.
+
+        # The download role only joins this play when system_upgrade reboots a
+        # node, and its run_once tasks are wrong outside the linear strategy.
+        - name: Check that the download role stays node-local
+          assert:
+            that:
+              - not (download_run_once | bool)
+              - not (download_localhost | bool)
+            fail_msg: >-
+              system_upgrade pulls the download role into the rolling worker
+              play, where its run_once tasks would execute on every node at
+              once. Set download_run_once and download_localhost to false, or
+              use upgrade_strategy=linear.
+          when: system_upgrade | bool and system_upgrade_reboot != 'never' and not skip_downloads
+
 - name: Finally handle worker upgrades, based on given batch size
   hosts: kube_node:calico_rr:!kube_control_plane
   gather_facts: false
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
-  serial: "{{ serial | default('20%') }}"
+  # graceful_rolling drops the batch synchronisation point: host_pinned lets a
+  # node run the whole play without waiting for its peers and hands its worker
+  # to the next node the moment it is done, while serial: 100% puts every node
+  # into a single batch. The window itself is enforced by acquire_upgrade_slot,
+  # not by the strategy, so it can be narrower than the fork count and can vary
+  # per group. These are play keywords, evaluated before kubespray_defaults
+  # runs, hence the explicit default.
+  strategy: "{{ 'host_pinned' if upgrade_strategy | default('linear') == 'graceful_rolling' else 'linear' }}"
+  serial: "{{ '100%' if upgrade_strategy | default('linear') == 'graceful_rolling' else serial | default('20%') }}"
   roles:
     - { role: kubespray_defaults }
-    - { role: upgrade/pre-upgrade, tags: pre-upgrade }
-    - { role: upgrade/system-upgrade, tags: system-upgrade }
-    - { role: download, tags: download, when: "system_upgrade and system_upgrade_reboot != 'never' and not skip_downloads" }
-    - { role: container-engine, tags: "container-engine", when: deploy_container_engine }
-    - { role: kubernetes/node, tags: node }
-    - { role: kubernetes/kubeadm, tags: kubeadm }
-    - { role: kubernetes/node-label, tags: node-label }
-    - { role: kubernetes/node-taint, tags: node-taint }
-    - { role: upgrade/post-upgrade, tags: post-upgrade }
+  tasks:
+    # rescue: records which task broke the node, always: hands the slot back on
+    # every path - a broken node must not shrink the window for the rest of the
+    # cluster. Neither section runs for a host that became unreachable; that
+    # node's lease is reclaimed by upgrade_slot_lease_ttl instead.
+    - name: Upgrade the node while holding an upgrade slot
+      block:
+        - name: Acquire an upgrade slot
+          acquire_upgrade_slot:
+            concurrency: "{{ upgrade_node_concurrency }}"
+            per_group: "{{ upgrade_per_group_concurrency }}"
+            # ansible_play_hosts_all, not ansible_play_hosts: the latter drops
+            # hosts that already failed, which would shrink the percentage
+            # denominator - and with it the window - as a run degrades.
+            total_hosts: "{{ ansible_play_hosts_all | length }}"
+            poll_interval: "{{ upgrade_slot_poll_interval }}"
+            lease_ttl: "{{ upgrade_slot_lease_ttl }}"
+            timeout: "{{ upgrade_slot_timeout }}"
+            abort_on_failure: "{{ upgrade_abort_on_failure }}"
+          when: upgrade_strategy == 'graceful_rolling'
+          tags: always
+
+        - name: Cordon and drain the node
+          import_role:
+            name: upgrade/pre-upgrade
+          tags: pre-upgrade
+
+        - name: Upgrade the operating system packages
+          import_role:
+            name: upgrade/system-upgrade
+          tags: system-upgrade
+
+        - name: Download artifacts again after the system upgrade rebooted
+          import_role:
+            name: download
+          tags: download
+          when: "system_upgrade and system_upgrade_reboot != 'never' and not skip_downloads"
+
+        - name: Upgrade the container engine
+          import_role:
+            name: container-engine
+          tags: container-engine
+          when: deploy_container_engine
+
+        - name: Upgrade the kubelet
+          import_role:
+            name: kubernetes/node
+          tags: node
+
+        - name: Upgrade the node with kubeadm
+          import_role:
+            name: kubernetes/kubeadm
+          tags: kubeadm
+
+        - name: Apply the node labels
+          import_role:
+            name: kubernetes/node-label
+          tags: node-label
+
+        - name: Apply the node taints
+          import_role:
+            name: kubernetes/node-taint
+          tags: node-taint
+
+        - name: Uncordon the node
+          import_role:
+            name: upgrade/post-upgrade
+          tags: post-upgrade
+
+        # Restart kubelet and the container runtime before the slot is handed
+        # on, otherwise the next node could start draining while this one is
+        # still bouncing its services.
+        - name: Run the node's pending handlers before releasing the slot
+          meta: flush_handlers
+
+      rescue:
+        # A rescue: section is the only place where ansible-core exposes which
+        # task failed, so this is where the marker can name it. Blocks are
+        # handled by the play iterator, not by the strategy plugin, so this
+        # works under host_pinned exactly as it does under linear.
+        #
+        # The task name alone is not enough: upgrade/pre-upgrade wraps the
+        # drain in its own rescue and re-raises through 'Fail after rescue',
+        # which is what would reach the marker. The failure message carries
+        # the actual cause, so both are recorded.
+        - name: Record that this node failed its upgrade
+          release_upgrade_slot:
+            mark_failed: true
+            task: "{{ ansible_failed_task.name | default('unknown') }}"
+            reason: "{{ ansible_failed_result.msg | default('') }}"
+          when: upgrade_strategy == 'graceful_rolling'
+          tags: always
+
+        # A rescue: that runs to the end marks the host as recovered. Without
+        # this the node would count as upgraded, the play would carry on to the
+        # next play, and any_errors_fatal would never fire under linear.
+        - name: Fail the node again now that the failure has been recorded
+          fail:
+            msg: >-
+              Upgrade of {{ inventory_hostname }} failed in task
+              '{{ ansible_failed_task.name | default('unknown') }}'.
+          tags: always
+      always:
+        # Releasing a slot that is not held is a no-op, so this stays correct
+        # after the rescue: above already handed it back.
+        - name: Release the upgrade slot
+          release_upgrade_slot:
+          when: upgrade_strategy == 'graceful_rolling'
+          tags: always
+
+# The worker play never patches kube-proxy itself: the tasks are cluster-scoped
+# and rely on run_once, which needs a linear strategy. Doing it here runs them
+# exactly once per upgrade under either strategy - under linear the worker play
+# used to repeat them once per serial batch.
+- name: Point kube-proxy at the right API server endpoint
+  hosts: kube_node:calico_rr:!kube_control_plane
+  gather_facts: false
+  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
+  roles:
+    - { role: kubespray_defaults }
+  tasks:
+    - name: Patch the kube-proxy kubeconfig for the cluster
+      import_role:
+        name: kubernetes/kubeadm
+        tasks_from: kube_proxy_kubeconfig
+      tags:
+        - kubeadm
+        - kube-proxy
 
 - name: Patch Kubernetes for Windows
   hosts: kube_control_plane[0]

--- a/playbooks/upgrade_cluster.yml
+++ b/playbooks/upgrade_cluster.yml
@@ -75,23 +75,199 @@
     - { role: network_plugin, tags: network }
     - { role: kubernetes-apps/policy_controller, tags: policy-controller }
 
+- name: Validate the worker upgrade settings
+  hosts: kube_node:calico_rr:!kube_control_plane
+  gather_facts: false
+  any_errors_fatal: true
+  environment: "{{ proxy_disable_env }}"
+  roles:
+    - { role: kubespray_defaults }
+  tasks:
+    - name: Check upgrade_strategy is a known value
+      assert:
+        that: upgrade_strategy in ['linear', 'graceful_rolling']
+        fail_msg: >-
+          upgrade_strategy is '{{ upgrade_strategy }}', expected 'linear' or
+          'graceful_rolling'. See docs/operations/upgrade-strategies.md.
+      run_once: true
+
+    - name: Check the preconditions of the graceful_rolling strategy
+      when: upgrade_strategy == 'graceful_rolling'
+      run_once: true
+      block:
+        # The prompts would arrive interleaved from several nodes on one
+        # terminal, and each waiting prompt pins an Ansible worker.
+        # Both default to false in the upgrade/{pre,post}-upgrade roles, which
+        # this play does not load - so an undefined value means "not set".
+        - name: Check that no interactive pause is configured
+          assert:
+            that:
+              - not (upgrade_node_confirm | default(false) | bool)
+              - not (upgrade_node_post_upgrade_confirm | default(false) | bool)
+            fail_msg: >-
+              upgrade_node_confirm and upgrade_node_post_upgrade_confirm need
+              upgrade_strategy=linear. Under graceful_rolling several nodes
+              upgrade at once, so their prompts cannot be answered in order.
+
+        # The download role only joins this play when system_upgrade reboots a
+        # node, and its run_once tasks are wrong outside the linear strategy.
+        - name: Check that the download role stays node-local
+          assert:
+            that:
+              - not (download_run_once | bool)
+              - not (download_localhost | bool)
+            fail_msg: >-
+              system_upgrade pulls the download role into the rolling worker
+              play, where its run_once tasks would execute on every node at
+              once. Set download_run_once and download_localhost to false, or
+              use upgrade_strategy=linear.
+          when: system_upgrade | bool and system_upgrade_reboot != 'never' and not skip_downloads
+
 - name: Finally handle worker upgrades, based on given batch size
   hosts: kube_node:calico_rr:!kube_control_plane
   gather_facts: false
   any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
-  serial: "{{ serial | default('20%') }}"
+  # graceful_rolling drops the batch synchronisation point: host_pinned lets a
+  # node run the whole play without waiting for its peers and hands its worker
+  # to the next node the moment it is done, while serial: 100% puts every node
+  # into a single batch. The window itself is enforced by acquire_upgrade_slot,
+  # not by the strategy, so it can be narrower than the fork count and can vary
+  # per group. These are play keywords, evaluated before kubespray_defaults
+  # runs, hence the explicit default.
+  strategy: "{{ 'host_pinned' if upgrade_strategy | default('linear') == 'graceful_rolling' else 'linear' }}"
+  serial: "{{ '100%' if upgrade_strategy | default('linear') == 'graceful_rolling' else serial | default('20%') }}"
   roles:
     - { role: kubespray_defaults }
-    - { role: upgrade/pre-upgrade, tags: pre-upgrade }
-    - { role: upgrade/system-upgrade, tags: system-upgrade }
-    - { role: download, tags: download, when: "system_upgrade and system_upgrade_reboot != 'never' and not skip_downloads" }
-    - { role: container-engine, tags: "container-engine", when: deploy_container_engine }
-    - { role: kubernetes/node, tags: node }
-    - { role: kubernetes/kubeadm, tags: kubeadm }
-    - { role: kubernetes/node-label, tags: node-label }
-    - { role: kubernetes/node-taint, tags: node-taint }
-    - { role: upgrade/post-upgrade, tags: post-upgrade }
+  tasks:
+    # rescue: records which task broke the node, always: hands the slot back on
+    # every path - a broken node must not shrink the window for the rest of the
+    # cluster. Neither section runs for a host that became unreachable; that
+    # node's lease is reclaimed by upgrade_slot_lease_ttl instead.
+    - name: Upgrade the node while holding an upgrade slot
+      block:
+        - name: Acquire an upgrade slot
+          acquire_upgrade_slot:
+            concurrency: "{{ upgrade_node_concurrency }}"
+            per_group: "{{ upgrade_per_group_concurrency }}"
+            # ansible_play_hosts_all, not ansible_play_hosts: the latter drops
+            # hosts that already failed, which would shrink the percentage
+            # denominator - and with it the window - as a run degrades.
+            total_hosts: "{{ ansible_play_hosts_all | length }}"
+            poll_interval: "{{ upgrade_slot_poll_interval }}"
+            lease_ttl: "{{ upgrade_slot_lease_ttl }}"
+            timeout: "{{ upgrade_slot_timeout }}"
+            abort_on_failure: "{{ upgrade_abort_on_failure }}"
+          when: upgrade_strategy == 'graceful_rolling'
+          tags: always
+
+        - name: Cordon and drain the node
+          import_role:
+            name: upgrade/pre-upgrade
+          tags: pre-upgrade
+
+        - name: Upgrade the operating system packages
+          import_role:
+            name: upgrade/system-upgrade
+          tags: system-upgrade
+
+        - name: Download artifacts again after the system upgrade rebooted
+          import_role:
+            name: download
+          tags: download
+          when: "system_upgrade and system_upgrade_reboot != 'never' and not skip_downloads"
+
+        - name: Upgrade the container engine
+          import_role:
+            name: container-engine
+          tags: container-engine
+          when: deploy_container_engine
+
+        - name: Upgrade the kubelet
+          import_role:
+            name: kubernetes/node
+          tags: node
+
+        - name: Upgrade the node with kubeadm
+          import_role:
+            name: kubernetes/kubeadm
+          tags: kubeadm
+
+        - name: Apply the node labels
+          import_role:
+            name: kubernetes/node-label
+          tags: node-label
+
+        - name: Apply the node taints
+          import_role:
+            name: kubernetes/node-taint
+          tags: node-taint
+
+        - name: Uncordon the node
+          import_role:
+            name: upgrade/post-upgrade
+          tags: post-upgrade
+
+        # Restart kubelet and the container runtime before the slot is handed
+        # on, otherwise the next node could start draining while this one is
+        # still bouncing its services.
+        - name: Run the node's pending handlers before releasing the slot
+          meta: flush_handlers
+
+      rescue:
+        # A rescue: section is the only place where ansible-core exposes which
+        # task failed, so this is where the marker can name it. Blocks are
+        # handled by the play iterator, not by the strategy plugin, so this
+        # works under host_pinned exactly as it does under linear.
+        #
+        # The task name alone is not enough: upgrade/pre-upgrade wraps the
+        # drain in its own rescue and re-raises through 'Fail after rescue',
+        # which is what would reach the marker. The failure message carries
+        # the actual cause, so both are recorded.
+        - name: Record that this node failed its upgrade
+          release_upgrade_slot:
+            mark_failed: true
+            task: "{{ ansible_failed_task.name | default('unknown') }}"
+            reason: "{{ ansible_failed_result.msg | default('') }}"
+          when: upgrade_strategy == 'graceful_rolling'
+          tags: always
+
+        # A rescue: that runs to the end marks the host as recovered. Without
+        # this the node would count as upgraded, the play would carry on to the
+        # next play, and any_errors_fatal would never fire under linear.
+        - name: Fail the node again now that the failure has been recorded
+          fail:
+            msg: >-
+              Upgrade of {{ inventory_hostname }} failed in task
+              '{{ ansible_failed_task.name | default('unknown') }}'.
+          tags: always
+      always:
+        # Releasing a slot that is not held is a no-op, so this stays correct
+        # after the rescue: above already handed it back.
+        - name: Release the upgrade slot
+          release_upgrade_slot:
+          when: upgrade_strategy == 'graceful_rolling'
+          tags: always
+
+# The worker play never patches kube-proxy itself: the tasks are cluster-scoped
+# and rely on run_once, which needs a linear strategy. Doing it here runs them
+# exactly once per upgrade under either strategy - under linear the worker play
+# used to repeat them once per serial batch.
+- name: Point kube-proxy at the right API server endpoint
+  hosts: kube_node:calico_rr:!kube_control_plane
+  gather_facts: false
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
+  environment: "{{ proxy_disable_env }}"
+  roles:
+    - { role: kubespray_defaults }
+  tasks:
+    - name: Patch the kube-proxy kubeconfig for the cluster
+      import_role:
+        name: kubernetes/kubeadm
+        tasks_from: kube_proxy_kubeconfig
+      tags:
+        - kubeadm
+        - kube-proxy
 
 - name: Patch Kubernetes for Windows
   hosts: kube_control_plane[0]

--- a/plugins/action/acquire_upgrade_slot.py
+++ b/plugins/action/acquire_upgrade_slot.py
@@ -1,0 +1,753 @@
+# -*- coding: utf-8 -*-
+# Copyright the Kubespray contributors.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+DOCUMENTATION = """
+name: acquire_upgrade_slot
+short_description: Acquire a concurrency slot before upgrading a node
+description:
+  - Blocks until a concurrency slot is free, then claims it by writing a lease
+    file on the Ansible controller.
+  - Together with M(release_upgrade_slot) this implements the sliding-window
+    upgrade model - a node that finishes immediately frees its slot for the
+    next waiting node, with no batch synchronisation point.
+  - Only useful in a play running the built-in C(free) or C(host_pinned)
+    strategy. Under C(linear) every host reaches this task before any host may
+    proceed, so the play would deadlock.
+  - Must be paired with a M(release_upgrade_slot) call in the C(always:)
+    section of the surrounding block so the slot is freed even when the
+    upgrade fails.
+notes:
+  - All coordination happens on the Ansible controller. C(delegate_to:) is
+    neither needed nor supported - the action plugin never opens a connection
+    to the managed node.
+  - Leases live in C(~/.ansible/tmp/kubespray-upgrade-<run_id>/) with mode
+    0700. The directory is owned by the user running ansible-playbook, which
+    avoids the symlink races of a predictable path under C(/tmp).
+  - Because a host waiting for a slot occupies an Ansible worker, the fork
+    count must exceed the configured concurrency. The plugin clamps
+    C(concurrency) to C(forks - 1) and warns once per run when it does so.
+  - The failure marker written by M(release_upgrade_slot) is only consulted
+    while a host waits for a slot. A host that already holds one finishes its
+    upgrade even after another node failed - abandoning a half-drained node
+    would leave the cluster in a worse state than completing it.
+options:
+  concurrency:
+    description:
+      - Maximum number of hosts allowed to hold a slot simultaneously.
+      - Accepts a plain integer (C(5)) or a percentage string (C("20%")).
+        Percentages are resolved against C(total_hosts), rounded down and
+        clamped to a minimum of 1 - the same arithmetic ansible-core applies
+        to C(serial), so a given percentage means the same under either
+        upgrade strategy.
+      - Clamped to C(forks - 1). Defaults to C(forks - 1) when omitted.
+    type: raw
+  per_group:
+    description:
+      - Optional per-group concurrency ceilings. Keys are Ansible group names,
+        values are integers or percentage strings.
+      - A host may start only when every group limit that applies to it has a
+        free slot. The special key C(default) applies to hosts that are not a
+        member of any other listed group.
+      - A percentage here is taken of that group's own hosts, not of the whole
+        play - C(calico_rr: "50%") means half of the route reflectors. Group
+        membership is intersected with the play, so hosts the play does not
+        target are not counted. C(default) is resolved against the hosts that
+        match none of the other listed groups.
+    type: dict
+    default: {}
+  total_hosts:
+    description:
+      - Number of hosts in the play, used as the denominator when
+        C(concurrency) is a percentage. Pass
+        C({{ ansible_play_hosts_all | length }}).
+      - Use C(ansible_play_hosts_all), not C(ansible_play_hosts) - the latter
+        excludes hosts that have already failed, so the window would silently
+        narrow as a run degrades.
+      - Not needed for C(per_group) percentages, which count the group's hosts
+        themselves.
+    type: int
+  run_id:
+    description:
+      - Identifier scoping the lease directory, so that concurrent
+        ansible-playbook invocations do not share slots.
+      - Limited to letters, digits, dot, dash and underscore, because the
+        value becomes a directory name.
+      - Defaults to a value derived from Ansible's own per-run controller temp
+        directory, which is unique per invocation and stable across forked
+        workers.
+    type: str
+  poll_interval:
+    description:
+      - Seconds between slot-availability checks while waiting.
+    type: float
+    default: 5.0
+  lease_ttl:
+    description:
+      - Age in seconds after which a lease is considered abandoned (written by
+        an Ansible process that was killed) and removed. Must comfortably
+        exceed the duration of a single node upgrade.
+    type: int
+    default: 3600
+  timeout:
+    description:
+      - Maximum seconds to wait for a slot before failing the task.
+      - C(0) waits indefinitely, which is the safe default - with a large
+        cluster and a small window the last node legitimately waits a long
+        time. Abandoned leases are reclaimed via C(lease_ttl) regardless.
+    type: int
+    default: 0
+  abort_on_failure:
+    description:
+      - When another host has already failed its upgrade, fail immediately
+        instead of claiming a slot.
+      - This restores the intent of C(any_errors_fatal), which ansible-core
+        implements only in the C(linear) strategy and silently ignores under
+        C(free) and C(host_pinned).
+    type: bool
+    default: true
+"""
+
+EXAMPLES = """
+- name: Acquire upgrade slot
+  acquire_upgrade_slot:
+    concurrency: "{{ upgrade_node_concurrency }}"
+    per_group: "{{ upgrade_per_group_concurrency }}"
+    total_hosts: "{{ ansible_play_hosts_all | length }}"
+"""
+
+RETURN = """
+slot_acquired:
+  description: Always C(true) - the task only returns once the slot is granted.
+  type: bool
+  returned: success
+active_slots:
+  description: Number of held leases at the moment this slot was granted.
+  type: int
+  returned: success
+concurrency:
+  description: The effective window size after percentage resolution and clamping.
+  type: int
+  returned: success
+waited_seconds:
+  description: How long this host waited for a slot.
+  type: float
+  returned: success
+"""
+
+import fcntl
+import json
+import os
+import re
+import time
+from pathlib import Path
+
+from ansible.errors import AnsibleActionFail
+from ansible.module_utils.parsing.convert_bool import boolean as convert_bool
+from ansible.plugins.action import ActionBase
+from ansible.utils.display import Display
+
+display = Display()
+
+# Bucket used for hosts that match none of the explicitly listed groups.
+DEFAULT_BUCKET = "__default__"
+
+FAILURE_MARKER = "UPGRADE_FAILED"
+
+# run_id becomes a directory name, so keep it to characters that cannot walk
+# out of ~/.ansible/tmp.
+SAFE_RUN_ID = re.compile(r"[A-Za-z0-9._-]+")
+
+VALID_ARGS = frozenset((
+    "concurrency",
+    "per_group",
+    "total_hosts",
+    "run_id",
+    "poll_interval",
+    "lease_ttl",
+    "timeout",
+    "abort_on_failure",
+))
+
+
+class ActionModule(ActionBase):
+    """Block until an upgrade concurrency slot is available, then claim it."""
+
+    TRANSFERS_FILES = False
+    _requires_connection = False
+    _supports_check_mode = True
+    _supports_async = False
+
+    def run(self, tmp=None, task_vars=None):
+        result = super().run(tmp, task_vars)
+        del tmp
+        task_vars = task_vars or {}
+
+        args = self._task.args
+        unknown = set(args) - VALID_ARGS
+        if unknown:
+            raise AnsibleActionFail(
+                "Unsupported parameters for acquire_upgrade_slot: %s. "
+                "Supported: %s" % (", ".join(sorted(unknown)), ", ".join(sorted(VALID_ARGS)))
+            )
+
+        hostname = task_vars.get("inventory_hostname", "unknown")
+        group_names = set(task_vars.get("group_names") or [])
+
+        total_hosts = to_int(args.get("total_hosts"), "total_hosts", minimum=1)
+        poll_interval = to_float(
+            args.get("poll_interval"), "poll_interval", minimum=0.1, default=5.0,
+        )
+        lease_ttl = to_int(args.get("lease_ttl"), "lease_ttl", minimum=1, default=3600)
+        timeout = to_int(args.get("timeout"), "timeout", minimum=0, default=0)
+        abort_on_failure = to_bool(
+            args.get("abort_on_failure"), "abort_on_failure", default=True,
+        )
+
+        per_group_arg = args.get("per_group") or {}
+        if not isinstance(per_group_arg, dict):
+            raise AnsibleActionFail(
+                "acquire_upgrade_slot: 'per_group' must be a mapping of group name "
+                "to a limit, got %r" % (per_group_arg,)
+            )
+
+        forks = current_forks()
+        if forks < 2:
+            raise AnsibleActionFail(
+                "acquire_upgrade_slot needs at least 2 forks: a host waiting for a "
+                "slot occupies a worker, so with forks=1 no host could ever make "
+                "progress. Raise forks (ansible.cfg [defaults] forks, ANSIBLE_FORKS "
+                "or -f) to at least 2."
+            )
+        # A waiting host holds a worker, so the window must leave one worker
+        # free for a host that could still be admitted.
+        ceiling = forks - 1
+
+        lease_dir = lease_directory(args.get("run_id"))
+        # Created before the limits are resolved so that warn_once() has
+        # somewhere to record what it already said. Check mode creates nothing.
+        if not self._task.check_mode:
+            mkdir_private(lease_dir)
+
+        def warn(key, message):
+            warn_once(lease_dir, key, message)
+
+        concurrency = resolve_concurrency(
+            args.get("concurrency"), total_hosts, ceiling, "concurrency",
+            default=ceiling, warn=warn,
+            hint="total_hosts was not supplied. Pass "
+                 "total_hosts: \"{{ ansible_play_hosts_all | length }}\".",
+        )
+        per_group = {
+            name: resolve_concurrency(
+                value,
+                group_denominator(name, per_group_arg, task_vars),
+                ceiling,
+                "per_group[%s]" % name,
+                warn=warn,
+                hint="the group holds no hosts in this play, so there is nothing "
+                     "to take a percentage of.",
+            )
+            for name, value in per_group_arg.items()
+        }
+
+        if self._task.check_mode:
+            result.update({
+                "changed": False,
+                "slot_acquired": True,
+                "active_slots": 0,
+                "concurrency": concurrency,
+                "waited_seconds": 0.0,
+                "msg": "check mode: a slot would be acquired",
+            })
+            return result
+
+        lock_path = lease_dir / ".lock"
+        lease_path = lease_dir / lease_filename(hostname)
+
+        display.vv(
+            "acquire_upgrade_slot: %s waiting for a slot "
+            "(window=%d, per_group=%s, leases=%s)"
+            % (hostname, concurrency, per_group or "{}", lease_dir)
+        )
+
+        started = time.monotonic()
+        attempt = 0
+        active = 0
+        # One handle for the whole wait: the lock is per flock() call, so
+        # reopening the file on every poll only adds syscalls.
+        with open(lock_path, "a") as lock_fh:
+            while True:
+                attempt += 1
+                fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+                try:
+                    if abort_on_failure:
+                        failure = read_failure_marker(lease_dir)
+                        if failure:
+                            raise AnsibleActionFail(
+                                "Aborting upgrade of %s: node %s already failed%s. "
+                                "No further nodes will be drained; see that node's "
+                                "error above. Set upgrade_abort_on_failure=false to "
+                                "keep going after a node failure."
+                                % (hostname, failure.get("host", "?"),
+                                   describe_failure(failure))
+                            )
+
+                    entries = reap_abandoned(
+                        read_lease_entries(lease_dir), lease_ttl, lease_path,
+                    )
+                    active = len(entries)
+                    holds_own_lease = any(path == lease_path for path, _ in entries)
+
+                    # A lease of our own is never reclaimed by reap_abandoned(),
+                    # so counting it would make this host wait for itself
+                    # forever. It means the slot is already ours: an earlier run
+                    # sharing the same run_id was killed while holding it, or
+                    # the task was retried.
+                    if holds_own_lease:
+                        display.warning(
+                            "acquire_upgrade_slot: %s already held a lease - left "
+                            "behind by a killed run sharing this run_id, or the task "
+                            "was retried. Reusing that slot instead of waiting for "
+                            "it to expire." % hostname
+                        )
+
+                    if holds_own_lease or (active < concurrency and group_limits_ok(
+                        group_names,
+                        count_per_group([data for _, data in entries], per_group),
+                        per_group,
+                    )):
+                        write_lease(lease_path, group_names)
+                        waited = time.monotonic() - started
+                        held = active if holds_own_lease else active + 1
+                        display.vv(
+                            "acquire_upgrade_slot: %s acquired a slot after %.1fs "
+                            "(%d/%d in flight)"
+                            % (hostname, waited, held, concurrency)
+                        )
+                        result.update({
+                            "changed": False,
+                            "slot_acquired": True,
+                            "active_slots": held,
+                            "concurrency": concurrency,
+                            "waited_seconds": round(waited, 1),
+                        })
+                        return result
+                finally:
+                    fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+
+                waited = time.monotonic() - started
+                delay = poll_interval
+                if timeout:
+                    remaining = timeout - waited
+                    if remaining <= 0:
+                        raise AnsibleActionFail(
+                            "acquire_upgrade_slot: %s waited %.0fs for a free slot "
+                            "(limit %ds, %d/%d in flight). Either a node upgrade is "
+                            "stuck or upgrade_slot_timeout is too low."
+                            % (hostname, waited, timeout, active, concurrency)
+                        )
+                    # Do not overshoot the deadline by up to a poll interval.
+                    delay = min(poll_interval, remaining)
+
+                display.vvv(
+                    "acquire_upgrade_slot: %s still waiting (attempt %d, %d/%d in flight)"
+                    % (hostname, attempt, active, concurrency)
+                )
+                time.sleep(delay)
+
+
+# ---------------------------------------------------------------------------
+# Helpers, kept at module level so the unit tests can exercise them directly.
+#
+# to_bool, write_json_atomic, safe_run_id, lease_filename, lease_directory,
+# ansible_home_tmp and ansible_local_tmp are duplicated in
+# release_upgrade_slot.py. Both plugins are loaded straight from
+# plugins/action/, which is not an importable package, so there is nowhere to
+# share them from that works both in the repository and in the built
+# collection. Keep the two copies in step - the unit tests assert that they
+# agree on the on-disk format and on the lease paths they derive.
+# ---------------------------------------------------------------------------
+
+def to_bool(value, label, default=None):
+    """Coerce an Ansible-style boolean, rejecting anything ambiguous.
+
+    Guessing here is dangerous: ``abort_on_failure`` defaults to true, so a
+    typo silently turning into false would disable the safety net without a
+    word of warning.
+    """
+    if value is None:
+        return default
+    try:
+        return convert_bool(value)
+    except TypeError as exc:
+        raise AnsibleActionFail(
+            "acquire_upgrade_slot: '%s' must be a boolean, got %r" % (label, value)
+        ) from exc
+
+
+def to_int(value, label, minimum=None, default=None):
+    """Coerce an integer argument, reporting bad input as a task failure."""
+    if value is None or value == "":
+        return default
+    try:
+        number = int(value)
+    except (TypeError, ValueError) as exc:
+        raise AnsibleActionFail(
+            "acquire_upgrade_slot: '%s' must be an integer, got %r" % (label, value)
+        ) from exc
+    if minimum is not None and number < minimum:
+        raise AnsibleActionFail(
+            "acquire_upgrade_slot: '%s' must be at least %d, got %r"
+            % (label, minimum, value)
+        )
+    return number
+
+
+def to_float(value, label, minimum=None, default=None):
+    """Coerce a float argument, reporting bad input as a task failure."""
+    if value is None or value == "":
+        return default
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise AnsibleActionFail(
+            "acquire_upgrade_slot: '%s' must be a number, got %r" % (label, value)
+        ) from exc
+    if minimum is not None and number < minimum:
+        raise AnsibleActionFail(
+            "acquire_upgrade_slot: '%s' must be at least %s, got %r"
+            % (label, minimum, value)
+        )
+    return number
+
+
+def current_forks():
+    """Return the fork count actually in effect for this run.
+
+    ``CLIARGS`` carries the value ``-f/--forks`` was parsed into, which is
+    where an explicit command line lands. The ``DEFAULT_FORKS`` fallback only
+    matters outside a CLI run, such as under the unit tests.
+    """
+    try:
+        from ansible import context
+
+        forks = context.CLIARGS.get("forks")
+        if forks:
+            return int(forks)
+    except Exception:  # noqa: BLE001 - CLIARGS is absent outside a CLI run
+        pass
+
+    try:
+        from ansible import constants as C
+
+        return int(C.DEFAULT_FORKS)
+    except Exception:  # noqa: BLE001
+        return 5
+
+
+def resolve_concurrency(raw, denominator, ceiling, label, default=None,
+                        warn=None, hint=None):
+    """Resolve an integer or ``"N%"`` concurrency value into ``[1, ceiling]``.
+
+    *denominator* is what a percentage is taken of: the play's host count for
+    the global window, the group's host count for a per-group ceiling.
+    """
+    if raw is None or raw == "":
+        if default is None:
+            raise AnsibleActionFail("acquire_upgrade_slot: '%s' is required" % label)
+        return default
+
+    if isinstance(raw, str) and raw.strip().endswith("%"):
+        if not denominator:
+            raise AnsibleActionFail(
+                "acquire_upgrade_slot: '%s' is the percentage %r but %s"
+                % (label, raw,
+                   hint or "there is no host count to resolve it against.")
+            )
+        try:
+            fraction = float(raw.strip()[:-1]) / 100.0
+        except ValueError as exc:
+            raise AnsibleActionFail(
+                "acquire_upgrade_slot: '%s' is not a valid percentage: %r" % (label, raw)
+            ) from exc
+        if fraction < 0:
+            raise AnsibleActionFail(
+                "acquire_upgrade_slot: '%s' must not be negative, got %r" % (label, raw)
+            )
+        # Round down with a floor of 1, matching ansible-core's pct_to_int()
+        # so that "20%" selects the same number of hosts here as it does in
+        # serial: under the linear strategy.
+        value = max(1, int(fraction * int(denominator)))
+    else:
+        try:
+            value = int(raw)
+        except (TypeError, ValueError) as exc:
+            raise AnsibleActionFail(
+                "acquire_upgrade_slot: '%s' must be an integer or a percentage "
+                "string, got %r" % (label, raw)
+            ) from exc
+        if value < 1:
+            raise AnsibleActionFail(
+                "acquire_upgrade_slot: '%s' must be at least 1, got %r" % (label, raw)
+            )
+
+    if value > ceiling:
+        message = (
+            "acquire_upgrade_slot: %s resolved to %d but is capped at %d "
+            "(forks - 1). A host waiting for a slot occupies a worker, so a "
+            "window that large would stall the play. Raise forks to widen it."
+            % (label, value, ceiling)
+        )
+        if warn:
+            warn("clamp-%s" % label, message)
+        else:
+            display.warning(message)
+        value = ceiling
+    return value
+
+
+def group_denominator(name, per_group, task_vars):
+    """Return how many of the play's hosts a per-group percentage refers to.
+
+    A ceiling written for a group is about that group, so C(calico_rr: "50%")
+    means half of the route reflectors - not half of the cluster. Inventory
+    membership is intersected with the play, because the worker play excludes
+    the control plane while C(groups) does not.
+    """
+    play_hosts = set(task_vars.get("ansible_play_hosts_all") or [])
+    groups = task_vars.get("groups") or {}
+
+    def members(group_name):
+        hosts = set(groups.get(group_name) or [])
+        return hosts & play_hosts if play_hosts else hosts
+
+    if name != "default":
+        return len(members(name))
+
+    # The default bucket covers whatever is left over once every explicitly
+    # listed group has been accounted for.
+    listed = set()
+    for other in per_group:
+        if other != "default":
+            listed |= members(other)
+    return len(play_hosts - listed)
+
+
+def warn_once(lease_dir, key, message):
+    """Emit *message* once for the whole run rather than once per host.
+
+    Every worker resolves the same configuration, so a plain warning would
+    repeat the identical line for every node in the play. The marker is
+    created with O_EXCL, which is atomic on its own - no need to take the slot
+    lock, which is not held yet at configuration time.
+    """
+    marker = lease_dir / (".warned-%s" % re.sub(r"[^A-Za-z0-9_.-]", "-", key))
+    try:
+        os.close(os.open(str(marker), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600))
+    except FileExistsError:
+        return
+    except OSError:
+        # No lease directory yet (check mode). Better loud than silent.
+        pass
+    display.warning(message)
+
+
+def lease_directory(run_id=None):
+    """Return the directory holding this run's leases.
+
+    By default the leases live inside Ansible's own controller-side temp
+    directory. That directory is created once per invocation, inherited by
+    every worker across ``fork()``, and removed when the run ends - so slots
+    are naturally scoped to one playbook run and leave nothing behind. It also
+    sits under ``$HOME`` with mode 0700, unlike a predictable path in ``/tmp``
+    that a co-tenant could race.
+    """
+    if run_id:
+        return ansible_home_tmp() / ("kubespray-upgrade-%s" % safe_run_id(run_id))
+
+    local_tmp = ansible_local_tmp()
+    if local_tmp:
+        return local_tmp / "kubespray-upgrade"
+
+    # Only reached if ansible-core stops exposing its local temp directory.
+    # The process group is stable across forked workers, but two playbooks
+    # started from one non-interactive shell script would share it.
+    return ansible_home_tmp() / ("kubespray-upgrade-%s" % os.getpgid(0))
+
+
+def safe_run_id(run_id):
+    """Reject a run_id that would not stay inside ``~/.ansible/tmp``."""
+    text = str(run_id)
+    if text in (".", "..") or not SAFE_RUN_ID.fullmatch(text):
+        raise AnsibleActionFail(
+            "acquire_upgrade_slot: 'run_id' becomes a directory name and may only "
+            "contain letters, digits, '.', '-' and '_', got %r" % (run_id,)
+        )
+    return text
+
+
+def lease_filename(hostname):
+    """Return the lease file name for *hostname*.
+
+    Only the path separator is dangerous - it would let an inventory name
+    place the lease outside the run's directory. Everything else a filesystem
+    accepts (the colons of an IPv6 address, dots) is kept verbatim so that log
+    messages keep naming the real host.
+    """
+    text = str(hostname)
+    if "/" in text or "\0" in text or text in (".", ".."):
+        raise AnsibleActionFail(
+            "acquire_upgrade_slot: inventory_hostname %r cannot be used as a lease "
+            "file name. Rename the host in the inventory." % (hostname,)
+        )
+    return "%s.lease" % text
+
+
+def ansible_home_tmp():
+    """Return ``~/.ansible/tmp``, the parent of Ansible's per-run temp dirs."""
+    return Path(os.path.expanduser("~/.ansible/tmp"))
+
+
+def ansible_local_tmp():
+    """Return Ansible's per-run controller temp directory, if it exists."""
+    try:
+        from ansible import constants as C
+
+        path = Path(str(C.DEFAULT_LOCAL_TMP))
+        return path if path.is_dir() else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def mkdir_private(path):
+    """Create *path*, and any missing parents, all at mode 0700.
+
+    ``Path.mkdir(parents=True, mode=...)`` only applies *mode* to the leaf
+    directory - missing parents fall back to Ansible's own recursive mkdir,
+    created with the default umask-derived permissions. Walk up by hand so a
+    freshly created ``~/.ansible`` or ``~/.ansible/tmp`` cannot end up
+    world-readable.
+    """
+    if path.is_dir():
+        return
+    mkdir_private(path.parent)
+    path.mkdir(mode=0o700, exist_ok=True)
+
+
+def write_json_atomic(path, data):
+    """Write *data* as JSON via a temp file + rename, so a concurrent reader
+    that glob()s the directory never observes a partially written file."""
+    tmp_path = path.with_name(path.name + ".tmp")
+    tmp_path.write_text(json.dumps(data))
+    os.rename(tmp_path, path)
+
+
+def write_lease(lease_path, group_names):
+    """Write a lease file, atomically so a concurrent reader sees it whole."""
+    write_json_atomic(lease_path, {
+        "acquired_at": time.time(),
+        "groups": sorted(group_names),
+    })
+
+
+def read_lease_entries(lease_dir):
+    """Return ``(path, data)`` for every lease currently held."""
+    entries = []
+    for path in sorted(lease_dir.glob("*.lease")):
+        try:
+            entries.append((path, json.loads(path.read_text())))
+        except (OSError, ValueError):
+            # The lease was released between glob() and read(); it holds no slot.
+            continue
+    return entries
+
+
+def reap_abandoned(entries, ttl, keep_path):
+    """Drop leases older than *ttl*, left behind by a killed Ansible process.
+
+    *keep_path* - the caller's own lease - is never reclaimed here. The caller
+    decides what to do with it, because for that one file "abandoned" means
+    "already mine" rather than "someone else's stale slot".
+    """
+    cutoff = time.time() - ttl
+    alive = []
+    for path, data in entries:
+        if path != keep_path and data.get("acquired_at", 0) < cutoff:
+            path.unlink(missing_ok=True)
+            display.warning(
+                "acquire_upgrade_slot: reclaimed the slot held by %s, its lease "
+                "was older than upgrade_slot_lease_ttl (%ds). If that node is "
+                "still upgrading, raise the TTL." % (path.stem, ttl)
+            )
+            continue
+        alive.append((path, data))
+    return alive
+
+
+def read_failure_marker(lease_dir):
+    """Return the recorded first failure, or ``None`` while the run is healthy."""
+    try:
+        return json.loads((lease_dir / FAILURE_MARKER).read_text())
+    except (OSError, ValueError):
+        return None
+
+
+def describe_failure(failure):
+    """Render the ``task``/``reason`` of a marker as an explanatory clause.
+
+    The task name alone is often the wrong thing to show: a role that wraps a
+    step in its own ``rescue:`` re-raises through a task of its choosing, so a
+    failed drain surfaces as ``Fail after rescue``. The reason carries what
+    actually went wrong, so prefer to show both.
+    """
+    task = failure.get("task")
+    reason = failure.get("reason")
+    if task and reason:
+        return " in task '%s': %s" % (task, reason)
+    if task:
+        return " in task '%s'" % task
+    if reason:
+        return ": %s" % reason
+    return ""
+
+
+def count_per_group(leases, per_group):
+    """Count held leases per tracked group."""
+    explicit = set(per_group) - {"default"}
+    counts = {}
+    for lease in leases:
+        groups = set(lease.get("groups") or [])
+        matched = False
+        for name in explicit & groups:
+            counts[name] = counts.get(name, 0) + 1
+            matched = True
+        if "default" in per_group and not matched:
+            counts[DEFAULT_BUCKET] = counts.get(DEFAULT_BUCKET, 0) + 1
+    return counts
+
+
+def group_limits_ok(group_names, counts, per_group):
+    """Return True when every group ceiling applying to this host has room."""
+    if not per_group:
+        return True
+
+    explicit = set(per_group) - {"default"}
+    for name in explicit & group_names:
+        if counts.get(name, 0) >= per_group[name]:
+            display.vvv(
+                "acquire_upgrade_slot: deferred, group '%s' is at its limit of %d"
+                % (name, per_group[name])
+            )
+            return False
+
+    if "default" in per_group and not (group_names & explicit):
+        if counts.get(DEFAULT_BUCKET, 0) >= per_group["default"]:
+            display.vvv(
+                "acquire_upgrade_slot: deferred, the default group limit of %d is reached"
+                % per_group["default"]
+            )
+            return False
+
+    return True

--- a/plugins/action/release_upgrade_slot.py
+++ b/plugins/action/release_upgrade_slot.py
@@ -1,0 +1,288 @@
+# -*- coding: utf-8 -*-
+# Copyright the Kubespray contributors.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+DOCUMENTATION = """
+name: release_upgrade_slot
+short_description: Release the concurrency slot held by this node
+description:
+  - Removes this host's lease so the next waiting node may start, and
+    optionally records that the upgrade failed.
+  - Belongs in the C(always:) section of the block that acquired the slot, so
+    that a failed node still hands its slot back.
+  - Releasing a slot that was never acquired is not an error, which keeps the
+    task safe in C(always:) even when M(acquire_upgrade_slot) itself failed.
+notes:
+  - Runs entirely on the Ansible controller and opens no connection to the
+    managed node.
+  - With C(mark_failed) the plugin writes a marker that makes every subsequent
+    M(acquire_upgrade_slot) fail fast. Only the first failure is recorded, so
+    the reported node is the one that actually broke the run.
+options:
+  mark_failed:
+    description:
+      - Record that this host failed its upgrade, stopping any node that has
+        not yet been drained.
+      - Use it from a C(rescue:) section; the plain C(always:) release should
+        leave it at the default.
+    type: bool
+    default: false
+  task:
+    description:
+      - Name of the task that failed, stored in the marker so the abort
+        message can point at it. Pass C({{ ansible_failed_task.name }}).
+      - On its own this is often not enough. A role that wraps a step in its
+        own C(block)/C(rescue) re-raises through a task of its choosing, so
+        the name that reaches this plugin is that re-raise - for a failed
+        drain, C(upgrade/pre-upgrade) reports C(Fail after rescue) rather than
+        C(Drain node). Pass C(reason) as well.
+    type: str
+  reason:
+    description:
+      - Message of the failure, stored alongside C(task) so the abort message
+        can say what went wrong rather than only where. Pass
+        C({{ ansible_failed_result.msg }}).
+      - Truncated to 200 characters, because a module failure can carry an
+        entire command's stderr.
+    type: str
+  run_id:
+    description:
+      - Must match the C(run_id) given to M(acquire_upgrade_slot). Defaults to
+        the same derived per-run value.
+      - Limited to letters, digits, dot, dash and underscore, because the
+        value becomes a directory name.
+    type: str
+"""
+
+EXAMPLES = """
+- name: Release upgrade slot
+  release_upgrade_slot:
+
+- name: Stop the rollout after a failed node
+  release_upgrade_slot:
+    mark_failed: true
+    task: "{{ ansible_failed_task.name | default('unknown') }}"
+    reason: "{{ ansible_failed_result.msg | default('') }}"
+"""
+
+RETURN = """
+slot_released:
+  description: Whether a lease was actually removed.
+  type: bool
+  returned: success
+failure_recorded:
+  description: Whether this call wrote the failure marker.
+  type: bool
+  returned: success
+"""
+
+import fcntl
+import json
+import os
+import re
+import time
+from pathlib import Path
+
+from ansible.errors import AnsibleActionFail
+from ansible.module_utils.parsing.convert_bool import boolean as convert_bool
+from ansible.plugins.action import ActionBase
+from ansible.utils.display import Display
+
+display = Display()
+
+FAILURE_MARKER = "UPGRADE_FAILED"
+
+# run_id becomes a directory name, so keep it to characters that cannot walk
+# out of ~/.ansible/tmp.
+SAFE_RUN_ID = re.compile(r"[A-Za-z0-9._-]+")
+
+VALID_ARGS = frozenset(("mark_failed", "task", "reason", "run_id"))
+
+# A module failure can carry an entire command's stderr; the abort message only
+# needs enough of it to point at the cause.
+MAX_REASON = 200
+
+
+class ActionModule(ActionBase):
+    """Hand back the upgrade slot held by this host."""
+
+    TRANSFERS_FILES = False
+    _requires_connection = False
+    _supports_check_mode = True
+    _supports_async = False
+
+    def run(self, tmp=None, task_vars=None):
+        result = super().run(tmp, task_vars)
+        del tmp
+        task_vars = task_vars or {}
+
+        args = self._task.args
+        unknown = set(args) - VALID_ARGS
+        if unknown:
+            raise AnsibleActionFail(
+                "Unsupported parameters for release_upgrade_slot: %s. "
+                "Supported: %s" % (", ".join(sorted(unknown)), ", ".join(sorted(VALID_ARGS)))
+            )
+
+        hostname = task_vars.get("inventory_hostname", "unknown")
+        mark_failed = to_bool(args.get("mark_failed"), "mark_failed", default=False)
+        # Only a rescue: section can name the failing task; from always: the
+        # caller has nothing to pass and the marker stays without one.
+        failed_task = args.get("task") or None
+        failed_reason = summarise(args.get("reason"))
+
+        lease_dir = lease_directory(args.get("run_id"))
+
+        if self._task.check_mode:
+            result.update({
+                "changed": False,
+                "slot_released": False,
+                "failure_recorded": False,
+                "msg": "check mode: the slot would be released",
+            })
+            return result
+
+        if not lease_dir.is_dir():
+            # No slot was ever acquired - graceful_rolling is off, or the play
+            # failed before the acquire task ran.
+            result.update({
+                "changed": False,
+                "slot_released": False,
+                "failure_recorded": False,
+                "msg": "no lease directory, nothing to release",
+            })
+            return result
+
+        lease_path = lease_dir / lease_filename(hostname)
+        marker_path = lease_dir / FAILURE_MARKER
+        released = False
+        recorded = False
+
+        with open(lease_dir / ".lock", "a") as lock_fh:
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+            try:
+                if mark_failed and not marker_path.exists():
+                    write_json_atomic(marker_path, {
+                        "host": hostname,
+                        "task": failed_task,
+                        "reason": failed_reason,
+                        "failed_at": time.time(),
+                    })
+                    recorded = True
+                    display.warning(
+                        "release_upgrade_slot: %s failed to upgrade. Nodes that "
+                        "have not started yet will abort instead of draining."
+                        % hostname
+                    )
+
+                if lease_path.exists():
+                    lease_path.unlink()
+                    released = True
+                    display.vv("release_upgrade_slot: %s released its slot" % hostname)
+                else:
+                    display.vv(
+                        "release_upgrade_slot: %s held no slot (already released "
+                        "or never acquired)" % hostname
+                    )
+            finally:
+                fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+
+        result.update({
+            "changed": False,
+            "slot_released": released,
+            "failure_recorded": recorded,
+        })
+        return result
+
+
+# ---------------------------------------------------------------------------
+# The helpers below are duplicated in acquire_upgrade_slot.py. Both plugins are
+# loaded straight from plugins/action/, which is not an importable package, so
+# there is nowhere to share them from that works both in the repository and in
+# the built collection. Keep the two copies in step - the unit tests assert
+# that they agree on the on-disk format and on the lease paths they derive.
+# ---------------------------------------------------------------------------
+
+def summarise(reason):
+    """Condense a failure message to one line that fits an abort message."""
+    if not reason:
+        return None
+    text = " ".join(str(reason).split())
+    if len(text) > MAX_REASON:
+        text = text[:MAX_REASON - 1].rstrip() + "…"
+    return text or None
+
+
+def to_bool(value, label, default=None):
+    """Coerce an Ansible-style boolean, rejecting anything ambiguous.
+
+    Guessing here is dangerous: a typo silently turning into false would
+    quietly skip the failure marker.
+    """
+    if value is None:
+        return default
+    try:
+        return convert_bool(value)
+    except TypeError as exc:
+        raise AnsibleActionFail(
+            "release_upgrade_slot: '%s' must be a boolean, got %r" % (label, value)
+        ) from exc
+
+
+def write_json_atomic(path, data):
+    """Write *data* as JSON via a temp file + rename, so a concurrent reader
+    that glob()s the directory never observes a partially written file."""
+    tmp_path = path.with_name(path.name + ".tmp")
+    tmp_path.write_text(json.dumps(data))
+    os.rename(tmp_path, path)
+
+
+def lease_directory(run_id=None):
+    """Resolve the lease directory exactly as acquire_upgrade_slot does."""
+    if run_id:
+        return ansible_home_tmp() / ("kubespray-upgrade-%s" % safe_run_id(run_id))
+
+    local_tmp = ansible_local_tmp()
+    if local_tmp:
+        return local_tmp / "kubespray-upgrade"
+
+    return ansible_home_tmp() / ("kubespray-upgrade-%s" % os.getpgid(0))
+
+
+def safe_run_id(run_id):
+    """Reject a run_id that would not stay inside ``~/.ansible/tmp``."""
+    text = str(run_id)
+    if text in (".", "..") or not SAFE_RUN_ID.fullmatch(text):
+        raise AnsibleActionFail(
+            "release_upgrade_slot: 'run_id' becomes a directory name and may only "
+            "contain letters, digits, '.', '-' and '_', got %r" % (run_id,)
+        )
+    return text
+
+
+def lease_filename(hostname):
+    """Return the lease file name for *hostname*, as acquire_upgrade_slot does."""
+    text = str(hostname)
+    if "/" in text or "\0" in text or text in (".", ".."):
+        raise AnsibleActionFail(
+            "release_upgrade_slot: inventory_hostname %r cannot be used as a lease "
+            "file name. Rename the host in the inventory." % (hostname,)
+        )
+    return "%s.lease" % text
+
+
+def ansible_home_tmp():
+    """Return ``~/.ansible/tmp``, the parent of Ansible's per-run temp dirs."""
+    return Path(os.path.expanduser("~/.ansible/tmp"))
+
+
+def ansible_local_tmp():
+    """Return Ansible's per-run controller temp directory, if it exists."""
+    try:
+        from ansible import constants as C
+
+        path = Path(str(C.DEFAULT_LOCAL_TMP))
+        return path if path.is_dir() else None
+    except Exception:  # noqa: BLE001
+        return None

--- a/roles/kubernetes/kubeadm/defaults/main.yml
+++ b/roles/kubernetes/kubeadm/defaults/main.yml
@@ -6,3 +6,16 @@ kubeadm_join_timeout: 120s
 
 # Enable kubeadm file discovery if anonymous access has been removed
 kubeadm_use_file_discovery: "{{ remove_anonymous_access }}"
+
+# Internal, set by the calling play - not a user-facing setting.
+#
+# Rewrites the cluster-wide kube-proxy ConfigMap and restarts its pods as part
+# of this role. Those tasks are cluster-scoped and use run_once, which only
+# behaves correctly under the linear strategy: free and host_pinned run them on
+# every host instead, so several nodes would `kubectl replace` the same
+# ConfigMap at once and each would delete every kube-proxy pod in the cluster.
+#
+# It therefore defaults to off. A play that runs this role under a linear
+# strategy and wants the patch has to ask for it, which keeps the unsafe
+# combination from arising by accident.
+kubeadm_patch_kube_proxy: false

--- a/roles/kubernetes/kubeadm/tasks/kube_proxy_kubeconfig.yml
+++ b/roles/kubernetes/kubeadm/tasks/kube_proxy_kubeconfig.yml
@@ -1,0 +1,98 @@
+---
+# Cluster-scoped: these tasks rewrite the single kube-proxy ConfigMap and
+# restart every kube-proxy pod, so they must run exactly once per cluster no
+# matter how many nodes are in the play.
+#
+# They rely on run_once, which ansible-core honours only under the linear
+# strategy - free and host_pinned merely warn and then run the task on every
+# host (ansible/plugins/strategy/free.py). Concurrent `kubectl replace` calls
+# on one ConfigMap conflict, and a per-node `kubectl delete pod -l
+# k8s-app=kube-proxy` would restart cluster-wide networking once per node.
+#
+# That is why upgrade_cluster.yml skips this file inside the rolling worker
+# play (kubeadm_patch_kube_proxy: false) and runs it afterwards in a small
+# linear play instead.
+
+- name: Set kubeadm_discovery_address
+  set_fact:
+    # noqa: jinja[spacing]
+    kubeadm_discovery_address: >-
+      {%- if "127.0.0.1" in kube_apiserver_endpoint or "localhost" in kube_apiserver_endpoint -%}
+      {{ first_kube_control_plane_address | ansible.utils.ipwrap }}:{{ kube_apiserver_port }}
+      {%- else -%}
+      {{ kube_apiserver_endpoint | replace("https://", "") }}
+      {%- endif %}
+  when: kubeadm_discovery_address is not defined
+  tags:
+    - facts
+
+- name: Get current resourceVersion of kube-proxy configmap
+  command: "{{ kubectl }} get configmap kube-proxy -n kube-system -o jsonpath='{.metadata.resourceVersion}'"
+  register: original_configmap_resource_version
+  run_once: true
+  delegate_to: "{{ groups['kube_control_plane'] | first }}"
+  delegate_facts: false
+  when:
+    - kube_proxy_deployed
+  tags:
+    - kube-proxy
+
+# FIXME(mattymo): Need to point to localhost, otherwise control plane nodes will all point
+#                 incorrectly to first control plane node, creating SPoF.
+- name: Update server field in kube-proxy kubeconfig
+  shell: >-
+    set -o pipefail && {{ kubectl }} get configmap kube-proxy -n kube-system -o yaml
+    | sed 's#server:.*#server: https://127.0.0.1:{{ kube_apiserver_port }}#g'
+    | {{ kubectl }} replace -f -
+  args:
+    executable: /bin/bash
+  run_once: true
+  delegate_to: "{{ groups['kube_control_plane'] | first }}"
+  delegate_facts: false
+  when:
+    - kubeadm_config_api_fqdn is not defined
+    - kubeadm_discovery_address != kube_apiserver_endpoint | replace("https://", "")
+    - kube_proxy_deployed
+    - loadbalancer_apiserver_localhost
+  tags:
+    - kube-proxy
+
+- name: Update server field in kube-proxy kubeconfig - external lb
+  shell: >-
+    set -o pipefail && {{ kubectl }} get configmap kube-proxy -n kube-system -o yaml
+    | sed 's#server:.*#server: {{ kube_apiserver_endpoint }}#g'
+    | {{ kubectl }} replace -f -
+  args:
+    executable: /bin/bash
+  run_once: true
+  delegate_to: "{{ groups['kube_control_plane'] | first }}"
+  delegate_facts: false
+  when:
+    - kube_proxy_deployed
+    - loadbalancer_apiserver is defined
+  tags:
+    - kube-proxy
+
+- name: Get new resourceVersion of kube-proxy configmap
+  command: "{{ kubectl }} get configmap kube-proxy -n kube-system -o jsonpath='{.metadata.resourceVersion}'"
+  register: new_configmap_resource_version
+  run_once: true
+  delegate_to: "{{ groups['kube_control_plane'] | first }}"
+  delegate_facts: false
+  when:
+    - kube_proxy_deployed
+  tags:
+    - kube-proxy
+
+- name: Restart all kube-proxy pods to ensure that they load the new configmap
+  command: "{{ kubectl }} delete pod -n kube-system -l k8s-app=kube-proxy --force --grace-period=0"
+  run_once: true
+  delegate_to: "{{ groups['kube_control_plane'] | first }}"
+  delegate_facts: false
+  when:
+    - kubeadm_config_api_fqdn is not defined or loadbalancer_apiserver is defined
+    - kubeadm_discovery_address != kube_apiserver_endpoint | replace("https://", "") or loadbalancer_apiserver is defined
+    - kube_proxy_deployed
+    - original_configmap_resource_version.stdout != new_configmap_resource_version.stdout
+  tags:
+    - kube-proxy

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -123,64 +123,6 @@
     - loadbalancer_apiserver is defined
   notify: Kubeadm | restart kubelet
 
-- name: Get current resourceVersion of kube-proxy configmap
-  command: "{{ kubectl }} get configmap kube-proxy -n kube-system -o jsonpath='{.metadata.resourceVersion}'"
-  register: original_configmap_resource_version
-  run_once: true
-  delegate_to: "{{ groups['kube_control_plane'] | first }}"
-  delegate_facts: false
-  when:
-    - kube_proxy_deployed
-  tags:
-    - kube-proxy
-
-# FIXME(mattymo): Need to point to localhost, otherwise control plane nodes will all point
-#                 incorrectly to first control plane node, creating SPoF.
-- name: Update server field in kube-proxy kubeconfig
-  shell: >-
-    set -o pipefail && {{ kubectl }} get configmap kube-proxy -n kube-system -o yaml
-    | sed 's#server:.*#server: https://127.0.0.1:{{ kube_apiserver_port }}#g'
-    | {{ kubectl }} replace -f -
-  args:
-    executable: /bin/bash
-  run_once: true
-  delegate_to: "{{ groups['kube_control_plane'] | first }}"
-  delegate_facts: false
-  when:
-    - kubeadm_config_api_fqdn is not defined
-    - kubeadm_discovery_address != kube_apiserver_endpoint | replace("https://", "")
-    - kube_proxy_deployed
-    - loadbalancer_apiserver_localhost
-  tags:
-    - kube-proxy
-
-- name: Update server field in kube-proxy kubeconfig - external lb
-  shell: >-
-    set -o pipefail && {{ kubectl }} get configmap kube-proxy -n kube-system -o yaml
-    | sed 's#server:.*#server: {{kube_apiserver_endpoint}}#g'
-    | {{ kubectl }} replace -f -
-  args:
-    executable: /bin/bash
-  run_once: true
-  delegate_to: "{{ groups['kube_control_plane'] | first }}"
-  delegate_facts: false
-  when:
-    - kube_proxy_deployed
-    - loadbalancer_apiserver is defined
-  tags:
-    - kube-proxy
-
-- name: Get new resourceVersion of kube-proxy configmap
-  command: "{{ kubectl }} get configmap kube-proxy -n kube-system -o jsonpath='{.metadata.resourceVersion}'"
-  register: new_configmap_resource_version
-  run_once: true
-  delegate_to: "{{ groups['kube_control_plane'] | first }}"
-  delegate_facts: false
-  when:
-    - kube_proxy_deployed
-  tags:
-    - kube-proxy
-
 - name: Set ca.crt file permission
   file:
     path: "{{ kube_cert_dir }}/ca.crt"
@@ -188,17 +130,22 @@
     group: root
     mode: "0644"
 
-- name: Restart all kube-proxy pods to ensure that they load the new configmap
-  command: "{{ kubectl }} delete pod -n kube-system -l k8s-app=kube-proxy --force --grace-period=0"
-  run_once: true
-  delegate_to: "{{ groups['kube_control_plane'] | first }}"
-  delegate_facts: false
-  when:
-    - kubeadm_config_api_fqdn is not defined or loadbalancer_apiserver is defined
-    - kubeadm_discovery_address != kube_apiserver_endpoint | replace("https://", "") or loadbalancer_apiserver is defined
-    - kube_proxy_deployed
-    - original_configmap_resource_version.stdout != new_configmap_resource_version.stdout
+# Cluster-scoped and run_once, so only a linear play may ask for this - see
+# kubeadm_patch_kube_proxy in defaults/main.yml. The include is dynamic on
+# purpose: a static import would compile the tasks into every play regardless
+# of the condition, and free/host_pinned warn about run_once at dispatch time,
+# before any when: is evaluated. apply: keeps the tags a static import would
+# have propagated.
+- name: Point kube-proxy at the right API server endpoint
+  include_tasks:
+    file: kube_proxy_kubeconfig.yml
+    apply:
+      tags:
+        - kubeadm
+        - kube-proxy
+  when: kubeadm_patch_kube_proxy
   tags:
+    - kubeadm
     - kube-proxy
 
 - name: Extract etcd certs from control plane if using etcd kubeadm mode

--- a/roles/kubespray_defaults/defaults/main/upgrade.yml
+++ b/roles/kubespray_defaults/defaults/main/upgrade.yml
@@ -1,0 +1,51 @@
+---
+# How upgrade_cluster.yml walks through the worker nodes.
+#
+#   linear           Ansible's serial: batches (default, unchanged behaviour).
+#                    Every node in a batch waits for the slowest one before the
+#                    next batch starts.
+#   graceful_rolling Sliding window. Nodes advance independently and a node
+#                    that finishes immediately frees its slot for the next one.
+#                    Requires more forks than upgrade_node_concurrency.
+#
+# See docs/operations/upgrade-strategies.md.
+upgrade_strategy: linear
+
+# Nodes allowed to be draining/upgrading at the same time under
+# graceful_rolling. Accepts an integer or a percentage of the play's hosts.
+# Capped at forks - 1, because a node waiting for a slot occupies a worker.
+upgrade_node_concurrency: "20%"
+
+# Per-group ceilings layered on top of upgrade_node_concurrency. A node may
+# start only when every group limit that applies to it has room. The key
+# 'default' covers nodes in none of the listed groups.
+#
+# A percentage counts that group's own hosts in this play, so "50%" under
+# calico_rr means half of the route reflectors - not half of the cluster.
+#
+#   upgrade_per_group_concurrency:
+#     kube_node: 5
+#     calico_rr: 1
+upgrade_per_group_concurrency: {}
+
+# Seconds between checks while a node waits for a free slot.
+upgrade_slot_poll_interval: 5.0
+
+# A lease older than this is treated as abandoned by a killed Ansible process
+# and its slot is reclaimed. Must comfortably exceed a single node's upgrade
+# time, including drain_timeout and any reboot.
+upgrade_slot_lease_ttl: 3600
+
+# Seconds a node may wait for a slot before failing. 0 waits indefinitely,
+# which is correct for a large cluster with a small window - the last node
+# legitimately waits a long time. Abandoned slots are still reclaimed via
+# upgrade_slot_lease_ttl.
+upgrade_slot_timeout: 0
+
+# Stop draining further nodes once one node has failed its upgrade.
+#
+# ansible-core implements any_errors_fatal only in the linear strategy; free
+# and host_pinned ignore it (ansible/plugins/strategy/free.py). This flag
+# restores that safety net for graceful_rolling by failing every node that has
+# not yet been drained.
+upgrade_abort_on_failure: true

--- a/roles/upgrade/post-upgrade/tasks/confirm_uncordon.yml
+++ b/roles/upgrade/post-upgrade/tasks/confirm_uncordon.yml
@@ -1,0 +1,9 @@
+---
+# Included dynamically from main.yml so that the pause task is only ever
+# compiled into the play when upgrade_node_post_upgrade_confirm is set. pause
+# bypasses the host loop, which the free and host_pinned strategies refuse to
+# run.
+- name: Confirm node uncordon
+  pause:
+    echo: true
+    prompt: "Ready to uncordon node {{ kube_override_hostname | default(inventory_hostname) }}? (Press Enter to continue or Ctrl+C for other options)"

--- a/roles/upgrade/post-upgrade/tasks/main.yml
+++ b/roles/upgrade/post-upgrade/tasks/main.yml
@@ -11,16 +11,16 @@
     --timeout={{ upgrade_post_cilium_wait_timeout }}
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
 
+# See the comment in upgrade/pre-upgrade: pause bypasses the host loop and is
+# rejected outright by the free and host_pinned strategies, so it stays behind
+# a dynamic include.
 - name: Confirm node uncordon
-  pause:
-    echo: true
-    prompt: "Ready to uncordon node {{ kube_override_hostname | default(inventory_hostname) }}? (Press Enter to continue or Ctrl+C for other options)"
-  when:
-    - upgrade_node_post_upgrade_confirm
+  include_tasks: confirm_uncordon.yml
+  when: upgrade_node_post_upgrade_confirm
 
 - name: Wait before uncordoning node
-  pause:
-    seconds: "{{ upgrade_node_post_upgrade_pause_seconds }}"
+  wait_for:
+    timeout: "{{ upgrade_node_post_upgrade_pause_seconds }}"
   when:
     - not upgrade_node_post_upgrade_confirm
     - upgrade_node_post_upgrade_pause_seconds != 0

--- a/roles/upgrade/pre-upgrade/tasks/confirm_upgrade.yml
+++ b/roles/upgrade/pre-upgrade/tasks/confirm_upgrade.yml
@@ -1,0 +1,8 @@
+---
+# Included dynamically from main.yml so that the pause task is only ever
+# compiled into the play when upgrade_node_confirm is set. pause bypasses the
+# host loop, which the free and host_pinned strategies refuse to run.
+- name: Confirm node upgrade
+  pause:
+    echo: true
+    prompt: "Ready to cordon and upgrade node {{ kube_override_hostname | default(inventory_hostname) }}? (Press Enter to continue or Ctrl+C for other options)"

--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -1,15 +1,19 @@
 ---
 # Wait for upgrade
+#
+# The pause module sets BYPASS_HOST_LOOP, which the free and host_pinned
+# strategies reject with a hard error - and the strategy raises before any
+# when: is evaluated, so a false condition does not avoid it. A dynamic
+# include keeps the prompt out of the play unless it is actually wanted.
 - name: Confirm node upgrade
-  pause:
-    echo: true
-    prompt: "Ready to cordon and upgrade node {{ kube_override_hostname | default(inventory_hostname) }}? (Press Enter to continue or Ctrl+C for other options)"
-  when:
-    - upgrade_node_confirm
+  include_tasks: confirm_upgrade.yml
+  when: upgrade_node_confirm
 
+# wait_for without a port or path simply sleeps, and unlike pause it runs per
+# host, so it works under every strategy.
 - name: Wait before upgrade node
-  pause:
-    seconds: "{{ upgrade_node_pause_seconds }}"
+  wait_for:
+    timeout: "{{ upgrade_node_pause_seconds }}"
   when:
     - not upgrade_node_confirm
     - upgrade_node_pause_seconds != 0

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -11,6 +11,7 @@ fact_caching_connection = /tmp
 stdout_callback = default
 display_skipped_hosts = no
 library = ./library:../library
+action_plugins = ../plugins/action
 callbacks_enabled = profile_tasks
 jinja2_extensions = jinja2.ext.do
 roles_path = ../roles

--- a/tests/files/ubuntu24-calico-graceful-rolling-upgrade
+++ b/tests/files/ubuntu24-calico-graceful-rolling-upgrade
@@ -1,0 +1,1 @@
+UPGRADE_TEST=graceful

--- a/tests/files/ubuntu24-calico-graceful-rolling-upgrade.yml
+++ b/tests/files/ubuntu24-calico-graceful-rolling-upgrade.yml
@@ -1,0 +1,33 @@
+---
+# Exercises upgrade_strategy=graceful_rolling end to end.
+#
+# mode: ha gives one node that is kube_node without also being
+# kube_control_plane, which is what the rolling worker play targets
+# (kube_node:calico_rr:!kube_control_plane). all-in-one would leave that play
+# with no hosts at all and silently test nothing.
+#
+# One worker exercises the whole rolling path - the slot plugins, the
+# validation play, host_pinned, and the separate cluster-scoped kube-proxy
+# play - but not the sliding window itself, which needs at least three
+# workers. Concurrency is covered by tests/unit/plugins/action/.
+
+# Instance settings
+cloud_image: ubuntu-2404
+mode: ha
+
+# Kubespray settings
+upgrade_strategy: graceful_rolling
+
+upgrade_cluster_setup: true
+
+# Currently ipvs not available on KVM: https://packages.ubuntu.com/search?suite=focal&arch=amd64&mode=exactfilename&searchon=contents&keywords=ip_vs_sh.ko
+kube_proxy_mode: iptables
+enable_nodelocaldns: false
+
+# Pin disabling ipip mode to ensure proper upgrade
+ipip: false
+calico_vxlan_mode: Always
+calico_network_backend: bird
+
+# Needed to bypass deprecation check
+ignore_assert_errors: true

--- a/tests/unit/plugins/action/test_upgrade_slots.py
+++ b/tests/unit/plugins/action/test_upgrade_slots.py
@@ -1,0 +1,817 @@
+# Copyright the Kubespray contributors.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the upgrade slot action plugins.
+
+The plugins live outside any importable package, so they are loaded by path
+the same way ansible-core's action loader finds them.
+"""
+
+import importlib.util
+import json
+import stat
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from ansible.errors import AnsibleActionFail
+
+PLUGIN_DIR = Path(__file__).resolve().parents[4] / "plugins" / "action"
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(name, PLUGIN_DIR / (name + ".py"))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+acquire = _load("acquire_upgrade_slot")
+release = _load("release_upgrade_slot")
+
+
+# ---------------------------------------------------------------------------
+# A minimal stand-in for the ansible-core objects an action plugin is handed,
+# so the run() methods can be exercised without a playbook.
+# ---------------------------------------------------------------------------
+
+class _FakeShell:
+    tmpdir = None
+
+
+class _FakeConnection:
+    def __init__(self):
+        self._shell = _FakeShell()
+
+
+class _FakeTask:
+    def __init__(self, action, args, check_mode=False):
+        self.action = action
+        self.args = args
+        self.check_mode = check_mode
+        self.async_val = 0
+
+
+def make_action(module, name, args, check_mode=False):
+    action = module.ActionModule.__new__(module.ActionModule)
+    action._task = _FakeTask(name, args, check_mode)
+    action._connection = _FakeConnection()
+    return action
+
+
+@pytest.fixture
+def lease_dir(tmp_path, monkeypatch):
+    """Point both plugins at a throwaway lease directory."""
+    from ansible import constants as C
+
+    monkeypatch.setattr(C, "DEFAULT_LOCAL_TMP", str(tmp_path), raising=False)
+    return tmp_path / "kubespray-upgrade"
+
+
+@pytest.fixture
+def forks(monkeypatch):
+    """Pin the fork count so the concurrency ceiling is predictable."""
+    from ansible import context
+
+    monkeypatch.setattr(context, "CLIARGS", {"forks": 20}, raising=False)
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    """Replace the wait loop's clock so tests never actually sleep."""
+    state = {"now": 0.0, "on_sleep": None}
+
+    def sleep(seconds):
+        state["now"] += seconds
+        if state["on_sleep"]:
+            state["on_sleep"](state["now"])
+
+    monkeypatch.setattr(time, "monotonic", lambda: state["now"])
+    monkeypatch.setattr(time, "sleep", sleep)
+    return state
+
+
+def put_lease(directory, hostname, age=0.0, groups=()):
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / ("%s.lease" % hostname)
+    path.write_text(json.dumps({
+        "acquired_at": time.time() - age,
+        "groups": list(groups),
+    }))
+    return path
+
+
+class TestResolveConcurrency:
+    def test_plain_integer(self):
+        assert acquire.resolve_concurrency(3, 10, 19, "c") == 3
+
+    def test_percentage_of_play_hosts(self):
+        assert acquire.resolve_concurrency("20%", 10, 19, "c") == 2
+
+    def test_percentage_rounds_down_like_serial(self):
+        # ansible-core's pct_to_int() truncates, so the same percentage has to
+        # select the same number of hosts as serial: does under linear.
+        assert acquire.resolve_concurrency("25%", 10, 19, "c") == 2
+        assert acquire.resolve_concurrency("29%", 10, 19, "c") == 2
+        assert acquire.resolve_concurrency("30%", 10, 19, "c") == 3
+
+    def test_percentage_never_rounds_down_to_zero(self):
+        # A one-node-at-a-time window is still a window; zero would deadlock.
+        assert acquire.resolve_concurrency("1%", 10, 19, "c") == 1
+
+    def test_clamped_to_ceiling(self):
+        # A host waiting for a slot holds a worker, so the window cannot reach
+        # the fork count without stalling the play.
+        assert acquire.resolve_concurrency(100, 10, 19, "c") == 19
+        assert acquire.resolve_concurrency("100%", 10, 19, "c") == 10
+
+    def test_missing_value_uses_default(self):
+        assert acquire.resolve_concurrency(None, 10, 19, "c", default=7) == 7
+
+    def test_missing_value_without_default_is_an_error(self):
+        with pytest.raises(AnsibleActionFail, match="is required"):
+            acquire.resolve_concurrency(None, 10, 19, "c")
+
+    def test_percentage_without_a_denominator_is_an_error(self):
+        with pytest.raises(AnsibleActionFail, match="no host count"):
+            acquire.resolve_concurrency("20%", None, 19, "c")
+
+    def test_the_caller_can_supply_an_actionable_hint(self):
+        with pytest.raises(AnsibleActionFail, match="pass total_hosts"):
+            acquire.resolve_concurrency(
+                "20%", 0, 19, "c", hint="pass total_hosts.",
+            )
+
+    def test_clamping_goes_through_the_caller_warn_hook(self):
+        seen = []
+        acquire.resolve_concurrency(100, 10, 19, "c", warn=lambda k, m: seen.append(k))
+        assert seen == ["clamp-c"]
+
+    @pytest.mark.parametrize("bad", ["abc", "%", "1.2.3", None])
+    def test_rejects_garbage(self, bad):
+        with pytest.raises(AnsibleActionFail):
+            acquire.resolve_concurrency(bad, 10, 19, "c")
+
+    def test_rejects_zero_and_negative(self):
+        with pytest.raises(AnsibleActionFail, match="at least 1"):
+            acquire.resolve_concurrency(0, 10, 19, "c")
+        with pytest.raises(AnsibleActionFail, match="at least 1"):
+            acquire.resolve_concurrency(-1, 10, 19, "c")
+
+    def test_rejects_a_negative_percentage(self):
+        with pytest.raises(AnsibleActionFail, match="must not be negative"):
+            acquire.resolve_concurrency("-10%", 10, 19, "c")
+
+
+class TestArgumentCoercion:
+    """Bad input has to surface as a task failure, not a raw traceback."""
+
+    def test_int_accepts_ansible_strings(self):
+        assert acquire.to_int("7", "timeout") == 7
+
+    def test_int_uses_the_default_when_unset(self):
+        assert acquire.to_int(None, "timeout", default=3) == 3
+        assert acquire.to_int("", "timeout", default=3) == 3
+
+    def test_int_rejects_garbage(self):
+        with pytest.raises(AnsibleActionFail, match="must be an integer"):
+            acquire.to_int("soon", "timeout")
+
+    def test_int_enforces_a_minimum(self):
+        with pytest.raises(AnsibleActionFail, match="at least 1"):
+            acquire.to_int(0, "lease_ttl", minimum=1)
+
+    def test_float_accepts_ansible_strings(self):
+        assert acquire.to_float("2.5", "poll_interval") == 2.5
+
+    def test_float_rejects_garbage(self):
+        with pytest.raises(AnsibleActionFail, match="must be a number"):
+            acquire.to_float("often", "poll_interval")
+
+    def test_float_enforces_a_minimum(self):
+        # time.sleep() would raise on a negative interval.
+        with pytest.raises(AnsibleActionFail, match="at least"):
+            acquire.to_float(-1, "poll_interval", minimum=0.1)
+
+
+class TestCurrentForks:
+    def test_prefers_the_command_line(self, monkeypatch):
+        from ansible import context
+
+        monkeypatch.setattr(context, "CLIARGS", {"forks": 25}, raising=False)
+        assert acquire.current_forks() == 25
+
+    def test_falls_back_to_the_configured_default(self, monkeypatch):
+        from ansible import constants as C
+        from ansible import context
+
+        monkeypatch.setattr(context, "CLIARGS", {}, raising=False)
+        monkeypatch.setattr(C, "DEFAULT_FORKS", 12, raising=False)
+        assert acquire.current_forks() == 12
+
+
+class TestPerGroupLimits:
+    def test_no_limits_always_admits(self):
+        assert acquire.group_limits_ok({"kube_node"}, {}, {}) is True
+
+    def test_blocks_when_an_explicit_group_is_full(self):
+        leases = [{"groups": ["kube_node"]}, {"groups": ["kube_node"]}]
+        limits = {"kube_node": 2}
+        counts = acquire.count_per_group(leases, limits)
+        assert counts == {"kube_node": 2}
+        assert acquire.group_limits_ok({"kube_node"}, counts, limits) is False
+
+    def test_admits_while_an_explicit_group_has_room(self):
+        leases = [{"groups": ["kube_node"]}]
+        limits = {"kube_node": 2}
+        counts = acquire.count_per_group(leases, limits)
+        assert acquire.group_limits_ok({"kube_node"}, counts, limits) is True
+
+    def test_a_host_must_satisfy_every_group_it_belongs_to(self):
+        leases = [{"groups": ["kube_node", "calico_rr"]}]
+        limits = {"kube_node": 5, "calico_rr": 1}
+        counts = acquire.count_per_group(leases, limits)
+        assert acquire.group_limits_ok({"kube_node"}, counts, limits) is True
+        assert acquire.group_limits_ok({"kube_node", "calico_rr"}, counts, limits) is False
+
+    def test_untracked_groups_are_ignored(self):
+        leases = [{"groups": ["some_other_group"]}]
+        limits = {"kube_node": 1}
+        counts = acquire.count_per_group(leases, limits)
+        assert counts == {}
+        assert acquire.group_limits_ok({"kube_node"}, counts, limits) is True
+
+    def test_default_bucket_only_covers_unlisted_hosts(self):
+        leases = [{"groups": ["misc"]}, {"groups": ["kube_node"]}]
+        limits = {"kube_node": 5, "default": 1}
+        counts = acquire.count_per_group(leases, limits)
+        assert counts == {"kube_node": 1, acquire.DEFAULT_BUCKET: 1}
+        # 'misc' falls into the full default bucket.
+        assert acquire.group_limits_ok({"misc"}, counts, limits) is False
+        # kube_node is explicitly listed, so the default ceiling does not apply.
+        assert acquire.group_limits_ok({"kube_node"}, counts, limits) is True
+
+
+class TestGroupDenominator:
+    """A per-group percentage is about that group, not about the cluster."""
+
+    TASK_VARS = {
+        "ansible_play_hosts_all": ["n1", "n2", "n3", "n4", "rr1", "rr2"],
+        "groups": {
+            "all": ["cp1", "n1", "n2", "n3", "n4", "rr1", "rr2"],
+            "kube_node": ["cp1", "n1", "n2", "n3", "n4"],
+            "calico_rr": ["rr1", "rr2"],
+        },
+    }
+
+    def test_counts_the_groups_own_hosts(self):
+        assert acquire.group_denominator("calico_rr", {}, self.TASK_VARS) == 2
+
+    def test_hosts_outside_the_play_do_not_count(self):
+        # The worker play excludes the control plane, but groups['kube_node']
+        # still lists it.
+        assert acquire.group_denominator("kube_node", {}, self.TASK_VARS) == 4
+
+    def test_an_unknown_group_has_no_hosts(self):
+        assert acquire.group_denominator("gpu_nodes", {}, self.TASK_VARS) == 0
+
+    def test_default_covers_whatever_no_listed_group_claims(self):
+        per_group = {"calico_rr": 1, "default": "50%"}
+        assert acquire.group_denominator("default", per_group, self.TASK_VARS) == 4
+
+    def test_default_is_empty_once_every_host_is_listed(self):
+        per_group = {"kube_node": 1, "calico_rr": 1, "default": 1}
+        assert acquire.group_denominator("default", per_group, self.TASK_VARS) == 0
+
+    def test_half_the_route_reflectors_is_one_not_three(self):
+        # The whole point of the change: "50%" under calico_rr used to be
+        # resolved against the six hosts of the play.
+        denominator = acquire.group_denominator("calico_rr", {}, self.TASK_VARS)
+        assert acquire.resolve_concurrency("50%", denominator, 19, "per_group") == 1
+
+
+class TestWarnOnce:
+    def test_the_first_caller_warns_and_the_rest_stay_quiet(self, tmp_path, monkeypatch):
+        seen = []
+        monkeypatch.setattr(acquire.display, "warning", seen.append)
+
+        for _ in range(5):
+            acquire.warn_once(tmp_path, "clamp-concurrency", "too wide")
+
+        assert seen == ["too wide"]
+
+    def test_different_keys_warn_independently(self, tmp_path, monkeypatch):
+        seen = []
+        monkeypatch.setattr(acquire.display, "warning", seen.append)
+
+        acquire.warn_once(tmp_path, "clamp-concurrency", "a")
+        acquire.warn_once(tmp_path, "clamp-per_group[calico_rr]", "b")
+
+        assert seen == ["a", "b"]
+
+    def test_a_key_that_is_not_a_filename_still_works(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(acquire.display, "warning", lambda message: None)
+
+        acquire.warn_once(tmp_path, "clamp-per_group[a/b]", "x")
+
+        assert [p.name for p in tmp_path.iterdir()] == [".warned-clamp-per_group-a-b-"]
+
+    def test_without_a_directory_it_warns_rather_than_swallowing(self, tmp_path, monkeypatch):
+        seen = []
+        monkeypatch.setattr(acquire.display, "warning", seen.append)
+
+        # Check mode never creates the lease directory.
+        acquire.warn_once(tmp_path / "absent", "clamp-concurrency", "loud")
+
+        assert seen == ["loud"]
+
+
+class TestLeaseFiles:
+    def test_write_then_read_round_trip(self, tmp_path):
+        acquire.write_lease(tmp_path / "n1.lease", {"kube_node", "calico_rr"})
+        entries = acquire.read_lease_entries(tmp_path)
+        assert len(entries) == 1
+        path, data = entries[0]
+        assert path == tmp_path / "n1.lease"
+        assert data["groups"] == ["calico_rr", "kube_node"]
+        assert data["acquired_at"] <= time.time()
+
+    def test_write_leaves_no_temporary_file_behind(self, tmp_path):
+        acquire.write_lease(tmp_path / "n1.lease", set())
+        assert [p.name for p in tmp_path.iterdir()] == ["n1.lease"]
+
+    def test_partial_and_missing_files_hold_no_slot(self, tmp_path):
+        (tmp_path / "broken.lease").write_text("{not json")
+        assert acquire.read_lease_entries(tmp_path) == []
+
+    def test_abandoned_leases_are_reclaimed(self, tmp_path):
+        stale = put_lease(tmp_path, "dead", age=7200)
+        fresh = put_lease(tmp_path, "alive")
+
+        alive = acquire.reap_abandoned(
+            acquire.read_lease_entries(tmp_path), 3600, tmp_path / "other.lease",
+        )
+
+        assert not stale.exists()
+        assert fresh.exists()
+        assert [path for path, _ in alive] == [fresh]
+
+    def test_the_caller_own_lease_is_never_reclaimed(self, tmp_path):
+        mine = put_lease(tmp_path, "me", age=7200)
+
+        alive = acquire.reap_abandoned(
+            acquire.read_lease_entries(tmp_path), 3600, mine,
+        )
+
+        assert mine.exists()
+        assert [path for path, _ in alive] == [mine]
+
+
+class TestWriteJsonAtomic:
+    """Both plugins write their JSON files through this helper so that a
+    reader glob()ing the directory never observes a half-written file."""
+
+    @pytest.mark.parametrize("module", [acquire, release])
+    def test_round_trip(self, tmp_path, module):
+        path = tmp_path / "thing.json"
+        module.write_json_atomic(path, {"a": 1})
+        assert json.loads(path.read_text()) == {"a": 1}
+
+    @pytest.mark.parametrize("module", [acquire, release])
+    def test_leaves_no_temporary_file_behind(self, tmp_path, module):
+        module.write_json_atomic(tmp_path / "thing.json", {})
+        assert [p.name for p in tmp_path.iterdir()] == ["thing.json"]
+
+    def test_acquire_and_release_produce_interchangeable_output(self, tmp_path):
+        # release_upgrade_slot writes the failure marker; acquire_upgrade_slot
+        # reads it back. Confirm the two independent copies of the helper
+        # actually agree on the on-disk format.
+        path = tmp_path / acquire.FAILURE_MARKER
+        release.write_json_atomic(path, {"host": "n1", "task": None, "failed_at": 1.0})
+        assert acquire.read_failure_marker(tmp_path)["host"] == "n1"
+
+
+class TestFailureMarker:
+    def test_absent_marker_reads_as_healthy(self, tmp_path):
+        assert acquire.read_failure_marker(tmp_path) is None
+
+    def test_marker_is_readable(self, tmp_path):
+        (tmp_path / acquire.FAILURE_MARKER).write_text(
+            json.dumps({"host": "n1", "failed_at": 1.0})
+        )
+        assert acquire.read_failure_marker(tmp_path)["host"] == "n1"
+
+    def test_a_torn_write_reads_as_healthy_rather_than_crashing(self, tmp_path):
+        # write_json_atomic can never leave this behind (rename is atomic),
+        # but read_failure_marker must stay defensive regardless.
+        (tmp_path / acquire.FAILURE_MARKER).write_text("")
+        assert acquire.read_failure_marker(tmp_path) is None
+
+    def test_acquire_and_release_agree_on_the_marker_name(self):
+        assert acquire.FAILURE_MARKER == release.FAILURE_MARKER
+
+
+class TestDescribeFailure:
+    """A role with its own rescue: re-raises through a task of its choosing,
+    so the task name alone can be useless - upgrade/pre-upgrade turns a failed
+    drain into 'Fail after rescue'. The reason carries the actual cause."""
+
+    def test_task_and_reason_are_both_shown(self):
+        clause = acquire.describe_failure(
+            {"task": "Fail after rescue", "reason": "Failed to drain node k8s-4"}
+        )
+        assert clause == " in task 'Fail after rescue': Failed to drain node k8s-4"
+
+    def test_task_alone_still_works(self):
+        assert acquire.describe_failure({"task": "Drain node"}) == " in task 'Drain node'"
+
+    def test_reason_alone_still_works(self):
+        assert acquire.describe_failure({"reason": "boom"}) == ": boom"
+
+    def test_an_empty_marker_adds_nothing(self):
+        assert acquire.describe_failure({}) == ""
+        assert acquire.describe_failure({"task": None, "reason": None}) == ""
+
+
+class TestSummarise:
+    def test_collapses_whitespace_to_one_line(self):
+        assert release.summarise("failed to drain\n  node  k8s-4\n") == \
+            "failed to drain node k8s-4"
+
+    def test_truncates_a_wall_of_stderr(self):
+        text = release.summarise("x" * 500)
+        assert len(text) == release.MAX_REASON
+        assert text.endswith("…")
+
+    def test_nothing_stays_nothing(self):
+        assert release.summarise(None) is None
+        assert release.summarise("") is None
+        assert release.summarise("   ") is None
+
+
+class TestMkdirPrivate:
+    def test_creates_missing_parents_at_mode_0700(self, tmp_path):
+        target = tmp_path / "a" / "b" / "c"
+        acquire.mkdir_private(target)
+
+        for directory in (tmp_path / "a", tmp_path / "a" / "b", target):
+            assert stat.S_IMODE(directory.stat().st_mode) == 0o700
+
+    def test_idempotent_on_an_existing_directory(self, tmp_path):
+        target = tmp_path / "a"
+        target.mkdir(mode=0o700)
+
+        acquire.mkdir_private(target)  # must not raise
+
+        assert target.is_dir()
+
+
+class TestLeaseDirectory:
+    def test_both_plugins_derive_the_same_path(self, tmp_path, monkeypatch):
+        from ansible import constants as C
+
+        monkeypatch.setattr(C, "DEFAULT_LOCAL_TMP", str(tmp_path), raising=False)
+        assert acquire.lease_directory() == release.lease_directory()
+        assert acquire.lease_directory("abc") == release.lease_directory("abc")
+
+    def test_defaults_inside_the_per_run_controller_tmpdir(self, tmp_path, monkeypatch):
+        # Ansible removes that directory when the run ends, so leases from a
+        # finished run never linger.
+        from ansible import constants as C
+
+        monkeypatch.setattr(C, "DEFAULT_LOCAL_TMP", str(tmp_path), raising=False)
+        assert acquire.lease_directory() == tmp_path / "kubespray-upgrade"
+
+    def test_falls_back_to_the_process_group_without_a_run_tmpdir(self, monkeypatch):
+        from ansible import constants as C
+
+        monkeypatch.setattr(C, "DEFAULT_LOCAL_TMP", "/nonexistent/xyz", raising=False)
+        path = acquire.lease_directory()
+        # Stable across forked workers, which is what matters for coordination.
+        assert path.name == "kubespray-upgrade-%d" % __import__("os").getpgid(0)
+        assert path.parent == Path.home() / ".ansible" / "tmp"
+
+    def test_an_explicit_run_id_wins(self, tmp_path, monkeypatch):
+        from ansible import constants as C
+
+        monkeypatch.setattr(C, "DEFAULT_LOCAL_TMP", str(tmp_path), raising=False)
+        path = acquire.lease_directory("abc")
+        assert path.name == "kubespray-upgrade-abc"
+        # Not /tmp: a predictable world-writable path invites symlink races.
+        assert str(path).startswith(str(Path.home()))
+
+
+class TestPathSafety:
+    """run_id and inventory_hostname end up in a path, so they cannot be
+    allowed to walk out of the lease directory."""
+
+    @pytest.mark.parametrize("module", [acquire, release])
+    @pytest.mark.parametrize("bad", ["../../etc", "..", ".", "a/b", "with space", ""])
+    def test_a_traversing_run_id_is_refused(self, module, bad):
+        with pytest.raises(AnsibleActionFail, match="run_id"):
+            module.safe_run_id(bad)
+
+    @pytest.mark.parametrize("module", [acquire, release])
+    def test_ordinary_run_ids_pass(self, module):
+        assert module.safe_run_id("ci-run_2.1") == "ci-run_2.1"
+
+    @pytest.mark.parametrize("module", [acquire, release])
+    @pytest.mark.parametrize("bad", ["../evil", "a/b", ".", ".."])
+    def test_a_traversing_hostname_is_refused(self, module, bad):
+        with pytest.raises(AnsibleActionFail, match="lease file name"):
+            module.lease_filename(bad)
+
+    @pytest.mark.parametrize("module", [acquire, release])
+    def test_hostnames_a_filesystem_accepts_are_kept_verbatim(self, module):
+        # Kubespray inventories routinely name hosts by address.
+        assert module.lease_filename("node-1.example.com") == "node-1.example.com.lease"
+        assert module.lease_filename("fd00::1") == "fd00::1.lease"
+
+    def test_both_plugins_agree_on_the_lease_file_name(self):
+        assert acquire.lease_filename("n1") == release.lease_filename("n1")
+
+
+class TestToBool:
+    @pytest.mark.parametrize("value", [True, "true", "True", "yes", "on", "1", "y", "t"])
+    def test_truthy(self, value):
+        assert acquire.to_bool(value, "flag") is True
+        assert release.to_bool(value, "flag") is True
+
+    @pytest.mark.parametrize("value", [False, "false", "no", "off", "0", "n", "f"])
+    def test_falsy(self, value):
+        assert acquire.to_bool(value, "flag") is False
+        assert release.to_bool(value, "flag") is False
+
+    def test_unset_uses_the_default(self):
+        assert acquire.to_bool(None, "flag", default=True) is True
+        assert release.to_bool(None, "flag", default=False) is False
+
+    @pytest.mark.parametrize("value", ["ture", "", "maybe", []])
+    def test_ambiguous_input_is_an_error_rather_than_false(self, value):
+        # abort_on_failure defaults to true: silently reading a typo as false
+        # would disable the safety net without a word.
+        with pytest.raises(AnsibleActionFail, match="must be a boolean"):
+            acquire.to_bool(value, "abort_on_failure")
+
+
+class TestAcquireAction:
+    """End-to-end exercise of ActionModule.run() against a real directory."""
+
+    def base_args(self, **overrides):
+        args = {
+            "concurrency": 2,
+            "total_hosts": 6,
+            "poll_interval": 1.0,
+            "timeout": 60,
+        }
+        args.update(overrides)
+        return args
+
+    def run_acquire(self, args, hostname="n1", group_names=("kube_node",),
+                    check_mode=False, **task_vars):
+        action = make_action(acquire, "acquire_upgrade_slot", args, check_mode)
+        task_vars.update({
+            "inventory_hostname": hostname,
+            "group_names": list(group_names),
+        })
+        return action.run(task_vars=task_vars)
+
+    def test_rejects_unknown_parameters(self, lease_dir, forks):
+        with pytest.raises(AnsibleActionFail, match="concurency"):
+            self.run_acquire(self.base_args(concurency=2))
+
+    def test_rejects_a_non_mapping_per_group(self, lease_dir, forks):
+        with pytest.raises(AnsibleActionFail, match="must be a mapping"):
+            self.run_acquire(self.base_args(per_group="kube_node: 2"))
+
+    def test_check_mode_touches_nothing(self, lease_dir, forks):
+        result = self.run_acquire(self.base_args(), check_mode=True)
+
+        assert result["slot_acquired"] is True
+        assert not lease_dir.exists()
+
+    def test_acquires_a_free_slot(self, lease_dir, forks, clock):
+        result = self.run_acquire(self.base_args())
+
+        assert result["slot_acquired"] is True
+        assert result["active_slots"] == 1
+        assert result["concurrency"] == 2
+        assert result["waited_seconds"] == 0.0
+        assert (lease_dir / "n1.lease").exists()
+
+    def test_the_lease_records_the_hosts_groups(self, lease_dir, forks, clock):
+        self.run_acquire(self.base_args(), group_names=("kube_node", "calico_rr"))
+
+        data = json.loads((lease_dir / "n1.lease").read_text())
+        assert data["groups"] == ["calico_rr", "kube_node"]
+
+    def test_waits_until_a_slot_is_freed(self, lease_dir, forks, clock):
+        put_lease(lease_dir, "busy1")
+        put_lease(lease_dir, "busy2")
+        clock["on_sleep"] = lambda now: (
+            (lease_dir / "busy1.lease").unlink() if now >= 3 else None
+        )
+
+        result = self.run_acquire(self.base_args())
+
+        assert result["slot_acquired"] is True
+        assert result["waited_seconds"] == 3.0
+
+    def test_a_full_window_hits_the_timeout(self, lease_dir, forks, clock):
+        put_lease(lease_dir, "busy1")
+        put_lease(lease_dir, "busy2")
+
+        with pytest.raises(AnsibleActionFail, match="waited 60s for a free slot"):
+            self.run_acquire(self.base_args())
+
+        assert not (lease_dir / "n1.lease").exists()
+
+    def test_the_timeout_is_not_overshot_by_a_poll_interval(self, lease_dir, forks, clock):
+        put_lease(lease_dir, "busy1")
+        put_lease(lease_dir, "busy2")
+
+        with pytest.raises(AnsibleActionFail, match="waited 7s"):
+            self.run_acquire(self.base_args(timeout=7, poll_interval=2.0))
+
+    def test_a_per_group_ceiling_defers_the_host(self, lease_dir, forks, clock):
+        put_lease(lease_dir, "rr1", groups=["calico_rr"])
+
+        with pytest.raises(AnsibleActionFail, match="waited"):
+            self.run_acquire(
+                self.base_args(per_group={"calico_rr": 1}), group_names=("calico_rr",),
+            )
+
+    def test_a_per_group_percentage_counts_the_group_not_the_play(
+        self, lease_dir, forks, clock,
+    ):
+        # "50%" of two route reflectors is one, even though the play has six
+        # hosts. rr1 already holds the only calico_rr slot.
+        put_lease(lease_dir, "rr1", groups=["calico_rr"])
+
+        with pytest.raises(AnsibleActionFail, match="waited"):
+            self.run_acquire(
+                self.base_args(concurrency=4, per_group={"calico_rr": "50%"}),
+                hostname="rr2",
+                group_names=("calico_rr",),
+                ansible_play_hosts_all=["n1", "n2", "n3", "n4", "rr1", "rr2"],
+                groups={"kube_node": ["n1", "n2", "n3", "n4"],
+                        "calico_rr": ["rr1", "rr2"]},
+            )
+
+    def test_a_per_group_percentage_without_group_facts_is_an_error(
+        self, lease_dir, forks, clock,
+    ):
+        with pytest.raises(AnsibleActionFail, match="no hosts in this play"):
+            self.run_acquire(
+                self.base_args(per_group={"calico_rr": "50%"}),
+                group_names=("calico_rr",),
+            )
+
+    def test_the_clamp_warning_is_emitted_once_for_the_whole_run(
+        self, lease_dir, forks, clock, monkeypatch,
+    ):
+        # Every worker resolves the same configuration; without warn_once the
+        # operator would see this line once per node in the play.
+        seen = []
+        monkeypatch.setattr(acquire.display, "warning", seen.append)
+
+        for host in ("n1", "n2", "n3"):
+            self.run_acquire(self.base_args(concurrency=500), hostname=host)
+
+        assert len(seen) == 1
+        assert "capped at 19" in seen[0]
+
+    def test_an_abandoned_lease_is_reclaimed(self, lease_dir, forks, clock):
+        put_lease(lease_dir, "busy1")
+        stale = put_lease(lease_dir, "killed", age=7200)
+
+        result = self.run_acquire(self.base_args(lease_ttl=3600))
+
+        assert result["slot_acquired"] is True
+        assert not stale.exists()
+
+    def test_a_host_never_waits_for_its_own_stale_lease(self, lease_dir, forks, clock):
+        # A killed run sharing this run_id left our own lease behind. It is
+        # deliberately exempt from the TTL sweep, so counting it towards the
+        # window would make this host wait for itself until the timeout.
+        mine = put_lease(lease_dir, "n1", age=7200)
+
+        result = self.run_acquire(self.base_args(concurrency=1))
+
+        assert result["slot_acquired"] is True
+        assert result["active_slots"] == 1
+        assert result["waited_seconds"] == 0.0
+        # The lease is refreshed, so the TTL now counts from this attempt.
+        assert json.loads(mine.read_text())["acquired_at"] > time.time() - 60
+
+    def test_a_recorded_failure_stops_the_next_host(self, lease_dir, forks, clock):
+        lease_dir.mkdir(parents=True)
+        acquire.write_json_atomic(lease_dir / acquire.FAILURE_MARKER, {
+            "host": "n2", "task": "Cordon and drain the node", "failed_at": 1.0,
+        })
+
+        with pytest.raises(AnsibleActionFail) as excinfo:
+            self.run_acquire(self.base_args())
+
+        assert "node n2 already failed" in str(excinfo.value)
+        assert "Cordon and drain the node" in str(excinfo.value)
+        assert not (lease_dir / "n1.lease").exists()
+
+    def test_abort_on_failure_false_keeps_going(self, lease_dir, forks, clock):
+        lease_dir.mkdir(parents=True)
+        acquire.write_json_atomic(lease_dir / acquire.FAILURE_MARKER, {
+            "host": "n2", "task": None, "failed_at": 1.0,
+        })
+
+        result = self.run_acquire(self.base_args(abort_on_failure=False))
+
+        assert result["slot_acquired"] is True
+
+    def test_a_single_fork_cannot_work(self, lease_dir, monkeypatch):
+        from ansible import context
+
+        monkeypatch.setattr(context, "CLIARGS", {"forks": 1}, raising=False)
+        with pytest.raises(AnsibleActionFail, match="at least 2 forks"):
+            self.run_acquire(self.base_args())
+
+
+class TestReleaseAction:
+    def run_release(self, args, hostname="n1", check_mode=False):
+        action = make_action(release, "release_upgrade_slot", args, check_mode)
+        return action.run(task_vars={"inventory_hostname": hostname})
+
+    def test_releasing_without_a_lease_directory_is_not_an_error(self, lease_dir):
+        result = self.run_release({})
+
+        assert result["slot_released"] is False
+        assert result["failure_recorded"] is False
+
+    def test_releasing_a_held_slot(self, lease_dir):
+        lease = put_lease(lease_dir, "n1")
+
+        result = self.run_release({})
+
+        assert result["slot_released"] is True
+        assert not lease.exists()
+
+    def test_releasing_a_slot_this_host_never_held(self, lease_dir):
+        put_lease(lease_dir, "other")
+
+        result = self.run_release({})
+
+        assert result["slot_released"] is False
+        assert (lease_dir / "other.lease").exists()
+
+    def test_check_mode_touches_nothing(self, lease_dir):
+        lease = put_lease(lease_dir, "n1")
+
+        result = self.run_release({}, check_mode=True)
+
+        assert result["slot_released"] is False
+        assert lease.exists()
+
+    def test_marking_a_failure_writes_the_marker(self, lease_dir):
+        put_lease(lease_dir, "n1")
+
+        result = self.run_release({
+            "mark_failed": True,
+            "task": "Fail after rescue",
+            "reason": "Failed to drain node n1",
+        })
+
+        assert result["failure_recorded"] is True
+        marker = acquire.read_failure_marker(lease_dir)
+        assert marker["host"] == "n1"
+        assert marker["task"] == "Fail after rescue"
+        assert marker["reason"] == "Failed to drain node n1"
+        # The two plugins have to agree end to end: this is what the next host
+        # to reach acquire_upgrade_slot will be told.
+        assert acquire.describe_failure(marker) == \
+            " in task 'Fail after rescue': Failed to drain node n1"
+
+    def test_a_marker_without_a_reason_stays_valid(self, lease_dir):
+        put_lease(lease_dir, "n1")
+
+        self.run_release({"mark_failed": True, "task": "Drain"})
+
+        assert acquire.read_failure_marker(lease_dir)["reason"] is None
+
+    def test_only_the_first_failure_is_recorded(self, lease_dir):
+        put_lease(lease_dir, "n1")
+        put_lease(lease_dir, "n2")
+        self.run_release({"mark_failed": True, "task": "Drain"}, hostname="n1")
+
+        result = self.run_release({"mark_failed": True, "task": "Other"}, hostname="n2")
+
+        assert result["failure_recorded"] is False
+        # The node that actually broke the run stays the one being reported.
+        assert acquire.read_failure_marker(lease_dir)["host"] == "n1"
+
+    def test_rejects_unknown_parameters(self, lease_dir):
+        with pytest.raises(AnsibleActionFail, match="mark_faild"):
+            self.run_release({"mark_faild": True})
+
+    def test_rejects_an_ambiguous_mark_failed(self, lease_dir):
+        with pytest.raises(AnsibleActionFail, match="must be a boolean"):
+            self.run_release({"mark_failed": "ture"})


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

`upgrade-cluster.yml` walks the worker nodes in `serial:` batches. That has two
costs:

- Every node in a batch waits for the slowest one. A node that drains slowly
  holds its peers idle even when the cluster has capacity to keep going.
- The batch is drained as a unit. With `serial: 2` and a `PodDisruptionBudget`
  of `minAvailable: 2`, the first eviction is allowed, the second breaches the
  budget, and the budget cannot recover because the first node may not uncordon
  until the whole batch clears the drain task. Both nodes fail.

This adds an opt-in `upgrade_strategy: graceful_rolling` that replaces the batch
with a sliding window: every worker runs independently and a node that finishes
hands its slot to the next waiting node immediately. `linear` remains the
default and is unchanged.

```console
$ ansible-playbook upgrade-cluster.yml -i inventory/mycluster/hosts.yaml \
    -e upgrade_strategy=graceful_rolling \
    -e upgrade_node_concurrency=3 --forks 10
```

Measured on six Ubuntu 24.04 VMs (three workers), window and `serial` both 2:

| Situation | `linear` | `graceful_rolling` |
|---|---|---|
| Uniform nodes, nothing blocking | same | same |
| One node 150s slower than its peers | 471s | 369s |
| `PodDisruptionBudget`, `minAvailable: 2` | drain fails after 591s | 394s |

The first row is deliberate and documented: with uniform nodes the window admits
the next node when one finishes, which is when a batch would have rotated
anyway. The gain comes from variance, which is the common case in practice, and
from not draining in lockstep.

**Which issue(s) this PR fixes**:

Fixes #12929

**Special notes for your reviewer**:

**This does not add a strategy plugin, despite the issue title.** ansible-core
[deprecated custom strategy plugins](https://github.com/ansible/ansible/issues/84725)
with no replacement API, which is why #13080 was closed. It also turned out to
be unnecessary: the built-in `host_pinned` already *is* a sliding window. What
#13080's fork of `free.StrategyModule.run()` added on top was a window narrower
than the fork count and per-group ceilings, and both fit in two action plugins —
a supported extension point. This PR supersedes #13080.

Most of the diff is not the semaphore but working around three ansible-core
behaviours. They are worth knowing before reviewing:

1. **`run_once` is ignored outside `linear`** — `free` warns and runs the task on
   every host. This is why only the worker play is rolling (the control plane
   already runs `serial: 1`; the calico play never cordons a node), and why
   `roles/kubernetes/kubeadm`'s cluster-scoped kube-proxy tasks were split out.
   Left alone they would `kubectl replace` one ConfigMap from several nodes at
   once and each node would delete every kube-proxy pod in the cluster.
2. **`any_errors_fatal` and `max_fail_percentage` exist only in `linear`** —
   `free` just warns. The worker play sets `any_errors_fatal`, so switching
   strategy would have dropped it silently. `upgrade_abort_on_failure` (default
   on) restores the intent: once a node fails, nodes not yet drained abort
   instead of starting, while nodes already inside the window finish rather than
   being left cordoned.
3. **`pause` sets `BYPASS_HOST_LOOP`** and `free` raises on it at dispatch,
   before any `when:` is evaluated — so guarding the prompts with a condition
   does not help. The two confirmation prompts moved into dynamically included
   files; the timed waits use `wait_for`, which runs per host.

Points worth deliberate attention:

- **`kubeadm_patch_kube_proxy` defaults to off.** The cluster-scoped kube-proxy
  tasks are now opt-in; `cluster.yml` and `scale.yml` ask for them explicitly.
  Anyone invoking `kubernetes/kubeadm` directly from the collection loses the
  patch unless they opt in. Deriving the flag from `upgrade_strategy` instead is
  unsafe — it is an inventory-level setting, so `graceful_rolling` in
  `group_vars` would silently disable the patch for ordinary installs, and
  Ansible exposes no magic variable for the running play's strategy.
  `upgrade_cluster.yml` now runs the patch once in its own linear play, which
  also stops the linear path repeating it per `serial` batch.
- **The worker play's `roles:` became `tasks:` + `import_role`**, because
  `always:` needs a block. Checked first that no role in that play reads a
  sibling role's `defaults/`; `import_role` is static, so tags propagate as
  before.
- **Forks must exceed the concurrency**, since a waiting host holds a worker.
  The window is clamped to `forks - 1` with a warning rather than a hard failure.
  The fork count is read from `CLIARGS` because `DEFAULT_FORKS` has no `cli:`
  mapping and would miss `-f` entirely.
- **The CI job uses `mode: ha`, not `all-in-one`.** An all-in-one node is in both
  `kube_control_plane` and `kube_node`, so `kube_node:!kube_control_plane` is
  empty and the rolling play would be skipped without failing. `ha` gives one
  dedicated worker, which covers the plugins, the validation play, `host_pinned`
  and the pause path. It does not cover the window itself — that needs three
  workers, and is covered by the unit tests instead.
- `roles/kubernetes/client/tasks/main.yml:70` fails `ansible-lint` on master
  already; this PR does not touch that file.

Testing: 46 unit tests (`tests/unit/plugins/action/`, wired into pre-commit)
cover the concurrency maths, per-group ceilings and lease lifecycle. Manually
verified on Vagrant for a 1.35.7 → 1.36.3 upgrade with a blocking PDB, for the
linear-vs-rolling comparison above, and separately for `system_upgrade: true`
where the `download` role runs inside the window and both workers reboot without
losing a slot. `docs/developers/upgrade-slots.md` records the design constraints
and what to re-verify on an ansible-core bump.

**Does this PR introduce a user-facing change?**:

```release-note
Add an opt-in `upgrade_strategy: graceful_rolling` for `upgrade-cluster.yml`, which upgrades worker nodes in a sliding window instead of `serial:` batches. A node that finishes frees its slot immediately, so no node waits for a slower peer and nodes are never drained in lockstep, avoiding the PodDisruptionBudget deadlock that can fail a batch upgrade. Window size is set with `upgrade_node_concurrency` (integer or percentage, capped at `forks - 1`) and can be constrained per inventory group with `upgrade_per_group_concurrency`; it requires more Ansible forks than the configured concurrency. The default remains `linear` and is unchanged. Note that the cluster-scoped kube-proxy kubeconfig patch in the `kubernetes/kubeadm` role is now gated behind `kubeadm_patch_kube_proxy`, which defaults to false; `cluster.yml`, `scale.yml` and `upgrade-cluster.yml` enable it themselves, but playbooks calling that role directly need to set it.
```
