### PR TITLE
local_volume_provisioner: match upstream storage class syntax

### DIFF
--- a/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-cm.yml.j2
+++ b/roles/kubernetes-apps/external_provisioner/local_volume_provisioner/templates/local-volume-provisioner-cm.yml.j2
@@ -1,14 +1,3 @@
-# Macro to convert camelCase dictionary keys to snake_case keys
-{% macro convert_keys(mydict) -%}
-  {% for key in mydict.keys() | list -%}
-    {% set key_split = key.split('_') -%}
-    {% set new_key = key_split[0] + key_split[1:] | map('capitalize') | join -%}
-    {% set value = mydict.pop(key) -%}
-    {{ mydict.__setitem__(new_key, value) -}}
-    {{ convert_keys(value) if value is mapping else None -}}
-  {% endfor -%}
-{% endmacro -%}
-
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -28,6 +17,5 @@ data:
   storageClassMap: |
 {% for class_name, storage_class in local_volume_provisioner_storage_classes.items() %}
     {{ class_name }}:
-      {{- convert_keys(storage_class) }}
       {{ storage_class | to_nice_yaml(indent=2) | indent(6) }}
 {%- endfor %}

--- a/roles/kubespray_defaults/vars/main/main.yml
+++ b/roles/kubespray_defaults/vars/main/main.yml
@@ -69,10 +69,10 @@ kube_pods_subnets: >-
 local_volume_provisioner_storage_classes_default:
   - key: "{{ local_volume_provisioner_storage_class }}"
     value:
-      host_dir: "{{ local_volume_provisioner_base_dir }}"
-      mount_dir: "{{ local_volume_provisioner_mount_dir }}"
-      volume_mode: Filesystem
-      fs_type: ext4
+      hostDir: "{{ local_volume_provisioner_base_dir }}"
+      mountDir: "{{ local_volume_provisioner_mount_dir }}"
+      volumeMode: Filesystem
+      fsType: ext4
 
 ssl_ca_dirs_per_os_family:
   Debian: &usr_share


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Use the upstream keys without converting them to snake case. This avoids
converting back to camel case when rendering, and aligns ourselves more
with our upstream.
The macro to convert was broken with ansible-core 2.19

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
action required
The keys of `local_volume_provisioner_storage_classes` now follow the local-volume-static-provisioner storageClassMap schema, using camel case instead of snake case. If you're using the variable directly, convert the key to camel case.
```
