### PR TITLE
docker: replace use of apt_key for getting docker repository key

### DIFF
--- a/roles/container-engine/docker/defaults/main.yml
+++ b/roles/container-engine/docker/defaults/main.yml
@@ -6,7 +6,7 @@ docker_package_info:
   pkgs:
 
 # Path where to store repo key
-# docker_repo_key_keyring: /etc/apt/trusted.gpg.d/docker.gpg
+docker_repo_key_keyring: /etc/apt/keyrings/docker.asc
 
 docker_repo_key_info:
   repo_keys:

--- a/roles/container-engine/docker/tasks/main.yml
+++ b/roles/container-engine/docker/tasks/main.yml
@@ -47,11 +47,10 @@
   import_tasks: pre-upgrade.yml
 
 - name: Ensure docker-ce repository public key is installed
-  apt_key:
-    id: "{{ item }}"
+  get_url:
     url: "{{ docker_repo_key_info.url }}"
-    keyring: "{{ docker_repo_key_keyring | default(omit) }}"
-    state: present
+    dest: "{{ docker_repo_key_keyring }}"
+    mode: "0644"
   register: keyserver_task_result
   until: keyserver_task_result is succeeded
   retries: 4

--- a/roles/container-engine/docker/vars/debian.yml
+++ b/roles/container-engine/docker/vars/debian.yml
@@ -100,6 +100,7 @@ docker_repo_key_info:
 docker_repo_info:
   repos:
     - >
-      deb {{ docker_debian_repo_base_url }}
+      deb [signed-by={{ docker_repo_key_keyring }}]
+      {{ docker_debian_repo_base_url }}
       {{ ansible_facts['distribution_release'] | lower }}
       stable

--- a/roles/system_packages/vars/main.yml
+++ b/roles/system_packages/vars/main.yml
@@ -43,7 +43,6 @@ pkgs:
   ebtables: []
   gnupg:
     - "{{ ansible_distribution == 'Debian' }}"
-    - "{{ ansible_distribution_major_version == '12' }}"
     - "{{ 'k8s_cluster' in group_names }}"
   iproute:
     - "{{ ansible_os_family == 'RedHat' }}"

--- a/tests/files/debian12-docker.yml
+++ b/tests/files/debian12-docker.yml
@@ -6,4 +6,3 @@ cloud_image: debian-12
 container_manager: docker
 etcd_deployment_type: docker
 resolvconf_mode: docker_dns
-docker_repo_key_keyring: /etc/apt/trusted.gpg.d/docker.gpg

--- a/tests/files/ubuntu22-all-in-one-docker.yml
+++ b/tests/files/ubuntu22-all-in-one-docker.yml
@@ -15,4 +15,3 @@ enable_nodelocaldns: false
 container_manager: docker
 etcd_deployment_type: docker
 resolvconf_mode: docker_dns
-docker_repo_key_keyring: /etc/apt/trusted.gpg.d/docker.gpg

--- a/tests/files/ubuntu24-all-in-one-docker.yml
+++ b/tests/files/ubuntu24-all-in-one-docker.yml
@@ -15,4 +15,3 @@ enable_nodelocaldns: false
 container_manager: docker
 etcd_deployment_type: docker
 resolvconf_mode: docker_dns
-docker_repo_key_keyring: /etc/apt/trusted.gpg.d/docker.gpg


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
apt-key no longer exists in Debian 13

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fix docker repository key acquisition in Debian 13
```

/label ci-full
to test the debian 13 docker case
