### PR TITLE
fix(kata/containerd-shim-kata-v2.j2): use exec in shim wrapper to preserve FD 3 socket

### DIFF
--- a/roles/container-engine/kata-containers/templates/containerd-shim-kata-v2.j2
+++ b/roles/container-engine/kata-containers/templates/containerd-shim-kata-v2.j2
@@ -1,2 +1,2 @@
 #!/bin/bash
-KATA_CONF_FILE={{ kata_containers_config_dir }}/configuration-{{ shim }}.toml {{ kata_containers_dir }}/bin/containerd-shim-kata-v2 $@
+exec env KATA_CONF_FILE={{ kata_containers_config_dir }}/configuration-{{ shim }}.toml {{ kata_containers_dir }}/bin/containerd-shim-kata-v2 "$@"


### PR DESCRIPTION
Without exec, bash stays as parent process and consumes FD 3 (the Unix socket CRI-O passes for shim communication), causing:
  getsockopt: socket operation on non-socket

Also quote $@ to preserve argument spacing.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Without exec, bash stays as parent process and consumes FD 3 (the Unix socket CRI-O passes for shim communication), causing this error in system logs and kata pods not running:
  getsockopt: socket operation on non-socket

Also quote $@ to preserve argument spacing.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
bugfix: kata: containerd-shim-kata-v2.j2: use exec in shim wrapper to preserve FD 3 socket
```
