### PR TITLE
lint: Disable name-casing (and remove comment)

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,8 +2,6 @@
 skip_list:
   # see https://docs.ansible.com/ansible-lint/rules/default_rules.html for a list of all default rules
 
-  # DO NOT add any other rules to this skip_list, instead use local `# noqa` with a comment explaining WHY it is necessary
-
   # These rules are intentionally skipped:
   #
   # [role-name] "meta/main.yml" Role name role-name does not match ``^+$`` pattern
@@ -35,6 +33,7 @@ skip_list:
   - 'run-once[task]'
 
   - 'jinja[spacing]'
+  - 'name[casing]'
 exclude_paths:
   # Generated files
   - tests/files/custom_cni/cilium.yaml


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
ansible-lint is pretty opiniated, and a lots of its opinion are not
particularly useful for Kubespray, so delete the comment about not
adding skip rule entries.

We should not add them willy-nilly but some stuff just does not make
sense, in that case name[casing] when prefixing tasks name with role
name.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
extracted from #12937 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/label ci-short
