### PR TITLE
Bump ansible-static-lint pre-commit hook to v0.5.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         files: "\\.sh$"
 
   - repo: https://github.com/arhuman/ansible-static-lint
-    rev: v0.5.0
+    rev: v0.5.1
     hooks:
       - id: astl
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Bumps the ansible-static-lint (astl) pre-commit hook from v0.5.0 to v0.5.1.

v0.5.1 fixes file discovery to match ansible-lint's exclusion behaviour: it now honours each directory's `.gitignore` and ansible-lint's builtin exclude list (`.ansible`, `.tox`, `__pycache__`, ...). For kubespray this means astl no longer lints gitignored virtualenv directories such as `venv/`, which ansible-lint already skipped. Full details in the release notes: https://github.com/arhuman/ansible-static-lint/releases/tag/v0.5.1 (reported in arhuman/ansible-static-lint#5 against a kubespray checkout).

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

Single line change, only the pinned `rev:` moves.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```