### PR TITLE
Upgrade metallb from 0.13.9 to 0.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Note:
   - [coredns](https://github.com/coredns/coredns) 1.14.2
   - [argocd](https://argoproj.github.io/) 2.14.5
   - [helm](https://helm.sh/) 3.18.4
-  - [metallb](https://metallb.universe.tf/) 0.13.9
+  - [metallb](https://metallb.universe.tf/) 0.16.0
   - [registry](https://github.com/distribution/distribution) 2.8.1
 - Storage Plugin
   - [aws-ebs-csi-plugin](https://github.com/kubernetes-sigs/aws-ebs-csi-driver) 0.5.0

--- a/docs/ingress/metallb.md
+++ b/docs/ingress/metallb.md
@@ -63,6 +63,16 @@ metallb_config:
       effect: "NoSchedule"
 ```
 
+## Metrics
+
+Since MetalLB v0.16.0 the metrics endpoint of the controller and of the speaker is served over
+HTTPS and requires authentication and authorization, instead of plain HTTP. The port it listens
+on stays configurable and defaults to 7472:
+
+```yaml
+metallb_port: "7472"
+```
+
 ## Pools
 
 First you need to specify all of the pools you are going to use:

--- a/roles/kubernetes-apps/metallb/tasks/main.yml
+++ b/roles/kubernetes-apps/metallb/tasks/main.yml
@@ -107,3 +107,24 @@
     resource: ConfigMap
     namespace: "{{ metallb_namespace }}"
     state: absent
+
+# The AddressPool CRD was removed in MetalLB v0.14.2 in favor of IPAddressPool,
+# the webhook Secret and Service were renamed in v0.16.0. None of them is part of
+# the manifest anymore, so they have to be cleaned up explicitly on upgrades.
+- name: Kubernetes Apps | Delete MetalLB resources removed upstream
+  kube:
+    name: "{{ item.name }}"
+    kubectl: "{{ bin_dir }}/kubectl"
+    resource: "{{ item.resource }}"
+    namespace: "{{ item.namespace | default(omit) }}"
+    state: absent
+  become: true
+  loop:
+    - name: addresspools.metallb.io
+      resource: CustomResourceDefinition
+    - name: webhook-server-cert
+      resource: Secret
+      namespace: "{{ metallb_namespace }}"
+    - name: webhook-service
+      resource: Service
+      namespace: "{{ metallb_namespace }}"

--- a/roles/kubernetes-apps/metallb/templates/metallb.yaml.j2
+++ b/roles/kubernetes-apps/metallb/templates/metallb.yaml.j2
@@ -7,220 +7,12 @@ metadata:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/warn: privileged
   name: {{ metallb_namespace }}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  name: addresspools.metallb.io
-spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlGWlRDQ0EwMmdBd0lCQWdJVU5GRW1XcTM3MVpKdGkrMmlSQzk1WmpBV1MxZ3dEUVlKS29aSWh2Y05BUUVMDQpCUUF3UWpFTE1Ba0dBMVVFQmhNQ1dGZ3hGVEFUQmdOVkJBY01ERVJsWm1GMWJIUWdRMmwwZVRFY01Cb0dBMVVFDQpDZ3dUUkdWbVlYVnNkQ0JEYjIxd1lXNTVJRXgwWkRBZUZ3MHlNakEzTVRrd09UTXlNek5hRncweU1qQTRNVGd3DQpPVE15TXpOYU1FSXhDekFKQmdOVkJBWVRBbGhZTVJVd0V3WURWUVFIREF4RVpXWmhkV3gwSUVOcGRIa3hIREFhDQpCZ05WQkFvTUUwUmxabUYxYkhRZ1EyOXRjR0Z1ZVNCTWRHUXdnZ0lpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElDDQpEd0F3Z2dJS0FvSUNBUUNxVFpxMWZRcC9vYkdlenhES0o3OVB3Ny94azJwellualNzMlkzb1ZYSm5sRmM4YjVlDQpma2ZZQnY2bndscW1keW5PL2phWFBaQmRQSS82aFdOUDBkdVhadEtWU0NCUUpyZzEyOGNXb3F0MGNTN3pLb1VpDQpvcU1tQ0QvRXVBeFFNZjhRZDF2c1gvVllkZ0poVTZBRXJLZEpIaXpFOUJtUkNkTDBGMW1OVW55Rk82UnRtWFZUDQpidkxsTDVYeTc2R0FaQVBLOFB4aVlDa0NtbDdxN0VnTWNiOXlLWldCYmlxQ3VkTXE5TGJLNmdKNzF6YkZnSXV4DQo1L1pXK2JraTB2RlplWk9ZODUxb1psckFUNzJvMDI4NHNTWW9uN0pHZVZkY3NoUnh5R1VpSFpSTzdkaXZVTDVTDQpmM2JmSDFYbWY1ZDQzT0NWTWRuUUV2NWVaOG8zeWVLa3ZrbkZQUGVJMU9BbjdGbDlFRVNNR2dhOGFaSG1URSttDQpsLzlMSmdDYjBnQmtPT0M0WnV4bWh2aERKV1EzWnJCS3pMQlNUZXN0NWlLNVlwcXRWVVk2THRyRW9FelVTK1lsDQpwWndXY2VQWHlHeHM5ZURsR3lNVmQraW15Y3NTU1UvVno2Mmx6MnZCS21NTXBkYldDQWhud0RsRTVqU2dyMjRRDQp0eGNXLys2N3d5KzhuQlI3UXdqVTFITndVRjBzeERWdEwrZ1NHVERnSEVZSlhZelYvT05zMy94TkpoVFNPSkxNDQpoeXNVdyttaGdackdhbUdXcHVIVU1DUitvTWJzMTc1UkcrQjJnUFFHVytPTjJnUTRyOXN2b0ZBNHBBQm8xd1dLDQpRYjRhY3pmeVVscElBOVFoSmFsZEY3S3dPSHVlV3gwRUNrNXg0T2tvVDBvWVp0dzFiR0JjRGtaSmF3SURBUUFCDQpvMU13VVRBZEJnTlZIUTRFRmdRVW90UlNIUm9IWTEyRFZ4R0NCdEhpb1g2ZmVFQXdId1lEVlIwakJCZ3dGb0FVDQpvdFJTSFJvSFkxMkRWeEdDQnRIaW9YNmZlRUF3RHdZRFZSMFRBUUgvQkFVd0F3RUIvekFOQmdrcWhraUc5dzBCDQpBUXNGQUFPQ0FnRUFSbkpsWWRjMTFHd0VxWnh6RDF2R3BDR2pDN2VWTlQ3aVY1d3IybXlybHdPYi9aUWFEa0xYDQpvVStaOVVXT1VlSXJTdzUydDdmQUpvVVAwSm5iYkMveVIrU1lqUGhvUXNiVHduOTc2ZldBWTduM3FMOXhCd1Y0DQphek41OXNjeUp0dlhMeUtOL2N5ak1ReDRLajBIMFg0bWJ6bzVZNUtzWWtYVU0vOEFPdWZMcEd0S1NGVGgrSEFDDQpab1Q5YnZHS25adnNHd0tYZFF0Wnh0akhaUjVqK3U3ZGtQOTJBT051RFNabS8rWVV4b2tBK09JbzdSR3BwSHNXDQo1ZTdNY0FTVXRtb1FORXd6dVFoVkJaRWQ1OGtKYjUrV0VWbGNzanlXNnRTbzErZ25tTWNqR1BsMWgxR2hVbjV4DQpFY0lWRnBIWXM5YWo1NmpBSjk1MVQvZjhMaWxmTlVnanBLQ0c1bnl0SUt3emxhOHNtdGlPdm1UNEpYbXBwSkI2DQo4bmdHRVluVjUrUTYwWFJ2OEhSSGp1VG9CRHVhaERrVDA2R1JGODU1d09FR2V4bkZpMXZYWUxLVllWb1V2MXRKDQo4dVdUR1pwNllDSVJldlBqbzg5ZytWTlJSaVFYUThJd0dybXE5c0RoVTlqTjA0SjdVL1RvRDFpNHE3VnlsRUc5DQorV1VGNkNLaEdBeTJIaEhwVncyTGFoOS9lUzdZMUZ1YURrWmhPZG1laG1BOCtqdHNZamJadnR5Mm1SWlF0UUZzDQpUU1VUUjREbUR2bVVPRVRmeStpRHdzK2RkWXVNTnJGeVVYV2dkMnpBQU4ydVl1UHFGY2pRcFNPODFzVTJTU3R3DQoxVzAyeUtYOGJEYmZFdjBzbUh3UzliQnFlSGo5NEM1Mjg0YXpsdTBmaUdpTm1OUEM4ckJLRmhBPQ0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ==
-        service:
-          name: webhook-service
-          namespace: "{{ metallb_namespace }}"
-          path: /convert
-      conversionReviewVersions:
-      - v1alpha1
-      - v1beta1
-  group: metallb.io
-  names:
-    kind: AddressPool
-    listKind: AddressPoolList
-    plural: addresspools
-    singular: addresspool
-  scope: Namespaced
-  versions:
-  - deprecated: true
-    deprecationWarning: metallb.io v1alpha1 AddressPool is deprecated
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: AddressPool is the Schema for the addresspools API.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AddressPoolSpec defines the desired state of AddressPool.
-            properties:
-              addresses:
-                description: A list of IP address ranges over which MetalLB has authority.
-                  You can list multiple ranges in a single pool, they will all share
-                  the same settings. Each range can be either a CIDR prefix, or an
-                  explicit start-end range of IPs.
-                items:
-                  type: string
-                type: array
-              autoAssign:
-                default: true
-                description: AutoAssign flag used to prevent MetallB from automatic
-                  allocation for a pool.
-                type: boolean
-              bgpAdvertisements:
-                description: When an IP is allocated from this pool, how should it
-                  be translated into BGP announcements?
-                items:
-                  properties:
-                    aggregationLength:
-                      default: 32
-                      description: The aggregation-length advertisement option lets
-                        you “roll up” the /32s into a larger prefix.
-                      format: int32
-                      minimum: 1
-                      type: integer
-                    aggregationLengthV6:
-                      default: 128
-                      description: Optional, defaults to 128 (i.e. no aggregation)
-                        if not specified.
-                      format: int32
-                      type: integer
-                    communities:
-                      description: BGP communities
-                      items:
-                        type: string
-                      type: array
-                    localPref:
-                      description: BGP LOCAL_PREF attribute which is used by BGP best
-                        path algorithm, Path with higher localpref is preferred over
-                        one with lower localpref.
-                      format: int32
-                      type: integer
-                  type: object
-                type: array
-              protocol:
-                description: Protocol can be used to select how the announcement is
-                  done.
-                enum:
-                - layer2
-                - bgp
-                type: string
-            required:
-            - addresses
-            - protocol
-            type: object
-          status:
-            description: AddressPoolStatus defines the observed state of AddressPool.
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
-  - deprecated: true
-    deprecationWarning: metallb.io v1beta1 AddressPool is deprecated, consider using
-      IPAddressPool
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: AddressPool represents a pool of IP addresses that can be allocated
-          to LoadBalancer services. AddressPool is deprecated and being replaced by
-          IPAddressPool.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AddressPoolSpec defines the desired state of AddressPool.
-            properties:
-              addresses:
-                description: A list of IP address ranges over which MetalLB has authority.
-                  You can list multiple ranges in a single pool, they will all share
-                  the same settings. Each range can be either a CIDR prefix, or an
-                  explicit start-end range of IPs.
-                items:
-                  type: string
-                type: array
-              autoAssign:
-                default: true
-                description: AutoAssign flag used to prevent MetallB from automatic
-                  allocation for a pool.
-                type: boolean
-              bgpAdvertisements:
-                description: Drives how an IP allocated from this pool should translated
-                  into BGP announcements.
-                items:
-                  properties:
-                    aggregationLength:
-                      default: 32
-                      description: The aggregation-length advertisement option lets
-                        you “roll up” the /32s into a larger prefix.
-                      format: int32
-                      minimum: 1
-                      type: integer
-                    aggregationLengthV6:
-                      default: 128
-                      description: Optional, defaults to 128 (i.e. no aggregation)
-                        if not specified.
-                      format: int32
-                      type: integer
-                    communities:
-                      description: BGP communities to be associated with the given
-                        advertisement.
-                      items:
-                        type: string
-                      type: array
-                    localPref:
-                      description: BGP LOCAL_PREF attribute which is used by BGP best
-                        path algorithm, Path with higher localpref is preferred over
-                        one with lower localpref.
-                      format: int32
-                      type: integer
-                  type: object
-                type: array
-              protocol:
-                description: Protocol can be used to select how the announcement is
-                  done.
-                enum:
-                - layer2
-                - bgp
-                type: string
-            required:
-            - addresses
-            - protocol
-            type: object
-          status:
-            description: AddressPoolStatus defines the observed state of AddressPool.
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: bfdprofiles.metallb.io
 spec:
   group: metallb.io
@@ -247,18 +39,24 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: BFDProfile represents the settings of the bfd session that can
-          be optionally associated with a BGP session.
+        description: |-
+          BFDProfile represents the settings of the bfd session that can be
+          optionally associated with a BGP session.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -266,48 +64,57 @@ spec:
             description: BFDProfileSpec defines the desired state of BFDProfile.
             properties:
               detectMultiplier:
-                description: Configures the detection multiplier to determine packet
-                  loss. The remote transmission interval will be multiplied by this
-                  value to determine the connection loss detection timer.
+                description: |-
+                  Configures the detection multiplier to determine
+                  packet loss. The remote transmission interval will be multiplied
+                  by this value to determine the connection loss detection timer.
                 format: int32
                 maximum: 255
                 minimum: 2
                 type: integer
               echoInterval:
-                description: Configures the minimal echo receive transmission interval
-                  that this system is capable of handling in milliseconds. Defaults
-                  to 50ms
+                description: |-
+                  Configures the minimal echo receive transmission
+                  interval that this system is capable of handling in milliseconds.
+                  Defaults to 50ms
                 format: int32
                 maximum: 60000
                 minimum: 10
                 type: integer
               echoMode:
-                description: Enables or disables the echo transmission mode. This
-                  mode is disabled by default, and not supported on multi hops setups.
+                description: |-
+                  Enables or disables the echo transmission mode.
+                  This mode is disabled by default, and not supported on multi
+                  hops setups.
                 type: boolean
               minimumTtl:
-                description: 'For multi hop sessions only: configure the minimum expected
-                  TTL for an incoming BFD control packet.'
+                description: |-
+                  For multi hop sessions only: configure the minimum
+                  expected TTL for an incoming BFD control packet.
                 format: int32
                 maximum: 254
                 minimum: 1
                 type: integer
               passiveMode:
-                description: 'Mark session as passive: a passive session will not
+                description: |-
+                  Mark session as passive: a passive session will not
                   attempt to start the connection and will wait for control packets
-                  from peer before it begins replying.'
+                  from peer before it begins replying.
                 type: boolean
               receiveInterval:
-                description: The minimum interval that this system is capable of receiving
-                  control packets in milliseconds. Defaults to 300ms.
+                description: |-
+                  The minimum interval that this system is capable of
+                  receiving control packets in milliseconds.
+                  Defaults to 300ms.
                 format: int32
                 maximum: 60000
                 minimum: 10
                 type: integer
               transmitInterval:
-                description: The minimum transmission interval (less jitter) that
-                  this system wants to use to send BFD control packets in milliseconds.
-                  Defaults to 300ms
+                description: |-
+                  The minimum transmission interval (less jitter)
+                  that this system wants to use to send BFD control packets in
+                  milliseconds. Defaults to 300ms
                 format: int32
                 maximum: 60000
                 minimum: 10
@@ -326,8 +133,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: bgpadvertisements.metallb.io
 spec:
   group: metallb.io
@@ -355,18 +161,25 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: BGPAdvertisement allows to advertise the IPs coming from the
-          selected IPAddressPools via BGP, setting the parameters of the BGP Advertisement.
+        description: |-
+          BGPAdvertisement allows to advertise the IPs coming
+          from the selected IPAddressPools via BGP, setting the parameters of the
+          BGP Advertisement.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -389,61 +202,63 @@ spec:
                 format: int32
                 type: integer
               communities:
-                description: The BGP communities to be associated with the announcement.
-                  Each item can be a community of the form 1234:1234 or the name of
-                  an alias defined in the Community CRD.
+                description: |-
+                  The BGP communities to be associated with the announcement. Each item can be a standard community of the
+                  form 1234:1234, a large community of the form large:1234:1234:1234 or the name of an alias defined in the
+                  Community CRD.
                 items:
                   type: string
                 type: array
               ipAddressPoolSelectors:
-                description: A selector for the IPAddressPools which would get advertised
-                  via this advertisement. If no IPAddressPool is selected by this
-                  or by the list, the advertisement is applied to all the IPAddressPools.
+                description: |-
+                  A selector for the IPAddressPools which would get advertised via this advertisement.
+                  If no IPAddressPool is selected by this or by the list, the advertisement is applied to all the IPAddressPools.
                 items:
-                  description: A label selector is a label query over a set of resources.
-                    The result of matchLabels and matchExpressions are ANDed. An empty
-                    label selector matches all objects. A null label selector matches
-                    no objects.
+                  description: |-
+                    A label selector is a label query over a set of resources. The result of matchLabels and
+                    matchExpressions are ANDed. An empty label selector matches all objects. A null
+                    label selector matches no objects.
                   properties:
                     matchExpressions:
                       description: matchExpressions is a list of label selector requirements.
                         The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
                         properties:
                           key:
                             description: key is the label key that the selector applies
                               to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
                             items:
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                         required:
                         - key
                         - operator
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
                   x-kubernetes-map-type: atomic
@@ -455,9 +270,9 @@ spec:
                   type: string
                 type: array
               localPref:
-                description: The BGP LOCAL_PREF attribute which is used by BGP best
-                  path algorithm, Path with higher localpref is preferred over one
-                  with lower localpref.
+                description: |-
+                  The BGP LOCAL_PREF attribute which is used by BGP best path algorithm,
+                  Path with higher localpref is preferred over one with lower localpref.
                 format: int32
                 type: integer
               nodeSelectors:
@@ -465,62 +280,127 @@ spec:
                   next hops for the LoadBalancer IP. When empty, all the nodes having  are
                   announced as next hops.
                 items:
-                  description: A label selector is a label query over a set of resources.
-                    The result of matchLabels and matchExpressions are ANDed. An empty
-                    label selector matches all objects. A null label selector matches
-                    no objects.
+                  description: |-
+                    A label selector is a label query over a set of resources. The result of matchLabels and
+                    matchExpressions are ANDed. An empty label selector matches all objects. A null
+                    label selector matches no objects.
                   properties:
                     matchExpressions:
                       description: matchExpressions is a list of label selector requirements.
                         The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
                         properties:
                           key:
                             description: key is the label key that the selector applies
                               to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
                             items:
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                         required:
                         - key
                         - operator
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
               peers:
-                description: Peers limits the bgppeer to advertise the ips of the
-                  selected pools to. When empty, the loadbalancer IP is announced
-                  to all the BGPPeers configured.
+                description: |-
+                  Peers limits the bgppeer to advertise the ips of the selected pools to.
+                  When empty, the loadbalancer IP is announced to all the BGPPeers configured.
                 items:
                   type: string
                 type: array
+              serviceSelectors:
+                description: |-
+                  ServiceSelectors limits the set of services that will be advertised via this advertisement.
+                  If empty, all services from the selected pools are advertised.
+                  This field is mutually exclusive with aggregationLength and aggregationLengthV6 -
+                  services can only be selected when using the default /32 (IPv4) or /128 (IPv6) aggregation.
+                items:
+                  description: |-
+                    A label selector is a label query over a set of resources. The result of matchLabels and
+                    matchExpressions are ANDed. An empty label selector matches all objects. A null
+                    label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
             type: object
+            x-kubernetes-validations:
+            - message: serviceSelectors and aggregationLength are mutually exclusive,
+                can only be used together with default aggregationLength (32) and
+                aggregationLengthV6 (128)
+              rule: '!has(self.serviceSelectors) || self.serviceSelectors.size() ==
+                0 || ((!has(self.aggregationLength) || self.aggregationLength == 32)
+                && (!has(self.aggregationLengthV6) || self.aggregationLengthV6 ==
+                128))'
           status:
             description: BGPAdvertisementStatus defines the observed state of BGPAdvertisement.
             type: object
@@ -534,16 +414,15 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: bgppeers.metallb.io
 spec:
   conversion:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlGWlRDQ0EwMmdBd0lCQWdJVU5GRW1XcTM3MVpKdGkrMmlSQzk1WmpBV1MxZ3dEUVlKS29aSWh2Y05BUUVMDQpCUUF3UWpFTE1Ba0dBMVVFQmhNQ1dGZ3hGVEFUQmdOVkJBY01ERVJsWm1GMWJIUWdRMmwwZVRFY01Cb0dBMVVFDQpDZ3dUUkdWbVlYVnNkQ0JEYjIxd1lXNTVJRXgwWkRBZUZ3MHlNakEzTVRrd09UTXlNek5hRncweU1qQTRNVGd3DQpPVE15TXpOYU1FSXhDekFKQmdOVkJBWVRBbGhZTVJVd0V3WURWUVFIREF4RVpXWmhkV3gwSUVOcGRIa3hIREFhDQpCZ05WQkFvTUUwUmxabUYxYkhRZ1EyOXRjR0Z1ZVNCTWRHUXdnZ0lpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElDDQpEd0F3Z2dJS0FvSUNBUUNxVFpxMWZRcC9vYkdlenhES0o3OVB3Ny94azJwellualNzMlkzb1ZYSm5sRmM4YjVlDQpma2ZZQnY2bndscW1keW5PL2phWFBaQmRQSS82aFdOUDBkdVhadEtWU0NCUUpyZzEyOGNXb3F0MGNTN3pLb1VpDQpvcU1tQ0QvRXVBeFFNZjhRZDF2c1gvVllkZ0poVTZBRXJLZEpIaXpFOUJtUkNkTDBGMW1OVW55Rk82UnRtWFZUDQpidkxsTDVYeTc2R0FaQVBLOFB4aVlDa0NtbDdxN0VnTWNiOXlLWldCYmlxQ3VkTXE5TGJLNmdKNzF6YkZnSXV4DQo1L1pXK2JraTB2RlplWk9ZODUxb1psckFUNzJvMDI4NHNTWW9uN0pHZVZkY3NoUnh5R1VpSFpSTzdkaXZVTDVTDQpmM2JmSDFYbWY1ZDQzT0NWTWRuUUV2NWVaOG8zeWVLa3ZrbkZQUGVJMU9BbjdGbDlFRVNNR2dhOGFaSG1URSttDQpsLzlMSmdDYjBnQmtPT0M0WnV4bWh2aERKV1EzWnJCS3pMQlNUZXN0NWlLNVlwcXRWVVk2THRyRW9FelVTK1lsDQpwWndXY2VQWHlHeHM5ZURsR3lNVmQraW15Y3NTU1UvVno2Mmx6MnZCS21NTXBkYldDQWhud0RsRTVqU2dyMjRRDQp0eGNXLys2N3d5KzhuQlI3UXdqVTFITndVRjBzeERWdEwrZ1NHVERnSEVZSlhZelYvT05zMy94TkpoVFNPSkxNDQpoeXNVdyttaGdackdhbUdXcHVIVU1DUitvTWJzMTc1UkcrQjJnUFFHVytPTjJnUTRyOXN2b0ZBNHBBQm8xd1dLDQpRYjRhY3pmeVVscElBOVFoSmFsZEY3S3dPSHVlV3gwRUNrNXg0T2tvVDBvWVp0dzFiR0JjRGtaSmF3SURBUUFCDQpvMU13VVRBZEJnTlZIUTRFRmdRVW90UlNIUm9IWTEyRFZ4R0NCdEhpb1g2ZmVFQXdId1lEVlIwakJCZ3dGb0FVDQpvdFJTSFJvSFkxMkRWeEdDQnRIaW9YNmZlRUF3RHdZRFZSMFRBUUgvQkFVd0F3RUIvekFOQmdrcWhraUc5dzBCDQpBUXNGQUFPQ0FnRUFSbkpsWWRjMTFHd0VxWnh6RDF2R3BDR2pDN2VWTlQ3aVY1d3IybXlybHdPYi9aUWFEa0xYDQpvVStaOVVXT1VlSXJTdzUydDdmQUpvVVAwSm5iYkMveVIrU1lqUGhvUXNiVHduOTc2ZldBWTduM3FMOXhCd1Y0DQphek41OXNjeUp0dlhMeUtOL2N5ak1ReDRLajBIMFg0bWJ6bzVZNUtzWWtYVU0vOEFPdWZMcEd0S1NGVGgrSEFDDQpab1Q5YnZHS25adnNHd0tYZFF0Wnh0akhaUjVqK3U3ZGtQOTJBT051RFNabS8rWVV4b2tBK09JbzdSR3BwSHNXDQo1ZTdNY0FTVXRtb1FORXd6dVFoVkJaRWQ1OGtKYjUrV0VWbGNzanlXNnRTbzErZ25tTWNqR1BsMWgxR2hVbjV4DQpFY0lWRnBIWXM5YWo1NmpBSjk1MVQvZjhMaWxmTlVnanBLQ0c1bnl0SUt3emxhOHNtdGlPdm1UNEpYbXBwSkI2DQo4bmdHRVluVjUrUTYwWFJ2OEhSSGp1VG9CRHVhaERrVDA2R1JGODU1d09FR2V4bkZpMXZYWUxLVllWb1V2MXRKDQo4dVdUR1pwNllDSVJldlBqbzg5ZytWTlJSaVFYUThJd0dybXE5c0RoVTlqTjA0SjdVL1RvRDFpNHE3VnlsRUc5DQorV1VGNkNLaEdBeTJIaEhwVncyTGFoOS9lUzdZMUZ1YURrWmhPZG1laG1BOCtqdHNZamJadnR5Mm1SWlF0UUZzDQpUU1VUUjREbUR2bVVPRVRmeStpRHdzK2RkWXVNTnJGeVVYV2dkMnpBQU4ydVl1UHFGY2pRcFNPODFzVTJTU3R3DQoxVzAyeUtYOGJEYmZFdjBzbUh3UzliQnFlSGo5NEM1Mjg0YXpsdTBmaUdpTm1OUEM4ckJLRmhBPQ0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ==
         service:
-          name: webhook-service
+          name: metallb-webhook-service
           namespace: "{{ metallb_namespace }}"
           path: /convert
       conversionReviewVersions:
@@ -570,20 +449,27 @@ spec:
     - jsonPath: .spec.ebgpMultiHop
       name: Multi Hops
       type: string
+    deprecated: true
+    deprecationWarning: v1beta1 is deprecated, please use v1beta2
     name: v1beta1
     schema:
       openAPIV3Schema:
         description: BGPPeer is the Schema for the peers API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -603,13 +489,14 @@ spec:
                 type: string
               myASN:
                 description: AS number to use for the local end of the session.
-                format: int32
+                format: int64
                 maximum: 4294967295
                 minimum: 0
                 type: integer
               nodeSelectors:
-                description: Only connect to this peer on nodes that match one of
-                  these selectors.
+                description: |-
+                  Only connect to this peer on nodes that match one of these
+                  selectors.
                 items:
                   properties:
                     matchExpressions:
@@ -642,7 +529,7 @@ spec:
                 type: string
               peerASN:
                 description: AS number to expect from the remote end of the session.
-                format: int32
+                format: int64
                 maximum: 4294967295
                 minimum: 0
                 type: integer
@@ -692,14 +579,19 @@ spec:
         description: BGPPeer is the Schema for the peers API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -711,70 +603,134 @@ spec:
                   associated to the BGP session. If not set, the BFD session won't
                   be set up.
                 type: string
+              connectTime:
+                description: Requested BGP connect time, controls how long BGP waits
+                  between connection attempts to a neighbor.
+                type: string
+                x-kubernetes-validations:
+                - message: connect time should be between 1 seconds to 65535
+                  rule: duration(self).getSeconds() >= 1 && duration(self).getSeconds()
+                    <= 65535
+                - message: connect time should contain a whole number of seconds
+                  rule: duration(self).getMilliseconds() % 1000 == 0
+              disableMP:
+                default: false
+                description: |-
+                  To set if we want to disable MP BGP that will separate IPv4 and IPv6 route exchanges into distinct BGP sessions.
+                  Deprecated: DisableMP is deprecated in favor of dualStackAddressFamily.
+                type: boolean
+              dualStackAddressFamily:
+                default: false
+                description: |-
+                  To set if we want to enable the neighbor not only for the ipfamily related to its session,
+                  but also the other one. This allows to advertise/receive IPv4 prefixes over IPv6 sessions and vice versa.
+                type: boolean
+              dynamicASN:
+                description: |-
+                  DynamicASN detects the AS number to use for the remote end of the session
+                  without explicitly setting it via the ASN field. Limited to:
+                  internal - if the neighbor's ASN is different than MyASN connection is denied.
+                  external - if the neighbor's ASN is the same as MyASN the connection is denied.
+                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
+                enum:
+                - internal
+                - external
+                type: string
               ebgpMultiHop:
                 description: To set if the BGPPeer is multi-hops away. Needed for
-                  FRR mode only.
+                  FRR-based modes (FRR-K8s, FRR) only.
                 type: boolean
+              enableGracefulRestart:
+                description: |-
+                  EnableGracefulRestart allows BGP peer to continue to forward data packets
+                  along known routes while the routing protocol information is being
+                  restored. This field is immutable because it requires restart of the BGP
+                  session. Supported for FRR-based modes (FRR-K8s, FRR) only.
+                type: boolean
+                x-kubernetes-validations:
+                - message: EnableGracefulRestart cannot be changed after creation
+                  rule: self == oldSelf
               holdTime:
                 description: Requested BGP hold time, per RFC4271.
+                type: string
+              interface:
+                description: |-
+                  Interface is the node interface over which the unnumbered BGP peering will
+                  be established. No API validation takes place as that string value
+                  represents an interface name on the host and if user provides an invalid
+                  value, only the actual BGP session will not be established.
+                  Address and Interface are mutually exclusive and one of them must be specified.
                 type: string
               keepaliveTime:
                 description: Requested BGP keepalive time, per RFC4271.
                 type: string
+              localASN:
+                description: |-
+                  LocalASN allows advertising a different AS number to the peer using BGP's
+                  local-as feature. When set, MetalLB will advertise this ASN to the peer
+                  via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding
+                  the router-level MyASN for this specific session.
+                  Not supported in native BGP mode.
+                format: int32
+                maximum: 4294967295
+                minimum: 1
+                type: integer
               myASN:
                 description: AS number to use for the local end of the session.
-                format: int32
+                format: int64
                 maximum: 4294967295
                 minimum: 0
                 type: integer
               nodeSelectors:
-                description: Only connect to this peer on nodes that match one of
-                  these selectors.
+                description: |-
+                  Only connect to this peer on nodes that match one of these
+                  selectors.
                 items:
-                  description: A label selector is a label query over a set of resources.
-                    The result of matchLabels and matchExpressions are ANDed. An empty
-                    label selector matches all objects. A null label selector matches
-                    no objects.
+                  description: |-
+                    A label selector is a label query over a set of resources. The result of matchLabels and
+                    matchExpressions are ANDed. An empty label selector matches all objects. A null
+                    label selector matches no objects.
                   properties:
                     matchExpressions:
                       description: matchExpressions is a list of label selector requirements.
                         The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
                         properties:
                           key:
                             description: key is the label key that the selector applies
                               to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
                             items:
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                         required:
                         - key
                         - operator
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
                   x-kubernetes-map-type: atomic
@@ -784,10 +740,11 @@ spec:
                   authenticated sessions
                 type: string
               passwordSecret:
-                description: passwordSecret is name of the authentication secret for
-                  BGP Peer. the secret must be of type "kubernetes.io/basic-auth",
-                  and created in the same namespace as the MetalLB deployment. The
-                  password is stored in the secret as the key "password".
+                description: |-
+                  passwordSecret is name of the authentication secret for BGP Peer.
+                  the secret must be of type "kubernetes.io/basic-auth", and created in the
+                  same namespace as the MetalLB deployment. The password is stored in the
+                  secret as the key "password".
                 properties:
                   name:
                     description: name is unique within a namespace to reference a
@@ -800,8 +757,10 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               peerASN:
-                description: AS number to expect from the remote end of the session.
-                format: int32
+                description: |-
+                  AS number to expect from the remote end of the session.
+                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
+                format: int64
                 maximum: 4294967295
                 minimum: 0
                 type: integer
@@ -812,7 +771,7 @@ spec:
                 default: 179
                 description: Port to dial when establishing the session.
                 maximum: 16384
-                minimum: 0
+                minimum: 1
                 type: integer
               routerID:
                 description: BGP router ID to advertise to the peer
@@ -821,13 +780,12 @@ spec:
                 description: Source address to use when establishing the session.
                 type: string
               vrf:
-                description: To set if we want to peer with the BGPPeer using an interface
-                  belonging to a host vrf
+                description: |-
+                  To set if we want to peer with the BGPPeer using an interface belonging to
+                  a host vrf
                 type: string
             required:
             - myASN
-            - peerASN
-            - peerAddress
             type: object
           status:
             description: BGPPeerStatus defines the observed state of Peer.
@@ -842,8 +800,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: communities.metallb.io
 spec:
   group: metallb.io
@@ -857,18 +814,24 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Community is a collection of aliases for communities. Users can
-          define named aliases to be used in the BGPPeer CRD.
+        description: |-
+          Community is a collection of aliases for communities.
+          Users can define named aliases to be used in the BGPPeer CRD.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -882,8 +845,9 @@ spec:
                       description: The name of the alias for the community.
                       type: string
                     value:
-                      description: The BGP community value corresponding to the given
-                        name.
+                      description: |-
+                        The BGP community value corresponding to the given name. Can be a standard community of the form 1234:1234
+                        or a large community of the form large:1234:1234:1234.
                       type: string
                   type: object
                 type: array
@@ -901,8 +865,141 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: configurationstates.metallb.io
+spec:
+  group: metallb.io
+  names:
+    kind: ConfigurationState
+    listKind: ConfigurationStateList
+    plural: configurationstates
+    singular: configurationstate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.result
+      name: Result
+      type: string
+    - jsonPath: .status.errorSummary
+      name: ErrorSummary
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ConfigurationState is a status-only CRD that reports configuration validation results from MetalLB components.
+          Labels:
+            - metallb.io/component-type: "controller" or "speaker"
+            - metallb.io/node-name: node name (only for speaker)
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          status:
+            description: ConfigurationStateStatus defines the observed state of ConfigurationState.
+            properties:
+              conditions:
+                description: Conditions contains the status conditions from the reconcilers
+                  running in this component.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              errorSummary:
+                description: |-
+                  ErrorSummary contains the aggregated error messages from reconciliation failures.
+                  This field is empty when Result is "Valid".
+                type: string
+              result:
+                description: Result indicates the configuration validation result.
+                enum:
+                - Valid
+                - Invalid
+                - Unknown
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: ipaddresspools.metallb.io
 spec:
   group: metallb.io
@@ -926,18 +1023,24 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: IPAddressPool represents a pool of IP addresses that can be allocated
+        description: |-
+          IPAddressPool represents a pool of IP addresses that can be allocated
           to LoadBalancer services.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -945,82 +1048,86 @@ spec:
             description: IPAddressPoolSpec defines the desired state of IPAddressPool.
             properties:
               addresses:
-                description: A list of IP address ranges over which MetalLB has authority.
-                  You can list multiple ranges in a single pool, they will all share
-                  the same settings. Each range can be either a CIDR prefix, or an
-                  explicit start-end range of IPs.
+                description: |-
+                  A list of IP address ranges over which MetalLB has authority.
+                  You can list multiple ranges in a single pool, they will all share the
+                  same settings. Each range can be either a CIDR prefix, or an explicit
+                  start-end range of IPs.
                 items:
                   type: string
                 type: array
               autoAssign:
                 default: true
-                description: AutoAssign flag used to prevent MetallB from automatic
-                  allocation for a pool.
+                description: |-
+                  AutoAssign flag used to prevent MetallB from automatic allocation
+                  for a pool.
                 type: boolean
               avoidBuggyIPs:
                 default: false
-                description: AvoidBuggyIPs prevents addresses ending with .0 and .255
+                description: |-
+                  AvoidBuggyIPs prevents addresses ending with .0 and .255
                   to be used by a pool.
                 type: boolean
               serviceAllocation:
-                description: AllocateTo makes ip pool allocation to specific namespace
-                  and/or service. The controller will use the pool with lowest value
-                  of priority in case of multiple matches. A pool with no priority
-                  set will be used only if the pools with priority can't be used.
-                  If multiple matching IPAddressPools are available it will check
-                  for the availability of IPs sorting the matching IPAddressPools
-                  by priority, starting from the highest to the lowest. If multiple
-                  IPAddressPools have the same priority, choice will be random.
+                description: |-
+                  AllocateTo makes ip pool allocation to specific namespace and/or service.
+                  The controller will use the pool with lowest value of priority in case of
+                  multiple matches. A pool with no priority set will be used only if the
+                  pools with priority can't be used. If multiple matching IPAddressPools are
+                  available it will check for the availability of IPs sorting the matching
+                  IPAddressPools by priority, starting from the highest to the lowest. If
+                  multiple IPAddressPools have the same priority, choice will be random.
                 properties:
                   namespaceSelectors:
-                    description: NamespaceSelectors list of label selectors to select
-                      namespace(s) for ip pool, an alternative to using namespace
-                      list.
+                    description: |-
+                      NamespaceSelectors list of label selectors to select namespace(s) for ip pool,
+                      an alternative to using namespace list.
                     items:
-                      description: A label selector is a label query over a set of
-                        resources. The result of matchLabels and matchExpressions
-                        are ANDed. An empty label selector matches all objects. A
-                        null label selector matches no objects.
+                      description: |-
+                        A label selector is a label query over a set of resources. The result of matchLabels and
+                        matchExpressions are ANDed. An empty label selector matches all objects. A null
+                        label selector matches no objects.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector
                             requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector
                                   applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship
-                                  to a set of values. Valid operators are In, NotIn,
-                                  Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values.
-                                  If the operator is In or NotIn, the values array
-                                  must be non-empty. If the operator is Exists or
-                                  DoesNotExist, the values array must be empty. This
-                                  array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                             - key
                             - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs.
-                            A single {key,value} in the matchLabels map is equivalent
-                            to an element of matchExpressions, whose key field is
-                            "key", the operator is "In", and the values array contains
-                            only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
@@ -1036,53 +1143,55 @@ spec:
                       on a service.
                     type: integer
                   serviceSelectors:
-                    description: ServiceSelectors list of label selector to select
-                      service(s) for which ip pool can be used for ip allocation.
+                    description: |-
+                      ServiceSelectors list of label selector to select service(s) for which ip pool
+                      can be used for ip allocation.
                     items:
-                      description: A label selector is a label query over a set of
-                        resources. The result of matchLabels and matchExpressions
-                        are ANDed. An empty label selector matches all objects. A
-                        null label selector matches no objects.
+                      description: |-
+                        A label selector is a label query over a set of resources. The result of matchLabels and
+                        matchExpressions are ANDed. An empty label selector matches all objects. A null
+                        label selector matches no objects.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector
                             requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector
                                   applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship
-                                  to a set of values. Valid operators are In, NotIn,
-                                  Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values.
-                                  If the operator is In or NotIn, the values array
-                                  must be non-empty. If the operator is Exists or
-                                  DoesNotExist, the values array must be empty. This
-                                  array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                             - key
                             - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs.
-                            A single {key,value} in the matchLabels map is equivalent
-                            to an element of matchExpressions, whose key field is
-                            "key", the operator is "In", and the values array contains
-                            only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
@@ -1093,6 +1202,28 @@ spec:
             type: object
           status:
             description: IPAddressPoolStatus defines the observed state of IPAddressPool.
+            properties:
+              assignedIPv4:
+                description: AssignedIPv4 is the number of assigned IPv4 addresses.
+                format: int64
+                type: integer
+              assignedIPv6:
+                description: AssignedIPv6 is the number of assigned IPv6 addresses.
+                format: int64
+                type: integer
+              availableIPv4:
+                description: AvailableIPv4 is the number of available IPv4 addresses.
+                format: int64
+                type: integer
+              availableIPv6:
+                description: AvailableIPv6 is the number of available IPv6 addresses.
+                format: int64
+                type: integer
+            required:
+            - assignedIPv4
+            - assignedIPv6
+            - availableIPv4
+            - availableIPv6
             type: object
         required:
         - spec
@@ -1106,8 +1237,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: l2advertisements.metallb.io
 spec:
   group: metallb.io
@@ -1135,18 +1265,24 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: L2Advertisement allows to advertise the LoadBalancer IPs provided
+        description: |-
+          L2Advertisement allows to advertise the LoadBalancer IPs provided
           by the selected pools via L2.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -1154,61 +1290,62 @@ spec:
             description: L2AdvertisementSpec defines the desired state of L2Advertisement.
             properties:
               interfaces:
-                description: A list of interfaces to announce from. The LB IP will
-                  be announced only from these interfaces. If the field is not set,
-                  we advertise from all the interfaces on the host.
+                description: |-
+                  A list of interfaces to announce from. The LB IP will be announced only from these interfaces.
+                  If the field is not set, we advertise from all the interfaces on the host.
                 items:
                   type: string
                 type: array
               ipAddressPoolSelectors:
-                description: A selector for the IPAddressPools which would get advertised
-                  via this advertisement. If no IPAddressPool is selected by this
-                  or by the list, the advertisement is applied to all the IPAddressPools.
+                description: |-
+                  A selector for the IPAddressPools which would get advertised via this advertisement.
+                  If no IPAddressPool is selected by this or by the list, the advertisement is applied to all the IPAddressPools.
                 items:
-                  description: A label selector is a label query over a set of resources.
-                    The result of matchLabels and matchExpressions are ANDed. An empty
-                    label selector matches all objects. A null label selector matches
-                    no objects.
+                  description: |-
+                    A label selector is a label query over a set of resources. The result of matchLabels and
+                    matchExpressions are ANDed. An empty label selector matches all objects. A null
+                    label selector matches no objects.
                   properties:
                     matchExpressions:
                       description: matchExpressions is a list of label selector requirements.
                         The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
                         properties:
                           key:
                             description: key is the label key that the selector applies
                               to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
                             items:
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                         required:
                         - key
                         - operator
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
                   x-kubernetes-map-type: atomic
@@ -1224,50 +1361,105 @@ spec:
                   next hops for the LoadBalancer IP. When empty, all the nodes having  are
                   announced as next hops.
                 items:
-                  description: A label selector is a label query over a set of resources.
-                    The result of matchLabels and matchExpressions are ANDed. An empty
-                    label selector matches all objects. A null label selector matches
-                    no objects.
+                  description: |-
+                    A label selector is a label query over a set of resources. The result of matchLabels and
+                    matchExpressions are ANDed. An empty label selector matches all objects. A null
+                    label selector matches no objects.
                   properties:
                     matchExpressions:
                       description: matchExpressions is a list of label selector requirements.
                         The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
                         properties:
                           key:
                             description: key is the label key that the selector applies
                               to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
                             items:
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                         required:
                         - key
                         - operator
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              serviceSelectors:
+                description: |-
+                  ServiceSelectors limits the set of services that will be advertised via this advertisement.
+                  If empty, all services from the selected pools are advertised.
+                items:
+                  description: |-
+                    A label selector is a label query over a set of resources. The result of matchLabels and
+                    matchExpressions are ANDed. An empty label selector matches all objects. A null
+                    label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
                   x-kubernetes-map-type: atomic
@@ -1282,19 +1474,191 @@ spec:
     subresources:
       status: {}
 ---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: servicebgpstatuses.metallb.io
+spec:
+  group: metallb.io
+  names:
+    kind: ServiceBGPStatus
+    listKind: ServiceBGPStatusList
+    plural: servicebgpstatuses
+    singular: servicebgpstatus
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.node
+      name: Node
+      type: string
+    - jsonPath: .status.serviceName
+      name: Service Name
+      type: string
+    - jsonPath: .status.serviceNamespace
+      name: Service Namespace
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ServiceBGPStatus exposes the BGP peers a service is configured
+          to be advertised to, per relevant node.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ServiceBGPStatusSpec defines the desired state of ServiceBGPStatus.
+            type: object
+          status:
+            description: MetalLBServiceBGPStatus defines the observed state of ServiceBGPStatus.
+            properties:
+              node:
+                description: Node indicates the node announcing the service.
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              peers:
+                description: |-
+                  Peers indicate the BGP peers for which the service is configured to be advertised to.
+                  The service being actually advertised to a given peer depends on the session state and is not indicated here.
+                items:
+                  type: string
+                type: array
+              serviceName:
+                description: ServiceName indicates the service this status represents.
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              serviceNamespace:
+                description: ServiceNamespace indicates the namespace of the service.
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: servicel2statuses.metallb.io
+spec:
+  group: metallb.io
+  names:
+    kind: ServiceL2Status
+    listKind: ServiceL2StatusList
+    plural: servicel2statuses
+    singular: servicel2status
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.node
+      name: Allocated Node
+      type: string
+    - jsonPath: .status.serviceName
+      name: Service Name
+      type: string
+    - jsonPath: .status.serviceNamespace
+      name: Service Namespace
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ServiceL2Status reveals the actual traffic status of loadbalancer
+          services in layer2 mode.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ServiceL2StatusSpec defines the desired state of ServiceL2Status.
+            type: object
+          status:
+            description: MetalLBServiceL2Status defines the observed state of ServiceL2Status.
+            properties:
+              interfaces:
+                description: Interfaces indicates the interfaces that receive the
+                  directed traffic
+                items:
+                  description: InterfaceInfo defines interface info of layer2 announcement.
+                  properties:
+                    name:
+                      description: Name the name of network interface card
+                      type: string
+                  type: object
+                type: array
+              node:
+                description: Node indicates the node that receives the directed traffic
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              serviceName:
+                description: ServiceName indicates the service this status represents
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              serviceNamespace:
+                description: ServiceNamespace indicates the namespace of the service
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
     app: metallb
-    pod-security.kubernetes.io/audit: privileged
-    pod-security.kubernetes.io/enforce: privileged
-    pod-security.kubernetes.io/warn: privileged
   name: controller
   namespace: "{{ metallb_namespace }}"
-
-{% if metallb_speaker_enabled %}
 ---
+{% if metallb_speaker_enabled %}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -1350,14 +1714,6 @@ rules:
 - apiGroups:
   - metallb.io
   resources:
-  - addresspools
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - metallb.io
-  resources:
   - bfdprofiles
   verbs:
   - get
@@ -1371,6 +1727,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - metallb.io
+  resources:
+  - ipaddresspools/status
+  verbs:
+  - update
 - apiGroups:
   - metallb.io
   resources:
@@ -1410,6 +1772,7 @@ rules:
   - pods
   verbs:
   - list
+  - get
 - apiGroups:
   - ""
   resources:
@@ -1419,9 +1782,9 @@ rules:
   - list
   - watch
 - apiGroups:
-  - metallb.io
+  - ""
   resources:
-  - addresspools
+  - configmaps
   verbs:
   - get
   - list
@@ -1474,6 +1837,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - metallb.io
+  resources:
+  - servicebgpstatuses
+  - servicebgpstatuses/status
+  verbs:
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1494,6 +1864,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - list
+- apiGroups:
+  - ""
+  resources:
   - services/status
   verbs:
   - update
@@ -1505,12 +1881,19 @@ rules:
   - create
   - patch
 - apiGroups:
+  - policy
+  resourceNames:
+  - controller
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+- apiGroups:
   - admissionregistration.k8s.io
   resourceNames:
   - metallb-webhook-configuration
   resources:
   - validatingwebhookconfigurations
-  - mutatingwebhookconfigurations
   verbs:
   - create
   - delete
@@ -1523,20 +1906,19 @@ rules:
   - admissionregistration.k8s.io
   resources:
   - validatingwebhookconfigurations
-  - mutatingwebhookconfigurations
   verbs:
   - list
   - watch
 - apiGroups:
   - apiextensions.k8s.io
   resourceNames:
-  - addresspools.metallb.io
   - bfdprofiles.metallb.io
   - bgpadvertisements.metallb.io
   - bgppeers.metallb.io
   - ipaddresspools.metallb.io
   - l2advertisements.metallb.io
   - communities.metallb.io
+  - configurationstates.metallb.io
   resources:
   - customresourcedefinitions
   verbs:
@@ -1554,6 +1936,26 @@ rules:
   verbs:
   - list
   - watch
+- apiGroups:
+  - metallb.io
+  resources:
+  - configurationstates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - metallb.io
+  resources:
+  - configurationstates/status
+  verbs:
+  - get
+  - patch
+  - update
 ---
 {% if metallb_speaker_enabled %}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1563,6 +1965,15 @@ metadata:
     app: metallb
   name: {{ metallb_namespace }}:speaker
 rules:
+- apiGroups:
+  - metallb.io
+  resources:
+  - servicel2statuses
+  - servicel2statuses/status
+  - configurationstates
+  - configurationstates/status
+  verbs:
+  - '*'
 - apiGroups:
   - ""
   resources:
@@ -1589,8 +2000,15 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - policy
+  resourceNames:
+  - speaker
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 {% endif %}
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -1607,7 +2025,6 @@ subjects:
 - kind: ServiceAccount
   name: controller
   namespace: "{{ metallb_namespace }}"
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -1621,10 +2038,12 @@ roleRef:
   kind: Role
   name: pod-lister
 subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: "{{ metallb_namespace }}"
 - kind: ServiceAccount
   name: speaker
   namespace: "{{ metallb_namespace }}"
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1640,9 +2059,8 @@ subjects:
 - kind: ServiceAccount
   name: controller
   namespace: "{{ metallb_namespace }}"
-
+---
 {% if metallb_speaker_enabled %}
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -1658,19 +2076,26 @@ subjects:
   name: speaker
   namespace: "{{ metallb_namespace }}"
 {% endif %}
-
+---
+apiVersion: v1
+data:
+  excludel2.yaml: |
+    announcedInterfacesToExclude: ["^docker.*", "^cbr.*", "^dummy.*", "^virbr.*", "^lxcbr.*", "^veth.*", "^lo$", "^cali.*", "^tunl.*", "^flannel.*", "^kube-ipvs.*", "^cni.*", "^nodelocaldns.*", "^lxc.*"]
+kind: ConfigMap
+metadata:
+  name: metallb-excludel2
+  namespace: "{{ metallb_namespace }}"
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: webhook-server-cert
+  name: metallb-webhook-cert
   namespace: "{{ metallb_namespace }}"
-
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: webhook-service
+  name: metallb-webhook-service
   namespace: "{{ metallb_namespace }}"
 spec:
   ports:
@@ -1678,7 +2103,6 @@ spec:
     targetPort: 9443
   selector:
     component: controller
-
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1712,6 +2136,10 @@ spec:
         - --lb-class={{ metallb_loadbalancer_class }}
 {% endif %}
         env:
+        - name: METALLB_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: METALLB_ML_SECRET_NAME
           value: memberlist
         - name: METALLB_DEPLOYMENT
@@ -1720,8 +2148,9 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /metrics
-            port: monitoring
+            host: 127.0.0.1
+            path: /healthz
+            port: 17472
           initialDelaySeconds: 10
           periodSeconds: 10
           successThreshold: 1
@@ -1729,15 +2158,16 @@ spec:
         name: controller
         ports:
         - containerPort: {{ metallb_port }}
-          name: monitoring
+          name: metricshttps
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /metrics
-            port: monitoring
+            host: 127.0.0.1
+            path: /readyz
+            port: 17472
           initialDelaySeconds: 10
           periodSeconds: 10
           successThreshold: 1
@@ -1771,8 +2201,7 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: webhook-server-cert
-
+          secretName: metallb-webhook-cert
 ---
 {% if metallb_speaker_enabled %}
 apiVersion: apps/v1
@@ -1809,6 +2238,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: METALLB_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: METALLB_HOST
           valueFrom:
             fieldRef:
@@ -1819,17 +2252,15 @@ spec:
               fieldPath: status.podIP
         - name: METALLB_ML_LABELS
           value: app=metallb,component=speaker
-        - name: METALLB_ML_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: secretkey
-              name: memberlist
+        - name: METALLB_ML_SECRET_KEY_PATH
+          value: /etc/ml_secret_key
         image: "{{ metallb_speaker_image_repo }}:{{ metallb_image_tag }}"
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /metrics
-            port: monitoring
+            host: 127.0.0.1
+            path: /healthz
+            port: 17472
           initialDelaySeconds: 10
           periodSeconds: 10
           successThreshold: 1
@@ -1837,7 +2268,7 @@ spec:
         name: speaker
         ports:
         - containerPort: {{ metallb_port }}
-          name: monitoring
+          name: metricshttps
         - containerPort: {{ metallb_memberlist_port }}
           name: memberlist-tcp
         - containerPort: {{ metallb_memberlist_port }}
@@ -1846,8 +2277,9 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /metrics
-            port: monitoring
+            host: 127.0.0.1
+            path: /readyz
+            port: 17472
           initialDelaySeconds: 10
           periodSeconds: 10
           successThreshold: 1
@@ -1860,6 +2292,16 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /etc/ml_secret_key
+          name: memberlist
+          readOnly: true
+        - mountPath: /etc/metallb
+          name: metallb-excludel2
+          readOnly: true
+        - mountPath: /etc/metallb/memberlist
+          name: memberlist-config
+          readOnly: true
       hostNetwork: true
       nodeSelector:
         {{ metallb_speaker_nodeselector | to_nice_yaml | indent(width=8) -}}
@@ -1874,8 +2316,20 @@ spec:
         {% if metallb_config.speaker is defined and metallb_config.speaker.tolerations is defined %}
         {{ metallb_config.speaker.tolerations | to_nice_yaml(indent=2) | indent(width=8) -}}
         {% endif %}
+      volumes:
+      - name: memberlist
+        secret:
+          defaultMode: 420
+          secretName: memberlist
+      - configMap:
+          defaultMode: 256
+          name: metallb-excludel2
+        name: metallb-excludel2
+      - configMap:
+          name: metallb-memberlist-config
+          optional: true
+        name: memberlist-config
 {% endif %}
-
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -1887,7 +2341,7 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: webhook-service
+      name: metallb-webhook-service
       namespace: "{{ metallb_namespace }}"
       path: /validate-metallb-io-v1beta2-bgppeer
   failurePolicy: Fail
@@ -1907,27 +2361,7 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: webhook-service
-      namespace: "{{ metallb_namespace }}"
-      path: /validate-metallb-io-v1beta1-addresspool
-  failurePolicy: Fail
-  name: addresspoolvalidationwebhook.metallb.io
-  rules:
-  - apiGroups:
-    - metallb.io
-    apiVersions:
-    - v1beta1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - addresspools
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: webhook-service
+      name: metallb-webhook-service
       namespace: "{{ metallb_namespace }}"
       path: /validate-metallb-io-v1beta1-bfdprofile
   failurePolicy: Fail
@@ -1947,7 +2381,7 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: webhook-service
+      name: metallb-webhook-service
       namespace: "{{ metallb_namespace }}"
       path: /validate-metallb-io-v1beta1-bgpadvertisement
   failurePolicy: Fail
@@ -1967,7 +2401,7 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: webhook-service
+      name: metallb-webhook-service
       namespace: "{{ metallb_namespace }}"
       path: /validate-metallb-io-v1beta1-community
   failurePolicy: Fail
@@ -1987,7 +2421,7 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: webhook-service
+      name: metallb-webhook-service
       namespace: "{{ metallb_namespace }}"
       path: /validate-metallb-io-v1beta1-ipaddresspool
   failurePolicy: Fail
@@ -2007,7 +2441,7 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: webhook-service
+      name: metallb-webhook-service
       namespace: "{{ metallb_namespace }}"
       path: /validate-metallb-io-v1beta1-l2advertisement
   failurePolicy: Fail

--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -365,7 +365,7 @@ gcp_pd_csi_registrar_image_tag: "v1.2.0-gke.0"
 
 metallb_speaker_image_repo: "{{ quay_image_repo }}/metallb/speaker"
 metallb_controller_image_repo: "{{ quay_image_repo }}/metallb/controller"
-metallb_version: 0.13.9
+metallb_version: 0.16.0
 metallb_image_tag: "v{{ metallb_version }}"
 
 node_feature_discovery_version: 0.16.4


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

The bundled MetalLB manifest was still the one from v0.13.9 (October 2023). This regenerates it from the upstream `config/manifests/metallb-native.yaml` of **v0.16.0** and re-applies the kubespray specific customizations:

* templated namespace (and the namespace derived ClusterRole / ClusterRoleBinding names)
* image repositories and tags from `metallb_controller_image_repo` / `metallb_speaker_image_repo` / `metallb_image_tag`
* `metallb_port`, `metallb_memberlist_port`, `metallb_log_level`, `metallb_loadbalancer_class`
* controller / speaker `nodeSelector` and `tolerations` from `metallb_config`
* `metallb_speaker_enabled` toggle for the speaker ServiceAccount, ClusterRole, ClusterRoleBinding and DaemonSet
* `priorityClassName: system-cluster-critical` on the controller

Notable upstream changes coming with the bump:

* the legacy `AddressPool` CRD is gone (removed in v0.14.2 in favor of `IPAddressPool`, which kubespray already renders in `pools.yaml.j2`)
* new `ConfigurationState`, `ServiceBGPStatus` and `ServiceL2Status` CRDs
* the webhook Secret and Service were renamed to `metallb-webhook-cert` and `metallb-webhook-service`
* the `metallb-excludel2` ConfigMap and the memberlist secret volume are now mounted by the speaker
* liveness / readiness probes moved to `127.0.0.1:17472` `/healthz` and `/readyz`, because the metrics endpoint is now served over HTTPS with authentication and authorization instead of plain HTTP

Since `kubectl apply` does not prune, the resources that are no longer part of the manifest (the `addresspools.metallb.io` CRD and the old `webhook-server-cert` Secret / `webhook-service` Service) are deleted explicitly, following the existing "Delete MetalLB ConfigMap" cleanup in the same role.

**Which issue(s) this PR fixes**:

Fixes #13126

**Special notes for your reviewer**:

* `metallb_port` intentionally keeps its current default of `7472`, although upstream moved its own default to `9120`. Changing it would break existing firewall rules and the documented [port requirements](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/operations/port-requirements.md). The variable stays user overridable.
* Native BGP mode is retained: the native manifest still defaults to `METALLB_BGP_TYPE=native`, so no behavior change for BGP users. FRR-K8s becoming the default backend upstream would be a separate feature.
* Replacing the manifest with the Helm chart (as attempted in #12126) was deliberately left out of this PR, to keep the version bump reviewable and backwards compatible. It needs its own migration story, because Helm only adopts existing objects that carry the `meta.helm.sh/release-name` annotations.
* How this was verified: the template was rendered with the Ansible filters and compared document by document against the upstream v0.16.0 manifest. All 26 resources match, with only the intended kubespray deltas (metrics port, `priorityClassName`, control-plane only toleration). Additionally rendered with `metallb_speaker_enabled: false` (22 resources), with a custom `metallb_namespace` and with controller / speaker `nodeselector` and `tolerations` overrides. There is currently no CI job covering MetalLB, so this was not exercised against a live cluster.

**Does this PR introduce a user-facing change?**:

```release-note
Upgrade MetalLB from 0.13.9 to 0.16.0. The deprecated `addresspools.metallb.io` CRD, removed upstream in v0.14.2, and the renamed webhook Secret and Service are deleted during the upgrade. The MetalLB metrics endpoint is now served over HTTPS with authentication and authorization instead of plain HTTP, on the unchanged default port 7472.
```
