### PR TITLE
fix/ansible-core 2.19: add conditional unit tests and fixes

### DIFF
--- a/.gitlab-ci/lint.yml
+++ b/.gitlab-ci/lint.yml
@@ -17,6 +17,13 @@ pre-commit:
     when: 'always'
   needs: []
 
+unit-tests:
+  extends: .job
+  stage: test
+  script:
+  - python3 -m pip install --target /tmp/ansible-core-2.19.3 ansible-core==2.19.3
+  - PYTHONPATH=/tmp/ansible-core-2.19.3 python3 -m unittest discover -s tests/unit -p 'test_*.py'
+
 vagrant-validate:
   extends: .job
   stage: test

--- a/roles/kubernetes-apps/registry/tasks/main.yml
+++ b/roles/kubernetes-apps/registry/tasks/main.yml
@@ -79,8 +79,8 @@
     - { name: registry-pvc, file: registry-pvc.yml, type: pvc }
   register: registry_manifests
   when:
-    - registry_storage_class != none and registry_storage_class
-    - registry_disk_size != none and registry_disk_size
+    - registry_storage_class is not none and registry_storage_class | length > 0
+    - registry_disk_size is not none and registry_disk_size | length > 0
     - inventory_hostname == groups['kube_control_plane'][0]
 
 - name: Registry | Apply PVC manifests
@@ -93,6 +93,6 @@
     state: "latest"
   with_items: "{{ registry_manifests.results }}"
   when:
-    - registry_storage_class != none and registry_storage_class
-    - registry_disk_size != none and registry_disk_size
+    - registry_storage_class is not none and registry_storage_class | length > 0
+    - registry_disk_size is not none and registry_disk_size | length > 0
     - inventory_hostname == groups['kube_control_plane'][0]

--- a/roles/recover_control_plane/control-plane/tasks/main.yml
+++ b/roles/recover_control_plane/control-plane/tasks/main.yml
@@ -8,7 +8,7 @@
   retries: 6
   delay: 10
   changed_when: false
-  when: groups['broken_kube_control_plane']
+  when: groups['broken_kube_control_plane'] | length > 0
 
 - name: Delete broken kube_control_plane nodes from cluster
   command: "{{ kubectl }} delete node {{ item }}"
@@ -17,7 +17,7 @@
   with_items: "{{ groups['broken_kube_control_plane'] }}"
   register: delete_broken_kube_control_plane_nodes
   failed_when: false
-  when: groups['broken_kube_control_plane']
+  when: groups['broken_kube_control_plane'] | length > 0
 
 - name: Fail if unable to delete broken kube_control_plane nodes from cluster
   fail:
@@ -25,5 +25,5 @@
   loop: "{{ delete_broken_kube_control_plane_nodes.results }}"
   changed_when: false
   when:
-    - groups['broken_kube_control_plane']
+    - groups['broken_kube_control_plane'] | length > 0
     - "item.rc != 0 and not 'NotFound' in item.stderr"

--- a/roles/recover_control_plane/etcd/tasks/main.yml
+++ b/roles/recover_control_plane/etcd/tasks/main.yml
@@ -12,24 +12,24 @@
     ETCDCTL_KEY: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
     ETCDCTL_CACERT: "{{ etcd_cert_dir }}/ca.pem"
   when:
-    - groups['broken_etcd']
+    - groups['broken_etcd'] | length > 0
 
 - name: Set healthy fact
   set_fact:
     healthy: "{{ etcd_endpoint_health.stderr is match('Error: unhealthy cluster') }}"
   when:
-    - groups['broken_etcd']
+    - groups['broken_etcd'] | length > 0
 
 - name: Set has_quorum fact
   set_fact:
     has_quorum: "{{ etcd_endpoint_health.stdout_lines | select('match', '.*is healthy.*') | list | length >= etcd_endpoint_health.stderr_lines | select('match', '.*is unhealthy.*') | list | length }}"
   when:
-    - groups['broken_etcd']
+    - groups['broken_etcd'] | length > 0
 
 - name: Recover lost etcd quorum
   include_tasks: recover_lost_quorum.yml
   when:
-    - groups['broken_etcd']
+    - groups['broken_etcd'] | length > 0
     - not has_quorum
 
 - name: Remove etcd data dir
