### PR TITLE
fix(kubeadm): preserve kubelet.conf server line indent via backrefs

### DIFF
--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -103,8 +103,9 @@
 - name: Update server field in kubelet kubeconfig
   lineinfile:
     dest: "{{ kube_config_dir }}/kubelet.conf"
-    regexp: 'server:'
-    line: '    server: {{ kube_apiserver_endpoint }}'
+    regexp: '^(\s*)server: .*$'
+    line: '\1server: {{ kube_apiserver_endpoint }}'
+    backrefs: true
     backup: true
   when:
     - kubeadm_config_api_fqdn is not defined
@@ -115,8 +116,9 @@
 - name: Update server field in kubelet kubeconfig - external lb
   lineinfile:
     dest: "{{ kube_config_dir }}/kubelet.conf"
-    regexp: '^    server: https'
-    line: '    server: {{ kube_apiserver_endpoint }}'
+    regexp: '^(\s*)server: .*$'
+    line: '\1server: {{ kube_apiserver_endpoint }}'
+    backrefs: true
     backup: true
   when:
     - ('kube_control_plane' not in group_names)


### PR DESCRIPTION
## Description
The "Update server field in kubelet kubeconfig" tasks rewrote the `server:` line with a fixed indent. When the on-disk kubelet.conf uses a different indent than assumed, `server:` lands outside the `cluster:` mapping and kubelet fails after upgrade with:

```
invalid configuration: no server found for cluster "default-cluster"
```

and worker nodes crash-loop (NotReady, tainted unreachable).

This switches both variants (default and external-lb) to `backrefs: true` with `regexp: '^(\s*)server: .*$'` and `line: '\1server: {{ kube_apiserver_endpoint }}'`, so the existing indent is captured and preserved while only the endpoint value is replaced.

Refs kubernetes-sigs/kubespray#13277

## Verification
Reproduced with real ansible-playbook 2.16 lineinfile before pushing: without `backrefs: true` the literal text `\1server:` is written (invalid YAML, parse error); with backrefs, both 4-space and 8-space indents are preserved, the endpoint is substituted, and the CA line is untouched.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

```release-note
Fix kubelet.conf `server:` handling to preserve the existing indentation when updating the endpoint, so worker nodes do not crash-loop after upgrade (kubernetes-sigs/kubespray#13277).
```