### PR TITLE
Fix kubelet.conf server: indentation in kubelet kubeconfig update

### DIFF
--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -104,7 +104,7 @@
   lineinfile:
     dest: "{{ kube_config_dir }}/kubelet.conf"
     regexp: 'server:'
-    line: '    server: {{ kube_apiserver_endpoint }}'
+    line: '        server: {{ kube_apiserver_endpoint }}'
     backup: true
   when:
     - kubeadm_config_api_fqdn is not defined
@@ -116,7 +116,7 @@
   lineinfile:
     dest: "{{ kube_config_dir }}/kubelet.conf"
     regexp: '^    server: https'
-    line: '    server: {{ kube_apiserver_endpoint }}'
+    line: '        server: {{ kube_apiserver_endpoint }}'
     backup: true
   when:
     - ('kube_control_plane' not in group_names)


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes kubernetes-sigs/kubespray#13277.

The "Update server field in kubelet kubeconfig" task writes `server:` with 4-space
indentation. On Kubernetes v1.35+, `kubeadm upgrade node` reformats `kubelet.conf`
using a 4-character list prefix (`-   cluster:`), so 4 spaces lands **outside** the
`cluster:` block. kubelet then fails with `invalid configuration: no server found
for cluster "default-cluster"` and worker nodes crash-loop after an upgrade.

This PR changes the written indentation to 8 spaces so `server:` stays inside the
`cluster:` block after kubeadm's reformat, matching the format kubelet expects.

#### Which issue(s) this PR fixes:
Fixes #13277

#### Special notes for your reviewer:
- One-line indentation change in `roles/kubernetes/kubeadm/tasks/main.yml` (both the
  default and external-lb variants).
- YAML validated; no playbook logic changed.

#### Does this PR introduce a user-facing change?:
```release-note
NONE
```

/kind bug