### PR TITLE
openSUSE: add Leap 16.0 support and CI coverage

### DIFF
--- a/.gitlab-ci/kubevirt.yml
+++ b/.gitlab-ci/kubevirt.yml
@@ -45,6 +45,7 @@ pr:
           - fedora42-calico
           - rockylinux9-cilium
           - rockylinux10-cilium
+          - opensuse-leap16-calico
           - ubuntu22-calico-all-in-one
           - ubuntu22-calico-all-in-one-upgrade
           - ubuntu24-calico-etcd-datastore

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ vagrant up
 - **CentOS Stream / RHEL** 9, 10
 - **Fedora** 39, 40, 41, 42
 - **Fedora CoreOS** (see [fcos Note](docs/operating_systems/fcos.md))
-- **openSUSE** Leap 15.x/Tumbleweed
+- **openSUSE** Leap 16.x/Tumbleweed
 - **Oracle Linux** 9, 10
 - **Alma Linux** 9, 10
 - **Rocky Linux** 9, 10 (experimental in 10: see [Rocky Linux 10 notes](docs/operating_systems/rhel.md#rocky-linux-10))

--- a/docs/developers/ci.md
+++ b/docs/developers/ci.md
@@ -15,6 +15,7 @@ fedora42 |  :white_check_mark: | :x: | :x: | :x: | :x: | :white_check_mark: | :x
 fedora43 |  :white_check_mark: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: |
 flatcar4081 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
 openeuler24 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
+opensuse |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
 rockylinux10 |  :white_check_mark: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
 rockylinux9 |  :white_check_mark: | :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
 ubuntu22 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
@@ -33,6 +34,7 @@ fedora42 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
 fedora43 |  :white_check_mark: | :x: | :x: | :white_check_mark: | :x: | :x: | :x: |
 flatcar4081 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 openeuler24 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
+opensuse |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 rockylinux10 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 rockylinux9 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 ubuntu22 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
@@ -51,6 +53,7 @@ fedora42 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 fedora43 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |
 flatcar4081 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 openeuler24 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
+opensuse |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 rockylinux10 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 rockylinux9 |  :x: | :x: | :x: | :x: | :x: | :x: | :x: |
 ubuntu22 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: |

--- a/docs/operating_systems/opensuse.md
+++ b/docs/operating_systems/opensuse.md
@@ -1,4 +1,4 @@
-# openSUSE Leap 15.6 and Tumbleweed
+# openSUSE Leap 16.0 and Tumbleweed
 
 openSUSE Leap installation Notes:
 

--- a/docs/operations/kernel-requirements.md
+++ b/docs/operations/kernel-requirements.md
@@ -28,7 +28,7 @@ The Kernel Version Matrixs:
 | Debian 11          | 5.10           | :white_check_mark: |
 | Fedora 40          | 6.8            | :white_check_mark: |
 | Fedora 39          | 6.5            | :white_check_mark: |
-| openSUSE Leap 15.5 | 5.14           | :white_check_mark: |
+| openSUSE Leap 16.0 | 6.12           | :white_check_mark: |
 | Amazon Linux 2     | 4.14           | :x:                |
 | openEuler 24.03    | 6.6            | :white_check_mark: |
 | openEuler 22.03    | 5.10           | :white_check_mark: |

--- a/roles/bootstrap_os/tasks/opensuse.yml
+++ b/roles/bootstrap_os/tasks/opensuse.yml
@@ -47,11 +47,3 @@
   become: true
   when:
     - http_proxy is defined or https_proxy is defined
-
-# Required for zypper module
-- name: Install python-xml
-  shell: zypper refresh && zypper --non-interactive install python-xml
-  changed_when: false
-  become: true
-  tags:
-    - facts

--- a/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
+++ b/test-infra/image-builder/roles/kubevirt-images/defaults/main.yml
@@ -169,13 +169,6 @@ images:
     converted: true
     tag: "latest"
 
-  opensuse-leap-15:
-    filename: openSUSE-Leap-15.3.x86_64-1.0.1-NoCloud-Build2.63.qcow2
-    url: https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.3/images/openSUSE-Leap-15.3.x86_64-1.0.1-NoCloud-Build2.63.qcow2
-    checksum: sha256:289248945e2d058551c71c1bdcb31a361cefe7136c7fd88a09b524eedfaf5215
-    converted: true
-    tag: "latest"
-
   opensuse-leap-15-6:
     filename: openSUSE-Leap-15.6.x86_64-1.0.1-NoCloud-Build1.177.qcow2
     url: https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.6/images/openSUSE-Leap-15.6.x86_64-1.0.1-NoCloud-Build1.177.qcow2

--- a/tests/files/opensuse-leap16-calico.yml
+++ b/tests/files/opensuse-leap16-calico.yml
@@ -1,0 +1,6 @@
+---
+# Instance settings
+cloud_image: opensuse-leap-16-0
+
+# Kubespray settings
+kube_network_plugin: calico


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds openSUSE Leap 16.0 support and representative KubeVirt CI coverage.

- Add an openSUSE Leap 16.0 Calico KubeVirt CI testcase.
- Add the Leap 16.0 testcase to the regular PR CI matrix.
- Update openSUSE supported OS documentation to Leap 16.0.
- Update the kernel requirements for openSUSE Leap 16.0.
- Remove the obsolete Leap 15.3 image definition.
- Retain the Leap 15.6 image for SLES 15 SP6 compatibility coverage.
- Remove the legacy `python-xml` bootstrap workaround.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13441

**Special notes for your reviewer**:

The openSUSE Leap 16.0 KubeVirt image is being added separately in #13453.

The existing `ansible-lint` failure in `roles/kubernetes/client/tasks/main.yml:70` is unrelated to this PR. Other relevant pre-commit checks, including `yamllint`, `jinja-syntax-check`, and `ci-matrix`, pass.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Yes. openSUSE Leap 16.0 is added as a supported operating system, with representative KubeVirt CI coverage.
```
