### PR TITLE
Bump Flannel version to v0.28.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Note:
   - [cni-plugins](https://github.com/containernetworking/plugins) 1.9.1
   - [calico](https://github.com/projectcalico/calico) 3.31.7
   - [cilium](https://github.com/cilium/cilium) 1.20.1
-  - [flannel](https://github.com/flannel-io/flannel) 0.28.4
+  - [flannel](https://github.com/flannel-io/flannel) 0.28.9
   - [kube-ovn](https://github.com/alauda/kube-ovn) 1.12.21
   - [kube-router](https://github.com/cloudnativelabs/kube-router) 2.1.1
   - [multus](https://github.com/k8snetworkplumbingwg/multus-cni) 4.2.2

--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -112,7 +112,7 @@ calico_apiserver_version: "{{ calico_version }}"
 typha_enabled: false
 calico_apiserver_enabled: false
 
-flannel_version: 0.28.4
+flannel_version: 0.28.9
 flannel_cni_version: 1.7.1-flannel1
 cni_version: "{{ (cni_binary_checksums['amd64'] | dict2items)[0].key }}"
 


### PR DESCRIPTION
What type of PR is this?

/kind feature

What this PR does / why we need it:
Bump the default Flannel CNI plugin version from `v0.28.4` to `v0.28.9`.

Flannel `v0.28.9` includes key stability and security updates:
- Security remediations for `CVE-2026-46600` and `CVE-2026-56852`
- Added `livenessProbe` and `readinessProbe` support to `flanneld`
- Fixed recovery of single-subnet etcd watches after compaction

Which issue(s) this PR fixes:
Fixes #13432

Special notes for your reviewer:
Updated `flannel_version` in `roles/kubespray_defaults/defaults/main/download.yml` and the component version matrix in `README.md`.

Does this PR introduce a user-facing change?:
```release-note
Bump default Flannel version to v0.28.9
```
