### PR TITLE
Bump Flannel version to v0.28.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Note:
   - [cni-plugins](https://github.com/containernetworking/plugins) 1.9.1
   - [calico](https://github.com/projectcalico/calico) 3.31.7
   - [cilium](https://github.com/cilium/cilium) 1.20.1
-  - [flannel](https://github.com/flannel-io/flannel) 0.28.4
+  - [flannel](https://github.com/flannel-io/flannel) 0.28.9
   - [kube-ovn](https://github.com/alauda/kube-ovn) 1.12.21
   - [kube-router](https://github.com/cloudnativelabs/kube-router) 2.1.1
   - [multus](https://github.com/k8snetworkplumbingwg/multus-cni) 4.2.2

--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -112,7 +112,7 @@ calico_apiserver_version: "{{ calico_version }}"
 typha_enabled: false
 calico_apiserver_enabled: false
 
-flannel_version: 0.28.4
+flannel_version: 0.28.9
 flannel_cni_version: 1.7.1-flannel1
 cni_version: "{{ (cni_binary_checksums['amd64'] | dict2items)[0].key }}"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What type of PR is this?**
/kind feature
**What this PR does / why we need it**:
Bumps default Flannel version from `v0.28.4` to `v0.28.9`.
Key updates in `v0.28.9`:
- Fixes security vulnerabilities: `CVE-2026-46600` and `CVE-2026-56852`
- Adds `livenessProbe` and `readinessProbe` support to `flanneld`
- Fixes recovery of single-subnet etcd watches after compaction events
**Which issue(s) this PR fixes**:
Fixes #13432
**Special notes for your reviewer**:
Updated `flannel_version` in `roles/kubespray_defaults/defaults/main/download.yml` and the component matrix in `README.md`.
**Does this PR introduce a user-facing change?**:

```release-note
Bump default Flannel version to v0.28.9