### PR TITLE
containerd: restore 1.x config rendering after runtime-default cleanup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,6 +104,14 @@ repos:
         additional_dependencies:
           - ansible
 
+      - id: check-containerd-templates
+        name: Check that the containerd config templates render
+        entry: scripts/assert-containerd-templates.yml
+        language: python
+        pass_filenames: false
+        additional_dependencies:
+          - ansible-core>=2.18.0,<2.19.0
+
   - repo: https://github.com/markdownlint/markdownlint
     rev: v0.12.0
     hooks:

--- a/roles/container-engine/containerd/templates/config-v1.toml.j2
+++ b/roles/container-engine/containerd/templates/config-v1.toml.j2
@@ -47,8 +47,8 @@ oom_score = {{ containerd_oom_score }}
 {% for runtime in [containerd_runc_runtime] + containerd_additional_runtimes %}
         [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.{{ runtime.name }}]
           runtime_type = "{{ runtime.type }}"
-          runtime_engine = "{{ runtime.engine }}"
-          runtime_root = "{{ runtime.root }}"
+          runtime_engine = "{{ runtime.engine | default('') }}"
+          runtime_root = "{{ runtime.root | default('') }}"
 {% if runtime.base_runtime_spec is defined %}
           base_runtime_spec = "{{ containerd_cfg_dir }}/{{ runtime.base_runtime_spec }}"
 {% endif %}

--- a/scripts/assert-containerd-templates.yml
+++ b/scripts/assert-containerd-templates.yml
@@ -1,0 +1,52 @@
+#!/usr/bin/env ansible-playbook
+---
+# CI never sets containerd_version, so only the 2.x branch of the role's template
+# selector is ever rendered. Render both templates here instead.
+- name: Verify the containerd config templates render with the role defaults
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    container_manager: containerd
+    _templates: ../roles/container-engine/containerd/templates
+    # Render config-v1.toml.j2 for a version the role can actually install, not
+    # for containerd_min_version_required, which is older than any shipped archive.
+    _v1_versions: "{{ containerd_archive_checksums['amd64'] | dict2items | map(attribute='key') | map('string') | select('version', '2.0.0', '<') | list }}"
+    # The extra runtime documented in the role defaults: like the shared runtime
+    # defaults, it carries no engine or root.
+    _extra_runtime:
+      name: kata
+      type: io.containerd.kata.v2
+      options:
+        Root: ""
+  vars_files:
+  - ../roles/container-engine/containerd/defaults/main.yml
+  roles:
+  - kubespray_defaults
+  tasks:
+  - name: Check that config-v1.toml.j2 is still reachable
+    assert:
+      that: _v1_versions | length > 0
+      fail_msg: >-
+        No containerd release below 2.0.0 is shipped any more.
+        Drop config-v1.toml.j2 instead of rendering it here.
+      quiet: true
+
+  - name: Render each containerd config template with the role defaults
+    vars:
+      # Scoped to the render: a task var would shadow the loop's containerd_version.
+      _rendered: >-
+        {{ lookup('template', _templates ~ '/' ~ item.template,
+                  template_vars={'containerd_version': item.version,
+                                 'containerd_additional_runtimes': [_extra_runtime]}) }}
+    assert:
+      that: ('runtimes.' ~ _extra_runtime.name ~ ']') in _rendered
+      fail_msg: "{{ item.template }} rendered without the extra runtime at containerd {{ item.version }}"
+      quiet: true
+    loop:
+    - version: "{{ _v1_versions | first }}"
+      template: config-v1.toml.j2
+    - version: "{{ containerd_version }}"
+      template: config.toml.j2
+    loop_control:
+      label: "{{ item.template }} at containerd {{ item.version }}"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Rendering the containerd config fails for any `containerd_version` below 2.0.0:

```
fatal: [localhost]: FAILED! => {"msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'engine'"}
```

#12820 dropped `engine` and `root` from `containerd_runc_runtime` and removed the matching lines from `config.toml.j2`, but `config-v1.toml.j2` still reads both:

```jinja
runtime_engine = "{{ runtime.engine }}"
runtime_root = "{{ runtime.root }}"
```

`tasks/main.yml` still picks that template when `containerd_version is version('2.0.0', '<')`, and `containerd_min_version_required` is 1.3.7, so nothing stops you from landing there. Putting only `engine` back moves the failure to `root`. It also catches anyone who overrides `containerd_runc_runtime` from the docs example, since that no longer carries either key and Ansible replaces the whole dict rather than merging it.

**Why `default('')` and not just deleting the two lines**

Empty is what the template emitted before #12820, and it is the only value containerd will accept here, because the default runtime is `io.containerd.runc.v2`:

> ```go
> if r.Engine != "" {
>     if r.Type != plugin.RuntimeLinuxV1 {
>         return warnings, fmt.Errorf("`runtime_engine` only works for runtime %s", plugin.RuntimeLinuxV1)
>     }
> ```
>
> containerd release/1.7, `pkg/cri/config/config.go`

A value someone did configure still gets through, the default runtime keeps emitting the same two empty fields it always did, and the 2.x template is left alone.

**Testing**

I did not deploy a 1.x cluster; the failure and the fix both live in the rendering. I rendered both templates against `kubespray_defaults` plus the role defaults on ansible-core 2.18.19 (`ansible==11.13.0`, from `requirements.txt`) and again on 2.19.12. The 1.x output is identical to the pre-#12820 output apart from the `Root = ""` option #12820 added on purpose, and it parses as TOML. Reverting the two lines makes the new check fail on both versions.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

If you would rather drop containerd 1.x than keep this path alive, say so and I will rework this into removing `config-v1.toml.j2`, raising `containerd_min_version_required` and dropping the 1.x checksums. I would not argue against that.

Nothing under `tests/files/` sets `containerd_version`, so CI only ever renders the 2.x branch, which is why this went unnoticed since January. `scripts/assert-containerd-templates.yml` renders each template the role ships using the role's own defaults, runs in the existing pre-commit job next to `check-checksums-sorted`, needs no VMs and takes about a second. It renders the 1.x template at the newest 1.x we ship checksums for rather than at `containerd_min_version_required`, which is 1.3.7 while the oldest archive we ship is 1.7.0; picking the real version also keeps the NRI block, gated on 1.7.0, inside what gets rendered. If those checksums ever go away the first task fails and says to drop the template, instead of the check quietly falling back to testing one file.

#13131 also edits `config-v1.toml.j2`, but in the gvisor block further down, so the two do not conflict in either merge order.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed containerd config rendering for containerd < 2.0.0, which failed with "'dict object' has no attribute 'engine'".
```
