### PR TITLE
Drop debian 13 docker support

### DIFF
--- a/.gitlab-ci/kubevirt.yml
+++ b/.gitlab-ci/kubevirt.yml
@@ -142,7 +142,6 @@ pr_extended:
           - almalinux9-calico
           - almalinux9-calico-remove-node
           - almalinux9-docker
-          - debian13-docker
           - debian12-calico
           - debian12-docker
           - debian13-calico

--- a/docs/developers/ci.md
+++ b/docs/developers/ci.md
@@ -47,7 +47,7 @@ ubuntu26 |  :x: | :x: | :x: | :x: | :x: | :x: |
 almalinux9 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
 amazon |  :x: | :x: | :x: | :x: | :x: | :x: |
 debian12 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
-debian13 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
+debian13 |  :x: | :x: | :x: | :x: | :x: | :x: |
 fedora43 |  :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
 fedora44 |  :x: | :x: | :x: | :x: | :x: | :x: |
 flatcar4081 |  :x: | :x: | :x: | :x: | :x: | :x: |

--- a/tests/files/debian13-docker.yml
+++ b/tests/files/debian13-docker.yml
@@ -1,8 +1,0 @@
----
-# Instance settings
-cloud_image: debian-13
-
-# Use docker
-container_manager: docker
-etcd_deployment_type: docker
-resolvconf_mode: docker_dns


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Debian 13 eliminated apt-key needed to add docker repository.
It needs some work to be supported again.
Contributors welcome


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
action required
Debian 13 with docker is no longer tested (see https://github.com/kubernetes-sigs/kubespray/pull/13495)
```

/cc @tico88612
