### PR TITLE
CI: add Ubuntu 26.04 support and coverage

### DIFF
--- a/.gitlab-ci/kubevirt.yml
+++ b/.gitlab-ci/kubevirt.yml
@@ -57,6 +57,7 @@ pr:
           - ubuntu24-ha-separate-etcd
           - ubuntu24-kube-router-sep
           - ubuntu24-kube-router-svc-proxy
+          - ubuntu26-calico-all-in-one
 
 # This is for flakey test so they don't disrupt the PR worklflow too much.
 # Jobs here MUST have a open issue so we don't lose sight of them

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ vagrant up
 
 - **Flatcar Container Linux by Kinvolk**
 - **Debian** Bookworm, Trixie
-- **Ubuntu** 22.04, 24.04
+- **Ubuntu** 22.04, 24.04, 26.04
 - **CentOS Stream / RHEL** 9, 10
 - **Fedora** 39, 40, 41, 42
 - **Fedora CoreOS** (see [fcos Note](docs/operating_systems/fcos.md))

--- a/docs/developers/ci.md
+++ b/docs/developers/ci.md
@@ -19,6 +19,7 @@ rockylinux10 |  :white_check_mark: | :white_check_mark: | :x: | :x: | :x: | :x: 
 rockylinux9 |  :white_check_mark: | :white_check_mark: | :x: | :x: | :x: | :x: |
 ubuntu22 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
 ubuntu24 |  :white_check_mark: | :white_check_mark: | :x: | :white_check_mark: | :x: | :white_check_mark: |
+ubuntu26 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
 
 ## crio
 
@@ -37,6 +38,7 @@ rockylinux10 |  :x: | :x: | :x: | :x: | :x: | :x: |
 rockylinux9 |  :x: | :x: | :x: | :x: | :x: | :x: |
 ubuntu22 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
 ubuntu24 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
+ubuntu26 |  :x: | :x: | :x: | :x: | :x: | :x: |
 
 ## docker
 
@@ -55,3 +57,4 @@ rockylinux10 |  :x: | :x: | :x: | :x: | :x: | :x: |
 rockylinux9 |  :x: | :x: | :x: | :x: | :x: | :x: |
 ubuntu22 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
 ubuntu24 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
+ubuntu26 |  :x: | :x: | :x: | :x: | :x: | :x: |

--- a/roles/kubernetes/node/vars/ubuntu-26.yml
+++ b/roles/kubernetes/node/vars/ubuntu-26.yml
@@ -1,0 +1,2 @@
+---
+kube_resolv_conf: "/run/systemd/resolve/resolv.conf"

--- a/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
@@ -32,6 +32,13 @@ images:
     converted: false
     tag: "latest"
 
+  ubuntu-2604:
+    filename: ubuntu-26.04-server-cloudimg-amd64.img
+    url: https://cloud-images.ubuntu.com/releases/resolute/release-20260823/ubuntu-26.04-server-cloudimg-amd64.img
+    checksum: sha256:8196be9d7958059cb56c6c75c80fdf6cee8a8885bc149ea791d7db1c7ef93035
+    converted: false
+    tag: "latest"
+
   fedora-37:
     filename: Fedora-Cloud-Base-37-1.7.x86_64.qcow2
     url: https://download.fedoraproject.org/pub/fedora/linux/releases/37/Cloud/x86_64/images/Fedora-Cloud-Base-37-1.7.x86_64.qcow2

--- a/tests/files/ubuntu26-calico-all-in-one.yml
+++ b/tests/files/ubuntu26-calico-all-in-one.yml
@@ -1,0 +1,27 @@
+---
+# Instance settings
+cloud_image: ubuntu-2604
+mode: all-in-one
+vm_memory: 3072
+
+# Kubespray settings
+auto_renew_certificates: true
+
+# Currently ipvs not available on KVM: https://packages.ubuntu.com/search?suite=resolute&arch=amd64&mode=exactfilename&searchon=contents&keywords=ip_vs_sh.ko
+kube_proxy_mode: iptables
+enable_nodelocaldns: false
+
+containerd_registries_mirrors:
+  - prefix: docker.io
+    mirrors:
+      - host: https://mirror.gcr.io
+        capabilities: ["pull", "resolve"]
+        skip_verify: false
+  - prefix: 172.19.16.11:5000
+    mirrors:
+      - host: http://172.19.16.11:5000
+        capabilities: ["pull", "resolve", "push"]
+        skip_verify: true
+
+kube_reserved: true
+system_reserved: true


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add Ubuntu 26.04 (Resolute) support and representative CI coverage.

- Add the Ubuntu 26.04 KubeVirt image definition
- Add `ubuntu26-calico-all-in-one` to the PR matrix
- Add Ubuntu 26.04 node-specific variables
- Update the supported OS and CI coverage documentation
- Publish `quay.io/kubespray/vm-ubuntu-2604`

Net change: +1 CI job.

**Which issue(s) this PR fixes**:

Fixes #13440

**Special notes for your reviewer**:

References: #11132 and #11167.

This PR was written in part with the assistance of generative AI.

**Does this PR introduce a user-facing change?**:

```release-note
Add Ubuntu 26.04 support.
```
