### PR TITLE
update-hashes: temporarily exclude gvisor

### DIFF
--- a/.github/workflows/upgrade-patch-versions.yml
+++ b/.github/workflows/upgrade-patch-versions.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: '3.13'
         cache: 'pip'
     - run: pip install scripts/component_hash_update pre-commit
-    - run: update-hashes
+    - run: update-hashes -e gvisor_containerd_shim_binary -e gvisor_runsc_binary
       env:
         API_KEY: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Gvisor changed it's release artefacts, which makes the whole updater
script fail.
Let's exclude them for now.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
