### PR TITLE
CI: add helm for kubelet-csr-approver/custom-cni-helm tests

### DIFF
--- a/tests/files/debian12-custom-cni-helm.yml
+++ b/tests/files/debian12-custom-cni-helm.yml
@@ -20,3 +20,5 @@ custom_cni_chart_values:
     operator:
       clusterPoolIPv4PodCIDRList:
         - "{{ kube_pods_subnet }}"
+
+helm_enabled: true

--- a/tests/files/debian13-kubelet-csr-approver.yml
+++ b/tests/files/debian13-kubelet-csr-approver.yml
@@ -8,3 +8,5 @@ kubelet_csr_approver_enabled: true
 kubelet_csr_approver_values:
   # Do not check DNS resolution in testing (not recommended in production)
   bypassDnsResolution: true
+
+helm_enabled: true

--- a/tests/files/ubuntu24-calico-all-in-one-hardening.yml
+++ b/tests/files/ubuntu24-calico-all-in-one-hardening.yml
@@ -75,6 +75,7 @@ etcd_deployment_type: kubeadm
 kubelet_authentication_token_webhook: true
 kube_read_only_port: 0
 kubelet_rotate_server_certificates: true
+helm_enabled: true
 kubelet_csr_approver_enabled: true # For hydrophone
 kubelet_csr_approver_values:
   # Do not check DNS resolution in testing (not recommended in production)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently this only works because helm_enabled is not actually checked
for some helm installation cases.

Extracted from #12299

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
