### PR TITLE
fix(cert_manager): stop deleting the namespace on every upgrade run

### DIFF
--- a/roles/kubernetes-apps/ingress_controller/cert_manager/tasks/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/tasks/main.yml
@@ -9,15 +9,6 @@
   tags:
     - upgrade
 
-- name: Cert Manager | Remove legacy namespace
-  command: >
-    {{ kubectl }} delete namespace {{ cert_manager_namespace }}
-  ignore_errors: true  # noqa ignore-errors
-  when:
-    - inventory_hostname == groups['kube_control_plane'][0]
-  tags:
-    - upgrade
-
 - name: Cert Manager | Create addon dir
   file:
     path: "{{ kube_config_dir }}/addons/cert_manager"


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

The cert_manager role's "Remove legacy namespace" task runs `kubectl delete namespace {{ cert_manager_namespace }}` on every playbook run carrying the `upgrade` tag. That wipes every user-managed resource in the namespace (for example custom Issuer secrets) together with cert-manager's own state, before the namespace is recreated and the manifests are re-applied.

The cleanup dates back to 2018 (62b116691) and migrated away from an old addon layout; the apply path (`kube` module, `state: latest`) upgrades cert-manager in place, so the unconditional namespace delete is now purely destructive. This removes it.

**Which issue(s) this PR fixes**:

Fixes #13486
