### PR TITLE
image-builder: add openSUSE Leap 16.0 image

### DIFF
--- a/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
@@ -183,6 +183,13 @@ images:
     converted: true
     tag: "latest"
 
+  opensuse-leap-16-0:
+    filename: Leap-16.0-Minimal-VM.x86_64-Cloud.qcow2
+    url: https://download.opensuse.org/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-Cloud.qcow2
+    checksum: sha256:c5cd6904632c86d5368dea3896da8c17571c238ef96a0e2c8b0ca1835d796e07
+    converted: true
+    tag: "latest"
+
   openeuler-2203:
     filename: openEuler-22.03-LTS-SP4-x86_64.qcow2.xz
     url: https://mirrors.ocf.berkeley.edu/openeuler/openEuler-22.03-LTS-SP4/virtual_machine_img/x86_64/openEuler-22.03-LTS-SP4-x86_64.qcow2.xz


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add the immutable openSUSE Leap 16.0 cloud image and checksum to the
KubeVirt image builder. This enables follow-up Leap 16.0 CI coverage
tracked in #13441.

**Which issue(s) this PR fixes**:

Related to #13441

**Special notes for your reviewer**:

Published image: `quay.io/kubespray/vm-opensuse-leap-16-0:latest`

Manifest digest:
`sha256:d8331bb7b700fcd27f01b1802bdcc1988dcea15d69ec53693ef01b14871a6a00`

This PR was written in part with the assistance of generative AI.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
