### PR TITLE
Fix k8s-certs-renew renewing all certificates on every timer run

### DIFF
--- a/roles/kubernetes/control-plane/templates/k8s-certs-renew.sh.j2
+++ b/roles/kubernetes/control-plane/templates/k8s-certs-renew.sh.j2
@@ -8,7 +8,7 @@ days_buffer=7 # set a time margin, because we should not renew at the last momen
 # systemctl show reports an empty NextElapseUSecRealtime while the timer's unit is
 # running, so use the calendar spec to get the next scheduled run.
 # https://github.com/kubernetes-sigs/kubespray/issues/13072
-next_time=$(LC_ALL=C systemd-analyze calendar "{{ auto_renew_certificates_systemd_calendar }}" | sed -n 's/^[[:space:]]*Next elapse:[[:space:]]*//p')
+next_time=$(LC_ALL=C systemd-analyze calendar "{{ auto_renew_certificates_systemd_calendar }}" | grep -oP 'Next elapse:\s*\K.*\S')
 
 if [ "${next_time}" == "" ] || [ "${next_time}" == "never" ]; then
 	echo "## Skip expiry comparison due to fail to parse next elapse from systemd calendar,do renewal directly ##"

--- a/roles/kubernetes/control-plane/templates/k8s-certs-renew.sh.j2
+++ b/roles/kubernetes/control-plane/templates/k8s-certs-renew.sh.j2
@@ -5,9 +5,12 @@ echo "## Check Expiration before renewal ##"
 {{ bin_dir }}/kubeadm certs check-expiration
 
 days_buffer=7 # set a time margin, because we should not renew at the last moment
-next_time=$(systemctl show k8s-certs-renew.timer  -p NextElapseUSecRealtime --value)
+# systemctl show reports an empty NextElapseUSecRealtime while the timer's unit is
+# running, so use the calendar spec to get the next scheduled run.
+# https://github.com/kubernetes-sigs/kubespray/issues/13072
+next_time=$(LC_ALL=C systemd-analyze calendar "{{ auto_renew_certificates_systemd_calendar }}" | sed -n 's/^[[:space:]]*Next elapse:[[:space:]]*//p')
 
-if [ "${next_time}" == "" ]; then
+if [ "${next_time}" == "" ] || [ "${next_time}" == "never" ]; then
 	echo "## Skip expiry comparison due to fail to parse next elapse from systemd calendar,do renewal directly ##"
 else
 	current_time=$(date +%s)

--- a/roles/kubernetes/control-plane/templates/k8s-certs-renew.sh.j2
+++ b/roles/kubernetes/control-plane/templates/k8s-certs-renew.sh.j2
@@ -7,7 +7,6 @@ echo "## Check Expiration before renewal ##"
 days_buffer=7 # set a time margin, because we should not renew at the last moment
 # systemctl show reports an empty NextElapseUSecRealtime while the timer's unit is
 # running, so use the calendar spec to get the next scheduled run.
-# https://github.com/kubernetes-sigs/kubespray/issues/13072
 next_time=$(LC_ALL=C systemd-analyze calendar "{{ auto_renew_certificates_systemd_calendar }}" | grep -oP 'Next elapse:\s*\K.*\S')
 
 if [ "${next_time}" == "" ] || [ "${next_time}" == "never" ]; then


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
While the timer-triggered service is running, systemd clears `NextElapseUSecRealtime`, so the script could never determine the next scheduled renewal and unconditionally renewed all certificates (restarting the control plane) on every run.

Compute the next elapse with systemd-analyze calendar from the calendar spec instead, which is independent of the timer's state. A spec resolving to never takes the existing renew-directly path.

**Which issue(s) this PR fixes**:
Fixes #13072

**Special notes for your reviewer**:
Since #13362 is abandoned, I opened this one. #13362 can be closed after this is merged.

**Does this PR introduce a user-facing change?**:
```release-note
Fix `k8s-certs-renew` renewing all control plane certificates on every timer run instead of only when they are close to expiry.
```
