### PR TITLE
image-builder: use stable Ubuntu 24.04 image

### DIFF
--- a/test-infra/image-builder/Makefile
+++ b/test-infra/image-builder/Makefile
@@ -63,6 +63,7 @@ validate-docker:
 		-e '{"kubevirt_images_push": false, "kubevirt_container_builder": "docker", "kubevirt_images_target_host": "localhost"}' \
 		cluster.yml
 
+validate-single-docker: image_name ?= ubuntu-2404
 validate-single-docker:
 	ansible-playbook -i localhost, -c local \
 		-e images_dir=$(CURDIR)/.image-builder \

--- a/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
@@ -26,9 +26,9 @@ images:
     tag: "latest"
 
   ubuntu-2404:
-    filename: noble-server-cloudimg-amd64.img
-    url: https://cloud-images.ubuntu.com/noble/20260323/noble-server-cloudimg-amd64.img
-    checksum: sha256:6e7016f2c9f4d3c00f48789eb6b9043ba2172ccc1b6b1eaf3ed1e29dd3e52bb3
+    filename: ubuntu-24.04-server-cloudimg-amd64.img
+    url: https://cloud-images.ubuntu.com/releases/noble/release-20260826/ubuntu-24.04-server-cloudimg-amd64.img
+    checksum: sha256:d0fe84bb5f80853425fa6be28e2c106f30104c3cfe8611933f2e65c9b63f0e30
     converted: false
     tag: "latest"
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The pinned Ubuntu 24.04 daily cloud image was pruned and now returns HTTP 404.
Use the immutable Noble `release-20260826` image and its matching SHA256
instead.

Also default `validate-single-docker` to `ubuntu-2404`, so callers do not need
to repeat `image_name=ubuntu-2404`.

**Which issue(s) this PR fixes**:

Fixes #13444

**Special notes for your reviewer**:

kubernetes/test-infra#37786 removes the redundant image argument from the Prow
job.

This PR was written in part with the assistance of generative AI.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