@@ -41,7 +41,7 @@
   ignore_errors: true  # noqa ignore-errors
   ignore_unreachable: true
   when:
-    - groups['broken_etcd']
+    - groups['broken_etcd'] | length > 0
     - has_quorum
 
 - name: Delete old certificates
@@ -49,7 +49,7 @@
   with_items: "{{ groups['broken_etcd'] }}"
   register: delete_old_cerificates
   ignore_errors: true
-  when: groups['broken_etcd']
+  when: groups['broken_etcd'] | length > 0
 
 - name: Fail if unable to delete old certificates
   fail:
@@ -57,7 +57,7 @@
   loop: "{{ delete_old_cerificates.results }}"
   changed_when: false
   when:
-    - groups['broken_etcd']
+    - groups['broken_etcd'] | length > 0
     - "item.rc != 0 and not 'No such file or directory' in item.stderr"
 
 - name: Get etcd cluster members
@@ -72,7 +72,7 @@
     ETCDCTL_KEY: "{{ etcd_cert_dir }}/admin-{{ inventory_hostname }}-key.pem"
     ETCDCTL_CACERT: "{{ etcd_cert_dir }}/ca.pem"
   when:
-    - groups['broken_etcd']
+    - groups['broken_etcd'] | length > 0
     - not healthy
     - has_quorum
 
@@ -88,7 +88,7 @@
     - "{{ groups['broken_etcd'] }}"
     - "{{ member_list.stdout_lines }}"
   when:
-    - groups['broken_etcd']
+    - groups['broken_etcd'] | length > 0
     - not healthy
     - has_quorum
     - hostvars[item[0]]['etcd_member_name'] == item[1].replace(' ', '').split(',')[2]

--- a/tests/testcases/025_check-csr-request.yml
+++ b/tests/testcases/025_check-csr-request.yml
@@ -45,4 +45,4 @@
     command: "{{ bin_dir }}/kubectl certificate approve {{ get_csr.stdout_lines | join(' ') }}"
     register: certificate_approve
     when: get_csr.stdout_lines | length > 0
-    changed_when: certificate_approve.stdout
+    changed_when: certificate_approve.stdout | length > 0

--- a/tests/unit/test_ansible_conditionals.py
+++ b/tests/unit/test_ansible_conditionals.py
@@ -1,145 +1,28 @@
 import unittest
-from collections import defaultdict
 from collections.abc import Mapping
 from pathlib import Path
 
 from ansible.errors import AnsibleBrokenConditionalError
 from ansible.parsing.dataloader import DataLoader
 from ansible.template import Templar, trust_as_template
-from jinja2 import Environment, nodes
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-JINJA_ENVIRONMENT = Environment()
-CONDITIONAL_FIELDS = ("when", "until", "changed_when", "failed_when")
 
 
-def yaml_patterns(*paths):
-    return tuple(
-        f"{path}/*.{extension}" for path in paths for extension in ("yml", "yaml")
-    )
-
-
-ANSIBLE_FILE_PATTERNS = yaml_patterns(
-    "playbooks/**",
-    "extra_playbooks/**",
-    "roles/**/handlers/**",
-    "roles/**/meta/**",
-    "roles/**/molecule/**",
-    "roles/**/tasks/**",
-    "tests/cloud_playbooks/**",
-    "tests/testcases/**",
-    "scripts",
-    "contrib/**",
-    "test-infra/**",
-)
-DEFAULT_FILE_PATTERNS = yaml_patterns("roles/**/defaults/**")
-
-NON_BOOLEAN_ATTRIBUTES = frozenset(
-    "files rc resources results stderr stderr_lines stdout stdout_lines".split()
-)
-
-
-def matching_paths(patterns):
-    return sorted({path for pattern in patterns for path in REPO_ROOT.glob(pattern)})
-
-
-def walk_mappings(value):
+def walk_tasks(value):
     if isinstance(value, Mapping):
-        yield value
+        if isinstance(value.get("name"), str):
+            yield value
         for child in value.values():
-            yield from walk_mappings(child)
+            yield from walk_tasks(child)
     elif isinstance(value, list):
         for child in value:
-            yield from walk_mappings(child)
+            yield from walk_tasks(child)
 
 
 def normalize_conditions(value):
     return value if isinstance(value, list) else [value]
