### PR TITLE
Add cleanup kubeadm backups under /etc/kubernetes/tmp

### DIFF
--- a/roles/kubernetes/control-plane/defaults/main/main.yml
+++ b/roles/kubernetes/control-plane/defaults/main/main.yml
@@ -246,6 +246,12 @@ auto_renew_certificates_systemd_calendar: "Mon *-*-1,2,3,4,5,6,7 03:00:00"
 # we can opt out from the default behavior by setting kubeadm_upgrade_auto_cert_renewal to false
 kubeadm_upgrade_auto_cert_renewal: true
 
+# Number of kubeadm upgrade backups to retain in /etc/kubernetes/tmp/.
+# Set to a negative value to retain all backups (default, no cleanup).
+# Set to 0 to remove all backups after upgrade.
+kubeadm_backup_retention_count: -1
+
+
 # Add Subject Alternative Names to the Kubernetes apiserver certificates.
 # Useful if you access the API from multiples load balancers, for instance.
 supplementary_addresses_in_ssl_keys: []

--- a/roles/kubernetes/control-plane/tasks/kubeadm-backup-cleanup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-backup-cleanup.yml
@@ -1,0 +1,46 @@
+---
+- name: Find kubeadm etcd backup directories
+  ansible.builtin.find:
+    paths: "/etc/kubernetes/tmp"
+    file_type: directory
+    recurse: false
+    patterns: "kubeadm-backup-*"
+  register: _kubeadm_etcd_backups
+  when: kubeadm_backup_retention_count >= 0
+
+- name: Remove old kubeadm etcd backups
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop: >-
+    {{
+      (_kubeadm_etcd_backups.files
+      | sort(attribute='ctime', reverse=True)
+      )[kubeadm_backup_retention_count:]
+      | map(attribute='path')
+    }}
+  when: kubeadm_backup_retention_count >= 0
+
+- name: Find kubeadm temporary upgrade files
+  ansible.builtin.find:
+    paths: "/etc/kubernetes/tmp"
+    file_type: any
+    recurse: false
+    patterns:
+      - "kubeadm-kubelet-config*"
+      - "kubeadm-kubelet-env*"
+  register: _kubeadm_tmp_files
+  when: kubeadm_backup_retention_count >= 0
+
+- name: Remove old kubeadm temporary upgrade files
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop: >-
+    {{
+      (_kubeadm_tmp_files.files
+      | sort(attribute='ctime', reverse=True)
+      )[kubeadm_backup_retention_count:]
+      | map(attribute='path')
+    }}
+  when: kubeadm_backup_retention_count >= 0

--- a/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
@@ -86,3 +86,6 @@
   - kubeadm_scale_down_coredns_enabled
   - dns_mode not in ['coredns', 'coredns_dual']
   changed_when: false
+
+- name: Kubeadm | cleanup old upgrade backups
+  import_tasks: kubeadm-backup-cleanup.yml

--- a/tests/files/ubuntu22-calico-all-in-one-upgrade.yml
+++ b/tests/files/ubuntu22-calico-all-in-one-upgrade.yml
@@ -26,3 +26,7 @@ containerd_registries_mirrors:
       - host: http://172.19.16.11:5000
         capabilities: ["pull", "resolve", "push"]
         skip_verify: true
+
+# Upgrade cluster settings
+# set 0 to clean all kubeadm backups
+kubeadm_backup_retention_count: 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind feature

**What this PR does / why we need it**:
These backups accumulate over multiple upgrades, consuming GBs of disk space and potentially filling root partition.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13412

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add `kubeadm_backup_retention_count` variable to automatically clean up old kubeadm backup directories and temporary upgrade files under `/etc/kubernetes/tmp/` after cluster upgrades. The default value of `-1` retains all backups (no cleanup). Set to `0` or a positive integer to keep only that many recent backups.
```
