### PR TITLE
kube-vip: Upgrade to v1.2.3 and expose newly added config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Note:
   - [kube-ovn](https://github.com/alauda/kube-ovn) 1.12.21
   - [kube-router](https://github.com/cloudnativelabs/kube-router) 2.1.1
   - [multus](https://github.com/k8snetworkplumbingwg/multus-cni) 4.2.2
-  - [kube-vip](https://github.com/kube-vip/kube-vip) 1.0.3
+  - [kube-vip](https://github.com/kube-vip/kube-vip) 1.2.3
 - Application
   - [cert-manager](https://github.com/jetstack/cert-manager) 1.15.3
   - [coredns](https://github.com/coredns/coredns) 1.14.2

--- a/docs/ingress/kube-vip.md
+++ b/docs/ingress/kube-vip.md
@@ -65,6 +65,18 @@ kube_vip_bgppeers:
 # kube_vip_bgp_peeras:
 # kube_vip_bgp_sourceip:
 # kube_vip_bgp_sourceif:
+# Assign BGP-advertised service VIPs to the configured interface as well:
+# kube_vip_bgp_attach_ip_to_interface: true
+```
+
+If using BGP without [routing table mode](https://kube-vip.io/docs/installation/static/#routing-table), you can have kube-vip poll the control plane over HTTP and withdraw its BGP routes on failure:
+
+```yaml
+kube_vip_control_plane_health_check_address: http://127.0.0.1:6443/healthz
+# kube_vip_control_plane_health_check_period_seconds: 5
+# kube_vip_control_plane_health_check_timeout_seconds: 3
+# kube_vip_control_plane_health_check_failure_threshold: 3
+# kube_vip_control_plane_health_check_ca_path: /etc/kubernetes/pki/ca.crt
 ```
 
 If using [control plane load-balancing](https://kube-vip.io/docs/about/architecture/#control-plane-load-balancing):

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -61,16 +61,22 @@ kubelet_status_update_frequency: 10s
 
 # kube-vip
 kube_vip_arp_enabled: false
+kube_vip_instance_name:
 kube_vip_interface:
 kube_vip_services_interface:
+kube_vip_allow_interface_not_up:
 kube_vip_cidr: 32
 kube_vip_dns_mode: first
+kube_vip_dhcp_backoff_attempts:
 kube_vip_controlplane_enabled: false
 kube_vip_ddns_enabled: false
 kube_vip_cp_detect: false
 kube_vip_services_enabled: false
 kube_vip_leader_election_enabled: "{{ kube_vip_arp_enabled }}"
+kube_vip_lose_leadership_enabled:
+kube_vip_lose_leadership_timeout_seconds:
 kube_vip_bgp_enabled: false
+kube_vip_bgp_attach_ip_to_interface:
 kube_vip_bgp_routerid:
 kube_vip_local_as: 65000
 kube_vip_bgp_peeraddress:
@@ -78,6 +84,12 @@ kube_vip_bgp_peerpass:
 kube_vip_bgp_peeras: 65000
 kube_vip_bgppeers:
 kube_vip_enableServicesElection: false
+# HTTP health-check polled against the control plane; only used alongside BGP routing (see kube-vip's ControlPlaneHealthCheck).
+kube_vip_control_plane_health_check_address:
+kube_vip_control_plane_health_check_period_seconds:
+kube_vip_control_plane_health_check_timeout_seconds:
+kube_vip_control_plane_health_check_failure_threshold:
+kube_vip_control_plane_health_check_ca_path:
 kube_vip_lb_enable: false
 kube_vip_leasename: plndr-cp-lock
 kube_vip_svc_leasename: plndr-svcs-lock
@@ -90,6 +102,10 @@ kube_vip_bgp_sourceif:
 kube_vip_metrics_enabled: false
 # TCP port for kube-vip Prometheus metrics; manifest sets prometheus_server to :PORT (same as kube-vip upstream default, see cmd/kube-vip.go).
 kube_vip_metrics_port: 2112
+# Keep the VIP address on the interface (ARP/NDP broadcasting stops, but the address stays assigned) instead of removing it on leadership loss.
+kube_vip_preserve_vip_on_leadership_loss:
+# Duration string (e.g. "1s") the watch-event debouncer waits before reacting; empty uses kube-vip's own default.
+kube_vip_debounce_time:
 
 # Requests for load balancer app
 loadbalancer_apiserver_memory_requests: 32M

--- a/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
@@ -1,4 +1,4 @@
-# Inspired by https://github.com/kube-vip/kube-vip/blob/v1.0.3/pkg/kubevip/config_generator.go#L103
+# Inspired by https://github.com/kube-vip/kube-vip/blob/v1.2.3/pkg/kubevip/config_generator.go#L103
 apiVersion: v1
 kind: Pod
 metadata:
@@ -18,6 +18,10 @@ spec:
       value: {{ kube_apiserver_port | string | to_json }}
     - name: vip_nodename
       value: {{ inventory_hostname }}
+{% if kube_vip_instance_name %}
+    - name: instance_name
+      value: {{ kube_vip_instance_name | string | to_json }}
+{% endif %}
 {% if kube_vip_interface %}
     - name: vip_interface
       value: {{ kube_vip_interface | string | to_json }}
@@ -26,6 +30,10 @@ spec:
     - name: vip_servicesinterface
       value: {{ kube_vip_services_interface | string | to_json }}
 {% endif %}
+{% if kube_vip_allow_interface_not_up is not none %}
+    - name: vip_allow_interface_not_up
+      value: {{ kube_vip_allow_interface_not_up | string | to_json }}
+{% endif %}
 {% if kube_vip_cidr %}
     - name: vip_{{ "subnet" if kube_vip_version is version('0.9.0', '>=') else "cidr" }}
       value: {{ kube_vip_cidr | string | to_json }}
@@ -33,6 +41,10 @@ spec:
 {% if kube_vip_dns_mode %}
     - name: dns_mode
       value: {{ kube_vip_dns_mode | string | to_json }}
+{% endif %}
+{% if kube_vip_dhcp_backoff_attempts is not none %}
+    - name: dhcp_backoff_attempts
+      value: {{ kube_vip_dhcp_backoff_attempts | string | to_json }}
 {% endif %}
 {% if kube_vip_controlplane_enabled %}
     - name: cp_enable
@@ -68,6 +80,14 @@ spec:
     - name: vip_retryperiod
       value: {{ kube_vip_retryperiod | string | to_json }}
 {% endif %}
+{% if kube_vip_lose_leadership_enabled is not none %}
+    - name: vip_loseleadership
+      value: {{ kube_vip_lose_leadership_enabled | string | to_json }}
+{% if kube_vip_lose_leadership_timeout_seconds is not none %}
+    - name: vip_loseleadership_timeout_seconds
+      value: {{ kube_vip_lose_leadership_timeout_seconds | string | to_json }}
+{% endif %}
+{% endif %}
 {% if kube_vip_enable_node_labeling %}
     - name: enable_node_labeling
       value: {{ kube_vip_enable_node_labeling | string | to_json }}
@@ -75,6 +95,10 @@ spec:
 {% if kube_vip_bgp_enabled %}
     - name: bgp_enable
       value: "true"
+{% if kube_vip_bgp_attach_ip_to_interface is not none %}
+    - name: bgp_attach_ip_to_interface
+      value: {{ kube_vip_bgp_attach_ip_to_interface | string | to_json }}
+{% endif %}
     - name: bgp_routerid
       value: {{ kube_vip_bgp_routerid | string | to_json }}
     - name: bgp_as
@@ -100,6 +124,26 @@ spec:
       value: {{ kube_vip_bgppeers | join(',')  | to_json }}
 {% endif %}
 {% endif %}
+{% if kube_vip_control_plane_health_check_address %}
+    - name: control_plane_health_check_address
+      value: {{ kube_vip_control_plane_health_check_address | string | to_json }}
+{% if kube_vip_control_plane_health_check_period_seconds is not none %}
+    - name: control_plane_health_check_period_seconds
+      value: {{ kube_vip_control_plane_health_check_period_seconds | string | to_json }}
+{% endif %}
+{% if kube_vip_control_plane_health_check_timeout_seconds is not none %}
+    - name: control_plane_health_check_timeout_seconds
+      value: {{ kube_vip_control_plane_health_check_timeout_seconds | string | to_json }}
+{% endif %}
+{% if kube_vip_control_plane_health_check_failure_threshold is not none %}
+    - name: control_plane_health_check_failure_threshold
+      value: {{ kube_vip_control_plane_health_check_failure_threshold | string | to_json }}
+{% endif %}
+{% if kube_vip_control_plane_health_check_ca_path %}
+    - name: control_plane_health_check_ca_path
+      value: {{ kube_vip_control_plane_health_check_ca_path | string | to_json }}
+{% endif %}
+{% endif %}
     - name: address
       value: {{ kube_vip_address | to_json }}
 {% if kube_vip_lb_enable %}
@@ -113,6 +157,14 @@ spec:
 {% if kube_vip_metrics_enabled %}
     - name: prometheus_server
       value: {{ (':' ~ (kube_vip_metrics_port | string)) | to_json }}
+{% endif %}
+{% if kube_vip_preserve_vip_on_leadership_loss is not none %}
+    - name: vip_preserve_on_leadership_loss
+      value: {{ kube_vip_preserve_vip_on_leadership_loss | string | to_json }}
+{% endif %}
+{% if kube_vip_debounce_time %}
+    - name: debounce_time
+      value: {{ kube_vip_debounce_time | string | to_json }}
 {% endif %}
     image: {{ kube_vip_image_repo }}:{{ kube_vip_image_tag }}
     imagePullPolicy: {{ k8s_image_pull_policy }}

--- a/roles/kubespray_defaults/defaults/main/download.yml
+++ b/roles/kubespray_defaults/defaults/main/download.yml
@@ -259,7 +259,7 @@ multus_image_tag: "v{{ multus_version }}"
 external_openstack_cloud_controller_image_repo: "{{ kube_image_repo }}/provider-os/openstack-cloud-controller-manager"
 external_openstack_cloud_controller_image_tag: "v1.35.0"
 
-kube_vip_version: 1.0.3
+kube_vip_version: 1.2.3
 kube_vip_image_repo: "{{ github_image_repo }}/kube-vip/kube-vip{{ '-iptables' if kube_vip_lb_fwdmethod == 'masquerade' else '' }}"
 kube_vip_image_tag: "v{{ kube_vip_version }}"
 nginx_image_repo: "{{ docker_image_repo }}/library/nginx"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Upgrades the default kube-vip version from 1.0.3 to 1.2.3, which includes the fix for leader election permanently deadlocking after ordinary leadership loss (kube-vip/kube-vip#1650), and exposes the config surface kube-vip added between v1.0.3 and v1.2.3 as new Kubespray variables: `kube_vip_instance_name`, `kube_vip_allow_interface_not_up`, `kube_vip_dhcp_backoff_attempts`, `kube_vip_lose_leadership_enabled`/`kube_vip_lose_leadership_timeout_seconds`, `kube_vip_bgp_attach_ip_to_interface`, `kube_vip_control_plane_health_check_*`, `kube_vip_preserve_vip_on_leadership_loss`, and `kube_vip_debounce_time`. All new variables are opt-in and default to kube-vip's own behavior when unset.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Env var names for the new options were verified against kube-vip's `config_envvar.go` and `config_environment.go` at v1.2.3, not just `config_generator.go` — the generator reuses the `vip_loseleadership` env var name for both the boolean flag and the timeout value, which looks like a bug on kube-vip's side, so this PR emits the two distinct names (`vip_loseleadership` / `vip_loseleadership_timeout_seconds`) that the reader side actually parses.

**Does this PR introduce a user-facing change?**:
```release-note
Upgrade kube-vip from 1.0.3 to 1.2.3 and add new optional variables: `kube_vip_instance_name`, `kube_vip_allow_interface_not_up`, `kube_vip_dhcp_backoff_attempts`, `kube_vip_lose_leadership_enabled`, `kube_vip_lose_leadership_timeout_seconds`, `kube_vip_bgp_attach_ip_to_interface`, `kube_vip_control_plane_health_check_address`/`_period_seconds`/`_timeout_seconds`/`_failure_threshold`/`_ca_path`, `kube_vip_preserve_vip_on_leadership_loss`, and `kube_vip_debounce_time`
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)