### PR TITLE
Fix anonymous access cleanup during cluster upgrade

### DIFF
--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -232,7 +232,10 @@
 
 - name: Remove binding to anonymous user
   command: "{{ kubectl }} -n kube-public delete rolebinding kubeadm:bootstrap-signer-clusterinfo --ignore-not-found"
-  when: inventory_hostname == first_kube_control_plane and remove_anonymous_access
+  when:
+    - inventory_hostname == first_kube_control_plane
+    - remove_anonymous_access
+    - not upgrade_cluster_setup
 
 - name: Create kubeadm token for joining nodes with 24h expiration (default)
   command: "{{ bin_dir }}/kubeadm --kubeconfig {{ kube_config_dir }}/admin.conf token create"

--- a/tests/files/ubuntu22-calico-all-in-one-upgrade.yml
+++ b/tests/files/ubuntu22-calico-all-in-one-upgrade.yml
@@ -7,6 +7,7 @@ vm_memory: 3072
 # Kubespray settings
 auto_renew_certificates: true
 system_upgrade_autoclean: true
+remove_anonymous_access: true
 
 # Currently ipvs not available on KVM: https://packages.ubuntu.com/search?suite=focal&arch=amd64&mode=exactfilename&searchon=contents&keywords=ip_vs_sh.ko
 kube_proxy_mode: iptables


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes the handling of anonymous API access during cluster upgrades when `remove_anonymous_access` is enabled.

Clusters configured with:

```yaml
remove_anonymous_access: true
```

should preserve their anonymous-access hardening behavior during upgrade operations.

The change ensures that the upgrade path respects the existing `remove_anonymous_access` configuration instead of falling back to behavior that depends on anonymous API access.

The scope of this PR is limited to anonymous-access handling during upgrades.

**Which issue(s) this PR fixes**:

Fixes #13410

**Special notes for your reviewer**:

This PR only changes behavior related to `remove_anonymous_access`.

The default behavior for clusters that do not enable `remove_anonymous_access` remains unchanged.

### Testing

The change was reviewed against the upgrade path with the following expected scenarios:

* `remove_anonymous_access: true`

  * Anonymous-access hardening is preserved during upgrade.
  * Upgrade logic does not depend on anonymous Kubernetes API access.

* `remove_anonymous_access: false`

  * Existing default behavior remains unchanged.

* Existing clusters using the default Kubespray configuration are not expected to require any configuration changes.

Full automated validation is left to the Kubespray CI test suite.

**Does this PR introduce a user-facing change?**:

```release-note
Preserve anonymous access hardening during cluster upgrades when `remove_anonymous_access` is enabled.
```
