### PR TITLE
fix(gateway-api): honor server_side_apply when installing Gateway API CRDs

### DIFF
--- a/roles/kubernetes-apps/common_crds/gateway_api/tasks/main.yml
+++ b/roles/kubernetes-apps/common_crds/gateway_api/tasks/main.yml
@@ -24,10 +24,18 @@
     - "inventory_hostname == groups['kube_control_plane'][0]"
 
 - name: Gateway API | Install Gateway API
-  kube:
-    name: Gateway API
-    kubectl: "{{ bin_dir }}/kubectl"
-    filename: "{{ kube_config_dir }}/addons/gateway_api/{{ gateway_api_channel }}-install.yaml"
-    state: latest
+  command:
+    cmd: >-
+      {{ bin_dir }}/kubectl apply
+      --server-side={{ server_side_apply | default(false) | lower }}
+      --filename={{ kube_config_dir }}/addons/gateway_api/{{ gateway_api_channel }}-install.yaml
   when:
     - "inventory_hostname == groups['kube_control_plane'][0]"
+  register: gateway_api_apply
+  retries: 3
+  delay: 5
+  until: gateway_api_apply is succeeded
+  changed_when:
+    - "' configured' in gateway_api_apply.stdout
+       or ' created' in gateway_api_apply.stdout
+       or ' serverside-applied' in gateway_api_apply.stdout"


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

The Gateway API CRD install task used the `kube` module, which always runs client-side `kubectl apply`. The `server_side_apply` variable (repo convention in `roles/kubernetes-apps/utils/vars/main.yml`) is ignored by this task.

When the Gateway API CRDs are re-applied across playbook runs (channel upgrades, re-runs), client-side apply keeps growing the `last-applied-configuration` annotation on the `httproutes.gateway.networking.k8s.io` CRD. Once it passes the 262144-byte etcd annotation limit, apply fails:

```
The CustomResourceDefinition "httproutes.gateway.networking.k8s.io" is invalid: metadata.annotations: Too long: may not be more than 262144 bytes
```

This leaves the cluster without HTTPRoute support, as reported.

This task now runs `kubectl apply --server-side={{ server_side_apply | default(false) | lower }}`, honors the existing repo variable, adds retries, and derives changed state from kubectl output (`configured` / `created` / `serverside-applied`).

## Which issue(s) this PR fixes

Relates to #13086 (CRD annotation growth failure mode; full repro details in the issue).

## Special notes for your reviewer

- Default stays `false`, so existing behavior is unchanged for users who never set the variable; users who set `server_side_apply: true` now get SSA here like everywhere else.
- I did not add `--force-conflicts`: SSA on CRDs from a single controller should not conflict; can add if reviewers prefer.
- `kube` module usages elsewhere (metallb, cluster_roles, nvidia) have the same latent pattern but smaller/no CRD YAMLs; left untouched to keep this PR minimal.

## Does this PR introduce a user-facing change?

```release-note
The Gateway API addon task now honors the server_side_apply variable; repeated installs no longer bloat the last-applied-configuration annotation on Gateway API CRDs past the etcd 256KB limit.
```