### PR TITLE
Make any_errors_fatal configurable again

### DIFF
--- a/extra_playbooks/upgrade-only-k8s.yml
+++ b/extra_playbooks/upgrade-only-k8s.yml
@@ -19,7 +19,7 @@
 
 - name: Bootstrap hosts OS for Ansible
   hosts: k8s_cluster:etcd:calico_rr
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   gather_facts: false
   vars:
     # Need to disable pipelining for bootstrap_os as some systems have requiretty in sudoers set, which makes pipelining
@@ -31,14 +31,14 @@
 
 - name: Preinstall
   hosts: k8s_cluster:etcd:calico_rr
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   roles:
     - { role: kubespray_defaults}
     - { role: kubernetes/preinstall, tags: preinstall }
 
 - name: Handle upgrades to control plane components first to maintain backwards compat.
   hosts: kube_control_plane
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   serial: 1
   roles:
     - { role: kubespray_defaults}
@@ -51,7 +51,7 @@
 
 - name: Finally handle worker upgrades, based on given batch size
   hosts: kube_node:!kube_control_plane
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   serial: "{{ serial | default('20%') }}"
   roles:
     - { role: kubespray_defaults}

--- a/playbooks/cluster.yml
+++ b/playbooks/cluster.yml
@@ -8,7 +8,7 @@
 - name: Prepare for etcd install
   hosts: k8s_cluster:etcd
   gather_facts: false
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray_defaults }
@@ -25,7 +25,7 @@
 - name: Install Kubernetes nodes
   hosts: k8s_cluster
   gather_facts: false
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray_defaults }
@@ -34,7 +34,7 @@
 - name: Install the control plane
   hosts: kube_control_plane
   gather_facts: false
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray_defaults }
@@ -45,7 +45,7 @@
 - name: Invoke kubeadm and install a CNI
   hosts: k8s_cluster
   gather_facts: false
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray_defaults }
@@ -58,7 +58,7 @@
 - name: Install Calico Route Reflector
   hosts: calico_rr
   gather_facts: false
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray_defaults }
@@ -67,7 +67,7 @@
 - name: Patch Kubernetes for Windows
   hosts: kube_control_plane[0]
   gather_facts: false
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray_defaults }
@@ -76,7 +76,7 @@
 - name: Install Kubernetes apps
   hosts: kube_control_plane
   gather_facts: false
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray_defaults }
@@ -89,7 +89,7 @@
 - name: Apply resolv.conf changes now that cluster DNS is up
   hosts: k8s_cluster
   gather_facts: false
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray_defaults }

--- a/playbooks/install_etcd.yml
+++ b/playbooks/install_etcd.yml
@@ -17,7 +17,7 @@
 - name: Install etcd
   hosts: etcd:kube_control_plane:_kubespray_needs_etcd
   gather_facts: false
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray_defaults }

--- a/playbooks/internal_facts.yml
+++ b/playbooks/internal_facts.yml
@@ -2,7 +2,7 @@
 - name: Bootstrap hosts for Ansible
   hosts: k8s_cluster:etcd:calico_rr
   strategy: linear
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   gather_facts: false
   environment: "{{ proxy_disable_env }}"
   roles:

--- a/playbooks/scale.yml
+++ b/playbooks/scale.yml
@@ -14,7 +14,7 @@
 - name: Download images to ansible host cache via first kube_control_plane node
   hosts: kube_control_plane[0]
   gather_facts: false
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray_defaults, when: "not skip_downloads and download_run_once and not download_localhost" }
@@ -24,7 +24,7 @@
 - name: Target only workers to get kubelet installed and checking in on any new nodes(engine)
   hosts: kube_node
   gather_facts: false
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray_defaults }
@@ -43,7 +43,7 @@
 - name: Target only workers to get kubelet installed and checking in on any new nodes(node)
   hosts: kube_node
   gather_facts: false
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray_defaults }
@@ -74,7 +74,7 @@
 - name: Target only workers to get kubelet installed and checking in on any new nodes(network)
   hosts: kube_node
   gather_facts: false
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray_defaults }
@@ -86,7 +86,7 @@
 - name: Apply resolv.conf changes now that cluster DNS is up
   hosts: k8s_cluster
   gather_facts: false
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray_defaults }

