### PR TITLE
fix: render routingMode native when cilium_tunnel_mode is disabled

### DIFF
--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -26,7 +26,10 @@ cilium_cpu_limit: 500m
 cilium_memory_requests: 64M
 cilium_cpu_requests: 100m
 
-# Overlay Network Mode
+# Cilium tunnel mode. Possible values: vxlan, geneve, disabled.
+# Set to 'disabled' to use native routing without tunneling.
+# When set to 'disabled', Kubespray renders routingMode: native in the Helm
+# values instead of tunnelProtocol, which is required by Cilium >= 1.14.
 cilium_tunnel_mode: vxlan
 
 # LoadBalancer Mode (snat/dsr/hybrid) Ref: https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/#dsr-mode

--- a/roles/network_plugin/cilium/templates/values.yaml.j2
+++ b/roles/network_plugin/cilium/templates/values.yaml.j2
@@ -25,7 +25,12 @@ healthPort: {{ cilium_agent_health_port }}
 
 identityAllocationMode: {{ cilium_identity_allocation_mode }}
 
+{% if cilium_tunnel_mode == 'disabled' %}
+routingMode: native
+{% else %}
 tunnelProtocol: {{ cilium_tunnel_mode }}
+{% endif %}
+
 
 loadBalancer:
   mode: {{ cilium_loadbalancer_mode }}

--- a/roles/network_plugin/cilium/templates/values.yaml.j2
+++ b/roles/network_plugin/cilium/templates/values.yaml.j2
@@ -31,7 +31,6 @@ routingMode: native
 tunnelProtocol: {{ cilium_tunnel_mode }}
 {% endif %}
 
-
 loadBalancer:
   mode: {{ cilium_loadbalancer_mode }}
 


### PR DESCRIPTION
### Description

Fixes kubernetes-sigs/kubespray#13267.

When `cilium_tunnel_mode` is set to `disabled`, the previous template rendered
`tunnelProtocol: disabled`, which Cilium does not recognise. The Cilium Helm
chart renders `tunnelProtocol` with `default "vxlan" | quote`, so an empty/invalid
value falls back to `vxlan` and conflicts with native routing, causing agent
CrashLoopBackOff.

This PR renders `routingMode: native` instead of `tunnelProtocol` when
`cilium_tunnel_mode == 'disabled'`, matching the Cilium Helm chart API
(Cilium >= 1.14). This is the approach from the maintainer review and #13314.

### Changes
- `roles/network_plugin/cilium/templates/values.yaml.j2`: wrap the tunnel/routing
  block in a conditional — `routingMode: native` when disabled, `tunnelProtocol:
  <mode>` otherwise (preserves vxlan/geneve).
- `roles/network_plugin/cilium/defaults/main.yml`: document the valid values and
  the native-routing behavior.

### Verification
Rendered the conditional with Jinja2 for `disabled`/`vxlan`/`geneve`:
- disabled -> `routingMode: native` (no `tunnelProtocol: disabled` leak)
- vxlan  -> `tunnelProtocol: vxlan`
- geneve -> `tunnelProtocol: geneve`

`routingMode` appears exactly once; the branch requires Cilium >= 1.15, which
supports `routingMode`.

Refs kubernetes-sigs/kubespray#13267

```release-note
Fix Cilium CrashLoopBackOff when cilium_tunnel_mode is set to disabled by
rendering routingMode: native instead of tunnelProtocol: disabled in the Helm
values.
```