### PR TITLE
fix(container-engine/cri-o): flush Restart crio handler inside the role

### DIFF
--- a/roles/container-engine/cri-o/tasks/main.yaml
+++ b/roles/container-engine/cri-o/tasks/main.yaml
@@ -285,6 +285,15 @@
     - config_install.changed or reg_auth_install.changed
     - not service_start.changed
 
+# Flush the "Restart crio" handler here so the cri-o service is actually
+# restarted as part of this role. Without this, the handler only fires when a
+# *different* role (kubernetes/node) runs its own meta: flush_handlers later in
+# the play. If that role is skipped, tagged out, or runs in a separate play
+# (as happens during cluster upgrades), the restart is silently dropped and the
+# node keeps running the old cri-o binary. See kubernetes-sigs/kubespray#13031.
+- name: Cri-o | flush handlers to apply cri-o restart
+  meta: flush_handlers
+
 - name: Cri-o | verify that crio is running
   command: "{{ bin_dir }}/{{ crio_status_command }} info"
   register: get_crio_info


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

During a Kubernetes upgrade (e.g. 1.32 -> 1.33) the cri-o systemd service is not
restarted even though the new cri-o binaries are deployed, leaving the node on the
old cri-o version (reported as `crio://1.32.x` after kubelet is upgraded to
`1.33.x`); a manual `systemctl restart crio` fixes it.

The cri-o role notifies `Restart crio` from several tasks (binary copy, config
install, registries, proxy drop-in, etc.) but never flushes the handler itself.
The handler only fired when the `kubernetes/node` role ran its own
`meta: flush_handlers` later in the same play. That cross-role dependency is
fragile during upgrades: if `kubernetes/node` is skipped, tagged out, or the flush
is reordered, the restart is silently dropped.

This PR adds an explicit `meta: flush_handlers` right after the restart-gate task
inside the cri-o role, so the restart is always applied as part of the role
regardless of any downstream role's flush timing.

**Which issue(s) this PR fixes**:
Fixes #13031

**Special notes for your reviewer**:
Verified with an Ansible serial repro: with the fix, `Restart crio` fires on every
node even when the downstream `kubernetes/node` flush is absent (the exact failure
mode in #13031).

**Does this PR introduce a user-facing change?**:
```release-note
Fix cri-o not being restarted during a Kubernetes upgrade when the downstream kubernetes/node role flush_handlers is skipped or reordered.
```
