### PR TITLE
Save cached container images with nerdctl instead of ctr on the control node

### DIFF
--- a/roles/download/tasks/set_container_facts.yml
+++ b/roles/download/tasks/set_container_facts.yml
@@ -46,7 +46,7 @@
 
 - name: Set image save/load command for containerd on localhost
   set_fact:
-    image_save_command_on_localhost: "{{ containerd_bin_dir }}/ctr -n k8s.io image export --platform linux/{{ image_arch }} {{ image_path_cached }} {{ image_reponame }}"
+    image_save_command_on_localhost: "{{ bin_dir }}/nerdctl -n k8s.io image save -o {{ image_path_cached }} {{ image_reponame }}"
   when: container_manager_on_localhost == 'containerd'
 
 - name: Set image save/load command for crio on localhost


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When images are downloaded/cached on the Ansible control node (`download_run_once` + `download_localhost: true`) with `container_manager_on_localhost == 'containerd'`, the image export step intermittently fails with:

```
ctr: failed to get reader: content digest sha256:<digest>: not found
```

The root cause is that two different tools are used for the two halves of the same operation:

* **Pull** uses `nerdctl`: `image_pull_command_on_localhost` resolves to `nerdctl_image_pull_command`
  (`{{ bin_dir }}/nerdctl -n k8s.io pull --quiet`) — see `roles/kubespray_defaults/defaults/main/download.yml`.
* **Save** uses `ctr`: `image_save_command_on_localhost` was
  `{{ containerd_bin_dir }}/ctr -n k8s.io image export --platform linux/{{ image_arch }} ...`
  — see `roles/download/tasks/set_container_facts.yml`.

`nerdctl pull` fetches only the blobs it needs for the requested platform and records that in the content store via the containerd transfer service. `ctr image export --platform ...` then walks the *index/manifest list* and demands every descriptor for the selected platform to be present as local content. With containerd 2.1+ the two paths no longer agree on which manifest/layer digests must be materialized for a multi-arch image, so the export aborts on the first descriptor that was never pulled — the `content digest ...: not found` above. This is exactly what is reported in the upstream issue.

Kubespray already solves this correctly for remote nodes, where both the pull and the save are done with `nerdctl` (`image_save_command` uses `nerdctl -n k8s.io image save`). This PR simply applies the same, already-proven logic to the localhost path.

**Before**

```yaml
- name: Set image save/load command for containerd on localhost
  set_fact:
    image_save_command_on_localhost: "{{ containerd_bin_dir }}/ctr -n k8s.io image export --platform linux/{{ image_arch }} {{ image_path_cached }} {{ image_reponame }}"
  when: container_manager_on_localhost == 'containerd'
```

**After**

```yaml
- name: Set image save/load command for containerd on localhost
  set_fact:
    image_save_command_on_localhost: "{{ bin_dir }}/nerdctl -n k8s.io image save -o {{ image_path_cached }} {{ image_reponame }}"
  when: container_manager_on_localhost == 'containerd'
```

The image is now pulled *and* exported by the same tool, so the archive is written from exactly the content `nerdctl` placed in the store. The output path (`image_path_cached`), the `k8s.io` namespace and the resulting Docker-archive format are unchanged, so the downstream copy to the nodes and the `nerdctl image load` on the remote side keep working as before — the produced tarball is the same format the remote `image_save_command` already produces.

**Which issue(s) this PR fixes**:

Fixes #13235

**Special notes for your reviewer**:

* The change is a one-liner in `roles/download/tasks/set_container_facts.yml` and only affects
  `container_manager_on_localhost == 'containerd'`. The `docker` and `crio` localhost branches, and all
  remote-node branches, are untouched.
* `nerdctl` is used because it is the tool Kubespray already installs and uses for containerd image
  handling; no new dependency is introduced. `{{ bin_dir }}` is the same prefix used by
  `nerdctl_image_pull_command` and by the remote `image_save_command`.
* **On the dropped `--platform linux/{{ image_arch }}`**: the flag could not do what it appeared to do.
  The pull on the control node (`nerdctl pull`, no `--all-platforms`/`--platform`) only ever fetches the
  control node's own platform, so requesting a different platform at export time is precisely the
  situation that triggers the reported error. `nerdctl image save` exports what was actually pulled, so
  the common same-architecture case is byte-for-byte equivalent and the cross-architecture case goes from
  "hard failure" to "exports the platform that was downloaded". Making the localhost cache genuinely
  multi-arch (i.e. `nerdctl pull --all-platforms` combined with a platform-aware save) is a separate
  feature and intentionally out of scope here.

**Testing done**:

* `pre-commit` passes on the change (`yamllint`, `misspell`, collection build, `ci-matrix`, checksum
  ordering, …). The `ansible-lint` hook reports a `jinja[invalid]` violation in
  `roles/kubernetes/client/tasks/main.yml`, but it reproduces identically on an unmodified `master`
  checkout, so it is pre-existing and unrelated to this change.
* Rendered `roles/download/tasks/set_container_facts.yml` in isolation with `ansible-playbook` and
  asserted the resulting facts:
  * tag form → `<bin_dir>/nerdctl -n k8s.io image save -o <download_cache_dir>/images/registry.k8s.io_pause_3.10.tar registry.k8s.io/pause:3.10`
  * digest form (`repo@sha256:...`) renders correctly for both the archive name and the image reference
  * `image_save_command` (remote) and `image_save_command_on_localhost` now resolve to the same binary
  * the `docker` and `crio` localhost branches are unchanged

**Does this PR introduce a user-facing change?**:

```release-note
Fixed container image export on the Ansible control node when using containerd. Images are now saved with `nerdctl image save` instead of `ctr image export`, matching the tool used to pull them and resolving `ctr: failed to get reader: content digest sha256:<digest>: not found` failures with containerd 2.1+.
```
