### PR TITLE
Run each etcd certificate task only once

### DIFF
--- a/playbooks/install_etcd.yml
+++ b/playbooks/install_etcd.yml
@@ -8,9 +8,7 @@
       group_by:
         key: "_kubespray_needs_etcd"
       when:
-        - kube_network_plugin in ["flannel", "canal", "cilium"] or
-          (cilium_deploy_additionally | default(false)) or
-          (kube_network_plugin == "calico" and calico_datastore == "etcd")
+        - network_plugin_requires_etcd
         - etcd_deployment_type != "kubeadm"
       tags: etcd
 

--- a/playbooks/scale.yml
+++ b/playbooks/scale.yml
@@ -31,14 +31,6 @@
     - { role: kubernetes/preinstall, tags: preinstall }
     - { role: container-engine, tags: "container-engine", when: deploy_container_engine }
     - { role: download, tags: download, when: "not skip_downloads" }
-    - role: etcd
-      tags: etcd
-      vars:
-        etcd_cluster_setup: false
-      when:
-        - etcd_deployment_type != "kubeadm"
-        - kube_network_plugin in ["calico", "flannel", "canal", "cilium"] or cilium_deploy_additionally | default(false) | bool
-        - kube_network_plugin != "calico" or calico_datastore == "etcd"
 
 - name: Target only workers to get kubelet installed and checking in on any new nodes(node)
   hosts: kube_node

--- a/roles/etcd/tasks/check_certs.yml
+++ b/roles/etcd/tasks/check_certs.yml
@@ -41,7 +41,7 @@
     - node-{{ inventory_hostname }}.pem
     - node-{{ inventory_hostname }}-key.pem
 
-- name: "Check_certs | Set 'gen_certs' to true if expected certificates are not on the first etcd node(1/2)"
+- name: "Check_certs | Set 'gen_certs' to true if expected certificates are not on the first etcd node"
   set_fact:
     gen_certs: true
   when: force_etcd_cert_refresh or not item in etcdcert_master.files | map(attribute='path') | list
@@ -57,38 +57,12 @@
         '{{ etcd_cert_dir }}/member-{{ host }}.pem',
         '{{ etcd_cert_dir }}/member-{{ host }}-key.pem',
       {% endfor %}
-      {% set k8s_nodes = groups['kube_control_plane'] %}
+      {% set k8s_nodes = etcd_node_cert_hosts | unique | sort %}
       {% for host in k8s_nodes %}
         '{{ etcd_cert_dir }}/node-{{ host }}.pem',
         '{{ etcd_cert_dir }}/node-{{ host }}-key.pem'
         {% if not loop.last %}{{ ',' }}{% endif %}
       {% endfor %}]
-
-- name: "Check_certs | Set 'gen_certs' to true if expected certificates are not on the first etcd node(2/2)"
-  set_fact:
-    gen_certs: true
-  run_once: true
-  with_items: "{{ expected_files }}"
-  vars:
-    expected_files: >-
-      ['{{ etcd_cert_dir }}/ca.pem',
-      {% set etcd_members = groups['etcd'] %}
-      {% for host in etcd_members %}
-        '{{ etcd_cert_dir }}/admin-{{ host }}.pem',
-        '{{ etcd_cert_dir }}/admin-{{ host }}-key.pem',
-        '{{ etcd_cert_dir }}/member-{{ host }}.pem',
-        '{{ etcd_cert_dir }}/member-{{ host }}-key.pem',
-      {% endfor %}
-      {% set k8s_nodes = groups['k8s_cluster'] | unique | sort %}
-      {% for host in k8s_nodes %}
-        '{{ etcd_cert_dir }}/node-{{ host }}.pem',
-        '{{ etcd_cert_dir }}/node-{{ host }}-key.pem'
-        {% if not loop.last %}{{ ',' }}{% endif %}
-      {% endfor %}]
-  when:
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally
-    - kube_network_plugin != "calico" or calico_datastore == "etcd"
-    - force_etcd_cert_refresh or not item in etcdcert_master.files | map(attribute='path') | list
 
 - name: "Check_certs | Set 'gen_*_certs' groups to track which nodes needs to have certs generated on first etcd node"
   vars:

