### PR TITLE
ci: restore molecule tests for kata-containers.

### DIFF
--- a/.gitlab-ci/molecule.yml
+++ b/.gitlab-ci/molecule.yml
@@ -35,6 +35,7 @@ molecule:
       - container-engine/containerd
       - container-engine/cri-o
       - container-engine/gvisor
+      - container-engine/kata-containers
       - adduser
       - bastion-ssh-config
       - bootstrap_os
@@ -50,7 +51,5 @@ molecule_full:
   parallel:
     matrix:
     - ROLE:
-      # FIXME : tests below are perma-failing
-      - container-engine/kata-containers
       # FIXME: until youki release 0.6.1
       - container-engine/youki


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR restores the automated molecule tests for Kata Containers in the CI pipeline.

Following the merge #13389 that introduced the new format update and fixed the `cgroup v2` incompatibilities (#10137), the Kata molecule tests are successfully passing again as shown in the [ last execution of the kata-containers test](https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/16244277821). 

This PR moves `container-engine/kata-containers` out of `molecule_full` manual job and restores it back to the standard `molecule` matrix so it is properly tested on every PR moving forward.

**Which issue(s) this PR fixes**:
Fixes #10137 

**Special notes for your reviewer**:
Since I don't have permissions to trigger the manual CI jobs to prove the fix prior to this PR, I've linked the recent automated [daily-ci pipeline run](https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/pipelines/2811226633)  which proves the `kata-containers` tests are now passing: [Successful Kata Containers GitLab CI Job](https://gitlab.com/kargo-ci/kubernetes-sigs-kubespray/-/jobs/16244277821)

**Does this PR introduce a user-facing change?**:
```release-note
Restore automated CI molecule tests for Kata Containers.
```
