### PR TITLE
fix(kubernetes/preinstall): skip when dir is empty

### DIFF
--- a/docs/ansible/vars.md
+++ b/docs/ansible/vars.md
@@ -172,6 +172,15 @@ kube_apiserver_admission_event_rate_limits:
 
 * *kube_apiserver_service_account_lookup* - Enable validation service account before validating token. Default `true`.
 
+* *kube_manifest_dir* - Directory where kubelet reads static pod manifests (kubelet's `staticPodPath`).
+  Defaults to `{{ kube_config_dir }}/manifests`. It can be set to an empty string (`""`) to disable
+  kubelet's static pod path entirely, which prevents kubelet from watching a manifests directory.
+  This must only be set to `""` in the group_vars of worker nodes (e.g. the `kube_node` group):
+  control plane nodes always require a manifests directory because `kubeadm` writes the static pod
+  manifests for the control plane components there. In addition, setting it to `""` on workers is only
+  supported when an external `loadbalancer_apiserver` is configured, since the default localhost
+  apiserver load balancer relies on a `nginx-proxy`/`haproxy` static pod written to this directory.
+
 Note, if cloud providers have any use of the ``10.233.0.0/16``, like instances'
 private addresses, make sure to pick another values for ``kube_service_addresses``
 and ``kube_pods_subnet``, for example from the ``172.18.0.0/16``.

--- a/docs/operations/hardening.md
+++ b/docs/operations/hardening.md
@@ -100,6 +100,12 @@ kubelet_make_iptables_util_chains: true
 kubelet_feature_gates: ["RotateKubeletServerCertificate=true"]
 kubelet_seccomp_default: true
 kubelet_systemd_hardening: true
+# Disable kubelet's staticPodPath on nodes that don't run static pods (STIG recommendation).
+# Set this only in the group_vars of worker nodes (e.g. the kube_node group): control plane
+# nodes always need the manifests dir because kubeadm writes the control plane static pods
+# there. It is also only supported when an external loadbalancer_apiserver is configured, since
+# the default localhost apiserver load balancer relies on a static pod in this directory.
+# kube_manifest_dir: ""
 # In case you have multiple interfaces in your
 # control plane nodes and you want to specify the right
 # IP addresses, kubelet_secure_addresses allows you

--- a/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
+++ b/roles/kubernetes/node/templates/kubelet-config.v1beta1.yaml.j2
@@ -25,7 +25,9 @@ enforceNodeAllocatable:
 - {{ item }}
 {% endfor %}
 {% endif %}
+{% if kube_manifest_dir %}
 staticPodPath: {{ kube_manifest_dir }}
+{% endif %}
 cgroupDriver: {{ kubelet_cgroup_driver | default('systemd') }}
 containerLogMaxFiles: {{ kubelet_logfiles_max_nr }}
 containerLogMaxSize: {{ kubelet_logfiles_max_size }}

--- a/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
+++ b/roles/kubernetes/preinstall/tasks/0050-create_directories.yml
@@ -5,7 +5,9 @@
     state: directory
     owner: "{{ kube_owner }}"
     mode: "0755"
-  when: ('k8s_cluster' in group_names)
+  when:
+    - ('k8s_cluster' in group_names)
+    - item | length > 0
   become: true
   tags:
     - kubelet


### PR DESCRIPTION
useful especially for setting manifests dir as empty

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
allows setting kube_manifests dir as empty and we should rightfully skip when other dir are empty as well

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13281

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
bugfix(preinstall): skip kube_manifest_dir dir creation when empty
```
