### PR TITLE
Fix k8s-certs-renew renewing on nodes without super-admin.conf

### DIFF
--- a/roles/kubernetes/control-plane/templates/k8s-certs-renew.sh.j2
+++ b/roles/kubernetes/control-plane/templates/k8s-certs-renew.sh.j2
@@ -13,11 +13,16 @@ else
 	current_time=$(date +%s)
 	target_time=$(date -d "${next_time} + ${days_buffer} days" +%s) # $next_time - $days_buffer days
 	expiry_threshold=$(( ${target_time} - ${current_time} ))
-	expired_certs=$({{ bin_dir }}/kubeadm certs check-expiration -o jsonpath="{.certificates[?(@.residualTime<${expiry_threshold}.0)]}")
+	# super-admin.conf only exists on the node where "kubeadm init" ran, the other
+	# control plane nodes see it as missing (residualTime 0). Don't let missing
+	# certs force a renewal here, kubeadm can't renew them anyway.
+	expired_certs=$({{ bin_dir }}/kubeadm certs check-expiration -o jsonpath="{range .certificates[?(@.residualTime<${expiry_threshold}.0)]}{.name}={.missing}{\"\n\"}{end}" | sed -n 's/=false$//p')
     if [ "${expired_certs}" == "" ];then
 		echo "## Skip cert renew and K8S container restart, since all residualTimes are beyond threshold ##"
 		exit 0
 	fi
+	echo "## Certificates to renew: ##"
+	echo "${expired_certs}"
 fi
 
 echo "## Renewing certificates managed by kubeadm ##"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
kubeadm creates `super-admin.conf` only on the node kubeadm init ran on. On the other control plane nodes kubeadm certs check-expiration reports it as missing with `residualTime: 0`:

{"expirationDate":null,"externallyManaged":false,"missing":true,"name":"super-admin.conf","residualTime":0}

That is always below the expiry threshold, so those nodes renewed all certificates and restarted their control plane on every timer run. Ignore missing certificates in the check (kubeadm certs renew all skips them anyway) and log the certificates which trigger a renewal.

**Which issue(s) this PR fixes**:
Related to https://github.com/kubernetes-sigs/kubespray/issues/12875#issuecomment-3802977582

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fix `k8s-certs-renew` failing when `super-admin.conf` is missing.
```
