### PR TITLE
CI: add support for Fedora 44 and retire Fedora 42 in CI configurations

### DIFF
--- a/.gitlab-ci/kubevirt.yml
+++ b/.gitlab-ci/kubevirt.yml
@@ -39,8 +39,8 @@ pr:
           - debian12-cilium
           - debian13-calico-collection
           - debian13-cilium
-          - fedora42-calico
-          - fedora42-kube-router
+          - fedora44-calico
+          - fedora44-kube-router
           - fedora43-flannel-crio-collection-scale
           - fedora43-kube-router
           - opensuse-leap16-calico
@@ -104,8 +104,8 @@ pr_full:
           - debian13-custom-cni
           - debian13-kubelet-csr-approver
           - debian12-custom-cni-helm
-          - fedora42-calico-swap-selinux
-          - fedora42-crio
+          - fedora44-calico-swap-selinux
+          - fedora44-crio
           - fedora43-calico-swap-selinux
           - fedora43-crio
           - openeuler24-calico # https://github.com/kubernetes-sigs/kubespray/issues/12877
@@ -166,7 +166,7 @@ periodic:
           - debian13-calico-upgrade
           - debian13-calico-upgrade-once
           - debian12-cilium-svc-proxy
-          - fedora42-calico-selinux
+          - fedora44-calico-selinux
           - fedora43-calico-selinux
           - fedora43-docker-calico
           - ubuntu24-calico-etcd-kubeadm-upgrade-ha

--- a/docs/developers/ci.md
+++ b/docs/developers/ci.md
@@ -10,8 +10,8 @@ almalinux9 |  :white_check_mark: | :x: | :x: | :x: | :white_check_mark: | :x: |
 amazon |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
 debian12 |  :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | :x: | :x: |
 debian13 |  :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | :x: | :x: |
-fedora42 |  :white_check_mark: | :x: | :x: | :x: | :x: | :white_check_mark: |
 fedora43 |  :white_check_mark: | :x: | :x: | :x: | :x: | :white_check_mark: |
+fedora44 |  :white_check_mark: | :x: | :x: | :x: | :x: | :white_check_mark: |
 flatcar4081 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
 openeuler24 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
 opensuse |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
@@ -28,8 +28,8 @@ almalinux9 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
 amazon |  :x: | :x: | :x: | :x: | :x: | :x: |
 debian12 |  :x: | :x: | :x: | :x: | :x: | :x: |
 debian13 |  :x: | :x: | :x: | :x: | :x: | :x: |
-fedora42 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
 fedora43 |  :white_check_mark: | :x: | :x: | :white_check_mark: | :x: | :x: |
+fedora44 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
 flatcar4081 |  :x: | :x: | :x: | :x: | :x: | :x: |
 openeuler24 |  :x: | :x: | :x: | :x: | :x: | :x: |
 opensuse |  :x: | :x: | :x: | :x: | :x: | :x: |
@@ -46,8 +46,8 @@ almalinux9 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
 amazon |  :x: | :x: | :x: | :x: | :x: | :x: |
 debian12 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
 debian13 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
-fedora42 |  :x: | :x: | :x: | :x: | :x: | :x: |
 fedora43 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
+fedora44 |  :x: | :x: | :x: | :x: | :x: | :x: |
 flatcar4081 |  :x: | :x: | :x: | :x: | :x: | :x: |
 openeuler24 |  :x: | :x: | :x: | :x: | :x: | :x: |
 opensuse |  :x: | :x: | :x: | :x: | :x: | :x: |

--- a/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
@@ -67,10 +67,10 @@ images:
     converted: true
     tag: "latest"
 
-  fedora-42:
-    filename: Fedora-Cloud-Base-Generic-42-1.1.x86_64.qcow2
-    url: https://download.fedoraproject.org/pub/fedora/linux/releases/42/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-42-1.1.x86_64.qcow2
-    checksum: sha256:e401a4db2e5e04d1967b6729774faa96da629bcf3ba90b67d8d9cce9906bec0f
+  fedora-44:
+    filename: Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2
+    url: https://download.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2
+    checksum: sha256:28680fe5b371a5a82ebf43a31926e086a168e59949d03969c5093e7071f90b7f
     converted: true
     tag: "latest"
 

--- a/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
@@ -67,17 +67,17 @@ images:
     converted: true
     tag: "latest"
 
-  fedora-44:
-    filename: Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2
-    url: https://download.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2
-    checksum: sha256:28680fe5b371a5a82ebf43a31926e086a168e59949d03969c5093e7071f90b7f
-    converted: true
-    tag: "latest"
-
   fedora-43:
     filename: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
     url: https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
     checksum: sha256:846574c8a97cd2d8dc1f231062d73107cc85cbbbda56335e264a46e3a6c8ab2f
+    converted: true
+    tag: "latest"
+
+  fedora-44:
+    filename: Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2
+    url: https://download.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2
+    checksum: sha256:28680fe5b371a5a82ebf43a31926e086a168e59949d03969c5093e7071f90b7f
     converted: true
     tag: "latest"
 

--- a/tests/files/fedora44-calico-selinux.yml
+++ b/tests/files/fedora44-calico-selinux.yml
@@ -1,6 +1,6 @@
 ---
 # Instance settings
-cloud_image: fedora-42
+cloud_image: fedora-44
 
 # Kubespray settings
 auto_renew_certificates: true

--- a/tests/files/fedora44-calico-swap-selinux.yml
+++ b/tests/files/fedora44-calico-swap-selinux.yml
@@ -1,6 +1,6 @@
 ---
 # Instance settings
-cloud_image: fedora-42
+cloud_image: fedora-44
 
 # Kubespray settings
 auto_renew_certificates: true

--- a/tests/files/fedora44-calico.yml
+++ b/tests/files/fedora44-calico.yml
@@ -1,6 +1,6 @@
 ---
 # Instance settings
-cloud_image: fedora-42
+cloud_image: fedora-44
 
 # Kubespray settings
 auto_renew_certificates: true

--- a/tests/files/fedora44-crio.yml
+++ b/tests/files/fedora44-crio.yml
@@ -1,6 +1,6 @@
 ---
 # Instance settings
-cloud_image: fedora-42
+cloud_image: fedora-44
 
 # Kubespray settings
 container_manager: crio

--- a/tests/files/fedora44-kube-router.yml
+++ b/tests/files/fedora44-kube-router.yml
@@ -1,5 +1,5 @@
 ---
-cloud_image: fedora-42
+cloud_image: fedora-44
 cluster_layout:
   - node_groups: ['kube_control_plane', 'etcd', 'kube_node']
   - node_groups: ['kube_node']


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

- Add the `fedora-44` image metadata  in `test-infra/image-builder/roles/kubevirt-images/defaults/main.yml` and remove `fedora-42`.
- Migrate the `fedora42-*` test cases to `fedora44-*` in
  `.gitlab-ci/kubevirt.yml`.
- Update the supported-distribution tables in `docs/developers/ci.md`.

**Which issue(s) this PR fixes**:

Fixes #13442

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:

```release-note
Add Fedora 44 to CI and retire the end-of-life Fedora 42.
```