### PR TITLE
fix(calico): grant calico-apiserver RBAC for ValidatingAdmissionPolicy on release-2.27

### DIFF
--- a/roles/network_plugin/calico/templates/calico-apiserver.yml.j2
+++ b/roles/network_plugin/calico/templates/calico-apiserver.yml.j2
@@ -235,6 +235,8 @@ rules:
   resources:
   - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
+  - validatingadmissionpolicies        # Required for Kubernetes 1.33+
+  - validatingadmissionpolicybindings  # Required for Kubernetes 1.33+
   verbs:
   - get
   - list


### PR DESCRIPTION
### What this PR does

Backports the RBAC fix from #12654 (already merged to master and release-2.29 via #12695) to the release-2.27 branch, mirroring #13461 for release-2.28.

The calico-webhook-reader ClusterRole gains read-only access to:
- validatingadmissionpolicies
- validatingadmissionpolicybindings

Without these, on Kubernetes 1.33+ the calico-apiserver reflectors are denied list/watch and the pod enters CrashLoopBackOff (reported in #13347, which covers v2.27.1 through v2.29.0).

### Verification (ran locally, ansible 2.16 render path)

- Rendered calico-apiserver.yml.j2 through ansible template with the branch's defaults; YAML parses (from_yaml_all)
- calico-webhook-reader ClusterRole resources now include validatingadmissionpolicies + validatingadmissionpolicybindings
- verbs stay get/list/watch; all other docs in the manifest untouched
- diff is byte-identical to the upstream #12654 change

Reviewed by two models (b-ai glm-5.3-flash: PASS; openrouter/free: PASS after checking rendered file).

### Release note

```release-note
Fix calico-apiserver CrashLoopBackOff on Kubernetes 1.33+ by granting the calico-webhook-reader ClusterRole read access to validatingadmissionpolicies and validatingadmissionpolicybindings
```