--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -36,29 +36,17 @@
   when:
     - inventory_hostname == groups['etcd'][0]
 
-- name: Gen_certs | run cert generation script for etcd and kube control plane nodes
+- name: Gen_certs | run cert generation script for etcd members and clients
   command: "bash -x {{ etcd_script_dir }}/make-ssl-etcd.sh -f {{ etcd_config_dir }}/openssl.conf -d {{ etcd_cert_dir }}"
   environment:
-    MASTERS: "{{ groups['gen_master_certs_True'] | ansible.builtin.intersect(groups['etcd']) | join(' ') }}"
-    HOSTS: "{{ groups['gen_node_certs_True'] | ansible.builtin.intersect(groups['kube_control_plane']) | join(' ') }}"
+    MASTERS: "{{ groups['gen_master_certs_True'] | default([]) | ansible.builtin.intersect(groups['etcd']) | join(' ') }}"
+    HOSTS: "{{ groups['gen_node_certs_True'] | default([]) | ansible.builtin.intersect(etcd_node_cert_hosts) | join(' ') }}"
   run_once: true
   delegate_to: "{{ groups['etcd'][0] }}"
   when: gen_certs
   notify: Set etcd_secret_changed
 
-- name: Gen_certs | run cert generation script for all clients
-  command: "bash -x {{ etcd_script_dir }}/make-ssl-etcd.sh -f {{ etcd_config_dir }}/openssl.conf -d {{ etcd_cert_dir }}"
-  environment:
-    HOSTS: "{{ groups['gen_node_certs_True'] | ansible.builtin.intersect(groups['k8s_cluster']) | join(' ') }}"
-  run_once: true
-  delegate_to: "{{ groups['etcd'][0] }}"
-  when:
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally
-    - kube_network_plugin != "calico" or calico_datastore == "etcd"
-    - gen_certs
-  notify: Set etcd_secret_changed
-
-- name: Gen_certs | Gather etcd member/admin and kube_control_plane client certs from first etcd node
+- name: Gen_certs | Gather etcd member/admin and client certs from first etcd node
   slurp:
     src: "{{ item }}"
   register: etcd_master_certs
@@ -71,18 +59,18 @@
         '{{ etcd_cert_dir }}/member-{{ node }}.pem',
         '{{ etcd_cert_dir }}/member-{{ node }}-key.pem',
         {% endfor %}]"
-    - "[{% for node in (groups['kube_control_plane']) %}
+    - "[{% for node in etcd_node_cert_hosts %}
         '{{ etcd_cert_dir }}/node-{{ node }}.pem',
         '{{ etcd_cert_dir }}/node-{{ node }}-key.pem',
         {% endfor %}]"
   delegate_to: "{{ groups['etcd'][0] }}"
   when:
     - ('etcd' in group_names)
-    - sync_certs
     - inventory_hostname != groups['etcd'][0]
+    - sync_certs or network_plugin_requires_etcd
   notify: Set etcd_secret_changed
 
-- name: Gen_certs | Write etcd member/admin and kube_control_plane client certs to other etcd nodes
+- name: Gen_certs | Write etcd member/admin and client certs to other etcd nodes
   copy:
     dest: "{{ item.item }}"
     content: "{{ item.content | b64decode }}"
@@ -92,57 +80,18 @@
   with_items: "{{ etcd_master_certs.results }}"
   when:
     - ('etcd' in group_names)
+    - inventory_hostname != groups['etcd'][0]
+    - sync_certs or network_plugin_requires_etcd
+  loop_control:
+    label: "{{ item.item }}"
+
+- name: Gen_certs | Distribute etcd certs to hosts which are not etcd members
+  include_tasks: gen_nodes_certs_script.yml
+  when:
     - sync_certs
