### PR TITLE
pre-commit: run slow hooks only in CI

### DIFF
--- a/.gitlab-ci/lint.yml
+++ b/.gitlab-ci/lint.yml
@@ -8,8 +8,7 @@ pre-commit:
     PRE_COMMIT_HOME: ${CI_PROJECT_DIR}/.cache/pre-commit
     ANSIBLE_STDOUT_CALLBACK: default
   script:
-  - pre-commit run --all-files --show-diff-on-failure
-  - pre-commit run ansible-lint --hook-stage manual --all-files --show-diff-on-failure
+  - pre-commit run --hook-stage manual --all-files --show-diff-on-failure
   cache:
     key: pre-commit-2
     paths:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,7 @@ repos:
   - repo: local
     hooks:
       - id: collection-build-install
+        stages: [manual]
         name: Build and install kubernetes-sigs.kubespray Ansible collection
         language: python
         additional_dependencies:
@@ -103,6 +104,7 @@ repos:
         pass_filenames: false
 
       - id: check-checksums-sorted
+        stages: [manual]
         name: Check that our checksums are correctly sorted by version
         entry: scripts/assert-sorted-checksums.yml
         language: python


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
collection-build-install and check-checksums-sorted have low value for
local development, as what they check isn't likely to be touched by most
contributors

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
