### PR TITLE
kata-containers: extract into kata_containers_dir to fix in-place upg…

### DIFF
--- a/roles/container-engine/kata-containers/tasks/main.yml
+++ b/roles/container-engine/kata-containers/tasks/main.yml
@@ -4,14 +4,48 @@
   vars:
     download: "{{ download_defaults | combine(downloads.kata_containers) }}"
 
+- name: Kata-containers | Ensure install directory exists
+  file:
+    path: "{{ kata_containers_dir }}"
+    state: directory
+    mode: "0755"
+
+# Empty the install dir first so upgrades (and same-version rebuilds) don't leave
+# stale files from a previous version behind. Only the contents are removed,
+# preserving kata_containers_dir itself (it may be a symlink to another fs).
+- name: Kata-containers | Find previous installation
+  find:
+    paths: "{{ kata_containers_dir }}"
+    file_type: any
+    hidden: true
+    follow: true
+  register: kata_installed_files
+
+- name: Kata-containers | Remove previous installation contents
+  file:
+    path: "{{ kata_installed_file.path }}"
+    state: absent
+  loop: "{{ kata_installed_files.files }}"
+  loop_control:
+    loop_var: kata_installed_file
+    label: "{{ kata_installed_file.path }}"
+
+# The archive stores files under an opt/kata/ prefix, so extract into
+# kata_containers_dir with that prefix stripped rather than unarchiving to /.
+# Extracting to / breaks when kata_containers_dir is a symlink onto another
+# filesystem: unarchive's "tar --diff" sees "File type differs"/cross-device,
+# wrongly skips the extract, then fails its attribute pass. Extracting into the
+# dir runs tar inside the target and avoids that.
 - name: Kata-containers | Copy kata-containers binary
   unarchive:
     src: "{{ downloads.kata_containers.dest }}"
-    dest: "/"
+    dest: "{{ kata_containers_dir }}"
     mode: "0755"
     owner: root
     group: root
     remote_src: true
+    extra_opts:
+      - --strip-components=2
 
 - name: Kata-containers | Create config directory
   file:


### PR DESCRIPTION
…rades

The kata-static archive stores files under an opt/kata/ prefix and the role extracted it with unarchive to /. That has two problems on re-runs/upgrades:

- Stale files from a previous version are never removed, since unarchive only overwrites members present in the new archive.
- If kata_containers_dir is a symlink onto another filesystem, extracting to / makes tar collide with the symlink. unarchive's "tar --diff" idempotency check reports "File type differs"/"Invalid cross-device link", which it does not recognise as "needs extracting", so it skips the extract and then fails its per-file attribute pass with "path .../VERSION does not exist".

Extract the contents into kata_containers_dir with the opt/kata/ prefix stripped instead, so tar runs inside the target directory and never traverses or replaces the symlink. Empty the directory first (preserving it) so upgrades and same-version rebuilds start from a clean tree.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Fix upgrade of kata version bump by first cleaning up the old files and then extract under the kata_containers_dir path

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
bugfix(upgrade) kata: cleanup older version files if present and extract to kata_containers_dir
```
