### PR TITLE
facts: continue gathering when a host is unreachable

### DIFF
--- a/playbooks/internal_facts.yml
+++ b/playbooks/internal_facts.yml
@@ -2,7 +2,7 @@
 - name: Bootstrap hosts for Ansible
   hosts: k8s_cluster:etcd:calico_rr
   strategy: linear
-  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(false) }}"
   gather_facts: false
   environment: "{{ proxy_disable_env }}"
   roles:


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

This PR prevents one unreachable inventory host from stopping fact gathering for all reachable hosts.

Setting `any_errors_fatal: false` explicitly on the bootstrap play allows reachable hosts to continue into the `Gather facts` play and populate their fact cache. The unreachable host is still reported by Ansible.

The existing `scale.yml --limit` safety check remains unchanged. A limited operation still fails when an excluded host has no cached facts.

**Which issue(s) this PR fixes**:

Fixes #13407

**Special notes for your reviewer**:

Rechecked the existing `scale.yml --limit` safety guard.

This change allows fact gathering and caching to continue for reachable hosts when another inventory host is unreachable, while preserving the existing limited-operation safety behavior: `scale.yml --limit` will still fail when an excluded host has no cached facts.
Following review feedback, the additional standalone regression-test machinery was removed from this PR. The broader unreachable-host scenario can be covered separately as part of the general CI suite.

Local validation and the full Kubespray CI pipeline pass successfully.

**Does this PR introduce a user-facing change?**:

```release-note
Allow facts to be gathered and cached for reachable hosts when another inventory host is unreachable.
```