-    - inventory_hostname != groups['etcd'][0]
-  loop_control:
-    label: "{{ item.item }}"
-
-- name: Gen_certs | Gather node certs from first etcd node
-  slurp:
-    src: "{{ item }}"
-  register: etcd_master_node_certs
-  with_items:
-    - "[{% for node in groups['k8s_cluster'] %}
-        '{{ etcd_cert_dir }}/node-{{ node }}.pem',
-        '{{ etcd_cert_dir }}/node-{{ node }}-key.pem',
-        {% endfor %}]"
-  delegate_to: "{{ groups['etcd'][0] }}"
-  when:
-    - ('etcd' in group_names)
-    - inventory_hostname != groups['etcd'][0]
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally
-    - kube_network_plugin != "calico" or calico_datastore == "etcd"
-  notify: Set etcd_secret_changed
-
-- name: Gen_certs | Write node certs to other etcd nodes
-  copy:
-    dest: "{{ item.item }}"
-    content: "{{ item.content | b64decode }}"
-    group: "{{ etcd_cert_group }}"
-    owner: "{{ etcd_owner }}"
-    mode: "0640"
-  with_items: "{{ etcd_master_node_certs.results }}"
-  when:
-    - ('etcd' in group_names)
-    - inventory_hostname != groups['etcd'][0]
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally
-    - kube_network_plugin != "calico" or calico_datastore == "etcd"
-  loop_control:
-    label: "{{ item.item }}"
-
-- name: Gen_certs | Generate etcd certs
-  include_tasks: gen_nodes_certs_script.yml
-  when:
-    - ('kube_control_plane' in group_names) and
-        sync_certs and inventory_hostname not in groups['etcd']
-
-- name: Gen_certs | Generate etcd certs on nodes if needed
-  include_tasks: gen_nodes_certs_script.yml
-  when:
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally
-    - kube_network_plugin != "calico" or calico_datastore == "etcd"
-    - ('k8s_cluster' in group_names) and
-        sync_certs and inventory_hostname not in groups['etcd']
+    - inventory_hostname not in groups['etcd']
+    - ('kube_control_plane' in group_names) or
+      (network_plugin_requires_etcd and ('k8s_cluster' in group_names))
 
 # This is a hack around the fact kubeadm expect the same certs path on all kube_control_plane
 # TODO: fix certs generation to have the same file everywhere

--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -50,19 +50,26 @@
   slurp:
     src: "{{ item }}"
   register: etcd_master_certs
-  with_items:
-    - "{{ etcd_cert_dir }}/ca.pem"
-    - "{{ etcd_cert_dir }}/ca-key.pem"
-    - "[{% for node in groups['etcd'] %}
+  # The CA and the member/admin key material is only needed when certs are
+  # actually out of sync; the node certs are also distributed when the network
+  # plugin needs them. Keep both parts separate so that no private key is moved
+  # around without a reason.
+  loop: "{{ (etcd_member_cert_files if sync_certs else []) + etcd_client_cert_files }}"
+  vars:
+    etcd_member_cert_files: >-
+      ['{{ etcd_cert_dir }}/ca.pem',
+      '{{ etcd_cert_dir }}/ca-key.pem',
+      {% for node in groups['etcd'] %}
         '{{ etcd_cert_dir }}/admin-{{ node }}.pem',
         '{{ etcd_cert_dir }}/admin-{{ node }}-key.pem',
         '{{ etcd_cert_dir }}/member-{{ node }}.pem',
         '{{ etcd_cert_dir }}/member-{{ node }}-key.pem',
-        {% endfor %}]"
-    - "[{% for node in etcd_node_cert_hosts %}
+      {% endfor %}]
+    etcd_client_cert_files: >-
+      [{% for node in etcd_node_cert_hosts %}
         '{{ etcd_cert_dir }}/node-{{ node }}.pem',
         '{{ etcd_cert_dir }}/node-{{ node }}-key.pem',
-        {% endfor %}]"
+        {% endfor %}]
   delegate_to: "{{ groups['etcd'][0] }}"
   when:
     - ('etcd' in group_names)

--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -49,6 +49,7 @@
 - name: Gen_certs | Gather etcd member/admin and client certs from first etcd node
   slurp:
     src: "{{ item }}"
