### PR TITLE
fix(calico): make IPv6 pool validation actually run

### DIFF
--- a/roles/network_plugin/calico/tasks/check.yml
+++ b/roles/network_plugin/calico/tasks/check.yml
@@ -186,10 +186,10 @@
 
 - name: "Set calico_pool_ipv6_conf"
   set_fact:
-    calico_pool_conf: '{{ calico_ipv6.stdout | from_json }}'
+    calico_pool_ipv6_conf: '{{ calico_ipv6.stdout | from_json }}'
   when:
     - ipv6_stack | bool
-    - alico_ipv6 is defined
+    - calico_ipv6 is defined
     - calico_ipv6.rc == 0 and calico_ipv6.stdout
   run_once: true
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
@@ -197,10 +197,10 @@
 - name: "Check if ipv6 inventory match current cluster configuration"
   assert:
     that:
-      - calico_pool_conf.spec.blockSize | int == calico_pool_blocksize_ipv6 | int
-      - calico_pool_conf.spec.cidr == (calico_pool_cidr_ipv6 | default(kube_pods_subnet_ipv6))
-      - not calico_pool_conf.spec.ipipMode is defined or calico_pool_conf.spec.ipipMode == calico_ipip_mode_ipv6
-      - not calico_pool_conf.spec.vxlanMode is defined or calico_pool_conf.spec.vxlanMode == calico_vxlan_mode_ipv6
+      - calico_pool_ipv6_conf.spec.blockSize | int == calico_pool_blocksize_ipv6 | int
+      - calico_pool_ipv6_conf.spec.cidr == (calico_pool_cidr_ipv6 | default(kube_pods_subnet_ipv6))
+      - not calico_pool_ipv6_conf.spec.ipipMode is defined or calico_pool_ipv6_conf.spec.ipipMode == calico_ipip_mode_ipv6
+      - not calico_pool_ipv6_conf.spec.vxlanMode is defined or calico_pool_ipv6_conf.spec.vxlanMode == calico_vxlan_mode_ipv6
     msg: "Your ipv6 inventory doesn't match the current cluster configuration"
   when:
     - ipv6_stack | bool


### PR DESCRIPTION
**What this fixes**

With ipv6_stack: true and Calico, the IPv6 pool validation in roles/network_plugin/calico/tasks/check.yml never executed:

1. set_fact gated on 'alico_ipv6 is defined' (typo of calico_ipv6, the registered var) -> always skipped silently.
2. The set_fact saved the pool as calico_pool_conf, clobbering the IPv4 pool fact on dual-stack clusters, while the IPv6 assertion gated on calico_pool_ipv6_conf, which was never set.
3. The assertion body also read calico_pool_conf, so even with the gate fixed it would compare IPv6 inventory against the IPv4 pool.

**The fix**

- Store the IPv6 pool as calico_pool_ipv6_conf.
- Gate the set_fact on calico_ipv6 (the actual registered var).
- Make the assertion read calico_pool_ipv6_conf everywhere.
- Mirrors the IPv4 block directly above it.

**Verification (ansible-playbook 2.16, mocked calicoctl JSON)**

- Old code: set_fact task SKIPPED -> assertion never ran (reproduces the silent-skip from issue 13341).
- New code with mismatched blockSize (118 on cluster vs 116 in inventory): assertion FAILS with 'Your ipv6 inventory doesn't match the current cluster configuration'.
- New code with matching config: passes.

/kind bug
/area calico

```release-note
Fix Calico IPv6 pool validation that never ran: a variable typo (alico_ipv6) skipped the check silently and the IPv6 pool overwrote the IPv4 pool fact on dual-stack clusters. IPv6 inventory mismatches now fail fast with a clear message.
```

Fixes #13341