--- a/playbooks/upgrade_cluster.yml
+++ b/playbooks/upgrade_cluster.yml
@@ -8,7 +8,7 @@
 - name: Download images to ansible host cache via first kube_control_plane node
   hosts: kube_control_plane[0]
   gather_facts: false
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray_defaults, when: "not skip_downloads and download_run_once and not download_localhost"}
@@ -18,7 +18,7 @@
 - name: Prepare nodes for upgrade
   hosts: k8s_cluster:etcd:calico_rr
   gather_facts: false
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray_defaults }
@@ -28,7 +28,7 @@
 - name: Upgrade container engine on non-cluster nodes
   hosts: etcd:calico_rr:!k8s_cluster
   gather_facts: false
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
   serial: "{{ serial | default('20%') }}"
   roles:
@@ -44,7 +44,7 @@
 - name: Handle upgrades to control plane components first to maintain backwards compat.
   gather_facts: false
   hosts: kube_control_plane
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
   serial: 1
   roles:
@@ -66,7 +66,7 @@
 - name: Upgrade calico and external cloud provider on all control plane nodes, calico-rrs, and nodes
   hosts: kube_control_plane:calico_rr:kube_node
   gather_facts: false
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   serial: "{{ serial | default('20%') }}"
   environment: "{{ proxy_disable_env }}"
   roles:
@@ -78,7 +78,7 @@
 - name: Finally handle worker upgrades, based on given batch size
   hosts: kube_node:calico_rr:!kube_control_plane
   gather_facts: false
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
   serial: "{{ serial | default('20%') }}"
   roles:
@@ -105,7 +105,7 @@
 - name: Install Calico Route Reflector
   hosts: calico_rr
   gather_facts: false
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray_defaults }
@@ -114,7 +114,7 @@
 - name: Install Kubernetes apps
   hosts: kube_control_plane
   gather_facts: false
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray_defaults }
@@ -125,7 +125,7 @@
 - name: Apply resolv.conf changes now that cluster DNS is up
   hosts: k8s_cluster
   gather_facts: false
-  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  any_errors_fatal: "{{ kubespray_any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
   roles:
     - { role: kubespray_defaults }


### PR DESCRIPTION
Fixes the inert knob reported in #13407.

### What is wrong

Several playbooks carry:

```yaml
any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
```

introduced by #1201 ("Make any_errors_fatal configurable") in 2017.

`any_errors_fatal` is an Ansible **play keyword**, and Ansible reserves keyword
names in the variable namespace. Setting it through `-e`, `group_vars` or
`host_vars` is dropped with `Found variable using reserved name:
any_errors_fatal`, so the expression always falls through to `default(true)`.
The option has never been settable. The reserved-name behaviour is intended on
the Ansible side (ansible/ansible#16009, #84427, ansible/ansible#84432), so this
is not waiting on an upstream Ansible change.

### What this changes

Renames the variable to `kubespray_any_errors_fatal` in the 28 places that use
the idiom. The play keyword is untouched and the default is still `true`, so
**default behaviour is unchanged**; `-e kubespray_any_errors_fatal=false` now
does what #1201 meant it to do.

The one literal `any_errors_fatal: true` in `playbooks/upgrade_cluster.yml` is
deliberately left alone.

### Why it is worth fixing

`playbooks/internal_facts.yml` is the sharpest case. Its first play
(`bootstrap_os`) is fatal-on-any-error; the second play is the one that gathers
and caches facts. A single unreachable host aborts the run in the first play, so
the caching play runs zero tasks and the fact cache ends up **empty** — while the
playbook exits 0 with a recap that looks healthy. A subsequent
`scale.yml --limit=<node>` then refuses, because its preinstall check asserts a
cache entry for every host in `groups['k8s_cluster'] | difference(ansible_limit)`.
So one dead node blocks every scale-up on the cluster, with nothing in the output
saying why.

`roles/network_facts/tasks/main.yaml` already sets `ignore_unreachable: true`,
so tolerating unreachable hosts during fact gathering was clearly intended — it
just never runs, because the fatal play in front of it ends the playbook first.

With this change an operator can pass `-e kubespray_any_errors_fatal=false` and
get facts cached for the hosts that are reachable.

The alternative fix discussed in #13407 — adding `ignore_unreachable: true` to
the `bootstrap_os` play — changes default behaviour for everyone, so this
smaller change is offered first. Happy to switch to that shape instead if
maintainers prefer it.

### Testing

`--syntax-check` passes on all six touched playbooks, and no occurrence of the
old spelling remains.

```release-note
The playbook variable `any_errors_fatal` is renamed to `kubespray_any_errors_fatal`. The old name could never be set, because `any_errors_fatal` is a reserved Ansible play keyword; `-e kubespray_any_errors_fatal=false` now works. Default behaviour is unchanged.
```