+  no_log: "{{ not (unsafe_show_logs | bool) }}"
   register: etcd_master_certs
   # The CA and the member/admin key material is only needed when certs are
   # actually out of sync; the node certs are also distributed when the network
@@ -84,6 +85,7 @@
     group: "{{ etcd_cert_group }}"
     owner: "{{ etcd_owner }}"
     mode: "0640"
+  no_log: "{{ not (unsafe_show_logs | bool) }}"
   with_items: "{{ etcd_master_certs.results }}"
   when:
     - ('etcd' in group_names)

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -16,16 +16,8 @@
 - name: Trust etcd CA
   include_tasks: upd_ca_trust.yml
   when:
-    - ('etcd' in group_names) or ('kube_control_plane' in group_names)
-  tags:
-    - etcd-secrets
-
-- name: Trust etcd CA on nodes if needed
-  include_tasks: upd_ca_trust.yml
-  when:
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally
-    - kube_network_plugin != "calico" or calico_datastore == "etcd"
-    - ('k8s_cluster' in group_names)
+    - ('etcd' in group_names) or ('kube_control_plane' in group_names) or
+      (network_plugin_requires_etcd and ('k8s_cluster' in group_names))
   tags:
     - etcd-secrets
 
@@ -35,8 +27,7 @@
   changed_when: false
   check_mode: false
   when:
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally
-    - kube_network_plugin != "calico" or calico_datastore == "etcd"
+    - network_plugin_requires_etcd
     - ('k8s_cluster' in group_names)
   tags:
     - control-plane
@@ -46,8 +37,7 @@
   set_fact:
     etcd_client_cert_serial: "{{ etcd_client_cert_serial_result.stdout.split('=')[1] }}"
   when:
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally
-    - kube_network_plugin != "calico" or calico_datastore == "etcd"
+    - network_plugin_requires_etcd
     - ('k8s_cluster' in group_names)
   tags:
     - control-plane

--- a/roles/etcd_defaults/defaults/main.yml
+++ b/roles/etcd_defaults/defaults/main.yml
@@ -67,7 +67,11 @@ etcd_max_request_bytes: "1572864"
 
 etcd_blkio_weight: 1000
 
-etcd_node_cert_hosts: "{{ groups['k8s_cluster'] }}"
+# Hosts which need an etcd client certificate ('node-<hostname>.pem'). The
+# control plane always needs one to reach etcd, the other cluster nodes only
+# when the networking stack talks to etcd itself.
+etcd_node_cert_hosts: >-
+  {{ groups['k8s_cluster'] if network_plugin_requires_etcd else groups['kube_control_plane'] }}
 
 ## Etcd auto compaction retention for mvcc key value store in hour
 etcd_compaction_retention: "8"

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -206,6 +206,5 @@
   when:
     - etcd_deployment_type == "kubeadm"
     - inventory_hostname not in groups['kube_control_plane']
-    - kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally
-    - kube_network_plugin != "calico" or calico_datastore == "etcd"
+    - network_plugin_requires_etcd
     - kube_network_plugin != "cilium" or cilium_identity_allocation_mode != 'crd'

--- a/roles/kubespray_defaults/defaults/main/main.yml
+++ b/roles/kubespray_defaults/defaults/main/main.yml
@@ -247,6 +247,13 @@ peer_with_calico_rr: "{{ 'calico_rr' in groups and groups['calico_rr'] | length 
 # Choose data store type for calico: "etcd" or "kdd" (kubernetes datastore)
 calico_datastore: "kdd"
 
+# Whether the networking stack talks to etcd directly. If it does, every node of
+# the cluster (and not only the etcd and control plane hosts) needs an etcd
+# client certificate and the etcd CA in its trust store.
+network_plugin_requires_etcd: >-
+  {{ (kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally)
+     and (kube_network_plugin != "calico" or calico_datastore == "etcd") }}
+
 # Kubernetes internal network for services, unused block of space.
 kube_service_addresses: 10.233.0.0/18
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When the networking stack talks to etcd directly — calico with `calico_datastore: etcd`, flannel, or cilium — every certificate related step of the `etcd` role runs twice within a single playbook run.

