### PR TITLE
fix(etcd): align cert ownership/permissions on first etcd node

### DIFF
--- a/roles/etcd/templates/make-ssl-etcd.sh.j2
+++ b/roles/etcd/templates/make-ssl-etcd.sh.j2
@@ -102,4 +102,11 @@ fi
 
 if [ -n "$(ls -A *.pem)" ]; then
     mv *.pem ${SSLDIR}/
+    # Align ownership and permissions with the certs copied to the other
+    # nodes. Without this, the first etcd node keeps root:root with
+    # umask-derived perms while every other node gets mode 0640,
+    # owner {{ etcd_owner }} and group {{ etcd_cert_group }} (see the
+    # copy tasks in gen_certs_script.yml). See kubernetes-sigs/kubespray#13250.
+    chown {{ etcd_owner }}:{{ etcd_cert_group }} ${SSLDIR}/*.pem
+    chmod 0640 ${SSLDIR}/*.pem
 fi


### PR DESCRIPTION
## Summary

Fixes kubernetes-sigs/kubespray#13250 — etcd certificates have inconsistent ownership/permissions on the first control-plane/etcd node vs the remaining nodes.

### Root cause
`roles/etcd/templates/make-ssl-etcd.sh.j2` did `mv *.pem ${SSLDIR}/` with no `chown`/`chmod`. On the first etcd node the certs therefore kept `root:root` with umask-derived perms (`-rw-------` keys, `-rw-r--r--` certs). On every other node the `copy:` tasks in `gen_certs_script.yml` set `mode: "0640"`, `owner: "{{ etcd_owner }}"` (etcd), `group: "{{ etcd_cert_group }}"` (root).

### Fix
After moving the certs, `chown {{ etcd_owner }}:{{ etcd_cert_group }}` and `chmod 0640` so the first node matches the others. Verified by rendering the template (vars resolve to `etcd`/`root`) and executing the install block: before `-rw------- root root` / `-rw-r--r-- root root`, after `-rw-r----- etcd root` for all `*.pem`.

### Test plan
- [x] Template renders with no unrendered `{{ }}`
- [x] Install block executed locally: certs become `0640 etcd:root` (matches other-node scheme)
- [ ] Full `molecule`/CI run on a real cluster (pending /ok-to-test)

## Checklist
- [x] Commits are signed off (CNCF CLA)
- [x] Change is minimal and scoped to the cert-install step

```release-note
Fix inconsistent etcd certificate ownership/permissions on the first etcd node: generated certs are now chowned to the etcd user and chmoded to 0640, matching the other nodes.
```