### PR TITLE
kata: templatize some qemu config variables

### DIFF
--- a/roles/container-engine/kata-containers/defaults/main.yml
+++ b/roles/container-engine/kata-containers/defaults/main.yml
@@ -4,7 +4,10 @@ kata_containers_config_dir: /etc/kata-containers
 kata_containers_containerd_bin_dir: /usr/local/bin
 
 kata_containers_qemu_default_memory: "{{ ansible_facts['memtotal_mb'] }}"
+kata_containers_qemu_default_maxmemory: "{{ kata_containers_qemu_default_memory }}"
 kata_containers_qemu_debug: 'false'
 kata_containers_qemu_sandbox_cgroup_only: 'true'
 kata_containers_qemu_enable_mem_prealloc: 'false'
 kata_containers_virtio_fs_cache: 'always'
+kata_containers_virtio_fs_extra_args: ["--thread-pool-size=1", "--announce-submounts"]
+kata_containers_qemu_create_container_timeout: 60

--- a/roles/container-engine/kata-containers/templates/configuration-qemu.toml.j2
+++ b/roles/container-engine/kata-containers/templates/configuration-qemu.toml.j2
@@ -155,7 +155,7 @@ default_memory = {{ kata_containers_qemu_default_memory }}
 # unspecified or == 0           --> will be set to the actual amount of physical RAM
 # > 0 <= amount of physical RAM --> will be set to the specified number
 # > amount of physical RAM      --> will be set to the actual amount of physical RAM
-default_maxmemory = 0
+default_maxmemory = {{ kata_containers_qemu_default_maxmemory }}
 
 # The size in MiB will be plused to max memory of hypervisor.
 # It is the memory address space for the NVDIMM devie.
@@ -217,7 +217,7 @@ virtio_fs_queue_size = 1024
 #   Set virtiofsd log level to debug : ["--log-level=debug"]
 #
 # see `virtiofsd -h` for possible options.
-virtio_fs_extra_args = ["--thread-pool-size=1", "--announce-submounts"]
+virtio_fs_extra_args = {{ kata_containers_virtio_fs_extra_args | to_json }}
 
 # Cache mode:
 #
@@ -685,7 +685,7 @@ experimental=[]
 # Note: The effective timeout is determined by the lesser of two values: runtime-request-timeout from kubelet config
 # (https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#:~:text=runtime%2Drequest%2Dtimeout) and create_container_timeout.
 # In essence, the timeout used for guest pull=runtime-request-timeout<create_container_timeout?runtime-request-timeout:create_container_timeout.
-create_container_timeout = 60
+create_container_timeout = {{ kata_containers_qemu_create_container_timeout }}
 {% endif %}
 
 # WARNING: All the options in the following section have not been implemented yet.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
- default_maxmemory is hardcoded to 0, which resolves to host total RAM and QEMU attempts hotplugging memory up to host RAM, resulting in "hotplug memory error: ENOENT"
- virtio_extra_args: on RHEL8, we need to set sandbox=chroot as some syscalls arent supported by that kernel
- create_container_timeout: good to have as configurable in case we want to reduce it and error out early.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kata(qemu): make create_container_timeout, default_maxmemory, virtiofs_extra_args configurable
```