The cause is the shape of #9173, which made the role skip nodes that do not need etcd client certs. Instead of widening the host list of the existing tasks, it added a *second copy* of each cert task, guarded by:

```yaml
- kube_network_plugin in ["calico", "flannel", "cilium"] or cilium_deploy_additionally
- kube_network_plugin != "calico" or calico_datastore == "etcd"
```

Every control plane host is a member of both `kube_control_plane` **and** `k8s_cluster`, so as soon as that guard is true, such a host matches the original task *and* its copy:

| Task | Today | This PR |
| --- | --- | --- |
| `upd_ca_trust.yml` | included 2x per etcd/control plane host | 1x |
| `make-ssl-etcd.sh` on the first etcd node | runs 2x, the second run regenerating the control plane client certs of the first | 1x |
| slurp + copy of member/client certs to the other etcd members | 2 pairs with overlapping file lists | 1 pair |
| `gen_nodes_certs_script.yml` | included 2x per control plane host which is not an etcd member | 1x |
| `check_certs.yml` `expected_files` loop | 2 loops over an almost identical list | 1 |

Each pair is merged into a single task whose condition is the **union** of the conditions of the two tasks it replaces, so which certificate ends up on which host does not change.

Two variables carry the intent:

* `network_plugin_requires_etcd` (in `kubespray_defaults`) replaces the two-line plugin condition that was copy-pasted ~10 times and had already drifted apart between the role (`["calico", "flannel", "cilium"]`) and the playbooks (`["flannel", "canal", "cilium"]`; `canal` no longer exists under `roles/network_plugin/`). The expression is a verbatim translation of the condition in the role, so the set of hosts it selects is unchanged.
* `etcd_node_cert_hosts` (in `etcd_defaults`) was defined but never used anywhere. It now holds the hosts which need a `node-<host>.pem` client certificate: `k8s_cluster` when the network plugin needs etcd, `kube_control_plane` otherwise.

Finally, `scale.yml` ran the **whole** etcd role twice on every worker: since a3e6e6620 it imports `install_etcd.yml`, whose first play already puts exactly those nodes into `_kubespray_needs_etcd`, making the later `kube_node` block redundant. That block is removed.

**Which issue(s) this PR fixes**:

None filed.

**Special notes for your reviewer**:

Related: #13354. The two do not overlap in intent and are not mutually exclusive — #13354 fixes *how often certificates are regenerated across runs* (the `force_etcd_cert_refresh: true` default) and the missing etcd restart afterwards, this PR fixes *how often the cert tasks execute within one run*. They do touch four files in common, but a test merge conflicts in `roles/etcd/tasks/gen_certs_script.yml` only; `check_certs.yml`, `main.yml` and `etcd_defaults/defaults/main.yml` merge cleanly. Resolving it means moving the `notify:` block of #13354 onto the single merged script task instead of two. Whichever lands first, I am happy to rebase.

Verification, with a 3 etcd / 2 control plane / 2 worker inventory on ansible-core 2.18.18:

* `network_plugin_requires_etcd` templates to a real `bool`, not the string `"False"` — relevant because it is used inside `or` expressions, where a non-empty string would be truthy.
* `etcd_node_cert_hosts` resolves to all four `k8s_cluster` hosts with `calico_datastore: etcd` and to the two control plane hosts with `kdd`, matching the two lists it replaces.
* The `expected_files` and slurp item templates still render valid lists of the expected length.
* `ansible-lint` passes on every changed role and playbook, `--syntax-check` passes on `cluster.yml`, `scale.yml` and `upgrade_cluster.yml`.

**Does this PR introduce a user-facing change?**:

```release-note
The etcd role no longer executes its certificate tasks twice per run when the network plugin needs etcd client certificates (calico with the etcd datastore, flannel, cilium), and scale.yml no longer runs the whole etcd role twice on worker nodes.
```
