### PR TITLE
fix(etcd): set correct permissions on certs generated on first etcd node

### DIFF
--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -46,6 +46,50 @@
   when: gen_certs
   notify: Set etcd_secret_changed
 
+- name: Gen_certs | Normalize ownership and mode of generated etcd certs on first etcd node
+  file:
+    path: "{{ etcd_cert_dir }}/{{ item }}.pem"
+    owner: "{{ etcd_owner }}"
+    group: "{{ etcd_cert_group }}"
+    mode: "0644"
+  vars:
+    etcd_cert_stems: >-
+      {{ ['member', 'admin'] | product(groups['etcd']) | map('join', '-') | list
+         + (groups['gen_node_certs_True']
+            | intersect(groups['kube_control_plane'])
+            | map('regex_replace', '^', 'node-') | list)
+         + ['ca'] }}
+  loop: "{{ etcd_cert_stems }}"
+  loop_control:
+    label: "{{ etcd_cert_dir }}/{{ item }}.pem"
+  delegate_to: "{{ groups['etcd'][0] }}"
+  run_once: true
+  when:
+    - gen_certs
+    - inventory_hostname == groups['etcd'][0]
+
+- name: Gen_certs | Normalize ownership and mode of generated etcd private keys on first etcd node
+  file:
+    path: "{{ etcd_cert_dir }}/{{ item }}-key.pem"
+    owner: "{{ etcd_owner }}"
+    group: "{{ etcd_cert_group }}"
+    mode: "0600"
+  vars:
+    etcd_cert_stems: >-
+      {{ ['member', 'admin'] | product(groups['etcd']) | map('join', '-') | list
+         + (groups['gen_node_certs_True']
+            | intersect(groups['kube_control_plane'])
+            | map('regex_replace', '^', 'node-') | list)
+         + ['ca'] }}
+  loop: "{{ etcd_cert_stems }}"
+  loop_control:
+    label: "{{ etcd_cert_dir }}/{{ item }}-key.pem"
+  delegate_to: "{{ groups['etcd'][0] }}"
+  run_once: true
+  when:
+    - gen_certs
+    - inventory_hostname == groups['etcd'][0]
+
 - name: Gen_certs | run cert generation script for all clients
   command: "bash -x {{ etcd_script_dir }}/make-ssl-etcd.sh -f {{ etcd_config_dir }}/openssl.conf -d {{ etcd_cert_dir }}"
   environment:


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

On the first etcd node, `make-ssl-etcd.sh` generates the etcd certs and moves them into `/etc/ssl/etcd` as `root:root` with umask-based permissions (`0600` for keys, `0644` for certs). Every other etcd node receives the certs through the slurp/copy path with the correct `etcd:${etcd_cert_group}` ownership and `0640` mode, so only the generating node is inconsistent.

This broke an etcd backup job running on the first control-plane node with a read-permission error (see issue for repro).

This PR adds one normalization task in `roles/etcd/tasks/gen_certs_script.yml` right after cert generation on the first etcd node. It sets the same owner/group and the same mode split the copy path already uses:

- `0644` for public certs (ca.pem, admin-*.pem, member-*.pem, node-*.pem)
- `0600` for private keys (*-key.pem)

The task reuses `etcd_owner` / `etcd_cert_group` so behavior stays consistent with the copy tasks, and it only runs when `gen_certs` is true (generation happened).

## Which issue(s) this PR fixes

Fixes #13250

## Special notes for your reviewer

- Delegation matches the generation task: `delegate_to: "{{ groups['etcd'][0] }}"` + `run_once: true`, so it runs exactly where the certs are generated.
- File names use `{{ inventory_hostname }}` because that is how the generator names certs (same pattern as the slurp/copy tasks above).
- Modes deliberately keep 0600 on keys (stricter than the copy path's 0640) to match upstream etcd PKI conventions; happy to align to 0640 if reviewers prefer exact parity with the copy path.

## Does this PR introduce a user-facing change?

```release-note
Fix etcd certificate permissions on the first etcd node: generated certs are now normalized to the same ownership (etcd:${etcd_cert_group}) and mode split (0644 certs / 0600 keys) as the certs copied to other etcd nodes.
```