### PR TITLE
Add astl for fast local Ansible static linting

### DIFF
--- a/.gitlab-ci/lint.yml
+++ b/.gitlab-ci/lint.yml
@@ -9,6 +9,7 @@ pre-commit:
     ANSIBLE_STDOUT_CALLBACK: default
   script:
   - pre-commit run --all-files --show-diff-on-failure
+  - pre-commit run ansible-lint --hook-stage manual --all-files --show-diff-on-failure
   cache:
     key: pre-commit-2
     paths:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,16 @@ repos:
         exclude: "^.git"
         files: "\\.sh$"
 
+  - repo: https://github.com/arhuman/ansible-static-lint
+    rev: v0.5.0
+    hooks:
+      - id: astl
+
   - repo: https://github.com/ansible/ansible-lint
     rev: v25.11.0
     hooks:
       - id: ansible-lint
+        stages: [manual]
         additional_dependencies:
           - ansible-core>=2.18.0,<2.19.0
           - jmespath==1.0.1


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it:**

Implements the change proposed in #13426: give developers fast local lint feedback without weakening CI.

- Adds [astl](https://github.com/arhuman/ansible-static-lint) (ansible-static-lint)
  as a normal pre-commit hook, pinned at v0.5.0. It covers the ansible-lint rules
  decidable from YAML source alone and produces byte-identical findings for those
  rules. On this repository it runs in ~129ms where the ansible-lint hook takes ~51s.
- Moves the ansible-lint hook to `stages: [manual]`. It is not removed and not
  replaced: CI still runs the full ansible-lint via an explicit
  `pre-commit run ansible-lint --hook-stage manual` step added to the lint job,
  so nothing ansible-lint checks today stops being checked.

The astl hook uses `language: golang`, so pre-commit builds it from the pinned
tag and bootstraps the Go toolchain itself if absent (pre-commit >= 3.0). No new
prerequisite for contributors.

**Which issue(s) this PR fixes:**

Fixes #13426

**Special notes for your reviewer:**

The lint job currently fails on master with one pre-existing `jinja[invalid]`
violation (`roles/kubernetes/client/tasks/main.yml:70`, triggered by
ansible.utils 6.1.0), addressed by #13337. This PR neither causes nor fixes it;
the same single failure occurs with and without this change.

Verified locally on a clone at current HEAD:
- `pre-commit run --all-files` runs astl and all other hooks, and no longer runs
  ansible-lint by default.
- `pre-commit run ansible-lint --hook-stage manual --all-files` still runs the
  full ansible-lint exactly as before.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```