-
-
-def load_non_boolean_defaults(loader):
-    types = defaultdict(set)
-    for path in matching_paths(DEFAULT_FILE_PATTERNS):
-        data = loader.load_from_file(str(path), trusted_as_template=True)
-        for name, value in data.items() if isinstance(data, Mapping) else ():
-            if isinstance(name, str):
-                templated = isinstance(value, str) and ("{{" in value or "{%" in value)
-                types[name].add(not isinstance(value, bool) and not templated)
-    return {name for name, values in types.items() if values == {True}}
-
-
-def is_non_boolean_expression(node, registered_variables, non_boolean_defaults):
-    if isinstance(node, (nodes.Compare, nodes.Not, nodes.Test)):
-        return False
-    if isinstance(node, nodes.Const):
-        return not isinstance(node.value, bool)
-    if isinstance(node, (nodes.Dict, nodes.List, nodes.Tuple)):
-        return True
-    if isinstance(node, nodes.Name):
-        return node.name in registered_variables or node.name in non_boolean_defaults
-    if isinstance(node, nodes.Getitem):
-        name = node.node.name if isinstance(node.node, nodes.Name) else None
-        return (
-            name == "groups"
-            or name in registered_variables
-            and isinstance(node.arg, nodes.Const)
-            and node.arg.value in NON_BOOLEAN_ATTRIBUTES
-        )
-    if isinstance(node, nodes.Getattr):
-        return (
-            isinstance(node.node, nodes.Name)
-            and node.node.name in registered_variables
-            and node.attr in NON_BOOLEAN_ATTRIBUTES
-        )
-    return False
-
-
-def is_non_boolean_condition(condition, registered_variables, non_boolean_defaults):
-    if isinstance(condition, bool):
-        return False
-    if not isinstance(condition, str):
-        return True
-    expression_text = condition.strip()
-    if expression_text.startswith("{{") and expression_text.endswith("}}"):
-        expression_text = expression_text[2:-2].strip()
-    parsed = JINJA_ENVIRONMENT.parse("{{ " + expression_text + " }}")
-    return is_non_boolean_expression(
-        parsed.body[0].nodes[0],
-        registered_variables,
-        non_boolean_defaults,
-    )
-
-
-def scan_non_boolean_conditionals(loader):
-    non_boolean_defaults = load_non_boolean_defaults(loader)
-    findings = []
-
-    for path in matching_paths(ANSIBLE_FILE_PATTERNS):
-        data = loader.load_from_file(str(path), trusted_as_template=True)
-        mappings = list(walk_mappings(data))
-        registered_variables = {
-            item["register"]
-            for item in mappings
-            if isinstance(item.get("register"), str)
-        }
-
-        for task in mappings:
-            for field in CONDITIONAL_FIELDS:
-                if field not in task:
-                    continue
-                for index, condition in enumerate(normalize_conditions(task[field])):
-                    if is_non_boolean_condition(
-                        condition,
-                        registered_variables,
-                        non_boolean_defaults,
-                    ):
-                        findings.append(
-                            f"{path.relative_to(REPO_ROOT)}: "
-                            f"{task.get('name', '<unnamed>')} "
-                            f"[{field}[{index}]]: {condition}"
-                        )
-    return findings
 
 
 class AnsibleConditionalTests(unittest.TestCase):
@@ -147,97 +30,131 @@ class AnsibleConditionalTests(unittest.TestCase):
     def setUpClass(cls):
         cls.loader = DataLoader()
 
-    def test_repository_has_no_definite_non_boolean_conditionals(self):
-        findings = scan_non_boolean_conditionals(self.loader)
-        self.assertFalse(findings, "\n".join(findings))
+    def load_task(self, path, name):
+        data = self.loader.load_from_file(
+            str(REPO_ROOT / path),
+            trusted_as_template=True,
+        )
+        return next(task for task in walk_tasks(data) if task["name"] == name)
 
-    def evaluator_is_broken(self, condition, variables=None):
+    def evaluate(self, condition, variables=None):
         if isinstance(condition, str):
             condition = trust_as_template(condition)
-        try:
-            result = Templar(
-                loader=self.loader,
-                variables=variables or {},
-            ).evaluate_conditional(condition)
-        except AnsibleBrokenConditionalError:
-            return True
-        self.assertIsInstance(result, bool)
-        return False
+        return Templar(
+            loader=self.loader,
+            variables=variables or {},
+        ).evaluate_conditional(condition)
 
-    def test_scanner_rules_match_ansible(self):
-        registered_variables = {"command_result"}
-        non_boolean_defaults = {"string_option"}
-        result = {"command_result": {"stdout": "value"}}
-        groups = {"groups": {"workers": ["node"]}}
-        cases = (
-            (None, {}, True),
-            (1, {}, True),
-            (1.0, {}, True),
-            ({}, {}, True),
-            ([], {}, True),
-            ([[]], {}, True),
-            (True, {}, False),
-            (False, {}, False),
-            ("command_result", result, True),
-            ("string_option", {"string_option": "value"}, True),
-            ("command_result.stdout", result, True),
-            ("command_result['stdout']", result, True),
-            ("groups['workers']", groups, True),
-            ("'value'", {}, True),
-            ("[]", {}, True),
-            ("{}", {}, True),
-            ("('a', 'b')", {}, True),
-            ("boolean_option", {"boolean_option": True}, False),
-            ("not boolean_option", {"boolean_option": True}, False),
-            ("option is defined", {}, False),
-            ("command_result is failed", {"command_result": {"failed": True}}, False),
-            ("'node' in groups['workers']", groups, False),
-            ("command_result.stdout | length > 0", result, False),
-            ("groups['workers'] | length > 0", groups, False),
-            ("boolean_mapping.stdout", {"boolean_mapping": {"stdout": True}}, False),
+    def assert_condition_results(
+        self,
+        path,
+        task_name,
+        field,
+        variables,
+        expected,
+    ):
+        conditions = normalize_conditions(self.load_task(path, task_name)[field])
+        self.assertEqual(
+            expected,
+            [self.evaluate(condition, variables) for condition in conditions],
         )
-        self.assertEqual([], normalize_conditions([]))
-        self.assertEqual([[]], normalize_conditions([[]]))
-        for expression, variables, expected in cases:
-            with self.subTest(expression=expression):
-                self.assertEqual(
-                    expected,
-                    is_non_boolean_condition(
-                        expression,
-                        registered_variables,
-                        non_boolean_defaults,
-                    ),
-                )
-                self.assertEqual(
-                    expected,
-                    self.evaluator_is_broken(expression, variables),
+
+    def test_registry_storage_conditions(self):
+        path = "roles/kubernetes-apps/registry/tasks/main.yml"
+        task_names = (
+            "Registry | Create PVC manifests",
+            "Registry | Apply PVC manifests",
+        )
+        cases = (
+            (None, None, [False, False, True]),
+            ("", "", [False, False, True]),
+            ("fast", "10Gi", [True, True, True]),
+        )
+
+        for task_name in task_names:
+            for storage_class, disk_size, expected in cases:
+                with self.subTest(
+                    task=task_name,
+                    storage_class=storage_class,
+                    disk_size=disk_size,
+                ):
+                    self.assert_condition_results(
+                        path,
+                        task_name,
+                        "when",
+                        {
+                            "registry_storage_class": storage_class,
+                            "registry_disk_size": disk_size,
+                            "inventory_hostname": "control-plane-1",
+                            "groups": {"kube_control_plane": ["control-plane-1"]},
+                        },
+                        expected,
+                    )
+
+    def test_recovery_group_conditions(self):
+        cases = (
+            (
+                "roles/recover_control_plane/control-plane/tasks/main.yml",
+                "broken_kube_control_plane",
+                (
+                    "Wait for apiserver",
+                    "Delete broken kube_control_plane nodes from cluster",
+                    "Fail if unable to delete broken kube_control_plane nodes from cluster",
+                ),
+            ),
+            (
+                "roles/recover_control_plane/etcd/tasks/main.yml",
+                "broken_etcd",
+                (
+                    "Get etcd endpoint health",
+                    "Set healthy fact",
+                    "Set has_quorum fact",
+                    "Recover lost etcd quorum",
+                    "Remove etcd data dir",
+                    "Delete old certificates",
+                    "Fail if unable to delete old certificates",
+                    "Get etcd cluster members",
+                    "Remove broken cluster members",
+                ),
+            ),
+        )
+
+        for path, group_name, task_names in cases:
+            for task_name in task_names:
+                condition = normalize_conditions(
+                    self.load_task(path, task_name)["when"]
+                )[0]
+                for group, expected in (([], False), (["node-1"], True)):
+                    with self.subTest(task=task_name, group=group):
+                        self.assertIs(
+                            self.evaluate(
+                                condition,
+                                {"groups": {group_name: group}},
+                            ),
+                            expected,
+                        )
+
+    def test_csr_changed_condition(self):
+        path = "tests/testcases/025_check-csr-request.yml"
+        task_name = "Approve certificates"
+
+        for stdout, expected in (
+            ("", False),
+            ("certificatesigningrequest approved", True),
+        ):
+            with self.subTest(stdout=stdout):
+                self.assert_condition_results(
+                    path,
+                    task_name,
+                    "changed_when",
+                    {"certificate_approve": {"stdout": stdout}},
+                    [expected],
                 )
 
     def test_ansible_evaluator_expression_boundaries(self):
-        old_registry = "registry_storage_class != none and registry_storage_class"
-        new_registry = (
-            "registry_storage_class is not none and registry_storage_class | length > 0"
-        )
-        result = {"command_result": {"stdout": "value"}}
-        short_circuit = "boolean_option or command_result.stdout"
         iterator_sum = "(range(1, 3) | map('pow', 2)) + (range(1, 3) | map('pow', 3))"
         iterator_comparison = f"({iterator_sum}) == [1.0, 4.0, 1.0, 8.0]"
-        cases = (
-            ("values | length", {"values": [1, 2]}, True),
-            (old_registry, {"registry_storage_class": None}, False),
-            (old_registry, {"registry_storage_class": "fast"}, True),
-            (short_circuit, {"boolean_option": True, **result}, False),
-            (short_circuit, {"boolean_option": False, **result}, True),
-            ("true or command_result.stdout", result, False),
-            (new_registry, {"registry_storage_class": None}, False),
-            (new_registry, {"registry_storage_class": ""}, False),
-            (new_registry, {"registry_storage_class": "fast"}, False),
-            (iterator_sum, {}, True),
-            (iterator_comparison, {}, False),
-        )
-        for expression, variables, broken in cases:
-            with self.subTest(expression=expression):
-                self.assertEqual(
-                    broken,
-                    self.evaluator_is_broken(expression, variables),
-                )
+
+        with self.assertRaises(AnsibleBrokenConditionalError):
+            self.evaluate(iterator_sum)
+        self.assertTrue(self.evaluate(iterator_comparison))

--- a/tests/unit/test_ansible_conditionals.py
+++ b/tests/unit/test_ansible_conditionals.py
@@ -1,0 +1,243 @@
+import unittest
+from collections import defaultdict
+from collections.abc import Mapping
+from pathlib import Path
+
+from ansible.errors import AnsibleBrokenConditionalError
+from ansible.parsing.dataloader import DataLoader
+from ansible.template import Templar, trust_as_template
+from jinja2 import Environment, nodes
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+JINJA_ENVIRONMENT = Environment()
+CONDITIONAL_FIELDS = ("when", "until", "changed_when", "failed_when")
+
+
+def yaml_patterns(*paths):
+    return tuple(
+        f"{path}/*.{extension}" for path in paths for extension in ("yml", "yaml")
+    )
+
+
+ANSIBLE_FILE_PATTERNS = yaml_patterns(
+    "playbooks/**",
+    "extra_playbooks/**",
+    "roles/**/handlers/**",
+    "roles/**/meta/**",
+    "roles/**/molecule/**",
+    "roles/**/tasks/**",
+    "tests/cloud_playbooks/**",
+    "tests/testcases/**",
+    "scripts",
+    "contrib/**",
+    "test-infra/**",
+)
+DEFAULT_FILE_PATTERNS = yaml_patterns("roles/**/defaults/**")
+
+NON_BOOLEAN_ATTRIBUTES = frozenset(
+    "files rc resources results stderr stderr_lines stdout stdout_lines".split()
+)
+
+
+def matching_paths(patterns):
+    return sorted({path for pattern in patterns for path in REPO_ROOT.glob(pattern)})
+
+
+def walk_mappings(value):
+    if isinstance(value, Mapping):
+        yield value
+        for child in value.values():
+            yield from walk_mappings(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from walk_mappings(child)
+
+
+def normalize_conditions(value):
+    return value if isinstance(value, list) else [value]
+
+
+def load_non_boolean_defaults(loader):
+    types = defaultdict(set)
+    for path in matching_paths(DEFAULT_FILE_PATTERNS):
+        data = loader.load_from_file(str(path), trusted_as_template=True)
+        for name, value in data.items() if isinstance(data, Mapping) else ():
+            if isinstance(name, str):
+                templated = isinstance(value, str) and ("{{" in value or "{%" in value)
+                types[name].add(not isinstance(value, bool) and not templated)
+    return {name for name, values in types.items() if values == {True}}
+
+
+def is_non_boolean_expression(node, registered_variables, non_boolean_defaults):
+    if isinstance(node, (nodes.Compare, nodes.Not, nodes.Test)):
+        return False
+    if isinstance(node, nodes.Const):
+        return not isinstance(node.value, bool)
+    if isinstance(node, (nodes.Dict, nodes.List, nodes.Tuple)):
+        return True
+    if isinstance(node, nodes.Name):
+        return node.name in registered_variables or node.name in non_boolean_defaults
+    if isinstance(node, nodes.Getitem):
+        name = node.node.name if isinstance(node.node, nodes.Name) else None
+        return (
+            name == "groups"
+            or name in registered_variables
+            and isinstance(node.arg, nodes.Const)
+            and node.arg.value in NON_BOOLEAN_ATTRIBUTES
+        )
+    if isinstance(node, nodes.Getattr):
+        return (
+            isinstance(node.node, nodes.Name)
+            and node.node.name in registered_variables
+            and node.attr in NON_BOOLEAN_ATTRIBUTES
+        )
+    return False
+
+
+def is_non_boolean_condition(condition, registered_variables, non_boolean_defaults):
+    if isinstance(condition, bool):
+        return False
+    if not isinstance(condition, str):
+        return True
+    expression_text = condition.strip()
+    if expression_text.startswith("{{") and expression_text.endswith("}}"):
+        expression_text = expression_text[2:-2].strip()
+    parsed = JINJA_ENVIRONMENT.parse("{{ " + expression_text + " }}")
+    return is_non_boolean_expression(
+        parsed.body[0].nodes[0],
+        registered_variables,
+        non_boolean_defaults,
+    )
+
+
+def scan_non_boolean_conditionals(loader):
+    non_boolean_defaults = load_non_boolean_defaults(loader)
+    findings = []
+
+    for path in matching_paths(ANSIBLE_FILE_PATTERNS):
+        data = loader.load_from_file(str(path), trusted_as_template=True)
+        mappings = list(walk_mappings(data))
+        registered_variables = {
+            item["register"]
+            for item in mappings
+            if isinstance(item.get("register"), str)
+        }
+
+        for task in mappings:
+            for field in CONDITIONAL_FIELDS:
+                if field not in task:
+                    continue
+                for index, condition in enumerate(normalize_conditions(task[field])):
+                    if is_non_boolean_condition(
+                        condition,
+                        registered_variables,
+                        non_boolean_defaults,
+                    ):
+                        findings.append(
+                            f"{path.relative_to(REPO_ROOT)}: "
+                            f"{task.get('name', '<unnamed>')} "
+                            f"[{field}[{index}]]: {condition}"
+                        )
+    return findings
+
+
+class AnsibleConditionalTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.loader = DataLoader()
+
+    def test_repository_has_no_definite_non_boolean_conditionals(self):
+        findings = scan_non_boolean_conditionals(self.loader)
+        self.assertFalse(findings, "\n".join(findings))
+
+    def evaluator_is_broken(self, condition, variables=None):
+        if isinstance(condition, str):
+            condition = trust_as_template(condition)
+        try:
+            result = Templar(
+                loader=self.loader,
+                variables=variables or {},
+            ).evaluate_conditional(condition)
+        except AnsibleBrokenConditionalError:
+            return True
+        self.assertIsInstance(result, bool)
+        return False
+
+    def test_scanner_rules_match_ansible(self):
+        registered_variables = {"command_result"}
+        non_boolean_defaults = {"string_option"}
+        result = {"command_result": {"stdout": "value"}}
+        groups = {"groups": {"workers": ["node"]}}
+        cases = (
+            (None, {}, True),
+            (1, {}, True),
+            (1.0, {}, True),
+            ({}, {}, True),
+            ([], {}, True),
+            ([[]], {}, True),
+            (True, {}, False),
+            (False, {}, False),
+            ("command_result", result, True),
+            ("string_option", {"string_option": "value"}, True),
+            ("command_result.stdout", result, True),
+            ("command_result['stdout']", result, True),
+            ("groups['workers']", groups, True),
+            ("'value'", {}, True),
+            ("[]", {}, True),
+            ("{}", {}, True),
+            ("('a', 'b')", {}, True),
+            ("boolean_option", {"boolean_option": True}, False),
+            ("not boolean_option", {"boolean_option": True}, False),
+            ("option is defined", {}, False),
+            ("command_result is failed", {"command_result": {"failed": True}}, False),
+            ("'node' in groups['workers']", groups, False),
+            ("command_result.stdout | length > 0", result, False),
+            ("groups['workers'] | length > 0", groups, False),
+            ("boolean_mapping.stdout", {"boolean_mapping": {"stdout": True}}, False),
+        )
+        self.assertEqual([], normalize_conditions([]))
+        self.assertEqual([[]], normalize_conditions([[]]))
+        for expression, variables, expected in cases:
+            with self.subTest(expression=expression):
+                self.assertEqual(
+                    expected,
+                    is_non_boolean_condition(
+                        expression,
+                        registered_variables,
+                        non_boolean_defaults,
+                    ),
+                )
+                self.assertEqual(
+                    expected,
+                    self.evaluator_is_broken(expression, variables),
+                )
+
+    def test_ansible_evaluator_expression_boundaries(self):
+        old_registry = "registry_storage_class != none and registry_storage_class"
+        new_registry = (
+            "registry_storage_class is not none and registry_storage_class | length > 0"
+        )
+        result = {"command_result": {"stdout": "value"}}
+        short_circuit = "boolean_option or command_result.stdout"
+        iterator_sum = "(range(1, 3) | map('pow', 2)) + (range(1, 3) | map('pow', 3))"
+        iterator_comparison = f"({iterator_sum}) == [1.0, 4.0, 1.0, 8.0]"
+        cases = (
+            ("values | length", {"values": [1, 2]}, True),
+            (old_registry, {"registry_storage_class": None}, False),
+            (old_registry, {"registry_storage_class": "fast"}, True),
+            (short_circuit, {"boolean_option": True, **result}, False),
+            (short_circuit, {"boolean_option": False, **result}, True),
+            ("true or command_result.stdout", result, False),
+            (new_registry, {"registry_storage_class": None}, False),
+            (new_registry, {"registry_storage_class": ""}, False),
+            (new_registry, {"registry_storage_class": "fast"}, False),
+            (iterator_sum, {}, True),
+            (iterator_comparison, {}, False),
+        )
+        for expression, variables, broken in cases:
+            with self.subTest(expression=expression):
+                self.assertEqual(
+                    broken,
+                    self.evaluator_is_broken(expression, variables),
+                )


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Ansible Core 2.19 requires conditionals to evaluate to booleans.

This PR:

- fixes confirmed non-boolean conditionals in the registry, control-plane recovery, and CSR test tasks;
- loads the affected conditions directly from their task YAML and evaluates them with Ansible Core 2.19.3;
- covers iterator behavior using Ansible's conditional evaluator;
- runs the unit tests against `ansible-core==2.19.3` in GitLab CI without changing Kubespray's supported Ansible version.

The focused tests prevent regressions in the affected conditions without maintaining a separate Jinja expression analyzer.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

Validation:

```text
PYTHONPATH=/tmp/ansible-core-2.19.3 python3 -m unittest discover -s tests/unit -p 'test_*.py' -v
ruff check tests/unit/test_ansible_conditionals.py
ruff format --check tests/unit/test_ansible_conditionals.py
pre-commit run yamllint --files <changed YAML files>
git diff --check
```

This PR was written in part with the assistance of generative AI.

**Does this PR introduce a user-facing change?**:

```release-note
Fix Ansible Core 2.19 failures caused by conditionals returning strings, lists, or registered result objects instead of booleans.
```
